### PR TITLE
fix(slack): respect userTokenReadOnly flag for read operations

### DIFF
--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -596,6 +596,20 @@ describe("handleSlackAction", () => {
     expect(await resolveSendToken(cfg)).toBeUndefined();
   });
 
+  it("uses bot token for reads when userTokenReadOnly is false", async () => {
+    const cfg = {
+      channels: { slack: { botToken: "xoxb-1", userToken: "xoxp-1", userTokenReadOnly: false } },
+    } as OpenClawConfig;
+    expect(await resolveReadToken(cfg)).toBeUndefined();
+  });
+
+  it("falls back to user token for reads when userTokenReadOnly is false and no bot token", async () => {
+    const cfg = {
+      channels: { slack: { userToken: "xoxp-1", userTokenReadOnly: false } },
+    } as OpenClawConfig;
+    expect(await resolveReadToken(cfg)).toBe("xoxp-1");
+  });
+
   it("allows user token writes when bot token is missing", async () => {
     const cfg = {
       channels: {

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -123,9 +123,12 @@ export async function handleSlackAction(
   const allowUserWrites = account.config.userTokenReadOnly === false;
 
   // Choose the most appropriate token for Slack read/write operations.
+  // When userTokenReadOnly is true (default), user token is specifically for reads — prefer it.
+  // When userTokenReadOnly is false, user token can also write — prefer bot token for reads
+  // since bot tokens typically have broader read scopes (channels:history etc.).
   const getTokenForOperation = (operation: "read" | "write") => {
     if (operation === "read") {
-      return userToken ?? botToken;
+      return allowUserWrites ? (botToken ?? userToken) : (userToken ?? botToken);
     }
     if (!allowUserWrites) {
       return botToken;


### PR DESCRIPTION
## Summary

- Problem: `getTokenForOperation("read")` unconditionally returns `userToken ?? botToken`, ignoring the `userTokenReadOnly` configuration flag.
- Why it matters: When `userTokenReadOnly: false` is set (to enable user-token writes), read operations still prefer the user token even when it lacks broad read scopes like `channels:history`, causing API failures.
- What changed: Read operations now check `userTokenReadOnly` — when `false`, reads prefer `botToken` (which typically has full read scopes) and fall back to `userToken` only when bot token is unavailable. When `true` (default), behavior is unchanged (user token preferred for reads).
- What did NOT change: Write-path token selection logic, token resolution in `resolveSlackAccount`, Zod schema defaults, or any other Slack action behavior.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #42752

## User-visible / Behavior Changes

When `userTokenReadOnly: false`, Slack read operations (readMessages, listPins, reactions, memberInfo, emojiList) now prefer the bot token instead of the user token. This prevents failures when the user token has limited read scopes (e.g., only `identify` and `search:read`).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — same tokens, different selection priority
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps
1. Configure Slack with both `botToken` (full scopes) and `userToken` (limited scopes: `identify`, `search:read`)
2. Set `userTokenReadOnly: false`
3. Try `readMessages` action

### Expected
- Reads use bot token (which has `channels:history`)

### Actual (before fix)
- Reads always use user token first → fails with scope error because user token lacks `channels:history`

## Evidence

- [x] Failing test/log before + passing after
- New tests added:
  - `uses bot token for reads when userTokenReadOnly is false`
  - `falls back to user token for reads when userTokenReadOnly is false and no bot token`

## Human Verification (required)

- Verified scenarios: userTokenReadOnly=true (default, unchanged), userTokenReadOnly=false (new behavior), no userToken (unchanged), no botToken with userTokenReadOnly=false (fallback)
- Edge cases checked: both tokens missing, only userToken present, only botToken present
- What you did **not** verify: live Slack API calls with real tokens

## Compatibility / Migration

- Backward compatible? Yes — default behavior (`userTokenReadOnly: true`) is unchanged
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert single commit, or set `userTokenReadOnly: true` (default)
- Files/config to restore: `src/agents/tools/slack-actions.ts`
- Known bad symptoms reviewers should watch for: Read operations failing when `userTokenReadOnly: false` with both tokens configured

## Risks and Mitigations

- Risk: Users who set `userTokenReadOnly: false` and relied on user token for reads may see different token used
  - Mitigation: Bot token has strictly broader scopes than user token in standard Slack setups; fallback to user token preserved when bot token is missing

| Scenario | Before | After |
|----------|--------|-------|
| `userTokenReadOnly: true` + both tokens | userToken for reads | userToken for reads (unchanged) |
| `userTokenReadOnly: false` + both tokens | userToken for reads | **botToken for reads** |
| `userTokenReadOnly: false` + userToken only | userToken for reads | userToken for reads (fallback) |
| `userTokenReadOnly: true` + botToken only | botToken for reads | botToken for reads (unchanged) |