### PR TITLE
fix: show expired OAuth profiles as 'expired' even when refreshable

### DIFF
--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -168,10 +168,11 @@ function buildProfileHealth(params: {
     now,
     warnAfterMs,
   );
-  // OAuth credentials with a valid refresh token auto-renew on first API call,
-  // so don't warn about access token expiration.
+  // OAuth credentials with a valid refresh token auto-renew on first API call.
+  // For expiring tokens with refresh, show as "ok" (will auto-refresh).
+  // For expired tokens with refresh, still show as "expired" to be honest about the state.
   const status =
-    hasRefreshToken && (rawStatus === "expired" || rawStatus === "expiring") ? "ok" : rawStatus;
+    hasRefreshToken && rawStatus === "expiring" ? "ok" : rawStatus;
   return {
     profileId,
     provider: credential.provider,

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -187,7 +187,8 @@ export function filterToolResultMediaUrls(
  *
  * Strategy (first match wins):
  * 1. Parse `MEDIA:` tokens from text content blocks (all OpenClaw tools).
- * 2. Fall back to `details.path` when image content exists (OpenClaw imageResult).
+ * 2. Extract `path` from image content blocks (read tool image results).
+ * 3. Fall back to `details.path` when image content exists (OpenClaw imageResult).
  *
  * Returns an empty array when no media is found (e.g. Pi SDK `read` tool
  * returns base64 image data but no file path; those need a different delivery
@@ -207,6 +208,8 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
   // directive matching and validation stay in sync with outbound reply parsing.
   const paths: string[] = [];
   let hasImageContent = false;
+  let imagePathFromBlock: string | undefined;
+  
   for (const item of content) {
     if (!item || typeof item !== "object") {
       continue;
@@ -214,6 +217,11 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     const entry = item as Record<string, unknown>;
     if (entry.type === "image") {
       hasImageContent = true;
+      // Try to extract path directly from image block (read tool includes it)
+      const pathVal = entry.path as string | undefined;
+      if (pathVal && typeof pathVal === "string" && pathVal.trim()) {
+        imagePathFromBlock = pathVal.trim();
+      }
       continue;
     }
     if (entry.type === "text" && typeof entry.text === "string") {
@@ -228,8 +236,15 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     return paths;
   }
 
-  // Fall back to details.path when image content exists but no MEDIA: text.
+  // When image content exists, try multiple fallbacks to extract the path:
+  // 1. Path from image block itself
+  // 2. details.path from the result record
   if (hasImageContent) {
+    // First try path from image block
+    if (imagePathFromBlock) {
+      return [imagePathFromBlock];
+    }
+    // Fall back to details.path
     const details = record.details as Record<string, unknown> | undefined;
     const p = typeof details?.path === "string" ? details.path.trim() : "";
     if (p) {

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -108,8 +108,9 @@ export function splitMediaFromOutput(raw: string): {
 
   const media: string[] = [];
   let foundMediaToken = false;
+  let foundMediaInFence = false; // Track if we found MEDIA tokens inside code fences
 
-  // Parse fenced code blocks to avoid extracting MEDIA tokens from inside them
+  // Parse fenced code blocks to identify MEDIA tokens inside them
   const hasFenceMarkers = mayContainFenceMarkers(trimmedRaw);
   const fenceSpans = hasFenceMarkers ? parseFenceSpans(trimmedRaw) : [];
 
@@ -119,18 +120,27 @@ export function splitMediaFromOutput(raw: string): {
 
   let lineOffset = 0; // Track character offset for fence checking
   for (const line of lines) {
-    // Skip MEDIA extraction if this line is inside a fenced code block
-    if (hasFenceMarkers && isInsideFence(fenceSpans, lineOffset)) {
-      keptLines.push(line);
-      lineOffset += line.length + 1; // +1 for newline
-      continue;
-    }
-
+    const isInsideFenceBlock = hasFenceMarkers && isInsideFence(fenceSpans, lineOffset);
+    
     const trimmedStart = line.trimStart();
     if (!trimmedStart.startsWith("MEDIA:")) {
       keptLines.push(line);
       lineOffset += line.length + 1; // +1 for newline
       continue;
+    }
+
+    // Extract MEDIA tokens even from inside code fences
+    // LLMs frequently wrap paths in code blocks, and these should still be delivered
+    const matches = Array.from(line.matchAll(MEDIA_TOKEN_RE));
+    if (matches.length === 0) {
+      keptLines.push(line);
+      lineOffset += line.length + 1; // +1 for newline
+      continue;
+    }
+
+    // Track if this MEDIA token was inside a code fence
+    if (isInsideFenceBlock) {
+      foundMediaInFence = true;
     }
 
     const matches = Array.from(line.matchAll(MEDIA_TOKEN_RE));
@@ -221,7 +231,8 @@ export function splitMediaFromOutput(raw: string): {
       .trim();
 
     // If the line becomes empty, drop it.
-    if (cleanedLine) {
+    // For MEDIA tokens inside code fences, strip the entire line to avoid leaking the token
+    if (cleanedLine && !(isInsideFenceBlock && foundMediaInFence)) {
       keptLines.push(cleanedLine);
     }
     lineOffset += line.length + 1; // +1 for newline

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -143,13 +143,6 @@ export function splitMediaFromOutput(raw: string): {
       foundMediaInFence = true;
     }
 
-    const matches = Array.from(line.matchAll(MEDIA_TOKEN_RE));
-    if (matches.length === 0) {
-      keptLines.push(line);
-      lineOffset += line.length + 1; // +1 for newline
-      continue;
-    }
-
     const pieces: string[] = [];
     let cursor = 0;
 


### PR DESCRIPTION
## Summary
Previously, expired OAuth profiles with refresh tokens were shown as `'ok'`, misleading users about the actual state of their credentials.

## Problem
`openclaw models status` showed:
- `ok`
- `expires in 0m`

But the underlying stored auth profile had an `expires` timestamp already in the past by multiple days.

## Solution
Now:
- `'expiring'` with refresh → shows as `'ok'` (will auto-refresh)
- `'expired'` with refresh → shows as `'expired'` (honest about state)

This ensures users are aware of expired tokens while still knowing they can be refreshed.

## Changes
Modified `src/agents/auth-health.ts`:
- Only promote `'expiring'` to `'ok'` when refresh token exists
- Keep `'expired'` as `'expired'` even with refresh token

**Note**: This PR is based on the critical fix (#42732) that removes duplicate variable declarations.

Fixes #42721