### PR TITLE
fix(webchat): paginated chat history loading + transcript auto-archival

### DIFF
--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -28,6 +28,7 @@ export const ChatHistoryParamsSchema = Type.Object(
   {
     sessionKey: NonEmptyString,
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+    before: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -51,6 +51,7 @@ import {
 import { CHAT_SEND_SESSION_KEY_MAX_LENGTH } from "../protocol/schema/primitives.js";
 import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
 import {
+  archiveOldTranscriptMessages,
   capArrayByJsonBytes,
   loadSessionEntry,
   readSessionMessages,
@@ -832,6 +833,13 @@ export const chatHandlers: GatewayRequestHandlers = {
       hasMore,
       oldestCursor,
     });
+
+    // Non-blocking: archive old transcript entries if the file is large.
+    if (sessionId && storePath) {
+      archiveOldTranscriptMessages(sessionId, storePath, entry?.sessionFile).catch(() => {
+        /* best-effort */
+      });
+    }
   },
   "chat.abort": ({ params, respond, context }) => {
     if (!validateChatAbortParams(params)) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -54,6 +54,7 @@ import {
   capArrayByJsonBytes,
   loadSessionEntry,
   readSessionMessages,
+  readSessionMessagesTail,
   resolveSessionModelRef,
 } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
@@ -751,20 +752,48 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { sessionKey, limit } = params as {
+    const { sessionKey, limit, before } = params as {
       sessionKey: string;
       limit?: number;
+      before?: string;
     };
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
     const sessionId = entry?.sessionId;
-    const rawMessages =
-      sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
+
     const hardMax = 1000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
     const max = Math.min(hardMax, requested);
-    const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
-    const sanitized = stripEnvelopeFromMessages(sliced);
+
+    let rawMessages: unknown[];
+    let hasMore = false;
+    let oldestCursor: string | null = null;
+
+    if (sessionId && storePath) {
+      if (before != null) {
+        // Cursor-based: read tail with before filter
+        const tail = readSessionMessagesTail(
+          sessionId,
+          storePath,
+          entry?.sessionFile,
+          max,
+          before,
+        );
+        rawMessages = tail.messages;
+        hasMore = tail.hasMore;
+        oldestCursor = tail.oldestCursor;
+      } else {
+        // Default: read tail (newest N messages)
+        const tail = readSessionMessagesTail(sessionId, storePath, entry?.sessionFile, max);
+        rawMessages = tail.messages;
+        hasMore = tail.hasMore;
+        oldestCursor = tail.oldestCursor;
+      }
+    } else {
+      rawMessages = [];
+    }
+
+    const sanitized = stripEnvelopeFromMessages(rawMessages);
     const normalized = sanitizeChatHistoryMessages(sanitized);
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
     const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);
@@ -800,6 +829,8 @@ export const chatHandlers: GatewayRequestHandlers = {
       messages: bounded.messages,
       thinkingLevel,
       verboseLevel,
+      hasMore,
+      oldestCursor,
     });
   },
   "chat.abort": ({ params, respond, context }) => {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -118,6 +118,156 @@ export function readSessionMessages(
   return messages;
 }
 
+/**
+ * Parse a single JSONL line into a chat-history message (same logic as readSessionMessages).
+ * Returns null for blank/malformed/non-message lines.
+ */
+function parseTranscriptLine(line: string): unknown | null {
+  if (!line.trim()) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(line);
+    if (parsed?.message) {
+      return parsed.message;
+    }
+    if (parsed?.type === "compaction") {
+      const ts = typeof parsed.timestamp === "string" ? Date.parse(parsed.timestamp) : Number.NaN;
+      const timestamp = Number.isFinite(ts) ? ts : Date.now();
+      return {
+        role: "system",
+        content: [{ type: "text", text: "Compaction" }],
+        timestamp,
+        __openclaw: {
+          kind: "compaction",
+          id: typeof parsed.id === "string" ? parsed.id : undefined,
+        },
+      };
+    }
+  } catch {
+    // ignore bad lines
+  }
+  return null;
+}
+
+export type SessionMessagesTailResult = {
+  messages: unknown[];
+  /** True when there are older messages before the returned window. */
+  hasMore: boolean;
+  /** Cursor string for the oldest returned message (its timestamp as a string). */
+  oldestCursor: string | null;
+};
+
+/**
+ * Read the last `limit` messages from a session transcript, using reverse-read from EOF.
+ * When `beforeCursor` is provided, only messages with timestamp < cursor are considered.
+ */
+export function readSessionMessagesTail(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile: string | undefined,
+  limit: number,
+  beforeCursor?: string,
+): SessionMessagesTailResult {
+  const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile);
+  const filePath = candidates.find((p) => fs.existsSync(p));
+  if (!filePath) {
+    return { messages: [], hasMore: false, oldestCursor: null };
+  }
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(filePath);
+  } catch {
+    return { messages: [], hasMore: false, oldestCursor: null };
+  }
+  if (stat.size === 0) {
+    return { messages: [], hasMore: false, oldestCursor: null };
+  }
+
+  const beforeTs = beforeCursor != null ? Number(beforeCursor) : null;
+
+  // Read from the tail in chunks, collecting messages in reverse until we have enough.
+  // Each chunk reads TAIL_CHUNK_BYTES from the end, expanding if needed.
+  const TAIL_CHUNK_BYTES = 64 * 1024;
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(filePath, "r");
+    const collected: unknown[] = [];
+    let offset = stat.size;
+    let leftover = "";
+    let exhaustedFile = false;
+
+    while (collected.length < limit + 1 && !exhaustedFile) {
+      const readLen = Math.min(TAIL_CHUNK_BYTES, offset);
+      if (readLen <= 0) {
+        exhaustedFile = true;
+        break;
+      }
+      offset -= readLen;
+      if (offset === 0) {
+        exhaustedFile = true;
+      }
+      const buf = Buffer.alloc(readLen);
+      fs.readSync(fd, buf, 0, readLen, offset);
+      const chunk = buf.toString("utf-8") + leftover;
+      const lines = chunk.split(/\r?\n/);
+      // First element may be partial (split mid-line); save for next iteration.
+      leftover = lines[0];
+
+      // Process lines in reverse (newest first).
+      for (let i = lines.length - 1; i >= 1; i--) {
+        const msg = parseTranscriptLine(lines[i]);
+        if (msg == null) {
+          continue;
+        }
+        const ts = (msg as Record<string, unknown>).timestamp;
+        if (beforeTs != null && typeof ts === "number" && ts >= beforeTs) {
+          continue;
+        }
+        collected.push(msg);
+        if (collected.length > limit) {
+          break;
+        }
+      }
+    }
+
+    // Process any remaining leftover (first line of the file).
+    if (leftover && collected.length <= limit) {
+      const msg = parseTranscriptLine(leftover);
+      if (msg != null) {
+        const ts = (msg as Record<string, unknown>).timestamp;
+        if (beforeTs == null || (typeof ts !== "number") || ts < beforeTs) {
+          collected.push(msg);
+        }
+      }
+    }
+
+    const hasMore = collected.length > limit;
+    const result = hasMore ? collected.slice(0, limit) : collected;
+    // Reverse to chronological order (we collected newest-first).
+    result.reverse();
+
+    const oldest = result.length > 0 ? result[0] : null;
+    const oldestTs =
+      oldest != null && typeof (oldest as Record<string, unknown>).timestamp === "number"
+        ? String((oldest as Record<string, unknown>).timestamp)
+        : null;
+
+    return { messages: result, hasMore, oldestCursor: oldestTs };
+  } catch {
+    return { messages: [], hasMore: false, oldestCursor: null };
+  } finally {
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
 export function resolveSessionTranscriptCandidates(
   sessionId: string,
   storePath: string | undefined,

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -416,6 +416,62 @@ export async function cleanupArchivedSessionTranscripts(opts: {
   return { removed, scanned };
 }
 
+const ARCHIVE_SIZE_THRESHOLD = 512 * 1024; // 512 KB
+const ARCHIVE_KEEP_TAIL_LINES = 30;
+
+/**
+ * If a transcript file exceeds ARCHIVE_SIZE_THRESHOLD, move old entries to an
+ * archive sidecar and keep only the last ARCHIVE_KEEP_TAIL_LINES in the main file.
+ * Returns the archive path if archival occurred, null otherwise.
+ */
+export async function archiveOldTranscriptMessages(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile?: string,
+): Promise<string | null> {
+  const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile);
+  const filePath = candidates.find((p) => fs.existsSync(p));
+  if (!filePath) {
+    return null;
+  }
+
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(filePath);
+  } catch {
+    return null;
+  }
+  if (stat.size < ARCHIVE_SIZE_THRESHOLD) {
+    return null;
+  }
+
+  try {
+    const content = await fs.promises.readFile(filePath, "utf-8");
+    const allLines = content.split(/\r?\n/);
+    // Keep only non-blank lines for counting, but preserve raw lines for rewriting.
+    const nonBlankIndices: number[] = [];
+    for (let i = 0; i < allLines.length; i++) {
+      if (allLines[i].trim()) {
+        nonBlankIndices.push(i);
+      }
+    }
+    if (nonBlankIndices.length <= ARCHIVE_KEEP_TAIL_LINES) {
+      return null;
+    }
+
+    const splitAt = nonBlankIndices[nonBlankIndices.length - ARCHIVE_KEEP_TAIL_LINES];
+    const archiveLines = allLines.slice(0, splitAt);
+    const keepLines = allLines.slice(splitAt);
+
+    const archivePath = `${filePath}.archive.${formatSessionArchiveTimestamp()}`;
+    await fs.promises.writeFile(archivePath, archiveLines.join("\n") + "\n", "utf-8");
+    await fs.promises.writeFile(filePath, keepLines.join("\n"), "utf-8");
+    return archivePath;
+  } catch {
+    return null;
+  }
+}
+
 export function capArrayByJsonBytes<T>(
   items: T[],
   maxBytes: number,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -48,6 +48,7 @@ import type {
 
 export {
   archiveFileOnDisk,
+  archiveOldTranscriptMessages,
   archiveSessionTranscripts,
   capArrayByJsonBytes,
   readFirstUserMessageFromTranscript,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -55,8 +55,10 @@ export {
   readSessionTitleFieldsFromTranscript,
   readSessionPreviewItemsFromTranscript,
   readSessionMessages,
+  readSessionMessagesTail,
   resolveSessionTranscriptCandidates,
 } from "./session-utils.fs.js";
+export type { SessionMessagesTailResult } from "./session-utils.fs.js";
 export type {
   GatewayAgentRow,
   GatewaySessionRow,

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -10,7 +10,7 @@ import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-iden
 import { loadAgentSkills } from "./controllers/agent-skills.ts";
 import { loadAgents, loadToolsCatalog, saveAgentsConfig } from "./controllers/agents.ts";
 import { loadChannels } from "./controllers/channels.ts";
-import { loadChatHistory } from "./controllers/chat.ts";
+import { loadChatHistory, loadMoreChatHistory } from "./controllers/chat.ts";
 import {
   applyConfig,
   ensureAgentConfigEntry,
@@ -1028,6 +1028,10 @@ export function renderApp(state: AppViewState) {
                 onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
                 assistantName: state.assistantName,
                 assistantAvatar: state.assistantAvatar,
+                // Pagination
+                hasMore: state.chatHasMore,
+                loadingMore: state.chatLoadingMore,
+                onLoadMore: () => void loadMoreChatHistory(state),
               })
             : nothing
         }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -55,6 +55,9 @@ export type AppViewState = {
   chatSending: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
+  chatHasMore: boolean;
+  chatOldestCursor: string | null;
+  chatLoadingMore: boolean;
   chatMessages: unknown[];
   chatToolMessages: unknown[];
   chatStreamSegments: Array<{ text: string; ts: number }>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -154,6 +154,9 @@ export class OpenClawApp extends LitElement {
   @state() chatThinkingLevel: string | null = null;
   @state() chatQueue: ChatQueueItem[] = [];
   @state() chatAttachments: ChatAttachment[] = [];
+  @state() chatHasMore = false;
+  @state() chatOldestCursor: string | null = null;
+  @state() chatLoadingMore = false;
   @state() chatManualRefreshInFlight = false;
   // Sidebar state for tool output viewing
   @state() sidebarOpen = false;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -16,6 +16,9 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     connected: true,
     lastError: null,
     sessionKey: "main",
+    chatHasMore: false,
+    chatOldestCursor: null,
+    chatLoadingMore: false,
     ...overrides,
   };
 }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -41,6 +41,12 @@ export type ChatState = {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   lastError: string | null;
+  /** Whether older messages exist beyond the current window. */
+  chatHasMore: boolean;
+  /** Cursor for fetching the next older page of messages. */
+  chatOldestCursor: string | null;
+  /** True while a "load more" request is in flight. */
+  chatLoadingMore: boolean;
 };
 
 export type ChatEventPayload = {
@@ -70,16 +76,20 @@ export async function loadChatHistory(state: ChatState) {
   state.chatLoading = true;
   state.lastError = null;
   try {
-    const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
-      "chat.history",
-      {
-        sessionKey: state.sessionKey,
-        limit: 50,
-      },
-    );
+    const res = await state.client.request<{
+      messages?: Array<unknown>;
+      thinkingLevel?: string;
+      hasMore?: boolean;
+      oldestCursor?: string;
+    }>("chat.history", {
+      sessionKey: state.sessionKey,
+      limit: 50,
+    });
     const messages = Array.isArray(res.messages) ? res.messages : [];
     state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
     state.chatThinkingLevel = res.thinkingLevel ?? null;
+    state.chatHasMore = res.hasMore === true;
+    state.chatOldestCursor = typeof res.oldestCursor === "string" ? res.oldestCursor : null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
     maybeResetToolStream(state);
@@ -89,6 +99,34 @@ export async function loadChatHistory(state: ChatState) {
     state.lastError = String(err);
   } finally {
     state.chatLoading = false;
+  }
+}
+
+/** Fetch the next older page and prepend to existing messages. */
+export async function loadMoreChatHistory(state: ChatState) {
+  if (!state.client || !state.connected || !state.chatHasMore || !state.chatOldestCursor) {
+    return;
+  }
+  state.chatLoadingMore = true;
+  try {
+    const res = await state.client.request<{
+      messages?: Array<unknown>;
+      hasMore?: boolean;
+      oldestCursor?: string;
+    }>("chat.history", {
+      sessionKey: state.sessionKey,
+      limit: 50,
+      before: state.chatOldestCursor,
+    });
+    const older = Array.isArray(res.messages) ? res.messages : [];
+    const filtered = older.filter((message) => !isAssistantSilentReply(message));
+    state.chatMessages = [...filtered, ...state.chatMessages];
+    state.chatHasMore = res.hasMore === true;
+    state.chatOldestCursor = typeof res.oldestCursor === "string" ? res.oldestCursor : null;
+  } catch (err) {
+    state.lastError = String(err);
+  } finally {
+    state.chatLoadingMore = false;
   }
 }
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -74,7 +74,7 @@ export async function loadChatHistory(state: ChatState) {
       "chat.history",
       {
         sessionKey: state.sessionKey,
-        limit: 200,
+        limit: 50,
       },
     );
     const messages = Array.isArray(res.messages) ? res.messages : [];

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -81,6 +81,10 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  // Pagination
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
@@ -270,6 +274,22 @@ export function renderChat(props: ChatProps) {
         props.loading
           ? html`
               <div class="muted">Loading chat…</div>
+            `
+          : nothing
+      }
+      ${
+        !props.loading && props.hasMore && props.onLoadMore
+          ? html`
+              <div class="chat-load-more">
+                <button
+                  class="btn chat-load-more__btn"
+                  type="button"
+                  ?disabled=${props.loadingMore}
+                  @click=${props.onLoadMore}
+                >
+                  ${props.loadingMore ? "Loading…" : "Load earlier messages"}
+                </button>
+              </div>
             `
           : nothing
       }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -480,7 +480,7 @@ export function renderChat(props: ChatProps) {
   `;
 }
 
-const CHAT_HISTORY_RENDER_LIMIT = 200;
+const CHAT_HISTORY_RENDER_LIMIT = 50;
 
 function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];


### PR DESCRIPTION
## Summary

Fixes #42684 — Webchat UI freezes when loading sessions with moderate-sized transcripts (~472KB, 65 messages).

**AI-assisted:** Built with Claude Code, reviewed and type-checked manually.
**Testing:** Type-checked (`pnpm tsgo` passes, 0 new errors). Not fully tested (no access to full test environment).

## Problem

The webchat UI loads ALL session messages at once through the entire pipeline:
1. **Storage**: `readSessionMessages()` reads the entire JSONL file into memory
2. **API**: `chat.history` returns up to 200 messages in a single response
3. **Rendering**: All messages rendered into DOM simultaneously

With ~65 messages containing verbose tool call results (~472KB), the UI freezes indefinitely.

## Changes

### Phase 1: Reduce Default Limits
- Reduced `chat.history` request limit from 200 → 50
- Reduced `CHAT_HISTORY_RENDER_LIMIT` from 200 → 50

### Phase 2: Cursor-based Pagination
- **Schema**: Added optional `before` cursor field to `ChatHistoryParamsSchema`
- **Backend**: `readSessionMessagesTail()` — reverse-reads JSONL from EOF in 64KB chunks, supports cursor-based filtering by timestamp
- **API**: `chat.history` now returns `hasMore` and `oldestCursor` for pagination
- **Frontend**: Added `loadMoreChatHistory()` controller + "Load earlier messages" button in chat UI

### Phase 3: Transcript Auto-Archival
- `archiveOldTranscriptMessages()` — when transcript exceeds 512KB, archives old entries to `{sessionId}.jsonl.archive.{timestamp}` and keeps last 30 lines
- Triggered non-blocking after `chat.history` responses

## Files Changed

| File | Change |
|------|--------|
| `ui/src/ui/controllers/chat.ts` | Reduced limit, added `loadMoreChatHistory()`, pagination state |
| `ui/src/ui/views/chat.ts` | Reduced render limit, added "Load earlier messages" button |
| `src/gateway/protocol/schema/logs-chat.ts` | Added `before` field to schema |
| `src/gateway/server-methods/chat.ts` | Cursor pagination + async archival trigger |
| `src/gateway/session-utils.fs.ts` | `readSessionMessagesTail()` + `archiveOldTranscriptMessages()` |
| `src/gateway/session-utils.ts` | Re-exported new functions/types |
| `ui/src/ui/app.ts` | Added pagination reactive state |
| `ui/src/ui/app-view-state.ts` | Added pagination fields to view state type |
| `ui/src/ui/app-render.ts` | Wired pagination props to `renderChat()` |
| `ui/src/ui/controllers/chat.test.ts` | Added defaults for new state fields |

## Backward Compatibility

- `chat.history` API is fully backward compatible — `before`, `hasMore`, `oldestCursor` are all optional
- Existing clients that don't send `before` get the same behavior as before (newest N messages)
- Auto-archival is best-effort and non-blocking