### PR TITLE
Fix Azure OpenAI Responses store forcing for azure-openai

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1458,6 +1458,20 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.store).toBe(true);
   });
 
+  it("forces store=true for Azure OpenAI Responses payloads keyed as azure-openai", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "azure-openai",
+      applyModelId: "gpt-5-mini",
+      model: {
+        api: "openai-responses",
+        provider: "azure-openai",
+        id: "gpt-5-mini",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+      } as unknown as Model<"openai-responses">,
+    });
+    expect(payload.store).toBe(true);
+  });
+
   it("injects configured OpenAI service_tier into Responses payloads", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "openai",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -28,7 +28,7 @@ const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as cons
 // NOTE: We only force `store=true` for *direct* OpenAI Responses.
 // Codex responses (chatgpt.com/backend-api/codex/responses) require `store=false`.
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
-const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
+const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
 
 /**
  * Resolve provider-specific extra params from model config.


### PR DESCRIPTION
## Summary

- Problem: OpenAI Responses `store=true` forcing skipped models keyed as `azure-openai`, leaving upstream `store:false` in payloads.
- Why it matters: Azure OpenAI multi-turn runs fail with HTTP 400 because referenced response items are not persisted.
- What changed: Added `azure-openai` to the Responses force-store provider allowlist and added a regression test for Azure base URLs with provider key `azure-openai`.
- What did NOT change (scope boundary): No changes to service tier logic, compaction defaults, or non-Responses providers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42800
- Related #39219

## User-visible / Behavior Changes

- Azure OpenAI Responses models configured under `azure-openai/*` now force `store: true` for direct Azure OpenAI base URLs, restoring multi-turn behavior.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (issue repro environment)
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: `openai-responses` via `azure-openai`
- Integration/channel (if any): cron / embedded agent turn path
- Relevant config (redacted): `models.providers.azure-openai.baseUrl=https://<resource>.openai.azure.com/openai/v1/`

### Steps

1. Configure `azure-openai` with `api: "openai-responses"` and Azure OpenAI base URL.
2. Run a first turn (succeeds) and then follow-up turn.
3. Confirm payload mutation keeps `store=true` for this provider key.

### Expected

- Multi-turn responses persist previous items and do not fail with `store is set to false`.

### Actual

- Before fix, provider key `azure-openai` was excluded from force-store allowlist, so `store:false` remained.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused checks run:

- `pnpm vitest run src/agents/pi-embedded-runner-extraparams.test.ts` ✅ (69 passed)
- `pnpm oxfmt --check src/agents/pi-embedded-runner/extra-params.ts src/agents/pi-embedded-runner-extraparams.test.ts` ✅

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `azure-openai` + Azure base URL now forces `store=true` in Responses payload mutation test.
- Edge cases checked: existing direct OpenAI Responses force-store behavior still passes in same suite.
- What you did **not** verify: live Azure API end-to-end run in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit to restore previous provider allowlist behavior.
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`.
- Known bad symptoms reviewers should watch for: Azure OpenAI multi-turn regresses to HTTP 400 with `store is set to false`.

## Risks and Mitigations

- Risk: Broadening provider allowlist could force `store=true` for unsupported Azure-like custom setups.
  - Mitigation: Force-store still requires `api: "openai-responses"`, provider key match, and direct OpenAI/Azure hostname check.
