### PR TITLE
skill(nano-banana-pro): add --base-url / GEMINI_BASE_URL proxy support

### DIFF
--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -50,6 +50,11 @@ API key
 - `GEMINI_API_KEY` env var
 - Or set `skills."nano-banana-pro".apiKey` / `skills."nano-banana-pro".env.GEMINI_API_KEY` in `~/.openclaw/openclaw.json`
 
+Custom base URL (optional, for proxies)
+
+- `GEMINI_BASE_URL` env var, or `--base-url` / `-u` argument
+- Overrides the default `https://generativelanguage.googleapis.com`; the proxy must speak the Google GenAI API format
+
 Specific aspect ratio (optional)
 
 ```bash

--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -42,6 +42,13 @@ def get_api_key(provided_key: str | None) -> str | None:
     return os.environ.get("GEMINI_API_KEY")
 
 
+def get_base_url(provided_url: str | None) -> str | None:
+    """Get base URL from argument first, then environment."""
+    if provided_url:
+        return provided_url
+    return os.environ.get("GEMINI_BASE_URL")
+
+
 def auto_detect_resolution(max_input_dim: int) -> str:
     """Infer output resolution from the largest input image dimension."""
     if max_input_dim >= 3000:
@@ -106,6 +113,10 @@ def main():
         "--api-key", "-k",
         help="Gemini API key (overrides GEMINI_API_KEY env var)"
     )
+    parser.add_argument(
+        "--base-url", "-u",
+        help="Custom base URL for the Gemini API (e.g., https://your-proxy.com)"
+    )
 
     args = parser.parse_args()
 
@@ -124,7 +135,12 @@ def main():
     from PIL import Image as PILImage
 
     # Initialise client
-    client = genai.Client(api_key=api_key)
+    base_url = get_base_url(args.base_url)
+    if base_url and not base_url.startswith(("http://", "https://")):
+        print(f"Error: --base-url must start with http:// or https://: {base_url!r}", file=sys.stderr)
+        sys.exit(1)
+    http_options = types.HttpOptions(base_url=base_url) if base_url else None
+    client = genai.Client(api_key=api_key, http_options=http_options)
 
     # Set up output path
     output_path = Path(args.filename)


### PR DESCRIPTION
## Summary

- Problem: `generate_image.py` hard-wires to `https://generativelanguage.googleapis.com`; users in restricted networks cannot reach it directly.
- Why it matters: Proxy support is a prerequisite for deploying the skill in network-restricted environments.
- What changed: Added `--base-url` / `-u` CLI argument and `GEMINI_BASE_URL` env var fallback; passed to `genai.Client` via `types.HttpOptions(base_url=...)`. Updated `SKILL.md` to document both.
- What did NOT change: All existing functionality (multi-image editing, resolution, aspect ratio) is unaffected; no behavior change when `--base-url` is not set.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New optional `--base-url` / `-u` argument on `generate_image.py`.
- New `GEMINI_BASE_URL` environment variable (lower priority than `--base-url`).
- When neither is set, behavior is identical to before.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — requests can now be routed to a user-supplied base URL instead of the default Google endpoint.
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk: user-supplied `--base-url` could point to an untrusted host, which would receive the API key and prompt. Mitigation: this is an operator-supplied argument; the user controls the value and is responsible for trusting the proxy.

## Repro + Verification

### Steps

1. `export GEMINI_API_KEY=<key>`
2. `export GEMINI_BASE_URL=https://your-proxy.com`
3. `uv run skills/nano-banana-pro/scripts/generate_image.py --prompt "a cat" --filename out.png`
4. Confirm requests hit the proxy.

Alternatively, pass `--base-url https://your-proxy.com` directly.

### Expected

- Requests routed through the specified base URL.
- Image saved and `MEDIA:` line printed as usual.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional `GEMINI_BASE_URL`
- Migration needed? No

## Failure Recovery (if this breaks)

- Unset `GEMINI_BASE_URL` / omit `--base-url` to revert to default behavior.

## Risks and Mitigations

None.
