### PR TITLE
fix(googlechat): honor replyToMode off for thread replies

### DIFF
--- a/extensions/googlechat/src/channel.outbound.test.ts
+++ b/extensions/googlechat/src/channel.outbound.test.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/googlechat";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const uploadGoogleChatAttachmentMock = vi.hoisted(() => vi.fn());
 const sendGoogleChatMessageMock = vi.hoisted(() => vi.fn());
@@ -28,6 +28,11 @@ function createGoogleChatCfg(): OpenClawConfig {
   };
 }
 
+beforeEach(() => {
+  uploadGoogleChatAttachmentMock.mockReset();
+  sendGoogleChatMessageMock.mockReset();
+});
+
 function setupRuntimeMediaMocks(params: { loadFileName: string; loadBytes: string }) {
   const loadWebMedia = vi.fn(async () => ({
     buffer: Buffer.from(params.loadBytes),
@@ -50,6 +55,60 @@ function setupRuntimeMediaMocks(params: { loadFileName: string; loadBytes: strin
 
   return { loadWebMedia, fetchRemoteMedia };
 }
+
+describe("googlechatPlugin outbound threading", () => {
+  it("suppresses thread replies when replyToMode is off", async () => {
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-off",
+    });
+
+    const cfg = createGoogleChatCfg();
+    cfg.channels!.googlechat!.replyToMode = "off";
+
+    await googlechatPlugin.outbound?.sendText?.({
+      cfg,
+      to: "spaces/AAA",
+      text: "hello",
+      accountId: "default",
+      replyToId: "spaces/AAA/threads/reply",
+      threadId: "spaces/AAA/threads/thread",
+    });
+
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "hello",
+        thread: undefined,
+      }),
+    );
+  });
+
+  it("keeps thread replies when replyToMode is enabled", async () => {
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-all",
+    });
+
+    const cfg = createGoogleChatCfg();
+    cfg.channels!.googlechat!.replyToMode = "all";
+
+    await googlechatPlugin.outbound?.sendText?.({
+      cfg,
+      to: "spaces/AAA",
+      text: "hello",
+      accountId: "default",
+      replyToId: "spaces/AAA/threads/reply",
+      threadId: "spaces/AAA/threads/thread",
+    });
+
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "hello",
+        thread: "spaces/AAA/threads/thread",
+      }),
+    );
+  });
+});
 
 describe("googlechatPlugin outbound sendMedia", () => {
   it("loads local media with mediaLocalRoots via runtime media loader", async () => {

--- a/extensions/googlechat/src/channel.outbound.test.ts
+++ b/extensions/googlechat/src/channel.outbound.test.ts
@@ -108,6 +108,37 @@ describe("googlechatPlugin outbound threading", () => {
       }),
     );
   });
+
+  it("suppresses thread replies when a resolved account override sets replyToMode off", async () => {
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-account-off",
+    });
+
+    const cfg = createGoogleChatCfg();
+    cfg.channels!.googlechat!.replyToMode = "all";
+    cfg.channels!.googlechat!.accounts = {
+      bota: {
+        replyToMode: "off",
+      },
+    };
+
+    await googlechatPlugin.outbound?.sendText?.({
+      cfg,
+      to: "spaces/AAA",
+      text: "hello",
+      accountId: "botA",
+      replyToId: "spaces/AAA/threads/reply",
+      threadId: "spaces/AAA/threads/thread",
+    });
+
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "hello",
+        thread: undefined,
+      }),
+    );
+  });
 });
 
 describe("googlechatPlugin outbound sendMedia", () => {

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -95,11 +95,11 @@ const resolveGoogleChatDmPolicy = createScopedDmSecurityResolver<ResolvedGoogleC
 });
 
 function resolveGoogleChatThread(params: {
-  cfg: OpenClawConfig;
+  replyToMode?: string | null;
   replyToId?: string | number | null;
   threadId?: string | number | null;
 }): string | undefined {
-  if (params.cfg.channels?.googlechat?.replyToMode === "off") {
+  if (params.replyToMode === "off") {
     return undefined;
   }
   return (params.threadId ?? params.replyToId ?? undefined) as string | undefined;
@@ -370,7 +370,11 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread = resolveGoogleChatThread({ cfg, replyToId, threadId });
+      const thread = resolveGoogleChatThread({
+        replyToMode: account.config.replyToMode,
+        replyToId,
+        threadId,
+      });
       const result = await sendGoogleChatMessage({
         account,
         space,
@@ -401,7 +405,11 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread = resolveGoogleChatThread({ cfg, replyToId, threadId });
+      const thread = resolveGoogleChatThread({
+        replyToMode: account.config.replyToMode,
+        replyToId,
+        threadId,
+      });
       const runtime = getGoogleChatRuntime();
       const maxBytes = resolveChannelMediaMaxBytes({
         cfg: cfg,

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -94,6 +94,17 @@ const resolveGoogleChatDmPolicy = createScopedDmSecurityResolver<ResolvedGoogleC
   normalizeEntry: (raw) => formatAllowFromEntry(raw),
 });
 
+function resolveGoogleChatThread(params: {
+  cfg: OpenClawConfig;
+  replyToId?: string | number | null;
+  threadId?: string | number | null;
+}): string | undefined {
+  if (params.cfg.channels?.googlechat?.replyToMode === "off") {
+    return undefined;
+  }
+  return (params.threadId ?? params.replyToId ?? undefined) as string | undefined;
+}
+
 export const googlechatDock: ChannelDock = {
   id: "googlechat",
   capabilities: {
@@ -359,7 +370,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread = (threadId ?? replyToId ?? undefined) as string | undefined;
+      const thread = resolveGoogleChatThread({ cfg, replyToId, threadId });
       const result = await sendGoogleChatMessage({
         account,
         space,
@@ -390,7 +401,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread = (threadId ?? replyToId ?? undefined) as string | undefined;
+      const thread = resolveGoogleChatThread({ cfg, replyToId, threadId });
       const runtime = getGoogleChatRuntime();
       const maxBytes = resolveChannelMediaMaxBytes({
         cfg: cfg,


### PR DESCRIPTION
## Summary
- honor `channels.googlechat.replyToMode: "off"` for thread-capable Google Chat sends
- stop forwarding thread identifiers when reply-to behavior is explicitly disabled
- add a focused regression test covering the `replyToMode: "off"` path

## Problem
Issue #42510 reports that Google Chat still forces threaded replies even when `replyToMode` is set to `off`. The channel path was still passing `threadId ?? replyToId` into the outbound sender, bypassing the opt-out behavior.

## What changed
- suppress Google Chat thread/reply identifiers when `replyToMode` resolves to `off`
- preserve the existing threaded behavior for the other reply modes
- add a focused outbound regression test for the disabled-reply path

## Verification
- `pnpm vitest run extensions/googlechat/src/channel.outbound.test.ts`

Closes #42510
