### PR TITLE
Memory: preserve chunks in FTS-only reindex mode

### DIFF
--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -15,18 +15,27 @@ vi.mock("./embeddings.js", () => {
     return [alpha, beta];
   };
   return {
-    createEmbeddingProvider: async (options: { model?: string }) => ({
-      requestedProvider: "openai",
-      provider: {
-        id: "mock",
-        model: options.model ?? "mock-embed",
-        embedQuery: async (text: string) => embedText(text),
-        embedBatch: async (texts: string[]) => {
-          embedBatchCalls += 1;
-          return texts.map(embedText);
+    createEmbeddingProvider: async (options: { model?: string }) => {
+      if (options.model === "fts-only-test") {
+        return {
+          requestedProvider: "auto",
+          provider: null,
+          providerUnavailableReason: "No embedding provider configured",
+        };
+      }
+      return {
+        requestedProvider: "openai",
+        provider: {
+          id: "mock",
+          model: options.model ?? "mock-embed",
+          embedQuery: async (text: string) => embedText(text),
+          embedBatch: async (texts: string[]) => {
+            embedBatchCalls += 1;
+            return texts.map(embedText);
+          },
         },
-      },
-    }),
+      };
+    },
   };
 });
 
@@ -41,6 +50,7 @@ describe("memory index", () => {
   let indexStatusPath = "";
   let indexSourceChangePath = "";
   let indexModelPath = "";
+  let indexFtsOnlyPath = "";
   let sourceChangeStateDir = "";
   const sourceChangeSessionLogLines = [
     JSON.stringify({
@@ -74,6 +84,7 @@ describe("memory index", () => {
     indexStatusPath = path.join(workspaceDir, "index-status.sqlite");
     indexSourceChangePath = path.join(workspaceDir, "index-source-change.sqlite");
     indexModelPath = path.join(workspaceDir, "index-model-change.sqlite");
+    indexFtsOnlyPath = path.join(workspaceDir, "index-fts-only.sqlite");
     sourceChangeStateDir = path.join(fixtureRoot, "state-source-change");
 
     await fs.mkdir(memoryDir, { recursive: true });
@@ -353,6 +364,27 @@ describe("memory index", () => {
 
     await manager.sync({ force: true });
     expect(embedBatchCalls).toBe(afterFirst);
+  });
+
+  it("keeps chunks indexed across force sync in FTS-only mode", async () => {
+    const cfg = createCfg({
+      storePath: indexFtsOnlyPath,
+      model: "fts-only-test",
+      hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ force: true });
+    const firstStatus = manager.status();
+    expect(firstStatus.provider).toBe("none");
+    expect(firstStatus.chunks).toBeGreaterThan(0);
+
+    await manager.sync({ force: true });
+    const secondStatus = manager.status();
+    expect(secondStatus.chunks).toBeGreaterThan(0);
+
+    const results = await manager.search("zebra");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.path).toContain("memory/2026-01-12.md");
   });
 
   it("finds keyword matches via hybrid search when query embedding is zero", async () => {

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -34,6 +34,7 @@ const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_LOCAL_MS = 10 * 60_000;
+const FTS_ONLY_MODEL = "fts-only";
 
 const vectorToBlob = (embedding: number[]): Buffer =>
   Buffer.from(new Float32Array(embedding).buffer);
@@ -694,31 +695,25 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     entry: MemoryFileEntry | SessionFileEntry,
     options: { source: MemorySource; content?: string },
   ) {
-    // FTS-only mode: skip indexing if no provider
-    if (!this.provider) {
-      log.debug("Skipping embedding indexing in FTS-only mode", {
-        path: entry.path,
-        source: options.source,
-      });
-      return;
-    }
-
+    const providerModel = this.provider?.model ?? FTS_ONLY_MODEL;
     const content = options.content ?? (await fs.readFile(entry.absPath, "utf-8"));
-    const chunks = enforceEmbeddingMaxInputTokens(
-      this.provider,
-      chunkMarkdown(content, this.settings.chunking).filter(
-        (chunk) => chunk.text.trim().length > 0,
-      ),
-      EMBEDDING_BATCH_MAX_TOKENS,
+    const chunked = chunkMarkdown(content, this.settings.chunking).filter(
+      (chunk) => chunk.text.trim().length > 0,
     );
+    const chunks = this.provider
+      ? enforceEmbeddingMaxInputTokens(this.provider, chunked, EMBEDDING_BATCH_MAX_TOKENS)
+      : chunked;
     if (options.source === "sessions" && "lineMap" in entry) {
       remapChunkLines(chunks, entry.lineMap);
     }
-    const embeddings = this.batch.enabled
-      ? await this.embedChunksWithBatch(chunks, entry, options.source)
-      : await this.embedChunksInBatches(chunks);
+    const embeddings = this.provider
+      ? this.batch.enabled
+        ? await this.embedChunksWithBatch(chunks, entry, options.source)
+        : await this.embedChunksInBatches(chunks)
+      : chunks.map(() => []);
     const sample = embeddings.find((embedding) => embedding.length > 0);
-    const vectorReady = sample ? await this.ensureVectorReady(sample.length) : false;
+    const vectorReady =
+      sample && this.provider ? await this.ensureVectorReady(sample.length) : false;
     const now = Date.now();
     if (vectorReady) {
       try {
@@ -731,9 +726,16 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
     if (this.fts.enabled && this.fts.available) {
       try {
-        this.db
-          .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-          .run(entry.path, options.source, this.provider.model);
+        if (this.provider) {
+          this.db
+            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
+            .run(entry.path, options.source, providerModel);
+        } else {
+          // FTS-only search scans all models, so remove stale rows for the file/source.
+          this.db
+            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+            .run(entry.path, options.source);
+        }
       } catch {}
     }
     this.db
@@ -743,7 +745,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       const chunk = chunks[i];
       const embedding = embeddings[i] ?? [];
       const id = hashText(
-        `${options.source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${this.provider.model}`,
+        `${options.source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${providerModel}`,
       );
       this.db
         .prepare(
@@ -763,7 +765,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           chunk.startLine,
           chunk.endLine,
           chunk.hash,
-          this.provider.model,
+          providerModel,
           chunk.text,
           JSON.stringify(embedding),
           now,
@@ -787,7 +789,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
             id,
             entry.path,
             options.source,
-            this.provider.model,
+            providerModel,
             chunk.startLine,
             chunk.endLine,
           );

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -643,12 +643,6 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    // FTS-only mode: skip embedding sync (no provider)
-    if (!this.provider) {
-      log.debug("Skipping memory file sync in FTS-only mode (no embedding provider)");
-      return;
-    }
-
     const files = await listMemoryFiles(this.workspaceDir, this.settings.extraPaths);
     const fileEntries = (
       await Promise.all(files.map(async (file) => buildFileEntry(file, this.workspaceDir)))
@@ -712,9 +706,15 @@ export abstract class MemoryManagerSyncOps {
       this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(stale.path, "memory");
       if (this.fts.enabled && this.fts.available) {
         try {
-          this.db
-            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-            .run(stale.path, "memory", this.provider.model);
+          if (this.provider) {
+            this.db
+              .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
+              .run(stale.path, "memory", this.provider.model);
+          } else {
+            this.db
+              .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+              .run(stale.path, "memory");
+          }
         } catch {}
       }
     }
@@ -724,12 +724,6 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    // FTS-only mode: skip embedding sync (no provider)
-    if (!this.provider) {
-      log.debug("Skipping session file sync in FTS-only mode (no embedding provider)");
-      return;
-    }
-
     const files = await listSessionFilesForAgent(this.agentId);
     const activePaths = new Set(files.map((file) => sessionPathForFile(file)));
     const indexAll = params.needsFullReindex || this.sessionsDirtyFiles.size === 0;
@@ -819,9 +813,15 @@ export abstract class MemoryManagerSyncOps {
         .run(stale.path, "sessions");
       if (this.fts.enabled && this.fts.available) {
         try {
-          this.db
-            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-            .run(stale.path, "sessions", this.provider.model);
+          if (this.provider) {
+            this.db
+              .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
+              .run(stale.path, "sessions", this.provider.model);
+          } else {
+            this.db
+              .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+              .run(stale.path, "sessions");
+          }
         } catch {}
       }
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In FTS-only mode (no embedding provider), full sync/reindex cleared `chunks`/`files` and then skipped re-indexing, leaving memory empty.
- Why it matters: `openclaw memory index` and gateway-triggered reindex could silently wipe stored memory data.
- What changed: FTS-only mode now still indexes memory/session files into `chunks` + FTS using a stable `fts-only` model key; stale FTS cleanup now handles no-provider mode correctly.
- What did NOT change (scope boundary): Embedding provider selection, vector indexing behavior, and non-memory subsystems.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42714
- Related #

## User-visible / Behavior Changes

- `openclaw memory index` no longer clears memory data when no embedding provider is configured.
- FTS-only mode now preserves and rebuilds searchable chunks during forced reindex.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22+, pnpm
- Model/provider: mocked embedding provider; explicit no-provider (FTS-only) path covered in test
- Integration/channel (if any): N/A
- Relevant config (redacted): memorySearch sqlite store paths in test fixtures

### Steps

1. Run memory indexing with no embedding provider available (FTS-only mode).
2. Force reindex again.
3. Verify chunks remain indexed and searchable.

### Expected

- Reindex in FTS-only mode preserves/rebuilds chunks instead of ending at zero rows.

### Actual

- After fix: chunks remain populated and keyword search returns results in FTS-only mode.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm vitest src/memory/index.test.ts`
  - Result: passed (11 tests)
- `pnpm vitest src/memory/manager.atomic-reindex.test.ts`
  - Result: passed (1 test)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: FTS-only forced reindex keeps chunks > 0 and returns keyword hits; provider-backed index tests still pass.
- Edge cases checked: stale FTS cleanup in no-provider mode deletes by path/source (all models) to avoid stale duplicate rows.
- What you did **not** verify: full end-to-end gateway install flow against a live user profile.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Memory: preserve chunks in FTS-only reindex`.
- Files/config to restore: `src/memory/manager-sync-ops.ts`, `src/memory/manager-embedding-ops.ts`.
- Known bad symptoms reviewers should watch for: duplicate or missing FTS rows after repeated syncs.

## Risks and Mitigations

- Risk: FTS table cleanup behavior differs when provider is absent.
  - Mitigation: explicit regression test covers forced reindex + search in FTS-only mode.
