### PR TITLE
docs(plugins): add Cortex Memory to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -50,7 +50,7 @@ Use this format when adding entries:
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
 
-- **Cortex Memory** — Local-first persistent memory engine for AI agents. 4-tier architecture (Working/Episodic/Semantic/Procedural), Bayesian belief tracking, people graph, sub-millisecond retrieval. Rust core, zero cloud dependency — your memory, your data, in local.
+- **Cortex Memory** — Local-first persistent memory engine for AI agents. 4-tier architecture (Working/Episodic/Semantic/Procedural), Bayesian belief tracking, people graph, sub-millisecond retrieval. Rust core, zero cloud dependency — your memory, your data, stored locally.
   npm: `@cortex-ai-memory/cortex-memory`
   repo: `https://github.com/gambletan/cortex`
   install: `openclaw plugins install @cortex-ai-memory/cortex-memory`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **Cortex Memory** — Local-first persistent memory engine for AI agents. 4-tier architecture (Working/Episodic/Semantic/Procedural), Bayesian belief tracking, people graph, sub-millisecond retrieval. Rust core, zero cloud dependency — your memory, your data, in local.
+  npm: `@cortex-ai-memory/cortex-memory`
+  repo: `https://github.com/gambletan/cortex`
+  install: `openclaw plugins install @cortex-ai-memory/cortex-memory`


### PR DESCRIPTION
## Summary

- Add **Cortex Memory** to the community plugins listing in `docs/plugins/community.md`
- Published on npm as [`@cortex-ai-memory/cortex-memory`](https://www.npmjs.com/package/@cortex-ai-memory/cortex-memory) (v1.3.0)
- Source: [github.com/gambletan/cortex](https://github.com/gambletan/cortex)

## Plugin details

Cortex is a local-first persistent memory engine for AI agents, built in Rust:

- **4-tier memory architecture**: Working → Episodic → Semantic → Procedural
- **Bayesian belief tracking** with evidence-based updates
- **People graph** with cross-platform identity resolution
- **Sub-millisecond retrieval** via HNSW vector index
- **Zero cloud dependency** — all data stays local
- **126 tests**, active maintenance, MIT licensed

Install: `openclaw plugins install @cortex-ai-memory/cortex-memory`

## Checklist

- [x] Package published on npmjs
- [x] Source code on GitHub (public repo)
- [x] README with setup/usage docs
- [x] Issue tracker enabled
- [x] Follows candidate format from community.md