### PR TITLE
fix(web-search): strip /chat/completions from baseUrl to prevent path doubling

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -24,6 +24,7 @@ const {
   extractKimiCitations,
   resolveBraveMode,
   mapBraveLlmContextResults,
+  stripCompletionsEndpoint,
 } = __testing;
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
@@ -344,6 +345,38 @@ describe("web_search kimi config resolution", () => {
   it("resolves default model and baseUrl", () => {
     expect(resolveKimiModel({})).toBe("moonshot-v1-128k");
     expect(resolveKimiBaseUrl({})).toBe("https://api.moonshot.ai/v1");
+  });
+});
+
+describe("stripCompletionsEndpoint", () => {
+  it("removes trailing /chat/completions to prevent path doubling", () => {
+    expect(stripCompletionsEndpoint("https://api.moonshot.ai/v1/chat/completions")).toBe(
+      "https://api.moonshot.ai/v1",
+    );
+  });
+
+  it("removes trailing slash before stripping endpoint", () => {
+    expect(stripCompletionsEndpoint("https://api.moonshot.ai/v1/chat/completions/")).toBe(
+      "https://api.moonshot.ai/v1",
+    );
+  });
+
+  it("preserves correct base URL without /chat/completions", () => {
+    expect(stripCompletionsEndpoint("https://api.moonshot.ai/v1")).toBe(
+      "https://api.moonshot.ai/v1",
+    );
+  });
+
+  it("handles base URL with only trailing slashes", () => {
+    expect(stripCompletionsEndpoint("https://api.perplexity.ai/")).toBe(
+      "https://api.perplexity.ai",
+    );
+  });
+
+  it("trims whitespace", () => {
+    expect(stripCompletionsEndpoint("  https://api.moonshot.ai/v1  ")).toBe(
+      "https://api.moonshot.ai/v1",
+    );
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -44,6 +44,19 @@ const KIMI_WEB_SEARCH_TOOL = {
   function: { name: "$web_search" },
 } as const;
 
+/**
+ * Strip a trailing `/chat/completions` segment from a base URL so that
+ * callers can safely append it without doubling the path.
+ *
+ * e.g. `"https://api.moonshot.ai/v1/chat/completions"` → `"https://api.moonshot.ai/v1"`
+ */
+function stripCompletionsEndpoint(url: string): string {
+  return url
+    .trim()
+    .replace(/\/+$/, "")
+    .replace(/\/chat\/completions$/, "");
+}
+
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
 const BRAVE_FRESHNESS_RANGE = /^(\d{4}-\d{2}-\d{2})to(\d{4}-\d{2}-\d{2})$/;
@@ -1254,7 +1267,7 @@ async function runPerplexitySearch(params: {
   timeoutSeconds: number;
   freshness?: string;
 }): Promise<{ content: string; citations: string[] }> {
-  const baseUrl = params.baseUrl.trim().replace(/\/$/, "");
+  const baseUrl = stripCompletionsEndpoint(params.baseUrl);
   const endpoint = `${baseUrl}/chat/completions`;
   const model = resolvePerplexityRequestModel(baseUrl, params.model);
 
@@ -1416,7 +1429,7 @@ async function runKimiSearch(params: {
   model: string;
   timeoutSeconds: number;
 }): Promise<{ content: string; citations: string[] }> {
-  const baseUrl = params.baseUrl.trim().replace(/\/$/, "");
+  const baseUrl = stripCompletionsEndpoint(params.baseUrl);
   const endpoint = `${baseUrl}/chat/completions`;
   const messages: Array<Record<string, unknown>> = [
     {
@@ -2219,4 +2232,5 @@ export const __testing = {
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,
   mapBraveLlmContextResults,
+  stripCompletionsEndpoint,
 } as const;


### PR DESCRIPTION
## Summary

When a user configures `baseUrl` as `https://api.moonshot.ai/v1/chat/completions` (with the endpoint path included), the Kimi and Perplexity web search providers unconditionally append `/chat/completions` again, producing `/v1/chat/completions/chat/completions` which returns 404.

## Changes

- Add `stripCompletionsEndpoint()` helper that normalises the base URL by removing a trailing `/chat/completions` segment before the endpoint is re-appended
- Apply to both `runKimiSearch()` and `runPerplexitySearch()`
- Add 5 test cases covering path doubling, trailing slashes, and whitespace

Closes #42676

lobster-biscuit