### PR TITLE
fix(memory): stop rewriting Han/CJK QMD search queries

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1109,7 +1109,7 @@ describe("QmdMemoryManager", () => {
     }
   });
 
-  it("normalizes mixed Han-script BM25 queries before qmd search", async () => {
+  it("keeps mixed Han-script queries unchanged before qmd search", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -1146,7 +1146,7 @@ describe("QmdMemoryManager", () => {
     );
     expect(searchCall?.[1]).toEqual([
       "search",
-      "記憶 憶系 系統 統升 升級 qmd",
+      "記憶系統升級 QMD",
       "--json",
       "-n",
       String(maxResults),

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -36,7 +36,6 @@ import type {
   ResolvedQmdMcporterConfig,
 } from "./backend-config.js";
 import { parseQmdQueryJson, type QmdQueryResult } from "./qmd-query-parser.js";
-import { extractKeywords } from "./query-expansion.js";
 
 const log = createSubsystemLogger("memory");
 
@@ -47,7 +46,6 @@ const NUL_MARKER_RE = /(?:\^@|\\0|\\x00|\\u0000|null\s*byte|nul\s*byte)/i;
 const QMD_EMBED_BACKOFF_BASE_MS = 60_000;
 const QMD_EMBED_BACKOFF_MAX_MS = 60 * 60 * 1000;
 const HAN_SCRIPT_RE = /[\u3400-\u9fff]/u;
-const QMD_BM25_HAN_KEYWORD_LIMIT = 12;
 
 let qmdEmbedQueueTail: Promise<void> = Promise.resolve();
 
@@ -60,29 +58,7 @@ function normalizeHanBm25Query(query: string): string {
   if (!trimmed || !hasHanScript(trimmed)) {
     return trimmed;
   }
-  const keywords = extractKeywords(trimmed);
-  const normalizedKeywords: string[] = [];
-  const seen = new Set<string>();
-  for (const keyword of keywords) {
-    const token = keyword.trim();
-    if (!token || seen.has(token)) {
-      continue;
-    }
-    const includesHan = hasHanScript(token);
-    // Han unigrams are usually too broad for BM25 and can drown signal.
-    if (includesHan && Array.from(token).length < 2) {
-      continue;
-    }
-    if (!includesHan && token.length < 2) {
-      continue;
-    }
-    seen.add(token);
-    normalizedKeywords.push(token);
-    if (normalizedKeywords.length >= QMD_BM25_HAN_KEYWORD_LIMIT) {
-      break;
-    }
-  }
-  return normalizedKeywords.length > 0 ? normalizedKeywords.join(" ") : trimmed;
+  return trimmed;
 }
 
 async function runWithQmdEmbedLock<T>(task: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
Fixes #42801.

## Summary
- keep Han/CJK QMD `search` queries as the original trimmed string
- remove the broken overlapping-token BM25 rewrite for Han queries
- update the existing QMD manager test to assert the query is passed through unchanged

## Validation
- `git diff --check`
- attempted `npm test -- --run src/memory/qmd-manager.test.ts`, but this environment has no `pnpm` on PATH
- reproducible test command in a normal dev env: `corepack pnpm test -- --run src/memory/qmd-manager.test.ts`
