### PR TITLE
Security: add path-scoped RWX permissions for exec and file tools

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolveFilesystemPermissions } from "../infra/filesystem-permissions.js";
 import { applyPatch } from "./apply-patch.js";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
@@ -114,6 +115,44 @@ describe("applyPatch", () => {
       } finally {
         await fs.rm(escapedPath, { force: true });
       }
+    });
+  });
+
+  it("enforces filesystem permission rules when provided", async () => {
+    await withTempDir(async (dir) => {
+      const allowedDir = path.join(dir, "allowed");
+      await fs.mkdir(allowedDir, { recursive: true });
+      const permissions = resolveFilesystemPermissions({
+        rules: {
+          [`${allowedDir}/**`]: "rw-",
+        },
+        default: "---",
+      });
+      expect(permissions).toBeDefined();
+
+      const deniedPatch = `*** Begin Patch
+*** Add File: blocked.txt
++blocked
+*** End Patch`;
+      await expect(
+        applyPatch(deniedPatch, {
+          cwd: dir,
+          workspaceOnly: false,
+          filesystemPermissions: permissions,
+        }),
+      ).rejects.toThrow(/filesystem permission denied \(w\)/);
+
+      const allowedPatch = `*** Begin Patch
+*** Add File: allowed/ok.txt
++ok
+*** End Patch`;
+      await expect(
+        applyPatch(allowedPatch, {
+          cwd: dir,
+          workspaceOnly: false,
+          filesystemPermissions: permissions,
+        }),
+      ).resolves.toBeDefined();
     });
   });
 

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { openBoundaryFile, type BoundaryFileOpenResult } from "../infra/boundary-file-read.js";
+import {
+  assertFilesystemPathPermission,
+  type ResolvedFilesystemPermissions,
+} from "../infra/filesystem-permissions.js";
 import { writeFileWithinRoot } from "../infra/fs-safe.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
@@ -73,6 +77,7 @@ type ApplyPatchOptions = {
   sandbox?: SandboxApplyPatchConfig;
   /** Restrict patch paths to the workspace root (cwd). Default: true. Set false to opt out. */
   workspaceOnly?: boolean;
+  filesystemPermissions?: ResolvedFilesystemPermissions;
   signal?: AbortSignal;
 };
 
@@ -83,7 +88,12 @@ const applyPatchSchema = Type.Object({
 });
 
 export function createApplyPatchTool(
-  options: { cwd?: string; sandbox?: SandboxApplyPatchConfig; workspaceOnly?: boolean } = {},
+  options: {
+    cwd?: string;
+    sandbox?: SandboxApplyPatchConfig;
+    workspaceOnly?: boolean;
+    filesystemPermissions?: ResolvedFilesystemPermissions;
+  } = {},
 ): AgentTool<typeof applyPatchSchema, ApplyPatchToolDetails> {
   const cwd = options.cwd ?? process.cwd();
   const sandbox = options.sandbox;
@@ -111,6 +121,7 @@ export function createApplyPatchTool(
         cwd,
         sandbox,
         workspaceOnly,
+        filesystemPermissions: options.filesystemPermissions,
         signal,
       });
 
@@ -152,6 +163,13 @@ export async function applyPatch(
 
     if (hunk.kind === "add") {
       const target = await resolvePatchPath(hunk.path, options);
+      assertFilesystemPathPermission({
+        permissions: options.filesystemPermissions,
+        targetPath: target.resolved,
+        operation: "write",
+        cwd: options.cwd,
+        context: "apply_patch add",
+      });
       await ensureDir(target.resolved, fileOps);
       await fileOps.writeFile(target.resolved, hunk.contents);
       recordSummary(summary, seen, "added", target.display);
@@ -160,18 +178,39 @@ export async function applyPatch(
 
     if (hunk.kind === "delete") {
       const target = await resolvePatchPath(hunk.path, options, PATH_ALIAS_POLICIES.unlinkTarget);
+      assertFilesystemPathPermission({
+        permissions: options.filesystemPermissions,
+        targetPath: target.resolved,
+        operation: "write",
+        cwd: options.cwd,
+        context: "apply_patch delete",
+      });
       await fileOps.remove(target.resolved);
       recordSummary(summary, seen, "deleted", target.display);
       continue;
     }
 
     const target = await resolvePatchPath(hunk.path, options);
+    assertFilesystemPathPermission({
+      permissions: options.filesystemPermissions,
+      targetPath: target.resolved,
+      operation: "write",
+      cwd: options.cwd,
+      context: "apply_patch update",
+    });
     const applied = await applyUpdateHunk(target.resolved, hunk.chunks, {
       readFile: (path) => fileOps.readFile(path),
     });
 
     if (hunk.movePath) {
       const moveTarget = await resolvePatchPath(hunk.movePath, options);
+      assertFilesystemPathPermission({
+        permissions: options.filesystemPermissions,
+        targetPath: moveTarget.resolved,
+        operation: "write",
+        cwd: options.cwd,
+        context: "apply_patch move",
+      });
       await ensureDir(moveTarget.resolved, fileOps);
       await fileOps.writeFile(moveTarget.resolved, applied);
       await fileOps.remove(target.resolved);

--- a/src/agents/bash-tools.exec-fs-permissions.test.ts
+++ b/src/agents/bash-tools.exec-fs-permissions.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { resolveFilesystemPermissions } from "../infra/filesystem-permissions.js";
+import { __testing, assertExecFilesystemPermissions } from "./bash-tools.exec-fs-permissions.js";
+
+describe("exec filesystem permissions", () => {
+  it("extracts read/write checks from cp and rm operands", () => {
+    const { checks, analysis } = __testing.collectExecPathPermissionChecks({
+      command: "cp ./src.txt ./dest.txt && rm ./dest.txt",
+      cwd: "/workspace",
+      env: {},
+    });
+    expect(analysis.ok).toBe(true);
+    const summary = checks.map((entry) => ({
+      op: entry.operation,
+      reason: entry.reason,
+      path: entry.targetPath,
+    }));
+    expect(summary).toContainEqual({
+      op: "read",
+      reason: "cp source",
+      path: "/workspace/src.txt",
+    });
+    expect(summary).toContainEqual({
+      op: "write",
+      reason: "cp destination",
+      path: "/workspace/dest.txt",
+    });
+    expect(summary).toContainEqual({
+      op: "write",
+      reason: "rm operand",
+      path: "/workspace/dest.txt",
+    });
+  });
+
+  it("blocks exec when a referenced path lacks required permission", () => {
+    const permissions = resolveFilesystemPermissions({
+      rules: {
+        "/workspace/**": "rw-",
+        "/bin/**": "r-x",
+      },
+      default: "---",
+    });
+    expect(permissions).toBeDefined();
+
+    expect(() =>
+      assertExecFilesystemPermissions({
+        command: "cat /etc/passwd",
+        cwd: "/workspace",
+        env: {},
+        permissions,
+      }),
+    ).toThrow(/filesystem permission denied \(r\)/);
+  });
+
+  it("allows exec when executable and operands are permitted", () => {
+    const permissions = resolveFilesystemPermissions({
+      rules: {
+        "/workspace/**": "rw-",
+        "/bin/**": "r-x",
+      },
+      default: "---",
+    });
+    expect(permissions).toBeDefined();
+
+    expect(() =>
+      assertExecFilesystemPermissions({
+        command: "/bin/cat /workspace/file.txt",
+        cwd: "/workspace",
+        env: {},
+        permissions,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/agents/bash-tools.exec-fs-permissions.ts
+++ b/src/agents/bash-tools.exec-fs-permissions.ts
@@ -1,0 +1,318 @@
+import path from "node:path";
+import {
+  analyzeShellCommand,
+  type ExecCommandSegment,
+  type ExecCommandAnalysis,
+} from "../infra/exec-approvals.js";
+import { parseExecArgvToken } from "../infra/exec-command-resolution.js";
+import {
+  assertFilesystemPathPermission,
+  resolveFilesystemPermissionPath,
+  type FilesystemPermissionOperation,
+  type ResolvedFilesystemPermissions,
+} from "../infra/filesystem-permissions.js";
+import { expandHomePrefix } from "../infra/home-dir.js";
+
+type ExecPathPermissionCheck = {
+  operation: FilesystemPermissionOperation;
+  targetPath: string;
+  reason: string;
+};
+
+const READ_POSITIONAL_COMMANDS = new Set([
+  "cat",
+  "cut",
+  "diff",
+  "du",
+  "file",
+  "head",
+  "less",
+  "ls",
+  "more",
+  "realpath",
+  "readlink",
+  "sort",
+  "stat",
+  "tail",
+  "tree",
+  "uniq",
+  "wc",
+]);
+
+const WRITE_POSITIONAL_COMMANDS = new Set([
+  "chmod",
+  "chown",
+  "chgrp",
+  "install",
+  "mkdir",
+  "mktemp",
+  "rm",
+  "rmdir",
+  "touch",
+  "truncate",
+]);
+
+const SCRIPT_INTERPRETERS = new Set([
+  "bash",
+  "dash",
+  "fish",
+  "ksh",
+  "node",
+  "nodejs",
+  "perl",
+  "php",
+  "python",
+  "python3",
+  "ruby",
+  "sh",
+  "zsh",
+]);
+
+function normalizeCommandName(segment: ExecCommandSegment): string {
+  const executable =
+    segment.resolution?.executableName?.trim() ||
+    segment.resolution?.rawExecutable?.trim() ||
+    segment.argv[0]?.trim() ||
+    "";
+  if (!executable) {
+    return "";
+  }
+  return path.basename(executable).toLowerCase();
+}
+
+function resolvePathToken(token: string, cwd: string): string | null {
+  const trimmed = token.trim();
+  if (!trimmed || trimmed === "-") {
+    return null;
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    return null;
+  }
+  if (trimmed.startsWith("$")) {
+    return null;
+  }
+  try {
+    return resolveFilesystemPermissionPath({
+      targetPath: trimmed.startsWith("~") ? expandHomePrefix(trimmed) : trimmed,
+      cwd,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function collectPositionalTokens(argv: string[]): string[] {
+  const tokens: string[] = [];
+  let afterTerminator = false;
+  for (let i = 1; i < argv.length; i += 1) {
+    const token = argv[i]?.trim() ?? "";
+    if (!token) {
+      continue;
+    }
+    if (!afterTerminator && token === "--") {
+      afterTerminator = true;
+      continue;
+    }
+    if (!afterTerminator) {
+      const parsed = parseExecArgvToken(token);
+      if (parsed.kind === "option" || parsed.kind === "terminator") {
+        continue;
+      }
+    }
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+function collectFindStartPaths(argv: string[]): string[] {
+  const roots: string[] = [];
+  for (let i = 1; i < argv.length; i += 1) {
+    const token = argv[i]?.trim() ?? "";
+    if (!token) {
+      continue;
+    }
+    if (token === "--") {
+      break;
+    }
+    if (token.startsWith("-") || token === "(" || token === "!" || token === ")") {
+      break;
+    }
+    roots.push(token);
+  }
+  return roots;
+}
+
+function collectPathChecksForSegment(params: {
+  segment: ExecCommandSegment;
+  cwd: string;
+}): ExecPathPermissionCheck[] {
+  const checks: ExecPathPermissionCheck[] = [];
+  const argv =
+    params.segment.resolution?.effectiveArgv && params.segment.resolution.effectiveArgv.length > 0
+      ? params.segment.resolution.effectiveArgv
+      : params.segment.argv;
+
+  const executablePath =
+    params.segment.resolution?.resolvedRealPath ?? params.segment.resolution?.resolvedPath;
+  if (executablePath) {
+    checks.push({
+      operation: "execute",
+      targetPath: executablePath,
+      reason: "command executable",
+    });
+  }
+
+  const command = normalizeCommandName(params.segment);
+  if (!command) {
+    return checks;
+  }
+
+  const addChecksFromTokens = (
+    tokens: string[],
+    operation: FilesystemPermissionOperation,
+    reason: string,
+  ) => {
+    for (const token of tokens) {
+      const resolved = resolvePathToken(token, params.cwd);
+      if (!resolved) {
+        continue;
+      }
+      checks.push({ operation, targetPath: resolved, reason });
+    }
+  };
+
+  if (command === "cp" || command === "mv") {
+    const positionals = collectPositionalTokens(argv);
+    if (positionals.length >= 2) {
+      const destination = positionals[positionals.length - 1];
+      addChecksFromTokens(positionals.slice(0, -1), "read", `${command} source`);
+      if (destination) {
+        addChecksFromTokens([destination], "write", `${command} destination`);
+      }
+    }
+    return checks;
+  }
+
+  if (command === "ln") {
+    const positionals = collectPositionalTokens(argv);
+    if (positionals.length >= 2) {
+      const target = positionals[positionals.length - 1];
+      addChecksFromTokens([positionals[0]], "read", "ln source");
+      if (target) {
+        addChecksFromTokens([target], "write", "ln target");
+      }
+    } else {
+      addChecksFromTokens(positionals, "write", "ln target");
+    }
+    return checks;
+  }
+
+  if (command === "dd") {
+    for (const token of argv.slice(1)) {
+      const trimmed = token.trim();
+      if (!trimmed) {
+        continue;
+      }
+      if (trimmed.startsWith("if=")) {
+        addChecksFromTokens([trimmed.slice(3)], "read", "dd input");
+      } else if (trimmed.startsWith("of=")) {
+        addChecksFromTokens([trimmed.slice(3)], "write", "dd output");
+      }
+    }
+    return checks;
+  }
+
+  if (command === "find") {
+    const roots = collectFindStartPaths(argv);
+    addChecksFromTokens(roots, "read", "find root");
+    return checks;
+  }
+
+  if (command === "grep" || command === "rg") {
+    const positionals = collectPositionalTokens(argv);
+    if (positionals.length > 1) {
+      addChecksFromTokens(positionals.slice(1), "read", `${command} file`);
+    }
+    return checks;
+  }
+
+  if (command === "sed" || command === "awk") {
+    const positionals = collectPositionalTokens(argv);
+    if (positionals.length > 1) {
+      addChecksFromTokens(positionals.slice(1), "read", `${command} file`);
+    }
+    return checks;
+  }
+
+  if (SCRIPT_INTERPRETERS.has(command)) {
+    const positionals = collectPositionalTokens(argv);
+    if (positionals.length > 0) {
+      addChecksFromTokens([positionals[0]], "read", `${command} script`);
+    }
+    return checks;
+  }
+
+  if (READ_POSITIONAL_COMMANDS.has(command)) {
+    addChecksFromTokens(collectPositionalTokens(argv), "read", `${command} operand`);
+    return checks;
+  }
+
+  if (WRITE_POSITIONAL_COMMANDS.has(command) || command === "tee") {
+    addChecksFromTokens(collectPositionalTokens(argv), "write", `${command} operand`);
+    return checks;
+  }
+
+  return checks;
+}
+
+function collectExecPathPermissionChecks(params: {
+  command: string;
+  cwd: string;
+  env: Record<string, string>;
+}): { analysis: ExecCommandAnalysis; checks: ExecPathPermissionCheck[] } {
+  const analysis = analyzeShellCommand({
+    command: params.command,
+    cwd: params.cwd,
+    env: params.env,
+    platform: process.platform,
+  });
+  if (!analysis.ok) {
+    return { analysis, checks: [] };
+  }
+  const checks: ExecPathPermissionCheck[] = [];
+  for (const segment of analysis.segments) {
+    checks.push(...collectPathChecksForSegment({ segment, cwd: params.cwd }));
+  }
+  return { analysis, checks };
+}
+
+export function assertExecFilesystemPermissions(params: {
+  command: string;
+  cwd: string;
+  env: Record<string, string>;
+  permissions: ResolvedFilesystemPermissions | undefined;
+}): void {
+  if (!params.permissions) {
+    return;
+  }
+  const { analysis, checks } = collectExecPathPermissionChecks(params);
+  if (!analysis.ok) {
+    throw new Error(
+      `exec denied: failed to analyze filesystem access (${analysis.reason ?? "unknown reason"})`,
+    );
+  }
+
+  for (const check of checks) {
+    assertFilesystemPathPermission({
+      permissions: params.permissions,
+      targetPath: check.targetPath,
+      operation: check.operation,
+      cwd: params.cwd,
+      context: `exec ${check.reason}`,
+    });
+  }
+}
+
+export const __testing = {
+  collectExecPathPermissionChecks,
+};

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -1,5 +1,6 @@
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
 import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
+import type { ResolvedFilesystemPermissions } from "../infra/filesystem-permissions.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 
 export type ExecToolDefaults = {
@@ -27,6 +28,7 @@ export type ExecToolDefaults = {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   cwd?: string;
+  filesystemPermissions?: ResolvedFilesystemPermissions;
 };
 
 export type ExecElevatedDefaults = {

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -36,6 +36,7 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
       autoAllowSkills: false,
     },
     allowlist: [],
+    permissions: {},
     file: {
       version: 1,
       socket: { path: "/tmp/exec-approvals.sock", token: "token" },

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -10,6 +10,7 @@ import {
 import { logInfo } from "../logger.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { markBackgrounded } from "./bash-process-registry.js";
+import { assertExecFilesystemPermissions } from "./bash-tools.exec-fs-permissions.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
 import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
 import {
@@ -398,6 +399,13 @@ export function createExecTool(
       } else {
         applyPathPrepend(env, defaultPathPrepend);
       }
+
+      assertExecFilesystemPermissions({
+        command: params.command,
+        cwd: workdir,
+        env,
+        permissions: defaults?.filesystemPermissions,
+      });
 
       if (host === "node") {
         return executeNodeHostCommand({

--- a/src/agents/pi-tools.filesystem-permissions.test.ts
+++ b/src/agents/pi-tools.filesystem-permissions.test.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createOpenClawCodingTools } from "./pi-tools.js";
+
+describe("tool filesystem permissions from exec approvals", () => {
+  let tmpDir: string;
+  let workspaceDir: string;
+  let outsideFile: string;
+  let previousOpenClawHome: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fs-perms-"));
+    workspaceDir = path.join(tmpDir, "workspace");
+    outsideFile = path.join(tmpDir, "outside.txt");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "inside.txt"), "inside", "utf8");
+    await fs.writeFile(outsideFile, "outside", "utf8");
+
+    previousOpenClawHome = process.env.OPENCLAW_HOME;
+    process.env.OPENCLAW_HOME = tmpDir;
+    const approvalsPath = path.join(tmpDir, ".openclaw", "exec-approvals.json");
+    await fs.mkdir(path.dirname(approvalsPath), { recursive: true });
+    await fs.writeFile(
+      approvalsPath,
+      `${JSON.stringify(
+        {
+          version: 1,
+          permissions: {
+            filesystem: {
+              rules: {
+                [`${workspaceDir.replace(/\\/g, "/")}/**`]: "rw-",
+              },
+              default: "---",
+            },
+          },
+          agents: {},
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  });
+
+  afterEach(async () => {
+    if (previousOpenClawHome === undefined) {
+      delete process.env.OPENCLAW_HOME;
+    } else {
+      process.env.OPENCLAW_HOME = previousOpenClawHome;
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("allows read inside the allowed workspace rule", async () => {
+    const tools = createOpenClawCodingTools({
+      workspaceDir,
+      config: { tools: { fs: { workspaceOnly: false } } },
+    });
+    const readTool = tools.find((tool) => tool.name === "read");
+    expect(readTool).toBeDefined();
+
+    await expect(
+      readTool!.execute("read-inside", {
+        path: path.join(workspaceDir, "inside.txt"),
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("blocks read and write outside allowed rules", async () => {
+    const tools = createOpenClawCodingTools({
+      workspaceDir,
+      config: { tools: { fs: { workspaceOnly: false } } },
+    });
+    const readTool = tools.find((tool) => tool.name === "read");
+    const writeTool = tools.find((tool) => tool.name === "write");
+    expect(readTool).toBeDefined();
+    expect(writeTool).toBeDefined();
+
+    await expect(
+      readTool!.execute("read-outside", {
+        path: outsideFile,
+      }),
+    ).rejects.toThrow(/filesystem permission denied \(r\)/);
+    await expect(
+      writeTool!.execute("write-outside", {
+        path: outsideFile,
+        content: "blocked",
+      }),
+    ).rejects.toThrow(/filesystem permission denied \(w\)/);
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -4,6 +4,11 @@ import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
 import {
+  assertFilesystemPathPermission,
+  type FilesystemPermissionOperation,
+  type ResolvedFilesystemPermissions,
+} from "../infra/filesystem-permissions.js";
+import {
   SafeOpenError,
   openFileWithinRoot,
   readFileWithinRoot,
@@ -352,6 +357,45 @@ async function normalizeReadImageResult(
 
 export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): AnyAgentTool {
   return wrapToolWorkspaceRootGuardWithOptions(tool, root);
+}
+
+export function wrapToolFilesystemPermissionsGuard(
+  tool: AnyAgentTool,
+  options: {
+    permissions?: ResolvedFilesystemPermissions;
+    operation: FilesystemPermissionOperation;
+    root: string;
+    containerWorkdir?: string;
+  },
+): AnyAgentTool {
+  if (!options.permissions) {
+    return tool;
+  }
+  return {
+    ...tool,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const normalized = normalizeToolParams(args);
+      const record =
+        normalized ??
+        (args && typeof args === "object" ? (args as Record<string, unknown>) : undefined);
+      const filePath = typeof record?.path === "string" ? record.path.trim() : "";
+      if (filePath) {
+        const sandboxPath = mapContainerPathToWorkspaceRoot({
+          filePath,
+          root: options.root,
+          containerWorkdir: options.containerWorkdir,
+        });
+        assertFilesystemPathPermission({
+          permissions: options.permissions,
+          targetPath: sandboxPath,
+          operation: options.operation,
+          cwd: options.root,
+          context: tool.name,
+        });
+      }
+      return tool.execute(toolCallId, normalized ?? args, signal, onUpdate);
+    },
+  };
 }
 
 function mapContainerPathToWorkspaceRoot(params: {

--- a/src/agents/pi-tools.safe-bins.test.ts
+++ b/src/agents/pi-tools.safe-bins.test.ts
@@ -53,6 +53,7 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
       autoAllowSkills: false,
     },
     allowlist: [],
+    permissions: {},
     file: {
       version: 1,
       socket: { path: "/tmp/exec-approvals.sock", token: "token" },

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -1,6 +1,7 @@
 import { codingTools, createReadTool, readTool } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import { loadExecApprovals, resolveExecApprovalsFromFile } from "../infra/exec-approvals.js";
 import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
@@ -34,6 +35,7 @@ import {
   createSandboxedEditTool,
   createSandboxedReadTool,
   createSandboxedWriteTool,
+  wrapToolFilesystemPermissionsGuard,
   normalizeToolParams,
   patchToolSchemaForClaudeCompatibility,
   wrapToolWorkspaceRootGuard,
@@ -321,8 +323,13 @@ export function createOpenClawCodingTools(options?: {
   ]);
   const execConfig = resolveExecConfig({ cfg: options?.config, agentId });
   const fsConfig = resolveToolFsConfig({ cfg: options?.config, agentId });
+  const approvals = resolveExecApprovalsFromFile({
+    file: loadExecApprovals(),
+    agentId,
+  });
   const fsPolicy = createToolFsPolicy({
     workspaceOnly: fsConfig.workspaceOnly,
+    permissions: approvals.permissions.filesystem,
   });
   const sandboxRoot = sandbox?.workspaceDir;
   const sandboxFsBridge = sandbox?.fsBridge;
@@ -356,12 +363,18 @@ export function createOpenClawCodingTools(options?: {
           modelContextWindowTokens: options?.modelContextWindowTokens,
           imageSanitization,
         });
+        const guarded = workspaceOnly
+          ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
+              containerWorkdir: sandbox.containerWorkdir,
+            })
+          : sandboxed;
         return [
-          workspaceOnly
-            ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
-                containerWorkdir: sandbox.containerWorkdir,
-              })
-            : sandboxed,
+          wrapToolFilesystemPermissionsGuard(guarded, {
+            permissions: fsPolicy.permissions,
+            operation: "read",
+            root: sandboxRoot,
+            containerWorkdir: sandbox.containerWorkdir,
+          }),
         ];
       }
       const freshReadTool = createReadTool(workspaceRoot);
@@ -369,7 +382,14 @@ export function createOpenClawCodingTools(options?: {
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,
       });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const guarded = workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped;
+      return [
+        wrapToolFilesystemPermissionsGuard(guarded, {
+          permissions: fsPolicy.permissions,
+          operation: "read",
+          root: workspaceRoot,
+        }),
+      ];
     }
     if (tool.name === "bash" || tool.name === execToolName) {
       return [];
@@ -379,14 +399,28 @@ export function createOpenClawCodingTools(options?: {
         return [];
       }
       const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const guarded = workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped;
+      return [
+        wrapToolFilesystemPermissionsGuard(guarded, {
+          permissions: fsPolicy.permissions,
+          operation: "write",
+          root: workspaceRoot,
+        }),
+      ];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
       const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const guarded = workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped;
+      return [
+        wrapToolFilesystemPermissionsGuard(guarded, {
+          permissions: fsPolicy.permissions,
+          operation: "write",
+          root: workspaceRoot,
+        }),
+      ];
     }
     return [tool];
   });
@@ -417,6 +451,7 @@ export function createOpenClawCodingTools(options?: {
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     notifyOnExitEmptySuccess:
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
+    filesystemPermissions: fsPolicy.permissions,
     sandbox: sandbox
       ? {
           containerName: sandbox.containerName,
@@ -440,30 +475,47 @@ export function createOpenClawCodingTools(options?: {
               ? { root: sandboxRoot, bridge: sandboxFsBridge! }
               : undefined,
           workspaceOnly: applyPatchWorkspaceOnly,
+          filesystemPermissions: fsPolicy.permissions,
         });
   const tools: AnyAgentTool[] = [
     ...base,
     ...(sandboxRoot
       ? allowWorkspaceWrites
         ? [
-            workspaceOnly
-              ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
-                  sandboxRoot,
-                  {
-                    containerWorkdir: sandbox.containerWorkdir,
-                  },
-                )
-              : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
-            workspaceOnly
-              ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
-                  sandboxRoot,
-                  {
-                    containerWorkdir: sandbox.containerWorkdir,
-                  },
-                )
-              : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+            wrapToolFilesystemPermissionsGuard(
+              workspaceOnly
+                ? wrapToolWorkspaceRootGuardWithOptions(
+                    createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                    sandboxRoot,
+                    {
+                      containerWorkdir: sandbox.containerWorkdir,
+                    },
+                  )
+                : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+              {
+                permissions: fsPolicy.permissions,
+                operation: "write",
+                root: sandboxRoot,
+                containerWorkdir: sandbox.containerWorkdir,
+              },
+            ),
+            wrapToolFilesystemPermissionsGuard(
+              workspaceOnly
+                ? wrapToolWorkspaceRootGuardWithOptions(
+                    createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                    sandboxRoot,
+                    {
+                      containerWorkdir: sandbox.containerWorkdir,
+                    },
+                  )
+                : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+              {
+                permissions: fsPolicy.permissions,
+                operation: "write",
+                root: sandboxRoot,
+                containerWorkdir: sandbox.containerWorkdir,
+              },
+            ),
           ]
         : []
       : []),

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -1,13 +1,19 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { ResolvedFilesystemPermissions } from "../infra/filesystem-permissions.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 
 export type ToolFsPolicy = {
   workspaceOnly: boolean;
+  permissions?: ResolvedFilesystemPermissions;
 };
 
-export function createToolFsPolicy(params: { workspaceOnly?: boolean }): ToolFsPolicy {
+export function createToolFsPolicy(params: {
+  workspaceOnly?: boolean;
+  permissions?: ResolvedFilesystemPermissions;
+}): ToolFsPolicy {
   return {
     workspaceOnly: params.workspaceOnly === true,
+    permissions: params.permissions,
   };
 }
 

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -53,6 +53,30 @@ describe("exec approvals wildcard agent", () => {
   });
 });
 
+describe("exec approvals filesystem permissions", () => {
+  it("resolves top-level filesystem permissions map", () => {
+    const resolved = resolveExecApprovalsFromFile({
+      file: {
+        version: 1,
+        permissions: {
+          filesystem: {
+            rules: {
+              "/workspace/**": "rw-",
+            },
+            default: "---",
+          },
+        },
+        agents: {},
+      },
+      agentId: "main",
+    });
+    expect(resolved.permissions.filesystem).toBeDefined();
+    expect(resolved.permissions.filesystem?.rules[0]?.pattern).toBe("/workspace/**");
+    expect(resolved.permissions.filesystem?.rules[0]?.bits).toBe("rw-");
+    expect(resolved.permissions.filesystem?.defaultBits).toBe("---");
+  });
+});
+
 describe("exec approvals node host allowlist check", () => {
   // These tests verify the allowlist satisfaction logic used by the node host path
   // The node host checks: matchAllowlist() || isSafeBinUsage() for each command segment

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -2,6 +2,12 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import {
+  normalizeFilesystemPermissionsConfig,
+  resolveFilesystemPermissions,
+  type FilesystemPermissionsConfig,
+  type ResolvedFilesystemPermissions,
+} from "./filesystem-permissions.js";
 import { expandHomePrefix } from "./home-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
 export * from "./exec-approvals-analysis.js";
@@ -101,6 +107,10 @@ export type ExecApprovalsDefaults = {
   autoAllowSkills?: boolean;
 };
 
+export type ExecApprovalsPermissions = {
+  filesystem?: FilesystemPermissionsConfig;
+};
+
 export type ExecAllowlistEntry = {
   id?: string;
   pattern: string;
@@ -119,6 +129,7 @@ export type ExecApprovalsFile = {
     path?: string;
     token?: string;
   };
+  permissions?: ExecApprovalsPermissions;
   defaults?: ExecApprovalsDefaults;
   agents?: Record<string, ExecApprovalsAgent>;
 };
@@ -138,6 +149,9 @@ export type ExecApprovalsResolved = {
   defaults: Required<ExecApprovalsDefaults>;
   agent: Required<ExecApprovalsDefaults>;
   allowlist: ExecAllowlistEntry[];
+  permissions: {
+    filesystem?: ResolvedFilesystemPermissions;
+  };
   file: ExecApprovalsFile;
 };
 
@@ -277,6 +291,11 @@ export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFi
       path: socketPath && socketPath.length > 0 ? socketPath : undefined,
       token: token && token.length > 0 ? token : undefined,
     },
+    permissions: file.permissions
+      ? {
+          filesystem: normalizeFilesystemPermissionsConfig(file.permissions.filesystem),
+        }
+      : undefined,
     defaults: {
       security: file.defaults?.security,
       ask: file.defaults?.ask,
@@ -466,6 +485,7 @@ export function resolveExecApprovalsFromFile(params: {
     ...(Array.isArray(wildcard.allowlist) ? wildcard.allowlist : []),
     ...(Array.isArray(agent.allowlist) ? agent.allowlist : []),
   ];
+  const filesystemPermissions = resolveFilesystemPermissions(file.permissions?.filesystem);
   return {
     path: params.path ?? resolveExecApprovalsPath(),
     socketPath: expandHomePrefix(
@@ -475,6 +495,7 @@ export function resolveExecApprovalsFromFile(params: {
     defaults: resolvedDefaults,
     agent: resolvedAgent,
     allowlist,
+    permissions: filesystemPermissions ? { filesystem: filesystemPermissions } : {},
     file,
   };
 }

--- a/src/infra/filesystem-permissions.test.ts
+++ b/src/infra/filesystem-permissions.test.ts
@@ -1,0 +1,94 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  evaluateFilesystemPathPermission,
+  normalizeFilesystemPermissionsConfig,
+  resolveFilesystemPermissions,
+} from "./filesystem-permissions.js";
+
+describe("filesystem permissions", () => {
+  it("uses most specific matching rule", () => {
+    const permissions = resolveFilesystemPermissions({
+      rules: {
+        "/workspace/**": "r--",
+        "/workspace/bin/**": "r-x",
+      },
+      default: "---",
+    });
+    expect(permissions).toBeDefined();
+    const decision = evaluateFilesystemPathPermission({
+      permissions: permissions!,
+      targetPath: "/workspace/bin/tool",
+      operation: "execute",
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.source).toBe("rule");
+    expect(decision.sourcePattern).toBe("/workspace/bin/**");
+  });
+
+  it("applies deny patterns before rules", () => {
+    const permissions = resolveFilesystemPermissions({
+      rules: {
+        "/workspace/**": "rwx",
+      },
+      deny: ["/workspace/secret/**"],
+      default: "---",
+    });
+    expect(permissions).toBeDefined();
+    const decision = evaluateFilesystemPathPermission({
+      permissions: permissions!,
+      targetPath: "/workspace/secret/private.txt",
+      operation: "read",
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.source).toBe("deny");
+    expect(decision.sourcePattern).toBe("/workspace/secret/**");
+  });
+
+  it("falls back to default when no rule matches", () => {
+    const permissions = resolveFilesystemPermissions({
+      rules: {
+        "/workspace/**": "rw-",
+      },
+      default: "r--",
+    });
+    expect(permissions).toBeDefined();
+    const decision = evaluateFilesystemPathPermission({
+      permissions: permissions!,
+      targetPath: "/unmatched/file.txt",
+      operation: "read",
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.source).toBe("default");
+    expect(decision.effectiveBits).toBe("r--");
+  });
+
+  it("normalizes malformed bits to safe defaults", () => {
+    const normalized = normalizeFilesystemPermissionsConfig({
+      rules: {
+        "/workspace/**": "not-valid",
+      },
+      default: "bad",
+    });
+    expect(normalized?.rules?.["/workspace/**"]).toBe("---");
+    expect(normalized?.default).toBeUndefined();
+  });
+
+  it("resolves relative targets using cwd", () => {
+    const permissions = resolveFilesystemPermissions({
+      rules: {
+        "/workspace/**": "rw-",
+      },
+      default: "---",
+    });
+    expect(permissions).toBeDefined();
+    const decision = evaluateFilesystemPathPermission({
+      permissions: permissions!,
+      targetPath: "./nested/file.txt",
+      operation: "write",
+      cwd: path.join(path.sep, "workspace"),
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.resolvedPath).toBe(path.join(path.sep, "workspace", "nested", "file.txt"));
+  });
+});

--- a/src/infra/filesystem-permissions.ts
+++ b/src/infra/filesystem-permissions.ts
@@ -1,0 +1,285 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { matchesExecAllowlistPattern } from "./exec-allowlist-pattern.js";
+import { expandHomePrefix } from "./home-dir.js";
+
+export type FilesystemPermissionBits = `${"r" | "-"}${"w" | "-"}${"x" | "-"}`;
+export type FilesystemPermissionOperation = "read" | "write" | "execute";
+
+export type FilesystemPermissionsConfig = {
+  rules?: Record<string, string>;
+  deny?: string[];
+  default?: string;
+};
+
+type ResolvedFilesystemPermissionRule = {
+  pattern: string;
+  bits: FilesystemPermissionBits;
+  specificity: number;
+  order: number;
+};
+
+export type ResolvedFilesystemPermissions = {
+  rules: ResolvedFilesystemPermissionRule[];
+  deny: string[];
+  defaultBits: FilesystemPermissionBits;
+};
+
+type FilesystemPermissionMatch = {
+  kind: "rule";
+  pattern: string;
+  bits: FilesystemPermissionBits;
+};
+
+type FilesystemPermissionDecision = {
+  allowed: boolean;
+  resolvedPath: string;
+  requiredBit: "r" | "w" | "x";
+  source: "deny" | "rule" | "default";
+  sourcePattern?: string;
+  effectiveBits: FilesystemPermissionBits;
+};
+
+const DEFAULT_FILESYSTEM_PERMISSIONS: FilesystemPermissionBits = "---";
+
+function isValidFilesystemPermissionBits(value: string): value is FilesystemPermissionBits {
+  return /^[-r][-w][-x]$/i.test(value);
+}
+
+export function normalizeFilesystemPermissionBits(
+  value: string | undefined,
+  fallback: FilesystemPermissionBits = DEFAULT_FILESYSTEM_PERMISSIONS,
+): FilesystemPermissionBits {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized || !isValidFilesystemPermissionBits(normalized)) {
+    return fallback;
+  }
+  return normalized;
+}
+
+function normalizePattern(pattern: string | undefined): string | null {
+  const trimmed = pattern?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed;
+}
+
+function normalizeDenyPatterns(deny: string[] | undefined): string[] | undefined {
+  if (!Array.isArray(deny)) {
+    return undefined;
+  }
+  const next = deny
+    .map((entry) => normalizePattern(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return next.length > 0 ? next : undefined;
+}
+
+function normalizeRuleEntries(
+  rules: Record<string, string> | undefined,
+): Record<string, FilesystemPermissionBits> | undefined {
+  if (!rules || typeof rules !== "object") {
+    return undefined;
+  }
+  const entries = Object.entries(rules)
+    .map(([rawPattern, rawBits]) => {
+      const pattern = normalizePattern(rawPattern);
+      if (!pattern) {
+        return null;
+      }
+      return [pattern, normalizeFilesystemPermissionBits(rawBits)] as const;
+    })
+    .filter((entry): entry is readonly [string, FilesystemPermissionBits] => entry !== null);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(entries);
+}
+
+export function normalizeFilesystemPermissionsConfig(
+  config: FilesystemPermissionsConfig | undefined,
+): FilesystemPermissionsConfig | undefined {
+  if (!config || typeof config !== "object") {
+    return undefined;
+  }
+
+  const rules = normalizeRuleEntries(config.rules);
+  const deny = normalizeDenyPatterns(config.deny);
+  const defaultBits = normalizeFilesystemPermissionBits(config.default);
+
+  return {
+    ...(rules ? { rules } : {}),
+    ...(deny ? { deny } : {}),
+    ...(defaultBits !== DEFAULT_FILESYSTEM_PERMISSIONS ? { default: defaultBits } : {}),
+  };
+}
+
+function resolveRuleSpecificity(pattern: string): number {
+  const expanded = pattern.startsWith("~") ? expandHomePrefix(pattern) : pattern;
+  return expanded.length;
+}
+
+export function resolveFilesystemPermissions(
+  config: FilesystemPermissionsConfig | undefined,
+): ResolvedFilesystemPermissions | undefined {
+  const normalized = normalizeFilesystemPermissionsConfig(config);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const deny = normalizeDenyPatterns(normalized.deny) ?? [];
+  const ruleEntries = Object.entries(normalized.rules ?? {});
+  const rules: ResolvedFilesystemPermissionRule[] = [];
+  for (let i = 0; i < ruleEntries.length; i += 1) {
+    const [pattern, bits] = ruleEntries[i];
+    rules.push({
+      pattern,
+      bits: normalizeFilesystemPermissionBits(bits),
+      specificity: resolveRuleSpecificity(pattern),
+      order: i,
+    });
+  }
+
+  return {
+    rules,
+    deny,
+    defaultBits: normalizeFilesystemPermissionBits(normalized.default),
+  };
+}
+
+function resolveRequiredBit(operation: FilesystemPermissionOperation): {
+  bit: "r" | "w" | "x";
+  index: number;
+} {
+  if (operation === "read") {
+    return { bit: "r", index: 0 };
+  }
+  if (operation === "write") {
+    return { bit: "w", index: 1 };
+  }
+  return { bit: "x", index: 2 };
+}
+
+function normalizePathLikeToken(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("~")) {
+    return expandHomePrefix(trimmed);
+  }
+  if (!/^file:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  try {
+    return fileURLToPath(trimmed);
+  } catch {
+    return trimmed;
+  }
+}
+
+export function resolveFilesystemPermissionPath(params: {
+  targetPath: string;
+  cwd?: string;
+}): string {
+  const normalized = normalizePathLikeToken(params.targetPath);
+  const base = params.cwd && params.cwd.trim() ? params.cwd : process.cwd();
+  const absolute = path.isAbsolute(normalized) ? normalized : path.resolve(base, normalized);
+  return path.resolve(absolute);
+}
+
+function matchMostSpecificRule(params: {
+  rules: ResolvedFilesystemPermissionRule[];
+  resolvedPath: string;
+}): FilesystemPermissionMatch | null {
+  let best: ResolvedFilesystemPermissionRule | null = null;
+  for (const rule of params.rules) {
+    if (!matchesExecAllowlistPattern(rule.pattern, params.resolvedPath)) {
+      continue;
+    }
+    if (
+      !best ||
+      rule.specificity > best.specificity ||
+      (rule.specificity === best.specificity && rule.order > best.order)
+    ) {
+      best = rule;
+    }
+  }
+  if (!best) {
+    return null;
+  }
+  return {
+    kind: "rule",
+    pattern: best.pattern,
+    bits: best.bits,
+  };
+}
+
+export function evaluateFilesystemPathPermission(params: {
+  permissions: ResolvedFilesystemPermissions;
+  targetPath: string;
+  operation: FilesystemPermissionOperation;
+  cwd?: string;
+}): FilesystemPermissionDecision {
+  const resolvedPath = resolveFilesystemPermissionPath({
+    targetPath: params.targetPath,
+    cwd: params.cwd,
+  });
+  const { bit: requiredBit, index } = resolveRequiredBit(params.operation);
+
+  for (const denyPattern of params.permissions.deny) {
+    if (matchesExecAllowlistPattern(denyPattern, resolvedPath)) {
+      return {
+        allowed: false,
+        resolvedPath,
+        requiredBit,
+        source: "deny",
+        sourcePattern: denyPattern,
+        effectiveBits: DEFAULT_FILESYSTEM_PERMISSIONS,
+      };
+    }
+  }
+
+  const match = matchMostSpecificRule({
+    rules: params.permissions.rules,
+    resolvedPath,
+  });
+  const effectiveBits = match?.bits ?? params.permissions.defaultBits;
+  const allowed = effectiveBits[index] === requiredBit;
+  return {
+    allowed,
+    resolvedPath,
+    requiredBit,
+    source: match ? "rule" : "default",
+    sourcePattern: match?.pattern,
+    effectiveBits,
+  };
+}
+
+export function assertFilesystemPathPermission(params: {
+  permissions: ResolvedFilesystemPermissions | undefined;
+  targetPath: string;
+  operation: FilesystemPermissionOperation;
+  cwd?: string;
+  context?: string;
+}): void {
+  if (!params.permissions) {
+    return;
+  }
+  const decision = evaluateFilesystemPathPermission({
+    permissions: params.permissions,
+    targetPath: params.targetPath,
+    operation: params.operation,
+    cwd: params.cwd,
+  });
+  if (decision.allowed) {
+    return;
+  }
+  const context = params.context ? `${params.context}: ` : "";
+  const sourceText =
+    decision.source === "deny"
+      ? `deny pattern "${decision.sourcePattern ?? ""}"`
+      : decision.source === "rule"
+        ? `rule "${decision.sourcePattern ?? ""}" => "${decision.effectiveBits}"`
+        : `default "${decision.effectiveBits}"`;
+  throw new Error(
+    `${context}filesystem permission denied (${decision.requiredBit}) for ${decision.resolvedPath} (${sourceText})`,
+  );
+}


### PR DESCRIPTION
## Summary

- Problem: exec approval allowlists are binary-scoped, and file tools only had a workspace-only boundary; there was no shared path-scoped RWX policy.
- Why it matters: operators could not enforce per-path read/write/execute controls consistently across `exec` and filesystem tools.
- What changed: added a shared filesystem permission evaluator (`rules`/`deny`/`default`, deny-first, longest-match-wins) and enforced it in `exec`, `read`/`write`/`edit`, and `apply_patch`.
- What did NOT change (scope boundary): existing exec allowlist behavior and security modes remain in place (backward compatible), and no changes were made to model/provider logic.

## Change Type (select all)

- [x] Feature
- [x] Security hardening

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] API / contracts

## Linked Issue/PR

- Closes #39979
- Related #12202

## User-visible / Behavior Changes

- `exec-approvals.json` now supports:
  - `permissions.filesystem.rules` (path glob -> `rwx` bits)
  - `permissions.filesystem.deny` (deny-first globs)
  - `permissions.filesystem.default` (fallback bits)
- When configured, these permissions are enforced for:
  - `exec` (executable path + extracted path operands)
  - `read`, `write`, `edit`
  - `apply_patch`
- Existing binary allowlist and approval flow are preserved for compatibility.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Risk: misconfigured rules could over-block workflows.
  - Mitigation: enforcement is opt-in (`permissions.filesystem` must be present), deny/rule/default diagnostics are included in errors, and compatibility with existing allowlist logic is preserved.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `exec-approvals.json` with `permissions.filesystem` map

### Steps

1. Configure `exec-approvals.json` `permissions.filesystem` rules/deny/default.
2. Invoke `read`/`write`/`edit`/`apply_patch` on allowed vs denied paths.
3. Invoke `exec` with commands that touch allowed vs denied paths.

### Expected

- Allowed paths pass.
- Denied paths fail before execution with permission-denied errors.

### Actual

- Matches expected in focused tests below.

## Evidence

- [x] Failing test/log before + passing after

Validation commands and outcomes:

- `pnpm install` ✅
- `pnpm test -- src/infra/filesystem-permissions.test.ts src/agents/bash-tools.exec-fs-permissions.test.ts src/agents/pi-tools.filesystem-permissions.test.ts src/agents/apply-patch.test.ts src/infra/exec-approvals-config.test.ts src/agents/pi-tools.safe-bins.test.ts src/agents/bash-tools.exec.path.test.ts` ✅ (7 files, 48 tests passed)
- `pnpm exec oxfmt --check src/infra/filesystem-permissions.ts src/infra/filesystem-permissions.test.ts src/infra/exec-approvals.ts src/infra/exec-approvals-config.test.ts src/agents/bash-tools.exec-fs-permissions.ts src/agents/bash-tools.exec-fs-permissions.test.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.exec-types.ts src/agents/pi-tools.ts src/agents/pi-tools.read.ts src/agents/pi-tools.filesystem-permissions.test.ts src/agents/apply-patch.ts src/agents/apply-patch.test.ts src/agents/tool-fs-policy.ts src/agents/pi-tools.safe-bins.test.ts src/agents/bash-tools.exec.path.test.ts` ✅
- `pnpm tsgo` ⚠️ fails on pre-existing unrelated type error in `src/agents/models-config.merge.test.ts` (`TS2352`, missing `baseUrl` on `ModelProviderConfig` cast)

## Human Verification (required)

- Verified scenarios:
  - Rule precedence (longest match)
  - Deny precedence over rules
  - Default fallback behavior
  - File tool read/write deny/allow behavior
  - apply_patch deny/allow behavior
  - exec path extraction deny/allow behavior
- Edge cases checked:
  - cp/mv source vs destination semantics
  - grep/rg and interpreter script path extraction
- What you did **not** verify:
  - Full repository-wide typecheck resolution beyond the pre-existing `tsgo` failure.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) Optional
- If yes, exact upgrade steps:
  1. Add `permissions.filesystem` to `~/.openclaw/exec-approvals.json`.
  2. Define `rules`, optional `deny`, and `default` bits.
  3. Reload/retry tool invocations.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove `permissions.filesystem` from `exec-approvals.json` (enforcement becomes inactive).
- Files/config to restore:
  - `~/.openclaw/exec-approvals.json`
- Known bad symptoms reviewers should watch for:
  - Unexpected `filesystem permission denied` errors due to too-strict rules/default.

## Risks and Mitigations

- Risk: command operand extraction for `exec` is heuristic for some binaries.
  - Mitigation: deny/rule/default checks are explicit in errors; extraction covers common filesystem-touching commands and still enforces executable `x` checks.
