### PR TITLE
docs(zh-CN): add Useful environment variables section to getting-started

### DIFF
--- a/docs/zh-CN/start/getting-started.md
+++ b/docs/zh-CN/start/getting-started.md
@@ -198,6 +198,16 @@ openclaw message send --target +15555550123 --message "Hello from OpenClaw"
 提示：`openclaw status --all` 是最佳的可粘贴、只读调试报告。
 健康探测：`openclaw health`（或 `openclaw status --deep`）向运行中的 Gateway 网关请求健康快照。
 
+## 有用的环境变量
+
+如果你以服务账户运行 OpenClaw 或想要自定义配置/状态位置：
+
+- `OPENCLAW_HOME` 设置用于内部路径解析的主目录。
+- `OPENCLAW_STATE_DIR` 覆盖状态目录。
+- `OPENCLAW_CONFIG_PATH` 覆盖配置文件路径。
+
+完整环境变量参考：[环境变量](/help/environment)。
+
 ## 下一步（可选，但很棒）
 
 - macOS 菜单栏应用 + 语音唤醒：[macOS 应用](/platforms/macos)


### PR DESCRIPTION
## Summary

Sync the Chinese getting-started guide with the English version by adding the missing
"Useful environment variables" section.

The English `docs/start/getting-started.md` includes a **"Useful environment variables"**
section, but the Chinese version `docs/zh-CN/start/getting-started.md` did not.
This PR adds the same section to the zh-CN guide so that both languages surface
the same important configuration information.

## Changes

- [x] Add a "Useful environment variables" section to `docs/zh-CN/start/getting-started.md`
- [x] Document three key environment variables:
  - `OPENCLAW_HOME` — base directory for internal path resolution
  - `OPENCLAW_STATE_DIR` — override the state directory
  - `OPENCLAW_CONFIG_PATH` — override the main config file path
- [x] Add a link to the full environment variable reference: `/help/environment`

## Verification

- [x] Compared the new zh-CN section with the English "Useful environment variables" section
- [x] Ran local markdown preview to ensure headings, lists, and links render correctly

## Scope

- [x] Docs

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**