### PR TITLE
Fix non-array content parsing crash in response handlers

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -594,6 +594,30 @@ describe("buildAssistantMessageFromResponse", () => {
     expect(msg.content).toEqual([]);
     expect(msg.stopReason).toBe("stop");
   });
+
+  it("ignores non-array message content in malformed provider payloads", () => {
+    const response = {
+      ...makeResponseObject("resp_8"),
+      output: [
+        {
+          type: "message",
+          id: "item_bad",
+          role: "assistant",
+          content: { type: "output_text", text: "bad shape" },
+        },
+        {
+          type: "message",
+          id: "item_ok",
+          role: "assistant",
+          content: [{ type: "output_text", text: "good text" }],
+        },
+      ],
+    } as unknown as ResponseObject;
+
+    const msg = buildAssistantMessageFromResponse(response, modelInfo);
+    expect(msg.content).toEqual([{ type: "text", text: "good text" }]);
+    expect(msg.stopReason).toBe("stop");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -292,7 +292,8 @@ export function buildAssistantMessageFromResponse(
 
   for (const item of response.output ?? []) {
     if (item.type === "message") {
-      for (const part of item.content ?? []) {
+      const contentParts = Array.isArray(item.content) ? item.content : [];
+      for (const part of contentParts) {
         if (part.type === "output_text" && part.text) {
           content.push({ type: "text", text: part.text });
         }

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -304,6 +304,23 @@ describe("web_search grok response parsing", () => {
     expect(result.text).toBe("direct output text");
     expect(result.annotationCitations).toEqual(["https://example.com/direct"]);
   });
+
+  it("ignores non-array message content and keeps scanning output items", () => {
+    const result = extractGrokContent({
+      output: [
+        {
+          type: "message",
+          content: { type: "output_text", text: "bad shape" },
+        },
+        {
+          type: "output_text",
+          text: "direct fallback text",
+        },
+      ],
+    } as Parameters<typeof extractGrokContent>[0]);
+    expect(result.text).toBe("direct fallback text");
+    expect(result.annotationCitations).toEqual([]);
+  });
 });
 
 describe("web_search kimi config resolution", () => {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -391,9 +391,11 @@ function extractGrokContent(data: GrokSearchResponse): {
   annotationCitations: string[];
 } {
   // xAI Responses API format: find the message output with text content
-  for (const output of data.output ?? []) {
+  const outputs = Array.isArray(data.output) ? data.output : [];
+  for (const output of outputs) {
     if (output.type === "message") {
-      for (const block of output.content ?? []) {
+      const contentBlocks = Array.isArray(output.content) ? output.content : [];
+      for (const block of contentBlocks) {
         if (block.type === "output_text" && typeof block.text === "string" && block.text) {
           const urls = (block.annotations ?? [])
             .filter((a) => a.type === "url_citation" && typeof a.url === "string")


### PR DESCRIPTION
## Summary

- Problem: malformed provider payloads with object-shaped `content` could trigger runtime iteration errors (`...content is not iterable`) and bubble up as 500s.
- Why it matters: this is user-facing and intermittent, so retries can randomly fail even when providers otherwise return usable output.
- What changed: added array guards before iterating `content` in OpenAI WS response parsing and Grok web-search response parsing; added regression tests for malformed `content` payloads.
- What did NOT change (scope boundary): no provider selection logic, no schema expansion, no behavior changes for valid array/string payloads.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42757
- Related: None

## User-visible / Behavior Changes

- OpenClaw no longer throws 500 when certain provider responses include non-array `content` in these parsing paths; malformed blocks are skipped and parsing continues.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: unit tests for OpenAI WS + Grok web-search parsers
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run focused tests against touched parsers.
2. Verify regression cases with malformed object-shaped `content` do not throw.

### Expected

- Tests pass and malformed `content` is ignored safely.

### Actual

- Passed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm test src/agents/tools/web-search.test.ts src/agents/openai-ws-stream.test.ts`
  - Result: `2 passed`, `85 passed` tests.

## Human Verification (required)

- Verified scenarios: malformed non-array message `content` in Grok response parsing; malformed non-array message `content` in OpenAI WS response parsing.
- Edge cases checked: valid direct `output_text` fallback still extracted after malformed message block.
- What you did **not** verify: full end-to-end live provider run on external APIs.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/openai-ws-stream.ts`, `src/agents/tools/web-search.ts`.
- Known bad symptoms reviewers should watch for: dropped text extraction if providers ship unexpected but valid new message shapes.

## Risks and Mitigations

- Risk: malformed payloads could hide useful data when skipped.
  - Mitigation: parser continues scanning remaining output items and keeps existing fallback extraction paths.

