### PR TITLE
Fix false unknown-entry warnings for optional coding tools

### DIFF
--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -45,6 +45,26 @@ describe("tool-policy-pipeline", () => {
     expect(warnings[0]).toContain("unknown entries (wat)");
   });
 
+  test("does not warn for known core ids that are currently unavailable", () => {
+    const warnings: string[] = [];
+    const tools = [{ name: "exec" }] as unknown as DummyTool[];
+    applyToolPolicyPipeline({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tools: tools as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      steps: [
+        {
+          policy: { allow: ["exec", "apply_patch", "memory_search", "memory_get"] },
+          label: "tools.profile (coding)",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+    expect(warnings.length).toBe(0);
+  });
+
   test("applies allowlist filtering when core tools are explicitly listed", () => {
     const tools = [{ name: "exec" }, { name: "process" }] as unknown as DummyTool[];
     const filtered = applyToolPolicyPipeline({

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -1,3 +1,4 @@
+import { isKnownCoreToolId } from "./tool-catalog.js";
 import {
   expandToolGroups,
   normalizeToolList,
@@ -173,10 +174,11 @@ export function stripPluginOnlyAllowlist(
       entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry);
     const expanded = expandToolGroups([entry]);
     const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
+    const isKnownCoreEntry = expanded.some((tool) => isKnownCoreToolId(tool));
     if (isCoreEntry) {
       hasCoreEntry = true;
     }
-    if (!isCoreEntry && !isPluginEntry) {
+    if (!isCoreEntry && !isPluginEntry && !isKnownCoreEntry) {
       unknownAllowlist.push(entry);
     }
   }


### PR DESCRIPTION
## Summary\n- treat known core tool ids as known during allowlist validation, even when that tool is unavailable in the current runtime\n- keep existing stripping behavior based on actually available core tools\n- add regression coverage for coding profile allowlists containing optional tools (pply_patch, memory_search, memory_get)\n\n## Repro\n1. Use 	ools.profile: coding\n2. Run in an environment where pply_patch and memory tools are disabled/unavailable\n3. Observe warning: llowlist contains unknown entries (apply_patch, memory_search, memory_get)\n\n## Result\nKnown core ids no longer produce that warning. Truly unknown entries still do.\n\nFixes #42726\n\n## Validation\n- pnpm test -- --run src/agents/tool-policy-pipeline.test.ts\n