### PR TITLE
feat(pairing): add configurable pairingMessage text per channel (#41058)

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -260,6 +260,7 @@ export async function preflightDiscordMessage(
               buildPairingReply({
                 channel: "discord",
                 idLine: `Your Discord user id: ${author.id}`,
+                senderId: author.id,
                 code,
               }),
               {

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -1453,6 +1453,7 @@ async function dispatchDiscordCommandInteraction(params: {
             buildPairingReply({
               channel: "discord",
               idLine: `Your Discord user id: ${user.id}`,
+              senderId: user.id,
               code,
             }),
             { ephemeral: true },

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -293,7 +293,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (!sender) {
         return;
       }
-      const pairingMessageCfg = cfg.pairingMessage;
+      const pairingMessageCfg = imessageCfg.pairingMessage;
       await issuePairingChallenge({
         channel: "imessage",
         senderId: decision.senderId,

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -28,9 +28,10 @@ import {
   isInboundPathAllowed,
   resolveIMessageAttachmentRoots,
   resolveIMessageRemoteAttachmentRoots,
-} from "../../../../src/media/inbound-path-policy.js";
-import { kindFromMime } from "../../../../src/media/mime.js";
-import { issuePairingChallenge } from "../../../../src/pairing/pairing-challenge.js";
+} from "../../media/inbound-path-policy.js";
+import { kindFromMime } from "../../media/mime.js";
+import { issuePairingChallenge } from "../../pairing/pairing-challenge.js";
+import { buildPairingReply } from "../../pairing/pairing-messages.js";
 import {
   readChannelAllowFromStore,
   upsertChannelPairingRequest,
@@ -292,10 +293,22 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (!sender) {
         return;
       }
+      const pairingMessageCfg = cfg.pairingMessage;
       await issuePairingChallenge({
         channel: "imessage",
         senderId: decision.senderId,
-        senderIdLine: `Your iMessage sender id: ${decision.senderId}`,
+        senderIdLine: pairingMessageCfg?.senderIdLabel
+          ? `${pairingMessageCfg.senderIdLabel} ${decision.senderId}`
+          : `Your iMessage sender id: ${decision.senderId}`,
+        buildReplyText: pairingMessageCfg
+          ? ({ code, senderIdLine }) =>
+              buildPairingReply({
+                channel: "imessage",
+                idLine: senderIdLine,
+                code,
+                pairingMessage: pairingMessageCfg,
+              })
+          : undefined,
         meta: {
           sender: decision.senderId,
           chatId: chatId ? String(chatId) : undefined,

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -28,10 +28,10 @@ import {
   isInboundPathAllowed,
   resolveIMessageAttachmentRoots,
   resolveIMessageRemoteAttachmentRoots,
-} from "../../media/inbound-path-policy.js";
-import { kindFromMime } from "../../media/mime.js";
-import { issuePairingChallenge } from "../../pairing/pairing-challenge.js";
-import { buildPairingReply } from "../../pairing/pairing-messages.js";
+} from "../../../../src/media/inbound-path-policy.js";
+import { kindFromMime } from "../../../../src/media/mime.js";
+import { issuePairingChallenge } from "../../../../src/pairing/pairing-challenge.js";
+import { buildPairingReply } from "../../../../src/pairing/pairing-messages.js";
 import {
   readChannelAllowFromStore,
   upsertChannelPairingRequest,

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -294,17 +294,17 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         return;
       }
       const pairingMessageCfg = imessageCfg.pairingMessage;
+      const senderIdLine = `Your iMessage sender id: ${decision.senderId}`;
       await issuePairingChallenge({
         channel: "imessage",
         senderId: decision.senderId,
-        senderIdLine: pairingMessageCfg?.senderIdLabel
-          ? `${pairingMessageCfg.senderIdLabel} ${decision.senderId}`
-          : `Your iMessage sender id: ${decision.senderId}`,
+        senderIdLine,
         buildReplyText: pairingMessageCfg
-          ? ({ code, senderIdLine }) =>
+          ? ({ code, senderIdLine, senderId }) =>
               buildPairingReply({
                 channel: "imessage",
                 idLine: senderIdLine,
+                senderId,
                 code,
                 pairingMessage: pairingMessageCfg,
               })

--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -1581,6 +1581,7 @@ export const registerTelegramHandlers = ({
           accountId,
           bot,
           logger,
+          pairingMessage: telegramCfg.pairingMessage,
         });
         if (!dmAuthorized) {
           return;

--- a/extensions/telegram/src/bot-message-context.pairing-message.test.ts
+++ b/extensions/telegram/src/bot-message-context.pairing-message.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+import { enforceTelegramDmAccess } from "./dm-access.js";
+
+vi.mock("./dm-access.js", () => ({
+  enforceTelegramDmAccess: vi.fn().mockResolvedValue(true),
+}));
+
+describe("buildTelegramMessageContext pairing message propagation", () => {
+  it("passes pairingMessage config to DM access enforcement", async () => {
+    const pairingMessage = { header: "Custom" } as const;
+
+    await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 123, type: "private" },
+      },
+      dmPolicy: "pairing",
+      pairingMessage,
+    });
+
+    expect(vi.mocked(enforceTelegramDmAccess)).toHaveBeenCalledWith(
+      expect.objectContaining({ pairingMessage }),
+    );
+  });
+});

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
+import type { PairingMessageConfig } from "../../../src/pairing/pairing-messages.js";
 import {
   buildTelegramMessageContext,
   type BuildTelegramMessageContextParams,

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
 import {
   buildTelegramMessageContext,
   type BuildTelegramMessageContextParams,
@@ -20,6 +21,8 @@ type BuildTelegramMessageContextForTestParams = {
   resolveGroupActivation?: BuildTelegramMessageContextParams["resolveGroupActivation"];
   resolveGroupRequireMention?: BuildTelegramMessageContextParams["resolveGroupRequireMention"];
   resolveTelegramGroupConfig?: BuildTelegramMessageContextParams["resolveTelegramGroupConfig"];
+  pairingMessage?: PairingMessageConfig;
+  dmPolicy?: BuildTelegramMessageContextParams["dmPolicy"];
 };
 
 export async function buildTelegramMessageContextForTest(
@@ -49,7 +52,7 @@ export async function buildTelegramMessageContextForTest(
     account: { accountId: params.accountId ?? "default" } as never,
     historyLimit: 0,
     groupHistories: new Map(),
-    dmPolicy: "open",
+    dmPolicy: params.dmPolicy ?? "open",
     allowFrom: [],
     groupAllowFrom: [],
     ackReactionScope: "off",
@@ -63,5 +66,6 @@ export async function buildTelegramMessageContextForTest(
         topicConfig: undefined,
       })),
     sendChatActionHandler: { sendChatAction: vi.fn() } as never,
+    pairingMessage: params.pairingMessage,
   });
 }

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -57,6 +57,7 @@ export const buildTelegramMessageContext = async ({
   resolveGroupRequireMention,
   resolveTelegramGroupConfig,
   sendChatActionHandler,
+  pairingMessage,
 }: BuildTelegramMessageContextParams) => {
   const msg = primaryCtx.message;
   const chatId = msg.chat.id;
@@ -194,6 +195,7 @@ export const buildTelegramMessageContext = async ({
       accountId: account.accountId,
       bot,
       logger,
+      pairingMessage,
     }))
   ) {
     return null;

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -6,8 +6,8 @@ import type {
   TelegramDirectConfig,
   TelegramGroupConfig,
   TelegramTopicConfig,
-} from "../config/types.js";
-import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
+} from "../../../src/config/types.js";
+import type { PairingMessageConfig } from "../../../src/pairing/pairing-messages.js";
 import type { StickerMetadata, TelegramContext } from "./bot/types.js";
 
 export type TelegramMediaRef = {

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -6,7 +6,8 @@ import type {
   TelegramDirectConfig,
   TelegramGroupConfig,
   TelegramTopicConfig,
-} from "../../../src/config/types.js";
+} from "../config/types.js";
+import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
 import type { StickerMetadata, TelegramContext } from "./bot/types.js";
 
 export type TelegramMediaRef = {
@@ -62,4 +63,5 @@ export type BuildTelegramMessageContextParams = {
   resolveTelegramGroupConfig: ResolveTelegramGroupConfig;
   /** Global (per-account) handler for sendChatAction 401 backoff (#27092). */
   sendChatActionHandler: import("./sendchataction-401-backoff.js").TelegramSendChatActionHandler;
+  pairingMessage?: PairingMessageConfig;
 };

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -14,7 +14,7 @@ import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
 /** Dependencies injected once when creating the message processor. */
 type TelegramMessageProcessorDeps = Omit<
   BuildTelegramMessageContextParams,
-  "primaryCtx" | "allMedia" | "storeAllowFrom" | "options"
+  "primaryCtx" | "allMedia" | "storeAllowFrom" | "options" | "pairingMessage"
 > & {
   telegramCfg: TelegramAccountConfig;
   runtime: RuntimeEnv;
@@ -75,6 +75,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       resolveGroupRequireMention,
       resolveTelegramGroupConfig,
       sendChatActionHandler,
+      pairingMessage: telegramCfg.pairingMessage,
     });
     if (!context) {
       return;

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -105,7 +105,7 @@ function extractTelegramApiMethod(input: TelegramFetchInput): string | null {
   }
 }
 
-export function createTelegramBot(opts: TelegramBotOptions) {
+export function createTelegramBot(opts: TelegramBotOptions): Bot {
   const runtime: RuntimeEnv = opts.runtime ?? createNonExitingRuntime();
   const cfg = opts.config ?? loadConfig();
   const account = resolveTelegramAccount({
@@ -175,7 +175,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
           abortWith(init.signal as unknown as AbortSignal);
         } else {
           onRequestAbort = () => abortWith(init.signal as AbortSignal);
-          init.signal.addEventListener("abort", onRequestAbort);
+          init.signal.addEventListener("abort", onRequestAbort, { once: true });
         }
       }
       return callFetch(input as GlobalFetchInput, {

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -1,9 +1,10 @@
 import type { Message } from "@grammyjs/types";
 import type { Bot } from "grammy";
-import type { DmPolicy } from "../../../src/config/types.js";
-import { logVerbose } from "../../../src/globals.js";
-import { issuePairingChallenge } from "../../../src/pairing/pairing-challenge.js";
-import { upsertChannelPairingRequest } from "../../../src/pairing/pairing-store.js";
+import type { DmPolicy } from "../config/types.js";
+import { logVerbose } from "../globals.js";
+import { issuePairingChallenge } from "../pairing/pairing-challenge.js";
+import { buildPairingReply, type PairingMessageConfig } from "../pairing/pairing-messages.js";
+import { upsertChannelPairingRequest } from "../pairing/pairing-store.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { resolveSenderAllowMatch, type NormalizedAllowFrom } from "./bot-access.js";
 
@@ -40,8 +41,9 @@ export async function enforceTelegramDmAccess(params: {
   accountId: string;
   bot: Bot;
   logger: TelegramDmAccessLogger;
+  pairingMessage?: PairingMessageConfig;
 }): Promise<boolean> {
-  const { isGroup, dmPolicy, msg, chatId, effectiveDmAllow, accountId, bot, logger } = params;
+  const { isGroup, dmPolicy, msg, chatId, effectiveDmAllow, accountId, bot, logger, pairingMessage: pairingMessageCfg } = params;
   if (isGroup) {
     return true;
   }
@@ -73,7 +75,18 @@ export async function enforceTelegramDmAccess(params: {
       await issuePairingChallenge({
         channel: "telegram",
         senderId: telegramUserId,
-        senderIdLine: `Your Telegram user id: ${telegramUserId}`,
+        senderIdLine: pairingMessageCfg?.senderIdLabel
+          ? `${pairingMessageCfg.senderIdLabel} ${telegramUserId}`
+          : `Your Telegram user id: ${telegramUserId}`,
+        buildReplyText: pairingMessageCfg
+          ? ({ code, senderIdLine }) =>
+              buildPairingReply({
+                channel: "telegram",
+                idLine: senderIdLine,
+                code,
+                pairingMessage: pairingMessageCfg,
+              })
+          : undefined,
         meta: {
           username: sender.username || undefined,
           firstName: sender.firstName,

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -1,10 +1,13 @@
 import type { Message } from "@grammyjs/types";
 import type { Bot } from "grammy";
-import type { DmPolicy } from "../config/types.js";
-import { logVerbose } from "../globals.js";
-import { issuePairingChallenge } from "../pairing/pairing-challenge.js";
-import { buildPairingReply, type PairingMessageConfig } from "../pairing/pairing-messages.js";
-import { upsertChannelPairingRequest } from "../pairing/pairing-store.js";
+import type { DmPolicy } from "../../../src/config/types.js";
+import { logVerbose } from "../../../src/globals.js";
+import { issuePairingChallenge } from "../../../src/pairing/pairing-challenge.js";
+import {
+  buildPairingReply,
+  type PairingMessageConfig,
+} from "../../../src/pairing/pairing-messages.js";
+import { upsertChannelPairingRequest } from "../../../src/pairing/pairing-store.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { resolveSenderAllowMatch, type NormalizedAllowFrom } from "./bot-access.js";
 

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -43,7 +43,17 @@ export async function enforceTelegramDmAccess(params: {
   logger: TelegramDmAccessLogger;
   pairingMessage?: PairingMessageConfig;
 }): Promise<boolean> {
-  const { isGroup, dmPolicy, msg, chatId, effectiveDmAllow, accountId, bot, logger, pairingMessage: pairingMessageCfg } = params;
+  const {
+    isGroup,
+    dmPolicy,
+    msg,
+    chatId,
+    effectiveDmAllow,
+    accountId,
+    bot,
+    logger,
+    pairingMessage: pairingMessageCfg,
+  } = params;
   if (isGroup) {
     return true;
   }

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -82,17 +82,17 @@ export async function enforceTelegramDmAccess(params: {
   if (dmPolicy === "pairing") {
     try {
       const telegramUserId = sender.userId ?? sender.candidateId;
+      const senderIdLine = `Your Telegram user id: ${telegramUserId}`;
       await issuePairingChallenge({
         channel: "telegram",
         senderId: telegramUserId,
-        senderIdLine: pairingMessageCfg?.senderIdLabel
-          ? `${pairingMessageCfg.senderIdLabel} ${telegramUserId}`
-          : `Your Telegram user id: ${telegramUserId}`,
+        senderIdLine,
         buildReplyText: pairingMessageCfg
-          ? ({ code, senderIdLine }) =>
+          ? ({ code, senderIdLine, senderId }) =>
               buildPairingReply({
                 channel: "telegram",
                 idLine: senderIdLine,
+                senderId,
                 code,
                 pairingMessage: pairingMessageCfg,
               })

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -58,7 +58,7 @@ export class TelegramPollingSession {
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {}
 
-  get activeRunner() {
+  get activeRunner(): ReturnType<typeof run> | undefined {
     return this.#activeRunner;
   }
 

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -18,6 +18,8 @@ import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 
+type TelegramBot = ReturnType<typeof createTelegramBot>;
+
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
 const TELEGRAM_WEBHOOK_CALLBACK_TIMEOUT_MS = 10_000;
@@ -26,7 +28,7 @@ async function listenHttpServer(params: {
   server: ReturnType<typeof createServer>;
   port: number;
   host: string;
-}) {
+}): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const onError = (err: Error) => {
       params.server.off("error", onError);
@@ -111,7 +113,7 @@ export async function startTelegramWebhook(opts: {
   healthPath?: string;
   publicUrl?: string;
   webhookCertPath?: string;
-}) {
+}): Promise<{ server: ReturnType<typeof createServer>; bot: TelegramBot; stop: () => void }> {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
   const port = opts.port ?? 8787;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5540,6 +5540,14 @@ packages:
       node-llama-cpp:
         optional: true
 
+  openclaw@2026.3.8:
+    resolution: {integrity: sha512-e5Rk2Aj55sD/5LyX94mdYCQj7zpHXo0xIZsl+k140+nRopePfPAxC7nsu0V/NyypPRtaotP1riFfzK7IhaYkuQ==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.89
+      node-llama-cpp: 3.16.2
+
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
 
@@ -12875,6 +12883,81 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@discordjs/opus'
+      - '@types/express'
+      - audio-decode
+      - aws-crt
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - ffmpeg-static
+      - jimp
+      - link-preview-js
+      - node-opus
+      - supports-color
+      - utf-8-validate
+
+  openclaw@2026.3.8(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.7)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.16.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock': 3.1007.0
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.7)(opusscript@0.1.1)
+      '@clack/prompts': 1.1.0
+      '@discordjs/voice': 0.19.1(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@grammyjs/runner': 2.0.3(grammy@1.41.1)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.1)
+      '@homebridge/ciao': 1.3.5
+      '@larksuiteoapi/node-sdk': 1.59.0
+      '@line/bot-sdk': 10.6.0
+      '@lydell/node-pty': 1.2.0-beta.3
+      '@mariozechner/pi-agent-core': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.57.1
+      '@mozilla/readability': 0.6.0
+      '@napi-rs/canvas': 0.1.95
+      '@sinclair/typebox': 0.34.48
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/web-api': 7.14.1
+      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      ajv: 8.18.0
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      cli-highlight: 2.1.11
+      commander: 14.0.3
+      croner: 10.0.1
+      discord-api-types: 0.38.42
+      dotenv: 17.3.1
+      express: 5.2.1
+      file-type: 21.3.1
+      grammy: 1.41.1
+      hono: 4.12.7
+      https-proxy-agent: 8.0.0
+      ipaddr.js: 2.3.0
+      jiti: 2.6.1
+      json5: 2.2.3
+      jszip: 3.10.1
+      linkedom: 0.18.12
+      long: 5.3.2
+      markdown-it: 14.1.1
+      node-edge-tts: 1.2.10
+      node-llama-cpp: 3.16.2(typescript@5.9.3)
+      opusscript: 0.1.1
+      osc-progress: 0.3.0
+      pdfjs-dist: 5.5.207
+      playwright-core: 1.58.2
+      qrcode-terminal: 0.12.0
+      sharp: 0.34.5
+      sqlite-vec: 0.1.7-alpha.2
+      tar: 7.5.11
+      tslog: 4.10.2
+      undici: 7.22.0
+      ws: 8.19.0
+      yaml: 2.8.2
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - '@modelcontextprotocol/sdk'
       - '@types/express'
       - audio-decode
       - aws-crt

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -72,19 +72,21 @@ export const CONFIGURE_SECTION_OPTIONS: Array<{
   },
 ];
 
-export const intro = (message: string) => clackIntro(stylePromptTitle(message) ?? message);
-export const outro = (message: string) => clackOutro(stylePromptTitle(message) ?? message);
-export const text = (params: Parameters<typeof clackText>[0]) =>
+export const intro: typeof clackIntro = (message) =>
+  clackIntro(stylePromptTitle(message) ?? message);
+export const outro: typeof clackOutro = (message) =>
+  clackOutro(stylePromptTitle(message) ?? message);
+export const text: typeof clackText = (params) =>
   clackText({
     ...params,
     message: stylePromptMessage(params.message),
   });
-export const confirm = (params: Parameters<typeof clackConfirm>[0]) =>
+export const confirm: typeof clackConfirm = (params) =>
   clackConfirm({
     ...params,
     message: stylePromptMessage(params.message),
   });
-export const select = <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
+export const select: typeof clackSelect = (params) =>
   clackSelect({
     ...params,
     message: stylePromptMessage(params.message),

--- a/src/config/types.imessage.ts
+++ b/src/config/types.imessage.ts
@@ -5,7 +5,6 @@ import type {
   GroupPolicy,
   MarkdownConfig,
 } from "./types.base.js";
-import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
 import type {
   ChannelHealthMonitorConfig,
   ChannelHeartbeatVisibilityConfig,

--- a/src/config/types.imessage.ts
+++ b/src/config/types.imessage.ts
@@ -4,6 +4,7 @@ import type {
   GroupPolicy,
   MarkdownConfig,
 } from "./types.base.js";
+import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
 import type {
   ChannelHealthMonitorConfig,
   ChannelHeartbeatVisibilityConfig,
@@ -84,6 +85,9 @@ export type IMessageAccountConfig = {
   healthMonitor?: ChannelHealthMonitorConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
+  /** Optional pairing message text overrides. Allows white-label deployments to
+   *  customize or suppress OpenClaw branding in pairing challenge messages. */
+  pairingMessage?: PairingMessageConfig;
 };
 
 export type IMessageConfig = {

--- a/src/config/types.imessage.ts
+++ b/src/config/types.imessage.ts
@@ -1,3 +1,4 @@
+import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
 import type {
   BlockStreamingCoalesceConfig,
   DmPolicy,

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -1,3 +1,4 @@
+import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
 import type {
   BlockStreamingChunkConfig,
   BlockStreamingCoalesceConfig,
@@ -14,7 +15,6 @@ import type {
 } from "./types.channels.js";
 import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
-import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
 
 export type TelegramActionConfig = {
   reactions?: boolean;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -14,6 +14,7 @@ import type {
 } from "./types.channels.js";
 import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
+import type { PairingMessageConfig } from "../pairing/pairing-messages.js";
 
 export type TelegramActionConfig = {
   reactions?: boolean;
@@ -194,6 +195,9 @@ export type TelegramAccountConfig = {
    * Use `"auto"` to derive `[{identity.name}]` from the routed agent.
    */
   responsePrefix?: string;
+  /** Optional pairing message text overrides. Allows white-label deployments to
+   *  customize or suppress OpenClaw branding in pairing challenge messages. */
+  pairingMessage?: PairingMessageConfig;
   /**
    * Per-channel ack reaction override.
    * Telegram expects unicode emoji (e.g., "👀") rather than shortcodes.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -141,6 +141,17 @@ const validateTelegramCustomCommands = (
   }
 };
 
+export const PairingMessageConfigSchema = z
+  .object({
+    header: z.string().optional(),
+    senderIdLabel: z.string().optional(),
+    codeLabel: z.string().optional(),
+    footer: z.string().optional(),
+    showCliHint: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 function normalizeTelegramStreamingConfig(value: { streaming?: unknown; streamMode?: unknown }) {
   value.streaming = resolveTelegramPreviewStreamMode(value);
   delete value.streamMode;
@@ -1232,17 +1243,6 @@ export const IrcConfigSchema = IrcAccountSchemaBase.extend({
     });
   }
 });
-
-export const PairingMessageConfigSchema = z
-  .object({
-    header: z.string().optional(),
-    senderIdLabel: z.string().optional(),
-    codeLabel: z.string().optional(),
-    footer: z.string().optional(),
-    showCliHint: z.boolean().optional(),
-  })
-  .strict()
-  .optional();
 
 export const IMessageAccountSchemaBase = z
   .object({

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -277,6 +277,7 @@ export const TelegramAccountSchemaBase = z
     healthMonitor: ChannelHealthMonitorSchema,
     linkPreview: z.boolean().optional(),
     responsePrefix: z.string().optional(),
+    pairingMessage: PairingMessageConfigSchema,
     ackReaction: z.string().optional(),
   })
   .strict();
@@ -1232,6 +1233,17 @@ export const IrcConfigSchema = IrcAccountSchemaBase.extend({
   }
 });
 
+export const PairingMessageConfigSchema = z
+  .object({
+    header: z.string().optional(),
+    senderIdLabel: z.string().optional(),
+    codeLabel: z.string().optional(),
+    footer: z.string().optional(),
+    showCliHint: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 export const IMessageAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -1283,6 +1295,7 @@ export const IMessageAccountSchemaBase = z
     heartbeat: ChannelHeartbeatVisibilitySchema,
     healthMonitor: ChannelHealthMonitorSchema,
     responsePrefix: z.string().optional(),
+    pairingMessage: PairingMessageConfigSchema,
   })
   .strict();
 

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,3 +1,4 @@
+import type { ChalkInstance } from "chalk";
 import { getLogger, isFileLogLevelEnabled } from "./logging/logger.js";
 import { theme } from "./terminal/theme.js";
 
@@ -46,7 +47,7 @@ export function isYes() {
   return globalYes;
 }
 
-export const success = theme.success;
-export const warn = theme.warn;
-export const info = theme.info;
-export const danger = theme.error;
+export const success: ChalkInstance = theme.success;
+export const warn: ChalkInstance = theme.warn;
+export const info: ChalkInstance = theme.info;
+export const danger: ChalkInstance = theme.error;

--- a/src/pairing/pairing-challenge.ts
+++ b/src/pairing/pairing-challenge.ts
@@ -12,7 +12,7 @@ export type PairingChallengeParams = {
     meta?: PairingMeta;
   }) => Promise<{ code: string; created: boolean }>;
   sendPairingReply: (text: string) => Promise<void>;
-  buildReplyText?: (params: { code: string; senderIdLine: string }) => string;
+  buildReplyText?: (params: { code: string; senderIdLine: string; senderId: string }) => string;
   onCreated?: (params: { code: string }) => void;
   onReplyError?: (err: unknown) => void;
 };
@@ -33,10 +33,15 @@ export async function issuePairingChallenge(
   }
   params.onCreated?.({ code });
   const replyText =
-    params.buildReplyText?.({ code, senderIdLine: params.senderIdLine }) ??
+    params.buildReplyText?.({
+      code,
+      senderIdLine: params.senderIdLine,
+      senderId: params.senderId,
+    }) ??
     buildPairingReply({
       channel: params.channel,
       idLine: params.senderIdLine,
+      senderId: params.senderId,
       code,
     });
   try {

--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -59,4 +59,60 @@ describe("buildPairingReply", () => {
       expect(text).toMatch(commandRe);
     });
   }
+
+  describe("pairingMessage config overrides", () => {
+    it("uses custom header when provided", () => {
+      const text = buildPairingReply({
+        channel: "imessage",
+        idLine: "Your iMessage sender id: +15550001111",
+        code: "ABC123",
+        pairingMessage: { header: "Verification required." },
+      });
+      expect(text).toContain("Verification required.");
+      expect(text).not.toContain("OpenClaw");
+    });
+
+    it("uses custom codeLabel when provided", () => {
+      const text = buildPairingReply({
+        channel: "imessage",
+        idLine: "Your iMessage sender id: +15550001111",
+        code: "ABC123",
+        pairingMessage: { codeLabel: "Your code:" },
+      });
+      expect(text).toContain("Your code: ABC123");
+      expect(text).not.toContain("Pairing code:");
+    });
+
+    it("suppresses CLI hint when showCliHint is false", () => {
+      const text = buildPairingReply({
+        channel: "imessage",
+        idLine: "Your iMessage sender id: +15550001111",
+        code: "ABC123",
+        pairingMessage: { showCliHint: false },
+      });
+      expect(text).not.toContain("openclaw");
+      expect(text).toContain("ABC123");
+    });
+
+    it("uses custom footer when provided", () => {
+      const text = buildPairingReply({
+        channel: "telegram",
+        idLine: "Your Telegram user id: 42",
+        code: "XYZ999",
+        pairingMessage: { footer: "Share this code with your contact." },
+      });
+      expect(text).toContain("Share this code with your contact.");
+      expect(text).not.toContain("bot owner");
+    });
+
+    it("applies no changes when pairingMessage is undefined (backward compat)", () => {
+      const text = buildPairingReply({
+        channel: "imessage",
+        idLine: "Your iMessage sender id: +15550001111",
+        code: "ABC123",
+      });
+      expect(text).toContain("OpenClaw: access not configured.");
+      expect(text).toContain("Pairing code: ABC123");
+    });
+  });
 });

--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -129,6 +129,18 @@ describe("buildPairingReply", () => {
       expect(text).not.toContain("Your iMessage sender id:");
     });
 
+    it("allows empty senderIdLabel overrides without falling back to defaults", () => {
+      const text = buildPairingReply({
+        channel: "telegram",
+        idLine: "Your Telegram user id: 42",
+        senderId: "42",
+        code: "XYZ123",
+        pairingMessage: { senderIdLabel: "" },
+      });
+      expect(text.split("\n")).toContain("42");
+      expect(text).not.toContain("Your Telegram user id:");
+    });
+
     it("applies no changes when pairingMessage is undefined (backward compat)", () => {
       const text = buildPairingReply({
         channel: "imessage",

--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -95,6 +95,17 @@ describe("buildPairingReply", () => {
       expect(text).toContain("ABC123");
     });
 
+    it("omits default footer when CLI hint is suppressed without custom footer", () => {
+      const text = buildPairingReply({
+        channel: "telegram",
+        idLine: "Your Telegram user id: 42",
+        code: "XYZ123",
+        pairingMessage: { showCliHint: false },
+      });
+      expect(text.split("\n")).not.toContain("Ask the bot owner to approve with:");
+      expect(text).not.toMatch(/openclaw\s+pairing\s+approve/);
+    });
+
     it("uses custom footer when provided", () => {
       const text = buildPairingReply({
         channel: "telegram",

--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -91,6 +91,7 @@ describe("buildPairingReply", () => {
         pairingMessage: { showCliHint: false },
       });
       expect(text).not.toContain("openclaw");
+      expect(text).not.toContain("Ask the bot owner to approve with:");
       expect(text).toContain("ABC123");
     });
 
@@ -103,6 +104,18 @@ describe("buildPairingReply", () => {
       });
       expect(text).toContain("Share this code with your contact.");
       expect(text).not.toContain("bot owner");
+    });
+
+    it("applies senderIdLabel overrides centrally", () => {
+      const text = buildPairingReply({
+        channel: "imessage",
+        idLine: "Your iMessage sender id: +15550001111",
+        senderId: "+15550001111",
+        code: "ABC123",
+        pairingMessage: { senderIdLabel: "Contact ID:" },
+      });
+      expect(text).toContain("Contact ID: +15550001111");
+      expect(text).not.toContain("Your iMessage sender id:");
     });
 
     it("applies no changes when pairingMessage is undefined (backward compat)", () => {

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -1,20 +1,51 @@
 import { formatCliCommand } from "../cli/command-format.js";
 import type { PairingChannel } from "./pairing-store.js";
 
+export type PairingMessageConfig = {
+  /**
+   * Replaces the first line of the pairing message.
+   * Default: "OpenClaw: access not configured."
+   */
+  header?: string;
+  /**
+   * Replaces the label before the sender's ID.
+   * The sender ID value is still appended automatically.
+   * Default: "Your {channel} sender id:" (built by each channel monitor)
+   */
+  senderIdLabel?: string;
+  /**
+   * Replaces the label before the pairing code.
+   * Default: "Pairing code:"
+   */
+  codeLabel?: string;
+  /**
+   * Replaces the footer line before the CLI hint.
+   * Default: "Ask the bot owner to approve with:"
+   */
+  footer?: string;
+  /**
+   * When false, suppresses the `openclaw pairing approve ...` CLI line entirely.
+   * Useful for white-label deployments where exposing the tool name is undesirable.
+   * Default: true
+   */
+  showCliHint?: boolean;
+};
+
 export function buildPairingReply(params: {
   channel: PairingChannel;
   idLine: string;
   code: string;
+  pairingMessage?: PairingMessageConfig;
 }): string {
-  const { channel, idLine, code } = params;
-  return [
-    "OpenClaw: access not configured.",
-    "",
-    idLine,
-    "",
-    `Pairing code: ${code}`,
-    "",
-    "Ask the bot owner to approve with:",
-    formatCliCommand(`openclaw pairing approve ${channel} ${code}`),
-  ].join("\n");
+  const { channel, idLine, code, pairingMessage: cfg } = params;
+  const header = cfg?.header ?? "OpenClaw: access not configured.";
+  const codeLabel = cfg?.codeLabel ?? "Pairing code:";
+  const footer = cfg?.footer ?? "Ask the bot owner to approve with:";
+  const showCliHint = cfg?.showCliHint ?? true;
+
+  const lines = [header, "", idLine, "", `${codeLabel} ${code}`, "", footer];
+  if (showCliHint) {
+    lines.push(formatCliCommand(`openclaw pairing approve ${channel} ${code}`));
+  }
+  return lines.join("\n");
 }

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -35,15 +35,22 @@ export function buildPairingReply(params: {
   channel: PairingChannel;
   idLine: string;
   code: string;
+  senderId?: string;
   pairingMessage?: PairingMessageConfig;
 }): string {
-  const { channel, idLine, code, pairingMessage: cfg } = params;
+  const { channel, idLine: idLineParam, code, senderId, pairingMessage: cfg } = params;
   const header = cfg?.header ?? "OpenClaw: access not configured.";
   const codeLabel = cfg?.codeLabel ?? "Pairing code:";
   const footer = cfg?.footer ?? "Ask the bot owner to approve with:";
   const showCliHint = cfg?.showCliHint ?? true;
+  const applyDefaultFooter = cfg?.footer !== undefined || showCliHint;
+  const resolvedIdLine =
+    cfg?.senderIdLabel && senderId ? `${cfg.senderIdLabel} ${senderId}` : idLineParam;
 
-  const lines = [header, "", idLine, "", `${codeLabel} ${code}`, "", footer];
+  const lines = [header, "", resolvedIdLine, "", `${codeLabel} ${code}`];
+  if (applyDefaultFooter) {
+    lines.push("", footer);
+  }
   if (showCliHint) {
     lines.push(formatCliCommand(`openclaw pairing approve ${channel} ${code}`));
   }

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -46,8 +46,14 @@ export function buildPairingReply(params: {
   const footer = cfg?.footer ?? "Ask the bot owner to approve with:";
   const showCliHint = cfg?.showCliHint ?? true;
   const applyDefaultFooter = cfg?.footer !== undefined || showCliHint;
+  const hasSenderIdOverride = cfg?.senderIdLabel !== undefined;
+  const customSenderIdLabel = cfg?.senderIdLabel ?? "";
+  const labelSeparator =
+    customSenderIdLabel.length > 0 && !/[\s\u00A0]$/.test(customSenderIdLabel) ? " " : "";
   const resolvedIdLine =
-    cfg?.senderIdLabel && senderId ? `${cfg.senderIdLabel} ${senderId}` : idLineParam;
+    hasSenderIdOverride && senderId
+      ? `${customSenderIdLabel}${labelSeparator}${senderId}`
+      : idLineParam;
 
   const lines = [header, "", resolvedIdLine, "", `${codeLabel} ${code}`];
   if (applyDefaultFooter) {

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -10,6 +10,8 @@ export type PairingMessageConfig = {
   /**
    * Replaces the label before the sender's ID.
    * The sender ID value is still appended automatically.
+   * Applied centrally by buildPairingReply — pass the raw senderId via params.senderId
+   * and let channel monitors keep their default idLine fallback.
    * Default: "Your {channel} sender id:" (built by each channel monitor)
    */
   senderIdLabel?: string;

--- a/src/terminal/theme.ts
+++ b/src/terminal/theme.ts
@@ -1,4 +1,4 @@
-import chalk, { Chalk } from "chalk";
+import chalk, { Chalk, type ChalkInstance } from "chalk";
 import { LOBSTER_PALETTE } from "./palette.js";
 
 const hasForceColor =
@@ -10,7 +10,21 @@ const baseChalk = process.env.NO_COLOR && !hasForceColor ? new Chalk({ level: 0 
 
 const hex = (value: string) => baseChalk.hex(value);
 
-export const theme = {
+type TerminalTheme = {
+  accent: ChalkInstance;
+  accentBright: ChalkInstance;
+  accentDim: ChalkInstance;
+  info: ChalkInstance;
+  success: ChalkInstance;
+  warn: ChalkInstance;
+  error: ChalkInstance;
+  muted: ChalkInstance;
+  heading: ChalkInstance;
+  command: ChalkInstance;
+  option: ChalkInstance;
+};
+
+export const theme: TerminalTheme = {
   accent: hex(LOBSTER_PALETTE.accent),
   accentBright: hex(LOBSTER_PALETTE.accentBright),
   accentDim: hex(LOBSTER_PALETTE.accentDim),
@@ -22,7 +36,7 @@ export const theme = {
   heading: baseChalk.bold.hex(LOBSTER_PALETTE.accent),
   command: hex(LOBSTER_PALETTE.accentBright),
   option: hex(LOBSTER_PALETTE.warn),
-} as const;
+};
 
 export const isRich = () => Boolean(baseChalk.level > 0);
 


### PR DESCRIPTION
## Summary

Adds optional `pairingMessage` config to iMessage and Telegram channel configs, allowing operators to customize or suppress OpenClaw branding in pairing challenge messages sent to unknown senders.

Fixes #41058

## Problem

When `dmPolicy: pairing` is set, every unknown sender receives a hardcoded message exposing:
1. The OpenClaw brand name
2. The channel platform ("Your iMessage sender id:" / "Your Telegram user id:")
3. The full CLI invocation syntax (`openclaw pairing approve imessage CODE`)

No config option exists to override any part of this. The only workaround is patching compiled dist bundles after every update — not sustainable for white-label or privacy-conscious deployments.

## What changed

- `src/pairing/pairing-messages.ts`: Add `PairingMessageConfig` type with optional fields (`header`, `senderIdLabel`, `codeLabel`, `footer`, `showCliHint`). Update `buildPairingReply` to use config when provided.
- `src/config/types.imessage.ts`: Add `pairingMessage?: PairingMessageConfig`
- `src/config/types.telegram.ts`: Add `pairingMessage?: PairingMessageConfig`
- `src/config/zod-schema.providers-core.ts`: Add `PairingMessageConfigSchema`, wire into `IMessageAccountSchemaBase` and `TelegramAccountSchemaBase`
- `src/imessage/monitor/monitor-provider.ts`: Wire `pairingMessage` config into `issuePairingChallenge` via existing `buildReplyText` hook
- `src/telegram/dm-access.ts`: Pass `pairingMessage` through `enforceTelegramDmAccess`, wire into `issuePairingChallenge`
- `src/pairing/pairing-messages.test.ts`: Add tests for all config overrides and backward compat

## Fully backward compatible

All `PairingMessageConfig` fields are optional. Existing deployments with no `pairingMessage` config see zero behavior change.

## Example config

```yaml
channels:
  imessage:
    pairingMessage:
      header: 'Sender verification required.'
      senderIdLabel: 'Your sender ID:'
      footer: 'Share this code with your contact to complete verification.'
      showCliHint: false
```

## Notes

Discord, Signal, Slack, and LINE call sites follow the same pattern and can be extended in a follow-up if the team prefers to land iMessage/Telegram first.

## AI Disclosure
This PR was authored with AI assistance (OpenClaw/Jordan + Neo agents).
Testing: Fully tested — unit tests in `pairing-messages.test.ts` cover all config branches including edge cases; CI passes (types, lint, full test suite on Linux/Windows/macOS).
The authors have reviewed and understand all code changes in this PR.