### PR TITLE
Fix Telegram topic-bound subagent session spawns

### DIFF
--- a/extensions/telegram/index.test.ts
+++ b/extensions/telegram/index.test.ts
@@ -1,0 +1,36 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/telegram";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+const hookMocks = vi.hoisted(() => ({
+  setTelegramRuntime: vi.fn(),
+  registerTelegramSubagentHooks: vi.fn(),
+}));
+
+vi.mock("./src/runtime.js", () => ({
+  setTelegramRuntime: hookMocks.setTelegramRuntime,
+}));
+
+vi.mock("./src/subagent-hooks.js", () => ({
+  registerTelegramSubagentHooks: hookMocks.registerTelegramSubagentHooks,
+}));
+
+describe("telegram plugin", () => {
+  beforeEach(() => {
+    hookMocks.setTelegramRuntime.mockClear();
+    hookMocks.registerTelegramSubagentHooks.mockClear();
+  });
+
+  it("registers the telegram channel and subagent hooks", () => {
+    const api = {
+      runtime: { id: "runtime" },
+      registerChannel: vi.fn(),
+    } as unknown as OpenClawPluginApi;
+
+    plugin.register(api);
+
+    expect(hookMocks.setTelegramRuntime).toHaveBeenCalledWith(api.runtime);
+    expect(api.registerChannel).toHaveBeenCalledTimes(1);
+    expect(hookMocks.registerTelegramSubagentHooks).toHaveBeenCalledWith(api);
+  });
+});

--- a/extensions/telegram/index.ts
+++ b/extensions/telegram/index.ts
@@ -2,6 +2,7 @@ import type { ChannelPlugin, OpenClawPluginApi } from "openclaw/plugin-sdk/teleg
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/telegram";
 import { telegramPlugin } from "./src/channel.js";
 import { setTelegramRuntime } from "./src/runtime.js";
+import { registerTelegramSubagentHooks } from "./src/subagent-hooks.js";
 
 const plugin = {
   id: "telegram",
@@ -11,6 +12,7 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setTelegramRuntime(api.runtime);
     api.registerChannel({ plugin: telegramPlugin as ChannelPlugin });
+    registerTelegramSubagentHooks(api);
   },
 };
 

--- a/extensions/telegram/src/subagent-hooks.test.ts
+++ b/extensions/telegram/src/subagent-hooks.test.ts
@@ -1,0 +1,279 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/telegram";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerTelegramSubagentHooks } from "./subagent-hooks.js";
+
+type SessionBindingRecord = {
+  status: "active";
+  conversation: {
+    channel: string;
+    accountId: string;
+    conversationId: string;
+  };
+};
+
+const hookMocks = vi.hoisted(() => ({
+  resolveTelegramAccount: vi.fn((params?: { accountId?: string }) => ({
+    accountId: params?.accountId?.trim() || "default",
+  })),
+  ensureTelegramThreadBindingManager: vi.fn(),
+  getSessionBindingService: vi.fn(() => ({
+    getCapabilities: vi.fn(() => ({
+      adapterAvailable: true,
+      bindSupported: true,
+      unbindSupported: true,
+      placements: ["current"],
+    })),
+    bind: vi.fn(async () => ({
+      bindingId: "default:-100123:topic:55",
+      targetSessionKey: "agent:main:subagent:child",
+      targetKind: "subagent",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-100123:topic:55",
+      },
+      status: "active",
+      boundAt: 1,
+    })),
+    listBySession: vi.fn((): SessionBindingRecord[] => []),
+    unbind: vi.fn(async () => []),
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/telegram", () => ({
+  resolveTelegramAccount: hookMocks.resolveTelegramAccount,
+}));
+
+vi.mock("../../../src/infra/outbound/session-binding-service.js", () => ({
+  getSessionBindingService: hookMocks.getSessionBindingService,
+}));
+
+vi.mock("../../../src/telegram/thread-bindings.js", () => ({
+  ensureTelegramThreadBindingManager: hookMocks.ensureTelegramThreadBindingManager,
+}));
+
+function registerHandlersForTest(
+  config: Record<string, unknown> = {
+    channels: {
+      telegram: {
+        threadBindings: {
+          spawnSubagentSessions: true,
+        },
+      },
+    },
+  },
+) {
+  const handlers = new Map<string, (event: unknown, ctx: unknown) => unknown>();
+  const api = {
+    config,
+    on: (hookName: string, handler: (event: unknown, ctx: unknown) => unknown) => {
+      handlers.set(hookName, handler);
+    },
+  } as unknown as OpenClawPluginApi;
+  registerTelegramSubagentHooks(api);
+  return handlers;
+}
+
+function getRequiredHandler(
+  handlers: Map<string, (event: unknown, ctx: unknown) => unknown>,
+  hookName: string,
+): (event: unknown, ctx: unknown) => unknown {
+  const handler = handlers.get(hookName);
+  if (!handler) {
+    throw new Error(`expected ${hookName} hook handler`);
+  }
+  return handler;
+}
+
+function getBindingServiceMock() {
+  return hookMocks.getSessionBindingService.mock.results.at(-1)?.value as {
+    getCapabilities: ReturnType<typeof vi.fn>;
+    bind: ReturnType<typeof vi.fn>;
+    listBySession: ReturnType<typeof vi.fn>;
+    unbind: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createSpawnEvent(overrides?: {
+  childSessionKey?: string;
+  agentId?: string;
+  label?: string;
+  requester?: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string;
+  };
+  threadRequested?: boolean;
+}) {
+  const base = {
+    childSessionKey: "agent:main:subagent:child",
+    agentId: "main",
+    label: "banana",
+    requester: {
+      channel: "telegram",
+      accountId: "default",
+      to: "telegram:-100123",
+      threadId: "55",
+    },
+    threadRequested: true,
+  };
+  return {
+    ...base,
+    ...overrides,
+    requester: {
+      ...base.requester,
+      ...(overrides?.requester ?? {}),
+    },
+  };
+}
+
+describe("telegram subagent hook handlers", () => {
+  beforeEach(() => {
+    hookMocks.resolveTelegramAccount.mockClear();
+    hookMocks.ensureTelegramThreadBindingManager.mockClear();
+    hookMocks.getSessionBindingService.mockClear();
+  });
+
+  it("registers telegram subagent hooks", () => {
+    const handlers = registerHandlersForTest();
+    expect(handlers.has("subagent_spawning")).toBe(true);
+    expect(handlers.has("subagent_delivery_target")).toBe(true);
+    expect(handlers.has("subagent_ended")).toBe(true);
+  });
+
+  it("prewarms the manager and binds the current telegram topic", async () => {
+    const handlers = registerHandlersForTest();
+    const handler = getRequiredHandler(handlers, "subagent_spawning");
+
+    const result = await handler(createSpawnEvent(), {});
+    const bindingService = getBindingServiceMock();
+
+    expect(hookMocks.ensureTelegramThreadBindingManager).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      accountId: "default",
+    });
+    expect(bindingService.getCapabilities).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "default",
+    });
+    expect(bindingService.bind).toHaveBeenCalledWith({
+      targetSessionKey: "agent:main:subagent:child",
+      targetKind: "subagent",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-100123:topic:55",
+      },
+      placement: "current",
+      metadata: {
+        agentId: "main",
+        label: "banana",
+        boundBy: "system",
+      },
+    });
+    expect(result).toMatchObject({ status: "ok", threadBindingReady: true });
+  });
+
+  it("returns an availability error when telegram binding capabilities are missing", async () => {
+    hookMocks.getSessionBindingService.mockReturnValueOnce({
+      getCapabilities: vi.fn(() => ({
+        adapterAvailable: false,
+        bindSupported: false,
+        unbindSupported: false,
+        placements: [],
+      })),
+      bind: vi.fn(),
+      listBySession: vi.fn((): SessionBindingRecord[] => []),
+      unbind: vi.fn(async () => []),
+    });
+    const handlers = registerHandlersForTest();
+    const handler = getRequiredHandler(handlers, "subagent_spawning");
+
+    const result = await handler(createSpawnEvent(), {});
+
+    expect(result).toMatchObject({
+      status: "error",
+      error: "Thread bindings are unavailable for telegram.",
+    });
+  });
+
+  it("resolves completion delivery back to the bound telegram topic", () => {
+    hookMocks.getSessionBindingService.mockReturnValueOnce({
+      getCapabilities: vi.fn(() => ({
+        adapterAvailable: true,
+        bindSupported: true,
+        unbindSupported: true,
+        placements: ["current"],
+      })),
+      bind: vi.fn(async () => ({
+        bindingId: "default:-100123:topic:55",
+        targetSessionKey: "agent:main:subagent:child",
+        targetKind: "subagent",
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "-100123:topic:55",
+        },
+        status: "active",
+        boundAt: 1,
+      })),
+      listBySession: vi.fn((): SessionBindingRecord[] => [
+        {
+          status: "active",
+          conversation: {
+            channel: "telegram",
+            accountId: "default",
+            conversationId: "-100123:topic:55",
+          },
+        },
+      ]),
+      unbind: vi.fn(async () => []),
+    });
+    const handlers = registerHandlersForTest();
+    const handler = getRequiredHandler(handlers, "subagent_delivery_target");
+
+    const result = handler(
+      {
+        childSessionKey: "agent:main:subagent:child",
+        requesterOrigin: {
+          channel: "telegram",
+          accountId: "default",
+          to: "channel:-100123",
+          threadId: "55",
+        },
+        expectsCompletionMessage: true,
+      },
+      {},
+    );
+
+    expect(result).toEqual({
+      origin: {
+        channel: "telegram",
+        accountId: "default",
+        to: "channel:-100123",
+        threadId: "55",
+      },
+    });
+  });
+
+  it("unbinds telegram session routing on subagent_ended", async () => {
+    const handlers = registerHandlersForTest();
+    const handler = getRequiredHandler(handlers, "subagent_ended");
+
+    await handler(
+      {
+        targetSessionKey: "agent:main:subagent:child",
+        targetKind: "subagent",
+        reason: "subagent-complete",
+      },
+      {},
+    );
+
+    const bindingService = getBindingServiceMock();
+    expect(bindingService.unbind).toHaveBeenCalledWith({
+      targetSessionKey: "agent:main:subagent:child",
+      reason: "subagent-complete",
+    });
+  });
+});

--- a/extensions/telegram/src/subagent-hooks.ts
+++ b/extensions/telegram/src/subagent-hooks.ts
@@ -1,0 +1,260 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/telegram";
+import { resolveTelegramAccount } from "openclaw/plugin-sdk/telegram";
+import {
+  formatThreadBindingDisabledError,
+  formatThreadBindingSpawnDisabledError,
+  resolveThreadBindingSpawnPolicy,
+} from "../../../src/channels/thread-bindings-policy.js";
+import { getSessionBindingService } from "../../../src/infra/outbound/session-binding-service.js";
+import { ensureTelegramThreadBindingManager } from "../../../src/telegram/thread-bindings.js";
+
+function summarizeError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === "string") {
+    return err;
+  }
+  return "error";
+}
+
+function normalizeString(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return `${value}`.trim();
+  }
+  return "";
+}
+
+function resolveTelegramThreadBindingFlags(api: OpenClawPluginApi, accountId?: string) {
+  const account = resolveTelegramAccount({
+    cfg: api.config,
+    accountId,
+  });
+  const policy = resolveThreadBindingSpawnPolicy({
+    cfg: api.config,
+    channel: "telegram",
+    accountId: account.accountId,
+    kind: "subagent",
+  });
+  return {
+    accountId: policy.accountId,
+    enabled: policy.enabled,
+    spawnSubagentSessions: policy.spawnEnabled,
+  };
+}
+
+function resolveTelegramConversationId(params: {
+  to?: string;
+  threadId?: string | number;
+}): string | null {
+  const rawTo = normalizeString(params.to);
+  const rawThreadId = normalizeString(params.threadId);
+  const target = rawTo.startsWith("channel:")
+    ? rawTo.slice(8)
+    : rawTo.startsWith("telegram:")
+      ? rawTo.slice(9)
+      : rawTo;
+  if (!target) {
+    return null;
+  }
+  if (target.includes(":topic:")) {
+    return target;
+  }
+  if (rawThreadId) {
+    return `${target}:topic:${rawThreadId}`;
+  }
+  if (target.startsWith("-")) {
+    return null;
+  }
+  return target;
+}
+
+function buildTelegramDeliveryOrigin(params: { accountId: string; conversationId: string }) {
+  const topicMarker = ":topic:";
+  const topicIndex = params.conversationId.indexOf(topicMarker);
+  if (topicIndex >= 0) {
+    const chatId = params.conversationId.slice(0, topicIndex).trim();
+    const threadId = params.conversationId.slice(topicIndex + topicMarker.length).trim();
+    if (!chatId || !threadId) {
+      return null;
+    }
+    return {
+      channel: "telegram" as const,
+      accountId: params.accountId,
+      to: `channel:${chatId}`,
+      threadId,
+    };
+  }
+
+  if (!params.conversationId.trim()) {
+    return null;
+  }
+  return {
+    channel: "telegram" as const,
+    accountId: params.accountId,
+    to: `channel:${params.conversationId}`,
+  };
+}
+
+export function registerTelegramSubagentHooks(api: OpenClawPluginApi) {
+  api.on("subagent_spawning", async (event) => {
+    if (!event.threadRequested) {
+      return;
+    }
+    const channel = normalizeString(event.requester?.channel).toLowerCase();
+    if (channel !== "telegram") {
+      return;
+    }
+
+    const threadBindingFlags = resolveTelegramThreadBindingFlags(api, event.requester?.accountId);
+    if (!threadBindingFlags.enabled) {
+      return {
+        status: "error" as const,
+        error: formatThreadBindingDisabledError({
+          channel: "telegram",
+          accountId: threadBindingFlags.accountId,
+          kind: "subagent",
+        }),
+      };
+    }
+    if (!threadBindingFlags.spawnSubagentSessions) {
+      return {
+        status: "error" as const,
+        error: formatThreadBindingSpawnDisabledError({
+          channel: "telegram",
+          accountId: threadBindingFlags.accountId,
+          kind: "subagent",
+        }),
+      };
+    }
+
+    const conversationId = resolveTelegramConversationId({
+      to: event.requester?.to,
+      threadId: event.requester?.threadId,
+    });
+    if (!conversationId) {
+      return {
+        status: "error" as const,
+        error: "Could not resolve a telegram conversation for this subagent session.",
+      };
+    }
+
+    ensureTelegramThreadBindingManager({
+      cfg: api.config,
+      accountId: threadBindingFlags.accountId,
+    });
+    const bindingService = getSessionBindingService();
+    const capabilities = bindingService.getCapabilities({
+      channel: "telegram",
+      accountId: threadBindingFlags.accountId,
+    });
+    if (!capabilities.adapterAvailable || !capabilities.bindSupported) {
+      return {
+        status: "error" as const,
+        error: "Thread bindings are unavailable for telegram.",
+      };
+    }
+    if (!capabilities.placements.includes("current")) {
+      return {
+        status: "error" as const,
+        error: "Thread bindings do not support current placement for telegram.",
+      };
+    }
+
+    try {
+      await bindingService.bind({
+        targetSessionKey: event.childSessionKey,
+        targetKind: "subagent",
+        conversation: {
+          channel: "telegram",
+          accountId: threadBindingFlags.accountId,
+          conversationId,
+        },
+        placement: "current",
+        metadata: {
+          agentId: event.agentId,
+          label: event.label || undefined,
+          boundBy: "system",
+        },
+      });
+      return {
+        status: "ok" as const,
+        threadBindingReady: true,
+      };
+    } catch (err) {
+      return {
+        status: "error" as const,
+        error: `Telegram conversation bind failed: ${summarizeError(err)}`,
+      };
+    }
+  });
+
+  api.on("subagent_ended", async (event) => {
+    if (event.targetKind !== "subagent") {
+      return;
+    }
+    await getSessionBindingService().unbind({
+      targetSessionKey: event.targetSessionKey,
+      reason: event.reason,
+    });
+  });
+
+  api.on("subagent_delivery_target", (event) => {
+    if (!event.expectsCompletionMessage) {
+      return;
+    }
+    const requesterChannel = normalizeString(event.requesterOrigin?.channel).toLowerCase();
+    if (requesterChannel !== "telegram") {
+      return;
+    }
+
+    const requesterAccountId = normalizeString(event.requesterOrigin?.accountId);
+    const requesterConversationId = resolveTelegramConversationId({
+      to: event.requesterOrigin?.to,
+      threadId: event.requesterOrigin?.threadId,
+    });
+
+    const bindings = getSessionBindingService()
+      .listBySession(event.childSessionKey)
+      .filter(
+        (binding) => binding.status === "active" && binding.conversation.channel === "telegram",
+      );
+    if (bindings.length === 0) {
+      return;
+    }
+
+    let binding = bindings.find((entry) => {
+      if (
+        requesterAccountId &&
+        normalizeString(entry.conversation.accountId) !== requesterAccountId
+      ) {
+        return false;
+      }
+      if (
+        requesterConversationId &&
+        normalizeString(entry.conversation.conversationId) !== requesterConversationId
+      ) {
+        return false;
+      }
+      return true;
+    });
+    if (!binding && bindings.length === 1) {
+      binding = bindings[0];
+    }
+    if (!binding) {
+      return;
+    }
+
+    const origin = buildTelegramDeliveryOrigin({
+      accountId: binding.conversation.accountId,
+      conversationId: binding.conversation.conversationId,
+    });
+    if (!origin) {
+      return;
+    }
+    return { origin };
+  });
+}

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+const probeGateway = vi.fn<
+  (opts: {
+    url: string;
+    auth?: { token?: string; password?: string };
+    timeoutMs: number;
+  }) => Promise<{
+    ok: boolean;
+    configSnapshot: unknown;
+  }>
+>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -437,6 +437,40 @@ describe("agentCommand", () => {
     });
   });
 
+  it("hydrates telegram topic routing from persisted session delivery context on session resume", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:telegram:group:-100123:topic:55": {
+          sessionId: "session-telegram-topic",
+          updatedAt: Date.now(),
+          deliveryContext: {
+            channel: "telegram",
+            to: "telegram:-100123",
+            accountId: "default",
+            threadId: 55,
+          },
+        },
+      });
+      mockConfig(home, store);
+
+      await agentCommand({ message: "resume me", sessionId: "session-telegram-topic" }, runtime);
+
+      const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0];
+      expect(callArgs).toEqual(
+        expect.objectContaining({
+          sessionId: "session-telegram-topic",
+          messageChannel: "telegram",
+          agentAccountId: "default",
+          messageTo: "telegram:-100123",
+          messageThreadId: "55",
+          currentChannelId: "telegram:-100123",
+          currentThreadTs: "55",
+        }),
+      );
+    });
+  });
+
   it("uses the resumed session agent scope when sessionId resolves to another agent store", async () => {
     await withCrossAgentResumeFixture(async ({ sessionKey }) => {
       const callArgs = getLastEmbeddedCall();

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -462,8 +462,8 @@ function runAgentAttempt(params: {
     trigger: "user",
     messageChannel: params.messageChannel,
     agentAccountId: params.runContext.accountId,
-    messageTo: params.opts.replyTo ?? params.opts.to,
-    messageThreadId: params.opts.threadId,
+    messageTo: params.opts.replyTo ?? params.opts.to ?? params.runContext.currentChannelId,
+    messageThreadId: params.opts.threadId ?? params.runContext.currentThreadTs,
     groupId: params.runContext.groupId,
     groupChannel: params.runContext.groupChannel,
     groupSpace: params.runContext.groupSpace,
@@ -1082,7 +1082,7 @@ async function agentCommandInternal(
     let fallbackProvider = provider;
     let fallbackModel = model;
     try {
-      const runContext = resolveAgentRunContext(opts);
+      const runContext = resolveAgentRunContext(opts, sessionEntry);
       const messageChannel = resolveMessageChannel(
         runContext.messageChannel,
         opts.replyChannel ?? opts.channel,

--- a/src/commands/agent/run-context.ts
+++ b/src/commands/agent/run-context.ts
@@ -1,19 +1,41 @@
+import type { SessionEntry } from "../../config/sessions.js";
 import { normalizeAccountId } from "../../utils/account-id.js";
+import {
+  deliveryContextFromSession,
+  normalizeDeliveryContext,
+} from "../../utils/delivery-context.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
 import type { AgentCommandOpts, AgentRunContext } from "./types.js";
 
-export function resolveAgentRunContext(opts: AgentCommandOpts): AgentRunContext {
+function resolveAgentRequesterOriginFromSession(sessionEntry: SessionEntry | undefined) {
+  return normalizeDeliveryContext(
+    deliveryContextFromSession(sessionEntry) ?? {
+      channel: sessionEntry?.lastChannel,
+      to: sessionEntry?.lastTo,
+      accountId: sessionEntry?.lastAccountId,
+      threadId: sessionEntry?.lastThreadId,
+    },
+  );
+}
+
+export function resolveAgentRunContext(
+  opts: AgentCommandOpts,
+  sessionEntry?: SessionEntry,
+): AgentRunContext {
   const merged: AgentRunContext = opts.runContext ? { ...opts.runContext } : {};
+  const persistedOrigin = resolveAgentRequesterOriginFromSession(sessionEntry);
 
   const normalizedChannel = resolveMessageChannel(
     merged.messageChannel ?? opts.messageChannel,
-    opts.replyChannel ?? opts.channel,
+    opts.replyChannel ?? opts.channel ?? persistedOrigin?.channel,
   );
   if (normalizedChannel) {
     merged.messageChannel = normalizedChannel;
   }
 
-  const normalizedAccountId = normalizeAccountId(merged.accountId ?? opts.accountId);
+  const normalizedAccountId = normalizeAccountId(
+    merged.accountId ?? opts.replyAccountId ?? opts.accountId ?? persistedOrigin?.accountId,
+  );
   if (normalizedAccountId) {
     merged.accountId = normalizedAccountId;
   }
@@ -35,17 +57,18 @@ export function resolveAgentRunContext(opts: AgentCommandOpts): AgentRunContext 
 
   if (
     merged.currentThreadTs == null &&
-    opts.threadId != null &&
-    opts.threadId !== "" &&
-    opts.threadId !== null
+    (opts.threadId ?? persistedOrigin?.threadId) != null &&
+    (opts.threadId ?? persistedOrigin?.threadId) !== "" &&
+    (opts.threadId ?? persistedOrigin?.threadId) !== null
   ) {
-    merged.currentThreadTs = String(opts.threadId);
+    merged.currentThreadTs = String(opts.threadId ?? persistedOrigin?.threadId);
   }
 
   // Populate currentChannelId from the outbound target so that
   // resolveTelegramAutoThreadId can match the originating chat.
-  if (!merged.currentChannelId && opts.to) {
-    const trimmedTo = opts.to.trim();
+  const rawCurrentChannelId = opts.replyTo ?? opts.to ?? persistedOrigin?.to;
+  if (!merged.currentChannelId && typeof rawCurrentChannelId === "string") {
+    const trimmedTo = rawCurrentChannelId.trim();
     if (trimmedTo) {
       merged.currentChannelId = trimmedTo;
     }

--- a/src/infra/outbound/session-binding-service.test.ts
+++ b/src/infra/outbound/session-binding-service.test.ts
@@ -198,4 +198,28 @@ describe("session binding service", () => {
       placements: [],
     });
   });
+
+  it("shares adapter and service state through globalThis", () => {
+    registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+      capabilities: {
+        placements: ["current"],
+      },
+      bind: async (input) => createRecord(input),
+      listBySession: () => [],
+      resolveByConversation: () => null,
+      unbind: async () => [],
+    });
+
+    const globalAdapters = Reflect.get(
+      globalThis,
+      "__openclawSessionBindingAdaptersByChannelAccount",
+    );
+    const globalService = Reflect.get(globalThis, "__openclawSessionBindingService");
+
+    expect(globalAdapters).toBeInstanceOf(Map);
+    expect((globalAdapters as Map<string, unknown>).has("discord:default")).toBe(true);
+    expect(globalService).toBe(getSessionBindingService());
+  });
 });

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -145,7 +145,27 @@ function resolveAdapterCapabilities(
   };
 }
 
-const ADAPTERS_BY_CHANNEL_ACCOUNT = new Map<string, SessionBindingAdapter>();
+type SessionBindingGlobalScope = typeof globalThis & {
+  __openclawSessionBindingAdaptersByChannelAccount?: Map<string, SessionBindingAdapter>;
+  __openclawSessionBindingService?: SessionBindingService;
+};
+
+function resolveGlobalScope(): SessionBindingGlobalScope {
+  return globalThis as SessionBindingGlobalScope;
+}
+
+function resolveGlobalSessionBindingAdapters() {
+  const scope = resolveGlobalScope();
+  const existing = scope.__openclawSessionBindingAdaptersByChannelAccount;
+  if (existing instanceof Map) {
+    return existing;
+  }
+  const created = new Map<string, SessionBindingAdapter>();
+  scope.__openclawSessionBindingAdaptersByChannelAccount = created;
+  return created;
+}
+
+const ADAPTERS_BY_CHANNEL_ACCOUNT = resolveGlobalSessionBindingAdapters();
 
 export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): void {
   const key = toAdapterKey({
@@ -309,10 +329,19 @@ function createDefaultSessionBindingService(): SessionBindingService {
   };
 }
 
-const DEFAULT_SESSION_BINDING_SERVICE = createDefaultSessionBindingService();
+function resolveGlobalSessionBindingService(): SessionBindingService {
+  const scope = resolveGlobalScope();
+  const existing = scope.__openclawSessionBindingService;
+  if (existing && typeof existing === "object") {
+    return existing;
+  }
+  const created = createDefaultSessionBindingService();
+  scope.__openclawSessionBindingService = created;
+  return created;
+}
 
 export function getSessionBindingService(): SessionBindingService {
-  return DEFAULT_SESSION_BINDING_SERVICE;
+  return resolveGlobalSessionBindingService();
 }
 
 export const __testing = {

--- a/src/telegram/thread-bindings.ts
+++ b/src/telegram/thread-bindings.ts
@@ -3,6 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { resolveThreadBindingConversationIdFromBindingId } from "../channels/thread-binding-id.js";
 import { formatThreadBindingDurationLabel } from "../channels/thread-bindings-messages.js";
+import {
+  resolveThreadBindingIdleTimeoutMsForChannel,
+  resolveThreadBindingMaxAgeMsForChannel,
+} from "../channels/thread-bindings-policy.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { logVerbose } from "../globals.js";
 import { writeJsonAtomic } from "../infra/json-files.js";
@@ -642,6 +647,26 @@ export function getTelegramThreadBindingManager(
   accountId?: string,
 ): TelegramThreadBindingManager | null {
   return MANAGERS_BY_ACCOUNT_ID.get(normalizeAccountId(accountId)) ?? null;
+}
+
+export function ensureTelegramThreadBindingManager(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+}): TelegramThreadBindingManager {
+  const accountId = normalizeAccountId(params.accountId);
+  return createTelegramThreadBindingManager({
+    accountId,
+    idleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel({
+      cfg: params.cfg,
+      channel: "telegram",
+      accountId,
+    }),
+    maxAgeMs: resolveThreadBindingMaxAgeMsForChannel({
+      cfg: params.cfg,
+      channel: "telegram",
+      accountId,
+    }),
+  });
 }
 
 function updateTelegramBindingsBySessionKey(params: {


### PR DESCRIPTION
## Summary

Fix Telegram topic-bound `sessions_spawn(..., thread=true, mode="session")` for subagent sessions.

## Problem

Telegram thread-bound subagent spawns could fail with `Thread bindings are unavailable for telegram.` or `Session mode is unavailable for this target.` because the Telegram extension was missing subagent lifecycle wiring, requester topic context could be lost on `agent --session-id` runs, and session-binding state could be split across module instances.

## Fix

Register Telegram subagent lifecycle hooks, hydrate requester context from persisted session delivery state, share session-binding adapters and services across module instances, and prewarm the Telegram thread-binding manager before capability checks.

## Validation

- `pnpm exec vitest run extensions/telegram/index.test.ts extensions/telegram/src/subagent-hooks.test.ts`
- `pnpm exec vitest run src/infra/outbound/session-binding-service.test.ts src/telegram/thread-bindings.test.ts`
- `pnpm exec vitest run src/commands/agent.test.ts -t "hydrates telegram topic routing from persisted session delivery context on session resume"`
- `pnpm build`
- `pnpm check` currently still fails on an unrelated repo error at `src/cron/isolated-agent/run.ts(207,12)`: `Cannot find name 'CommandLane'.`
