### PR TITLE
fix(whatsapp): never permanently stop reconnect monitor loop

### DIFF
--- a/src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -97,59 +97,89 @@ describe("web auto-reply connection", () => {
     expect(() => formatEnvelopeTimestamp(d, " America/Los_Angeles ")).not.toThrow();
   });
 
-  it("handles reconnect progress and max-attempt stop behavior", async () => {
-    for (const scenario of [
-      {
-        reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1 },
-        expectedCallsAfterFirstClose: 2,
-        closeTwiceAndFinish: false,
-        expectedError: "Retry 1",
-      },
-      {
-        reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 2, factor: 1.1 },
-        expectedCallsAfterFirstClose: 2,
-        closeTwiceAndFinish: true,
-        expectedError: "max attempts reached",
-      },
-    ]) {
-      const closeResolvers: Array<() => void> = [];
-      const sleep = vi.fn(async () => {});
-      const listenerFactory = vi.fn(async () => {
-        const onClose = new Promise<void>((res) => {
-          closeResolvers.push(res);
-        });
-        return { close: vi.fn(), onClose };
+  it("handles reconnect progress and reports retries", async () => {
+    const closeResolvers: Array<() => void> = [];
+    const sleep = vi.fn(async () => {});
+    const listenerFactory = vi.fn(async () => {
+      const onClose = new Promise<void>((res) => {
+        closeResolvers.push(res);
       });
-      const { runtime, controller, run } = startMonitorWebChannel({
-        monitorWebChannelFn: monitorWebChannel as never,
-        listenerFactory,
-        sleep,
-        reconnect: scenario.reconnect,
+      return { close: vi.fn(), onClose };
+    });
+    const { runtime, controller, run } = startMonitorWebChannel({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory,
+      sleep,
+      reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1 },
+    });
+
+    await Promise.resolve();
+    expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+    closeResolvers.shift()?.();
+    await vi.waitFor(
+      () => {
+        expect(listenerFactory).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 250, interval: 2 },
+    );
+
+    controller.abort();
+    closeResolvers.shift()?.();
+    await Promise.resolve();
+    await run;
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Retry 1"));
+  });
+
+  it("enters degraded mode with slow retry instead of stopping when maxAttempts reached", async () => {
+    const closeResolvers: Array<() => void> = [];
+    const sleep = vi.fn(async () => {});
+    const listenerFactory = vi.fn(async () => {
+      const onClose = new Promise<void>((res) => {
+        closeResolvers.push(res);
       });
+      return { close: vi.fn(), onClose };
+    });
+    const { runtime, controller, run } = startMonitorWebChannel({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory,
+      sleep,
+      reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 2, factor: 1.1 },
+    });
 
-      await Promise.resolve();
-      expect(listenerFactory).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(listenerFactory).toHaveBeenCalledTimes(1);
 
-      closeResolvers.shift()?.();
-      await vi.waitFor(
-        () => {
-          expect(listenerFactory).toHaveBeenCalledTimes(scenario.expectedCallsAfterFirstClose);
-        },
-        { timeout: 250, interval: 2 },
-      );
+    // First close → reconnect attempt 1
+    closeResolvers.shift()?.();
+    await vi.waitFor(
+      () => {
+        expect(listenerFactory).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 250, interval: 2 },
+    );
 
-      if (scenario.closeTwiceAndFinish) {
-        closeResolvers.shift()?.();
-        await run;
-      } else {
-        controller.abort();
-        closeResolvers.shift()?.();
-        await Promise.resolve();
-        await run;
-      }
+    // Second close → reconnect attempt 2 = maxAttempts → degraded mode
+    closeResolvers.shift()?.();
+    await vi.waitFor(
+      () => {
+        // Should NOT have stopped; should be sleeping in degraded mode
+        // and then retry (listenerFactory called a 3rd time)
+        expect(listenerFactory).toHaveBeenCalledTimes(3);
+      },
+      { timeout: 250, interval: 2 },
+    );
 
-      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(scenario.expectedError));
-    }
+    // Now abort to stop the monitor
+    controller.abort();
+    closeResolvers.shift()?.();
+    await run;
+
+    // Should have logged degraded mode, NOT "Stopping web monitoring"
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("max attempts reached"));
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("degraded mode"));
+    expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("Stopping web monitoring"));
   });
 
   it("treats status 440 as non-retryable and stops without retrying", async () => {

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -421,6 +421,12 @@ export async function monitorWebChannel(
     reconnectAttempts += 1;
     status.reconnectAttempts = reconnectAttempts;
     emitStatus();
+
+    // When maxAttempts is reached, enter degraded mode with a longer cooldown
+    // instead of permanently stopping the monitor loop. A dead listener with
+    // stale "linked" status is worse than slow retries.
+    const DEGRADED_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+    let delay: number;
     if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
       reconnectLogger.warn(
         {
@@ -428,17 +434,21 @@ export async function monitorWebChannel(
           status: statusCode,
           reconnectAttempts,
           maxAttempts: reconnectPolicy.maxAttempts,
+          degradedCooldownMs: DEGRADED_COOLDOWN_MS,
         },
-        "web reconnect: max attempts reached; continuing in degraded mode",
+        "web reconnect: max attempts reached; entering degraded mode with slow retry",
       );
       runtime.error(
-        `WhatsApp Web reconnect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Stopping web monitoring.`,
+        `WhatsApp Web reconnect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Entering degraded mode — retrying every ${DEGRADED_COOLDOWN_MS / 1000}s.`,
       );
-      await closeListener();
-      break;
+      // Reset counter so the next cycle gets a fresh batch of fast retries
+      // if the connection recovers briefly then drops again.
+      reconnectAttempts = 0;
+      status.reconnectAttempts = reconnectAttempts;
+      delay = DEGRADED_COOLDOWN_MS;
+    } else {
+      delay = computeBackoff(reconnectPolicy, reconnectAttempts);
     }
-
-    const delay = computeBackoff(reconnectPolicy, reconnectAttempts);
     reconnectLogger.info(
       {
         connectionId,

--- a/src/web/reconnect.test.ts
+++ b/src/web/reconnect.test.ts
@@ -12,6 +12,10 @@ import {
 describe("web reconnect helpers", () => {
   const cfg: OpenClawConfig = {};
 
+  it("defaults to unlimited reconnect attempts (maxAttempts=0)", () => {
+    expect(DEFAULT_RECONNECT_POLICY.maxAttempts).toBe(0);
+  });
+
   it("resolves sane reconnect defaults with clamps", () => {
     const policy = resolveReconnectPolicy(cfg, {
       initialMs: 100,

--- a/src/web/reconnect.ts
+++ b/src/web/reconnect.ts
@@ -9,12 +9,20 @@ export type ReconnectPolicy = BackoffPolicy & {
 };
 
 export const DEFAULT_HEARTBEAT_SECONDS = 60;
+/**
+ * Default reconnect policy for the WhatsApp Web monitor loop.
+ *
+ * maxAttempts=0 means unlimited retries. The gateway process is long-lived;
+ * permanently giving up on reconnection leaves WhatsApp silently dead while
+ * status still reports "linked" (because auth credentials persist on disk).
+ * Operators who want bounded retries can set web.reconnect.maxAttempts in config.
+ */
 export const DEFAULT_RECONNECT_POLICY: ReconnectPolicy = {
   initialMs: 2_000,
   maxMs: 30_000,
   factor: 1.8,
   jitter: 0.25,
-  maxAttempts: 12,
+  maxAttempts: 0,
 };
 
 export function resolveHeartbeatSeconds(cfg: OpenClawConfig, overrideSeconds?: number): number {


### PR DESCRIPTION
## Summary

The WhatsApp Web monitor loop exits permanently after exhausting `maxAttempts` (default: 12) reconnect tries. This leaves the listener dead while `openclaw status` still reports "linked" (auth credentials persist on disk), creating a silent failure mode where no outbound messages can be sent.

This is the root cause of #41950, #38734, #30177, and #30806.

## Changes

### 1. Default `maxAttempts`: 12 → 0 (unlimited)

A long-lived gateway daemon should never permanently give up on reconnection. The default was 12 attempts with exponential backoff (2s initial, 30s max, 1.8× factor), which exhausts in roughly 5-10 minutes. WhatsApp Web sessions commonly drop overnight (Meta server-side timeout), and 12 attempts is not enough to survive a prolonged outage.

Operators who want bounded retries can still set `web.reconnect.maxAttempts` explicitly.

### 2. Degraded mode instead of permanent stop

When `maxAttempts` IS explicitly set and reached, the monitor now enters **degraded mode** with a 5-minute cooldown between retries instead of `break`ing out of the loop. The reconnect counter resets after each degraded cycle so the next connection gets a fresh batch of fast retries if the server becomes reachable again.

Before:
```
maxAttempts reached → closeListener() → break → status.running = false
// Monitor loop dead. Status shows "linked". No outbound messages possible.
// Only fix: gateway restart.
```

After:
```
maxAttempts reached → log "degraded mode" → sleep 5min → reset counter → retry
// Monitor keeps trying. Will recover automatically when WhatsApp becomes available.
```

### 3. Updated tests

- New test: verifies default `maxAttempts` is 0
- Updated e2e test: verifies degraded-mode behavior (continued retries + degraded log message instead of permanent stop)
- 440 (session conflict) test unchanged — non-retryable statuses still correctly stop the monitor

## Testing

**Reproduced on:** OpenClaw 2026.3.8, Docker (Debian 12), Node 22.22.1

The issue occurred on 3 consecutive days (March 1, 10, 11) with the WhatsApp listener dying overnight and requiring manual gateway restarts to recover. After applying `web.reconnect.maxAttempts: 0` as a config workaround, the listener survived overnight disconnects.

## Files changed

| File | Change |
|------|--------|
| `src/web/reconnect.ts` | Default `maxAttempts` 12→0, added JSDoc |
| `src/web/auto-reply/monitor.ts` | Degraded-mode cooldown instead of `break` |
| `src/web/reconnect.test.ts` | New test for default value |
| `src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts` | Updated max-attempts scenario |

Fixes #41950
Refs #38734, #30177, #30806