### PR TITLE
docs(zh-CN): add Core auto-updater section to updating guide

### DIFF
--- a/docs/zh-CN/install/updating.md
+++ b/docs/zh-CN/install/updating.md
@@ -73,6 +73,32 @@ openclaw update --channel stable
 
 注意：在 npm 安装上，Gateway 网关在启动时会记录更新提示（检查当前渠道标签）。通过 `update.checkOnStart: false` 禁用。
 
+### 核心自动更新（可选）
+
+自动更新**默认关闭**，是 Gateway 网关的核心功能（非插件）。
+
+```json
+{
+  "update": {
+    "channel": "stable",
+    "auto": {
+      "enabled": true,
+      "stableDelayHours": 6,
+      "stableJitterHours": 12,
+      "betaCheckIntervalHours": 1
+    }
+  }
+}
+```
+
+行为说明：
+
+- `stable`：当发现新版本时，OpenClaw 等待 `stableDelayHours`，然后在 `stableJitterHours` 内按每安装确定性抖动应用（分批发布）。
+- `beta`：按 `betaCheckIntervalHours` 间隔（默认每小时）检查，有更新时应用。
+- `dev`：不自动应用；需手动执行 `openclaw update`。
+
+在启用自动更新前，可使用 `openclaw update --dry-run` 预览将要执行的操作。
+
 然后：
 
 ```bash


### PR DESCRIPTION
## Summary

Sync the Chinese updating guide with the English version by adding the missing
"Core auto-updater (optional)" section.

The English `docs/install/updating.md` includes a **Core auto-updater (optional)**
subsection under "Update (global install)" with config example and behavior notes.
The Chinese `docs/zh-CN/install/updating.md` lacked this block. This PR adds the
equivalent "核心自动更新（可选）" section so zh-CN users have the same documentation
for optional auto-update configuration.

## Changes

- [x] Add "核心自动更新（可选）" section to `docs/zh-CN/install/updating.md`
- [x] Include JSON config example for `update.auto` (channel, stableDelayHours, stableJitterHours, betaCheckIntervalHours)
- [x] Add behavior notes for `stable`, `beta`, and `dev` channels
- [x] Mention `openclaw update --dry-run` for previewing update actions

## Verification

- [x] Compared the new zh-CN section with the English "Core auto-updater (optional)" subsection
- [x] Confirmed placement between the "Note: on npm installs..." paragraph and the "Then:" CLI block

## Scope

- [x] Docs

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**