### PR TITLE
fix: derive Termux home when HOME resolves to /home

### DIFF
--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -35,6 +35,29 @@ describe("resolveEffectiveHomeDir", () => {
 
     expect(resolveEffectiveHomeDir(env)).toBe(path.resolve("/home/alice/svc"));
   });
+
+  it("uses Termux home derived from PREFIX when HOME is /home", () => {
+    const env = {
+      HOME: "/home",
+      PREFIX: "/data/data/com.termux/files/usr",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveEffectiveHomeDir(env, () => "/ignored")).toBe(
+      path.resolve("/data/data/com.termux/files/home"),
+    );
+  });
+
+  it("expands OPENCLAW_HOME with Termux-derived home when HOME is /home", () => {
+    const env = {
+      OPENCLAW_HOME: "~/workspace",
+      HOME: "/home",
+      PREFIX: "/data/data/com.termux/files/usr",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveEffectiveHomeDir(env, () => "/ignored")).toBe(
+      path.resolve("/data/data/com.termux/files/home/workspace"),
+    );
+  });
 });
 
 describe("resolveRequiredHomeDir", () => {

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -6,6 +6,34 @@ function normalize(value: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function resolveTermuxHome(env: NodeJS.ProcessEnv): string | undefined {
+  const prefix = normalize(env.PREFIX)?.replace(/\\/g, "/");
+  if (!prefix) {
+    return undefined;
+  }
+
+  const lower = prefix.toLowerCase();
+  if (!lower.startsWith("/data/data/com.termux/files/") || !lower.endsWith("/usr")) {
+    return undefined;
+  }
+
+  return `${prefix.slice(0, -4)}/home`;
+}
+
+function resolveEnvHome(env: NodeJS.ProcessEnv): string | undefined {
+  const envHome = normalize(env.HOME);
+  if (!envHome) {
+    return undefined;
+  }
+
+  const termuxHome = resolveTermuxHome(env);
+  if (termuxHome && envHome === "/home") {
+    return termuxHome;
+  }
+
+  return envHome;
+}
+
 export function resolveEffectiveHomeDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
@@ -18,8 +46,7 @@ function resolveRawHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): strin
   const explicitHome = normalize(env.OPENCLAW_HOME);
   if (explicitHome) {
     if (explicitHome === "~" || explicitHome.startsWith("~/") || explicitHome.startsWith("~\\")) {
-      const fallbackHome =
-        normalize(env.HOME) ?? normalize(env.USERPROFILE) ?? normalizeSafe(homedir);
+      const fallbackHome = resolveEnvHome(env) ?? normalize(env.USERPROFILE) ?? normalizeSafe(homedir);
       if (fallbackHome) {
         return explicitHome.replace(/^~(?=$|[\\/])/, fallbackHome);
       }
@@ -28,7 +55,7 @@ function resolveRawHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): strin
     return explicitHome;
   }
 
-  const envHome = normalize(env.HOME);
+  const envHome = resolveEnvHome(env);
   if (envHome) {
     return envHome;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: On Android/Termux, some environments report `HOME=/home`, which is not writable/valid for OpenClaw workspace initialization.
- Why it matters: setup/onboarding can fail with `ENOENT ... mkdir '/home'`, blocking first-run and gateway startup.
- What changed: `resolveEffectiveHomeDir` now derives Termux home from `PREFIX` (`/data/data/com.termux/files/usr` -> `/data/data/com.termux/files/home`) when `HOME` is the misleading `/home`; this is also applied when expanding `OPENCLAW_HOME=~...`.
- What did NOT change (scope boundary): no changes to non-Termux home resolution order, workspace layout, or config migration behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42828
- Related #

## User-visible / Behavior Changes

- On Termux environments where `HOME=/home` but `PREFIX` points to Termux, OpenClaw now resolves the effective home to `/data/data/com.termux/files/home`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 10 host (logic under test is cross-platform path resolution)
- Runtime/container: Node.js + Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Set env to mimic Termux mismatch (`HOME=/home`, `PREFIX=/data/data/com.termux/files/usr`).
2. Call `resolveEffectiveHomeDir`.
3. Verify resolved path points to Termux home.

### Expected

- Effective home resolves to `/data/data/com.termux/files/home` (and `OPENCLAW_HOME=~/...` expands from that base).

### Actual

- Added tests now pass for both direct resolution and `OPENCLAW_HOME` tilde expansion in this scenario.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm vitest run src/infra/home-dir.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: existing home-dir tests + new Termux-specific cases in `src/infra/home-dir.test.ts`.
- Edge cases checked: `OPENCLAW_HOME` tilde expansion with Termux-derived home.
- What you did **not** verify: full end-to-end run inside an actual Termux device session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore previous home-resolution behavior.
- Files/config to restore: `src/infra/home-dir.ts`.
- Known bad symptoms reviewers should watch for: unexpected home path fallback on niche Android-like envs with custom `PREFIX` formats.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: overly broad Termux detection could affect non-Termux environments that happen to use similar `PREFIX` format.
  - Mitigation: detection is constrained to `/data/data/com.termux/files/*` and only applies when `HOME` is exactly `/home`.
