### PR TITLE
Infra: rewrite session paths after state dir migration

### DIFF
--- a/src/infra/state-migrations.state-dir.test.ts
+++ b/src/infra/state-migrations.state-dir.test.ts
@@ -49,4 +49,59 @@ describe("legacy state dir auto-migration", () => {
     expect(fs.readFileSync(path.join(root, ".moltbot", "marker.txt"), "utf-8")).toBe("ok");
     expect(fs.readFileSync(path.join(root, ".clawdbot", "marker.txt"), "utf-8")).toBe("ok");
   });
+
+  it("rewrites migrated sessionFile paths away from the legacy state dir", async () => {
+    const root = await makeTempRoot();
+    const legacyDir = path.join(root, ".clawdbot");
+    const legacySessionsDir = path.join(legacyDir, "agents", "main", "sessions");
+    const legacyTranscript = path.join(legacySessionsDir, "legacy-session.jsonl");
+
+    fs.mkdirSync(legacySessionsDir, { recursive: true });
+    fs.writeFileSync(legacyTranscript, '{"type":"session"}\n', "utf-8");
+    fs.writeFileSync(
+      path.join(legacySessionsDir, "sessions.json"),
+      JSON.stringify({
+        main: {
+          sessionId: "sess-1",
+          updatedAt: 1,
+          sessionFile: legacyTranscript,
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await autoMigrateLegacyStateDir({
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => root,
+    });
+
+    expect(result.migrated).toBe(true);
+
+    const migratedStorePath = path.join(
+      root,
+      ".openclaw",
+      "agents",
+      "main",
+      "sessions",
+      "sessions.json",
+    );
+    const migratedStore = JSON.parse(fs.readFileSync(migratedStorePath, "utf-8")) as Record<
+      string,
+      { sessionFile?: string }
+    >;
+    const migratedEntry = Object.values(migratedStore)[0];
+
+    expect(migratedEntry?.sessionFile).toBe(
+      path.join(root, ".openclaw", "agents", "main", "sessions", "legacy-session.jsonl"),
+    );
+    expect(migratedEntry?.sessionFile).not.toContain(".clawdbot");
+    expect(
+      fs.existsSync(
+        path.join(root, ".openclaw", "agents", "main", "sessions", "legacy-session.jsonl"),
+      ),
+    ).toBe(true);
+    expect(result.changes).toContain(
+      `Rewrote 1 migrated sessionFile path(s) in ${migratedStorePath}`,
+    );
+  });
 });

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -454,6 +454,107 @@ function isLegacyDirSymlinkMirror(legacyDir: string, targetDir: string): boolean
   return isLegacyTreeSymlinkMirror(legacyDir, realTargetDir);
 }
 
+function collectSessionStorePaths(rootDir: string): string[] {
+  const pending = [rootDir];
+  const stores: string[] = [];
+
+  while (pending.length > 0) {
+    const currentDir = pending.pop();
+    if (!currentDir) {
+      continue;
+    }
+    for (const entry of safeReadDir(currentDir)) {
+      const entryPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+      if (entry.isFile() && entry.name === "sessions.json") {
+        stores.push(entryPath);
+      }
+    }
+  }
+
+  return stores;
+}
+
+function rewriteSessionFilePathForStateDirMigration(
+  sessionFile: string | undefined,
+  legacyDir: string,
+  targetDir: string,
+): string | null {
+  const trimmed = sessionFile?.trim();
+  if (!trimmed || !path.isAbsolute(trimmed)) {
+    return null;
+  }
+  const absoluteSessionFile = path.normalize(trimmed);
+  if (!isWithinDir(legacyDir, absoluteSessionFile)) {
+    return null;
+  }
+  const relativeSessionFile = path.relative(legacyDir, absoluteSessionFile);
+  if (
+    !relativeSessionFile ||
+    relativeSessionFile === "." ||
+    relativeSessionFile.startsWith(`..${path.sep}`) ||
+    relativeSessionFile === ".." ||
+    path.isAbsolute(relativeSessionFile)
+  ) {
+    return null;
+  }
+  return path.join(targetDir, relativeSessionFile);
+}
+
+async function rewriteMigratedSessionStorePaths(params: {
+  legacyDir: string;
+  targetDir: string;
+}): Promise<{ changes: string[]; warnings: string[] }> {
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const sessionStorePaths = Array.from(
+    new Set(
+      [path.join(params.targetDir, "agents"), path.join(params.targetDir, "sessions")].flatMap(
+        (rootDir) => collectSessionStorePaths(rootDir),
+      ),
+    ),
+  );
+
+  for (const storePath of sessionStorePaths) {
+    const parsed = readSessionStoreJson5(storePath);
+    if (!parsed.ok) {
+      warnings.push(`Skipping unreadable migrated sessions store: ${storePath}`);
+      continue;
+    }
+
+    const rewrittenStore: Record<string, SessionEntry> = {};
+    let rewrittenCount = 0;
+    for (const [key, entry] of Object.entries(parsed.store)) {
+      const normalizedEntry = normalizeSessionEntry(entry);
+      if (!normalizedEntry) {
+        continue;
+      }
+      const rewrittenSessionFile = rewriteSessionFilePathForStateDirMigration(
+        normalizedEntry.sessionFile,
+        params.legacyDir,
+        params.targetDir,
+      );
+      if (rewrittenSessionFile && rewrittenSessionFile !== normalizedEntry.sessionFile) {
+        normalizedEntry.sessionFile = rewrittenSessionFile;
+        rewrittenCount += 1;
+      }
+      rewrittenStore[key] = normalizedEntry;
+    }
+
+    if (rewrittenCount === 0) {
+      continue;
+    }
+
+    await saveSessionStore(storePath, rewrittenStore, { skipMaintenance: true });
+    changes.push(`Rewrote ${rewrittenCount} migrated sessionFile path(s) in ${storePath}`);
+  }
+
+  return { changes, warnings };
+}
+
 export async function autoMigrateLegacyStateDir(params: {
   env?: NodeJS.ProcessEnv;
   homedir?: () => string;
@@ -593,9 +694,24 @@ export async function autoMigrateLegacyStateDir(params: {
         warnings.push(
           `Rollback failed; set OPENCLAW_STATE_DIR=${targetDir} to avoid split state: ${String(rollbackErr)}`,
         );
+        const rewritten = await rewriteMigratedSessionStorePaths({
+          legacyDir: legacyDir ?? targetDir,
+          targetDir,
+        });
+        changes.push(...rewritten.changes);
+        warnings.push(...rewritten.warnings);
         changes.push(`State dir: ${legacyDir ?? "unknown"} → ${targetDir}`);
       }
     }
+  }
+
+  if (legacyDir) {
+    const rewritten = await rewriteMigratedSessionStorePaths({
+      legacyDir,
+      targetDir,
+    });
+    changes.push(...rewritten.changes);
+    warnings.push(...rewritten.warnings);
   }
 
   return { migrated: changes.length > 0, skipped: false, changes, warnings };


### PR DESCRIPTION
Closes #5631.

## Summary
- rewrite migrated `sessionFile` entries after the top-level state dir move from `.clawdbot` to `.openclaw`
- scan migrated session stores under the new state dir so absolute transcript paths follow the renamed root
- add a regression test that exercises `autoMigrateLegacyStateDir()` with a legacy `agents/main/sessions/sessions.json`

## Testing
- pnpm test src/infra/state-migrations.state-dir.test.ts
- pnpm test src/config/sessions/sessions.test.ts
