### PR TITLE
fix(web-search): fix Kimi API URL path duplication (#42676)

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -21,6 +21,7 @@ const {
   resolveKimiApiKey,
   resolveKimiModel,
   resolveKimiBaseUrl,
+  resolveKimiChatCompletionsUrl,
   extractKimiCitations,
   resolveBraveMode,
   mapBraveLlmContextResults,
@@ -344,6 +345,44 @@ describe("web_search kimi config resolution", () => {
   it("resolves default model and baseUrl", () => {
     expect(resolveKimiModel({})).toBe("moonshot-v1-128k");
     expect(resolveKimiBaseUrl({})).toBe("https://api.moonshot.ai/v1");
+  });
+});
+
+describe("resolveKimiChatCompletionsUrl", () => {
+  it("appends /chat/completions when baseUrl already includes /v1", () => {
+    expect(resolveKimiChatCompletionsUrl("https://api.moonshot.ai/v1")).toBe(
+      "https://api.moonshot.ai/v1/chat/completions",
+    );
+    expect(resolveKimiChatCompletionsUrl("https://api.moonshot.ai/v1/")).toBe(
+      "https://api.moonshot.ai/v1/chat/completions",
+    );
+  });
+
+  it("adds /v1/chat/completions when baseUrl omits the version path", () => {
+    expect(resolveKimiChatCompletionsUrl("https://api.moonshot.ai")).toBe(
+      "https://api.moonshot.ai/v1/chat/completions",
+    );
+    expect(resolveKimiChatCompletionsUrl("https://api.moonshot.ai/")).toBe(
+      "https://api.moonshot.ai/v1/chat/completions",
+    );
+  });
+
+  it("keeps explicit chat completion endpoints unchanged", () => {
+    expect(resolveKimiChatCompletionsUrl("https://api.moonshot.ai/v1/chat/completions")).toBe(
+      "https://api.moonshot.ai/v1/chat/completions",
+    );
+    expect(
+      resolveKimiChatCompletionsUrl("https://proxy.example.com/moonshot/chat/completions"),
+    ).toBe("https://proxy.example.com/moonshot/chat/completions");
+  });
+
+  it("preserves proxy subpaths while normalizing the Kimi endpoint", () => {
+    expect(resolveKimiChatCompletionsUrl("https://proxy.example.com/moonshot")).toBe(
+      "https://proxy.example.com/moonshot/v1/chat/completions",
+    );
+    expect(resolveKimiChatCompletionsUrl("https://proxy.example.com/moonshot/v1/")).toBe(
+      "https://proxy.example.com/moonshot/v1/chat/completions",
+    );
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -889,6 +889,37 @@ function resolveKimiBaseUrl(kimi?: KimiConfig): string {
   return fromConfig || DEFAULT_KIMI_BASE_URL;
 }
 
+function resolveKimiChatCompletionsUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim();
+  if (!trimmed) {
+    return `${DEFAULT_KIMI_BASE_URL}/chat/completions`;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const normalizedPath = url.pathname.replace(/\/+$/, "") || "/";
+
+    if (normalizedPath.endsWith("/chat/completions")) {
+      url.pathname = normalizedPath;
+      return url.toString();
+    }
+
+    url.pathname = normalizedPath.endsWith("/v1")
+      ? `${normalizedPath}/chat/completions`
+      : `${normalizedPath === "/" ? "" : normalizedPath}/v1/chat/completions`;
+    return url.toString();
+  } catch {
+    const normalizedBaseUrl = trimmed.replace(/\/+$/, "");
+    if (normalizedBaseUrl.endsWith("/chat/completions")) {
+      return normalizedBaseUrl;
+    }
+    if (normalizedBaseUrl.endsWith("/v1")) {
+      return `${normalizedBaseUrl}/chat/completions`;
+    }
+    return `${normalizedBaseUrl}/v1/chat/completions`;
+  }
+}
+
 function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
   if (!search || typeof search !== "object") {
     return {};
@@ -1416,8 +1447,7 @@ async function runKimiSearch(params: {
   model: string;
   timeoutSeconds: number;
 }): Promise<{ content: string; citations: string[] }> {
-  const baseUrl = params.baseUrl.trim().replace(/\/$/, "");
-  const endpoint = `${baseUrl}/chat/completions`;
+  const endpoint = resolveKimiChatCompletionsUrl(params.baseUrl);
   const messages: Array<Record<string, unknown>> = [
     {
       role: "user",
@@ -2215,6 +2245,7 @@ export const __testing = {
   resolveKimiApiKey,
   resolveKimiModel,
   resolveKimiBaseUrl,
+  resolveKimiChatCompletionsUrl,
   extractKimiCitations,
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,


### PR DESCRIPTION
Fixes #42676

## Summary

Kimi web search provider URL concatenation produced duplicate paths when `baseUrl` included `/v1` (e.g. `/v1/chat/completions/chat/completions`).

## Changes

- Add `resolveKimiChatCompletionsUrl()` helper using `new URL()` for safe path joining
- Handles all baseUrl variants: with/without `/v1`, trailing slashes, proxy subpaths, already-complete endpoints
- Update `runKimiSearch()` to use the new helper

## Testing

- Added URL normalization tests covering all edge cases
- 51 tests pass