### PR TITLE
fix(cron): prevent duplicate job execution after gateway restart (#42640)

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -148,6 +148,53 @@ describe("CronService restart catch-up", () => {
     cron.stop();
     await store.cleanup();
   });
+  it("does not re-run an already-executed stale due slot on restart", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    await writeStoreJobs(store.storePath, [
+      {
+        id: "restart-already-executed-due-slot",
+        name: "already executed stale due slot",
+        enabled: true,
+        createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+        updatedAtMs: Date.parse("2025-12-13T16:30:00.000Z"),
+        schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC" },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "should not duplicate" },
+        state: {
+          // This can happen if startup catch-up (or a manual repair) already
+          // executed the 16:00 slot, but the persisted nextRunAtMs still points
+          // at that stale expired slot.
+          nextRunAtMs: Date.parse("2025-12-13T16:00:00.000Z"),
+          lastRunAtMs: Date.parse("2025-12-13T16:30:00.000Z"),
+          lastStatus: "ok",
+        },
+      },
+    ]);
+
+    const cron = createRestartCronService({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+    });
+
+    await cron.start();
+
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(requestHeartbeatNow).not.toHaveBeenCalled();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const updated = jobs.find((job) => job.id === "restart-already-executed-due-slot");
+    expect((updated?.state.nextRunAtMs ?? 0) > Date.parse("2025-12-13T17:00:00.000Z")).toBe(true);
+    expect(updated?.state.lastRunAtMs).toBe(Date.parse("2025-12-13T16:30:00.000Z"));
+
+    cron.stop();
+    await store.cleanup();
+  });
+
   it("replays the most recent missed cron slot after restart when nextRunAtMs already advanced", async () => {
     vi.setSystemTime(new Date("2025-12-13T04:02:00.000Z"));
     const store = await makeStorePath();

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -735,8 +735,10 @@ function hasAlreadyExecutedScheduledSlot(job: CronJob, scheduledAtMs: number): b
   // Guard against stale expired nextRunAtMs values that still point at a slot
   // the scheduler already executed (for example via startup catch-up). In that
   // case we must not treat the expired timestamp as runnable again.
+  // Use strict > (not >=) so that retry slots where nextRunAtMs === lastRunAtMs
+  // (e.g. zero-backoff retries finishing in the same millisecond) are still permitted.
   return (
-    typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs) && lastRunAtMs >= scheduledAtMs
+    typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs) && lastRunAtMs > scheduledAtMs
   );
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -730,6 +730,16 @@ export async function onTimer(state: CronServiceState) {
   }
 }
 
+function hasAlreadyExecutedScheduledSlot(job: CronJob, scheduledAtMs: number): boolean {
+  const lastRunAtMs = job.state.lastRunAtMs;
+  // Guard against stale expired nextRunAtMs values that still point at a slot
+  // the scheduler already executed (for example via startup catch-up). In that
+  // case we must not treat the expired timestamp as runnable again.
+  return (
+    typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs) && lastRunAtMs >= scheduledAtMs
+  );
+}
+
 function isRunnableJob(params: {
   job: CronJob;
   nowMs: number;
@@ -769,7 +779,9 @@ function isRunnableJob(params: {
   }
   const next = job.state.nextRunAtMs;
   if (typeof next === "number" && Number.isFinite(next) && nowMs >= next) {
-    return true;
+    if (!hasAlreadyExecutedScheduledSlot(job, next)) {
+      return true;
+    }
   }
   if (
     typeof next === "number" &&


### PR DESCRIPTION
Fixes #42640

## Summary

After gateway restart, the cron scheduler re-executed jobs that already ran before the restart, causing duplicate deliveries. The root cause: `isRunnableJob` treated stale `nextRunAtMs <= now` slots as due without checking whether they had already been executed.

## Changes

- Add `hasAlreadyExecutedScheduledSlot` guard in `timer.ts`: if `lastRunAtMs >= nextRunAtMs`, the expired slot was already executed — skip it
- Preserves missed-slot fallthrough so genuinely missed jobs still get caught up

## Testing

- Added regression test: `does not re-run an already-executed stale due slot on restart`
- 501 tests pass across cron module