### PR TITLE
fix(whatsapp): trigger watchdog reconnect even when no messages received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WhatsApp/watchdog: track connection-established time so the watchdog triggers a reconnect even when no messages have been received since connect, preventing stuck silent connections. (#99)
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.
 - Gateway/Control UI: keep dashboard auth tokens in session-scoped browser storage so same-tab refreshes preserve remote token auth without restoring long-lived localStorage token persistence, while scoping tokens to the selected gateway URL and fragment-only bootstrap flow. (#40892) thanks @velvet-shark.
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.

--- a/src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -201,6 +201,55 @@ describe("web auto-reply connection", () => {
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Stopping web monitoring"));
   });
 
+  it("forces reconnect when watchdog fires with no messages received (regression #99)", async () => {
+    vi.useFakeTimers();
+    try {
+      const sleep = vi.fn(async () => {});
+      const closeResolvers: Array<(reason: unknown) => void> = [];
+      const listenerFactory = vi.fn(async () => {
+        let resolveClose: (reason: unknown) => void = () => {};
+        const onClose = new Promise<unknown>((res) => {
+          resolveClose = res;
+          closeResolvers.push(res);
+        });
+        return {
+          close: vi.fn(),
+          onClose,
+          signalClose: (reason?: unknown) => resolveClose(reason),
+        };
+      });
+      const { controller, run } = startMonitorWebChannel({
+        monitorWebChannelFn: monitorWebChannel as never,
+        listenerFactory,
+        sleep,
+        heartbeatSeconds: 60,
+        messageTimeoutMs: 30,
+        watchdogCheckMs: 5,
+      });
+
+      await Promise.resolve();
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+      // Advance time past the timeout without sending any messages.
+      // The watchdog should still trigger based on connectionEstablishedAt.
+      await vi.advanceTimersByTimeAsync(200);
+      await Promise.resolve();
+      await vi.waitFor(
+        () => {
+          expect(listenerFactory).toHaveBeenCalledTimes(2);
+        },
+        { timeout: 250, interval: 2 },
+      );
+
+      controller.abort();
+      closeResolvers[1]?.({ status: 499, isLoggedOut: false });
+      await Promise.resolve();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("forces reconnect when watchdog closes without onClose", async () => {
     vi.useFakeTimers();
     try {

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -152,6 +152,7 @@ export async function monitorWebChannel(
     let heartbeat: NodeJS.Timeout | null = null;
     let watchdogTimer: NodeJS.Timeout | null = null;
     let lastMessageAt: number | null = null;
+    let connectionEstablishedAt: number | null = null;
     let handledMessages = 0;
     let _lastInboundMsg: WebInboundMsg | null = null;
     let unregisterUnhandled: (() => void) | null = null;
@@ -211,7 +212,8 @@ export async function monitorWebChannel(
       },
     });
 
-    Object.assign(status, createConnectedChannelStatusPatch());
+    connectionEstablishedAt = Date.now();
+    Object.assign(status, createConnectedChannelStatusPatch(connectionEstablishedAt));
     status.lastError = null;
     emitStatus();
 
@@ -294,10 +296,11 @@ export async function monitorWebChannel(
       }, heartbeatSeconds * 1000);
 
       watchdogTimer = setInterval(() => {
-        if (!lastMessageAt) {
+        const lastActivityAt = Math.max(connectionEstablishedAt ?? 0, lastMessageAt ?? 0);
+        if (!lastActivityAt) {
           return;
         }
-        const timeSinceLastMessage = Date.now() - lastMessageAt;
+        const timeSinceLastMessage = Date.now() - lastActivityAt;
         if (timeSinceLastMessage <= MESSAGE_TIMEOUT_MS) {
           return;
         }
@@ -306,7 +309,8 @@ export async function monitorWebChannel(
           {
             connectionId,
             minutesSinceLastMessage,
-            lastMessageAt: new Date(lastMessageAt),
+            connectionEstablishedAt: connectionEstablishedAt ? new Date(connectionEstablishedAt) : null,
+            lastMessageAt: lastMessageAt ? new Date(lastMessageAt) : null,
             messagesHandled: handledMessages,
           },
           "Message timeout detected - forcing reconnect",


### PR DESCRIPTION
## Summary

- Problem: WhatsApp watchdog timer skips reconnect when no messages received since connect — `lastMessageAt` is null so the interval returns early, leaving silent dead connections undetected.
- Why it matters: A stuck WhatsApp socket with no incoming traffic will never be recovered automatically, causing the gateway to appear connected but not process messages.
- What changed: Track `connectionEstablishedAt` when the connection is set up; watchdog now uses `Math.max(connectionEstablishedAt, lastMessageAt)` as the last-activity baseline.
- What did NOT change: Reconnect logic, backoff, heartbeat interval, or any other behavior.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #99

## User-visible / Behavior Changes

WhatsApp connections that receive no messages will now be detected and reconnected after the configured timeout (default 30 minutes), instead of staying silently stuck.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: WhatsApp (web provider)

### Steps

1. Connect WhatsApp gateway
2. Ensure no messages arrive for > `MESSAGE_TIMEOUT_MS` (default 30m)
3. Observe watchdog never fires (before fix)

### Expected

- Watchdog triggers reconnect after timeout even with no messages received

### Actual (before fix)

- Watchdog returns early because `lastMessageAt === null`

## Evidence

- [x] Failing test/log before + passing after — new regression test `"forces reconnect when watchdog fires with no messages received (regression #99)"` covers this case exactly.

## Human Verification (required)

- Verified scenarios: Code review of watchdog logic; regression test passes
- Edge cases checked: Connection with messages (existing behavior unchanged), connection with no messages (new fix)
- What you did not verify: Live WhatsApp environment test

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the watchdog block in `src/web/auto-reply/monitor.ts`
- Known bad symptoms: None expected; change only affects connections with zero messages received

## Risks and Mitigations

- Risk: Watchdog fires on a healthy connection that receives no messages for 30+ minutes
  - Mitigation: This is the intended behavior — a 30-minute silent connection is already considered stale by the existing timeout logic

AI-assisted: true