### PR TITLE
fix(feishu): restore command queue bypass during active runs

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -240,6 +240,13 @@ function registerEventHandlers(
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
   const enqueue = createChatQueue();
+  const shouldBypassChatQueue = (event: FeishuMessageEvent): boolean => {
+    const text = resolveDebounceText(event);
+    if (!text) {
+      return false;
+    }
+    return core.channel.commands.isControlCommandMessage(text, cfg);
+  };
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
     const chatId = event.message.chat_id?.trim() || "unknown";
     const task = () =>
@@ -252,6 +259,10 @@ function registerEventHandlers(
         chatHistories,
         accountId,
       });
+    if (shouldBypassChatQueue(event)) {
+      await task();
+      return;
+    }
     await enqueue(chatId, task);
   };
   const resolveSenderDebounceId = (event: FeishuMessageEvent): string | undefined => {

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -593,8 +593,9 @@ describe("Feishu inbound debounce regressions", () => {
     setDedupPassThroughMocks();
 
     let releaseBlocked: (() => void) | undefined;
-    handleFeishuMessageMock.mockImplementation(async (params: { event?: FeishuMessageEvent }) => {
-      if (params.event?.message.message_id !== "om_blocked") {
+    handleFeishuMessageMock.mockImplementation(async (params) => {
+      const event = (params as { event?: FeishuMessageEvent } | undefined)?.event;
+      if (event?.message.message_id !== "om_blocked") {
         return;
       }
       await new Promise<void>((resolve) => {

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -1,6 +1,9 @@
 import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { hasControlCommand } from "../../../src/auto-reply/command-detection.js";
+import {
+  hasControlCommand,
+  isControlCommandMessage,
+} from "../../../src/auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
@@ -77,13 +80,13 @@ async function resolveReactionWithLookup(params: {
 
 type FeishuMention = NonNullable<FeishuMessageEvent["message"]["mentions"]>[number];
 
-function buildDebounceConfig(): ClawdbotConfig {
+function buildDebounceConfig(debounceMsByChannel = 20): ClawdbotConfig {
   return {
     messages: {
       inbound: {
         debounceMs: 0,
         byChannel: {
-          feishu: 20,
+          feishu: debounceMsByChannel,
         },
       },
     },
@@ -136,6 +139,7 @@ function createTextEvent(params: {
 async function setupDebounceMonitor(params?: {
   botOpenId?: string;
   botName?: string;
+  debounceMsByChannel?: number;
 }): Promise<(data: unknown) => Promise<void>> {
   const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
     handlers = registered;
@@ -143,7 +147,7 @@ async function setupDebounceMonitor(params?: {
   createEventDispatcherMock.mockReturnValue({ register });
 
   await monitorSingleAccount({
-    cfg: buildDebounceConfig(),
+    cfg: buildDebounceConfig(params?.debounceMsByChannel),
     account: buildDebounceAccount(),
     runtime: {
       log: vi.fn(),
@@ -398,6 +402,9 @@ describe("Feishu inbound debounce regressions", () => {
           text: {
             hasControlCommand,
           },
+          commands: {
+            isControlCommandMessage,
+          },
         },
       }),
     );
@@ -580,5 +587,33 @@ describe("Feishu inbound debounce regressions", () => {
     expect(combined.text).toBe("fresh");
     expect(recordSpy).toHaveBeenCalledWith("default:om_old");
     expect(recordSpy).not.toHaveBeenCalledWith("default:om_new");
+  });
+
+  it("bypasses the per-chat queue for control-command messages", async () => {
+    setDedupPassThroughMocks();
+
+    let releaseBlocked: (() => void) | undefined;
+    handleFeishuMessageMock.mockImplementation(async (params: { event?: FeishuMessageEvent }) => {
+      if (params.event?.message.message_id !== "om_blocked") {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        releaseBlocked = resolve;
+      });
+    });
+
+    const onMessage = await setupDebounceMonitor({ debounceMsByChannel: 0 });
+    const first = onMessage(createTextEvent({ messageId: "om_blocked", text: "run long task" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
+
+    const second = onMessage(createTextEvent({ messageId: "om_control", text: "/status" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(2);
+
+    releaseBlocked?.();
+    await Promise.all([first, second]);
   });
 });


### PR DESCRIPTION
## Summary
- restore Feishu text control-command fast path while keeping per-chat serialization for normal traffic
- bypass the Feishu per-chat monitor queue when an inbound message is a control-command message (`/stop`, `/new`, `/status`, etc.)
- add a regression test proving command-only messages execute immediately even when a previous same-chat run is still active

## Root cause
`extensions/feishu/src/monitor.account.ts` serializes all same-chat events through a per-chat queue. Since command-only Feishu messages also went through that queue, `/stop`/`/new`/`/status` could not execute until the active run finished.

## Fix
- detect control-command messages in the Feishu monitor event handler
- run those command messages immediately instead of enqueueing behind the active same-chat task

## Validation
- `pnpm test extensions/feishu/src/monitor.reaction.test.ts` ✅ (18 passed)

Closes #42803
