### PR TITLE
Nostr: restore DM delivery path

### DIFF
--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -44,8 +44,10 @@ describe("nostr outbound cfg threading", () => {
       getProfileState: vi.fn(async () => null),
     };
     mocks.startNostrBus.mockResolvedValueOnce(bus as any);
+    const abort = new AbortController();
 
-    const cleanup = (await nostrPlugin.gateway!.startAccount!(
+    let settled = false;
+    const task = nostrPlugin.gateway!.startAccount!(
       createStartAccountContext({
         account: {
           accountId: "default",
@@ -56,9 +58,17 @@ describe("nostr outbound cfg threading", () => {
           relays: ["wss://relay.example.com"],
           config: {},
         },
-        abortSignal: new AbortController().signal,
+        abortSignal: abort.signal,
       }),
-    )) as { stop: () => void };
+    );
+    void task.then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.startNostrBus).toHaveBeenCalledOnce();
+    });
+    expect(settled).toBe(false);
 
     const cfg = {
       channels: {
@@ -83,6 +93,67 @@ describe("nostr outbound cfg threading", () => {
     expect(mocks.normalizePubkey).toHaveBeenCalledWith("NPUB123");
     expect(sendDm).toHaveBeenCalledWith("normalized-npub123", "converted:|a|b|");
 
-    cleanup.stop();
+    abort.abort();
+    await task;
+    expect(bus.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to attachment links for sendMedia", async () => {
+    const resolveMarkdownTableMode = vi.fn(() => "off");
+    const convertMarkdownTables = vi.fn((text: string) => text);
+    setNostrRuntime({
+      channel: {
+        text: {
+          resolveMarkdownTableMode,
+          convertMarkdownTables,
+        },
+      },
+      reply: {},
+    } as unknown as PluginRuntime);
+
+    const sendDm = vi.fn(async () => {});
+    const bus = {
+      sendDm,
+      close: vi.fn(),
+      getMetrics: vi.fn(() => ({ counters: {} })),
+      publishProfile: vi.fn(),
+      getProfileState: vi.fn(async () => null),
+    };
+    mocks.startNostrBus.mockResolvedValueOnce(bus as any);
+    const abort = new AbortController();
+    const task = nostrPlugin.gateway!.startAccount!(
+      createStartAccountContext({
+        account: {
+          accountId: "default",
+          enabled: true,
+          configured: true,
+          privateKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", // pragma: allowlist secret
+          publicKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", // pragma: allowlist secret
+          relays: ["wss://relay.example.com"],
+          config: {},
+        },
+        abortSignal: abort.signal,
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(mocks.startNostrBus).toHaveBeenCalledOnce();
+    });
+
+    await nostrPlugin.outbound!.sendMedia!({
+      cfg: {} as any,
+      to: "NPUB123",
+      text: "see attachment",
+      mediaUrl: "https://example.com/file.png",
+      accountId: "default",
+    });
+
+    expect(sendDm).toHaveBeenCalledWith(
+      "normalized-npub123",
+      "see attachment\n\nAttachment: https://example.com/file.png",
+    );
+
+    abort.abort();
+    await task;
   });
 });

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -26,6 +26,15 @@ const activeBuses = new Map<string, NostrBusHandle>();
 // Store metrics snapshots per account (for status reporting)
 const metricsSnapshots = new Map<string, MetricsSnapshot>();
 
+function formatNostrOutboundText(text: string, mediaUrl?: string): string {
+  const trimmedText = text.trim();
+  if (!mediaUrl) {
+    return trimmedText;
+  }
+  const attachmentLine = `Attachment: ${mediaUrl}`;
+  return trimmedText ? `${trimmedText}\n\n${attachmentLine}` : attachmentLine;
+}
+
 export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
   id: "nostr",
   meta: {
@@ -155,6 +164,15 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
         messageId: `nostr-${Date.now()}`,
       };
     },
+    sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+      const combined = formatNostrOutboundText(text ?? "", mediaUrl);
+      return await nostrPlugin.outbound!.sendText!({
+        cfg,
+        to,
+        text: combined,
+        accountId,
+      });
+    },
   },
 
   status: {
@@ -273,15 +291,27 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
         `[${account.accountId}] Nostr provider started, connected to ${account.relays.length} relay(s)`,
       );
 
-      // Return cleanup function
-      return {
-        stop: () => {
-          bus.close();
-          activeBuses.delete(account.accountId);
-          metricsSnapshots.delete(account.accountId);
-          ctx.log?.info(`[${account.accountId}] Nostr provider stopped`);
-        },
+      let stopped = false;
+      const stop = () => {
+        if (stopped) {
+          return;
+        }
+        stopped = true;
+        bus.close();
+        activeBuses.delete(account.accountId);
+        metricsSnapshots.delete(account.accountId);
+        ctx.log?.info(`[${account.accountId}] Nostr provider stopped`);
       };
+
+      try {
+        if (!ctx.abortSignal.aborted) {
+          await new Promise<void>((resolve) => {
+            ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        }
+      } finally {
+        stop();
+      }
     },
   },
 };

--- a/extensions/nostr/src/nostr-bus.subscribe.test.ts
+++ b/extensions/nostr/src/nostr-bus.subscribe.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const subscribeMany = vi.fn(() => ({ close: vi.fn() }));
+  const publish = vi.fn(async () => undefined);
+  const poolInstance = { subscribeMany, publish };
+  const createSeenTracker = vi.fn(() => ({
+    seed: vi.fn(),
+    peek: vi.fn(() => false),
+    add: vi.fn(),
+    size: vi.fn(() => 0),
+    stop: vi.fn(),
+  }));
+  const metrics = {
+    emit: vi.fn(),
+    getSnapshot: vi.fn(() => ({ counters: {} })),
+  };
+  return {
+    subscribeMany,
+    publish,
+    poolInstance,
+    createSeenTracker,
+    metrics,
+    readNostrBusState: vi.fn(async () => null),
+    writeNostrBusState: vi.fn(async () => undefined),
+    computeSinceTimestamp: vi.fn(() => 123),
+    readNostrProfileState: vi.fn(async () => null),
+    writeNostrProfileState: vi.fn(async () => undefined),
+    publishProfile: vi.fn(),
+  };
+});
+
+vi.mock("nostr-tools", () => ({
+  SimplePool: class {
+    constructor() {
+      return mocks.poolInstance;
+    }
+  },
+  finalizeEvent: vi.fn((event) => event),
+  getPublicKey: vi.fn(() => "a".repeat(64)),
+  verifyEvent: vi.fn(() => true),
+  nip19: {
+    decode: vi.fn(() => {
+      throw new Error("not used");
+    }),
+  },
+}));
+
+vi.mock("nostr-tools/nip04", () => ({
+  decrypt: vi.fn(),
+  encrypt: vi.fn(),
+}));
+
+vi.mock("./metrics.js", () => ({
+  createMetrics: vi.fn(() => mocks.metrics),
+  createNoopMetrics: vi.fn(() => mocks.metrics),
+}));
+
+vi.mock("./seen-tracker.js", () => ({
+  createSeenTracker: mocks.createSeenTracker,
+}));
+
+vi.mock("./nostr-state-store.js", () => ({
+  readNostrBusState: mocks.readNostrBusState,
+  writeNostrBusState: mocks.writeNostrBusState,
+  computeSinceTimestamp: mocks.computeSinceTimestamp,
+  readNostrProfileState: mocks.readNostrProfileState,
+  writeNostrProfileState: mocks.writeNostrProfileState,
+}));
+
+vi.mock("./nostr-profile.js", () => ({
+  publishProfile: mocks.publishProfile,
+}));
+
+import { startNostrBus } from "./nostr-bus.js";
+
+describe("startNostrBus subscribe filters", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes a single filter object to subscribeMany", async () => {
+    const bus = await startNostrBus({
+      accountId: "default",
+      privateKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      relays: ["wss://relay.example.com"],
+      onMessage: async () => {},
+    });
+
+    expect(mocks.subscribeMany).toHaveBeenCalledTimes(1);
+    expect(mocks.subscribeMany).toHaveBeenCalledWith(
+      ["wss://relay.example.com"],
+      expect.objectContaining({
+        kinds: [4],
+        "#p": ["a".repeat(64)],
+        since: 3,
+      }),
+      expect.any(Object),
+    );
+
+    bus.close();
+  });
+});

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -490,7 +490,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
 
   const sub = pool.subscribeMany(
     relays,
-    [{ kinds: [4], "#p": [pk], since }] as unknown as Parameters<typeof pool.subscribeMany>[1],
+    { kinds: [4], "#p": [pk], since } as unknown as Parameters<typeof pool.subscribeMany>[1],
     {
       onevent: handleEvent,
       oneose: () => {


### PR DESCRIPTION
## Summary
- pass a single DM subscription filter object to `subscribeMany()`
- keep `gateway.startAccount()` alive until abort instead of resolving immediately
- add a `sendMedia` fallback so outbound delivery can send attachment links over DM

## Root cause
`main` still had all three failures described in #32252:
1. `nostr-bus.ts` wrapped the DM filter in an array before calling `subscribeMany()`.
2. `channel.ts` resolved `startAccount()` immediately after startup instead of waiting for abort.
3. the outbound adapter only exposed `sendText`, so the generic delivery layer treated Nostr outbound as unconfigured.

## Testing
- `pnpm test extensions/nostr/src/channel.outbound.test.ts`
- `pnpm test extensions/nostr/src/nostr-bus.subscribe.test.ts`
- `pnpm test extensions/nostr/src/channel.test.ts`

Closes #32252
