### PR TITLE
fix(memory): rate-limit Gemini embedding requests and cache per-batch

### DIFF
--- a/src/memory/embeddings-gemini.ts
+++ b/src/memory/embeddings-gemini.ts
@@ -24,6 +24,12 @@ export const DEFAULT_GEMINI_EMBEDDING_MODEL = "gemini-embedding-001";
 const GEMINI_MAX_INPUT_TOKENS: Record<string, number> = {
   "text-embedding-004": 2048,
 };
+
+// Module-level rate limiter: serializes ALL Gemini embedding requests across
+// all provider instances (multiple agents sharing the same API key).
+// 1.2s between requests ≈ 50 RPM, well under free-tier 100 RPM limit.
+let geminiEmbedRateLimitQueue: Promise<void> = Promise.resolve();
+const GEMINI_EMBED_DELAY_MS = 1200;
 function resolveRemoteApiKey(remoteApiKey: unknown): string | undefined {
   const trimmed = resolveMemorySecretInputString({
     value: remoteApiKey,
@@ -118,25 +124,56 @@ export async function createGeminiEmbeddingProvider(
     return payload.embedding?.values ?? [];
   };
 
+  const GEMINI_QUEUE_ITEM_TIMEOUT_MS = 30_000;
+
+  const rateLimitedBatch = async (texts: string[]): Promise<number[][]> => {
+    return new Promise((resolve, reject) => {
+      geminiEmbedRateLimitQueue = geminiEmbedRateLimitQueue.then(async () => {
+        // Per-item timeout prevents a stuck request from blocking the entire queue.
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), GEMINI_QUEUE_ITEM_TIMEOUT_MS);
+        try {
+          const requests = texts.map((text) => ({
+            model: client.modelPath,
+            content: { parts: [{ text }] },
+            taskType: "RETRIEVAL_DOCUMENT",
+          }));
+          debugEmbeddingsLog("gemini rate-limited batch: sending", {
+            texts: texts.length,
+            totalChars: texts.reduce((sum, t) => sum + t.length, 0),
+          });
+          const payload = await executeWithApiKeyRotation({
+            provider: "google",
+            apiKeys: client.apiKeys,
+            execute: (apiKey) => fetchWithGeminiAuth(apiKey, batchUrl, { requests }),
+          });
+          const embeddings = Array.isArray(payload.embeddings) ? payload.embeddings : [];
+          debugEmbeddingsLog("gemini rate-limited batch: success", {
+            texts: texts.length,
+            embeddingsReturned: embeddings.length,
+            dims: embeddings[0]?.values?.length ?? 0,
+          });
+          resolve(texts.map((_, index) => embeddings[index]?.values ?? []));
+        } catch (err) {
+          debugEmbeddingsLog("gemini rate-limited batch: failed", {
+            texts: texts.length,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          reject(err);
+        } finally {
+          clearTimeout(timer);
+        }
+        await new Promise((r) => setTimeout(r, GEMINI_EMBED_DELAY_MS));
+      });
+    });
+  };
+
   const embedBatch = async (texts: string[]): Promise<number[][]> => {
     if (texts.length === 0) {
       return [];
     }
-    const requests = texts.map((text) => ({
-      model: client.modelPath,
-      content: { parts: [{ text }] },
-      taskType: "RETRIEVAL_DOCUMENT",
-    }));
-    const payload = await executeWithApiKeyRotation({
-      provider: "google",
-      apiKeys: client.apiKeys,
-      execute: (apiKey) =>
-        fetchWithGeminiAuth(apiKey, batchUrl, {
-          requests,
-        }),
-    });
-    const embeddings = Array.isArray(payload.embeddings) ? payload.embeddings : [];
-    return texts.map((_, index) => embeddings[index]?.values ?? []);
+    debugEmbeddingsLog("gemini embedBatch called", { texts: texts.length });
+    return rateLimitedBatch(texts);
   };
 
   return {

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -26,9 +26,9 @@ const FTS_TABLE = "chunks_fts";
 const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const EMBEDDING_BATCH_MAX_TOKENS = 8000;
 const EMBEDDING_INDEX_CONCURRENCY = 4;
-const EMBEDDING_RETRY_MAX_ATTEMPTS = 3;
-const EMBEDDING_RETRY_BASE_DELAY_MS = 500;
-const EMBEDDING_RETRY_MAX_DELAY_MS = 8000;
+const EMBEDDING_RETRY_MAX_ATTEMPTS = 8;
+const EMBEDDING_RETRY_BASE_DELAY_MS = 2000;
+const EMBEDDING_RETRY_MAX_DELAY_MS = 15000;
 const BATCH_FAILURE_LIMIT = 2;
 const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
@@ -186,21 +186,28 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
     const missingChunks = missing.map((m) => m.chunk);
     const batches = this.buildEmbeddingBatches(missingChunks);
-    const toCache: Array<{ hash: string; embedding: number[] }> = [];
     let cursor = 0;
     for (const batch of batches) {
       const batchEmbeddings = await this.embedBatchWithRetry(batch.map((chunk) => chunk.text));
+      const batchCache: Array<{ hash: string; embedding: number[] }> = [];
       for (let i = 0; i < batch.length; i += 1) {
         const item = missing[cursor + i];
         const embedding = batchEmbeddings[i] ?? [];
         if (item) {
           embeddings[item.index] = embedding;
-          toCache.push({ hash: item.chunk.hash, embedding });
+          batchCache.push({ hash: item.chunk.hash, embedding });
         }
       }
+      // Save immediately after each successful batch
+      this.upsertEmbeddingCache(batchCache);
+      log.debug("memory embeddings: batch cached", {
+        batchIndex: batches.indexOf(batch) + 1,
+        totalBatches: batches.length,
+        chunksCached: batchCache.length,
+        cursorAfter: cursor + batch.length,
+      });
       cursor += batch.length;
     }
-    this.upsertEmbeddingCache(toCache);
     return embeddings;
   }
 


### PR DESCRIPTION
## Summary
- serialize Gemini embedding batch requests at module scope
- add spacing between requests to stay below free-tier request limits
- cache embeddings after each successful batch instead of only at the end
- raise retry backoff to better tolerate quota pressure and transient failures

## Why
Gemini embedding requests can exceed free-tier rate limits when multiple batches or agent instances hit the provider in quick succession. This caused 429s during indexing and made retries less effective.

This change reduces request burstiness, prevents one stuck queue item from blocking everything behind it, and preserves completed work by caching per batch.

## Scope
This PR only touches Gemini memory embedding flow:
- `src/memory/embeddings-gemini.ts`
- `src/memory/manager-embedding-ops.ts`