### PR TITLE
fix(gateway): seed Control UI origins for CLI --bind and --port overrides

### DIFF
--- a/src/config/gateway-control-ui-origins.test.ts
+++ b/src/config/gateway-control-ui-origins.test.ts
@@ -176,6 +176,28 @@ describe("ensureControlUiAllowedOriginsForNonLoopbackBind", () => {
     expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://127.0.0.1:19000");
   });
 
+  it("includes origins for both override and configured bind modes when different", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind(
+      {
+        gateway: {
+          bind: "custom",
+          customBindHost: "myhost.local",
+          port: 18789,
+        },
+      },
+      { bindOverride: "lan" },
+    );
+    expect(result.seededOrigins).not.toBe(null);
+    expect(result.bind).toBe("lan");
+    // Should include localhost origins (for both modes)
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://localhost:18789");
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://127.0.0.1:18789");
+    // Should also include custom host origin (for future runs without override)
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain(
+      "http://myhost.local:18789",
+    );
+  });
+
   it("skips seeding when Control UI is explicitly disabled", () => {
     const result = ensureControlUiAllowedOriginsForNonLoopbackBind(
       {

--- a/src/config/gateway-control-ui-origins.test.ts
+++ b/src/config/gateway-control-ui-origins.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDefaultControlUiAllowedOrigins,
+  ensureControlUiAllowedOriginsForNonLoopbackBind,
+  hasConfiguredControlUiAllowedOrigins,
+  isGatewayNonLoopbackBindMode,
+  resolveGatewayPortWithDefault,
+} from "./gateway-control-ui-origins.js";
+
+describe("isGatewayNonLoopbackBindMode", () => {
+  it("returns true for non-loopback bind modes", () => {
+    expect(isGatewayNonLoopbackBindMode("lan")).toBe(true);
+    expect(isGatewayNonLoopbackBindMode("tailnet")).toBe(true);
+    expect(isGatewayNonLoopbackBindMode("custom")).toBe(true);
+  });
+
+  it("returns false for loopback and other values", () => {
+    expect(isGatewayNonLoopbackBindMode("loopback")).toBe(false);
+    expect(isGatewayNonLoopbackBindMode("auto")).toBe(false);
+    expect(isGatewayNonLoopbackBindMode(undefined)).toBe(false);
+    expect(isGatewayNonLoopbackBindMode(null)).toBe(false);
+  });
+});
+
+describe("hasConfiguredControlUiAllowedOrigins", () => {
+  it("returns true when dangerous fallback is enabled", () => {
+    expect(
+      hasConfiguredControlUiAllowedOrigins({
+        allowedOrigins: [],
+        dangerouslyAllowHostHeaderOriginFallback: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when allowedOrigins has non-empty strings", () => {
+    expect(
+      hasConfiguredControlUiAllowedOrigins({
+        allowedOrigins: ["http://localhost:18789"],
+        dangerouslyAllowHostHeaderOriginFallback: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when allowedOrigins is empty", () => {
+    expect(
+      hasConfiguredControlUiAllowedOrigins({
+        allowedOrigins: [],
+        dangerouslyAllowHostHeaderOriginFallback: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when allowedOrigins contains only whitespace", () => {
+    expect(
+      hasConfiguredControlUiAllowedOrigins({
+        allowedOrigins: ["  ", ""],
+        dangerouslyAllowHostHeaderOriginFallback: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveGatewayPortWithDefault", () => {
+  it("returns the port when it's a positive number", () => {
+    expect(resolveGatewayPortWithDefault(19000)).toBe(19000);
+    expect(resolveGatewayPortWithDefault(8080)).toBe(8080);
+  });
+
+  it("returns the fallback for invalid ports", () => {
+    expect(resolveGatewayPortWithDefault(0, 18789)).toBe(18789);
+    expect(resolveGatewayPortWithDefault(-1, 18789)).toBe(18789);
+    expect(resolveGatewayPortWithDefault(undefined, 18789)).toBe(18789);
+    expect(resolveGatewayPortWithDefault(null, 18789)).toBe(18789);
+  });
+});
+
+describe("buildDefaultControlUiAllowedOrigins", () => {
+  it("includes localhost and 127.0.0.1 for standard port", () => {
+    const origins = buildDefaultControlUiAllowedOrigins({ port: 18789, bind: "lan" });
+    expect(origins).toContain("http://localhost:18789");
+    expect(origins).toContain("http://127.0.0.1:18789");
+  });
+
+  it("uses custom port in origins", () => {
+    const origins = buildDefaultControlUiAllowedOrigins({ port: 19000, bind: "lan" });
+    expect(origins).toContain("http://localhost:19000");
+    expect(origins).toContain("http://127.0.0.1:19000");
+  });
+
+  it("includes custom bind host when bind is custom", () => {
+    const origins = buildDefaultControlUiAllowedOrigins({
+      port: 18789,
+      bind: "custom",
+      customBindHost: "192.168.1.100",
+    });
+    expect(origins).toContain("http://localhost:18789");
+    expect(origins).toContain("http://127.0.0.1:18789");
+    expect(origins).toContain("http://192.168.1.100:18789");
+  });
+
+  it("does not include custom bind host for non-custom bind modes", () => {
+    const origins = buildDefaultControlUiAllowedOrigins({
+      port: 18789,
+      bind: "lan",
+      customBindHost: "192.168.1.100",
+    });
+    expect(origins).not.toContain("http://192.168.1.100:18789");
+  });
+});
+
+describe("ensureControlUiAllowedOriginsForNonLoopbackBind", () => {
+  it("returns null when bind is loopback", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind({
+      gateway: { bind: "loopback" },
+    });
+    expect(result.seededOrigins).toBe(null);
+    expect(result.bind).toBe(null);
+  });
+
+  it("returns null when allowedOrigins are already configured", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind({
+      gateway: {
+        bind: "lan",
+        controlUi: {
+          allowedOrigins: ["http://example.com:18789"],
+        },
+      },
+    });
+    expect(result.seededOrigins).toBe(null);
+  });
+
+  it("seeds allowedOrigins for lan bind without existing origins", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind({
+      gateway: { bind: "lan" },
+    });
+    expect(result.seededOrigins).not.toBe(null);
+    expect(result.bind).toBe("lan");
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://localhost:18789");
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://127.0.0.1:18789");
+  });
+
+  it("uses bindOverride instead of config bind", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind(
+      {
+        gateway: { bind: "loopback" },
+      },
+      { bindOverride: "lan" },
+    );
+    expect(result.seededOrigins).not.toBe(null);
+    expect(result.bind).toBe("lan");
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://localhost:18789");
+  });
+
+  it("uses defaultPort override for custom ports", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind(
+      {
+        gateway: { bind: "lan" },
+      },
+      { defaultPort: 19000 },
+    );
+    expect(result.seededOrigins).not.toBe(null);
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://localhost:19000");
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://127.0.0.1:19000");
+  });
+
+  it("uses both bindOverride and defaultPort together", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind(
+      {
+        gateway: { bind: "loopback", port: 18789 },
+      },
+      { bindOverride: "lan", defaultPort: 19000 },
+    );
+    expect(result.seededOrigins).not.toBe(null);
+    expect(result.bind).toBe("lan");
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://localhost:19000");
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain("http://127.0.0.1:19000");
+  });
+
+  it("skips seeding when Control UI is explicitly disabled", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind(
+      {
+        gateway: {
+          bind: "lan",
+          controlUi: { enabled: false },
+        },
+      },
+      { requireControlUiEnabled: true },
+    );
+    expect(result.seededOrigins).toBe(null);
+  });
+
+  it("seeds when Control UI is enabled and required", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind(
+      {
+        gateway: {
+          bind: "lan",
+          controlUi: { enabled: true },
+        },
+      },
+      { requireControlUiEnabled: true },
+    );
+    expect(result.seededOrigins).not.toBe(null);
+  });
+});

--- a/src/config/gateway-control-ui-origins.ts
+++ b/src/config/gateway-control-ui-origins.ts
@@ -45,13 +45,17 @@ export function buildDefaultControlUiAllowedOrigins(params: {
 
 export function ensureControlUiAllowedOriginsForNonLoopbackBind(
   config: OpenClawConfig,
-  opts?: { defaultPort?: number; requireControlUiEnabled?: boolean },
+  opts?: {
+    defaultPort?: number;
+    requireControlUiEnabled?: boolean;
+    bindOverride?: GatewayNonLoopbackBindMode;
+  },
 ): {
   config: OpenClawConfig;
   seededOrigins: string[] | null;
   bind: GatewayNonLoopbackBindMode | null;
 } {
-  const bind = config.gateway?.bind;
+  const bind = opts?.bindOverride ?? config.gateway?.bind;
   if (!isGatewayNonLoopbackBindMode(bind)) {
     return { config, seededOrigins: null, bind: null };
   }

--- a/src/config/gateway-control-ui-origins.ts
+++ b/src/config/gateway-control-ui-origins.ts
@@ -72,7 +72,7 @@ export function ensureControlUiAllowedOriginsForNonLoopbackBind(
     return { config, seededOrigins: null, bind };
   }
 
-  const port = resolveGatewayPortWithDefault(config.gateway?.port, opts?.defaultPort);
+  const port = resolveGatewayPortWithDefault(opts?.defaultPort, config.gateway?.port);
   const seededOrigins = buildDefaultControlUiAllowedOrigins({
     port,
     bind,

--- a/src/config/gateway-control-ui-origins.ts
+++ b/src/config/gateway-control-ui-origins.ts
@@ -73,11 +73,31 @@ export function ensureControlUiAllowedOriginsForNonLoopbackBind(
   }
 
   const port = resolveGatewayPortWithDefault(opts?.defaultPort, config.gateway?.port);
-  const seededOrigins = buildDefaultControlUiAllowedOrigins({
+
+  // Build origins for the effective bind mode (override or configured)
+  let allOrigins = buildDefaultControlUiAllowedOrigins({
     port,
     bind,
     customBindHost: config.gateway?.customBindHost,
   });
+
+  // If using bindOverride and it differs from configured bind, also include
+  // origins for the configured bind mode so future runs without override work
+  if (
+    opts?.bindOverride &&
+    isGatewayNonLoopbackBindMode(config.gateway?.bind) &&
+    opts.bindOverride !== config.gateway.bind
+  ) {
+    const configuredOrigins = buildDefaultControlUiAllowedOrigins({
+      port,
+      bind: config.gateway.bind,
+      customBindHost: config.gateway?.customBindHost,
+    });
+    // Merge and dedupe
+    const merged = new Set([...allOrigins, ...configuredOrigins]);
+    allOrigins = [...merged];
+  }
+
   return {
     config: {
       ...config,
@@ -85,11 +105,11 @@ export function ensureControlUiAllowedOriginsForNonLoopbackBind(
         ...config.gateway,
         controlUi: {
           ...config.gateway?.controlUi,
-          allowedOrigins: seededOrigins,
+          allowedOrigins: allOrigins,
         },
       },
     },
-    seededOrigins,
+    seededOrigins: allOrigins,
     bind,
   };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -18,6 +18,7 @@ import {
   readConfigFileSnapshot,
   writeConfigFile,
 } from "../config/config.js";
+import { isGatewayNonLoopbackBindMode } from "../config/gateway-control-ui-origins.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
@@ -460,6 +461,8 @@ export async function startGatewayServer(
     config: cfgAtStart,
     writeConfig: writeConfigFile,
     log,
+    bindOverride: isGatewayNonLoopbackBindMode(opts.bind) ? opts.bind : undefined,
+    defaultPort: port,
   });
 
   initSubagentRegistry();

--- a/src/gateway/startup-control-ui-origins.ts
+++ b/src/gateway/startup-control-ui-origins.ts
@@ -8,8 +8,13 @@ export async function maybeSeedControlUiAllowedOriginsAtStartup(params: {
   config: OpenClawConfig;
   writeConfig: (config: OpenClawConfig) => Promise<void>;
   log: { info: (msg: string) => void; warn: (msg: string) => void };
+  bindOverride?: GatewayNonLoopbackBindMode;
+  defaultPort?: number;
 }): Promise<OpenClawConfig> {
-  const seeded = ensureControlUiAllowedOriginsForNonLoopbackBind(params.config);
+  const seeded = ensureControlUiAllowedOriginsForNonLoopbackBind(params.config, {
+    bindOverride: params.bindOverride,
+    defaultPort: params.defaultPort,
+  });
   if (!seeded.seededOrigins || !seeded.bind) {
     return params.config;
   }


### PR DESCRIPTION
## Summary

- **Problem**: Docker gateway crash-loops when `--bind lan` is passed via CLI but `gateway.bind` is not in config file (or when using `--port` override with non-default ports)
- **Why it matters**: Blocks Docker deployments that rely on CLI args instead of config persistence; `docker-setup.sh` can fail silently and leave users with a broken setup
- **What changed**: Thread CLI `--bind` and `--port` overrides through to `maybeSeedControlUiAllowedOriginsAtStartup` so origins are seeded correctly regardless of how bind/port are specified
- **What did NOT change**: Config-file-based seeding still works identically; no behavior changes for existing configs with `gateway.bind` already set

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39228
- Related to #29385 (original Control UI origins requirement)
- Supersedes #39851, #39342, #39243 (previous incomplete attempts)

## User-visible / Behavior Changes

- Gateway now correctly seeds `gateway.controlUi.allowedOrigins` when started with CLI `--bind lan` (or other non-loopback modes) even when config file has no `gateway.bind` entry
- Gateway now respects custom `--port` values when seeding origins (e.g., `--port 19000 --bind lan` will seed `http://localhost:19000` instead of defaulting to `18789`)
- Docker users running `docker-compose up` with `--bind lan` in compose file will no longer crash on startup
- No changes for users who already have `gateway.controlUi.allowedOrigins` configured

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- Risk + mitigation: This fix actually **improves** security posture by ensuring Control UI origin validation is correctly applied even when bind mode is specified via CLI rather than config.

## Repro + Verification

### Environment

- OS: macOS Sequoia 15.2
- Runtime/container: Docker Desktop 4.36.0, node:22-bookworm base image
- Model/provider: N/A (gateway startup issue)
- Integration/channel: N/A
- Relevant config:
  ```json
  {
    "gateway": {
      "bind": "loopback",  // or missing entirely
      "controlUi": {
        "allowedOrigins": []  // or missing
      }
    }
  }
  ```

### Steps

1. Start with config file that has `gateway.bind: "loopback"` or no bind setting
2. Run gateway with CLI override: `openclaw gateway --bind lan`
3. Or via Docker: `docker-compose up` (passes `--bind lan` in CMD)

### Expected

Gateway starts successfully and auto-seeds `gateway.controlUi.allowedOrigins: ["http://localhost:18789", "http://127.0.0.1:18789"]`

### Actual (before fix)

```
Gateway failed to start: Error: non-loopback Control UI requires gateway.controlUi.allowedOrigins (set explicit origins), or set gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true to use Host-header origin fallback mode
```

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Before fix**: Gateway crash-loop in Docker logs (as shown in issue #39228)

**After fix**:
- Added comprehensive test suite in `src/config/gateway-control-ui-origins.test.ts`
- All tests pass including edge cases:
  - CLI bind override with config file bind mismatch
  - CLI port override with custom ports
  - Both overrides together
  - Control UI disabled cases

## Human Verification (required)

**Verified scenarios:**
- Docker gateway startup with `--bind lan` CLI arg and `bind: "loopback"` in config → now seeds origins and starts successfully
- Custom port override (`--port 19000 --bind lan`) → seeds correct port in origins
- Existing configs with `allowedOrigins` already set → no changes (skips seeding as expected)

**Edge cases checked:**
- Control UI explicitly disabled (`controlUi.enabled: false`) → correctly skips seeding
- Loopback bind mode → no seeding (correct behavior)
- Both bind and port overrides together → both values respected in seeded origins

**What I did NOT verify:**
- Tailscale bind mode with custom origins (out of scope for this fix)
- Production Docker deployments with all extension combinations (would need multi-arch CI validation)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** (auto-migration at startup)
- Migration needed? **No** (automatic)
- Upgrade path: Existing configs work unchanged; upgrade automatically enables origin seeding for CLI-override scenarios

## Failure Recovery (if this breaks)

- How to disable/revert: Roll back to previous version or manually set `gateway.controlUi.allowedOrigins` in config to explicit values
- Files/config to restore: None (changes are code-only, config auto-seed is additive)
- Known bad symptoms: If seeding logic has bugs, worst case is origins include wrong port/host (easily fixable by manual config set)

## Risks and Mitigations

- **Risk**: Origin seeding could produce incorrect values if bind/port resolution logic has edge cases we didn't test
  - **Mitigation**: Comprehensive test coverage including all combinations; seeding only happens when `allowedOrigins` is empty/missing, so existing configs are unaffected
- **Risk**: Docker users who rely on crash behavior to detect missing config might not notice seeding happened automatically
  - **Mitigation**: Startup log message already exists (`gateway: seeded gateway.controlUi.allowedOrigins ...`) to inform users; this is working as intended per docs
