### PR TITLE
Update: use a stable cwd for global package installs

### DIFF
--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -156,12 +156,12 @@ describe("runGatewayUpdate", () => {
   }
 
   async function runWithCommand(
-    runCommand: (argv: string[]) => Promise<CommandResult>,
+    runCommand: (argv: string[], options?: { cwd?: string }) => Promise<CommandResult>,
     options?: { channel?: "stable" | "beta"; tag?: string; cwd?: string },
   ) {
     return runGatewayUpdate({
       cwd: options?.cwd ?? tempDir,
-      runCommand: async (argv, _runOptions) => runCommand(argv),
+      runCommand: async (argv, runOptions) => runCommand(argv, { cwd: runOptions.cwd }),
       timeoutMs: 5000,
       ...(options?.channel ? { channel: options.channel } : {}),
       ...(options?.tag ? { tag: options.tag } : {}),
@@ -169,7 +169,7 @@ describe("runGatewayUpdate", () => {
   }
 
   async function runWithRunner(
-    runner: (argv: string[]) => Promise<CommandResult>,
+    runner: (argv: string[], options?: { cwd?: string }) => Promise<CommandResult>,
     options?: { channel?: "stable" | "beta"; tag?: string; cwd?: string },
   ) {
     return runWithCommand(runner, options);
@@ -417,6 +417,40 @@ describe("runGatewayUpdate", () => {
     expect(result.before?.version).toBe("1.0.0");
     expect(result.after?.version).toBe("2.0.0");
     expect(calls.some((call) => call === expectedInstallCommand)).toBe(true);
+  });
+
+  it("runs global npm updates from the stable global root instead of the package dir", async () => {
+    const nodeModules = path.join(tempDir, "node_modules");
+    const pkgRoot = path.join(nodeModules, "openclaw");
+    await seedGlobalPackageRoot(pkgRoot);
+
+    const installCwds: string[] = [];
+    const { runCommand } = createGlobalInstallHarness({
+      pkgRoot,
+      npmRootOutput: nodeModules,
+      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      onInstall: async () => {
+        await fs.writeFile(
+          path.join(pkgRoot, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "2.0.0" }),
+          "utf-8",
+        );
+      },
+    });
+
+    const result = await runWithCommand(
+      async (argv, options) => {
+        if (argv.join(" ") === "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error") {
+          installCwds.push(options?.cwd ?? "");
+        }
+        return runCommand(argv, options);
+      },
+      { cwd: pkgRoot },
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.steps[0]?.cwd).toBe(nodeModules);
+    expect(installCwds).toEqual([nodeModules]);
   });
 
   it("cleans stale npm rename dirs before global update", async () => {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -99,6 +99,11 @@ function normalizeDir(value?: string | null) {
   return path.resolve(trimmed);
 }
 
+function resolveStableGlobalUpdateCwd(pkgRoot: string): string {
+  const parentDir = path.dirname(pkgRoot);
+  return parentDir === pkgRoot ? os.homedir() : parentDir;
+}
+
 function resolveNodeModulesBinPackageRoot(argv1: string): string | null {
   const normalized = path.resolve(argv1);
   const parts = normalized.split(path.sep);
@@ -861,6 +866,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
   const beforeVersion = await readPackageVersion(pkgRoot);
   const globalManager = await detectGlobalInstallManagerForRoot(runCommand, pkgRoot, timeoutMs);
   if (globalManager) {
+    const globalUpdateCwd = resolveStableGlobalUpdateCwd(pkgRoot);
     const packageName = (await readPackageName(pkgRoot)) ?? DEFAULT_PACKAGE_NAME;
     await cleanupGlobalRenameDirs({
       globalRoot: path.dirname(pkgRoot),
@@ -874,7 +880,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       runCommand,
       name: "global update",
       argv: globalInstallArgs(globalManager, spec),
-      cwd: pkgRoot,
+      cwd: globalUpdateCwd,
       timeoutMs,
       progress,
       stepIndex: 0,
@@ -890,7 +896,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
           runCommand,
           name: "global update (omit optional)",
           argv: fallbackArgv,
-          cwd: pkgRoot,
+          cwd: globalUpdateCwd,
           timeoutMs,
           progress,
           stepIndex: 0,


### PR DESCRIPTION
Closes #7135.

## Summary
- run global package-manager updates from a stable parent directory instead of the package install dir being replaced
- keep npm fallback retries on the same stable cwd
- add a regression test that asserts the install step no longer runs inside the global `openclaw` package directory

## Testing
- pnpm test src/infra/update-runner.test.ts
- pnpm test src/cli/update-cli.test.ts
