### PR TITLE
fix(sessions): preserve labels during heartbeat polls

### DIFF
--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -43,12 +43,12 @@ const mergeOrigin = (
 };
 
 export function deriveSessionOrigin(ctx: MsgContext): SessionOrigin | undefined {
-  const label = resolveConversationLabel(ctx)?.trim();
   const providerRaw =
     (typeof ctx.OriginatingChannel === "string" && ctx.OriginatingChannel) ||
     ctx.Surface ||
     ctx.Provider;
   const provider = normalizeMessageChannel(providerRaw);
+  const label = provider === "heartbeat" ? undefined : resolveConversationLabel(ctx)?.trim();
   const surface = ctx.Surface?.trim().toLowerCase();
   const chatType = normalizeChatType(ctx.ChatType) ?? undefined;
   const from = ctx.From?.trim();

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -145,4 +145,46 @@ describe("session store key normalization", () => {
     expect(store[CANONICAL_KEY]?.updatedAt).toBe(1111);
     expect(store[CANONICAL_KEY]?.origin?.provider).toBe("webchat");
   });
+
+  it("does not let heartbeat metadata overwrite an existing origin label", async () => {
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [CANONICAL_KEY]: {
+            sessionId: "existing-session",
+            updatedAt: 1111,
+            chatType: "direct",
+            channel: "webchat",
+            origin: {
+              provider: "webchat",
+              label: "My App — Project: Dashboard",
+              chatType: "direct",
+              from: "webchat:user-1",
+              to: "webchat:agent",
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    clearSessionStoreCacheForTest();
+
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: CANONICAL_KEY,
+      ctx: {
+        Provider: "heartbeat",
+        From: "heartbeat",
+        To: "heartbeat",
+        SessionKey: CANONICAL_KEY,
+      },
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[CANONICAL_KEY]?.origin?.label).toBe("My App — Project: Dashboard");
+    expect(store[CANONICAL_KEY]?.origin?.provider).toBe("heartbeat");
+  });
 });


### PR DESCRIPTION
## Summary
- prevent heartbeat polls from overwriting session display names used by the control UI
- preserve user-facing labels while still allowing heartbeat runs to use canonical session keys
- add a focused regression test covering heartbeat/main-session metadata normalization

## Problem
Issue #42495 reports that heartbeat polls can overwrite the session `displayName` with `heartbeat`, which breaks the control UI session selector and makes the main session label unstable.

## What changed
- stop heartbeat metadata normalization from clobbering the existing user-facing session label
- keep the canonical key normalization behavior intact
- add a focused regression test for the heartbeat-path label preservation case

## Verification
- `npx vitest run src/config/sessions/store.session-key-normalization.test.ts`

Closes #42495
