### PR TITLE
Fix unknown-model fallback notice and model resolution edge cases

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -1,6 +1,7 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { isModernModelRef } from "./live-model-filter.js";
 import { normalizeModelCompat } from "./model-compat.js";
 import { resolveForwardCompatModel } from "./model-forward-compat.js";
@@ -391,6 +392,76 @@ describe("resolveForwardCompatModel", () => {
       "anthropic/claude-opus-4-5": createTemplateModel("anthropic", "claude-opus-4-5"),
     });
     const model = resolveForwardCompatModel("openai", "claude-opus-4-6", registry);
+    expect(model).toBeUndefined();
+  });
+
+  it("resolves xai grok-4.1-fast via template fallback", () => {
+    // Create xAI template model
+    const xaiTemplate = {
+      id: "grok-4-1-fast",
+      name: "Grok 4.1 Fast",
+      provider: "xai",
+      api: "openai-completions" as const,
+      baseUrl: "https://api.x.ai/v1",
+      input: ["text"] as const,
+      reasoning: true,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131_072,
+      maxTokens: 32_768,
+    };
+    const registry = createRegistry({
+      "xai/grok-4-1-fast": xaiTemplate as Model<Api>,
+    });
+    const model = resolveForwardCompatModel("xai", "grok-4.1-fast", registry);
+    expectResolvedForwardCompat(model, { provider: "xai", id: "grok-4.1-fast" });
+    expect(model?.api).toBe("openai-completions");
+    expect(model?.baseUrl).toBe("https://api.x.ai/v1");
+    expect(model?.reasoning).toBe(true);
+  });
+
+  it("resolves xai grok-4 family models without templates using defaults", () => {
+    const registry = createRegistry({});
+
+    // Test various grok-4 variants
+    const model1 = resolveForwardCompatModel("xai", "grok-4-1-fast-reasoning-latest", registry);
+    expectResolvedForwardCompat(model1, { provider: "xai", id: "grok-4-1-fast-reasoning-latest" });
+    expect(model1?.api).toBe("openai-completions");
+    expect(model1?.baseUrl).toBe("https://api.x.ai/v1");
+    expect(model1?.reasoning).toBe(true);
+    expect(model1?.contextWindow).toBe(DEFAULT_CONTEXT_TOKENS);
+    expect(model1?.maxTokens).toBe(DEFAULT_CONTEXT_TOKENS);
+
+    const model2 = resolveForwardCompatModel(
+      "xai",
+      "grok-4.20-experimental-beta-0304-reasoning",
+      registry,
+    );
+    expectResolvedForwardCompat(model2, {
+      provider: "xai",
+      id: "grok-4.20-experimental-beta-0304-reasoning",
+    });
+    expect(model2?.api).toBe("openai-completions");
+    expect(model2?.baseUrl).toBe("https://api.x.ai/v1");
+  });
+
+  it("does not resolve xai models for other providers", () => {
+    // Create xAI template model
+    const xaiTemplate = {
+      id: "grok-4-1-fast",
+      name: "Grok 4.1 Fast",
+      provider: "xai",
+      api: "openai-completions" as const,
+      baseUrl: "https://api.x.ai/v1",
+      input: ["text"] as const,
+      reasoning: true,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131_072,
+      maxTokens: 32_768,
+    };
+    const registry = createRegistry({
+      "xai/grok-4-1-fast": xaiTemplate as Model<Api>,
+    });
+    const model = resolveForwardCompatModel("openai", "grok-4-1-fast", registry);
     expect(model).toBeUndefined();
   });
 });

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -73,6 +73,21 @@ function createOpenAICodexTemplateModel(id: string): Model<Api> {
   } as Model<Api>;
 }
 
+function createXaiTemplateModel(id: string): Model<Api> {
+  return {
+    id,
+    name: id,
+    provider: "xai",
+    api: "openai-completions",
+    baseUrl: "https://api.x.ai/v1",
+    input: ["text"],
+    reasoning: true,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 131_072,
+    maxTokens: 32_768,
+  } as Model<Api>;
+}
+
 function createRegistry(models: Record<string, Model<Api>>): ModelRegistry {
   return {
     find(provider: string, modelId: string) {
@@ -396,21 +411,8 @@ describe("resolveForwardCompatModel", () => {
   });
 
   it("resolves xai grok-4.1-fast via template fallback", () => {
-    // Create xAI template model
-    const xaiTemplate = {
-      id: "grok-4-1-fast",
-      name: "Grok 4.1 Fast",
-      provider: "xai",
-      api: "openai-completions" as const,
-      baseUrl: "https://api.x.ai/v1",
-      input: ["text"] as const,
-      reasoning: true,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 131_072,
-      maxTokens: 32_768,
-    };
     const registry = createRegistry({
-      "xai/grok-4-1-fast": xaiTemplate as Model<Api>,
+      "xai/grok-4-1-fast": createXaiTemplateModel("grok-4-1-fast"),
     });
     const model = resolveForwardCompatModel("xai", "grok-4.1-fast", registry);
     expectResolvedForwardCompat(model, { provider: "xai", id: "grok-4.1-fast" });
@@ -422,7 +424,6 @@ describe("resolveForwardCompatModel", () => {
   it("resolves xai grok-4 family models without templates using defaults", () => {
     const registry = createRegistry({});
 
-    // Test various grok-4 variants
     const model1 = resolveForwardCompatModel("xai", "grok-4-1-fast-reasoning-latest", registry);
     expectResolvedForwardCompat(model1, { provider: "xai", id: "grok-4-1-fast-reasoning-latest" });
     expect(model1?.api).toBe("openai-completions");
@@ -442,24 +443,16 @@ describe("resolveForwardCompatModel", () => {
     });
     expect(model2?.api).toBe("openai-completions");
     expect(model2?.baseUrl).toBe("https://api.x.ai/v1");
+    expect(model2?.reasoning).toBe(true);
+
+    const model3 = resolveForwardCompatModel("xai", "grok-4-fast", registry);
+    expectResolvedForwardCompat(model3, { provider: "xai", id: "grok-4-fast" });
+    expect(model3?.reasoning).toBe(false);
   });
 
   it("does not resolve xai models for other providers", () => {
-    // Create xAI template model
-    const xaiTemplate = {
-      id: "grok-4-1-fast",
-      name: "Grok 4.1 Fast",
-      provider: "xai",
-      api: "openai-completions" as const,
-      baseUrl: "https://api.x.ai/v1",
-      input: ["text"] as const,
-      reasoning: true,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 131_072,
-      maxTokens: 32_768,
-    };
     const registry = createRegistry({
-      "xai/grok-4-1-fast": xaiTemplate as Model<Api>,
+      "xai/grok-4-1-fast": createXaiTemplateModel("grok-4-1-fast"),
     });
     const model = resolveForwardCompatModel("openai", "grok-4-1-fast", registry);
     expect(model).toBeUndefined();

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -33,6 +33,10 @@ const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
 const XAI_GROK_4_PREFIX = "grok-4";
 const XAI_GROK_4_TEMPLATE_IDS = ["grok-4-1-fast"] as const;
 
+function inferXaiGrokReasoning(modelId: string): boolean {
+  return modelId.toLowerCase().includes("reasoning");
+}
+
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not yet in pi-ai's built-in
 // google-gemini-cli catalog. Clone the gemini-3-pro/flash-preview template so users
 // don't get "Unknown model" errors when Google releases a new minor version.
@@ -357,7 +361,7 @@ function resolveXaiGrokForwardCompatModel(
         ...template,
         id: trimmed,
         name: trimmed,
-        reasoning: true,
+        reasoning: template.reasoning ?? inferXaiGrokReasoning(trimmed),
       } as Model<Api>);
     }
   }
@@ -369,7 +373,7 @@ function resolveXaiGrokForwardCompatModel(
     api: "openai-completions",
     provider: normalizedProvider,
     baseUrl: "https://api.x.ai/v1",
-    reasoning: true,
+    reasoning: inferXaiGrokReasoning(trimmed),
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: DEFAULT_CONTEXT_TOKENS,

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -28,6 +28,11 @@ const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet
 const ZAI_GLM5_MODEL_ID = "glm-5";
 const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
 
+// xAI's grok models may not be present in pi-ai's built-in model catalog.
+// Support grok-4 and grok-4.1 variants that users configure but aren't in the registry.
+const XAI_GROK_4_PREFIX = "grok-4";
+const XAI_GROK_4_TEMPLATE_IDS = ["grok-4-1-fast"] as const;
+
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not yet in pi-ai's built-in
 // google-gemini-cli catalog. Clone the gemini-3-pro/flash-preview template so users
 // don't get "Unknown model" errors when Google releases a new minor version.
@@ -325,6 +330,53 @@ function resolveZaiGlm5ForwardCompatModel(
   } as Model<Api>);
 }
 
+// xAI's grok-4 family models may not be present in pi-ai's built-in model catalog.
+// Support grok-4, grok-4.1, grok-4.20, etc. variants that users configure but aren't in the registry.
+function resolveXaiGrokForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (normalizedProvider !== "xai") {
+    return undefined;
+  }
+  const trimmed = modelId.trim();
+  const lower = trimmed.toLowerCase();
+
+  // Support grok-4, grok-4.1, grok-4.20, grok-4.1-fast-reasoning, etc.
+  if (!lower.startsWith(XAI_GROK_4_PREFIX)) {
+    return undefined;
+  }
+
+  // Try to find a template model in the registry
+  for (const templateId of XAI_GROK_4_TEMPLATE_IDS) {
+    const template = modelRegistry.find("xai", templateId) as Model<Api> | null;
+    if (template) {
+      return normalizeModelCompat({
+        ...template,
+        id: trimmed,
+        name: trimmed,
+        reasoning: true,
+      } as Model<Api>);
+    }
+  }
+
+  // If no template found, create a basic forward-compat model with xAI's API
+  return normalizeModelCompat({
+    id: trimmed,
+    name: trimmed,
+    api: "openai-completions",
+    provider: normalizedProvider,
+    baseUrl: "https://api.x.ai/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_TOKENS,
+    maxTokens: DEFAULT_CONTEXT_TOKENS,
+  } as Model<Api>);
+}
+
 export function resolveForwardCompatModel(
   provider: string,
   modelId: string,
@@ -336,6 +388,7 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
+    resolveXaiGrokForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveGoogle31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -219,7 +219,8 @@ export function resolveModelWithRegistry(params: {
   const modelHeaders = sanitizeModelHeaders(configuredModel?.headers, {
     stripSecretRefMarkers: true,
   });
-  if (providerConfig || modelId.startsWith("mock-")) {
+  // Only create inline model if explicitly configured in providerConfig.models
+  if (configuredModel) {
     return normalizeResolvedModel({
       provider,
       model: {
@@ -241,6 +242,23 @@ export function resolveModelWithRegistry(params: {
           DEFAULT_CONTEXT_TOKENS,
         headers:
           providerHeaders || modelHeaders ? { ...providerHeaders, ...modelHeaders } : undefined,
+      } as Model<Api>,
+    });
+  }
+
+  // Allow mock models for testing even without providerConfig
+  if (modelId.startsWith("mock-")) {
+    return normalizeResolvedModel({
+      provider,
+      model: {
+        id: modelId,
+        name: modelId,
+        api: "openai-responses",
+        provider,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: DEFAULT_CONTEXT_TOKENS,
+        maxTokens: DEFAULT_CONTEXT_TOKENS,
       } as Model<Api>,
     });
   }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -219,19 +219,22 @@ export function resolveModelWithRegistry(params: {
   const modelHeaders = sanitizeModelHeaders(configuredModel?.headers, {
     stripSecretRefMarkers: true,
   });
-  // Only create inline model if explicitly configured in providerConfig.models
-  if (configuredModel) {
+  const hasProviderTransportOverrides =
+    Boolean(providerConfig?.baseUrl) || Boolean(providerConfig?.api) || Boolean(providerHeaders);
+  // Preserve provider-level fallback for configured custom/proxy providers with explicit
+  // transport settings, while still requiring explicit model entries for plain provider configs.
+  if (configuredModel || hasProviderTransportOverrides) {
     return normalizeResolvedModel({
       provider,
       model: {
         id: modelId,
         name: modelId,
-        api: providerConfig?.api ?? "openai-responses",
+        api: configuredModel?.api ?? providerConfig?.api ?? "openai-responses",
         provider,
         baseUrl: providerConfig?.baseUrl,
         reasoning: configuredModel?.reasoning ?? false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        input: configuredModel?.input ?? ["text"],
+        cost: configuredModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow:
           configuredModel?.contextWindow ??
           providerConfig?.models?.[0]?.contextWindow ??

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -737,10 +737,41 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
-  it("announces model fallback only when verbose mode is enabled", async () => {
+  it("announces model fallback only when verbose mode is enabled, except unknown-model fallback", async () => {
     const cases = [
-      { name: "verbose on", verbose: "on" as const, expectNotice: true },
-      { name: "verbose off", verbose: "off" as const, expectNotice: false },
+      {
+        name: "verbose on",
+        verbose: "on" as const,
+        expectNotice: true,
+        attempt: {
+          provider: "fireworks",
+          model: "fireworks/minimax-m2p5",
+          error: "Provider fireworks is in cooldown (all profiles unavailable)",
+          reason: "rate_limit",
+        },
+      },
+      {
+        name: "verbose off",
+        verbose: "off" as const,
+        expectNotice: false,
+        attempt: {
+          provider: "fireworks",
+          model: "fireworks/minimax-m2p5",
+          error: "Provider fireworks is in cooldown (all profiles unavailable)",
+          reason: "rate_limit",
+        },
+      },
+      {
+        name: "verbose off unknown model",
+        verbose: "off" as const,
+        expectNotice: true,
+        attempt: {
+          provider: "xai",
+          model: "grok-4.99-preview",
+          error: "Unknown model: xai/grok-4.99-preview",
+          reason: "model_not_found",
+        },
+      },
     ] as const;
     for (const testCase of cases) {
       const sessionEntry: SessionEntry = {
@@ -757,14 +788,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
           result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
           provider: "deepinfra",
           model: "moonshotai/Kimi-K2.5",
-          attempts: [
-            {
-              provider: "fireworks",
-              model: "fireworks/minimax-m2p5",
-              error: "Provider fireworks is in cooldown (all profiles unavailable)",
-              reason: "rate_limit",
-            },
-          ],
+          attempts: [testCase.attempt],
         }),
       );
 
@@ -789,7 +813,9 @@ describe("runReplyAgent typing (heartbeat)", () => {
       if (testCase.expectNotice) {
         expect(payload.text, testCase.name).toContain("Model Fallback:");
         expect(payload.text, testCase.name).toContain("deepinfra/moonshotai/Kimi-K2.5");
-        expect(sessionEntry.fallbackNoticeReason, testCase.name).toBe("rate limit");
+        expect(sessionEntry.fallbackNoticeReason, testCase.name).toBe(
+          testCase.attempt.reason.replace(/_/g, " "),
+        );
         continue;
       }
       expect(payload.text, testCase.name).not.toContain("Model Fallback:");

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -626,7 +626,9 @@ export async function runReplyAgent(params: {
           attempts: fallbackAttempts,
         },
       });
-      if (verboseEnabled) {
+      const shouldShowFallbackNotice =
+        verboseEnabled || fallbackAttempts.some((attempt) => attempt.reason === "model_not_found");
+      if (shouldShowFallbackNotice) {
         const fallbackNotice = buildFallbackNotice({
           selectedProvider,
           selectedModel,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw could silently fall back when a selected model was unknown, and users often weren’t told why unless verbose mode was enabled.
- Why it matters: Silent fallback is confusing and hides model selection mistakes; users can think their chosen model ran when it actually didn’t.
- What changed: Unknown-model fallback (`model_not_found`) now surfaces the existing fallback notice even when verbose mode is off. Follow-up fixes preserve provider-level fallback for configured custom/proxy providers with explicit transport overrides, tighten xAI/Grok reasoning inference so `grok-4*` models do not all default to `reasoning: true`, and clean up the xAI forward-compat test setup for CI typechecking.
- What did NOT change (scope boundary): General fallback notices are still verbose-only for other reasons like rate limits/timeouts; no changes to model execution, permissions, networking, or fallback selection strategy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #37813

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- When a selected model is unknown and OpenClaw falls back with `model_not_found`, the fallback notice is now shown even if verbose mode is off.
- Other fallback reasons remain unchanged and still follow existing verbose-mode behavior.
- Configured custom/proxy providers retain provider-level fallback behavior for unlisted model ids when transport overrides are explicitly configured.
- xAI/Grok forward-compat behavior is more conservative for reasoning capability inference.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: local OpenClaw source checkout
- Model/provider: simulated fallback paths in tests; xAI forward-compat model resolution tests
- Integration/channel (if any): none
- Relevant config (redacted): default test harness config plus focused model-resolution test fixtures

### Steps

1. Configure or simulate a run where the selected model is unknown and fallback occurs with reason model_not_found.
2. Run a reply-agent turn with verbose mode off.
3. Observe the returned payload text.
4. Simulate model resolution for configured custom/proxy providers with transport overrides but without an explicit matching model entry.
5. Resolve xAI/Grok forward-compat model ids with and without `reasoning` in the id.


### Expected

- A fallback notice is included so the user sees that the selected model was not used for `model_not_found`.
- Non-`model_not_found` fallback notices remain gated by verbose mode.
- Configured custom/proxy providers still resolve unlisted model ids through provider-level fallback when explicit transport settings are present.
- xAI/Grok forward-compat models do not overclaim reasoning support.

### Actual

- After this change, the payload includes `Model Fallback:` even with verbose off for `model_not_found`.
- Other fallback reasons still follow existing verbose gating.
- Custom/provider-proxy fallback behavior is preserved.
- xAI/Grok reasoning inference is now narrower and typecheck-clean.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  • Verbose on + normal fallback still shows fallback notice
  • Verbose off + rate-limit fallback still does not show fallback notice
  • Verbose off + `model_not_found` fallback now shows fallback notice
  • xAI/Grok forward-compat still resolves supported `grok-4*` variants
  • Configured custom/provider-proxy fallback remains available for unlisted models with explicit transport overrides
- Edge cases checked:
  • Existing fallback state tracking still updates correctly
  • Reason summary stored as normalized text (`model not found`)
  • Non-reasoning Grok ids no longer default to `reasoning: true`
  • Template-based xAI fallback preserves template capabilities
- What you did **not** verify:
  • Full end-to-end run against live providers
  • Channel-specific rendering outside the test harness
  • Full repository `pnpm check` in this shell environment

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `0af8b96` (or revert the PR branch)
- Files/config to restore:
  • src/auto-reply/reply/agent-runner.ts
  • src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
  • src/agents/pi-embedded-runner/model.ts
  • src/agents/model-forward-compat.ts
  • src/agents/model-compat.test.ts
- Known bad symptoms reviewers should watch for:
  • Fallback notices appearing for non-`model_not_found` cases when verbose is off
  • Duplicate fallback notices during an already-active fallback state
  • Configured custom providers no longer resolving unlisted model ids
  • Grok forward-compat models incorrectly marked as reasoning-capable

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Users may see an extra notice in cases newly classified as `model_not_found`
- Mitigation: Scope is intentionally narrow; only unknown-model fallback bypasses the verbose gate
- Risk: Narrowing the original fix could accidentally preserve too much fallback behavior
- Mitigation: Provider-level fallback is only preserved for configured custom/proxy providers with explicit transport overrides, not plain built-in provider configs
- Risk: Conservative Grok reasoning inference may underreport capabilities for future variants
- Mitigation: Template-based resolution still preserves known capabilities, and future registry/template updates can refine model metadata
