### PR TITLE
fix: honor proxy env during codex oauth token exchange

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12305,6 +12305,81 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
+  openclaw@2026.3.8(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.5)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.15.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock': 3.1004.0
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
+      '@clack/prompts': 1.1.0
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@grammyjs/runner': 2.0.3(grammy@1.41.1)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.1)
+      '@homebridge/ciao': 1.3.5
+      '@larksuiteoapi/node-sdk': 1.59.0
+      '@line/bot-sdk': 10.6.0
+      '@lydell/node-pty': 1.2.0-beta.3
+      '@mariozechner/pi-agent-core': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.57.1
+      '@mozilla/readability': 0.6.0
+      '@napi-rs/canvas': 0.1.95
+      '@sinclair/typebox': 0.34.48
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/web-api': 7.14.1
+      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      ajv: 8.18.0
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      cli-highlight: 2.1.11
+      commander: 14.0.3
+      croner: 10.0.1
+      discord-api-types: 0.38.41
+      dotenv: 17.3.1
+      express: 5.2.1
+      file-type: 21.3.0
+      grammy: 1.41.1
+      https-proxy-agent: 7.0.6
+      ipaddr.js: 2.3.0
+      jiti: 2.6.1
+      json5: 2.2.3
+      jszip: 3.10.1
+      linkedom: 0.18.12
+      long: 5.3.2
+      markdown-it: 14.1.1
+      node-edge-tts: 1.2.10
+      node-llama-cpp: 3.16.2(typescript@5.9.3)
+      opusscript: 0.1.1
+      osc-progress: 0.3.0
+      pdfjs-dist: 5.5.207
+      playwright-core: 1.58.2
+      qrcode-terminal: 0.12.0
+      sharp: 0.34.5
+      sqlite-vec: 0.1.7-alpha.2
+      tar: 7.5.11
+      tslog: 4.10.2
+      undici: 7.22.0
+      ws: 8.19.0
+      yaml: 2.8.2
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - '@modelcontextprotocol/sdk'
+      - '@types/express'
+      - audio-decode
+      - aws-crt
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - ffmpeg-static
+      - hono
+      - jimp
+      - link-preview-js
+      - node-opus
+      - supports-color
+      - utf-8-validate
+
   opus-decoder@0.7.11:
     dependencies:
       '@wasm-audio-decoders/common': 9.0.7

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -77,8 +77,11 @@ describe("loginOpenAICodexOAuth", () => {
     mocks.runOpenAIOAuthTlsPreflight.mockResolvedValue({ ok: true });
     mocks.formatOpenAIOAuthTlsPreflightFix.mockReturnValue("tls fix");
     for (const key of PROXY_ENV_KEYS) {
-      if (prevProxyEnv[key] == null) delete process.env[key];
-      else process.env[key] = prevProxyEnv[key];
+      if (prevProxyEnv[key] == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prevProxyEnv[key];
+      }
     }
   });
 

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -192,6 +192,31 @@ describe("loginOpenAICodexOAuth", () => {
     expect(mocks.setGlobalDispatcher.mock.calls[1]?.[0]).toEqual({ kind: "original" });
   });
 
+  it("falls back to direct transport when proxy dispatcher setup fails", async () => {
+    process.env.HTTPS_PROXY = "bad-proxy-url";
+    const creds = {
+      provider: "openai-codex" as const,
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      email: "user@example.com",
+    };
+    mocks.EnvHttpProxyAgent.mockImplementationOnce(() => {
+      throw new Error("invalid proxy url");
+    });
+    mocks.createVpsAwareOAuthHandlers.mockReturnValue({ onAuth: vi.fn(), onPrompt: vi.fn() });
+    mocks.loginOpenAICodex.mockResolvedValue(creds);
+
+    const { result, runtime } = await runCodexOAuth({ isRemote: false });
+
+    expect(result).toEqual(creds);
+    expect(mocks.setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(mocks.loginOpenAICodex).toHaveBeenCalledOnce();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("proxy dispatcher setup failed; falling back to direct transport"),
+    );
+  });
+
   it("continues OAuth flow on non-certificate preflight failures", async () => {
     const creds = {
       provider: "openai-codex" as const,

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -67,17 +67,19 @@ async function runCodexOAuth(params: { isRemote: boolean }) {
 }
 
 describe("loginOpenAICodexOAuth", () => {
-  const prevHttpsProxy = process.env.HTTPS_PROXY;
-  const prevHttpProxy = process.env.HTTP_PROXY;
+  const PROXY_ENV_KEYS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"] as const;
+  const prevProxyEnv = Object.fromEntries(
+    PROXY_ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.runOpenAIOAuthTlsPreflight.mockResolvedValue({ ok: true });
     mocks.formatOpenAIOAuthTlsPreflightFix.mockReturnValue("tls fix");
-    if (prevHttpsProxy == null) delete process.env.HTTPS_PROXY;
-    else process.env.HTTPS_PROXY = prevHttpsProxy;
-    if (prevHttpProxy == null) delete process.env.HTTP_PROXY;
-    else process.env.HTTP_PROXY = prevHttpProxy;
+    for (const key of PROXY_ENV_KEYS) {
+      if (prevProxyEnv[key] == null) delete process.env[key];
+      else process.env[key] = prevProxyEnv[key];
+    }
   });
 
   it("returns credentials on successful oauth login", async () => {
@@ -175,6 +177,7 @@ describe("loginOpenAICodexOAuth", () => {
 
     expect(mocks.EnvHttpProxyAgent).toHaveBeenCalledTimes(1);
     expect(mocks.setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    expect(mocks.setGlobalDispatcher.mock.calls[0]?.[0]).toMatchObject({ kind: "env-proxy" });
     expect(mocks.setGlobalDispatcher.mock.calls[1]?.[0]).toEqual({ kind: "original" });
   });
 

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -7,10 +7,21 @@ const mocks = vi.hoisted(() => ({
   createVpsAwareOAuthHandlers: vi.fn(),
   runOpenAIOAuthTlsPreflight: vi.fn(),
   formatOpenAIOAuthTlsPreflightFix: vi.fn(),
+  setGlobalDispatcher: vi.fn(),
+  getGlobalDispatcher: vi.fn(() => ({ kind: "original" })),
+  EnvHttpProxyAgent: vi.fn(function MockEnvHttpProxyAgent(this: unknown) {
+    return { kind: "env-proxy", self: this };
+  }),
 }));
 
 vi.mock("@mariozechner/pi-ai/oauth", () => ({
   loginOpenAICodex: mocks.loginOpenAICodex,
+}));
+
+vi.mock("undici", () => ({
+  EnvHttpProxyAgent: mocks.EnvHttpProxyAgent,
+  getGlobalDispatcher: mocks.getGlobalDispatcher,
+  setGlobalDispatcher: mocks.setGlobalDispatcher,
 }));
 
 vi.mock("./oauth-flow.js", () => ({
@@ -56,10 +67,17 @@ async function runCodexOAuth(params: { isRemote: boolean }) {
 }
 
 describe("loginOpenAICodexOAuth", () => {
+  const prevHttpsProxy = process.env.HTTPS_PROXY;
+  const prevHttpProxy = process.env.HTTP_PROXY;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.runOpenAIOAuthTlsPreflight.mockResolvedValue({ ok: true });
     mocks.formatOpenAIOAuthTlsPreflightFix.mockReturnValue("tls fix");
+    if (prevHttpsProxy == null) delete process.env.HTTPS_PROXY;
+    else process.env.HTTPS_PROXY = prevHttpsProxy;
+    if (prevHttpProxy == null) delete process.env.HTTP_PROXY;
+    else process.env.HTTP_PROXY = prevHttpProxy;
   });
 
   it("returns credentials on successful oauth login", async () => {
@@ -139,6 +157,36 @@ describe("loginOpenAICodexOAuth", () => {
       "Trouble with OAuth? See https://docs.openclaw.ai/start/faq",
       "OAuth help",
     );
+  });
+
+  it("installs EnvHttpProxyAgent around oauth when proxy env is configured", async () => {
+    process.env.HTTPS_PROXY = "http://127.0.0.1:7890";
+    const creds = {
+      provider: "openai-codex" as const,
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      email: "user@example.com",
+    };
+    mocks.createVpsAwareOAuthHandlers.mockReturnValue({ onAuth: vi.fn(), onPrompt: vi.fn() });
+    mocks.loginOpenAICodex.mockResolvedValue(creds);
+
+    await runCodexOAuth({ isRemote: false });
+
+    expect(mocks.EnvHttpProxyAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    expect(mocks.setGlobalDispatcher.mock.calls[1]?.[0]).toEqual({ kind: "original" });
+  });
+
+  it("restores dispatcher after oauth failure under proxy env", async () => {
+    process.env.HTTPS_PROXY = "http://127.0.0.1:7890";
+    mocks.createVpsAwareOAuthHandlers.mockReturnValue({ onAuth: vi.fn(), onPrompt: vi.fn() });
+    mocks.loginOpenAICodex.mockRejectedValue(new Error("oauth failed"));
+
+    await expect(runCodexOAuth({ isRemote: false })).rejects.toThrow("oauth failed");
+
+    expect(mocks.setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    expect(mocks.setGlobalDispatcher.mock.calls[1]?.[0]).toEqual({ kind: "original" });
   });
 
   it("continues OAuth flow on non-certificate preflight failures", async () => {

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -18,15 +18,29 @@ function hasConfiguredProxyEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   });
 }
 
-async function withTemporaryProxyDispatcher<T>(work: () => Promise<T>): Promise<T> {
+async function withTemporaryProxyDispatcher<T>(params: {
+  work: () => Promise<T>;
+  runtime: RuntimeEnv;
+}): Promise<T> {
   if (!hasConfiguredProxyEnv()) {
-    return work();
+    return params.work();
   }
 
-  const previous = getGlobalDispatcher();
-  setGlobalDispatcher(new EnvHttpProxyAgent());
+  let previous: ReturnType<typeof getGlobalDispatcher>;
+  let proxyDispatcher: EnvHttpProxyAgent;
   try {
-    return await work();
+    previous = getGlobalDispatcher();
+    proxyDispatcher = new EnvHttpProxyAgent();
+  } catch (err) {
+    params.runtime.log(
+      `[openai-codex-oauth] proxy dispatcher setup failed; falling back to direct transport: ${String(err)}`,
+    );
+    return params.work();
+  }
+
+  setGlobalDispatcher(proxyDispatcher);
+  try {
+    return await params.work();
   } finally {
     setGlobalDispatcher(previous);
   }
@@ -74,13 +88,15 @@ export async function loginOpenAICodexOAuth(params: {
       localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser…",
     });
 
-    const creds = await withTemporaryProxyDispatcher(() =>
-      loginOpenAICodex({
-        onAuth: baseOnAuth,
-        onPrompt,
-        onProgress: (msg: string) => spin.update(msg),
-      }),
-    );
+    const creds = await withTemporaryProxyDispatcher({
+      runtime,
+      work: () =>
+        loginOpenAICodex({
+          onAuth: baseOnAuth,
+          onPrompt,
+          onProgress: (msg: string) => spin.update(msg),
+        }),
+    });
     spin.stop("OpenAI OAuth complete");
     return creds ?? null;
   } catch (err) {

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -9,14 +9,7 @@ import {
   runOpenAIOAuthTlsPreflight,
 } from "./oauth-tls-preflight.js";
 
-const PROXY_ENV_KEYS = [
-  "HTTPS_PROXY",
-  "https_proxy",
-  "HTTP_PROXY",
-  "http_proxy",
-  "ALL_PROXY",
-  "all_proxy",
-];
+const PROXY_ENV_KEYS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"] as const;
 
 function hasConfiguredProxyEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   return PROXY_ENV_KEYS.some((key) => {

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -1,5 +1,6 @@
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { loginOpenAICodex } from "@mariozechner/pi-ai/oauth";
+import { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { createVpsAwareOAuthHandlers } from "./oauth-flow.js";
@@ -7,6 +8,36 @@ import {
   formatOpenAIOAuthTlsPreflightFix,
   runOpenAIOAuthTlsPreflight,
 } from "./oauth-tls-preflight.js";
+
+const PROXY_ENV_KEYS = [
+  "HTTPS_PROXY",
+  "https_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+];
+
+function hasConfiguredProxyEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return PROXY_ENV_KEYS.some((key) => {
+    const value = env[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
+async function withTemporaryProxyDispatcher<T>(work: () => Promise<T>): Promise<T> {
+  if (!hasConfiguredProxyEnv()) {
+    return work();
+  }
+
+  const previous = getGlobalDispatcher();
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+  try {
+    return await work();
+  } finally {
+    setGlobalDispatcher(previous);
+  }
+}
 
 export async function loginOpenAICodexOAuth(params: {
   prompter: WizardPrompter;
@@ -50,11 +81,13 @@ export async function loginOpenAICodexOAuth(params: {
       localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser…",
     });
 
-    const creds = await loginOpenAICodex({
-      onAuth: baseOnAuth,
-      onPrompt,
-      onProgress: (msg: string) => spin.update(msg),
-    });
+    const creds = await withTemporaryProxyDispatcher(() =>
+      loginOpenAICodex({
+        onAuth: baseOnAuth,
+        onPrompt,
+        onProgress: (msg: string) => spin.update(msg),
+      }),
+    );
     spin.stop("OpenAI OAuth complete");
     return creds ?? null;
   } catch (err) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw models auth login --provider openai-codex` could fail after browser OAuth succeeds when running behind proxy/TUN setups, because internal token exchange/refresh requests might bypass proxy env routing.
- Why it matters: OAuth appears to succeed in-browser but fails in terminal (`ENOTFOUND`, `ECONNREFUSED`, or region/network errors), blocking login in proxy-only environments.
- What changed: Wrapped `loginOpenAICodex()` in a temporary `EnvHttpProxyAgent` global dispatcher when proxy env vars are present (`HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`, case-insensitive), and always restore the previous dispatcher in `finally`.
- What did NOT change (scope boundary): No changes to OAuth UX, auth profile storage format, non-proxy execution path, or provider logic outside `openai-codex` OAuth login.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42020
- Related #41917

## User-visible / Behavior Changes

- In proxy/TUN environments, OpenAI Codex OAuth login is now more reliable: token exchange/refresh honors proxy env settings during the login flow.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - N/A

## Repro + Verification

### Environment

- OS: Linux (development/test environment)
- Runtime/container: Node.js CLI runtime
- Model/provider: `openai-codex`
- Integration/channel (if any): OAuth login via CLI + browser callback
- Relevant config (redacted): Proxy env set (e.g. `HTTPS_PROXY=http://127.0.0.1:7890`)

### Steps

1. Set proxy env vars and run `openclaw models auth login --provider openai-codex`.
2. Complete browser sign-in and return to terminal.
3. Observe token exchange/refresh behavior.

### Expected

- OAuth token exchange/refresh follows proxy env routing and login completes.

### Actual

- Before fix: post-browser token exchange could fail in proxy-only setups.
- After fix: login path uses temporary proxy-aware dispatcher and restores global dispatcher afterward.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Proxy env present: installs `EnvHttpProxyAgent`, runs OAuth call, restores original dispatcher.
  - Proxy env present + OAuth throw: still restores original dispatcher.
  - Proxy env absent: no dispatcher swap.
- Edge cases checked:
  - Restoration occurs in both success and failure paths (`finally`).
  - Case-insensitive env key handling.
- What you did **not** verify:
  - Live end-to-end OAuth against every proxy type (HTTP proxy, SOCKS/TUN variants) in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/commands/openai-codex-oauth.ts`
  - `src/commands/openai-codex-oauth.test.ts`
- Known bad symptoms reviewers should watch for:
  - Global dispatcher not restored after failed OAuth login.
  - Unexpected network behavior in subsequent requests after OAuth attempt.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Temporary global dispatcher swap could affect concurrent network operations during OAuth flow.
  - Mitigation: Scope is limited to login command path; dispatcher restoration is guaranteed via `finally`; tests cover both success/failure restoration.
