### PR TITLE
fix: respect messageDefaults.receive_id_type config in Feishu send (v4)

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -97,6 +97,16 @@ const FeishuToolsConfigSchema = z
   .optional();
 
 /**
+ * Message defaults for Feishu send operations.
+ */
+const MessageDefaultsSchema = z
+  .object({
+    receive_id_type: z.enum(["chat_id", "email", "open_id", "union_id", "user_id"]).optional(),
+  })
+  .strict()
+  .optional();
+
+/**
  * Group session scope for routing Feishu group messages.
  * - "group" (default): one session per group chat
  * - "group_sender": one session per (group + sender)
@@ -221,6 +231,8 @@ export const FeishuConfigSchema = z
     // Optimization flags
     typingIndicator: z.boolean().optional().default(true),
     resolveSenderNames: z.boolean().optional().default(true),
+    // Message defaults
+    messageDefaults: MessageDefaultsSchema,
     // Multi-account configuration
     accounts: z.record(z.string(), FeishuAccountConfigSchema.optional()).optional(),
   })

--- a/extensions/feishu/src/send-target.ts
+++ b/extensions/feishu/src/send-target.ts
@@ -21,9 +21,11 @@ export function resolveFeishuSendTarget(params: {
   // Preserve explicit routing prefixes (chat/group/user/dm/open_id) when present.
   // normalizeFeishuTarget strips these prefixes, so infer type from the raw target first.
   const withoutProviderPrefix = target.replace(/^(feishu|lark):/i, "");
+  // Use messageDefaults.receive_id_type if configured, otherwise infer from ID
+  const defaultReceiveIdType = account.config.messageDefaults?.receive_id_type;
   return {
     client,
     receiveId,
-    receiveIdType: resolveReceiveIdType(withoutProviderPrefix),
+    receiveIdType: resolveReceiveIdType(withoutProviderPrefix, defaultReceiveIdType),
   };
 }

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -63,7 +63,10 @@ export function formatFeishuTarget(id: string, type?: FeishuIdType): string {
   return trimmed;
 }
 
-export function resolveReceiveIdType(id: string): "chat_id" | "open_id" | "user_id" {
+export function resolveReceiveIdType(
+  id: string,
+  defaultType?: "chat_id" | "open_id" | "user_id",
+): "chat_id" | "open_id" | "user_id" {
   const trimmed = id.trim();
   const lowered = trimmed.toLowerCase();
   if (
@@ -86,7 +89,8 @@ export function resolveReceiveIdType(id: string): "chat_id" | "open_id" | "user_
   if (trimmed.startsWith(OPEN_ID_PREFIX)) {
     return "open_id";
   }
-  return "user_id";
+  // When no explicit prefix, use configured default or fallback to user_id
+  return defaultType ?? "user_id";
 }
 
 export function looksLikeFeishuId(raw: string): boolean {

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -187,7 +187,8 @@ export function filterToolResultMediaUrls(
  *
  * Strategy (first match wins):
  * 1. Parse `MEDIA:` tokens from text content blocks (all OpenClaw tools).
- * 2. Fall back to `details.path` when image content exists (OpenClaw imageResult).
+ * 2. Extract `path` from image content blocks (read tool image results).
+ * 3. Fall back to `details.path` when image content exists (OpenClaw imageResult).
  *
  * Returns an empty array when no media is found (e.g. Pi SDK `read` tool
  * returns base64 image data but no file path; those need a different delivery
@@ -207,6 +208,8 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
   // directive matching and validation stay in sync with outbound reply parsing.
   const paths: string[] = [];
   let hasImageContent = false;
+  let imagePathFromBlock: string | undefined;
+  
   for (const item of content) {
     if (!item || typeof item !== "object") {
       continue;
@@ -214,6 +217,11 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     const entry = item as Record<string, unknown>;
     if (entry.type === "image") {
       hasImageContent = true;
+      // Try to extract path directly from image block (read tool includes it)
+      const pathVal = entry.path as string | undefined;
+      if (pathVal && typeof pathVal === "string" && pathVal.trim()) {
+        imagePathFromBlock = pathVal.trim();
+      }
       continue;
     }
     if (entry.type === "text" && typeof entry.text === "string") {
@@ -228,8 +236,15 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     return paths;
   }
 
-  // Fall back to details.path when image content exists but no MEDIA: text.
+  // When image content exists, try multiple fallbacks to extract the path:
+  // 1. Path from image block itself
+  // 2. details.path from the result record
   if (hasImageContent) {
+    // First try path from image block
+    if (imagePathFromBlock) {
+      return [imagePathFromBlock];
+    }
+    // Fall back to details.path
     const details = record.details as Record<string, unknown> | undefined;
     const p = typeof details?.path === "string" ? details.path.trim() : "";
     if (p) {

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -108,8 +108,9 @@ export function splitMediaFromOutput(raw: string): {
 
   const media: string[] = [];
   let foundMediaToken = false;
+  let foundMediaInFence = false; // Track if we found MEDIA tokens inside code fences
 
-  // Parse fenced code blocks to avoid extracting MEDIA tokens from inside them
+  // Parse fenced code blocks to identify MEDIA tokens inside them
   const hasFenceMarkers = mayContainFenceMarkers(trimmedRaw);
   const fenceSpans = hasFenceMarkers ? parseFenceSpans(trimmedRaw) : [];
 
@@ -119,18 +120,27 @@ export function splitMediaFromOutput(raw: string): {
 
   let lineOffset = 0; // Track character offset for fence checking
   for (const line of lines) {
-    // Skip MEDIA extraction if this line is inside a fenced code block
-    if (hasFenceMarkers && isInsideFence(fenceSpans, lineOffset)) {
-      keptLines.push(line);
-      lineOffset += line.length + 1; // +1 for newline
-      continue;
-    }
-
+    const isInsideFenceBlock = hasFenceMarkers && isInsideFence(fenceSpans, lineOffset);
+    
     const trimmedStart = line.trimStart();
     if (!trimmedStart.startsWith("MEDIA:")) {
       keptLines.push(line);
       lineOffset += line.length + 1; // +1 for newline
       continue;
+    }
+
+    // Extract MEDIA tokens even from inside code fences
+    // LLMs frequently wrap paths in code blocks, and these should still be delivered
+    const matches = Array.from(line.matchAll(MEDIA_TOKEN_RE));
+    if (matches.length === 0) {
+      keptLines.push(line);
+      lineOffset += line.length + 1; // +1 for newline
+      continue;
+    }
+
+    // Track if this MEDIA token was inside a code fence
+    if (isInsideFenceBlock) {
+      foundMediaInFence = true;
     }
 
     const matches = Array.from(line.matchAll(MEDIA_TOKEN_RE));
@@ -221,7 +231,8 @@ export function splitMediaFromOutput(raw: string): {
       .trim();
 
     // If the line becomes empty, drop it.
-    if (cleanedLine) {
+    // For MEDIA tokens inside code fences, strip the entire line to avoid leaking the token
+    if (cleanedLine && !(isInsideFenceBlock && foundMediaInFence)) {
       keptLines.push(cleanedLine);
     }
     lineOffset += line.length + 1; // +1 for newline

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -143,13 +143,6 @@ export function splitMediaFromOutput(raw: string): {
       foundMediaInFence = true;
     }
 
-    const matches = Array.from(line.matchAll(MEDIA_TOKEN_RE));
-    if (matches.length === 0) {
-      keptLines.push(line);
-      lineOffset += line.length + 1; // +1 for newline
-      continue;
-    }
-
     const pieces: string[] = [];
     let cursor = 0;
 


### PR DESCRIPTION
## Summary
Previously, `resolveReceiveIdType()` always defaulted to `'user_id'` when no explicit prefix was present, ignoring user configuration.

## Problem
Users who configured `messageDefaults.receive_id_type: 'open_id'` in their `openclaw.json` still got 404 errors because OpenClaw was sending `receive_id_type=user_id` instead of the configured `open_id`.

## Solution
This commit:
- Adds `messageDefaults.receive_id_type` config option to `FeishuConfigSchema`
- Modifies `resolveReceiveIdType()` to accept an optional `defaultType` parameter
- Updates `resolveFeishuSendTarget()` to pass the configured default

## Usage
Now users can set:
```json
{
  "channels": {
    "feishu": {
      "messageDefaults": {
        "receive_id_type": "open_id"
      }
    }
  }
}
```

This will use `open_id` by default instead of `user_id`, fixing 404 errors for apps configured with open_id-based receive IDs.

**Note**: This PR is based on the critical fix (#42732) that removes duplicate variable declarations.

Fixes #42448