### PR TITLE
IRC: disable block streaming by default

### DIFF
--- a/extensions/irc/src/inbound.policy.test.ts
+++ b/extensions/irc/src/inbound.policy.test.ts
@@ -34,4 +34,26 @@ describe("irc inbound policy", () => {
 
     expect(resolved.effectiveGroupAllowFrom).toEqual([]);
   });
+
+  it("disables block streaming by default for IRC replies", () => {
+    expect(
+      __testing.resolveIrcDisableBlockStreaming({
+        config: {},
+      } as never),
+    ).toBe(true);
+
+    expect(
+      __testing.resolveIrcDisableBlockStreaming({
+        config: { blockStreaming: false },
+      } as never),
+    ).toBe(true);
+  });
+
+  it("allows opting back into IRC block streaming per account", () => {
+    expect(
+      __testing.resolveIrcDisableBlockStreaming({
+        config: { blockStreaming: true },
+      } as never),
+    ).toBe(false);
+  });
 });

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -54,6 +54,13 @@ function resolveIrcEffectiveAllowlists(params: {
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 
+function resolveIrcDisableBlockStreaming(account: ResolvedIrcAccount): boolean {
+  // IRC delivery is line-oriented and some providers only surface the last
+  // streamed text block. Keep full final replies by default unless IRC
+  // block streaming is explicitly opted in on the account.
+  return account.config.blockStreaming !== true;
+}
+
 async function deliverIrcReply(params: {
   payload: OutboundReplyPayload;
   target: string;
@@ -354,14 +361,12 @@ export async function handleIrcInbound(params: {
     },
     replyOptions: {
       skillFilter: groupMatch.groupConfig?.skills,
-      disableBlockStreaming:
-        typeof account.config.blockStreaming === "boolean"
-          ? !account.config.blockStreaming
-          : undefined,
+      disableBlockStreaming: resolveIrcDisableBlockStreaming(account),
     },
   });
 }
 
 export const __testing = {
   resolveIrcEffectiveAllowlists,
+  resolveIrcDisableBlockStreaming,
 };


### PR DESCRIPTION
## Summary
- disable IRC block streaming unless `channels.irc.blockStreaming=true` is explicitly set
- keep existing per-account opt-in behavior for users who want streamed IRC replies
- add regression coverage for the IRC block-streaming default

## Root cause
IRC inherited the global block-streaming default when `channels.irc.blockStreaming` was unset. With some models, only the last streamed text block was emitted before the full final reply was suppressed by the block-streaming path, which matches #42121.

## Testing
- `pnpm test extensions/irc/src/inbound.policy.test.ts`
- `pnpm test extensions/irc/src/monitor.test.ts`
- `pnpm test extensions/irc/src/send.test.ts`

Closes #42121
