### PR TITLE
fix(discord): apply configured proxy to RequestClient REST calls

### DIFF
--- a/src/discord/client.test.ts
+++ b/src/discord/client.test.ts
@@ -1,7 +1,27 @@
 import type { RequestClient } from "@buape/carbon";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { createDiscordRestClient } from "./client.js";
+
+const { undiciFetchMock, proxyAgentSpy } = vi.hoisted(() => ({
+  undiciFetchMock: vi.fn(),
+  proxyAgentSpy: vi.fn(),
+}));
+
+vi.mock("undici", () => {
+  class ProxyAgent {
+    proxyUrl: string;
+    constructor(proxyUrl: string) {
+      this.proxyUrl = proxyUrl;
+      proxyAgentSpy(proxyUrl);
+    }
+  }
+  return {
+    ProxyAgent,
+    EnvHttpProxyAgent: class {},
+    fetch: undiciFetchMock,
+  };
+});
 
 describe("createDiscordRestClient", () => {
   const fakeRest = {} as RequestClient;
@@ -87,5 +107,38 @@ describe("createDiscordRestClient", () => {
         cfg,
       ),
     ).toThrow(/unresolved SecretRef/i);
+  });
+
+  it("routes Discord REST requests through configured proxy", async () => {
+    undiciFetchMock.mockClear().mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+    proxyAgentSpy.mockClear();
+
+    const cfg = {
+      channels: {
+        discord: {
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = createDiscordRestClient(
+      {
+        token: "Bot explicit-token",
+      },
+      cfg,
+    );
+
+    await result.rest.get("/oauth2/applications/@me");
+
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(undiciFetchMock).toHaveBeenCalledWith(
+      "https://discord.com/api/oauth2/applications/@me",
+      expect.objectContaining({
+        method: "GET",
+        dispatcher: expect.objectContaining({ proxyUrl: "http://proxy.test:8080" }),
+      }),
+    );
+    const requestInit = undiciFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect((requestInit?.headers as Headers).get("Authorization")).toBe("Bot explicit-token");
   });
 });

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -9,6 +9,7 @@ import {
   type ResolvedDiscordAccount,
 } from "./accounts.js";
 import { normalizeDiscordToken } from "./token.js";
+import { ProxyDiscordRequestClient } from "./proxy-rest-client.js";
 
 export type DiscordClientOpts = {
   cfg?: ReturnType<typeof loadConfig>;
@@ -29,8 +30,15 @@ function resolveToken(params: { accountId: string; fallbackToken?: string }) {
   return fallback;
 }
 
-function resolveRest(token: string, rest?: RequestClient) {
-  return rest ?? new RequestClient(token);
+function resolveRest(params: { token: string; rest?: RequestClient; proxy?: string }) {
+  if (params.rest) {
+    return params.rest;
+  }
+  const proxy = params.proxy?.trim();
+  if (proxy) {
+    return new ProxyDiscordRequestClient(params.token, proxy);
+  }
+  return new RequestClient(params.token);
 }
 
 function resolveAccountWithoutToken(params: {
@@ -66,7 +74,7 @@ export function createDiscordRestClient(
       accountId: account.accountId,
       fallbackToken: account.token,
     });
-  const rest = resolveRest(token, opts.rest);
+  const rest = resolveRest({ token, rest: opts.rest, proxy: account.config.proxy });
   return { token, rest, account };
 }
 

--- a/src/discord/proxy-rest-client.ts
+++ b/src/discord/proxy-rest-client.ts
@@ -1,0 +1,194 @@
+import { DiscordError, RateLimitError, RequestClient, type RequestClientOptions } from "@buape/carbon";
+import { makeProxyFetch } from "../infra/net/proxy-fetch.js";
+import { wrapFetchWithAbortSignal } from "../infra/fetch.js";
+
+type RequestData = {
+  body?: unknown;
+  rawBody?: boolean;
+  headers?: Record<string, string>;
+};
+
+type QueryParams = Record<string, string | number | boolean>;
+
+/**
+ * RequestClient variant that preserves Carbon-compatible error shapes while routing
+ * all HTTP calls through a configured proxy dispatcher.
+ */
+export class ProxyDiscordRequestClient extends RequestClient {
+  private readonly fetcher: typeof fetch;
+  private readonly token: string;
+
+  constructor(token: string, proxyUrl: string, options?: RequestClientOptions) {
+    super(token, options);
+    this.token = token;
+    this.fetcher = wrapFetchWithAbortSignal(makeProxyFetch(proxyUrl));
+  }
+
+  override get(path: string, query?: QueryParams): Promise<unknown> {
+    return this.proxyRequest("GET", path, undefined, query);
+  }
+
+  override post(path: string, data?: RequestData, query?: QueryParams): Promise<unknown> {
+    return this.proxyRequest("POST", path, data, query);
+  }
+
+  override patch(path: string, data?: RequestData, query?: QueryParams): Promise<unknown> {
+    return this.proxyRequest("PATCH", path, data, query);
+  }
+
+  override put(path: string, data?: RequestData, query?: QueryParams): Promise<unknown> {
+    return this.proxyRequest("PUT", path, data, query);
+  }
+
+  override delete(path: string, data?: RequestData, query?: QueryParams): Promise<unknown> {
+    return this.proxyRequest("DELETE", path, data, query);
+  }
+
+  private async proxyRequest(
+    method: string,
+    path: string,
+    data?: RequestData,
+    query?: QueryParams,
+  ): Promise<unknown> {
+    const queryString = query
+      ? `?${Object.entries(query)
+          .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+          .join("&")}`
+      : "";
+
+    const url = `${this.options.baseUrl}${path}${queryString}`;
+
+    const headers =
+      this.token === "webhook"
+        ? new Headers()
+        : new Headers({ Authorization: `${this.options.tokenHeader} ${this.token}` });
+
+    if (data?.headers) {
+      for (const [key, value] of Object.entries(data.headers)) {
+        headers.set(key, value);
+      }
+    }
+
+    let body: BodyInit | undefined;
+
+    if (
+      data?.body &&
+      typeof data.body === "object" &&
+      ("files" in data.body ||
+        ("data" in data.body &&
+          data.body.data &&
+          typeof data.body.data === "object" &&
+          "files" in data.body.data))
+    ) {
+      const payload = data.body as
+        | { files?: Array<{ data: BlobPart | Blob; name: string; description?: string }>; attachments?: unknown[] }
+        | {
+            data?: {
+              files?: Array<{ data: BlobPart | Blob; name: string; description?: string }>;
+            };
+            attachments?: unknown[];
+          };
+
+      const normalizedPayload =
+        typeof payload === "string" ? { content: payload, attachments: [] } : { ...payload, attachments: [] };
+
+      const formData = new FormData();
+      const files = "files" in payload ? payload.files || [] : payload.data?.files || [];
+
+      for (const [index, file] of files.entries()) {
+        let { data: fileData } = file;
+        if (!(fileData instanceof Blob)) {
+          fileData = new Blob([fileData]);
+        }
+        formData.append(`files[${index}]`, fileData, file.name);
+        normalizedPayload.attachments.push({
+          id: index,
+          filename: file.name,
+          description: file.description,
+        });
+      }
+
+      const cleanedBody = {
+        ...normalizedPayload,
+        files: undefined,
+      };
+      formData.append("payload_json", JSON.stringify(cleanedBody));
+      body = formData;
+    } else if (data?.body != null) {
+      headers.set("Content-Type", "application/json");
+      body = data.rawBody ? (data.body as BodyInit) : JSON.stringify(data.body);
+    }
+
+    const controller = new AbortController();
+    const timeoutMs =
+      typeof this.options.timeout === "number" && this.options.timeout > 0
+        ? this.options.timeout
+        : undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    if (timeoutMs !== undefined) {
+      timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetcher(url, {
+        method,
+        headers,
+        body,
+        signal: controller.signal,
+      });
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+
+    const rawBody = await response.text().catch(() => "");
+    let parsedBody: unknown;
+    if (rawBody.length > 0) {
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch {
+        parsedBody = undefined;
+      }
+    }
+
+    if (response.status === 429) {
+      const retryAfterHeader = response.headers.get("Retry-After");
+      const rateLimitBody =
+        parsedBody && typeof parsedBody === "object" && "retry_after" in parsedBody && "message" in parsedBody
+          ? parsedBody
+          : {
+              message:
+                typeof parsedBody === "string"
+                  ? parsedBody
+                  : rawBody || "You are being rate limited.",
+              retry_after:
+                retryAfterHeader && !Number.isNaN(Number(retryAfterHeader))
+                  ? Number(retryAfterHeader)
+                  : 1,
+              global: response.headers.get("X-RateLimit-Scope") === "global",
+            };
+      throw new RateLimitError(response, rateLimitBody as { message: string; retry_after: number; global?: boolean });
+    }
+
+    if (response.status >= 400 && response.status < 600) {
+      const discordErrorBody =
+        parsedBody && typeof parsedBody === "object"
+          ? parsedBody
+          : {
+              message: rawBody || "Discord API error",
+              code: 0,
+            };
+      throw new DiscordError(response, discordErrorBody as { message: string; code: number });
+    }
+
+    if (parsedBody !== undefined) {
+      return parsedBody;
+    }
+    if (rawBody.length > 0) {
+      return rawBody;
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary\n- add a proxy-aware Discord REST client subclass used when channels.discord.proxy is configured\n- route all Carbon RequestClient REST calls through undici ProxyAgent while preserving Discord/RateLimit error shapes for retry handling\n- keep existing behavior for explicit injected est clients and non-proxy configurations\n- add regression coverage proving proxy dispatch is used by createDiscordRestClient\n\n## Issue\nFixes #42702\n\n## Validation\n- pnpm vitest run src/discord/client.test.ts src/discord/monitor/provider.rest-proxy.test.ts\n