### PR TITLE
fix(reply): suppress entire message when NO_REPLY appears on its own line

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -3,6 +3,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   HEARTBEAT_TOKEN,
   isSilentReplyText,
+  isSilentTokenOnOwnLine,
   SILENT_REPLY_TOKEN,
   stripSilentToken,
 } from "../tokens.js";
@@ -48,14 +49,25 @@ export function normalizeReplyPayload(
     }
     text = "";
   }
-  // Strip NO_REPLY from mixed-content messages (e.g. "😄 NO_REPLY") so the
-  // token never leaks to end users.  If stripping leaves nothing, treat it as
-  // silent just like the exact-match path above.  (#30916, #30955)
+  // When NO_REPLY appears on its own line (preceded by \n), the model intended
+  // silence — the preceding text is internal narration, not user-facing content.
+  // Suppress the entire message.  (#42472, #30916)
+  //
+  // When NO_REPLY appears inline (e.g. "😄 NO_REPLY"), strip only the token so
+  // the non-token text can still be delivered.  (#30916, #30955)
   if (text && text.includes(silentToken) && !isSilentReplyText(text, silentToken)) {
-    text = stripSilentToken(text, silentToken);
-    if (!text && !hasMedia && !hasChannelData) {
-      opts.onSkip?.("silent");
-      return null;
+    if (isSilentTokenOnOwnLine(text, silentToken)) {
+      if (!hasMedia && !hasChannelData) {
+        opts.onSkip?.("silent");
+        return null;
+      }
+      text = "";
+    } else {
+      text = stripSilentToken(text, silentToken);
+      if (!text && !hasMedia && !hasChannelData) {
+        opts.onSkip?.("silent");
+        return null;
+      }
     }
   }
   if (text && !trimmed) {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -116,13 +116,26 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).not.toContain("NO_REPLY");
   });
 
-  it("strips NO_REPLY appended after substantive text (#30916)", () => {
-    const result = normalizeReplyPayload({
-      text: "File's there. Not urgent.\n\nNO_REPLY",
-    });
-    expect(result).not.toBeNull();
-    expect(result!.text).toContain("File's there");
-    expect(result!.text).not.toContain("NO_REPLY");
+  it("suppresses entire message when NO_REPLY is on its own line (#42472)", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      { text: "File's there. Not urgent.\n\nNO_REPLY" },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
+
+  it("suppresses heartbeat narration followed by newline NO_REPLY (#42472)", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      {
+        text: "All tasks completed:\n• infra: 0 alerts\n• gmail: 0 new\nNO_REPLY",
+      },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
   });
 
   it("keeps NO_REPLY when used as leading substantive text", () => {

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isSilentReplyPrefixText, isSilentReplyText, stripSilentToken } from "./tokens.js";
+import {
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  isSilentTokenOnOwnLine,
+  stripSilentToken,
+} from "./tokens.js";
 
 describe("isSilentReplyText", () => {
   it("returns true for exact token", () => {
@@ -70,6 +75,42 @@ describe("stripSilentToken", () => {
 
   it("works with custom token", () => {
     expect(stripSilentToken("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe("done");
+  });
+});
+
+describe("isSilentTokenOnOwnLine", () => {
+  it("matches token on its own line after text (#42472)", () => {
+    expect(isSilentTokenOnOwnLine("Checked inbox.\n\nNO_REPLY")).toBe(true);
+    expect(isSilentTokenOnOwnLine("All done.\nNO_REPLY")).toBe(true);
+    expect(isSilentTokenOnOwnLine("tasks:\n• email: ok\n• wa: ok\nNO_REPLY")).toBe(true);
+  });
+
+  it("matches token with leading whitespace on its line", () => {
+    expect(isSilentTokenOnOwnLine("Some text.\n  NO_REPLY")).toBe(true);
+    expect(isSilentTokenOnOwnLine("Some text.\n  NO_REPLY  ")).toBe(true);
+  });
+
+  it("matches standalone token (no preceding text)", () => {
+    expect(isSilentTokenOnOwnLine("NO_REPLY")).toBe(true);
+  });
+
+  it("does not match inline token (same line as content)", () => {
+    expect(isSilentTokenOnOwnLine("😄 NO_REPLY")).toBe(false);
+    expect(isSilentTokenOnOwnLine("ok NO_REPLY")).toBe(false);
+  });
+
+  it("does not match token in the middle of text", () => {
+    expect(isSilentTokenOnOwnLine("NO_REPLY but here is more")).toBe(false);
+    expect(isSilentTokenOnOwnLine("Please NO_REPLY to this")).toBe(false);
+  });
+
+  it("returns false for empty/undefined input", () => {
+    expect(isSilentTokenOnOwnLine("")).toBe(false);
+  });
+
+  it("works with custom token", () => {
+    expect(isSilentTokenOnOwnLine("done\nHEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
+    expect(isSilentTokenOnOwnLine("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
   });
 });
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -56,10 +56,7 @@ export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKE
  * not user-facing content.  Inline occurrences like `"😄 NO_REPLY"` are left to
  * {@link stripSilentToken} so the non-token text can still be delivered.
  */
-export function isSilentTokenOnOwnLine(
-  text: string,
-  token: string = SILENT_REPLY_TOKEN,
-): boolean {
+export function isSilentTokenOnOwnLine(text: string, token: string = SILENT_REPLY_TOKEN): boolean {
   if (!text) {
     return false;
   }

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -49,6 +49,24 @@ export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKE
   return text.replace(getSilentTrailingRegex(token), "").trim();
 }
 
+/**
+ * Check whether the silent token appears on its own line at the end of the text.
+ * When the model outputs reasoning/narration followed by `\nNO_REPLY`, the entire
+ * response should be treated as silent — the preceding text is internal narration,
+ * not user-facing content.  Inline occurrences like `"😄 NO_REPLY"` are left to
+ * {@link stripSilentToken} so the non-token text can still be delivered.
+ */
+export function isSilentTokenOnOwnLine(
+  text: string,
+  token: string = SILENT_REPLY_TOKEN,
+): boolean {
+  if (!text) {
+    return false;
+  }
+  const escaped = escapeRegExp(token);
+  return new RegExp(`(\\n|^)\\s*${escaped}\\s*$`).test(text);
+}
+
 export function isSilentReplyPrefixText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,


### PR DESCRIPTION
## Problem

When the model outputs internal narration/reasoning followed by `NO_REPLY` on a separate line, the preceding text leaks to the user as a visible message.

```
Model output:    "Checked inbox, nothing new.\n\nNO_REPLY"
User sees:       "Checked inbox, nothing new."
Expected:        (nothing — the model intended silence)
```

This is especially common with heartbeat tasks and weaker models that output internal status summaries before appending `NO_REPLY`, but it also affects stronger models (Claude Opus 4.6) during heartbeat runs.

The current `stripSilentToken` removes the trailing `NO_REPLY` but delivers the preceding text. This violates the model's intent — when `NO_REPLY` appears on its own line, the preceding text is internal narration, not user-facing content.

## Fix

Introduces `isSilentTokenOnOwnLine()` in `src/auto-reply/tokens.ts` which checks whether `NO_REPLY` appears on its own line (preceded by `\n` or at the start of text). When it does, the **entire** response is treated as silent.

Inline occurrences like `"😄 NO_REPLY"` continue to use `stripSilentToken` and deliver the non-token text, preserving the existing behavior from #30916.

### Decision matrix

| Pattern | Before | After |
|---------|--------|-------|
| `"NO_REPLY"` (exact) | ✅ Silent | ✅ Silent (unchanged) |
| `"😄 NO_REPLY"` (inline) | Delivers `😄` | Delivers `😄` (unchanged) |
| `"text...\n\nNO_REPLY"` (own line) | ❌ Delivers `text...` | ✅ Silent |
| `"tasks:\n• ok\nNO_REPLY"` (own line) | ❌ Delivers `tasks: • ok` | ✅ Silent |
| `"NO_REPLY -- nope"` (leading) | Delivers as-is | Delivers as-is (unchanged) |

## Changes

- `src/auto-reply/tokens.ts`: Add `isSilentTokenOnOwnLine()`
- `src/auto-reply/reply/normalize-reply.ts`: Use own-line check before falling back to `stripSilentToken`
- `src/auto-reply/tokens.test.ts`: Add tests for `isSilentTokenOnOwnLine`
- `src/auto-reply/reply/reply-utils.test.ts`: Update `normalizeReplyPayload` tests

**+99 / -15 lines, 4 files.**

Closes #42472
Refs #30916, #33544, #27959, #30955