### PR TITLE
fix(cron): import CommandLane for isolated lane resolution

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -47,6 +47,7 @@ import {
 import type { AgentDefaultsConfig } from "../../config/types.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { logWarn } from "../../logger.js";
+import { CommandLane } from "../../process/lanes.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import {
   buildSafeExternalPrompt,


### PR DESCRIPTION
## Summary
- add missing `CommandLane` import in `src/cron/isolated-agent/run.ts`
- keep existing cron->nested lane remap working without TS build errors

## Why
`resolveCronEmbeddedAgentLane()` returns `CommandLane.Nested` but the symbol was not imported, which breaks type-check (`Cannot find name 'CommandLane'`) and blocks CI.

Fixes #41798

## Validation
- `pnpm vitest run src/cron/isolated-agent.lane.test.ts --config vitest.unit.config.ts`
- `pnpm vitest run src/cron/service.issue-regressions.test.ts --config vitest.unit.config.ts -t "queues manual cron.run requests behind the cron execution lane"`