### PR TITLE
fix(feishu): guard response.code checks against undefined in wiki operations

### DIFF
--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -19,7 +19,7 @@ const WIKI_ACCESS_HINT =
 
 async function listSpaces(client: Lark.Client) {
   const res = await client.wiki.space.list({});
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -42,7 +42,7 @@ async function listNodes(client: Lark.Client, spaceId: string, parentNodeToken?:
     path: { space_id: spaceId },
     params: { parent_node_token: parentNodeToken },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -62,7 +62,7 @@ async function getNode(client: Lark.Client, token: string) {
   const res = await client.wiki.space.getNode({
     params: { token },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -96,7 +96,7 @@ async function createNode(
       parent_node_token: parentNodeToken,
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -123,7 +123,7 @@ async function moveNode(
       target_parent_token: targetParentToken,
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -138,7 +138,7 @@ async function renameNode(client: Lark.Client, spaceId: string, nodeToken: strin
     path: { space_id: spaceId, node_token: nodeToken },
     data: { title },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 


### PR DESCRIPTION
## Summary

The Lark SDK types declare `code` as `code?: number | undefined`. When SDK v1.30+ returns a successful response without wrapping data in a `{ code: 0, data: ... }` envelope, `code` is `undefined`. The existing check `res.code !== 0` evaluates `undefined !== 0` as `true`, causing all 6 wiki operations to throw on successful responses.

## Changes

Apply the same guard pattern already used in `media.ts` (lines 33, 209, 282):

```diff
- if (res.code !== 0) {
+ if (res.code !== undefined && res.code !== 0) {
```

Affected functions:
- `listSpaces()` (line 22)
- `listNodes()` (line 45)
- `getNode()` (line 65)
- `createNode()` (line 99)
- `moveNode()` (line 126)
- `renameNode()` (line 141)

This is a follow-up to the messaging files fix in #41527.

lobster-biscuit