### PR TITLE
Feat/opensandbox backend

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -1,17 +1,17 @@
 ---
 title: Sandbox CLI
-summary: "Manage sandbox containers and inspect effective sandbox policy"
+summary: "Manage sandbox runtimes and inspect effective sandbox policy"
 read_when: "You are managing sandbox containers or debugging sandbox/tool-policy behavior."
 status: active
 ---
 
 # Sandbox CLI
 
-Manage Docker-based sandbox containers for isolated agent execution.
+Manage sandbox runtimes for isolated agent execution.
 
 ## Overview
 
-OpenClaw can run agents in isolated Docker containers for security. The `sandbox` commands help you manage these containers, especially after updates or configuration changes.
+OpenClaw can run agents in isolated sandbox runtimes for security. The `sandbox` commands help you inspect effective sandbox policy and manage Docker-backed sandbox containers after updates or configuration changes.
 
 ## Commands
 
@@ -28,7 +28,7 @@ openclaw sandbox explain --json
 
 ### `openclaw sandbox list`
 
-List all sandbox containers with their status and configuration.
+List all Docker-backed sandbox containers with their status and configuration.
 
 ```bash
 openclaw sandbox list
@@ -46,7 +46,7 @@ openclaw sandbox list --json     # JSON output
 
 ### `openclaw sandbox recreate`
 
-Remove sandbox containers to force recreation with updated images/config.
+Remove Docker-backed sandbox containers to force recreation with updated images/config.
 
 ```bash
 openclaw sandbox recreate --all                # Recreate all containers
@@ -64,7 +64,7 @@ openclaw sandbox recreate --all --force        # Skip confirmation
 - `--browser`: Only recreate browser containers
 - `--force`: Skip confirmation prompt
 
-**Important:** Containers are automatically recreated when the agent is next used.
+**Important:** Docker containers are automatically recreated when the agent is next used.
 
 ## Use Cases
 
@@ -108,7 +108,7 @@ openclaw sandbox recreate --agent alfred
 
 ## Why is this needed?
 
-**Problem:** When you update sandbox Docker images or configuration:
+**Problem:** When you update Docker sandbox images or configuration:
 
 - Existing containers continue running with old settings
 - Containers are only pruned after 24h of inactivity
@@ -119,6 +119,17 @@ openclaw sandbox recreate --agent alfred
 Tip: prefer `openclaw sandbox recreate` over manual `docker rm`. It uses the
 Gateway’s container naming and avoids mismatches when scope/session keys change.
 
+## Backend awareness
+
+`openclaw sandbox explain` reports the effective sandbox backend, mode, scope, workspace access, and tool policy.
+
+Current management commands are Docker-focused:
+
+- `openclaw sandbox list` lists Docker-backed sandbox containers
+- `openclaw sandbox recreate` recreates Docker-backed sandbox containers
+
+If you use `sandbox.backend: "opensandbox"`, use `sandbox explain` for policy/debugging. Runtime lifecycle is managed through [Alibaba OpenSandbox](https://github.com/alibaba/OpenSandbox) rather than local Docker container commands.
+
 ## Configuration
 
 Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sandbox` (per-agent overrides go in `agents.list[].sandbox`):
@@ -128,6 +139,7 @@ Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sand
   "agents": {
     "defaults": {
       "sandbox": {
+        "backend": "docker", // docker, opensandbox
         "mode": "all", // off, non-main, all
         "scope": "agent", // session, agent, shared
         "docker": {

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -9,7 +9,7 @@ status: active
 
 OpenClaw has three related (but different) controls:
 
-1. **Sandbox** (`agents.defaults.sandbox.*` / `agents.list[].sandbox.*`) decides **where tools run** (Docker vs host).
+1. **Sandbox** (`agents.defaults.sandbox.*` / `agents.list[].sandbox.*`) decides **where tools run** (sandbox backend vs host).
 2. **Tool policy** (`tools.*`, `tools.sandbox.tools.*`, `agents.list[].tools.*`) decides **which tools are available/allowed**.
 3. **Elevated** (`tools.elevated.*`, `agents.list[].tools.elevated.*`) is an **exec-only escape hatch** to run on the host when you’re sandboxed.
 
@@ -39,7 +39,13 @@ Sandboxing is controlled by `agents.defaults.sandbox.mode`:
 - `"non-main"`: only non-main sessions are sandboxed (common “surprise” for groups/channels).
 - `"all"`: everything is sandboxed.
 
-See [Sandboxing](/gateway/sandboxing) for the full matrix (scope, workspace mounts, images).
+See [Sandboxing](/gateway/sandboxing) for the full matrix (backend, scope, workspace access, images).
+
+Sandbox backend notes:
+
+- `backend: "docker"` runs tools in local Docker containers.
+- `backend: "opensandbox"` runs tools in an [Alibaba OpenSandbox](https://github.com/alibaba/OpenSandbox)-managed runtime.
+- `exec.host: "sandbox"` still means "run inside the configured sandbox backend". OpenSandbox does **not** introduce a separate exec host value.
 
 ### Bind mounts (security quick check)
 

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -1,5 +1,5 @@
 ---
-summary: "How OpenClaw sandboxing works: modes, scopes, workspace access, and images"
+summary: "How OpenClaw sandboxing works: backends, modes, scopes, workspace access, and images"
 title: Sandboxing
 read_when: "You want a dedicated explanation of sandboxing or need to tune agents.defaults.sandbox."
 status: active
@@ -7,7 +7,7 @@ status: active
 
 # Sandboxing
 
-OpenClaw can run **tools inside Docker containers** to reduce blast radius.
+OpenClaw can run **tools inside an isolated sandbox backend** to reduce blast radius.
 This is **optional** and controlled by configuration (`agents.defaults.sandbox` or
 `agents.list[].sandbox`). If sandboxing is off, tools run on the host.
 The Gateway stays on the host; tool execution runs in an isolated sandbox
@@ -16,10 +16,25 @@ when enabled.
 This is not a perfect security boundary, but it materially limits filesystem
 and process access when the model does something dumb.
 
+## Sandbox backend
+
+`agents.defaults.sandbox.backend` controls **which sandbox runtime** OpenClaw uses:
+
+- `"docker"` (default): runs tools in local Docker containers.
+- `"opensandbox"`: runs tools in an [Alibaba OpenSandbox](https://github.com/alibaba/OpenSandbox)-managed sandbox.
+
+Current OpenSandbox limits:
+
+- only `workspaceAccess: "none"` is supported
+- sandbox browser is not supported
+- interactive PTY and interactive `process` input (`write`, `send-keys`, `submit`, `paste`) are not supported
+
+OpenSandbox still uses the normal sandbox execution path. Keep `exec.host: "sandbox"` if you want commands to run in the sandbox. It is **not** a separate exec host.
+
 ## What gets sandboxed
 
 - Tool execution (`exec`, `read`, `write`, `edit`, `apply_patch`, `process`, etc.).
-- Optional sandboxed browser (`agents.defaults.sandbox.browser`).
+- Optional sandboxed browser (`agents.defaults.sandbox.browser`) when `backend: "docker"`.
   - By default, the sandbox browser auto-starts (ensures CDP is reachable) when the browser tool needs it.
     Configure via `agents.defaults.sandbox.browser.autoStart` and `agents.defaults.sandbox.browser.autoStartTimeoutMs`.
   - By default, sandbox browser containers use a dedicated Docker network (`openclaw-sandbox-browser`) instead of the global `bridge` network.
@@ -50,23 +65,25 @@ Not sandboxed:
 
 `agents.defaults.sandbox.scope` controls **how many containers** are created:
 
-- `"session"` (default): one container per session.
-- `"agent"`: one container per agent.
-- `"shared"`: one container shared by all sandboxed sessions.
+- `"session"` (default): one sandbox runtime per session.
+- `"agent"`: one sandbox runtime per agent.
+- `"shared"`: one sandbox runtime shared by all sandboxed sessions.
 
 ## Workspace access
 
 `agents.defaults.sandbox.workspaceAccess` controls **what the sandbox can see**:
 
 - `"none"` (default): tools see a sandbox workspace under `~/.openclaw/sandboxes`.
-- `"ro"`: mounts the agent workspace read-only at `/agent` (disables `write`/`edit`/`apply_patch`).
-- `"rw"`: mounts the agent workspace read/write at `/workspace`.
+- `"ro"`: mounts the agent workspace read-only at `/agent` (Docker backend only; disables `write`/`edit`/`apply_patch`).
+- `"rw"`: mounts the agent workspace read/write at `/workspace` (Docker backend only).
 
 Inbound media is copied into the active sandbox workspace (`media/inbound/*`).
 Skills note: the `read` tool is sandbox-rooted. With `workspaceAccess: "none"`,
 OpenClaw mirrors eligible skills into the sandbox workspace (`.../skills`) so
 they can be read. With `"rw"`, workspace skills are readable from
 `/workspace/skills`.
+
+With `backend: "opensandbox"`, OpenClaw currently creates and uses the isolated sandbox workspace only. The agent workspace is not mounted or synchronized bidirectionally.
 
 ## Custom bind mounts
 
@@ -114,7 +131,7 @@ Security notes:
 - Combine with `workspaceAccess: "ro"` if you only need read access to the workspace; bind modes stay independent.
 - See [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) for how binds interact with tool policy and elevated exec.
 
-## Images + setup
+## Docker images + setup
 
 Default image: `openclaw-sandbox:bookworm-slim`
 
@@ -145,7 +162,7 @@ Sandboxed browser image:
 scripts/sandbox-browser-setup.sh
 ```
 
-By default, sandbox containers run with **no network**.
+By default, Docker sandbox containers run with **no network**.
 Override with `agents.defaults.sandbox.docker.network`.
 
 The bundled sandbox browser image also applies conservative Chromium startup defaults
@@ -196,7 +213,47 @@ Set `OPENCLAW_SANDBOX=1` (or `true`/`yes`/`on`) to enable that path. You can
 override socket location with `OPENCLAW_DOCKER_SOCKET`. Full setup and env
 reference: [Docker](/install/docker#enable-agent-sandbox-for-docker-gateway-opt-in).
 
-## setupCommand (one-time container setup)
+## OpenSandbox setup
+
+OpenSandbox is configured under `agents.defaults.sandbox.opensandbox`.
+OpenClaw integrates with [Alibaba OpenSandbox](https://github.com/alibaba/OpenSandbox) as an alternative sandbox backend.
+
+Minimal example:
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        backend: "opensandbox",
+        mode: "all",
+        scope: "session",
+        workspaceAccess: "none",
+        opensandbox: {
+          endpoint: "http://127.0.0.1:8080",
+          image: "opensandbox/code-interpreter:latest",
+          workdir: "/workspace",
+        },
+      },
+    },
+  },
+}
+```
+
+Common fields:
+
+- `endpoint`: OpenSandbox lifecycle API base URL
+- `apiKey`: optional API key for the lifecycle API
+- `image`: OpenSandbox image name
+- `workdir`: remote sandbox working directory
+- `timeoutSeconds`: sandbox lifetime
+- `readyTimeoutSeconds`: how long OpenClaw waits for the sandbox to become ready
+- `env`: environment variables to inject into the sandbox
+- `metadata`: extra metadata sent when creating the sandbox
+
+OpenClaw currently uploads the isolated sandbox workspace into OpenSandbox when the runtime is created. This gives `read`, `write`, `edit`, `apply_patch`, and `exec` a consistent sandbox-local filesystem, but it is not the same as Docker bind-mount access.
+
+## Docker setupCommand (one-time container setup)
 
 `setupCommand` runs **once** after the sandbox container is created (not on every run).
 It executes inside the container via `sh -lc`.

--- a/src/agents/bash-process-registry.test-helpers.ts
+++ b/src/agents/bash-process-registry.test-helpers.ts
@@ -11,6 +11,8 @@ export function createProcessSessionFixture(params: {
   backgrounded?: boolean;
   pid?: number;
   child?: ChildProcessWithoutNullStreams;
+  onKill?: () => void | Promise<void>;
+  unsupportedInputReason?: string;
 }): ProcessSession {
   const session: ProcessSession = {
     id: params.id,
@@ -31,6 +33,8 @@ export function createProcessSessionFixture(params: {
     exitSignal: undefined,
     truncated: false,
     backgrounded: params.backgrounded ?? false,
+    onKill: params.onKill,
+    unsupportedInputReason: params.unsupportedInputReason,
   };
   if (params.pid !== undefined) {
     session.pid = params.pid;

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -52,6 +52,8 @@ export interface ProcessSession {
   exited: boolean;
   truncated: boolean;
   backgrounded: boolean;
+  onKill?: () => void | Promise<void>;
+  unsupportedInputReason?: string;
 }
 
 export interface FinishedSession {

--- a/src/agents/bash-tools.exec-opensandbox.ts
+++ b/src/agents/bash-tools.exec-opensandbox.ts
@@ -1,0 +1,192 @@
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { ProcessSession } from "./bash-process-registry.js";
+import { markExited } from "./bash-process-registry.js";
+import type { ExecProcessHandle, ExecProcessOutcome } from "./bash-tools.exec-runtime.js";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { BashSandboxConfig } from "./bash-tools.shared.js";
+import {
+  interruptOpenSandboxCommand,
+  readOpenSandboxCommandStatus,
+  runOpenSandboxCommand,
+  syncOpenSandboxWorkspaceToLocalSnapshot,
+} from "./sandbox/opensandbox.js";
+
+const OPEN_SANDBOX_UNSUPPORTED_INPUT_REASON =
+  "Interactive process input is unsupported for sandbox backend=opensandbox.";
+
+function formatErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function resolveOpenSandboxExitCode(params: {
+  execdBaseUrl: string;
+  commandId?: string;
+  exitCode: number | null;
+  apiKey?: string;
+}) {
+  if (typeof params.exitCode === "number" || !params.commandId) {
+    return params.exitCode;
+  }
+  const status = await readOpenSandboxCommandStatus({
+    execdBaseUrl: params.execdBaseUrl,
+    commandId: params.commandId,
+    apiKey: params.apiKey,
+  });
+  return typeof status.exit_code === "number" ? status.exit_code : null;
+}
+
+async function refreshOpenSandboxWorkspaceSnapshot(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  localWorkspaceDir: string;
+  remoteWorkspaceDir: string;
+  signal: AbortSignal;
+  onStderr: (data: string) => void;
+}) {
+  try {
+    await syncOpenSandboxWorkspaceToLocalSnapshot({
+      execdBaseUrl: params.execdBaseUrl,
+      apiKey: params.apiKey,
+      localWorkspaceDir: params.localWorkspaceDir,
+      remoteWorkspaceDir: params.remoteWorkspaceDir,
+      signal: params.signal,
+    });
+  } catch (error) {
+    params.onStderr(
+      `\n[warn] failed to refresh OpenSandbox workspace snapshot: ${formatErrorMessage(error)}\n`,
+    );
+  }
+}
+
+export async function runOpenSandboxExecProcess(params: {
+  startedAt: number;
+  command: string;
+  execCommand: string;
+  timeoutMs?: number;
+  containerWorkdir?: string | null;
+  sandbox: BashSandboxConfig;
+  usePty: boolean;
+  session: ProcessSession;
+  onStdout: (data: string) => void;
+  onStderr: (data: string) => void;
+  onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
+  emitUpdate: () => void;
+  maybeNotifyOnExit: (session: ProcessSession, status: "completed" | "failed") => void;
+}): Promise<ExecProcessHandle> {
+  if (params.usePty) {
+    throw new Error("PTY is not supported for sandbox.backend=opensandbox.");
+  }
+  const execdBaseUrl = params.sandbox.opensandbox?.execdBaseUrl?.trim();
+  if (!execdBaseUrl) {
+    throw new Error("OpenSandbox execd base URL is unavailable.");
+  }
+
+  const commandAbortController = new AbortController();
+  let commandId: string | undefined;
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  let abortReason: "manual" | "timeout" | undefined;
+  const forwardAbort = (reason: "manual" | "timeout" = "manual") => {
+    if (commandAbortController.signal.aborted) {
+      return;
+    }
+    abortReason = reason;
+    commandAbortController.abort();
+    if (commandId) {
+      void interruptOpenSandboxCommand({
+        execdBaseUrl,
+        commandId,
+        apiKey: params.sandbox.opensandbox?.apiKey,
+      });
+    }
+  };
+
+  if (params.onUpdate) {
+    params.emitUpdate();
+  }
+
+  const promise = (async (): Promise<ExecProcessOutcome> => {
+    const started = Date.now();
+    if (typeof params.timeoutMs === "number" && params.timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        forwardAbort("timeout");
+      }, params.timeoutMs);
+    }
+    try {
+      const commandResult = await runOpenSandboxCommand({
+        execdBaseUrl,
+        apiKey: params.sandbox.opensandbox?.apiKey,
+        command: params.execCommand,
+        cwd: params.containerWorkdir ?? params.sandbox.containerWorkdir,
+        background: false,
+        signal: commandAbortController.signal,
+        onInit: (id) => {
+          commandId = id;
+        },
+        onStdout: params.onStdout,
+        onStderr: params.onStderr,
+      });
+      const exitCode = await resolveOpenSandboxExitCode({
+        execdBaseUrl,
+        commandId: commandResult.commandId,
+        exitCode: commandResult.exitCode,
+        apiKey: params.sandbox.opensandbox?.apiKey,
+      });
+      const exitSignal: NodeJS.Signals | number | null = null;
+      await refreshOpenSandboxWorkspaceSnapshot({
+        execdBaseUrl,
+        apiKey: params.sandbox.opensandbox?.apiKey,
+        localWorkspaceDir: params.sandbox.workspaceDir,
+        remoteWorkspaceDir: params.sandbox.containerWorkdir,
+        signal: commandAbortController.signal,
+        onStderr: params.onStderr,
+      });
+      const status: "completed" | "failed" =
+        exitCode === 0 && !commandResult.error ? "completed" : "failed";
+      markExited(params.session, exitCode ?? null, exitSignal, status);
+      params.maybeNotifyOnExit(params.session, status);
+      return {
+        status,
+        exitCode: exitCode ?? null,
+        exitSignal,
+        durationMs: Date.now() - started,
+        aggregated: params.session.aggregated,
+        timedOut: false,
+        reason: commandResult.error,
+      };
+    } catch (error) {
+      const timedOut = abortReason === "timeout";
+      const reason = timedOut
+        ? `Command timed out after ${params.timeoutMs}ms.`
+        : formatErrorMessage(error);
+      markExited(params.session, null, null, "failed");
+      params.maybeNotifyOnExit(params.session, "failed");
+      return {
+        status: "failed",
+        exitCode: null,
+        exitSignal: null,
+        durationMs: Date.now() - started,
+        aggregated: params.session.aggregated,
+        timedOut,
+        reason,
+      };
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  })();
+
+  params.session.onKill = () => {
+    forwardAbort("manual");
+  };
+  params.session.unsupportedInputReason = OPEN_SANDBOX_UNSUPPORTED_INPUT_REASON;
+
+  return {
+    session: params.session,
+    startedAt: params.startedAt,
+    promise,
+    kill: () => {
+      forwardAbort("manual");
+    },
+  };
+}

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -8,6 +8,7 @@ import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import type { ProcessSession } from "./bash-process-registry.js";
+import { runOpenSandboxExecProcess } from "./bash-tools.exec-opensandbox.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 export { applyPathPrepend, findPathKey, normalizePathPrepend } from "../infra/path-prepend.js";
@@ -384,6 +385,24 @@ export async function runExecProcess(opts: {
     typeof opts.timeoutSec === "number" && opts.timeoutSec > 0
       ? Math.floor(opts.timeoutSec * 1000)
       : undefined;
+
+  if (opts.sandbox?.backend === "opensandbox") {
+    return await runOpenSandboxExecProcess({
+      startedAt,
+      command: opts.command,
+      execCommand,
+      timeoutMs,
+      containerWorkdir: opts.containerWorkdir,
+      sandbox: opts.sandbox,
+      usePty: opts.usePty,
+      session,
+      onStdout: handleStdout,
+      onStderr: handleStderr,
+      onUpdate: opts.onUpdate,
+      emitUpdate,
+      maybeNotifyOnExit,
+    });
+  }
 
   const spawnSpec:
     | {

--- a/src/agents/bash-tools.process.opensandbox.test.ts
+++ b/src/agents/bash-tools.process.opensandbox.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { addSession, getSession, resetProcessRegistryForTests } from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { createProcessTool } from "./bash-tools.process.js";
+
+describe("process tool opensandbox sessions", () => {
+  afterEach(() => {
+    resetProcessRegistryForTests();
+  });
+
+  it("returns a clear error for unsupported interactive input", async () => {
+    addSession(
+      createProcessSessionFixture({
+        id: "sbx-proc",
+        command: "python app.py",
+        backgrounded: true,
+        unsupportedInputReason:
+          "Interactive process input is unsupported for sandbox backend=opensandbox.",
+      }),
+    );
+    const processTool = createProcessTool();
+
+    const result = await processTool.execute("toolcall", {
+      action: "write",
+      sessionId: "sbx-proc",
+      data: "hello",
+    });
+
+    expect(result.details).toMatchObject({ status: "failed" });
+    expect(result.content[0]).toMatchObject({
+      type: "text",
+      text: "Interactive process input is unsupported for sandbox backend=opensandbox.",
+    });
+  });
+
+  it("routes kill through the sandbox kill handler", async () => {
+    const onKill = vi.fn(async () => undefined);
+    addSession(
+      createProcessSessionFixture({
+        id: "sbx-kill",
+        command: "sleep 999",
+        backgrounded: true,
+        onKill,
+        unsupportedInputReason:
+          "Interactive process input is unsupported for sandbox backend=opensandbox.",
+      }),
+    );
+    const processTool = createProcessTool();
+
+    const result = await processTool.execute("toolcall", {
+      action: "kill",
+      sessionId: "sbx-kill",
+    });
+
+    expect(onKill).toHaveBeenCalledTimes(1);
+    expect(getSession("sbx-kill")).toBeDefined();
+    expect(result.content[0]).toMatchObject({
+      type: "text",
+      text: "Termination requested for session sbx-kill.",
+    });
+  });
+});

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -146,6 +146,20 @@ export function createProcessTool(
     return true;
   };
 
+  const terminateSession = async (
+    session: ProcessSession,
+  ): Promise<false | "requested" | "terminated"> => {
+    if (session.onKill) {
+      await session.onKill();
+      return "requested";
+    }
+    const canceled = cancelManagedSession(session.id);
+    if (canceled) {
+      return "requested";
+    }
+    return terminateSessionFallback(session) ? "terminated" : false;
+  };
+
   return {
     name: "process",
     label: "process",
@@ -254,6 +268,12 @@ export function createProcessTool(
           return {
             ok: false as const,
             result: failedResult(`Session ${params.sessionId} is not backgrounded.`),
+          };
+        }
+        if (scopedSession.unsupportedInputReason) {
+          return {
+            ok: false as const,
+            result: failedResult(scopedSession.unsupportedInputReason),
           };
         }
         const stdin = scopedSession.stdin ?? scopedSession.child?.stdin;
@@ -544,14 +564,13 @@ export function createProcessTool(
           if (!scopedSession.backgrounded) {
             return failText(`Session ${params.sessionId} is not backgrounded.`);
           }
-          const canceled = cancelManagedSession(scopedSession.id);
-          if (!canceled) {
-            const terminated = terminateSessionFallback(scopedSession);
-            if (!terminated) {
-              return failText(
-                `Unable to terminate session ${params.sessionId}: no active supervisor run or process id.`,
-              );
-            }
+          const terminated = await terminateSession(scopedSession);
+          if (!terminated) {
+            return failText(
+              `Unable to terminate session ${params.sessionId}: no active supervisor run or process id.`,
+            );
+          }
+          if (terminated === "terminated") {
             markExited(scopedSession, null, "SIGKILL", "failed");
           }
           resetPollRetrySuggestion(params.sessionId);
@@ -559,9 +578,10 @@ export function createProcessTool(
             content: [
               {
                 type: "text",
-                text: canceled
-                  ? `Termination requested for session ${params.sessionId}.`
-                  : `Killed session ${params.sessionId}.`,
+                text:
+                  terminated === "requested"
+                    ? `Termination requested for session ${params.sessionId}.`
+                    : `Killed session ${params.sessionId}.`,
               },
             ],
             details: {
@@ -593,18 +613,18 @@ export function createProcessTool(
 
         case "remove": {
           if (scopedSession) {
-            const canceled = cancelManagedSession(scopedSession.id);
-            if (canceled) {
-              // Keep remove semantics deterministic: drop from process registry now.
-              scopedSession.backgrounded = false;
+            const terminated = await terminateSession(scopedSession);
+            if (!terminated) {
+              return failText(
+                `Unable to remove session ${params.sessionId}: no active supervisor run or process id.`,
+              );
+            }
+            if (terminated === "requested") {
+              if (!scopedSession.onKill) {
+                scopedSession.backgrounded = false;
+              }
               deleteSession(params.sessionId);
             } else {
-              const terminated = terminateSessionFallback(scopedSession);
-              if (!terminated) {
-                return failText(
-                  `Unable to remove session ${params.sessionId}: no active supervisor run or process id.`,
-                );
-              }
               markExited(scopedSession, null, "SIGKILL", "failed");
               deleteSession(params.sessionId);
             }
@@ -613,9 +633,10 @@ export function createProcessTool(
               content: [
                 {
                   type: "text",
-                  text: canceled
-                    ? `Removed session ${params.sessionId} (termination requested).`
-                    : `Removed session ${params.sessionId}.`,
+                  text:
+                    terminated === "requested" && !scopedSession.onKill
+                      ? `Removed session ${params.sessionId} (termination requested).`
+                      : `Removed session ${params.sessionId}.`,
                 },
               ],
               details: {

--- a/src/agents/bash-tools.shared.test.ts
+++ b/src/agents/bash-tools.shared.test.ts
@@ -20,6 +20,7 @@ describe("resolveSandboxWorkdir", () => {
       const resolved = await resolveSandboxWorkdir({
         workdir: "/workspace",
         sandbox: {
+          backend: "docker",
           containerName: "sandbox-1",
           workspaceDir,
           containerWorkdir: "/workspace",
@@ -41,6 +42,7 @@ describe("resolveSandboxWorkdir", () => {
       const resolved = await resolveSandboxWorkdir({
         workdir: "/workspace/scripts/runner",
         sandbox: {
+          backend: "docker",
           containerName: "sandbox-2",
           workspaceDir,
           containerWorkdir: "/workspace",
@@ -62,6 +64,7 @@ describe("resolveSandboxWorkdir", () => {
       const resolved = await resolveSandboxWorkdir({
         workdir: "/sandbox-root/project",
         sandbox: {
+          backend: "docker",
           containerName: "sandbox-3",
           workspaceDir,
           containerWorkdir: "/sandbox-root",

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -8,10 +8,16 @@ import { assertSandboxPath } from "./sandbox-paths.js";
 const CHUNK_LIMIT = 8 * 1024;
 
 export type BashSandboxConfig = {
+  backend: "docker" | "opensandbox";
   containerName: string;
   workspaceDir: string;
   containerWorkdir: string;
   env?: Record<string, string>;
+  opensandbox?: {
+    sandboxId: string;
+    execdBaseUrl: string;
+    apiKey?: string;
+  };
 };
 
 export function buildSandboxEnv(params: {

--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -55,6 +55,7 @@ describe("models-config merge helpers", () => {
     const merged = mergeProviders({
       explicit: {
         " custom ": {
+          baseUrl: "https://config.example/v1",
           api: "openai-responses",
           models: [] as ProviderConfig["models"],
         } as ProviderConfig,
@@ -133,6 +134,7 @@ describe("models-config merge helpers", () => {
     const merged = mergeWithExistingProviderSecrets({
       nextProviders: {
         custom: {
+          baseUrl: "https://config.example/v1",
           apiKey: "OPENAI_API_KEY", // pragma: allowlist secret
           models: [{ id: "model", api: "openai-responses" }],
         } as ProviderConfig,

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -5,6 +5,7 @@ import type { SandboxContext } from "./sandbox.js";
 function createSandboxContext(overrides?: Partial<SandboxContext>): SandboxContext {
   const base = {
     enabled: true,
+    backend: "docker",
     sessionKey: "session:test",
     workspaceDir: "/tmp/openclaw-sandbox",
     agentWorkspaceDir: "/tmp/openclaw-workspace",

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -574,6 +574,7 @@ describe("Agent-specific tool filtering", () => {
       agentDir: "/tmp/agent-restricted",
       sandbox: {
         enabled: true,
+        backend: "docker",
         sessionKey: "agent:restricted:main",
         workspaceDir: "/tmp/sandbox",
         agentWorkspaceDir: "/tmp/test-restricted",
@@ -634,6 +635,44 @@ describe("Agent-specific tool filtering", () => {
 
     const resultDetails = result?.details as { status?: string } | undefined;
     expect(resultDetails?.status).toBe("completed");
+  });
+
+  it('keeps Docker sandbox workspaceAccess "none" write tools disabled', () => {
+    const tools = createOpenClawCodingTools({
+      sessionKey: "agent:docker-none:main",
+      workspaceDir: "/tmp/test-docker-none",
+      agentDir: "/tmp/agent-docker-none",
+      sandbox: {
+        enabled: true,
+        backend: "docker",
+        sessionKey: "agent:docker-none:main",
+        workspaceDir: "/tmp/sandbox-docker-none",
+        agentWorkspaceDir: "/tmp/test-docker-none",
+        workspaceAccess: "none",
+        containerName: "test-container",
+        containerWorkdir: "/workspace",
+        docker: {
+          image: "test-image",
+          containerPrefix: "test-",
+          workdir: "/workspace",
+          readOnlyRoot: true,
+          tmpfs: [],
+          network: "none",
+          capDrop: [],
+        } satisfies SandboxDockerConfig,
+        tools: {
+          allow: [],
+          deny: [],
+        },
+        fsBridge: sandboxFsBridgeStub,
+        browserAllowHostControl: false,
+      },
+    });
+
+    const toolNames = tools.map((tool) => tool.name);
+    expect(toolNames).not.toContain("write");
+    expect(toolNames).not.toContain("edit");
+    expect(toolNames).not.toContain("apply_patch");
   });
 
   it("keeps sandbox as the implicit exec host default without forcing gateway approvals", async () => {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -342,7 +342,11 @@ export function createOpenClawCodingTools(options?: {
   });
   const sandboxRoot = sandbox?.workspaceDir;
   const sandboxFsBridge = sandbox?.fsBridge;
-  const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
+  const allowWorkspaceWrites = sandbox
+    ? sandbox.backend === "opensandbox"
+      ? sandbox.workspaceAccess !== "ro"
+      : sandbox.workspaceAccess === "rw"
+    : false;
   const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
   const workspaceOnly = fsPolicy.workspaceOnly;
   const applyPatchConfig = execConfig.applyPatch;
@@ -435,10 +439,18 @@ export function createOpenClawCodingTools(options?: {
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
     sandbox: sandbox
       ? {
+          backend: sandbox.backend,
           containerName: sandbox.containerName,
           workspaceDir: sandbox.workspaceDir,
           containerWorkdir: sandbox.containerWorkdir,
-          env: sandbox.docker.env,
+          env: sandbox.backend === "docker" ? sandbox.docker.env : undefined,
+          opensandbox: sandbox.opensandbox
+            ? {
+                sandboxId: sandbox.opensandbox.sandboxId,
+                execdBaseUrl: sandbox.opensandbox.execdBaseUrl,
+                apiKey: sandbox.opensandbox.apiKey,
+              }
+            : undefined,
         }
       : undefined,
   });

--- a/src/agents/sandbox.opensandbox-config.test.ts
+++ b/src/agents/sandbox.opensandbox-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { resolveSandboxConfigForAgent } from "./sandbox/config.js";
+
+describe("resolveSandboxConfigForAgent (opensandbox)", () => {
+  it("resolves opensandbox backend defaults", () => {
+    const sandbox = resolveSandboxConfigForAgent({
+      agents: {
+        defaults: {
+          sandbox: {
+            backend: "opensandbox",
+            mode: "all",
+            opensandbox: {
+              endpoint: "http://127.0.0.1:18080",
+              image: "opensandbox/custom-image:latest",
+            },
+          },
+        },
+      },
+    });
+
+    expect(sandbox.backend).toBe("opensandbox");
+    expect(sandbox.opensandbox.endpoint).toBe("http://127.0.0.1:18080");
+    expect(sandbox.opensandbox.image).toBe("opensandbox/custom-image:latest");
+    expect(sandbox.workspaceAccess).toBe("none");
+  });
+
+  it("rejects workspaceAccess other than none", () => {
+    expect(() =>
+      resolveSandboxConfigForAgent({
+        agents: {
+          defaults: {
+            sandbox: {
+              backend: "opensandbox",
+              workspaceAccess: "rw",
+            },
+          },
+        },
+      }),
+    ).toThrow(/workspaceAccess=none/);
+  });
+
+  it("rejects browser sandboxing on opensandbox backend", () => {
+    expect(() =>
+      resolveSandboxConfigForAgent({
+        agents: {
+          defaults: {
+            sandbox: {
+              backend: "opensandbox",
+              browser: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow(/browser\.enabled/);
+  });
+});

--- a/src/agents/sandbox.opensandbox-path.integration.test.ts
+++ b/src/agents/sandbox.opensandbox-path.integration.test.ts
@@ -1,0 +1,481 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as tar from "tar";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runExecProcess } from "./bash-tools.exec-runtime.js";
+import {
+  cleanupTempDirs,
+  makeTempDir,
+  resolveOpenSandboxContextForTest,
+  sseResponse,
+} from "./sandbox.opensandbox-test-helpers.js";
+import { createSandboxFsBridge } from "./sandbox/fs-bridge.js";
+import { resetOpenSandboxRuntimesForTests } from "./sandbox/opensandbox.js";
+
+type RemoteEntry =
+  | { type: "file"; data: Buffer; modifiedAt: string }
+  | { type: "directory"; modifiedAt: string };
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function buildRemoteFsTarBase64(remoteFs: Map<string, RemoteEntry>) {
+  const tarRoot = await makeTempDir("openclaw-opensandbox-remote-sync-");
+  for (const [remotePath, entry] of remoteFs) {
+    if (remotePath === "/workspace") {
+      continue;
+    }
+    const localPath = path.join(
+      tarRoot,
+      path.posix.relative("/workspace", remotePath).split(path.posix.sep).join(path.sep),
+    );
+    if (entry.type === "directory") {
+      await fs.mkdir(localPath, { recursive: true });
+      continue;
+    }
+    await fs.mkdir(path.dirname(localPath), { recursive: true });
+    await fs.writeFile(localPath, entry.data);
+  }
+  const tarDir = await makeTempDir("openclaw-opensandbox-remote-archive-");
+  const tarPath = path.join(tarDir, "workspace.tar");
+  await tar.c({ cwd: tarRoot, file: tarPath }, ["."]);
+  const tarBuffer = await fs.readFile(tarPath);
+  return tarBuffer.toString("base64");
+}
+
+async function readFormDataUpload(body: FormData) {
+  const metadata = body.get("metadata");
+  const file = body.get("file");
+  return {
+    metadataText: metadata instanceof Blob ? await metadata.text() : "",
+    fileText: file instanceof Blob ? await file.text() : "",
+    fileBuffer:
+      file instanceof Blob
+        ? Buffer.from(new Uint8Array(await file.arrayBuffer()))
+        : Buffer.alloc(0),
+  };
+}
+
+describe("opensandbox integration path", () => {
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    resetOpenSandboxRuntimesForTests();
+    await cleanupTempDirs();
+  });
+
+  async function runOpenSandboxExecForTest(params: {
+    workspaceDir: string;
+    command: string;
+    timeoutSec?: number | null;
+    containerWorkdir?: string;
+  }) {
+    const sandbox = await resolveOpenSandboxContextForTest(params.workspaceDir);
+    expect(sandbox?.backend).toBe("opensandbox");
+    if (!sandbox) {
+      throw new Error("Expected sandbox context.");
+    }
+    const execHandle = await runExecProcess({
+      command: params.command,
+      workdir: params.workspaceDir,
+      env: {},
+      sandbox: {
+        backend: "opensandbox",
+        containerName: sandbox.containerName,
+        workspaceDir: sandbox.workspaceDir,
+        containerWorkdir: sandbox.containerWorkdir,
+        opensandbox: sandbox.opensandbox,
+      },
+      containerWorkdir: params.containerWorkdir ?? sandbox.containerWorkdir,
+      usePty: false,
+      warnings: [],
+      maxOutput: 20_000,
+      pendingMaxOutput: 10_000,
+      notifyOnExit: false,
+      timeoutSec: params.timeoutSec ?? null,
+    });
+    return { sandbox, execHandle, execResult: await execHandle.promise };
+  }
+
+  it("connects sandbox context, fs bridge, and exec runtime through the opensandbox backend", async () => {
+    const workspaceDir = await makeTempDir("openclaw-opensandbox-path-");
+    await fs.writeFile(path.join(workspaceDir, "seed.txt"), "seed");
+
+    const remoteFs = new Map<string, RemoteEntry>([
+      ["/workspace", { type: "directory", modifiedAt: nowIso() }],
+    ]);
+    const commandBodies: string[] = [];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+
+      if (url === "http://opensandbox.test/v1/sandboxes" && method === "POST") {
+        return Response.json({ id: "sbx-test" });
+      }
+      if (
+        url === "http://opensandbox.test/v1/sandboxes/sbx-test/endpoints/44772" &&
+        method === "GET"
+      ) {
+        return Response.json({ endpoint: "opensandbox.test" });
+      }
+      if (url === "http://opensandbox.test/v1/sandboxes/sbx-test" && method === "GET") {
+        return Response.json({ status: { state: "Running" } });
+      }
+      if (url === "http://opensandbox.test/health/ping" && method === "GET") {
+        return new Response("ok", { status: 200 });
+      }
+      if (url === "http://opensandbox.test/directories" && method === "POST") {
+        const payload = JSON.parse((init?.body as string | undefined) ?? "{}") as Record<
+          string,
+          unknown
+        >;
+        for (const dirPath of Object.keys(payload)) {
+          remoteFs.set(dirPath, { type: "directory", modifiedAt: nowIso() });
+        }
+        return Response.json({});
+      }
+      if (
+        url === "http://opensandbox.test/files/upload" &&
+        method === "POST" &&
+        init?.body instanceof FormData
+      ) {
+        const upload = await readFormDataUpload(init.body);
+        const metadata = JSON.parse(upload.metadataText) as { path: string };
+        remoteFs.set(metadata.path, {
+          type: "file",
+          data: upload.fileBuffer,
+          modifiedAt: nowIso(),
+        });
+        return Response.json({});
+      }
+      if (url.startsWith("http://opensandbox.test/files/info") && method === "GET") {
+        const requestUrl = new URL(url);
+        const filePath = requestUrl.searchParams.get("path") ?? "";
+        const entry = remoteFs.get(filePath);
+        if (!entry) {
+          return new Response("not found", { status: 404 });
+        }
+        return Response.json({
+          [filePath]: {
+            size: entry.type === "file" ? entry.data.length : 0,
+            modifiedAt: entry.modifiedAt,
+            mode: entry.type === "directory" ? 0o040755 : 0o100644,
+          },
+        });
+      }
+      if (url.startsWith("http://opensandbox.test/files/download") && method === "GET") {
+        const requestUrl = new URL(url);
+        const filePath = requestUrl.searchParams.get("path") ?? "";
+        const entry = remoteFs.get(filePath);
+        if (!entry || entry.type !== "file") {
+          return new Response("not found", { status: 404 });
+        }
+        return new Response(new Uint8Array(entry.data), { status: 200 });
+      }
+      if (url === "http://opensandbox.test/files/mv" && method === "POST") {
+        const payload = JSON.parse((init?.body as string | undefined) ?? "[]") as Array<{
+          src: string;
+          dest: string;
+        }>;
+        for (const move of payload) {
+          const entry = remoteFs.get(move.src);
+          if (!entry) {
+            return new Response("not found", { status: 404 });
+          }
+          remoteFs.set(move.dest, entry);
+          remoteFs.delete(move.src);
+        }
+        return Response.json({});
+      }
+      if (url.startsWith("http://opensandbox.test/files?") && method === "DELETE") {
+        const requestUrl = new URL(url);
+        const filePath = requestUrl.searchParams.get("path") ?? "";
+        remoteFs.delete(filePath);
+        return new Response(null, { status: 200 });
+      }
+      if (url.startsWith("http://opensandbox.test/directories?") && method === "DELETE") {
+        const requestUrl = new URL(url);
+        const filePath = requestUrl.searchParams.get("path") ?? "";
+        for (const key of remoteFs.keys()) {
+          if (key === filePath || key.startsWith(`${filePath}/`)) {
+            remoteFs.delete(key);
+          }
+        }
+        return new Response(null, { status: 200 });
+      }
+      if (url === "http://opensandbox.test/command" && method === "POST") {
+        const body = (init?.body as string | undefined) ?? "";
+        commandBodies.push(body);
+        if (body.includes('"command":"tar -cf - . | base64"')) {
+          return sseResponse([
+            'data: {"type":"init","text":"cmd-sync"}\n\n',
+            `data: ${JSON.stringify({
+              type: "stdout",
+              text: await buildRemoteFsTarBase64(remoteFs),
+            })}\n\n`,
+            'data: {"type":"status","text":"0"}\n\n',
+            'data: {"type":"execution_complete"}\n\n',
+          ]);
+        }
+        remoteFs.set("/workspace/generated.txt", {
+          type: "file",
+          data: Buffer.from("via exec"),
+          modifiedAt: nowIso(),
+        });
+        return sseResponse([
+          'data: {"type":"init","text":"cmd-456"}\n\n',
+          'data: {"type":"stdout","text":"sandbox output"}\n\n',
+          'data: {"type":"status","text":"0"}\n\n',
+          'data: {"type":"execution_complete"}\n\n',
+        ]);
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sandbox = await resolveOpenSandboxContextForTest(workspaceDir);
+    expect(sandbox?.backend).toBe("opensandbox");
+    if (!sandbox) {
+      throw new Error("Expected sandbox context.");
+    }
+
+    const bridge = createSandboxFsBridge({ sandbox });
+    await bridge.writeFile({ filePath: "notes.txt", data: "hello opensandbox" });
+    const stat = await bridge.stat({ filePath: "notes.txt" });
+    const content = await bridge.readFile({ filePath: "notes.txt" });
+    await bridge.rename({ from: "notes.txt", to: "nested/renamed.txt" });
+    await bridge.remove({ filePath: "nested/renamed.txt", force: true });
+
+    expect(stat?.type).toBe("file");
+    expect(content.toString("utf8")).toBe("hello opensandbox");
+    expect(remoteFs.has("/workspace/notes.txt")).toBe(false);
+    expect(remoteFs.has("/workspace/nested/renamed.txt")).toBe(false);
+
+    const { execResult } = await runOpenSandboxExecForTest({
+      workspaceDir,
+      command: "printf 'via exec' > generated.txt && echo sandbox output",
+    });
+
+    expect(execResult.status).toBe("completed");
+    expect(execResult.exitCode).toBe(0);
+    expect(execResult.aggregated).toContain("sandbox output");
+    expect(await fs.readFile(path.join(sandbox.workspaceDir, "generated.txt"), "utf8")).toBe(
+      "via exec",
+    );
+    expect(commandBodies).toHaveLength(2);
+    expect(commandBodies[0]).toContain('"cwd":"/workspace"');
+    expect(commandBodies[0]).toContain(`generated.txt`);
+    expect(commandBodies[0]).toContain(`echo sandbox output`);
+    expect(commandBodies[1]).toContain(`"command":"tar -cf - . | base64"`);
+    expect(commandBodies[1]).toContain('"cwd":"/workspace"');
+  });
+
+  it("syncs workspace snapshots from the sandbox root even when exec runs in a subdirectory", async () => {
+    const workspaceDir = await makeTempDir("openclaw-opensandbox-subdir-cwd-");
+    const commandBodies: string[] = [];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+
+      if (url === "http://opensandbox.test/v1/sandboxes" && method === "POST") {
+        return Response.json({ id: "sbx-subdir-cwd" });
+      }
+      if (
+        url === "http://opensandbox.test/v1/sandboxes/sbx-subdir-cwd/endpoints/44772" &&
+        method === "GET"
+      ) {
+        return Response.json({ endpoint: "opensandbox.test" });
+      }
+      if (url === "http://opensandbox.test/v1/sandboxes/sbx-subdir-cwd" && method === "GET") {
+        return Response.json({ status: { state: "Running" } });
+      }
+      if (url === "http://opensandbox.test/health/ping" && method === "GET") {
+        return new Response("ok", { status: 200 });
+      }
+      if (url === "http://opensandbox.test/directories" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/files/upload" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/command" && method === "POST") {
+        const body = (init?.body as string | undefined) ?? "";
+        commandBodies.push(body);
+        if (body.includes('"command":"tar -cf - . | base64"')) {
+          return sseResponse([
+            'data: {"type":"init","text":"cmd-sync"}\n\n',
+            `data: ${JSON.stringify({
+              type: "stdout",
+              text: await buildRemoteFsTarBase64(
+                new Map<string, RemoteEntry>([
+                  ["/workspace", { type: "directory", modifiedAt: nowIso() }],
+                ]),
+              ),
+            })}\n\n`,
+            'data: {"type":"status","text":"0"}\n\n',
+            'data: {"type":"execution_complete"}\n\n',
+          ]);
+        }
+        return sseResponse([
+          'data: {"type":"init","text":"cmd-subdir"}\n\n',
+          'data: {"type":"status","text":"0"}\n\n',
+          'data: {"type":"execution_complete"}\n\n',
+        ]);
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { execResult } = await runOpenSandboxExecForTest({
+      workspaceDir,
+      command: "echo subdir",
+      containerWorkdir: "/workspace/subdir",
+    });
+
+    expect(execResult.status).toBe("completed");
+    expect(commandBodies).toHaveLength(2);
+    expect(commandBodies[0]).toContain('"command":"echo subdir"');
+    expect(commandBodies[0]).toContain('"cwd":"/workspace/subdir"');
+    expect(commandBodies[1]).toContain('"command":"tar -cf - . | base64"');
+    expect(commandBodies[1]).toContain('"cwd":"/workspace"');
+  });
+
+  it("keeps successful exec outcomes completed when the snapshot refresh fails", async () => {
+    const workspaceDir = await makeTempDir("openclaw-opensandbox-sync-warning-");
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+
+      if (url === "http://opensandbox.test/v1/sandboxes" && method === "POST") {
+        return Response.json({ id: "sbx-sync-warning" });
+      }
+      if (
+        url === "http://opensandbox.test/v1/sandboxes/sbx-sync-warning/endpoints/44772" &&
+        method === "GET"
+      ) {
+        return Response.json({ endpoint: "opensandbox.test" });
+      }
+      if (url === "http://opensandbox.test/v1/sandboxes/sbx-sync-warning" && method === "GET") {
+        return Response.json({ status: { state: "Running" } });
+      }
+      if (url === "http://opensandbox.test/health/ping" && method === "GET") {
+        return new Response("ok", { status: 200 });
+      }
+      if (url === "http://opensandbox.test/directories" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/files/upload" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/command" && method === "POST") {
+        const body = (init?.body as string | undefined) ?? "";
+        if (body.includes('"command":"tar -cf - . | base64"')) {
+          return sseResponse([
+            'data: {"type":"init","text":"cmd-sync"}\n\n',
+            'data: {"type":"stderr","text":"tar: not found"}\n\n',
+            'data: {"type":"status","text":"127"}\n\n',
+            'data: {"type":"execution_complete"}\n\n',
+          ]);
+        }
+        return sseResponse([
+          'data: {"type":"init","text":"cmd-ok"}\n\n',
+          'data: {"type":"stdout","text":"command ok"}\n\n',
+          'data: {"type":"status","text":"0"}\n\n',
+          'data: {"type":"execution_complete"}\n\n',
+        ]);
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { execResult } = await runOpenSandboxExecForTest({
+      workspaceDir,
+      command: "echo command ok",
+    });
+
+    expect(execResult.status).toBe("completed");
+    expect(execResult.exitCode).toBe(0);
+    expect(execResult.aggregated).toContain("command ok");
+    expect(execResult.aggregated).toContain("failed to refresh OpenSandbox workspace snapshot");
+  });
+
+  it("applies exec timeout to the snapshot refresh step", async () => {
+    const workspaceDir = await makeTempDir("openclaw-opensandbox-sync-timeout-");
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+
+      if (url === "http://opensandbox.test/v1/sandboxes" && method === "POST") {
+        return Response.json({ id: "sbx-sync-timeout" });
+      }
+      if (
+        url === "http://opensandbox.test/v1/sandboxes/sbx-sync-timeout/endpoints/44772" &&
+        method === "GET"
+      ) {
+        return Response.json({ endpoint: "opensandbox.test" });
+      }
+      if (url === "http://opensandbox.test/v1/sandboxes/sbx-sync-timeout" && method === "GET") {
+        return Response.json({ status: { state: "Running" } });
+      }
+      if (url === "http://opensandbox.test/health/ping" && method === "GET") {
+        return new Response("ok", { status: 200 });
+      }
+      if (url === "http://opensandbox.test/directories" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/files/upload" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/command" && method === "POST") {
+        const body = (init?.body as string | undefined) ?? "";
+        if (body.includes('"command":"tar -cf - . | base64"')) {
+          const signal = init?.signal;
+          return await new Promise<Response>((_resolve, reject) => {
+            signal?.addEventListener(
+              "abort",
+              () => {
+                reject(new Error("snapshot aborted"));
+              },
+              { once: true },
+            );
+          });
+        }
+        return sseResponse([
+          'data: {"type":"init","text":"cmd-ok"}\n\n',
+          'data: {"type":"stdout","text":"command ok"}\n\n',
+          'data: {"type":"status","text":"0"}\n\n',
+          'data: {"type":"execution_complete"}\n\n',
+        ]);
+      }
+      if (url.startsWith("http://opensandbox.test/command?") && method === "DELETE") {
+        return new Response(null, { status: 200 });
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { execResult } = await runOpenSandboxExecForTest({
+      workspaceDir,
+      command: "echo command ok",
+      timeoutSec: 0.01,
+    });
+
+    expect(execResult.status).toBe("completed");
+    expect(execResult.exitCode).toBe(0);
+    expect(execResult.aggregated).toContain("command ok");
+    expect(execResult.aggregated).toContain("failed to refresh OpenSandbox workspace snapshot");
+  });
+});

--- a/src/agents/sandbox.opensandbox-test-helpers.ts
+++ b/src/agents/sandbox.opensandbox-test-helpers.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { resolveSandboxContext } from "./sandbox/context.js";
+
+const tempDirs: string[] = [];
+
+export async function makeTempDir(prefix: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+export async function cleanupTempDirs() {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+}
+
+export function sseResponse(frames: string[]) {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const frame of frames) {
+          controller.enqueue(encoder.encode(frame));
+        }
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+      },
+    },
+  );
+}
+
+export function buildOpenSandboxTestConfig(endpoint = "http://opensandbox.test") {
+  return {
+    agents: {
+      defaults: {
+        sandbox: {
+          backend: "opensandbox" as const,
+          mode: "all" as const,
+          opensandbox: {
+            endpoint,
+          },
+        },
+      },
+      list: [{ id: "main" }],
+    },
+  };
+}
+
+export async function resolveOpenSandboxContextForTest(workspaceDir: string) {
+  return await resolveSandboxContext({
+    config: buildOpenSandboxTestConfig(),
+    sessionKey: "agent:main:task",
+    workspaceDir,
+  });
+}

--- a/src/agents/sandbox.opensandbox.test.ts
+++ b/src/agents/sandbox.opensandbox.test.ts
@@ -1,0 +1,482 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildOpenSandboxTestConfig,
+  cleanupTempDirs,
+  makeTempDir,
+  sseResponse,
+} from "./sandbox.opensandbox-test-helpers.js";
+import { resolveSandboxConfigForAgent } from "./sandbox/config.js";
+import {
+  ensureOpenSandboxRuntime,
+  resetOpenSandboxRuntimesForTests,
+  runOpenSandboxCommand,
+} from "./sandbox/opensandbox.js";
+
+type FetchRecord = {
+  input: string;
+  method: string;
+  bodyText?: string;
+};
+
+describe("opensandbox runtime", () => {
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    resetOpenSandboxRuntimesForTests();
+    await cleanupTempDirs();
+  });
+
+  it("creates an opensandbox runtime, syncs workspace contents, and reuses healthy cache entries", async () => {
+    const workspaceDir = await makeTempDir("openclaw-opensandbox-runtime-");
+    await fs.mkdir(path.join(workspaceDir, "nested"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "root.txt"), "root-data");
+    await fs.writeFile(path.join(workspaceDir, "nested", "child.txt"), "child-data");
+
+    const requests: FetchRecord[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      const record: FetchRecord = {
+        input: url,
+        method,
+      };
+
+      if (typeof init?.body === "string") {
+        record.bodyText = init.body;
+      } else if (init?.body instanceof FormData) {
+        const metadata = init.body.get("metadata");
+        const file = init.body.get("file");
+        record.bodyText = [
+          metadata instanceof Blob ? await metadata.text() : "",
+          file instanceof Blob ? await file.text() : "",
+        ].join("\n");
+      }
+
+      requests.push(record);
+
+      if (url === "http://opensandbox.test/v1/sandboxes" && method === "POST") {
+        return Response.json({ id: "sbx-test" });
+      }
+      if (
+        url === "http://opensandbox.test/v1/sandboxes/sbx-test/endpoints/44772" &&
+        method === "GET"
+      ) {
+        return Response.json({ endpoint: "opensandbox.test" });
+      }
+      if (url === "http://opensandbox.test/v1/sandboxes/sbx-test" && method === "GET") {
+        return Response.json({ status: { state: "Running" } });
+      }
+      if (url === "http://opensandbox.test/health/ping" && method === "GET") {
+        return new Response("ok", { status: 200 });
+      }
+      if (url === "http://opensandbox.test/directories" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/files/upload" && method === "POST") {
+        return Response.json({});
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const cfg = resolveSandboxConfigForAgent(buildOpenSandboxTestConfig());
+
+    const runtime = await ensureOpenSandboxRuntime({
+      cfg,
+      scopeKey: "agent:main",
+      sessionKey: "agent:main:task",
+      workspaceDir,
+    });
+    await fs.writeFile(path.join(workspaceDir, "new-host-file.txt"), "host-refresh-data");
+    const reused = await ensureOpenSandboxRuntime({
+      cfg,
+      scopeKey: "agent:main",
+      sessionKey: "agent:main:task",
+      workspaceDir,
+    });
+
+    const createCalls = requests.filter(
+      (request) =>
+        request.input === "http://opensandbox.test/v1/sandboxes" && request.method === "POST",
+    );
+    const uploadBodies = requests
+      .filter((request) => request.input === "http://opensandbox.test/files/upload")
+      .map((request) => request.bodyText ?? "");
+    const directoryBodies = requests
+      .filter((request) => request.input === "http://opensandbox.test/directories")
+      .map((request) => request.bodyText ?? "");
+
+    expect(runtime.sandboxId).toBe("sbx-test");
+    expect(runtime.execdBaseUrl).toBe("http://opensandbox.test");
+    expect(reused).toBe(runtime);
+    expect(createCalls).toHaveLength(1);
+    expect(directoryBodies.some((body) => body.includes("/workspace/nested"))).toBe(true);
+    expect(
+      uploadBodies.some(
+        (body) => body.includes('"path":"/workspace/root.txt"') && body.includes("root-data"),
+      ),
+    ).toBe(true);
+    expect(
+      uploadBodies.some(
+        (body) =>
+          body.includes('"path":"/workspace/nested/child.txt"') && body.includes("child-data"),
+      ),
+    ).toBe(true);
+    expect(
+      uploadBodies.some(
+        (body) =>
+          body.includes('"path":"/workspace/new-host-file.txt"') &&
+          body.includes("host-refresh-data"),
+      ),
+    ).toBe(true);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "syncs symlinked files and directories that stay within the workspace",
+    async () => {
+      const workspaceDir = await makeTempDir("openclaw-opensandbox-symlink-runtime-");
+      await fs.mkdir(path.join(workspaceDir, "real-dir"), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "real.txt"), "real-data");
+      await fs.writeFile(path.join(workspaceDir, "real-dir", "nested.txt"), "nested-data");
+      await fs.symlink("real.txt", path.join(workspaceDir, "linked.txt"));
+      await fs.symlink("real-dir", path.join(workspaceDir, "linked-dir"));
+
+      const uploads: string[] = [];
+      const directories: string[] = [];
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        const method = init?.method ?? "GET";
+
+        if (url === "http://opensandbox.test/v1/sandboxes" && method === "POST") {
+          return Response.json({ id: "sbx-symlink" });
+        }
+        if (
+          url === "http://opensandbox.test/v1/sandboxes/sbx-symlink/endpoints/44772" &&
+          method === "GET"
+        ) {
+          return Response.json({ endpoint: "opensandbox.test" });
+        }
+        if (url === "http://opensandbox.test/v1/sandboxes/sbx-symlink" && method === "GET") {
+          return Response.json({ status: { state: "Running" } });
+        }
+        if (url === "http://opensandbox.test/health/ping" && method === "GET") {
+          return new Response("ok", { status: 200 });
+        }
+        if (url === "http://opensandbox.test/directories" && method === "POST") {
+          directories.push(typeof init?.body === "string" ? init.body : "");
+          return Response.json({});
+        }
+        if (url === "http://opensandbox.test/files/upload" && method === "POST") {
+          if (init?.body instanceof FormData) {
+            const metadata = init.body.get("metadata");
+            const file = init.body.get("file");
+            uploads.push(
+              [
+                metadata instanceof Blob ? await metadata.text() : "",
+                file instanceof Blob ? await file.text() : "",
+              ].join("\n"),
+            );
+          }
+          return Response.json({});
+        }
+
+        throw new Error(`Unhandled fetch: ${method} ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const cfg = resolveSandboxConfigForAgent(buildOpenSandboxTestConfig());
+
+      await ensureOpenSandboxRuntime({
+        cfg,
+        scopeKey: "agent:symlink",
+        sessionKey: "agent:symlink:task",
+        workspaceDir,
+      });
+
+      expect(
+        uploads.some(
+          (body) => body.includes('"path":"/workspace/linked.txt"') && body.includes("real-data"),
+        ),
+      ).toBe(true);
+      expect(directories.some((body) => body.includes("/workspace/linked-dir"))).toBe(true);
+      expect(
+        uploads.some(
+          (body) =>
+            body.includes('"path":"/workspace/linked-dir/nested.txt"') &&
+            body.includes("nested-data"),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("parses streamed command output and exit status", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url === "http://opensandbox.test/command" && method === "POST") {
+        return sseResponse([
+          'data: {"type":"init","text":"cmd-123"}\n\n',
+          'data: {"type":"stdout","text":"hello "}\n\ndata: {"type":"stdout","text":"world"}\n\n',
+          'data: {"type":"stderr","text":"warn"}\n\n',
+          'data: {"type":"status","text":"0"}\n\n',
+          'data: {"type":"execution_complete"}\n\n',
+        ]);
+      }
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    const initIds: string[] = [];
+
+    const result = await runOpenSandboxCommand({
+      execdBaseUrl: "http://opensandbox.test",
+      command: "echo hello",
+      captureOutput: true,
+      onInit: (commandId) => initIds.push(commandId),
+      onStdout: (text) => stdoutChunks.push(text),
+      onStderr: (text) => stderrChunks.push(text),
+    });
+
+    expect(result).toMatchObject({
+      commandId: "cmd-123",
+      stdout: "hello world",
+      stderr: "warn",
+      exitCode: 0,
+    });
+    expect(initIds).toEqual(["cmd-123"]);
+    expect(stdoutChunks).toEqual(["hello ", "world"]);
+    expect(stderrChunks).toEqual(["warn"]);
+  });
+
+  it("parses multi-line SSE data frames across chunk boundaries", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url === "http://opensandbox.test/command" && method === "POST") {
+        return sseResponse([
+          'data: {"type":"init",',
+          '"text":"cmd-456"}\r\n\r\n',
+          'data: {"type":"stdout",\r\n',
+          'data: "text":"chunked output"}\r\n\r\n',
+          'data: {"type":"status","text":"0"}\r\n\r\n',
+        ]);
+      }
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runOpenSandboxCommand({
+      execdBaseUrl: "http://opensandbox.test",
+      command: "echo chunked",
+      captureOutput: true,
+    });
+
+    expect(result).toMatchObject({
+      commandId: "cmd-456",
+      stdout: "chunked output",
+      exitCode: 0,
+    });
+  });
+
+  it("deduplicates concurrent runtime creation by scope key", async () => {
+    const workspaceDir = await makeTempDir("openclaw-opensandbox-concurrent-runtime-");
+    let createCount = 0;
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+
+      if (url === "http://opensandbox.test/v1/sandboxes" && method === "POST") {
+        createCount += 1;
+        return Response.json({ id: "sbx-concurrent" });
+      }
+      if (
+        url === "http://opensandbox.test/v1/sandboxes/sbx-concurrent/endpoints/44772" &&
+        method === "GET"
+      ) {
+        return Response.json({ endpoint: "opensandbox.test" });
+      }
+      if (url === "http://opensandbox.test/v1/sandboxes/sbx-concurrent" && method === "GET") {
+        return Response.json({ status: { state: "Running" } });
+      }
+      if (url === "http://opensandbox.test/health/ping" && method === "GET") {
+        return new Response("ok", { status: 200 });
+      }
+      if (url === "http://opensandbox.test/directories" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/files/upload" && method === "POST") {
+        return Response.json({});
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const cfg = resolveSandboxConfigForAgent(buildOpenSandboxTestConfig());
+
+    const [runtimeA, runtimeB] = await Promise.all([
+      ensureOpenSandboxRuntime({
+        cfg,
+        scopeKey: "agent:shared",
+        sessionKey: "agent:shared:one",
+        workspaceDir,
+      }),
+      ensureOpenSandboxRuntime({
+        cfg,
+        scopeKey: "agent:shared",
+        sessionKey: "agent:shared:two",
+        workspaceDir,
+      }),
+    ]);
+
+    expect(createCount).toBe(1);
+    expect(runtimeA).toBe(runtimeB);
+  });
+
+  it("recreates cached runtimes when the cached execd probe fails", async () => {
+    const workspaceDir = await makeTempDir("openclaw-opensandbox-recreate-runtime-");
+    const createdIds = ["sbx-stale", "sbx-fresh"];
+    let createCount = 0;
+    let healthChecks = 0;
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+
+      if (url === "http://opensandbox.test/v1/sandboxes" && method === "POST") {
+        const id = createdIds[createCount] ?? `sbx-${createCount}`;
+        createCount += 1;
+        return Response.json({ id });
+      }
+      if (
+        url === "http://opensandbox.test/v1/sandboxes/sbx-stale/endpoints/44772" &&
+        method === "GET"
+      ) {
+        return Response.json({ endpoint: "opensandbox.test/stale" });
+      }
+      if (
+        url === "http://opensandbox.test/v1/sandboxes/sbx-fresh/endpoints/44772" &&
+        method === "GET"
+      ) {
+        return Response.json({ endpoint: "opensandbox.test/fresh" });
+      }
+      if (
+        (url === "http://opensandbox.test/v1/sandboxes/sbx-stale" ||
+          url === "http://opensandbox.test/v1/sandboxes/sbx-fresh") &&
+        method === "GET"
+      ) {
+        return Response.json({ status: { state: "Running" } });
+      }
+      if (url === "http://opensandbox.test/stale/health/ping" && method === "GET") {
+        healthChecks += 1;
+        if (healthChecks === 2) {
+          throw new Error("socket hang up");
+        }
+        return new Response("ok", { status: 200 });
+      }
+      if (url === "http://opensandbox.test/fresh/health/ping" && method === "GET") {
+        return new Response("ok", { status: 200 });
+      }
+      if (url === "http://opensandbox.test/stale/directories" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/stale/files/upload" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/fresh/directories" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/fresh/files/upload" && method === "POST") {
+        return Response.json({});
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const cfg = resolveSandboxConfigForAgent(
+      buildOpenSandboxTestConfig("http://opensandbox.test/v1"),
+    );
+
+    const stale = await ensureOpenSandboxRuntime({
+      cfg,
+      scopeKey: "agent:main",
+      sessionKey: "agent:main:first",
+      workspaceDir,
+    });
+    const fresh = await ensureOpenSandboxRuntime({
+      cfg,
+      scopeKey: "agent:main",
+      sessionKey: "agent:main:second",
+      workspaceDir,
+    });
+
+    expect(stale.sandboxId).toBe("sbx-stale");
+    expect(fresh.sandboxId).toBe("sbx-fresh");
+    expect(createCount).toBe(2);
+  });
+
+  it("tolerates transient execd probe failures while waiting for readiness", async () => {
+    const workspaceDir = await makeTempDir("openclaw-opensandbox-ready-retry-");
+    let healthChecks = 0;
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+
+      if (url === "http://opensandbox.test/v1/sandboxes" && method === "POST") {
+        return Response.json({ id: "sbx-retry" });
+      }
+      if (
+        url === "http://opensandbox.test/v1/sandboxes/sbx-retry/endpoints/44772" &&
+        method === "GET"
+      ) {
+        return Response.json({ endpoint: "opensandbox.test" });
+      }
+      if (url === "http://opensandbox.test/v1/sandboxes/sbx-retry" && method === "GET") {
+        return Response.json({ status: { state: "Running" } });
+      }
+      if (url === "http://opensandbox.test/health/ping" && method === "GET") {
+        healthChecks += 1;
+        if (healthChecks === 1) {
+          throw new Error("connection reset");
+        }
+        return new Response("ok", { status: 200 });
+      }
+      if (url === "http://opensandbox.test/directories" && method === "POST") {
+        return Response.json({});
+      }
+      if (url === "http://opensandbox.test/files/upload" && method === "POST") {
+        return Response.json({});
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const cfg = resolveSandboxConfigForAgent(buildOpenSandboxTestConfig());
+
+    const runtime = await ensureOpenSandboxRuntime({
+      cfg,
+      scopeKey: "agent:retry",
+      sessionKey: "agent:retry:task",
+      workspaceDir,
+    });
+
+    expect(runtime.sandboxId).toBe("sbx-retry");
+    expect(healthChecks).toBe(2);
+  });
+});

--- a/src/agents/sandbox.resolveSandboxContext.opensandbox.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.opensandbox.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveSandboxContext } from "./sandbox/context.js";
+
+const opensandboxMocks = vi.hoisted(() => ({
+  ensureOpenSandboxRuntime: vi.fn(),
+}));
+
+vi.mock("./sandbox/opensandbox.js", () => ({
+  ensureOpenSandboxRuntime: opensandboxMocks.ensureOpenSandboxRuntime,
+}));
+
+const tempDirs: string[] = [];
+
+async function makeTempWorkspace() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-opensandbox-context-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("resolveSandboxContext (opensandbox)", () => {
+  afterEach(async () => {
+    opensandboxMocks.ensureOpenSandboxRuntime.mockReset();
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("returns an opensandbox-backed sandbox context", async () => {
+    const workspaceDir = await makeTempWorkspace();
+    opensandboxMocks.ensureOpenSandboxRuntime.mockResolvedValue({
+      sandboxId: "sbx-test",
+      lifecycleBaseUrl: "http://127.0.0.1:8080/v1",
+      execdBaseUrl: "http://127.0.0.1:8080/sandboxes/sbx-test/port/44772",
+      apiKey: "token",
+    });
+
+    const sandbox = await resolveSandboxContext({
+      config: {
+        agents: {
+          defaults: {
+            sandbox: {
+              backend: "opensandbox",
+              mode: "all",
+              opensandbox: {
+                endpoint: "http://127.0.0.1:8080",
+              },
+            },
+          },
+          list: [{ id: "main" }],
+        },
+      },
+      sessionKey: "agent:main:task",
+      workspaceDir,
+    });
+
+    expect(sandbox?.backend).toBe("opensandbox");
+    expect(sandbox?.containerName).toBe("sbx-test");
+    expect(sandbox?.opensandbox).toMatchObject({
+      sandboxId: "sbx-test",
+      lifecycleBaseUrl: "http://127.0.0.1:8080/v1",
+      execdBaseUrl: "http://127.0.0.1:8080/sandboxes/sbx-test/port/44772",
+      apiKey: "token",
+    });
+    expect(opensandboxMocks.ensureOpenSandboxRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: "agent:main",
+        sessionKey: "agent:main:task",
+        workspaceDir: expect.any(String),
+      }),
+    );
+  });
+});

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -47,6 +47,7 @@ vi.mock("../../browser/bridge-server.js", () => ({
 
 function buildConfig(enableNoVnc: boolean): SandboxConfig {
   return {
+    backend: "docker",
     mode: "all",
     scope: "session",
     workspaceAccess: "none",
@@ -60,6 +61,19 @@ function buildConfig(enableNoVnc: boolean): SandboxConfig {
       network: "none",
       capDrop: ["ALL"],
       env: { LANG: "C.UTF-8" },
+    },
+    opensandbox: {
+      endpoint: "http://127.0.0.1:8080",
+      protocol: "http",
+      image: "opensandbox/code-interpreter:latest",
+      workdir: "/workspace",
+      timeoutSeconds: 1800,
+      readyTimeoutSeconds: 30,
+      resourceLimits: {},
+      env: {},
+      metadata: {},
+      extensions: {},
+      execdPort: 44772,
     },
     browser: {
       enabled: true,

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -1,6 +1,12 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveAgentConfig } from "../agent-scope.js";
 import {
+  DEFAULT_OPENSANDBOX_ENDPOINT,
+  DEFAULT_OPENSANDBOX_EXECD_PORT,
+  DEFAULT_OPENSANDBOX_IMAGE,
+  DEFAULT_OPENSANDBOX_PROTOCOL,
+  DEFAULT_OPENSANDBOX_READY_TIMEOUT_SECONDS,
+  DEFAULT_OPENSANDBOX_TIMEOUT_SECONDS,
   DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS,
   DEFAULT_SANDBOX_BROWSER_CDP_PORT,
   DEFAULT_SANDBOX_BROWSER_IMAGE,
@@ -17,9 +23,11 @@ import {
 } from "./constants.js";
 import { resolveSandboxToolPolicyForAgent } from "./tool-policy.js";
 import type {
+  SandboxBackend,
   SandboxBrowserConfig,
   SandboxConfig,
   SandboxDockerConfig,
+  SandboxWorkspaceAccess,
   SandboxPruneConfig,
   SandboxScope,
 } from "./types.js";
@@ -119,6 +127,55 @@ export function resolveSandboxDockerConfig(params: {
   };
 }
 
+function resolveSandboxBackend(params: {
+  globalBackend?: SandboxBackend;
+  agentBackend?: SandboxBackend;
+}): SandboxBackend {
+  return params.agentBackend ?? params.globalBackend ?? "docker";
+}
+
+function resolveOpenSandboxConfig(params: {
+  globalOpenSandbox?: SandboxConfig["opensandbox"];
+  agentOpenSandbox?: SandboxConfig["opensandbox"];
+}) {
+  return {
+    endpoint:
+      params.agentOpenSandbox?.endpoint ??
+      params.globalOpenSandbox?.endpoint ??
+      DEFAULT_OPENSANDBOX_ENDPOINT,
+    apiKey: params.agentOpenSandbox?.apiKey ?? params.globalOpenSandbox?.apiKey,
+    protocol:
+      params.agentOpenSandbox?.protocol ??
+      params.globalOpenSandbox?.protocol ??
+      DEFAULT_OPENSANDBOX_PROTOCOL,
+    image:
+      params.agentOpenSandbox?.image ??
+      params.globalOpenSandbox?.image ??
+      DEFAULT_OPENSANDBOX_IMAGE,
+    workdir:
+      params.agentOpenSandbox?.workdir ??
+      params.globalOpenSandbox?.workdir ??
+      DEFAULT_SANDBOX_WORKDIR,
+    timeoutSeconds:
+      params.agentOpenSandbox?.timeoutSeconds ??
+      params.globalOpenSandbox?.timeoutSeconds ??
+      DEFAULT_OPENSANDBOX_TIMEOUT_SECONDS,
+    readyTimeoutSeconds:
+      params.agentOpenSandbox?.readyTimeoutSeconds ??
+      params.globalOpenSandbox?.readyTimeoutSeconds ??
+      DEFAULT_OPENSANDBOX_READY_TIMEOUT_SECONDS,
+    resourceLimits:
+      params.agentOpenSandbox?.resourceLimits ?? params.globalOpenSandbox?.resourceLimits ?? {},
+    env: params.agentOpenSandbox?.env ?? params.globalOpenSandbox?.env ?? {},
+    metadata: params.agentOpenSandbox?.metadata ?? params.globalOpenSandbox?.metadata ?? {},
+    extensions: params.agentOpenSandbox?.extensions ?? params.globalOpenSandbox?.extensions ?? {},
+    execdPort:
+      params.agentOpenSandbox?.execdPort ??
+      params.globalOpenSandbox?.execdPort ??
+      DEFAULT_OPENSANDBOX_EXECD_PORT,
+  };
+}
+
 export function resolveSandboxBrowserConfig(params: {
   scope: SandboxScope;
   globalBrowser?: Partial<SandboxBrowserConfig>;
@@ -186,11 +243,32 @@ export function resolveSandboxConfigForAgent(
   });
 
   const toolPolicy = resolveSandboxToolPolicyForAgent(cfg, agentId);
+  const backend = resolveSandboxBackend({
+    globalBackend: agent?.backend,
+    agentBackend: agentSandbox?.backend,
+  });
+  const workspaceAccess = agentSandbox?.workspaceAccess ?? agent?.workspaceAccess ?? "none";
+  const browser = resolveSandboxBrowserConfig({
+    scope,
+    globalBrowser: agent?.browser,
+    agentBrowser: agentSandbox?.browser,
+  });
+  const opensandbox = resolveOpenSandboxConfig({
+    globalOpenSandbox: agent?.opensandbox as SandboxConfig["opensandbox"] | undefined,
+    agentOpenSandbox: agentSandbox?.opensandbox as SandboxConfig["opensandbox"] | undefined,
+  });
+
+  validateResolvedSandboxConfig({
+    backend,
+    workspaceAccess,
+    browserEnabled: browser.enabled,
+  });
 
   return {
+    backend,
     mode: agentSandbox?.mode ?? agent?.mode ?? "off",
     scope,
-    workspaceAccess: agentSandbox?.workspaceAccess ?? agent?.workspaceAccess ?? "none",
+    workspaceAccess,
     workspaceRoot:
       agentSandbox?.workspaceRoot ?? agent?.workspaceRoot ?? DEFAULT_SANDBOX_WORKSPACE_ROOT,
     docker: resolveSandboxDockerConfig({
@@ -198,11 +276,8 @@ export function resolveSandboxConfigForAgent(
       globalDocker: agent?.docker,
       agentDocker: agentSandbox?.docker,
     }),
-    browser: resolveSandboxBrowserConfig({
-      scope,
-      globalBrowser: agent?.browser,
-      agentBrowser: agentSandbox?.browser,
-    }),
+    opensandbox,
+    browser,
     tools: {
       allow: toolPolicy.allow,
       deny: toolPolicy.deny,
@@ -213,4 +288,22 @@ export function resolveSandboxConfigForAgent(
       agentPrune: agentSandbox?.prune,
     }),
   };
+}
+
+function validateResolvedSandboxConfig(params: {
+  backend: SandboxBackend;
+  workspaceAccess: SandboxWorkspaceAccess;
+  browserEnabled: boolean;
+}) {
+  if (params.backend !== "opensandbox") {
+    return;
+  }
+  if (params.workspaceAccess !== "none") {
+    throw new Error(
+      `sandbox.backend=opensandbox currently supports only workspaceAccess=none (got ${params.workspaceAccess}).`,
+    );
+  }
+  if (params.browserEnabled) {
+    throw new Error("sandbox.browser.enabled is not supported when sandbox.backend=opensandbox.");
+  }
 }

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -7,6 +7,12 @@ export const DEFAULT_SANDBOX_WORKSPACE_ROOT = path.join(STATE_DIR, "sandboxes");
 export const DEFAULT_SANDBOX_IMAGE = "openclaw-sandbox:bookworm-slim";
 export const DEFAULT_SANDBOX_CONTAINER_PREFIX = "openclaw-sbx-";
 export const DEFAULT_SANDBOX_WORKDIR = "/workspace";
+export const DEFAULT_OPENSANDBOX_ENDPOINT = "http://127.0.0.1:8080";
+export const DEFAULT_OPENSANDBOX_PROTOCOL = "http";
+export const DEFAULT_OPENSANDBOX_IMAGE = "opensandbox/code-interpreter:latest";
+export const DEFAULT_OPENSANDBOX_EXECD_PORT = 44772;
+export const DEFAULT_OPENSANDBOX_TIMEOUT_SECONDS = 1800;
+export const DEFAULT_OPENSANDBOX_READY_TIMEOUT_SECONDS = 30;
 export const DEFAULT_SANDBOX_IDLE_HOURS = 24;
 export const DEFAULT_SANDBOX_MAX_AGE_DAYS = 7;
 

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -11,6 +11,7 @@ import { ensureSandboxBrowser } from "./browser.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
 import { ensureSandboxContainer } from "./docker.js";
 import { createSandboxFsBridge } from "./fs-bridge.js";
+import { ensureOpenSandboxRuntime } from "./opensandbox.js";
 import { maybePruneSandboxes } from "./prune.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
 import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js";
@@ -105,6 +106,83 @@ function resolveSandboxSession(params: { config?: OpenClawConfig; sessionKey?: s
   return { rawSessionKey, runtime, cfg };
 }
 
+function createOpenSandboxContext(params: {
+  rawSessionKey: string;
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+  cfg: ReturnType<typeof resolveSandboxConfigForAgent>;
+  runtime: Awaited<ReturnType<typeof ensureOpenSandboxRuntime>>;
+}): SandboxContext {
+  const sandboxContext: SandboxContext = {
+    enabled: true,
+    backend: "opensandbox",
+    sessionKey: params.rawSessionKey,
+    workspaceDir: params.workspaceDir,
+    agentWorkspaceDir: params.agentWorkspaceDir,
+    workspaceAccess: params.cfg.workspaceAccess,
+    containerName: params.runtime.sandboxId,
+    containerWorkdir: params.cfg.opensandbox.workdir,
+    docker: params.cfg.docker,
+    opensandbox: {
+      sandboxId: params.runtime.sandboxId,
+      lifecycleBaseUrl: params.runtime.lifecycleBaseUrl,
+      execdBaseUrl: params.runtime.execdBaseUrl,
+      apiKey: params.runtime.apiKey,
+    },
+    tools: params.cfg.tools,
+    browserAllowHostControl: false,
+  };
+  sandboxContext.fsBridge = createSandboxFsBridge({ sandbox: sandboxContext });
+  return sandboxContext;
+}
+
+async function resolveSandboxBrowserAuth(params: {
+  config?: OpenClawConfig;
+  browserEnabled: boolean;
+}) {
+  if (!params.browserEnabled) {
+    return undefined;
+  }
+  // Sandbox browser bridge server runs on a loopback TCP port; always wire up
+  // the same auth that loopback browser clients will send (token/password).
+  const cfgForAuth = params.config ?? loadConfig();
+  let browserAuth = resolveBrowserControlAuth(cfgForAuth);
+  try {
+    const ensured = await ensureBrowserControlAuth({ cfg: cfgForAuth });
+    browserAuth = ensured.auth;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : JSON.stringify(error);
+    defaultRuntime.error?.(`Sandbox browser auth ensure failed: ${message}`);
+  }
+  return browserAuth;
+}
+
+function createDockerSandboxContext(params: {
+  rawSessionKey: string;
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+  cfg: ReturnType<typeof resolveSandboxConfigForAgent>;
+  containerName: string;
+  browser: Awaited<ReturnType<typeof ensureSandboxBrowser>>;
+}): SandboxContext {
+  const sandboxContext: SandboxContext = {
+    enabled: true,
+    backend: "docker",
+    sessionKey: params.rawSessionKey,
+    workspaceDir: params.workspaceDir,
+    agentWorkspaceDir: params.agentWorkspaceDir,
+    workspaceAccess: params.cfg.workspaceAccess,
+    containerName: params.containerName,
+    containerWorkdir: params.cfg.docker.workdir,
+    docker: params.cfg.docker,
+    tools: params.cfg.tools,
+    browserAllowHostControl: params.cfg.browser.allowHostControl,
+    browser: params.browser ?? undefined,
+  };
+  sandboxContext.fsBridge = createSandboxFsBridge({ sandbox: sandboxContext });
+  return sandboxContext;
+}
+
 export async function resolveSandboxContext(params: {
   config?: OpenClawConfig;
   sessionKey?: string;
@@ -125,6 +203,23 @@ export async function resolveSandboxContext(params: {
     workspaceDir: params.workspaceDir,
   });
 
+  if (cfg.backend === "opensandbox") {
+    const runtime = await ensureOpenSandboxRuntime({
+      config: params.config,
+      cfg,
+      scopeKey,
+      sessionKey: rawSessionKey,
+      workspaceDir,
+    });
+    return createOpenSandboxContext({
+      rawSessionKey,
+      workspaceDir,
+      agentWorkspaceDir,
+      cfg,
+      runtime,
+    });
+  }
+
   const docker = await resolveSandboxDockerUser({
     docker: cfg.docker,
     workspaceDir,
@@ -141,22 +236,10 @@ export async function resolveSandboxContext(params: {
   const evaluateEnabled =
     params.config?.browser?.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED;
 
-  const bridgeAuth = cfg.browser.enabled
-    ? await (async () => {
-        // Sandbox browser bridge server runs on a loopback TCP port; always wire up
-        // the same auth that loopback browser clients will send (token/password).
-        const cfgForAuth = params.config ?? loadConfig();
-        let browserAuth = resolveBrowserControlAuth(cfgForAuth);
-        try {
-          const ensured = await ensureBrowserControlAuth({ cfg: cfgForAuth });
-          browserAuth = ensured.auth;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : JSON.stringify(error);
-          defaultRuntime.error?.(`Sandbox browser auth ensure failed: ${message}`);
-        }
-        return browserAuth;
-      })()
-    : undefined;
+  const bridgeAuth = await resolveSandboxBrowserAuth({
+    config: params.config,
+    browserEnabled: resolvedCfg.browser.enabled,
+  });
   const browser = await ensureSandboxBrowser({
     scopeKey,
     workspaceDir,
@@ -165,24 +248,14 @@ export async function resolveSandboxContext(params: {
     evaluateEnabled,
     bridgeAuth,
   });
-
-  const sandboxContext: SandboxContext = {
-    enabled: true,
-    sessionKey: rawSessionKey,
+  return createDockerSandboxContext({
+    rawSessionKey,
     workspaceDir,
     agentWorkspaceDir,
-    workspaceAccess: resolvedCfg.workspaceAccess,
+    cfg: resolvedCfg,
     containerName,
-    containerWorkdir: resolvedCfg.docker.workdir,
-    docker: resolvedCfg.docker,
-    tools: resolvedCfg.tools,
-    browserAllowHostControl: resolvedCfg.browser.allowHostControl,
-    browser: browser ?? undefined,
-  };
-
-  sandboxContext.fsBridge = createSandboxFsBridge({ sandbox: sandboxContext });
-
-  return sandboxContext;
+    browser,
+  });
 }
 
 export async function ensureSandboxWorkspaceForSession(params: {
@@ -205,6 +278,6 @@ export async function ensureSandboxWorkspaceForSession(params: {
 
   return {
     workspaceDir,
-    containerWorkdir: cfg.docker.workdir,
+    containerWorkdir: cfg.backend === "opensandbox" ? cfg.opensandbox.workdir : cfg.docker.workdir,
   };
 }

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -90,6 +90,7 @@ function createSandboxConfig(
   workspaceAccess: "rw" | "ro" | "none" = "rw",
 ): SandboxConfig {
   return {
+    backend: "docker",
     mode: "all",
     scope: "shared",
     workspaceAccess,
@@ -107,6 +108,19 @@ function createSandboxConfig(
       extraHosts: ["host.docker.internal:host-gateway"],
       binds: binds ?? ["/tmp/workspace:/workspace:rw"],
       dangerouslyAllowReservedContainerTargets: true,
+    },
+    opensandbox: {
+      endpoint: "http://127.0.0.1:8080",
+      protocol: "http",
+      image: "opensandbox/code-interpreter:latest",
+      workdir: "/workspace",
+      timeoutSeconds: 1800,
+      readyTimeoutSeconds: 30,
+      resourceLimits: {},
+      env: {},
+      metadata: {},
+      extensions: {},
+      execdPort: 44772,
     },
     browser: {
       enabled: false,

--- a/src/agents/sandbox/fs-bridge-opensandbox.ts
+++ b/src/agents/sandbox/fs-bridge-opensandbox.ts
@@ -1,0 +1,245 @@
+import path from "node:path";
+import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.js";
+import {
+  createOpenSandboxDirectories,
+  deleteOpenSandboxDirectories,
+  deleteOpenSandboxFiles,
+  getOpenSandboxFileInfo,
+  moveOpenSandboxFile,
+  readOpenSandboxFile,
+  writeOpenSandboxFile,
+} from "./opensandbox.js";
+import type { SandboxContext, SandboxWorkspaceAccess } from "./types.js";
+
+export class OpenSandboxFsBridgeImpl implements SandboxFsBridge {
+  constructor(private readonly sandbox: SandboxContext) {}
+
+  private get execdRequestBase() {
+    return {
+      execdBaseUrl: this.requireExecdBaseUrl(),
+      apiKey: this.sandbox.opensandbox?.apiKey,
+    };
+  }
+
+  resolvePath(params: { filePath: string; cwd?: string }): SandboxResolvedPath {
+    const { containerPath, hostPath } = this.resolveSandboxPath(params);
+    return {
+      hostPath,
+      relativePath: path.relative(this.sandbox.workspaceDir, hostPath),
+      containerPath,
+    };
+  }
+
+  async readFile(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<Buffer> {
+    const target = this.resolveSandboxPath(params);
+    return await readOpenSandboxFile({
+      ...this.execdRequestBase,
+      filePath: target.containerPath,
+      signal: params.signal,
+    });
+  }
+
+  async writeFile(params: {
+    filePath: string;
+    cwd?: string;
+    data: Buffer | string;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveSandboxPath(params);
+    this.ensureWritable(target.containerPath, "write files");
+    if (params.mkdir !== false) {
+      await this.mkdirParent(target.containerPath, params.signal);
+    }
+    await writeOpenSandboxFile({
+      ...this.execdRequestBase,
+      filePath: target.containerPath,
+      data: Buffer.isBuffer(params.data)
+        ? params.data
+        : Buffer.from(params.data, params.encoding ?? "utf8"),
+      signal: params.signal,
+    });
+  }
+
+  async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
+    const target = this.resolveSandboxPath(params);
+    this.ensureWritable(target.containerPath, "create directories");
+    await createOpenSandboxDirectories({
+      ...this.execdRequestBase,
+      filePath: target.containerPath,
+      signal: params.signal,
+    });
+  }
+
+  async remove(params: {
+    filePath: string;
+    cwd?: string;
+    recursive?: boolean;
+    force?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveSandboxPath(params);
+    this.ensureWritable(target.containerPath, "remove files");
+    const stat = await this.stat(params);
+    if (!stat) {
+      if (params.force) {
+        return;
+      }
+      throw new Error(`No such file or directory: ${target.containerPath}`);
+    }
+    if (stat.type === "directory") {
+      if (params.recursive !== true) {
+        throw new Error(`Cannot remove directory without recursive=true: ${target.containerPath}`);
+      }
+      await deleteOpenSandboxDirectories({
+        ...this.execdRequestBase,
+        filePath: target.containerPath,
+        signal: params.signal,
+      });
+      return;
+    }
+    await deleteOpenSandboxFiles({
+      ...this.execdRequestBase,
+      filePath: target.containerPath,
+      signal: params.signal,
+    });
+  }
+
+  async rename(params: {
+    from: string;
+    to: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const from = this.resolveSandboxPath({ filePath: params.from, cwd: params.cwd });
+    const to = this.resolveSandboxPath({ filePath: params.to, cwd: params.cwd });
+    this.ensureWritable(from.containerPath, "rename files");
+    this.ensureWritable(to.containerPath, "rename files");
+    await this.mkdirParent(to.containerPath, params.signal);
+    await moveOpenSandboxFile({
+      ...this.execdRequestBase,
+      from: from.containerPath,
+      to: to.containerPath,
+      signal: params.signal,
+    });
+  }
+
+  async stat(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<SandboxFsStat | null> {
+    const target = this.resolveSandboxPath(params);
+    try {
+      const info = await getOpenSandboxFileInfo({
+        ...this.execdRequestBase,
+        filePath: target.containerPath,
+        signal: params.signal,
+      });
+      const entry = info[target.containerPath];
+      if (!entry) {
+        return null;
+      }
+      return {
+        type: inferOpenSandboxStatType(target.containerPath, entry.mode),
+        size: typeof entry.size === "number" ? entry.size : 0,
+        mtimeMs: entry.modifiedAt ? Date.parse(entry.modifiedAt) || 0 : 0,
+      };
+    } catch (error) {
+      if (error instanceof Error && /not found|no such/i.test(error.message)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private resolveSandboxPath(params: { filePath: string; cwd?: string }) {
+    const input = params.filePath.trim();
+    const cwd = params.cwd?.trim() ? params.cwd : this.sandbox.workspaceDir;
+    const posixInput = input.replace(/\\/g, "/");
+    let hostPath: string;
+    if (
+      path.posix.isAbsolute(posixInput) &&
+      (posixInput === this.sandbox.containerWorkdir ||
+        posixInput.startsWith(`${this.sandbox.containerWorkdir}/`))
+    ) {
+      const relativeContainer = path.posix.relative(this.sandbox.containerWorkdir, posixInput);
+      const relativeHost = relativeContainer
+        ? relativeContainer.split(path.posix.sep).join(path.sep)
+        : "";
+      hostPath = relativeHost
+        ? path.resolve(this.sandbox.workspaceDir, relativeHost)
+        : path.resolve(this.sandbox.workspaceDir);
+    } else {
+      hostPath = path.resolve(cwd, input);
+    }
+    const relativePath = path.relative(this.sandbox.workspaceDir, hostPath);
+    if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+      throw new Error(`Sandbox path escapes workspace root: ${params.filePath}`);
+    }
+    const containerPath = relativePath
+      ? path.posix.join(
+          this.sandbox.containerWorkdir,
+          relativePath.split(path.sep).join(path.posix.sep),
+        )
+      : this.sandbox.containerWorkdir;
+    return {
+      hostPath,
+      containerPath,
+    };
+  }
+
+  private requireExecdBaseUrl() {
+    const baseUrl = this.sandbox.opensandbox?.execdBaseUrl?.trim();
+    if (!baseUrl) {
+      throw new Error("OpenSandbox execd base URL is unavailable.");
+    }
+    return baseUrl;
+  }
+
+  private ensureWritable(containerPath: string, action: string) {
+    if (!allowsWrites(this.sandbox.workspaceAccess)) {
+      throw new Error(`Sandbox path is read-only; cannot ${action}: ${containerPath}`);
+    }
+  }
+
+  private async mkdirParent(containerPath: string, signal?: AbortSignal) {
+    const parent = path.posix.dirname(containerPath);
+    if (!parent || parent === "." || parent === "/") {
+      return;
+    }
+    await createOpenSandboxDirectories({
+      ...this.execdRequestBase,
+      filePath: parent,
+      signal,
+    });
+  }
+}
+
+function allowsWrites(access: SandboxWorkspaceAccess): boolean {
+  return access !== "ro";
+}
+
+function inferOpenSandboxStatType(
+  containerPath: string,
+  mode?: number,
+): "file" | "directory" | "other" {
+  if (containerPath.endsWith("/")) {
+    return "directory";
+  }
+  if (typeof mode === "number") {
+    const fileTypeMask = mode & 0o170000;
+    if (fileTypeMask === 0o040000) {
+      return "directory";
+    }
+    if (fileTypeMask === 0o100000) {
+      return "file";
+    }
+  }
+  return "file";
+}

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -6,6 +6,7 @@ import {
   buildPinnedRenamePlan,
   buildPinnedWritePlan,
 } from "./fs-bridge-mutation-helper.js";
+import { OpenSandboxFsBridgeImpl } from "./fs-bridge-opensandbox.js";
 import { SandboxFsPathGuard } from "./fs-bridge-path-safety.js";
 import { buildStatPlan, type SandboxFsCommandPlan } from "./fs-bridge-shell-command-plans.js";
 import {
@@ -62,10 +63,12 @@ export type SandboxFsBridge = {
 };
 
 export function createSandboxFsBridge(params: { sandbox: SandboxContext }): SandboxFsBridge {
-  return new SandboxFsBridgeImpl(params.sandbox);
+  return params.sandbox.backend === "opensandbox"
+    ? new OpenSandboxFsBridgeImpl(params.sandbox)
+    : new DockerSandboxFsBridgeImpl(params.sandbox);
 }
 
-class SandboxFsBridgeImpl implements SandboxFsBridge {
+class DockerSandboxFsBridgeImpl implements SandboxFsBridge {
   private readonly sandbox: SandboxContext;
   private readonly mounts: ReturnType<typeof buildSandboxFsMounts>;
   private readonly pathGuard: SandboxFsPathGuard;

--- a/src/agents/sandbox/opensandbox-client.ts
+++ b/src/agents/sandbox/opensandbox-client.ts
@@ -1,0 +1,39 @@
+export const OPEN_SANDBOX_HEALTH_PATH = "/health/ping";
+
+export function normalizeOpenSandboxEndpointBase(endpoint: string) {
+  const trimmed = endpoint.trim().replace(/\/+$/, "");
+  return trimmed.endsWith("/v1") ? trimmed.slice(0, -3) : trimmed;
+}
+
+export function buildOpenSandboxLifecycleBaseUrl(endpoint: string) {
+  return `${normalizeOpenSandboxEndpointBase(endpoint)}/v1`;
+}
+
+export function buildOpenSandboxHeaders(apiKey?: string, extra?: Record<string, string>) {
+  return {
+    accept: "application/json",
+    ...(apiKey ? { "open-sandbox-api-key": apiKey } : {}),
+    ...extra,
+  };
+}
+
+export async function fetchOpenSandboxJson<T>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(input, init);
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(body.trim() || `OpenSandbox request failed (${response.status}).`);
+  }
+  return (await response.json()) as T;
+}
+
+export async function fetchOpenSandbox(input: RequestInfo | URL, init?: RequestInit) {
+  const response = await fetch(input, init);
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(body.trim() || `OpenSandbox request failed (${response.status}).`);
+  }
+  return response;
+}

--- a/src/agents/sandbox/opensandbox-exec.ts
+++ b/src/agents/sandbox/opensandbox-exec.ts
@@ -1,0 +1,280 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as tar from "tar";
+import {
+  buildOpenSandboxHeaders,
+  fetchOpenSandbox,
+  fetchOpenSandboxJson,
+} from "./opensandbox-client.js";
+
+export type OpenSandboxCommandResult = {
+  commandId?: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  error?: string;
+};
+
+export async function readOpenSandboxCommandStatus(params: {
+  execdBaseUrl: string;
+  commandId: string;
+  apiKey?: string;
+}) {
+  return await fetchOpenSandboxJson<{
+    running?: boolean;
+    exit_code?: number | null;
+    error?: string;
+    started_at?: string;
+    finished_at?: string | null;
+  }>(`${params.execdBaseUrl}/command/status/${encodeURIComponent(params.commandId)}`, {
+    method: "GET",
+    headers: buildOpenSandboxHeaders(params.apiKey),
+  });
+}
+
+function findSseFrameBoundary(buffer: string) {
+  const unixBoundary = buffer.indexOf("\n\n");
+  const windowsBoundary = buffer.indexOf("\r\n\r\n");
+  if (unixBoundary === -1) {
+    return windowsBoundary;
+  }
+  if (windowsBoundary === -1) {
+    return unixBoundary;
+  }
+  return Math.min(unixBoundary, windowsBoundary);
+}
+
+function parseSseEvent(frame: string): Record<string, unknown> | null {
+  const dataLines = frame
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trimStart());
+  if (dataLines.length === 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(dataLines.join("\n")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function consumeSseBuffer(
+  buffer: string,
+  onEvent: (event: Record<string, unknown>) => void,
+): string {
+  let remainder = buffer;
+  while (true) {
+    const boundary = findSseFrameBoundary(remainder);
+    if (boundary === -1) {
+      return remainder;
+    }
+    const frame = remainder.slice(0, boundary);
+    const separatorLength = remainder.startsWith("\r\n\r\n", boundary) ? 4 : 2;
+    remainder = remainder.slice(boundary + separatorLength);
+    const event = parseSseEvent(frame);
+    if (event) {
+      onEvent(event);
+    }
+  }
+}
+
+function applyCommandEvent(params: {
+  event: Record<string, unknown>;
+  result: OpenSandboxCommandResult;
+  captureOutput: boolean;
+  onInit?: (commandId: string) => void;
+  onStdout?: (text: string) => void;
+  onStderr?: (text: string) => void;
+}) {
+  const type = typeof params.event.type === "string" ? params.event.type : "";
+  const text = typeof params.event.text === "string" ? params.event.text : "";
+  if (type === "init" && text) {
+    params.result.commandId = text;
+    params.onInit?.(text);
+    return;
+  }
+  if (type === "stdout") {
+    if (params.captureOutput) {
+      params.result.stdout += text;
+    }
+    params.onStdout?.(text);
+    return;
+  }
+  if (type === "stderr") {
+    if (params.captureOutput) {
+      params.result.stderr += text;
+    }
+    params.onStderr?.(text);
+    return;
+  }
+  if (type === "error") {
+    params.result.error = text || params.result.error || "OpenSandbox command failed.";
+    return;
+  }
+  if (type === "status" && text) {
+    const maybeCode = Number.parseInt(text, 10);
+    if (Number.isFinite(maybeCode)) {
+      params.result.exitCode = maybeCode;
+    }
+  }
+}
+
+export async function runOpenSandboxCommand(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  command: string;
+  cwd?: string;
+  background?: boolean;
+  captureOutput?: boolean;
+  signal?: AbortSignal;
+  onInit?: (commandId: string) => void;
+  onStdout?: (text: string) => void;
+  onStderr?: (text: string) => void;
+}) {
+  const response = await fetchOpenSandbox(`${params.execdBaseUrl}/command`, {
+    method: "POST",
+    headers: buildOpenSandboxHeaders(params.apiKey, {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+    }),
+    body: JSON.stringify({
+      command: params.command,
+      cwd: params.cwd,
+      background: params.background === true,
+    }),
+    signal: params.signal,
+  });
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("OpenSandbox command stream body is unavailable.");
+  }
+  const decoder = new TextDecoder();
+  let buffered = "";
+  const captureOutput = params.captureOutput === true;
+  const result: OpenSandboxCommandResult = {
+    stdout: "",
+    stderr: "",
+    exitCode: null,
+  };
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffered += decoder.decode(value, { stream: true });
+    buffered = consumeSseBuffer(buffered, (event) => {
+      applyCommandEvent({
+        event,
+        result,
+        captureOutput,
+        onInit: params.onInit,
+        onStdout: params.onStdout,
+        onStderr: params.onStderr,
+      });
+    });
+  }
+  if (buffered.trim()) {
+    const trailingEvent = parseSseEvent(buffered);
+    if (trailingEvent) {
+      applyCommandEvent({
+        event: trailingEvent,
+        result,
+        captureOutput,
+        onInit: params.onInit,
+        onStdout: params.onStdout,
+        onStderr: params.onStderr,
+      });
+    }
+  }
+  if (params.background && !result.commandId) {
+    throw new Error("OpenSandbox background command did not return a command id.");
+  }
+  return result;
+}
+
+export async function syncOpenSandboxWorkspaceToLocalSnapshot(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  localWorkspaceDir: string;
+  remoteWorkspaceDir: string;
+  signal?: AbortSignal;
+}) {
+  const tarResult = await runOpenSandboxCommand({
+    execdBaseUrl: params.execdBaseUrl,
+    apiKey: params.apiKey,
+    cwd: params.remoteWorkspaceDir,
+    command: "tar -cf - . | base64",
+    captureOutput: true,
+    signal: params.signal,
+  });
+  if (tarResult.exitCode !== 0) {
+    throw new Error(
+      tarResult.error ||
+        `OpenSandbox workspace snapshot command failed (${tarResult.exitCode ?? "unknown"}).`,
+    );
+  }
+  const tarBase64 = tarResult.stdout.replaceAll(/\s+/g, "");
+  const tarBuffer = Buffer.from(tarBase64, "base64");
+  const localParentDir = path.dirname(params.localWorkspaceDir);
+  const tempDir = await fs.mkdtemp(path.join(localParentDir, ".opensandbox-sync-"));
+  const tarPath = path.join(tempDir, "workspace.tar");
+
+  try {
+    await fs.writeFile(tarPath, tarBuffer);
+    await tar.x({
+      file: tarPath,
+      cwd: tempDir,
+      strict: true,
+    });
+    await fs.rm(tarPath, { force: true });
+    await fs.rm(params.localWorkspaceDir, { recursive: true, force: true });
+    await fs.rename(tempDir, params.localWorkspaceDir);
+  } catch (error) {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+export async function readOpenSandboxCommandLogs(params: {
+  execdBaseUrl: string;
+  commandId: string;
+  apiKey?: string;
+  cursor?: number;
+}) {
+  const url = new URL(
+    `${params.execdBaseUrl}/command/${encodeURIComponent(params.commandId)}/logs`,
+  );
+  if (typeof params.cursor === "number") {
+    url.searchParams.set("cursor", String(params.cursor));
+  }
+  const response = await fetch(url, {
+    method: "GET",
+    headers: buildOpenSandboxHeaders(params.apiKey),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(body.trim() || `OpenSandbox logs request failed (${response.status}).`);
+  }
+  return {
+    body: await response.text(),
+    cursorHeader: response.headers.get("EXECD-COMMANDS-TAIL-CURSOR") ?? undefined,
+  };
+}
+
+export async function interruptOpenSandboxCommand(params: {
+  execdBaseUrl: string;
+  commandId: string;
+  apiKey?: string;
+}) {
+  const url = new URL(`${params.execdBaseUrl}/command`);
+  url.searchParams.set("id", params.commandId);
+  const response = await fetch(url, {
+    method: "DELETE",
+    headers: buildOpenSandboxHeaders(params.apiKey),
+  });
+  if (!response.ok && response.status !== 404) {
+    const body = await response.text().catch(() => "");
+    throw new Error(body.trim() || `OpenSandbox interrupt failed (${response.status}).`);
+  }
+}

--- a/src/agents/sandbox/opensandbox-fs.ts
+++ b/src/agents/sandbox/opensandbox-fs.ts
@@ -1,0 +1,142 @@
+import {
+  buildOpenSandboxHeaders,
+  fetchOpenSandbox,
+  fetchOpenSandboxJson,
+} from "./opensandbox-client.js";
+
+type OpenSandboxExecdRequestParams = {
+  execdBaseUrl: string;
+  apiKey?: string;
+  signal?: AbortSignal;
+};
+
+function buildExecdUrl(execdBaseUrl: string, pathname: string) {
+  return new URL(pathname, `${execdBaseUrl.replace(/\/+$/, "")}/`);
+}
+
+function buildJsonRequestInit(params: OpenSandboxExecdRequestParams, body?: string): RequestInit {
+  return {
+    headers: buildOpenSandboxHeaders(params.apiKey, { "content-type": "application/json" }),
+    body,
+    signal: params.signal,
+  };
+}
+
+export async function readOpenSandboxFile(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  filePath: string;
+  signal?: AbortSignal;
+}) {
+  const url = buildExecdUrl(params.execdBaseUrl, "files/download");
+  url.searchParams.set("path", params.filePath);
+  const response = await fetchOpenSandbox(url, {
+    method: "GET",
+    headers: buildOpenSandboxHeaders(params.apiKey),
+    signal: params.signal,
+  });
+  return Buffer.from(await response.arrayBuffer());
+}
+
+export async function writeOpenSandboxFile(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  filePath: string;
+  data: Buffer;
+  signal?: AbortSignal;
+}) {
+  const form = new FormData();
+  form.append(
+    "metadata",
+    new Blob([JSON.stringify({ path: params.filePath })], {
+      type: "application/json",
+    }),
+    "metadata",
+  );
+  form.append("file", new Blob([new Uint8Array(params.data)]), "file");
+  await fetchOpenSandbox(buildExecdUrl(params.execdBaseUrl, "files/upload"), {
+    method: "POST",
+    headers: params.apiKey ? { "open-sandbox-api-key": params.apiKey } : undefined,
+    body: form,
+    signal: params.signal,
+  });
+}
+
+export async function getOpenSandboxFileInfo(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  filePath: string;
+  signal?: AbortSignal;
+}) {
+  const url = buildExecdUrl(params.execdBaseUrl, "files/info");
+  url.searchParams.append("path", params.filePath);
+  return await fetchOpenSandboxJson<
+    Record<string, { size?: number; modifiedAt?: string; mode?: number }>
+  >(url, {
+    method: "GET",
+    headers: buildOpenSandboxHeaders(params.apiKey),
+    signal: params.signal,
+  });
+}
+
+export async function createOpenSandboxDirectories(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  filePath: string;
+  signal?: AbortSignal;
+}) {
+  await fetchOpenSandbox(buildExecdUrl(params.execdBaseUrl, "directories"), {
+    method: "POST",
+    ...buildJsonRequestInit(
+      params,
+      JSON.stringify({
+        [params.filePath]: {
+          mode: 0,
+        },
+      }),
+    ),
+  });
+}
+
+export async function deleteOpenSandboxFiles(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  filePath: string;
+  signal?: AbortSignal;
+}) {
+  const url = buildExecdUrl(params.execdBaseUrl, "files");
+  url.searchParams.append("path", params.filePath);
+  await fetchOpenSandbox(url, {
+    method: "DELETE",
+    headers: buildOpenSandboxHeaders(params.apiKey),
+    signal: params.signal,
+  });
+}
+
+export async function deleteOpenSandboxDirectories(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  filePath: string;
+  signal?: AbortSignal;
+}) {
+  const url = buildExecdUrl(params.execdBaseUrl, "directories");
+  url.searchParams.append("path", params.filePath);
+  await fetchOpenSandbox(url, {
+    method: "DELETE",
+    headers: buildOpenSandboxHeaders(params.apiKey),
+    signal: params.signal,
+  });
+}
+
+export async function moveOpenSandboxFile(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  from: string;
+  to: string;
+  signal?: AbortSignal;
+}) {
+  await fetchOpenSandbox(buildExecdUrl(params.execdBaseUrl, "files/mv"), {
+    method: "POST",
+    ...buildJsonRequestInit(params, JSON.stringify([{ src: params.from, dest: params.to }])),
+  });
+}

--- a/src/agents/sandbox/opensandbox-lifecycle.ts
+++ b/src/agents/sandbox/opensandbox-lifecycle.ts
@@ -1,0 +1,389 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveConfiguredSecretInputString } from "../../gateway/resolve-configured-secret-input-string.js";
+import {
+  buildOpenSandboxHeaders,
+  buildOpenSandboxLifecycleBaseUrl,
+  fetchOpenSandboxJson,
+  OPEN_SANDBOX_HEALTH_PATH,
+} from "./opensandbox-client.js";
+import { createOpenSandboxDirectories, writeOpenSandboxFile } from "./opensandbox-fs.js";
+import type { SandboxConfig } from "./types.js";
+
+const DEFAULT_ENTRYPOINT = ["tail", "-f", "/dev/null"];
+
+export type OpenSandboxRuntime = {
+  scopeKey: string;
+  sessionKey: string;
+  sandboxId: string;
+  lifecycleBaseUrl: string;
+  execdBaseUrl: string;
+  apiKey?: string;
+  lastUsedAtMs: number;
+};
+
+type OpenSandboxStatusResponse = {
+  status?: {
+    state?: string;
+  };
+};
+
+type OpenSandboxCreateResponse = {
+  id?: string;
+};
+
+type OpenSandboxEndpointResponse = {
+  endpoint?: string;
+};
+
+const OPEN_SANDBOX_RUNTIMES = new Map<string, OpenSandboxRuntime>();
+const OPEN_SANDBOX_RUNTIME_CREATIONS = new Map<string, Promise<OpenSandboxRuntime>>();
+
+export function resetOpenSandboxRuntimesForTests() {
+  OPEN_SANDBOX_RUNTIMES.clear();
+  OPEN_SANDBOX_RUNTIME_CREATIONS.clear();
+}
+
+function formatErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function pingExecd(params: { execdBaseUrl: string; apiKey?: string }) {
+  try {
+    const response = await fetch(`${params.execdBaseUrl}${OPEN_SANDBOX_HEALTH_PATH}`, {
+      method: "GET",
+      headers: buildOpenSandboxHeaders(params.apiKey),
+    });
+    return {
+      ok: response.ok,
+      detail: response.ok ? undefined : `HTTP ${response.status}`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      detail: formatErrorMessage(error),
+    };
+  }
+}
+
+async function syncWorkspaceToRuntime(params: {
+  runtime: Pick<OpenSandboxRuntime, "execdBaseUrl" | "apiKey">;
+  localWorkspaceDir: string;
+  remoteWorkspaceDir: string;
+}) {
+  await syncWorkspaceToOpenSandbox({
+    execdBaseUrl: params.runtime.execdBaseUrl,
+    apiKey: params.runtime.apiKey,
+    localWorkspaceDir: params.localWorkspaceDir,
+    remoteWorkspaceDir: params.remoteWorkspaceDir,
+  });
+}
+
+async function waitForSandboxReady(params: {
+  lifecycleBaseUrl: string;
+  sandboxId: string;
+  execdBaseUrl: string;
+  apiKey?: string;
+  timeoutMs: number;
+}) {
+  const deadline = Date.now() + params.timeoutMs;
+  let lastState = "Creating";
+  let lastDetail = "awaiting sandbox status";
+  while (Date.now() < deadline) {
+    try {
+      const status = await fetchOpenSandboxJson<OpenSandboxStatusResponse>(
+        `${params.lifecycleBaseUrl}/sandboxes/${encodeURIComponent(params.sandboxId)}`,
+        {
+          method: "GET",
+          headers: buildOpenSandboxHeaders(params.apiKey),
+        },
+      );
+      lastState = status.status?.state?.trim() || lastState;
+      lastDetail = `state: ${lastState}`;
+      if (lastState === "Running") {
+        const health = await pingExecd(params);
+        if (health.ok) {
+          return;
+        }
+        if (health.detail) {
+          lastDetail = `state: ${lastState}; execd: ${health.detail}`;
+        }
+      }
+    } catch (error) {
+      lastDetail = `state: ${lastState}; status: ${formatErrorMessage(error)}`;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(
+    `Timed out waiting for OpenSandbox ${params.sandboxId} to become ready (${lastDetail}).`,
+  );
+}
+
+async function getSandboxEndpoint(params: {
+  lifecycleBaseUrl: string;
+  sandboxId: string;
+  apiKey?: string;
+  protocol: "http" | "https";
+  execdPort: number;
+}) {
+  const endpoint = await fetchOpenSandboxJson<OpenSandboxEndpointResponse>(
+    `${params.lifecycleBaseUrl}/sandboxes/${encodeURIComponent(params.sandboxId)}/endpoints/${params.execdPort}`,
+    {
+      method: "GET",
+      headers: buildOpenSandboxHeaders(params.apiKey),
+    },
+  );
+  const raw = endpoint.endpoint?.trim();
+  if (!raw) {
+    throw new Error(`OpenSandbox did not return an execd endpoint for ${params.sandboxId}.`);
+  }
+  return `${params.protocol}://${raw}`;
+}
+
+async function resolveApiKey(params: { config?: OpenClawConfig; sandboxConfig: SandboxConfig }) {
+  if (!params.config || !params.sandboxConfig.opensandbox.apiKey) {
+    return undefined;
+  }
+  const resolved = await resolveConfiguredSecretInputString({
+    config: params.config,
+    env: process.env,
+    value: params.sandboxConfig.opensandbox.apiKey,
+    path: "agents.defaults.sandbox.opensandbox.apiKey",
+  });
+  if (resolved.unresolvedRefReason) {
+    throw new Error(resolved.unresolvedRefReason);
+  }
+  return resolved.value;
+}
+
+async function syncWorkspaceToOpenSandbox(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  localWorkspaceDir: string;
+  remoteWorkspaceDir: string;
+}) {
+  const workspaceRootRealPath = await fs.realpath(params.localWorkspaceDir);
+  await syncWorkspaceDirectory({
+    execdBaseUrl: params.execdBaseUrl,
+    apiKey: params.apiKey,
+    localWorkspaceDir: params.localWorkspaceDir,
+    remoteWorkspaceDir: params.remoteWorkspaceDir,
+    workspaceRootRealPath,
+    activeDirectoryRealPaths: new Set<string>(),
+  });
+}
+
+function ensurePathWithinWorkspace(params: {
+  workspaceRootRealPath: string;
+  targetRealPath: string;
+  localPath: string;
+}) {
+  const relative = path.relative(params.workspaceRootRealPath, params.targetRealPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`OpenSandbox workspace sync rejected symlink escape: ${params.localPath}`);
+  }
+}
+
+async function syncWorkspaceDirectory(params: {
+  execdBaseUrl: string;
+  apiKey?: string;
+  localWorkspaceDir: string;
+  remoteWorkspaceDir: string;
+  workspaceRootRealPath: string;
+  activeDirectoryRealPaths: Set<string>;
+}) {
+  const directoryRealPath = await fs.realpath(params.localWorkspaceDir);
+  ensurePathWithinWorkspace({
+    workspaceRootRealPath: params.workspaceRootRealPath,
+    targetRealPath: directoryRealPath,
+    localPath: params.localWorkspaceDir,
+  });
+  if (params.activeDirectoryRealPaths.has(directoryRealPath)) {
+    throw new Error(
+      `OpenSandbox workspace sync detected a symlink directory cycle: ${directoryRealPath}`,
+    );
+  }
+  params.activeDirectoryRealPaths.add(directoryRealPath);
+  const entries = await fs.readdir(params.localWorkspaceDir, { withFileTypes: true });
+  try {
+    for (const entry of entries) {
+      const localPath = path.join(params.localWorkspaceDir, entry.name);
+      const remotePath = path.posix.join(params.remoteWorkspaceDir, entry.name);
+      const stat = entry.isSymbolicLink() ? await fs.stat(localPath) : null;
+      const isDirectory = entry.isDirectory() || stat?.isDirectory() === true;
+      const isFile = entry.isFile() || stat?.isFile() === true;
+
+      if (entry.isSymbolicLink()) {
+        const targetRealPath = await fs.realpath(localPath);
+        ensurePathWithinWorkspace({
+          workspaceRootRealPath: params.workspaceRootRealPath,
+          targetRealPath,
+          localPath,
+        });
+      }
+
+      if (isDirectory) {
+        await createOpenSandboxDirectories({
+          execdBaseUrl: params.execdBaseUrl,
+          apiKey: params.apiKey,
+          filePath: remotePath,
+        });
+        await syncWorkspaceDirectory({
+          execdBaseUrl: params.execdBaseUrl,
+          apiKey: params.apiKey,
+          localWorkspaceDir: localPath,
+          remoteWorkspaceDir: remotePath,
+          workspaceRootRealPath: params.workspaceRootRealPath,
+          activeDirectoryRealPaths: params.activeDirectoryRealPaths,
+        });
+        continue;
+      }
+      if (!isFile) {
+        continue;
+      }
+      await writeOpenSandboxFile({
+        execdBaseUrl: params.execdBaseUrl,
+        apiKey: params.apiKey,
+        filePath: remotePath,
+        data: await fs.readFile(localPath),
+      });
+    }
+  } finally {
+    params.activeDirectoryRealPaths.delete(directoryRealPath);
+  }
+}
+
+async function createRuntime(params: {
+  config?: OpenClawConfig;
+  cfg: SandboxConfig;
+  scopeKey: string;
+  sessionKey: string;
+  workspaceDir: string;
+}) {
+  const lifecycleBaseUrl = buildOpenSandboxLifecycleBaseUrl(params.cfg.opensandbox.endpoint);
+  const apiKey = await resolveApiKey({
+    config: params.config,
+    sandboxConfig: params.cfg,
+  });
+  const metadata = {
+    ...params.cfg.opensandbox.metadata,
+    openclaw_scope_key: params.scopeKey,
+    openclaw_session_key: params.sessionKey,
+  };
+  const created = await fetchOpenSandboxJson<OpenSandboxCreateResponse>(
+    `${lifecycleBaseUrl}/sandboxes`,
+    {
+      method: "POST",
+      headers: buildOpenSandboxHeaders(apiKey, { "content-type": "application/json" }),
+      body: JSON.stringify({
+        image: { uri: params.cfg.opensandbox.image },
+        entrypoint: DEFAULT_ENTRYPOINT,
+        timeout: params.cfg.opensandbox.timeoutSeconds,
+        resourceLimits: params.cfg.opensandbox.resourceLimits,
+        env: {
+          ...params.cfg.opensandbox.env,
+          HOME: params.cfg.opensandbox.workdir,
+        },
+        metadata,
+        extensions: params.cfg.opensandbox.extensions,
+      }),
+    },
+  );
+  const sandboxId = created.id?.trim();
+  if (!sandboxId) {
+    throw new Error("OpenSandbox createSandbox returned an empty sandbox id.");
+  }
+  const execdBaseUrl = await getSandboxEndpoint({
+    lifecycleBaseUrl,
+    sandboxId,
+    apiKey,
+    protocol: params.cfg.opensandbox.protocol,
+    execdPort: params.cfg.opensandbox.execdPort,
+  });
+  await waitForSandboxReady({
+    lifecycleBaseUrl,
+    sandboxId,
+    execdBaseUrl,
+    apiKey,
+    timeoutMs: params.cfg.opensandbox.readyTimeoutSeconds * 1000,
+  });
+  await syncWorkspaceToOpenSandbox({
+    execdBaseUrl,
+    apiKey,
+    localWorkspaceDir: params.workspaceDir,
+    remoteWorkspaceDir: params.cfg.opensandbox.workdir,
+  });
+  const runtime: OpenSandboxRuntime = {
+    scopeKey: params.scopeKey,
+    sessionKey: params.sessionKey,
+    sandboxId,
+    lifecycleBaseUrl,
+    execdBaseUrl,
+    apiKey,
+    lastUsedAtMs: Date.now(),
+  };
+  OPEN_SANDBOX_RUNTIMES.set(params.scopeKey, runtime);
+  return runtime;
+}
+
+export async function ensureOpenSandboxRuntime(params: {
+  config?: OpenClawConfig;
+  cfg: SandboxConfig;
+  scopeKey: string;
+  sessionKey: string;
+  workspaceDir: string;
+}) {
+  const existing = OPEN_SANDBOX_RUNTIMES.get(params.scopeKey);
+  if (existing) {
+    existing.lastUsedAtMs = Date.now();
+    const health = await pingExecd({
+      execdBaseUrl: existing.execdBaseUrl,
+      apiKey: existing.apiKey,
+    });
+    if (health.ok) {
+      try {
+        await syncWorkspaceToRuntime({
+          runtime: existing,
+          localWorkspaceDir: params.workspaceDir,
+          remoteWorkspaceDir: params.cfg.opensandbox.workdir,
+        });
+      } catch (error) {
+        OPEN_SANDBOX_RUNTIMES.delete(params.scopeKey);
+        throw new Error(
+          `Failed to sync workspace into cached OpenSandbox runtime ${existing.sandboxId}: ${formatErrorMessage(error)}`,
+          { cause: error },
+        );
+      }
+      return existing;
+    }
+    OPEN_SANDBOX_RUNTIMES.delete(params.scopeKey);
+  }
+  const inFlight = OPEN_SANDBOX_RUNTIME_CREATIONS.get(params.scopeKey);
+  if (inFlight) {
+    return await inFlight;
+  }
+  const creation = createRuntime(params).finally(() => {
+    OPEN_SANDBOX_RUNTIME_CREATIONS.delete(params.scopeKey);
+  });
+  OPEN_SANDBOX_RUNTIME_CREATIONS.set(params.scopeKey, creation);
+  return await creation;
+}
+
+export async function deleteOpenSandboxRuntime(params: {
+  lifecycleBaseUrl: string;
+  sandboxId: string;
+  apiKey?: string;
+}) {
+  const response = await fetch(
+    `${params.lifecycleBaseUrl}/sandboxes/${encodeURIComponent(params.sandboxId)}`,
+    {
+      method: "DELETE",
+      headers: buildOpenSandboxHeaders(params.apiKey),
+    },
+  );
+  if (!response.ok && response.status !== 404) {
+    const body = await response.text().catch(() => "");
+    throw new Error(body.trim() || `OpenSandbox delete failed (${response.status}).`);
+  }
+}

--- a/src/agents/sandbox/opensandbox.ts
+++ b/src/agents/sandbox/opensandbox.ts
@@ -1,0 +1,23 @@
+export {
+  deleteOpenSandboxRuntime,
+  ensureOpenSandboxRuntime,
+  resetOpenSandboxRuntimesForTests,
+  type OpenSandboxRuntime,
+} from "./opensandbox-lifecycle.js";
+export {
+  interruptOpenSandboxCommand,
+  readOpenSandboxCommandLogs,
+  readOpenSandboxCommandStatus,
+  runOpenSandboxCommand,
+  syncOpenSandboxWorkspaceToLocalSnapshot,
+  type OpenSandboxCommandResult,
+} from "./opensandbox-exec.js";
+export {
+  createOpenSandboxDirectories,
+  deleteOpenSandboxDirectories,
+  deleteOpenSandboxFiles,
+  getOpenSandboxFileInfo,
+  moveOpenSandboxFile,
+  readOpenSandboxFile,
+  writeOpenSandboxFile,
+} from "./opensandbox-fs.js";

--- a/src/agents/sandbox/test-fixtures.ts
+++ b/src/agents/sandbox/test-fixtures.ts
@@ -28,6 +28,7 @@ export function createSandboxTestContext(params?: {
 
   return {
     enabled: true,
+    backend: "docker",
     sessionKey: "sandbox:test",
     workspaceDir: "/tmp/workspace",
     agentWorkspaceDir: "/tmp/workspace",

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -1,3 +1,4 @@
+import type { SandboxBackend, SandboxOpenSandboxSettings } from "../../config/types.sandbox.js";
 import type { SandboxFsBridge } from "./fs-bridge.js";
 import type { SandboxDockerConfig } from "./types.docker.js";
 
@@ -26,6 +27,8 @@ export type SandboxToolPolicyResolved = {
   };
 };
 
+export type { SandboxBackend } from "../../config/types.sandbox.js";
+
 export type SandboxWorkspaceAccess = "none" | "ro" | "rw";
 
 export type SandboxBrowserConfig = {
@@ -53,11 +56,30 @@ export type SandboxPruneConfig = {
 export type SandboxScope = "session" | "agent" | "shared";
 
 export type SandboxConfig = {
+  backend: SandboxBackend;
   mode: "off" | "non-main" | "all";
   scope: SandboxScope;
   workspaceAccess: SandboxWorkspaceAccess;
   workspaceRoot: string;
   docker: SandboxDockerConfig;
+  opensandbox: Required<
+    Pick<
+      SandboxOpenSandboxSettings,
+      | "endpoint"
+      | "protocol"
+      | "image"
+      | "workdir"
+      | "timeoutSeconds"
+      | "readyTimeoutSeconds"
+      | "resourceLimits"
+      | "env"
+      | "metadata"
+      | "extensions"
+      | "execdPort"
+    >
+  > & {
+    apiKey?: SandboxOpenSandboxSettings["apiKey"];
+  };
   browser: SandboxBrowserConfig;
   tools: SandboxToolPolicy;
   prune: SandboxPruneConfig;
@@ -71,6 +93,7 @@ export type SandboxBrowserContext = {
 
 export type SandboxContext = {
   enabled: boolean;
+  backend: SandboxBackend;
   sessionKey: string;
   workspaceDir: string;
   agentWorkspaceDir: string;
@@ -78,6 +101,12 @@ export type SandboxContext = {
   containerName: string;
   containerWorkdir: string;
   docker: SandboxDockerConfig;
+  opensandbox?: {
+    sandboxId: string;
+    lifecycleBaseUrl: string;
+    execdBaseUrl: string;
+    apiKey?: string;
+  };
   tools: SandboxToolPolicy;
   browserAllowHostControl: boolean;
   browser?: SandboxBrowserContext;

--- a/src/agents/test-helpers/pi-tools-sandbox-context.ts
+++ b/src/agents/test-helpers/pi-tools-sandbox-context.ts
@@ -18,6 +18,7 @@ export function createPiToolsSandboxContext(params: PiToolsSandboxContextParams)
   const workspaceDir = params.workspaceDir;
   return {
     enabled: true,
+    backend: "docker",
     sessionKey: params.sessionKey ?? "sandbox:test",
     workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir ?? workspaceDir,

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -185,6 +185,19 @@ export async function maybeRepairSandboxImages(
   if (!sandbox || mode === "off") {
     return cfg;
   }
+  if ((sandbox.backend ?? "docker") === "opensandbox") {
+    const endpoint = sandbox.opensandbox?.endpoint?.trim();
+    if (!endpoint) {
+      note(
+        [
+          `Sandbox mode is enabled (mode: "${mode}", backend: "opensandbox") but no endpoint is configured.`,
+          "Set agents.defaults.sandbox.opensandbox.endpoint to your OpenSandbox lifecycle API URL.",
+        ].join("\n"),
+        "Sandbox",
+      );
+    }
+    return cfg;
+  }
 
   const dockerAvailable = await isDockerAvailable();
   if (!dockerAvailable) {

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -235,6 +235,7 @@ export async function sandboxExplainCommand(
     sessionKey,
     mainSessionKey,
     sandbox: {
+      backend: sandboxCfg.backend,
       mode: sandboxCfg.mode,
       scope: sandboxCfg.scope,
       perSession: sandboxCfg.scope === "session",

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -1,6 +1,8 @@
 import type {
+  SandboxBackend,
   SandboxBrowserSettings,
   SandboxDockerSettings,
+  SandboxOpenSandboxSettings,
   SandboxPruneSettings,
 } from "./types.sandbox.js";
 
@@ -14,6 +16,7 @@ export type AgentModelConfig =
     };
 
 export type AgentSandboxConfig = {
+  backend?: SandboxBackend;
   mode?: "off" | "non-main" | "all";
   /** Agent workspace access inside the sandbox. */
   workspaceAccess?: "none" | "ro" | "rw";
@@ -30,6 +33,8 @@ export type AgentSandboxConfig = {
   workspaceRoot?: string;
   /** Docker-specific sandbox settings. */
   docker?: SandboxDockerSettings;
+  /** OpenSandbox-specific sandbox settings. */
+  opensandbox?: SandboxOpenSandboxSettings;
   /** Optional sandboxed browser settings. */
   browser?: SandboxBrowserSettings;
   /** Auto-prune sandbox settings. */

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -1,3 +1,7 @@
+import type { SecretInput } from "./types.secrets.js";
+
+export type SandboxBackend = "docker" | "opensandbox";
+
 export type SandboxDockerSettings = {
   /** Docker image to use for sandbox containers. */
   image?: string;
@@ -57,6 +61,33 @@ export type SandboxDockerSettings = {
    * Default behavior blocks container namespace joins to preserve sandbox isolation.
    */
   dangerouslyAllowContainerNamespaceJoin?: boolean;
+};
+
+export type SandboxOpenSandboxSettings = {
+  /** OpenSandbox lifecycle API base URL. */
+  endpoint?: string;
+  /** Optional API key for lifecycle/execd requests. */
+  apiKey?: SecretInput;
+  /** Protocol for returned endpoint URLs. */
+  protocol?: "http" | "https";
+  /** Sandbox image URI. */
+  image?: string;
+  /** Sandbox workdir inside the runtime (default: /workspace). */
+  workdir?: string;
+  /** Sandbox timeout in seconds. */
+  timeoutSeconds?: number;
+  /** Time to wait for sandbox readiness. */
+  readyTimeoutSeconds?: number;
+  /** Resource limits passed to OpenSandbox. */
+  resourceLimits?: Record<string, string>;
+  /** Extra environment variables for sandbox startup. */
+  env?: Record<string, string>;
+  /** Arbitrary metadata for sandbox creation. */
+  metadata?: Record<string, string>;
+  /** Optional extensions payload passed to OpenSandbox. */
+  extensions?: Record<string, string>;
+  /** Execd port exposed by the sandbox runtime. */
+  execdPort?: number;
 };
 
 export type SandboxBrowserSettings = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -233,6 +233,24 @@ export const SandboxBrowserSchema = z
   .strict()
   .optional();
 
+export const SandboxOpenSandboxSchema = z
+  .object({
+    endpoint: z.string().optional(),
+    apiKey: SecretInputSchema.optional().register(sensitive),
+    protocol: z.enum(["http", "https"]).optional(),
+    image: z.string().optional(),
+    workdir: z.string().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+    readyTimeoutSeconds: z.number().int().positive().optional(),
+    resourceLimits: z.record(z.string(), z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+    extensions: z.record(z.string(), z.string()).optional(),
+    execdPort: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const SandboxPruneSchema = z
   .object({
     idleHours: z.number().int().nonnegative().optional(),
@@ -482,6 +500,7 @@ const ToolLoopDetectionSchema = z
 
 export const AgentSandboxSchema = z
   .object({
+    backend: z.enum(["docker", "opensandbox"]).optional(),
     mode: z.union([z.literal("off"), z.literal("non-main"), z.literal("all")]).optional(),
     workspaceAccess: z.union([z.literal("none"), z.literal("ro"), z.literal("rw")]).optional(),
     sessionToolsVisibility: z.union([z.literal("spawned"), z.literal("all")]).optional(),
@@ -489,6 +508,7 @@ export const AgentSandboxSchema = z
     perSession: z.boolean().optional(),
     workspaceRoot: z.string().optional(),
     docker: SandboxDockerSchema,
+    opensandbox: SandboxOpenSandboxSchema,
     browser: SandboxBrowserSchema,
     prune: SandboxPruneSchema,
   })
@@ -505,6 +525,20 @@ export const AgentSandboxSchema = z
         message:
           'Sandbox security: browser network mode "container:*" is blocked by default. ' +
           "Set sandbox.docker.dangerouslyAllowContainerNamespaceJoin=true only when you fully trust this runtime.",
+      });
+    }
+    if (data.backend === "opensandbox" && data.workspaceAccess && data.workspaceAccess !== "none") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["workspaceAccess"],
+        message: "sandbox.backend=opensandbox currently supports only workspaceAccess=none.",
+      });
+    }
+    if (data.backend === "opensandbox" && data.browser?.enabled) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["browser", "enabled"],
+        message: "sandbox.browser.enabled is not supported when backend=opensandbox.",
       });
     }
   })


### PR DESCRIPTION
## Summary

- Problem: OpenClaw's sandbox abstraction was still effectively Docker-shaped, so there was no clean way to support [Alibaba OpenSandbox](https://github.com/alibaba/OpenSandbox) as a sandbox runtime without modeling it as a separate exec host.
- Why it matters: Alibaba OpenSandbox provides lifecycle, command execution, and filesystem APIs that fit OpenClaw's sandbox model, but the previous implementation could not support that backend while preserving existing sandbox semantics.
- What changed: Added `sandbox.backend="opensandbox"`, implemented Alibaba OpenSandbox-backed lifecycle/exec/filesystem adapters, wired them into sandbox context resolution and tool execution, added runtime recreation/cleanup safeguards, and added docs plus targeted tests.
- What did NOT change (scope boundary): This PR does not add OpenSandbox browser support, `workspaceAccess: "ro"` / `"rw"` for OpenSandbox, interactive PTY/input support, or a new exec host such as `host="cloud"`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Added `agents.defaults.sandbox.backend` with `docker` (default) and `opensandbox`.
- Added `agents.defaults.sandbox.opensandbox.*` config for Alibaba OpenSandbox endpoint/image/runtime settings.
- `exec.host: "sandbox"` now runs inside the configured sandbox backend, including Alibaba OpenSandbox.
- `openclaw sandbox explain` now reports the effective sandbox backend.
- `doctor sandbox` no longer assumes Docker when `sandbox.backend=opensandbox`.
- `sandbox.backend=opensandbox` currently supports only `workspaceAccess: "none"`.
- `sandbox.backend=opensandbox` currently rejects sandbox browser and interactive PTY/process input actions.
- OpenSandbox runtime reuse now recreates runtimes when the effective OpenSandbox config changes.
- OpenSandbox sandbox filesystem mutations now update both the remote runtime and the local sandbox workspace snapshot used for runtime re-sync.
- Docker `workspaceAccess: "none"` write behavior is unchanged; Docker sandbox file mutations still require `workspaceAccess: "rw"`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `Yes`
- Secrets/tokens handling changed? (`Yes/No`) `Yes`
- New/changed network calls? (`Yes/No`) `Yes`
- Command/tool execution surface changed? (`Yes/No`) `Yes`
- Data access scope changed? (`Yes/No`) `Yes`
- If any `Yes`, explain risk + mitigation:

This PR adds a new sandbox backend that can make outbound HTTP calls to an Alibaba OpenSandbox lifecycle API and exec/filesystem endpoints. It also allows sandboxed command and file operations to run through that backend when explicitly configured.

Risk is limited by:
- keeping Docker as the default backend
- requiring explicit `sandbox.backend=opensandbox`
- restricting the first version to `workspaceAccess: "none"`
- rejecting sandbox browser for OpenSandbox
- rejecting interactive PTY/process input actions for OpenSandbox
- continuing to route everything through existing sandbox semantics rather than adding a broader new exec host

API key handling is limited to resolving `sandbox.opensandbox.apiKey` through the existing configured secret resolver path.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, local workspace, mocked Alibaba OpenSandbox HTTP APIs in tests
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):

```json5
{
  agents: {
    defaults: {
      sandbox: {
        backend: "opensandbox",
        mode: "all",
        scope: "session",
        workspaceAccess: "none",
        opensandbox: {
          endpoint: "http://127.0.0.1:8080",
          image: "opensandbox/code-interpreter:latest",
          workdir: "/workspace",
        },
      },
    },
  },
}
```

### Steps

1. Configure `agents.defaults.sandbox.backend = "opensandbox"` with `workspaceAccess = "none"`.
2. Resolve a sandbox context for a sandboxed session and run sandboxed file + exec operations.
3. Re-run with cached runtime reuse, config changes, simulated probe failures, and simulated initialization failures.

### Expected

- OpenClaw resolves an Alibaba OpenSandbox-backed `SandboxContext`.
- Sandbox file operations (`read` / `write` / `edit` / `apply_patch`) run through the OpenSandbox filesystem bridge.
- `exec.host: "sandbox"` runs through Alibaba OpenSandbox command execution.
- OpenSandbox runtime reuse respects effective config changes and self-heals stale cached runtimes.
- Unsupported interactive process input is rejected clearly.

### Actual

- Verified via targeted tests and integration-style mocked runtime tests.
- OpenSandbox-backed sandbox context, lifecycle, FS bridge, and exec path behave as expected.
- Cached runtime replacement and cleanup paths are covered by regression tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing tests after change:
- `src/agents/sandbox.opensandbox-config.test.ts`
- `src/agents/bash-tools.process.opensandbox.test.ts`
- `src/agents/sandbox.opensandbox.test.ts`
- `src/agents/sandbox.resolveSandboxContext.opensandbox.test.ts`
- `src/agents/sandbox.opensandbox-path.integration.test.ts`
- `src/agents/pi-tools-agent-config.test.ts`

## Human Verification (required)

- Verified scenarios:
  - OpenSandbox config validation
  - OpenSandbox sandbox context resolution
  - OpenSandbox runtime creation/reuse behavior
  - OpenSandbox workspace sync behavior
  - OpenSandbox filesystem bridge read/write/stat/rename/remove flow
  - OpenSandbox local workspace snapshot mirroring for file mutations
  - OpenSandbox exec runtime flow through `runExecProcess(...)`
  - non-zero exit handling parity with existing exec behavior
  - timeout handling for OpenSandbox exec
  - cached runtime recreation on config changes
  - stale runtime cleanup during replacement
  - newly created runtime cleanup when initialization fails after create
  - process kill / unsupported interactive input behavior
  - LF, CRLF, and trailing-buffer SSE parsing paths
- Edge cases checked:
  - cache reuse for healthy runtime
  - cached execd probe throws
  - readiness probe throws before eventual success
  - unsupported interactive PTY/input paths
  - schema rejection for unsupported OpenSandbox config combinations
  - missing-path `stat()` and `remove(force: true)` semantics on OpenSandbox 404s
  - Docker `workspaceAccess: "none"` write behavior remains unchanged
- What you did **not** verify:
  - real end-to-end execution against a live Alibaba OpenSandbox deployment
  - sandbox browser with OpenSandbox
  - `workspaceAccess: "ro"` / `"rw"` with OpenSandbox

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `Yes`
- Migration needed? (`Yes/No`) `No`

Users who want Alibaba OpenSandbox must opt in by setting:
- `agents.defaults.sandbox.backend = "opensandbox"`
- `agents.defaults.sandbox.opensandbox.*`

Existing Docker sandbox users do not need to change anything.

The final implementation does not intentionally change Docker sandbox write semantics: Docker `workspaceAccess: "none"` remains non-writable, while OpenSandbox `workspaceAccess: "none"` is writable for the isolated sandbox workspace.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - set `agents.defaults.sandbox.backend = "docker"`
  - or set `agents.defaults.sandbox.mode = "off"`
- Files/config to restore:
  - `agents.defaults.sandbox.backend`
  - `agents.defaults.sandbox.mode`
  - optional `agents.defaults.sandbox.opensandbox.*`
- Known bad symptoms reviewers should watch for:
  - sandbox sessions fail with missing OpenSandbox endpoint / execd URL errors
  - unsupported config combinations (`workspaceAccess != none`, sandbox browser enabled) throw validation errors
  - sandbox exec/file tools fail only when backend is explicitly set to `opensandbox`
  - stale runtime replacement paths failing to recreate or clean up runtimes

## Risks and Mitigations

- Risk:
  - OpenSandbox support changes sandbox execution behavior for users who opt in.
  - Mitigation:
    - Docker remains the default backend and OpenSandbox requires explicit config.

- Risk:
  - The first OpenSandbox version does not match Docker feature parity.
  - Mitigation:
    - Unsupported behavior is explicitly rejected in schema/runtime/docs instead of silently degrading.

- Risk:
  - New network calls to Alibaba OpenSandbox endpoints introduce external runtime dependency.
  - Mitigation:
    - endpoint/API key are explicit config, errors are surfaced clearly, and fallback is to keep using Docker.

- Risk:
  - Added code path complexity across sandbox context, exec, filesystem routing, and runtime lifecycle replacement.
  - Mitigation:
    - OpenSandbox logic is split across lifecycle/exec/fs modules and covered with targeted tests plus integration-style path tests.

- Risk:
  - Runtime replacement and initialization cleanup paths could leak remote sandboxes if regressions are introduced later.
  - Mitigation:
    - Added regression coverage for config-change recreation, stale-runtime replacement, and cleanup on post-create initialization failures.
