### PR TITLE
Tests: clear inherited WSL env in wsl detection test

### DIFF
--- a/src/infra/wsl.test.ts
+++ b/src/infra/wsl.test.ts
@@ -30,6 +30,9 @@ describe("wsl detection", () => {
 
   beforeEach(() => {
     envSnapshot = captureEnv(["WSL_INTEROP", "WSL_DISTRO_NAME", "WSLENV"]);
+    delete process.env.WSL_INTEROP;
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.WSLENV;
     readFileSyncMock.mockReset();
     readFileMock.mockReset();
     resetWSLStateForTests();


### PR DESCRIPTION
## Summary

- Problem: `src/infra/wsl.test.ts` assumed `WSL_INTEROP`, `WSL_DISTRO_NAME`, and `WSLENV` were absent.
- Why it matters: on WSL-backed shells, the real env short-circuits detection before the mocked `/proc` reads, so the test becomes host-dependent and fails.
- What changed: clear those WSL env vars in `beforeEach()` before running the assertions.
- What did NOT change (scope boundary): no runtime WSL detection logic changed; this only stabilizes the test setup.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows PowerShell in a WSL-backed environment
- Runtime/container: Node via `pnpm test`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): WSL env vars present in shell (`WSL_INTEROP`, `WSL_DISTRO_NAME`, `WSLENV`)

### Steps

1. Run `pnpm test src/infra/wsl.test.ts` in a shell with WSL env vars present.
2. Observe `isWSLEnv()` short-circuit the tests before the mocked file reads.
3. Apply this change and rerun the same test.

### Expected

- The test should control the environment explicitly and exercise the mocked `/proc` code paths.
- `pnpm test src/infra/wsl.test.ts` should pass regardless of host WSL env leakage.

### Actual

- Before the change, the test failed on WSL-backed shells because inherited env vars bypassed the mocked reads.
- After the change, the focused test passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the failing focused test from the provided output; after the change, the user reran `pnpm test src/infra/wsl.test.ts` and it passed (`10 passed`).
- Edge cases checked: the change only clears the three WSL env vars inside test setup before restoring them in `afterEach()`.
- What you did **not** verify: full test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit e6998c01c32aa69a3bd6a28da64c779f1ba508e4.
- Files/config to restore: `src/infra/wsl.test.ts`
- Known bad symptoms reviewers should watch for: none beyond the test becoming host-dependent again on WSL-backed shells.

## Risks and Mitigations

- Risk: the test setup could mask a future case that intentionally wants inherited WSL env vars.
- Mitigation: the existing env-specific assertions still cover WSL env detection explicitly in dedicated test cases.
