### PR TITLE
Gateway/Dashboard: surface config validation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 - Agents/error rendering: ignore stale assistant `errorMessage` fields on successful turns so background/tool-side failures no longer prepend synthetic billing errors over valid replies. (#40616) Thanks @ingyukoh.
 - Agents/fallback: recognize Venice `402 Insufficient USD or Diem balance` billing errors so configured model fallbacks trigger instead of surfacing the raw provider error. (#43205) Thanks @Squabble9.
 - Dependencies: refresh workspace dependencies except the pinned Carbon package, and harden ACP session-config writes against non-string SDK values so newer ACP clients fail fast instead of tripping type/runtime mismatches.
+- Gateway/config errors: surface up to three validation issues in top-level `config.set`, `config.patch`, and `config.apply` error messages while preserving structured issue details. (#42664) Thanks @huntharo.
 
 ## 2026.3.8
 

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -10,6 +10,7 @@ import {
   validateConfigObjectWithPlugins,
   writeConfigFile,
 } from "../../config/config.js";
+import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { applyLegacyMigrations } from "../../config/legacy.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import {
@@ -23,7 +24,7 @@ import {
   type ConfigSchemaResponse,
 } from "../../config/schema.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
@@ -53,6 +54,8 @@ import { resolveBaseHashParam } from "./base-hash.js";
 import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+const MAX_CONFIG_ISSUES_IN_ERROR_MESSAGE = 3;
 
 function requireConfigBaseHash(
   params: unknown,
@@ -158,13 +161,27 @@ function parseValidateConfigFromRawOrRespond(
     respond(
       false,
       undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, "invalid config", {
+      errorShape(ErrorCodes.INVALID_REQUEST, summarizeConfigValidationIssues(validated.issues), {
         details: { issues: validated.issues },
       }),
     );
     return null;
   }
   return { config: validated.config, schema };
+}
+
+function summarizeConfigValidationIssues(issues: ReadonlyArray<ConfigValidationIssue>): string {
+  const trimmed = issues.slice(0, MAX_CONFIG_ISSUES_IN_ERROR_MESSAGE);
+  const lines = formatConfigIssueLines(trimmed, "", { normalizeRoot: true })
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return "invalid config";
+  }
+  const hiddenCount = Math.max(0, issues.length - lines.length);
+  return `invalid config: ${lines.join("; ")}${
+    hiddenCount > 0 ? ` (+${hiddenCount} more issue${hiddenCount === 1 ? "" : "s"})` : ""
+  }`;
 }
 
 function resolveConfigRestartRequest(params: unknown): {
@@ -398,7 +415,7 @@ export const configHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid config", {
+        errorShape(ErrorCodes.INVALID_REQUEST, summarizeConfigValidationIssues(validated.issues), {
           details: { issues: validated.issues },
         }),
       );

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -72,6 +72,38 @@ describe("gateway config methods", () => {
     expect(res.payload?.config).toBeTruthy();
   });
 
+  it("returns config.set validation details in the top-level error message", async () => {
+    const current = await rpcReq<{
+      hash?: string;
+    }>(requireWs(), "config.get", {});
+    expect(current.ok).toBe(true);
+    expect(typeof current.payload?.hash).toBe("string");
+
+    const res = await rpcReq<{
+      ok?: boolean;
+      error?: {
+        message?: string;
+      };
+    }>(requireWs(), "config.set", {
+      raw: JSON.stringify({ gateway: { bind: 123 } }),
+      baseHash: current.payload?.hash,
+    });
+    const error = res.error as
+      | {
+          message?: string;
+          details?: {
+            issues?: Array<{ path?: string; message?: string }>;
+          };
+        }
+      | undefined;
+
+    expect(res.ok).toBe(false);
+    expect(error?.message ?? "").toContain("invalid config:");
+    expect(error?.message ?? "").toContain("gateway.bind");
+    expect(error?.message ?? "").toContain("allowed:");
+    expect(error?.details?.issues?.[0]?.path).toBe("gateway.bind");
+  });
+
   it("returns a path-scoped config schema lookup", async () => {
     const res = await rpcReq<{
       path: string;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: gateway config mutations could reject invalid config payloads with a generic top-level `invalid config` error even when structured validation issues were available.
- Why it matters: callers do not get an actionable error at the point of failure, which makes debugging rejected `config.set`, `config.patch`, and `config.apply` requests slower and more error-prone.
- What changed: invalid config responses now summarize up to three validation issues directly in the top-level error message while preserving the existing structured `details.issues` payload; a gateway test now verifies the message includes the failing path and constraint details.
- What did NOT change (scope boundary): this does not change config schema rules, plugin validation behavior, restart behavior, or the shape of the structured validation details.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #39535

## User-visible / Behavior Changes

- Invalid `config.set`, `config.patch`, and `config.apply` requests now return a more actionable top-level error message that includes validation paths and constraint text instead of only `invalid config`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.2
- Runtime/container: Node.js v24.13.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): gateway RPC test server
- Relevant config (redacted): invalid payload example `{"gateway":{"bind":123}}`

### Steps

1. Start the gateway RPC test server and fetch the current config hash with `config.get`.
2. Submit an invalid `config.set` request with `raw: {"gateway":{"bind":123}}` and the current `baseHash`.
3. Observe the top-level error message and the structured `details.issues` response.
4. Run `pnpm exec vitest run src/gateway/server.config-patch.test.ts`.

### Expected

- Invalid config requests are rejected.
- The top-level error message includes actionable validation details such as the failing path (`gateway.bind`) and constraint text.
- Structured validation issues remain present under `error.details.issues`.

### Actual

- The new test verifies the top-level error contains `invalid config:`, `gateway.bind`, and `allowed:`, and that `error.details.issues[0].path === "gateway.bind"`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: saved invalid config in dashboard - confirmed useful error message presented in dashboard and in gateway logs.
- Edge cases checked: confirmed the logs have the keys and the types not the values - the assumption is sensitive data (secrets) are unlikely to be in the keys and rather would only ever be values.
- What you did **not** verify: none?


### After

#### After - Gateway Logs

```
15:04:11 [ws] ⇄ res ✗ config.set 32ms errorCode=INVALID_REQUEST errorMessage=invalid config: channels.discord.allowFrom.0: Discord IDs must be strings (wrap numeric IDs in quotes).; channels.discord.guilds.1480554271907905731.users.0: Discord IDs must be strings (wrap numeric IDs in quotes).; channels.discord.execAp... conn=3ef13fa9…006b id=ab5ba498…aeb0
```

<img width="1385" height="55" alt="image" src="https://github.com/user-attachments/assets/240d16d1-2ee7-4d85-95fb-c4ebf63ed752" />

#### After - Gateway WebSocket Error Response with Details

- Details where already there
- Summary message has changed

<img width="686" height="212" alt="image" src="https://github.com/user-attachments/assets/2c29a33c-2c3a-4846-9bc1-6251b1d63447" />

#### After - Dashboard Error

```
GatewayRequestError: invalid config: channels.discord.allowFrom.0: Discord IDs must be strings (wrap numeric IDs in quotes).; channels.discord.guilds.1480554271907905731.users.0: Discord IDs must be strings (wrap numeric IDs in quotes).; channels.discord.execApprovals.approvers.0: Discord IDs must be strings (wrap numeric IDs in quotes).
```

<img width="1201" height="815" alt="image" src="https://github.com/user-attachments/assets/3331e890-f3e2-41d3-bd34-75a23990e479" />

### Before

#### Before - Gateway Logs

```
14:54:02 [ws] ⇄ res ✓ config.get 71ms conn=700f2bea…a1bc id=c3efcadb…0a8d
14:54:17 [ws] ⇄ res ✗ config.set 50ms errorCode=INVALID_REQUEST errorMessage=invalid config conn=700f2bea…a1bc id=4e7ecfd5…d416
```

<img width="965" height="60" alt="image" src="https://github.com/user-attachments/assets/7a59c80a-95d7-4b7d-8457-049370e283e5" />

#### Before - Gateway WebSocket Error Response with Details

- The summary message was limited in info
- The message already had details, so no change in data exposure in the protocol

<img width="689" height="348" alt="image" src="https://github.com/user-attachments/assets/a8d7b70d-c6af-43c9-b9f7-9fb62e964a89" />

#### Before - Dashboard Error

```
GatewayRequestError: invalid config
```

<img width="1201" height="815" alt="image" src="https://github.com/user-attachments/assets/0d18ba2d-d41e-4be4-9628-8ab27981570e" />

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `daaf342123` or remove the validation-message summarization helper usage in `src/gateway/server-methods/config.ts`.
- Files/config to restore: `src/gateway/server-methods/config.ts`, `src/gateway/server.config-patch.test.ts`
- Known bad symptoms reviewers should watch for: missing validation details in top-level gateway errors, unexpectedly truncated or malformed error messages, or any contract consumer depending on the exact previous top-level `invalid config` string.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some client code may compare the top-level error string exactly and will now see a more specific message.
  - Mitigation: the structured `error.details.issues` payload is unchanged, the error code is unchanged, and the summary is intentionally bounded to three issues.
