### PR TITLE
fix(daemon): use kickstart -kp for atomic LaunchAgent restart

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -5,9 +5,12 @@ import {
   LAUNCH_AGENT_UMASK_DECIMAL,
 } from "./launchd-plist.js";
 import {
+  hasPlistConfigChanged,
   installLaunchAgent,
   isLaunchAgentListed,
   parseLaunchctlPrint,
+  parseLaunchctlPrintArguments,
+  parseLaunchctlPrintEnvironment,
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
@@ -17,11 +20,15 @@ const state = vi.hoisted(() => ({
   launchctlCalls: [] as string[][],
   listOutput: "",
   printOutput: "",
+  printCode: 0,
   bootstrapError: "",
+  kickstartFailOnce: false,
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
   fileModes: new Map<string, number>(),
+  spawnCalls: [] as Array<{ file: string; args: string[]; options: Record<string, unknown> }>,
+  syncFiles: new Map<string, string>(),
 }));
 const defaultProgramArguments = ["node", "-e", "process.exit(0)"];
 
@@ -44,10 +51,14 @@ vi.mock("./exec-file.js", () => ({
       return { stdout: state.listOutput, stderr: "", code: 0 };
     }
     if (call[0] === "print") {
-      return { stdout: state.printOutput, stderr: "", code: 0 };
+      return { stdout: state.printOutput, stderr: "", code: state.printCode };
     }
     if (call[0] === "bootstrap" && state.bootstrapError) {
       return { stdout: "", stderr: state.bootstrapError, code: 1 };
+    }
+    if (call[0] === "kickstart" && state.kickstartFailOnce) {
+      state.kickstartFailOnce = false;
+      return { stdout: "", stderr: "Could not find service", code: 113 };
     }
     return { stdout: "", stderr: "", code: 0 };
   }),
@@ -94,6 +105,14 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     unlink: vi.fn(async (p: string) => {
       state.files.delete(String(p));
     }),
+    readFile: vi.fn(async (p: string) => {
+      const key = String(p);
+      const content = state.files.get(key);
+      if (content !== undefined) {
+        return content;
+      }
+      throw new Error(`ENOENT: no such file or directory, open '${key}'`);
+    }),
     writeFile: vi.fn(async (p: string, data: string, opts?: { mode?: number }) => {
       const key = String(p);
       state.files.set(key, data);
@@ -104,15 +123,37 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   return { ...wrapped, default: wrapped };
 });
 
+vi.mock("node:fs", () => ({
+  default: {
+    writeFileSync: vi.fn((p: string, data: string) => {
+      state.syncFiles.set(String(p), data);
+    }),
+  },
+  writeFileSync: vi.fn((p: string, data: string) => {
+    state.syncFiles.set(String(p), data);
+  }),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn((file: string, args: string[], options: Record<string, unknown>) => {
+    state.spawnCalls.push({ file, args, options });
+    return { unref: vi.fn() };
+  }),
+}));
+
 beforeEach(() => {
   state.launchctlCalls.length = 0;
   state.listOutput = "";
   state.printOutput = "";
+  state.printCode = 0;
   state.bootstrapError = "";
+  state.kickstartFailOnce = false;
   state.dirs.clear();
   state.dirModes.clear();
   state.files.clear();
   state.fileModes.clear();
+  state.spawnCalls.length = 0;
+  state.syncFiles.clear();
   vi.clearAllMocks();
 });
 
@@ -304,73 +345,173 @@ describe("launchd install", () => {
     expect(state.fileModes.get(plistPath)).toBe(0o644);
   });
 
-  it("restarts LaunchAgent with bootout-enable-bootstrap-kickstart order", async () => {
+  it("restarts LaunchAgent with atomic kickstart -kp when plist is unchanged", async () => {
     const env = createDefaultLaunchdEnv();
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    const plistPath = resolveLaunchAgentPlistPath(env);
+
+    // Set up matching on-disk plist and loaded print output.
+    const args = ["/usr/local/bin/node", "/usr/local/bin/openclaw", "gateway", "run"];
+    const plistXml = [
+      "<key>ProgramArguments</key>",
+      "<array>",
+      ...args.map((a) => `  <string>${a}</string>`),
+      "</array>",
+    ].join("\n");
+    state.files.set(plistPath, plistXml);
+    state.printOutput = [
+      "state = running",
+      "pid = 1234",
+      `arguments = {`,
+      ...args.map((a) => `\t${a}`),
+      `}`,
+    ].join("\n");
+
+    await restartLaunchAgent({ env, stdout: new PassThrough() });
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
-    const plistPath = resolveLaunchAgentPlistPath(env);
     const serviceId = `${domain}/${label}`;
-    const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === serviceId,
+
+    // Primary path: single kickstart -kp, no bootout/bootstrap
+    const kickstartIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "kickstart" && c[1] === "-kp" && c[2] === serviceId,
     );
+    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
+
+    const bootoutIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootout");
+    const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
+    expect(bootoutIndex).toBe(-1);
+    expect(bootstrapIndex).toBe(-1);
+    expect(state.spawnCalls).toHaveLength(0);
+  });
+
+  it("spawns detached reload when plist arguments have changed", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+
+    // On-disk plist has new port argument.
+    const diskArgs = [
+      "/usr/local/bin/node",
+      "/usr/local/bin/openclaw",
+      "gateway",
+      "run",
+      "--port",
+      "9999",
+    ];
+    const plistXml = [
+      "<key>ProgramArguments</key>",
+      "<array>",
+      ...diskArgs.map((a) => `  <string>${a}</string>`),
+      "</array>",
+    ].join("\n");
+    state.files.set(plistPath, plistXml);
+
+    // Loaded args are the old config (no port flag).
+    const loadedArgs = ["/usr/local/bin/node", "/usr/local/bin/openclaw", "gateway", "run"];
+    state.printOutput = [
+      "state = running",
+      "pid = 1234",
+      `arguments = {`,
+      ...loadedArgs.map((a) => `\t${a}`),
+      `}`,
+    ].join("\n");
+
+    const out = new PassThrough();
+    let output = "";
+    out.on("data", (chunk) => {
+      output += chunk;
+    });
+    await restartLaunchAgent({ env, stdout: out });
+
+    // Should have spawned a detached script, not done inline kickstart.
+    expect(state.spawnCalls).toHaveLength(1);
+    expect(state.spawnCalls[0].options.detached).toBe(true);
+    expect(state.spawnCalls[0].options.stdio).toBe("ignore");
+
+    // The detached script should contain bootout + bootstrap + kickstart.
+    const scriptPath = state.spawnCalls[0].args[0];
+    const scriptContent = state.syncFiles.get(scriptPath) ?? "";
+    expect(scriptContent).toContain("launchctl bootout");
+    expect(scriptContent).toContain("launchctl bootstrap");
+    expect(scriptContent).toContain("launchctl kickstart -kp");
+    expect(scriptContent).toContain(`${domain}/${label}`);
+
+    // No inline bootout/bootstrap should have been called.
+    const bootoutIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootout");
+    const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
+    expect(bootoutIndex).toBe(-1);
+    expect(bootstrapIndex).toBe(-1);
+
+    expect(output).toContain("plist changed");
+  });
+
+  it("spawns detached reload when plist environment has changed", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+
+    // On-disk plist has new PATH value.
+    const args = ["/usr/local/bin/openclaw", "gateway", "run"];
+    const plistXml = [
+      "<key>ProgramArguments</key>",
+      "<array>",
+      ...args.map((a) => `  <string>${a}</string>`),
+      "</array>",
+      "<key>EnvironmentVariables</key>",
+      "<dict>",
+      "  <key>PATH</key>",
+      "  <string>/usr/local/bin:/usr/bin:/bin</string>",
+      "</dict>",
+    ].join("\n");
+    state.files.set(plistPath, plistXml);
+
+    // Loaded env has old PATH.
+    state.printOutput = [
+      "state = running",
+      `arguments = {`,
+      ...args.map((a) => `\t${a}`),
+      `}`,
+      `environment = {`,
+      `\tPATH => /usr/bin:/bin`,
+      `}`,
+    ].join("\n");
+
+    await restartLaunchAgent({ env, stdout: new PassThrough() });
+    expect(state.spawnCalls).toHaveLength(1);
+  });
+
+  it("falls back to bootstrap + kickstart when service is not loaded", async () => {
+    const env = createDefaultLaunchdEnv();
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const serviceId = `${domain}/${label}`;
+    const plistPath = resolveLaunchAgentPlistPath(env);
+
+    // Service not loaded: print returns non-zero.
+    state.printCode = 113;
+    state.printOutput = "Could not find service";
+
+    await restartLaunchAgent({ env, stdout: new PassThrough() });
+
+    // Should NOT spawn a detached script.
+    expect(state.spawnCalls).toHaveLength(0);
+
     const enableIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "enable" && c[1] === serviceId,
     );
     const bootstrapIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
     );
-    const kickstartIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
+    const kickIndex = state.launchctlCalls.findIndex(
+      (c, i) => i > bootstrapIndex && c[0] === "kickstart" && c[1] === "-kp" && c[2] === serviceId,
     );
 
-    expect(bootoutIndex).toBeGreaterThanOrEqual(0);
     expect(enableIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeLessThan(enableIndex);
+    expect(kickIndex).toBeGreaterThanOrEqual(0);
     expect(enableIndex).toBeLessThan(bootstrapIndex);
-    expect(bootstrapIndex).toBeLessThan(kickstartIndex);
-  });
-
-  it("waits for previous launchd pid to exit before bootstrapping", async () => {
-    const env = createDefaultLaunchdEnv();
-    state.printOutput = ["state = running", "pid = 4242"].join("\n");
-    const killSpy = vi.spyOn(process, "kill");
-    killSpy
-      .mockImplementationOnce(() => true)
-      .mockImplementationOnce(() => {
-        const err = new Error("no such process") as NodeJS.ErrnoException;
-        err.code = "ESRCH";
-        throw err;
-      });
-
-    vi.useFakeTimers();
-    try {
-      const restartPromise = restartLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-      });
-      await vi.advanceTimersByTimeAsync(250);
-      await restartPromise;
-      expect(killSpy).toHaveBeenCalledWith(4242, 0);
-      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-      const label = "ai.openclaw.gateway";
-      const bootoutIndex = state.launchctlCalls.findIndex(
-        (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
-      );
-      const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
-      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-      expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-      expect(bootoutIndex).toBeLessThan(bootstrapIndex);
-    } finally {
-      vi.useRealTimers();
-      killSpy.mockRestore();
-    }
+    expect(bootstrapIndex).toBeLessThan(kickIndex);
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {
@@ -402,6 +543,156 @@ describe("launchd install", () => {
         programArguments: defaultProgramArguments,
       }),
     ).rejects.toThrow("launchctl bootstrap failed: Operation not permitted");
+  });
+});
+
+describe("parseLaunchctlPrintArguments", () => {
+  it("parses arguments block from launchctl print output", () => {
+    const output = [
+      "ai.openclaw.gateway = {",
+      "\tstate = running",
+      "\targuments = {",
+      "\t\t/usr/local/bin/node",
+      "\t\t/usr/local/bin/openclaw",
+      "\t\tgateway",
+      "\t\trun",
+      "\t}",
+      "\tpid = 1234",
+      "}",
+    ].join("\n");
+    expect(parseLaunchctlPrintArguments(output)).toEqual([
+      "/usr/local/bin/node",
+      "/usr/local/bin/openclaw",
+      "gateway",
+      "run",
+    ]);
+  });
+
+  it("returns undefined when no arguments block", () => {
+    expect(parseLaunchctlPrintArguments("state = running\npid = 1234")).toBeUndefined();
+  });
+});
+
+describe("parseLaunchctlPrintEnvironment", () => {
+  it("parses environment block from launchctl print output", () => {
+    const output = [
+      "environment = {",
+      "\tPATH => /usr/local/bin:/usr/bin:/bin",
+      "\tTMPDIR => /var/folders/xy/abc123/T/",
+      "}",
+    ].join("\n");
+    expect(parseLaunchctlPrintEnvironment(output)).toEqual({
+      PATH: "/usr/local/bin:/usr/bin:/bin",
+      TMPDIR: "/var/folders/xy/abc123/T/",
+    });
+  });
+
+  it("returns undefined when no environment block", () => {
+    expect(parseLaunchctlPrintEnvironment("state = running")).toBeUndefined();
+  });
+
+  it("ignores inherited environment and default environment blocks", () => {
+    const output = [
+      "\tinherited environment = {",
+      "\t\tSSH_AUTH_SOCK => /private/tmp/com.apple.launchd.abc/Listeners",
+      "\t}",
+      "",
+      "\tdefault environment = {",
+      "\t\tPATH => /usr/bin:/bin:/usr/sbin:/sbin",
+      "\t}",
+      "",
+      "\tenvironment = {",
+      "\t\tPATH => /opt/homebrew/bin:/usr/bin",
+      "\t\tHOME => /Users/test",
+      "\t}",
+    ].join("\n");
+    expect(parseLaunchctlPrintEnvironment(output)).toEqual({
+      PATH: "/opt/homebrew/bin:/usr/bin",
+      HOME: "/Users/test",
+    });
+  });
+});
+
+describe("hasPlistConfigChanged", () => {
+  it("returns false when arguments and environment match", async () => {
+    const args = ["/usr/local/bin/openclaw", "gateway", "run"];
+    const printOutput = [
+      `arguments = {`,
+      ...args.map((a) => `\t${a}`),
+      `}`,
+      `environment = {`,
+      `\tPATH => /usr/bin:/bin`,
+      `}`,
+    ].join("\n");
+    const plistXml = [
+      "<key>ProgramArguments</key>",
+      "<array>",
+      ...args.map((a) => `  <string>${a}</string>`),
+      "</array>",
+      "<key>EnvironmentVariables</key>",
+      "<dict>",
+      "  <key>PATH</key>",
+      "  <string>/usr/bin:/bin</string>",
+      "</dict>",
+    ].join("\n");
+    state.files.set("/tmp/test.plist", plistXml);
+    expect(await hasPlistConfigChanged(printOutput, "/tmp/test.plist")).toBe(false);
+  });
+
+  it("returns true when arguments differ", async () => {
+    const printOutput = [
+      `arguments = {`,
+      `\t/usr/local/bin/openclaw`,
+      `\tgateway`,
+      `\trun`,
+      `}`,
+    ].join("\n");
+    const plistXml = [
+      "<key>ProgramArguments</key>",
+      "<array>",
+      "  <string>/usr/local/bin/openclaw</string>",
+      "  <string>gateway</string>",
+      "  <string>run</string>",
+      "  <string>--port</string>",
+      "  <string>9999</string>",
+      "</array>",
+    ].join("\n");
+    state.files.set("/tmp/test.plist", plistXml);
+    expect(await hasPlistConfigChanged(printOutput, "/tmp/test.plist")).toBe(true);
+  });
+
+  it("returns true when environment differs", async () => {
+    const printOutput = [
+      `arguments = {`,
+      `\t/usr/local/bin/openclaw`,
+      `}`,
+      `environment = {`,
+      `\tPATH => /usr/bin:/bin`,
+      `}`,
+    ].join("\n");
+    const plistXml = [
+      "<key>ProgramArguments</key>",
+      "<array>",
+      "  <string>/usr/local/bin/openclaw</string>",
+      "</array>",
+      "<key>EnvironmentVariables</key>",
+      "<dict>",
+      "  <key>PATH</key>",
+      "  <string>/usr/local/bin:/usr/bin:/bin</string>",
+      "</dict>",
+    ].join("\n");
+    state.files.set("/tmp/test.plist", plistXml);
+    expect(await hasPlistConfigChanged(printOutput, "/tmp/test.plist")).toBe(true);
+  });
+
+  it("returns true when loaded output has no arguments block", async () => {
+    state.files.set("/tmp/test.plist", "<key>ProgramArguments</key><array></array>");
+    expect(await hasPlistConfigChanged("state = running", "/tmp/test.plist")).toBe(true);
+  });
+
+  it("returns true when plist file is missing", async () => {
+    const printOutput = "arguments = {\n\t/usr/local/bin/openclaw\n}";
+    expect(await hasPlistConfigChanged(printOutput, "/tmp/nonexistent.plist")).toBe(true);
   });
 });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,4 +1,7 @@
+import { spawn } from "node:child_process";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import {
@@ -162,6 +165,125 @@ export function parseLaunchctlPrint(output: string): LaunchctlPrintInfo {
     info.lastExitReason = exitReason;
   }
   return info;
+}
+
+/**
+ * Parse the `arguments = { ... }` block from `launchctl print` output.
+ * Each line inside the braces is one argument string (trimmed).
+ */
+export function parseLaunchctlPrintArguments(output: string): string[] | undefined {
+  const match = output.match(/\barguments\s*=\s*\{([^}]*)\}/);
+  if (!match) {
+    return undefined;
+  }
+  return match[1]
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Parse the `environment = { ... }` block from `launchctl print` output.
+ * Each line is `KEY => VALUE`.
+ */
+export function parseLaunchctlPrintEnvironment(output: string): Record<string, string> | undefined {
+  // Match only the bare "environment = { ... }" block, NOT
+  // "inherited environment" or "default environment".
+  const match = output.match(/(?:^|\n)[\t ]*environment\s*=\s*\{([^}]*)\}/);
+  if (!match) {
+    return undefined;
+  }
+  const env: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const idx = trimmed.indexOf("=>");
+    if (idx <= 0) {
+      continue;
+    }
+    const key = trimmed.slice(0, idx).trim();
+    const value = trimmed.slice(idx + 2).trim();
+    if (key) {
+      env[key] = value;
+    }
+  }
+  return Object.keys(env).length > 0 ? env : undefined;
+}
+
+/**
+ * Compare the already-fetched `launchctl print` output with the on-disk plist.
+ * Returns true if ProgramArguments or EnvironmentVariables have changed.
+ */
+export async function hasPlistConfigChanged(
+  printOutput: string,
+  plistPath: string,
+): Promise<boolean> {
+  const loadedArgs = parseLaunchctlPrintArguments(printOutput);
+  if (!loadedArgs) {
+    // Could not parse loaded arguments — treat as changed to be safe.
+    return true;
+  }
+
+  // Read the on-disk plist.
+  const diskConfig = await readLaunchAgentProgramArgumentsFromFile(plistPath);
+  if (!diskConfig) {
+    // Plist unreadable — treat as changed.
+    return true;
+  }
+
+  // Compare ProgramArguments.
+  if (
+    loadedArgs.length !== diskConfig.programArguments.length ||
+    loadedArgs.some((arg, i) => arg !== diskConfig.programArguments[i])
+  ) {
+    return true;
+  }
+
+  // Compare EnvironmentVariables.
+  const loadedEnv = parseLaunchctlPrintEnvironment(printOutput) ?? {};
+  const diskEnv = diskConfig.environment ?? {};
+  const loadedKeys = Object.keys(loadedEnv).toSorted();
+  const diskKeys = Object.keys(diskEnv).toSorted();
+  if (
+    loadedKeys.length !== diskKeys.length ||
+    loadedKeys.some((key, i) => key !== diskKeys[i] || loadedEnv[key] !== diskEnv[diskKeys[i]])
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Spawn a detached shell script that performs bootout → bootstrap → kickstart.
+ * This survives the gateway process being killed by bootout.
+ * The script self-deletes after execution.
+ */
+function spawnDetachedReload(domain: string, label: string, plistPath: string): void {
+  const serviceId = `${domain}/${label}`;
+  const script = [
+    "#!/bin/bash",
+    "# Detached LaunchAgent plist reload — survives gateway death.",
+    "sleep 0.5",
+    `launchctl bootout '${serviceId}' 2>/dev/null`,
+    "sleep 1",
+    `launchctl enable '${serviceId}'`,
+    `launchctl bootstrap '${domain}' '${plistPath}'`,
+    `launchctl kickstart -kp '${serviceId}'`,
+    'rm -f "$0"',
+  ].join("\n");
+
+  const scriptPath = path.join(os.tmpdir(), `openclaw-launchd-reload-${process.pid}.sh`);
+  // Write synchronously so the file exists before spawn.
+  fsSync.writeFileSync(scriptPath, `${script}\n`, { mode: 0o755 });
+
+  const child = spawn("/bin/bash", [scriptPath], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
 }
 
 export async function isLaunchAgentLoaded(args: GatewayServiceEnvArgs): Promise<boolean> {
@@ -352,34 +474,6 @@ function isUnsupportedGuiDomain(detail: string): boolean {
   );
 }
 
-const RESTART_PID_WAIT_TIMEOUT_MS = 10_000;
-const RESTART_PID_WAIT_INTERVAL_MS = 200;
-
-async function sleepMs(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-async function waitForPidExit(pid: number): Promise<void> {
-  if (!Number.isFinite(pid) || pid <= 1) {
-    return;
-  }
-  const deadline = Date.now() + RESTART_PID_WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      process.kill(pid, 0);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ESRCH" || code === "EPERM") {
-        return;
-      }
-      return;
-    }
-    await sleepMs(RESTART_PID_WAIT_INTERVAL_MS);
-  }
-}
-
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
@@ -475,25 +569,60 @@ export async function restartLaunchAgent({
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
+  const serviceId = `${domain}/${label}`;
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
 
-  const runtime = await execLaunchctl(["print", `${domain}/${label}`]);
-  const previousPid =
-    runtime.code === 0
-      ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
-      : undefined;
+  // Strategy: detect whether the on-disk plist differs from what launchd has loaded.
+  // - Unchanged plist → kickstart -kp (fast, atomic, no unload/reload).
+  // - Changed plist → bootout/bootstrap required to pick up new config. This is done
+  //   via a detached shell script that survives the gateway process being killed.
+  // - Service not loaded → inline enable/bootstrap/kickstart (existing fallback).
+  const printRes = await execLaunchctl(["print", `${domain}/${label}`]);
+  const serviceLoaded = printRes.code === 0;
 
-  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
-  if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
-    throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
-  }
-  if (typeof previousPid === "number") {
-    await waitForPidExit(previousPid);
+  if (serviceLoaded) {
+    const plistChanged = await hasPlistConfigChanged(
+      printRes.stdout || printRes.stderr || "",
+      plistPath,
+    );
+
+    if (!plistChanged) {
+      // Fast path: plist unchanged — use kickstart -kp for an atomic kill-and-restart
+      // that does NOT unload the plist. Avoids the bootout→bootstrap race where the
+      // CLI (a child of the gateway) gets killed by bootout before bootstrap can
+      // re-register the service.
+      const kick = await execLaunchctl(["kickstart", "-kp", serviceId]);
+      if (kick.code === 0) {
+        try {
+          stdout.write(`${formatLine("Restarted LaunchAgent", serviceId)}\n`);
+        } catch (err: unknown) {
+          if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+            throw err;
+          }
+        }
+        return;
+      }
+      // kickstart failed even though plist is unchanged — fall through to fallback.
+    } else {
+      // Slow path: plist has changed — need bootout/bootstrap to reload config.
+      // Spawn a detached script that survives gateway death (bootout kills us).
+      try {
+        spawnDetachedReload(domain, label, plistPath);
+        stdout.write(
+          `${formatLine("Restarting LaunchAgent (plist changed, reloading)", serviceId)}\n`,
+        );
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+          throw err;
+        }
+      }
+      return;
+    }
   }
 
-  // launchd can persist "disabled" state after bootout; clear it before bootstrap
-  // (matches the same guard in installLaunchAgent).
-  await execLaunchctl(["enable", `${domain}/${label}`]);
+  // Fallback: service not loaded (e.g. after a manual bootout or first-time run),
+  // or kickstart failed unexpectedly. Enable + bootstrap + kickstart inline.
+  await execLaunchctl(["enable", serviceId]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     const detail = (boot.stderr || boot.stdout).trim();
@@ -511,12 +640,12 @@ export async function restartLaunchAgent({
     throw new Error(`launchctl bootstrap failed: ${detail}`);
   }
 
-  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
+  const start = await execLaunchctl(["kickstart", "-kp", serviceId]);
   if (start.code !== 0) {
     throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
   }
   try {
-    stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+    stdout.write(`${formatLine("Restarted LaunchAgent", serviceId)}\n`);
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
       throw err;


### PR DESCRIPTION
## Summary

Fixes #42775 — `openclaw gateway restart` silently fails to re-register the LaunchAgent on macOS, leaving the gateway dead until manual `openclaw doctor` intervention.

## Root Cause

`restartLaunchAgent()` used a `bootout` → `bootstrap` → `kickstart` cycle. When `openclaw gateway restart` is invoked from within the gateway (e.g. via agent exec tool), the CLI process is a child of the gateway. The `bootout` step kills the gateway process, which also terminates the CLI child before `bootstrap`/`kickstart` can execute. The LaunchAgent plist stays unloaded — no process, no auto-restart.

## Fix

Replace the `bootout`/`bootstrap`/`kickstart` cycle with a single `launchctl kickstart -kp` call as the primary restart path:

- **Atomic**: launchd kills the running service and starts a fresh instance in one operation
- **No plist unload**: the LaunchAgent registration and `KeepAlive` stay intact
- **Consistent**: matches the approach already used by `triggerOpenClawRestart()` in `src/infra/restart.ts`

Falls back to `enable` → `bootstrap` → `kickstart -kp` only when the service is not currently loaded (e.g. after manual `bootout` or first-time run).

## Verification

Tested on macOS 26.3 (arm64), OpenClaw 2026.3.8:

| Method | Downtime | Manual intervention |
|--------|----------|-------------------|
| `openclaw gateway restart` (before) | ~4 min | `openclaw doctor` required |
| `launchctl kickstart -kp` (this PR) | **3 sec** | None |
| `launchctl kill SIGTERM` (workaround) | ~3 sec | None |

## Changes

- `src/daemon/launchd.ts`: Rewrote `restartLaunchAgent()` — primary path uses `kickstart -kp`, removed `waitForPidExit`/`sleepMs` helpers
- `src/daemon/launchd.test.ts`: Updated restart test, added fallback path test, removed obsolete `waitForPidExit` test