### PR TITLE
fix(agent): auto-select auth profile for local provider runs

### DIFF
--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, type MockInstance, vi } from "vitest"
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 import "../cron/isolated-agent.mocks.js";
 import * as cliRunnerModule from "../agents/cli-runner.js";
+import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
 import { FailoverError } from "../agents/failover-error.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import * as modelSelectionModule from "../agents/model-selection.js";
@@ -686,6 +687,49 @@ describe("agentCommand", () => {
       expect(entry?.fallbackNoticeSelectedModel).toBeUndefined();
       expect(entry?.fallbackNoticeActiveModel).toBeUndefined();
       expect(entry?.fallbackNoticeReason).toBeUndefined();
+    });
+  });
+
+  it("auto-selects auth profile for provider-backed local sessions", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const sessionKey = "agent:main:subagent:openrouter-local";
+      mockConfig(home, store, {
+        model: { primary: "openrouter/auto" },
+        models: { "openrouter/auto": {} },
+      });
+
+      vi.mocked(ensureAuthProfileStore).mockReturnValue({
+        version: 1,
+        profiles: {
+          "openrouter:default": {
+            provider: "openrouter",
+            type: "api_key",
+            key: "sk-openrouter-test",
+            source: "config",
+          },
+        },
+      } as never);
+
+      await agentCommand(
+        {
+          message: "hi",
+          sessionKey,
+        },
+        runtime,
+      );
+
+      const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0];
+      expect(callArgs?.provider).toBe("openrouter");
+      expect(callArgs?.authProfileId).toBe("openrouter:default");
+      expect(callArgs?.authProfileIdSource).toBe("auto");
+
+      const saved = readSessionStore<{
+        authProfileOverride?: string;
+        authProfileOverrideSource?: string;
+      }>(store);
+      expect(saved[sessionKey]?.authProfileOverride).toBe("openrouter:default");
+      expect(saved[sessionKey]?.authProfileOverrideSource).toBe("auto");
     });
   });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -15,8 +15,7 @@ import {
   resolveAgentSkillsFilter,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
-import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
-import { clearSessionAuthProfileOverride } from "../agents/auth-profiles/session-override.js";
+import { resolveSessionAuthProfileOverride } from "../agents/auth-profiles/session-override.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../agents/bootstrap-budget.js";
 import { runCliAgent } from "../agents/cli-runner.js";
 import { getCliSessionId, setCliSessionId } from "../agents/cli-session.js";
@@ -1000,22 +999,16 @@ async function agentCommandInternal(
       }
     }
     if (sessionEntry) {
-      const authProfileId = sessionEntry.authProfileOverride;
-      if (authProfileId) {
-        const entry = sessionEntry;
-        const store = ensureAuthProfileStore();
-        const profile = store.profiles[authProfileId];
-        if (!profile || profile.provider !== provider) {
-          if (sessionStore && sessionKey) {
-            await clearSessionAuthProfileOverride({
-              sessionEntry: entry,
-              sessionStore,
-              sessionKey,
-              storePath,
-            });
-          }
-        }
-      }
+      await resolveSessionAuthProfileOverride({
+        cfg,
+        provider,
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey,
+        storePath,
+        isNewSession,
+      });
     }
 
     if (!resolvedThinkLevel) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw agent --local` only forwarded `authProfileId` when a session already had a manual override, so fresh sessions could call provider APIs without auth headers even when onboarding had saved provider credentials.
- Why it matters: local embedded runs failed with provider 401s (`Missing Authentication header`) right after clean onboarding, which blocks first-run CLI usage.
- What changed: replaced the ad-hoc stale override check with `resolveSessionAuthProfileOverride(...)` in `agentCommand`, so local runs auto-select/persist a valid provider-scoped auth profile for the session (and still clear invalid/mismatched overrides).
- What did NOT change (scope boundary): gateway `agent` route behavior, provider fallback ordering, and auth-profile storage format.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42839
- Related #

## User-visible / Behavior Changes

- `openclaw agent --local` now auto-selects a valid saved auth profile for the active provider on new sessions, instead of requiring a pre-existing manual session override.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 (dev), local vitest
- Runtime/container: Node.js 22 + pnpm
- Model/provider: openrouter/auto (mocked in unit test)
- Integration/channel (if any): CLI local embedded run path
- Relevant config (redacted): `agents.defaults.model.primary=openrouter/auto`

### Steps

1. Seed a local session with provider-backed model default (`openrouter/auto`) and an auth profile store containing `openrouter:default`.
2. Run `agentCommand` for a local embedded session.
3. Assert embedded runner args and persisted session entry.

### Expected

- Embedded run gets `authProfileId=openrouter:default` with `authProfileIdSource=auto`.
- Session store persists `authProfileOverride=openrouter:default`.

### Actual

- After fix, expected behavior is observed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm vitest run src/commands/agent.test.ts -t "auto-selects auth profile for provider-backed local sessions"`
- `pnpm vitest run src/commands/agent.test.ts -t "persists cleared model and auth override fields"`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new local provider-backed session now receives an auto-resolved auth profile and persists it to session state.
- Edge cases checked: existing stale/mismatched profile overrides are still handled by `resolveSessionAuthProfileOverride` (same helper already used by auto-reply/cron paths).
- What you did **not** verify: full end-to-end manual reproduction on Apple Silicon/macOS CLI with live OpenRouter key.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fix(agent): auto-select auth profile for local provider runs`.
- Files/config to restore: `src/commands/agent.ts`, `src/commands/agent.test.ts`.
- Known bad symptoms reviewers should watch for: local runs selecting an unintended profile for provider-scoped sessions.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: automatic profile rotation on brand-new sessions could pick a different valid profile than a user expected.
  - Mitigation: behavior uses existing `resolveSessionAuthProfileOverride` policy already shared by other runtime paths, keeping selection consistent across subsystems.
