### PR TITLE
docker: move Playwright browser cache to /opt and expose chrome on PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,16 +158,24 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 # Build with: docker build --build-arg OPENCLAW_INSTALL_BROWSER=1 ...
 # Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
 # Must run after node_modules COPY so playwright-core is available.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/openclaw/ms-playwright
 ARG OPENCLAW_INSTALL_BROWSER=""
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
     if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
-      mkdir -p /home/node/.cache/ms-playwright && \
-      PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
+      mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" /opt/openclaw/bin && \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
-      chown -R node:node /home/node/.cache/ms-playwright; \
+      chromium_path="$(find "$PLAYWRIGHT_BROWSERS_PATH" -maxdepth 4 -type f -path '*/chrome-linux*/chrome' | head -n1)" && \
+      if [ -z "$chromium_path" ]; then \
+        echo "ERROR: Chromium binary not found under $PLAYWRIGHT_BROWSERS_PATH" >&2; \
+        exit 1; \
+      fi && \
+      ln -sfn "$chromium_path" /opt/openclaw/bin/chromium && \
+      ln -sfn "$chromium_path" /usr/local/bin/chromium && \
+      ln -sfn "$chromium_path" /usr/local/bin/chrome && \
+      chown -R node:node "$PLAYWRIGHT_BROWSERS_PATH" /opt/openclaw/bin; \
     fi
 
 # Optionally install Docker CLI for sandbox container management.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -384,10 +384,10 @@ If you need Playwright to install system deps, rebuild the image with
 
 4. **Persist Playwright browser downloads**:
 
-- Set `PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright` in
+- Set `PLAYWRIGHT_BROWSERS_PATH=/opt/openclaw/ms-playwright` in
   `docker-compose.yml`.
-- Ensure `/home/node` persists via `OPENCLAW_HOME_VOLUME`, or mount
-  `/home/node/.cache/ms-playwright` via `OPENCLAW_EXTRA_MOUNTS`.
+- Mount `/opt/openclaw/ms-playwright` via `OPENCLAW_EXTRA_MOUNTS` (or a direct bind mount)
+  if you want browser binaries to persist across container rebuilds.
 
 ### Permissions + EACCES
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -412,8 +412,8 @@ docker compose run --rm openclaw-cli \
 ```
 
 To persist browser downloads, set `PLAYWRIGHT_BROWSERS_PATH` (for example,
-`/home/node/.cache/ms-playwright`) and make sure `/home/node` is persisted via
-`OPENCLAW_HOME_VOLUME` or a bind mount. See [Docker](/install/docker).
+`/opt/openclaw/ms-playwright`) and mount that path via `OPENCLAW_EXTRA_MOUNTS`
+or a direct bind mount. See [Docker](/install/docker).
 
 ## How it works (internal)
 

--- a/docs/zh-CN/install/docker.md
+++ b/docs/zh-CN/install/docker.md
@@ -190,8 +190,8 @@ docker compose run --rm openclaw-cli \
 
 4. **持久化 Playwright 浏览器下载**：
 
-- 在 `docker-compose.yml` 中设置 `PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright`。
-- 确保 `/home/node` 通过 `OPENCLAW_HOME_VOLUME` 持久化，或通过 `OPENCLAW_EXTRA_MOUNTS` 挂载 `/home/node/.cache/ms-playwright`。
+- 在 `docker-compose.yml` 中设置 `PLAYWRIGHT_BROWSERS_PATH=/opt/openclaw/ms-playwright`。
+- 如果希望浏览器二进制在容器重建后保留，请通过 `OPENCLAW_EXTRA_MOUNTS`（或直接 bind mount）挂载 `/opt/openclaw/ms-playwright`。
 
 ### 权限 + EACCES
 

--- a/docs/zh-CN/tools/browser.md
+++ b/docs/zh-CN/tools/browser.md
@@ -321,7 +321,7 @@ docker compose run --rm openclaw-cli \
   node /app/node_modules/playwright-core/cli.js install chromium
 ```
 
-要持久化浏览器下载，设置 `PLAYWRIGHT_BROWSERS_PATH`（例如 `/home/node/.cache/ms-playwright`）并确保 `/home/node` 通过 `OPENCLAW_HOME_VOLUME` 或绑定挂载持久化。参见 [Docker](/install/docker)。
+要持久化浏览器下载，设置 `PLAYWRIGHT_BROWSERS_PATH`（例如 `/opt/openclaw/ms-playwright`），并通过 `OPENCLAW_EXTRA_MOUNTS` 或直接绑定挂载该路径。参见 [Docker](/install/docker)。
 
 ## 工作原理（内部）
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Docker browser installs were written under `/home/node/.cache/ms-playwright`, and users had to reference versioned Chromium paths directly.
- Why it matters: versioned Playwright directories change across rebuilds, so hardcoded absolute binary paths are brittle.
- What changed: switched Docker default browser cache path to `/opt/openclaw/ms-playwright`, and added stable PATH symlinks (`/usr/local/bin/chrome` and `/usr/local/bin/chromium`) to the installed Chromium binary.
- What did NOT change (scope boundary): no browser runtime logic/tool API changes; this is Docker packaging + docs only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #42819
- Related #

## User-visible / Behavior Changes

- Browser-enabled Docker builds now default to `PLAYWRIGHT_BROWSERS_PATH=/opt/openclaw/ms-playwright`.
- Chromium is exposed on PATH via stable symlinks (`chrome`, `chromium`) after browser install.
- Docker/browser docs updated to match the new path and persistence guidance.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 10 (author environment)
- Runtime/container: Dockerfile changes only
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Review Docker browser install stage and set `PLAYWRIGHT_BROWSERS_PATH` to `/opt/openclaw/ms-playwright`.
2. Add stable symlink creation for detected Chromium binary (`chrome`/`chromium` on PATH).
3. Update Docker/browser docs (EN + zh-CN) to use the new persistence path.

### Expected

- Browser assets install outside `.cache` (under `/opt/openclaw/ms-playwright`).
- Chromium binary is reachable via stable PATH entry.

### Actual

- Dockerfile now installs to `/opt/openclaw/ms-playwright` and writes stable PATH symlinks.
- Docs point to the same path and mount strategy.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace snippet used for verification:

```bash
git grep -n "/home/node/.cache/ms-playwright" -- Dockerfile docs
# (no matches)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Dockerfile now sets `PLAYWRIGHT_BROWSERS_PATH=/opt/openclaw/ms-playwright`; symlink creation for `chrome`/`chromium` is present; docs updated consistently in EN + zh-CN.
- Edge cases checked: install step fails fast if Chromium binary cannot be discovered after Playwright install.
- What you did **not** verify: full image build/run with `OPENCLAW_INSTALL_BROWSER=1` in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`Recommended`)
- If yes, exact upgrade steps:
  1. If you previously set `PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright`, update it to `/opt/openclaw/ms-playwright`.
  2. Update your Docker mounts to persist `/opt/openclaw/ms-playwright`.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit, or override `PLAYWRIGHT_BROWSERS_PATH` to previous path at runtime.
- Files/config to restore: `Dockerfile` and Docker/browser docs listed in this PR.
- Known bad symptoms reviewers should watch for: Chromium install step fails with "Chromium binary not found" if upstream Playwright layout changes.

## Risks and Mitigations

- Risk: Playwright changes binary layout and the `find` pattern no longer matches.
  - Mitigation: explicit guard exits build with a clear error; easy to adjust pattern in one place.
