### PR TITLE
Route exec approval prompts to originating chat channels

### DIFF
--- a/src/channels/plugins/outbound/slack.sendpayload.test.ts
+++ b/src/channels/plugins/outbound/slack.sendpayload.test.ts
@@ -80,6 +80,23 @@ describe("slackOutbound sendPayload", () => {
     expect(result).toEqual({ channel: "slack", messageId: "" });
   });
 
+  it("passes Slack blocks from channelData on text payloads", async () => {
+    const blocks = [{ type: "divider" }];
+    const ctx = baseCtx({
+      text: "",
+      channelData: { slack: { blocks } },
+    });
+    const result = await slackOutbound.sendPayload!(ctx);
+
+    expect(ctx.deps.sendSlack).toHaveBeenCalledTimes(1);
+    expect(ctx.deps.sendSlack).toHaveBeenCalledWith(
+      "C12345",
+      "",
+      expect.objectContaining({ blocks }),
+    );
+    expect(result).toMatchObject({ channel: "slack", messageId: "sl-1" });
+  });
+
   it("text exceeding chunk limit is sent as-is when chunker is null", async () => {
     // Slack has chunker: null, so long text should be sent as a single message
     const ctx = baseCtx({ text: "a".repeat(5000) });

--- a/src/channels/plugins/outbound/slack.ts
+++ b/src/channels/plugins/outbound/slack.ts
@@ -1,3 +1,5 @@
+import type { Block, KnownBlock } from "@slack/web-api";
+import type { ReplyPayload } from "../../../auto-reply/types.js";
 import type { OutboundIdentity } from "../../../infra/outbound/identity.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { sendMessageSlack, type SlackSendIdentity } from "../../../slack/send.js";
@@ -51,6 +53,7 @@ async function sendSlackOutboundMessage(params: {
   cfg: NonNullable<Parameters<typeof sendMessageSlack>[2]>["cfg"];
   to: string;
   text: string;
+  blocks?: (Block | KnownBlock)[];
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
   accountId?: string | null;
@@ -87,17 +90,41 @@ async function sendSlackOutboundMessage(params: {
     ...(params.mediaUrl
       ? { mediaUrl: params.mediaUrl, mediaLocalRoots: params.mediaLocalRoots }
       : {}),
+    ...(params.blocks ? { blocks: params.blocks } : {}),
     ...(slackIdentity ? { identity: slackIdentity } : {}),
   });
   return { channel: "slack" as const, ...result };
+}
+
+function resolveSlackBlocks(payload: ReplyPayload): (Block | KnownBlock)[] | undefined {
+  const slackData = payload.channelData?.slack as { blocks?: unknown } | undefined;
+  return Array.isArray(slackData?.blocks)
+    ? (slackData.blocks as (Block | KnownBlock)[])
+    : undefined;
 }
 
 export const slackOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 4000,
-  sendPayload: async (ctx) =>
-    await sendTextMediaPayload({ channel: "slack", ctx, adapter: slackOutbound }),
+  sendPayload: async (ctx) => {
+    const blocks = resolveSlackBlocks(ctx.payload);
+    const hasMedia = Boolean(ctx.payload.mediaUrl) || (ctx.payload.mediaUrls?.length ?? 0) > 0;
+    if (blocks && !hasMedia) {
+      return await sendSlackOutboundMessage({
+        cfg: ctx.cfg,
+        to: ctx.to,
+        text: ctx.payload.text ?? "",
+        blocks,
+        accountId: ctx.accountId,
+        deps: ctx.deps,
+        replyToId: ctx.replyToId,
+        threadId: ctx.threadId,
+        identity: ctx.identity,
+      });
+    }
+    return await sendTextMediaPayload({ channel: "slack", ctx, adapter: slackOutbound });
+  },
   sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity }) => {
     return await sendSlackOutboundMessage({
       cfg,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -611,7 +611,7 @@ export const FIELD_HELP: Record<string, string> = {
   "approvals.exec":
     "Groups exec-approval forwarding behavior including enablement, routing mode, filters, and explicit targets. Configure here when approval prompts must reach operational channels instead of only the origin thread.",
   "approvals.exec.enabled":
-    "Enables forwarding of exec approval requests to configured delivery destinations (default: false). Keep disabled in low-risk setups and enable only when human approval responders need channel-visible prompts.",
+    "Enables forwarding of exec approval requests to configured delivery destinations (default: true). Set false only when you intentionally want approvals to stay on operator clients such as Control UI.",
   "approvals.exec.mode":
     'Controls where approval prompts are sent: "session" uses origin chat, "targets" uses configured targets, and "both" sends to both paths. Use "session" as baseline and expand only when operational workflow requires redundancy.',
   "approvals.exec.agentFilter":

--- a/src/config/types.approvals.ts
+++ b/src/config/types.approvals.ts
@@ -12,7 +12,7 @@ export type ExecApprovalForwardTarget = {
 };
 
 export type ExecApprovalForwardingConfig = {
-  /** Enable forwarding exec approvals to chat channels. Default: false. */
+  /** Enable forwarding exec approvals to chat channels. Default: true. */
   enabled?: boolean;
   /** Delivery mode (session=origin chat, targets=config targets, both=both). Default: session. */
   mode?: ExecApprovalForwardingMode;

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -505,13 +505,32 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       );
     }
 
-    // Initialize exec approvals handler if enabled
+    // Initialize exec approvals handler when explicitly enabled, or implicitly
+    // when allowFrom is configured (so approval buttons work in the origin channel).
     const execApprovalsConfig = discordCfg.execApprovals ?? {};
-    const execApprovalsHandler = execApprovalsConfig.enabled
+    const fallbackApprovers = Array.isArray(allowFrom)
+      ? [...new Set(allowFrom.map((entry) => String(entry).trim()).filter(Boolean))]
+      : [];
+    const resolvedExecApprovalsConfig = {
+      ...execApprovalsConfig,
+      approvers:
+        execApprovalsConfig.approvers && execApprovalsConfig.approvers.length > 0
+          ? execApprovalsConfig.approvers
+          : fallbackApprovers,
+      enabled:
+        execApprovalsConfig.enabled ??
+        (fallbackApprovers.length > 0 ? true : execApprovalsConfig.enabled),
+      target:
+        execApprovalsConfig.target ??
+        (execApprovalsConfig.enabled === undefined && fallbackApprovers.length > 0
+          ? "channel"
+          : undefined),
+    };
+    const execApprovalsHandler = resolvedExecApprovalsConfig.enabled
       ? new DiscordExecApprovalHandler({
           token,
           accountId: account.accountId,
-          config: execApprovalsConfig,
+          config: resolvedExecApprovalsConfig,
           cfg,
           runtime,
         })

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -27,6 +27,16 @@ function getFirstDeliveryText(deliver: ReturnType<typeof vi.fn>): string {
   return firstCall?.payloads?.[0]?.text ?? "";
 }
 
+function getFirstDeliveryPayload(deliver: ReturnType<typeof vi.fn>): {
+  text?: string;
+  channelData?: Record<string, unknown>;
+} {
+  const firstCall = deliver.mock.calls[0]?.[0] as
+    | { payloads?: Array<{ text?: string; channelData?: Record<string, unknown> }> }
+    | undefined;
+  return firstCall?.payloads?.[0] ?? {};
+}
+
 const TARGETS_CFG = {
   approvals: {
     exec: {
@@ -57,17 +67,27 @@ function createForwarder(params: {
   return { deliver, forwarder };
 }
 
-function makeSessionCfg(options: { discordExecApprovalsEnabled?: boolean } = {}): OpenClawConfig {
+function makeSessionCfg(
+  options: {
+    discordExecApprovalsEnabled?: boolean;
+    discordAllowFrom?: string[];
+  } = {},
+): OpenClawConfig {
+  const discordChannelConfig: Record<string, unknown> = {};
+  if (options.discordAllowFrom?.length) {
+    discordChannelConfig.allowFrom = options.discordAllowFrom;
+  }
+  if (options.discordExecApprovalsEnabled) {
+    discordChannelConfig.execApprovals = {
+      enabled: true,
+      approvers: ["123"],
+    };
+  }
   return {
-    ...(options.discordExecApprovalsEnabled
+    ...(Object.keys(discordChannelConfig).length > 0
       ? {
           channels: {
-            discord: {
-              execApprovals: {
-                enabled: true,
-                approvers: ["123"],
-              },
-            },
+            discord: discordChannelConfig,
           },
         }
       : {}),
@@ -191,12 +211,23 @@ describe("exec approval forwarder", () => {
     expect(getFirstDeliveryText(deliver)).toContain("Command:\n```\necho `uname`\necho done\n```");
   });
 
-  it("returns false when forwarding is disabled", async () => {
+  it("returns false when forwarding is explicitly disabled", async () => {
     const { deliver, forwarder } = createForwarder({
-      cfg: {} as OpenClawConfig,
+      cfg: {
+        approvals: { exec: { enabled: false } },
+      } as OpenClawConfig,
     });
     await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(false);
     expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("forwards by default when approvals.exec is omitted", async () => {
+    const { deliver, forwarder } = createForwarder({
+      cfg: {} as OpenClawConfig,
+      resolveSessionTarget: () => ({ channel: "slack", to: "U1" }),
+    });
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+    expect(deliver).toHaveBeenCalledTimes(1);
   });
 
   it("rejects unsafe nested-repetition regex in sessionFilter", async () => {
@@ -236,6 +267,14 @@ describe("exec approval forwarder", () => {
   it("skips discord forwarding when discord exec approvals handler is enabled", async () => {
     await expectDiscordSessionTargetRequest({
       cfg: makeSessionCfg({ discordExecApprovalsEnabled: true }),
+      expectedAccepted: false,
+      expectedDeliveryCount: 0,
+    });
+  });
+
+  it("skips discord forwarding when discord allowFrom implies inline approval handler", async () => {
+    await expectDiscordSessionTargetRequest({
+      cfg: makeSessionCfg({ discordAllowFrom: ["123"] }),
       expectedAccepted: false,
       expectedDeliveryCount: 0,
     });
@@ -336,5 +375,73 @@ describe("exec approval forwarder", () => {
     ).resolves.toBe(true);
 
     expect(getFirstDeliveryText(deliver)).toContain("Command:\n````\necho ```danger```\n````");
+  });
+
+  it("adds Telegram inline approval buttons for forwarded requests", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+
+    const payload = getFirstDeliveryPayload(deliver);
+    expect(payload.channelData).toEqual({
+      telegram: {
+        buttons: [
+          [
+            { text: "✅ Allow", callback_data: "/approve req-1 allow-once" },
+            { text: "⚠️ Always", callback_data: "/approve req-1 allow-always" },
+            { text: "❌ Deny", callback_data: "/approve req-1 deny" },
+          ],
+        ],
+      },
+    });
+  });
+
+  it("adds Slack action blocks for forwarded requests", async () => {
+    vi.useFakeTimers();
+    const cfg = {
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "slack", to: "C1" }],
+        },
+      },
+    } as OpenClawConfig;
+    const { deliver, forwarder } = createForwarder({ cfg });
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+
+    const payload = getFirstDeliveryPayload(deliver);
+    expect(payload.channelData).toEqual({
+      slack: {
+        blocks: [
+          {
+            type: "actions",
+            block_id: "openclaw_exec_approval_req-1",
+            elements: [
+              {
+                type: "button",
+                text: { type: "plain_text", text: "✅ Allow once", emoji: true },
+                style: "primary",
+                action_id: "openclaw:exec-approval:allow-once",
+                value: "req-1",
+              },
+              {
+                type: "button",
+                text: { type: "plain_text", text: "⚠️ Always allow", emoji: true },
+                action_id: "openclaw:exec-approval:allow-always",
+                value: "req-1",
+              },
+              {
+                type: "button",
+                text: { type: "plain_text", text: "❌ Deny", emoji: true },
+                style: "danger",
+                action_id: "openclaw:exec-approval:deny",
+                value: "req-1",
+              },
+            ],
+          },
+        ],
+      },
+    });
   });
 });

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -32,6 +32,11 @@ type PendingApproval = {
   timeoutId: NodeJS.Timeout | null;
 };
 
+type ForwardDeliveryPayload = {
+  text: string;
+  channelData?: Record<string, unknown>;
+};
+
 export type ExecApprovalForwarder = {
   handleRequested: (request: ExecApprovalRequest) => Promise<boolean>;
   handleResolved: (resolved: ExecApprovalResolved) => Promise<void>;
@@ -69,10 +74,10 @@ function shouldForward(params: {
   request: ExecApprovalRequest;
 }): boolean {
   const config = params.config;
-  if (!config?.enabled) {
+  if (config?.enabled === false) {
     return false;
   }
-  if (config.agentFilter?.length) {
+  if (config?.agentFilter?.length) {
     const agentId =
       params.request.request.agentId ??
       parseAgentSessionKey(params.request.request.sessionKey)?.agentId;
@@ -83,7 +88,7 @@ function shouldForward(params: {
       return false;
     }
   }
-  if (config.sessionFilter?.length) {
+  if (config?.sessionFilter?.length) {
     const sessionKey = params.request.request.sessionKey;
     if (!sessionKey) {
       return false;
@@ -132,10 +137,14 @@ function shouldSkipDiscordForwarding(
   }
   const discord = cfg.channels?.discord as
     | {
+        allowFrom?: Array<string | number>;
         execApprovals?: { enabled?: boolean; approvers?: Array<string | number> };
         accounts?: Record<
           string,
-          { execApprovals?: { enabled?: boolean; approvers?: Array<string | number> } }
+          {
+            allowFrom?: Array<string | number>;
+            execApprovals?: { enabled?: boolean; approvers?: Array<string | number> };
+          }
         >;
       }
     | undefined;
@@ -144,7 +153,10 @@ function shouldSkipDiscordForwarding(
   }
   const account = resolveChannelAccountConfig(discord.accounts, target.accountId);
   const execApprovals = account?.execApprovals ?? discord.execApprovals;
-  return Boolean(execApprovals?.enabled && (execApprovals.approvers?.length ?? 0) > 0);
+  const hasConfiguredApprovers = (execApprovals?.approvers?.length ?? 0) > 0;
+  const fallbackApprovers = account?.allowFrom?.length ?? discord.allowFrom?.length ?? 0;
+  const enabled = execApprovals?.enabled ?? fallbackApprovers > 0;
+  return Boolean(enabled && (hasConfiguredApprovers || fallbackApprovers > 0));
 }
 
 function formatApprovalCommand(command: string): { inline: boolean; text: string } {
@@ -193,6 +205,84 @@ function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
   lines.push(`Expires in: ${expiresIn}s`);
   lines.push("Reply with: /approve <id> allow-once|allow-always|deny");
   return lines.join("\n");
+}
+
+function buildTelegramApprovalButtons(request: ExecApprovalRequest): {
+  telegram: {
+    buttons: Array<Array<{ text: string; callback_data: string }>>;
+  };
+} {
+  return {
+    telegram: {
+      buttons: [
+        [
+          { text: "✅ Allow", callback_data: `/approve ${request.id} allow-once` },
+          { text: "⚠️ Always", callback_data: `/approve ${request.id} allow-always` },
+          { text: "❌ Deny", callback_data: `/approve ${request.id} deny` },
+        ],
+      ],
+    },
+  };
+}
+
+function buildSlackApprovalBlocks(request: ExecApprovalRequest): {
+  slack: {
+    blocks: Array<Record<string, unknown>>;
+  };
+} {
+  return {
+    slack: {
+      blocks: [
+        {
+          type: "actions",
+          block_id: `openclaw_exec_approval_${request.id}`,
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "✅ Allow once", emoji: true },
+              style: "primary",
+              action_id: "openclaw:exec-approval:allow-once",
+              value: request.id,
+            },
+            {
+              type: "button",
+              text: { type: "plain_text", text: "⚠️ Always allow", emoji: true },
+              action_id: "openclaw:exec-approval:allow-always",
+              value: request.id,
+            },
+            {
+              type: "button",
+              text: { type: "plain_text", text: "❌ Deny", emoji: true },
+              style: "danger",
+              action_id: "openclaw:exec-approval:deny",
+              value: request.id,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function buildRequestPayload(
+  channel: DeliverableMessageChannel,
+  request: ExecApprovalRequest,
+  nowMs: number,
+): ForwardDeliveryPayload {
+  const text = buildRequestMessage(request, nowMs);
+  if (channel === "telegram") {
+    return {
+      text,
+      channelData: buildTelegramApprovalButtons(request),
+    };
+  }
+  if (channel === "slack") {
+    return {
+      text,
+      channelData: buildSlackApprovalBlocks(request),
+    };
+  }
+  return { text };
 }
 
 function decisionLabel(decision: ExecApprovalDecision): string {
@@ -261,7 +351,11 @@ function defaultResolveSessionTarget(params: {
 async function deliverToTargets(params: {
   cfg: OpenClawConfig;
   targets: ForwardTarget[];
-  text: string;
+  payload?: ForwardDeliveryPayload;
+  resolvePayload?: (
+    channel: DeliverableMessageChannel,
+    target: ForwardTarget,
+  ) => ForwardDeliveryPayload;
   deliver: typeof deliverOutboundPayloads;
   shouldSend?: () => boolean;
 }) {
@@ -273,6 +367,10 @@ async function deliverToTargets(params: {
     if (!isDeliverableMessageChannel(channel)) {
       return;
     }
+    const payload = params.resolvePayload?.(channel, target) ??
+      params.payload ?? {
+        text: "",
+      };
     try {
       await params.deliver({
         cfg: params.cfg,
@@ -280,7 +378,7 @@ async function deliverToTargets(params: {
         to: target.to,
         accountId: target.accountId,
         threadId: target.threadId,
-        payloads: [{ text: params.text }],
+        payloads: [{ text: payload.text, channelData: payload.channelData }],
       });
     } catch (err) {
       log.error(`exec approvals: failed to deliver to ${channel}:${target.to}: ${String(err)}`);
@@ -366,7 +464,12 @@ export function createExecApprovalForwarder(
         }
         pending.delete(request.id);
         const expiredText = buildExpiredMessage(request);
-        await deliverToTargets({ cfg, targets: entry.targets, text: expiredText, deliver });
+        await deliverToTargets({
+          cfg,
+          targets: entry.targets,
+          payload: { text: expiredText },
+          deliver,
+        });
       })();
     }, expiresInMs);
     timeoutId.unref?.();
@@ -378,11 +481,10 @@ export function createExecApprovalForwarder(
       return false;
     }
 
-    const text = buildRequestMessage(request, nowMs());
     void deliverToTargets({
       cfg,
       targets: filteredTargets,
-      text,
+      resolvePayload: (channel) => buildRequestPayload(channel, request, nowMs()),
       deliver,
       shouldSend: () => pending.get(request.id) === pendingEntry,
     }).catch((err) => {
@@ -423,7 +525,7 @@ export function createExecApprovalForwarder(
       return;
     }
     const text = buildResolvedMessage(resolved);
-    await deliverToTargets({ cfg, targets, text, deliver });
+    await deliverToTargets({ cfg, targets, payload: { text }, deliver });
   };
 
   const stop = () => {

--- a/src/slack/monitor/events/interactions.test.ts
+++ b/src/slack/monitor/events/interactions.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import { registerSlackInteractionEvents } from "./interactions.js";
 
 const enqueueSystemEventMock = vi.fn();
+const callGatewayMock = vi.fn();
 
 vi.mock("../../../infra/system-events.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+vi.mock("../../../gateway/call.js", () => ({
+  callGateway: (...args: unknown[]) => callGatewayMock(...args),
 }));
 
 type RegisteredHandler = (args: {
@@ -151,8 +156,109 @@ function createContext(overrides?: {
 }
 
 describe("registerSlackInteractionEvents", () => {
+  it("resolves exec approvals from button clicks without emitting system events", async () => {
+    enqueueSystemEventMock.mockClear();
+    callGatewayMock.mockReset();
+    callGatewayMock.mockResolvedValue({ ok: true });
+    const { ctx, app, getHandler } = createContext();
+    registerSlackInteractionEvents({ ctx: ctx as never });
+
+    const handler = getHandler();
+    expect(handler).toBeTruthy();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await handler!({
+      ack,
+      respond,
+      body: {
+        user: { id: "U123" },
+        channel: { id: "C1" },
+        container: { channel_id: "C1", message_ts: "100.200", thread_ts: "100.100" },
+        message: {
+          ts: "100.200",
+          text: "fallback",
+          blocks: [
+            {
+              type: "actions",
+              block_id: "openclaw_exec_approval_req-1",
+              elements: [{ type: "button", action_id: "openclaw:exec-approval:allow-once" }],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:exec-approval:allow-once",
+        block_id: "openclaw_exec_approval_req-1",
+        value: "req-1",
+        text: { type: "plain_text", text: "Allow once" },
+      },
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "exec.approval.resolve",
+        params: { id: "req-1", decision: "allow-once" },
+      }),
+    );
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(app.client.chat.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns ephemeral error when exec approval resolve fails", async () => {
+    enqueueSystemEventMock.mockClear();
+    callGatewayMock.mockReset();
+    callGatewayMock.mockRejectedValue(new Error("unknown approval id"));
+    const { ctx, app, getHandler } = createContext();
+    registerSlackInteractionEvents({ ctx: ctx as never });
+
+    const handler = getHandler();
+    expect(handler).toBeTruthy();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await handler!({
+      ack,
+      respond,
+      body: {
+        user: { id: "U123" },
+        channel: { id: "C1" },
+        container: { channel_id: "C1", message_ts: "100.200", thread_ts: "100.100" },
+        message: {
+          ts: "100.200",
+          text: "fallback",
+          blocks: [
+            {
+              type: "actions",
+              block_id: "openclaw_exec_approval_req-1",
+              elements: [{ type: "button", action_id: "openclaw:exec-approval:deny" }],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:exec-approval:deny",
+        block_id: "openclaw_exec_approval_req-1",
+        value: "req-1",
+        text: { type: "plain_text", text: "Deny" },
+      },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith({
+      text: "Failed to submit approval. It may have expired.",
+      response_type: "ephemeral",
+    });
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(app.client.chat.update).not.toHaveBeenCalled();
+  });
+
   it("enqueues structured events and updates button rows", async () => {
     enqueueSystemEventMock.mockClear();
+    callGatewayMock.mockReset();
     const { ctx, app, getHandler, resolveSessionKey } = createContext();
     registerSlackInteractionEvents({ ctx: ctx as never });
 

--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -1,5 +1,6 @@
 import type { SlackActionMiddlewareArgs } from "@slack/bolt";
 import type { Block, KnownBlock } from "@slack/web-api";
+import { callGateway } from "../../../gateway/call.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
@@ -12,6 +13,7 @@ import {
 
 // Prefix for OpenClaw-generated action IDs to scope our handler
 const OPENCLAW_ACTION_PREFIX = "openclaw:";
+const EXEC_APPROVAL_ACTION_PREFIX = "openclaw:exec-approval:";
 const SLACK_INTERACTION_EVENT_PREFIX = "Slack interaction: ";
 const REDACTED_INTERACTION_VALUE = "[redacted]";
 const SLACK_INTERACTION_EVENT_MAX_CHARS = 2400;
@@ -52,6 +54,30 @@ type InteractionSummary = InteractionSelectionFields & {
   messageTs?: string;
   threadTs?: string;
 };
+
+type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
+
+function parseExecApprovalAction(params: {
+  actionId: string;
+  value: unknown;
+}): { approvalId: string; decision: ExecApprovalDecision } | null {
+  const actionId = params.actionId.trim().toLowerCase();
+  if (!actionId.startsWith(EXEC_APPROVAL_ACTION_PREFIX)) {
+    return null;
+  }
+  const decisionRaw = actionId.slice(EXEC_APPROVAL_ACTION_PREFIX.length);
+  if (decisionRaw !== "allow-once" && decisionRaw !== "allow-always" && decisionRaw !== "deny") {
+    return null;
+  }
+  const approvalId = typeof params.value === "string" ? params.value.trim() : "";
+  if (!approvalId) {
+    return null;
+  }
+  return {
+    approvalId,
+    decision: decisionRaw,
+  };
+}
 
 function truncateInteractionString(
   value: string,
@@ -542,6 +568,40 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
         threadTs,
       };
 
+      const approvalAction = parseExecApprovalAction({
+        actionId,
+        value: actionSummary.value,
+      });
+      if (approvalAction) {
+        try {
+          await callGateway({
+            config: ctx.cfg,
+            method: "exec.approval.resolve",
+            params: {
+              id: approvalAction.approvalId,
+              decision: approvalAction.decision,
+            },
+            clientDisplayName: `Slack approval (${userId})`,
+            mode: "backend",
+          });
+        } catch (err) {
+          ctx.runtime.log?.(
+            `slack:interaction approval resolve failed action=${actionId} user=${userId}: ${String(err)}`,
+          );
+          if (respond) {
+            try {
+              await respond({
+                text: "Failed to submit approval. It may have expired.",
+                response_type: "ephemeral",
+              });
+            } catch {
+              // best-effort feedback only
+            }
+          }
+          return;
+        }
+      }
+
       // Log the interaction for debugging
       ctx.runtime.log?.(
         `slack:interaction action=${actionId} type=${actionSummary.actionType ?? "unknown"} user=${userId} channel=${channelId}`,
@@ -559,10 +619,12 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
       const contextParts = ["slack:interaction", channelId, messageTs, actionId].filter(Boolean);
       const contextKey = contextParts.join(":");
 
-      enqueueSystemEvent(formatSlackInteractionSystemEvent(eventPayload), {
-        sessionKey,
-        contextKey,
-      });
+      if (!approvalAction) {
+        enqueueSystemEvent(formatSlackInteractionSystemEvent(eventPayload), {
+          sessionKey,
+          contextKey,
+        });
+      }
 
       const originalBlocks = typedBody.message?.blocks;
       if (!Array.isArray(originalBlocks) || !channelId || !messageTs) {


### PR DESCRIPTION
## Summary

- Problem: exec approval prompts were not consistently shown in the originating chat channel and Slack/Telegram lacked direct in-message approval actions.
- Why it matters: users had to switch to Control UI for approvals, causing friction and timeouts in chat-first/mobile workflows.
- What changed:
  - Exec approval forwarding now defaults to session-origin routing unless explicitly disabled (`approvals.exec.enabled=false`).
  - Forwarded approval prompts now include Telegram inline buttons and Slack Block Kit buttons.
  - Slack button clicks now resolve approvals immediately via `exec.approval.resolve` (no queued system-event detour).
  - Discord provider now auto-enables its existing exec-approval button handler when `allowFrom` is configured, defaulting delivery target to the originating channel for this implicit mode.
  - Added/updated focused tests for forwarder payloads, Slack outbound block delivery, Slack interaction approval resolution, and Discord provider lifecycle coverage.
- What did NOT change (scope boundary):
  - No changes to Web UI approval flow.
  - No changes to core exec approval policy evaluation/allowlist matching.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #28753
- Related #24639
- Related #22078
- Related #26739

## User-visible / Behavior Changes

- Exec approval forwarding now defaults on for session-origin routing unless explicitly disabled.
- Telegram forwarded approvals include inline approval buttons.
- Slack forwarded approvals include in-message buttons; clicking them resolves approvals immediately.
- Discord can now implicitly use its existing button approval handler in channel when `allowFrom` is configured and no explicit exec-approval config is provided.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Slack interactions now invoke gateway RPC (`exec.approval.resolve`) on button click. Mitigation: existing Slack interaction authorization gate remains in place; failed resolution returns ephemeral error and does not auto-approve.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Discord, Slack, Telegram
- Relevant config (redacted): default + channel test fixtures

### Steps

1. Trigger an exec approval request from a session bound to Slack/Telegram/Discord.
2. Verify forwarded prompt appears in originating session target.
3. Click approval actions (Slack/Telegram buttons, Discord handler buttons) and verify approval resolves.

### Expected

- Approval prompt appears in originating channel/session.
- Inline/chat actions resolve approval without switching to Web UI.

### Actual

- Matches expected in focused test coverage below.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios:
  - Focused test suites for forwarder payload routing, Slack outbound payload handling, Slack interaction execution path, and Discord provider lifecycle.
- Edge cases checked:
  - Explicit forwarding disable (`approvals.exec.enabled=false`).
  - Discord duplicate-prevention when Discord inline approval handler path is active.
- What you did **not** verify:
  - Live manual clicks against real Slack/Telegram/Discord accounts in this run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Mostly`)
- Config/env changes? (`Behavior default changed`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - Optional rollback: set `approvals.exec.enabled=false` to disable forwarding.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Set `approvals.exec.enabled=false`.
- Files/config to restore:
  - `src/infra/exec-approval-forwarder.ts`
  - `src/slack/monitor/events/interactions.ts`
  - `src/channels/plugins/outbound/slack.ts`
  - `src/discord/monitor/provider.ts`
- Known bad symptoms reviewers should watch for:
  - Duplicate Discord approval prompts when explicit Discord exec-approval config and forwarding overlap.
  - Slack approval buttons rendering without resolution (interaction auth or gateway call failures).

## Risks and Mitigations

- Risk: default-forwarding may increase approval prompt visibility in chat channels.
  - Mitigation: can be disabled via `approvals.exec.enabled=false`; forwarding still respects filters/matching.
- Risk: Slack button-based resolution path could fail due transient gateway call errors.
  - Mitigation: failures are surfaced ephemerally and do not auto-approve.
