### PR TITLE
Fix Feishu dynamicAgentCreation routing on named accounts

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1187,6 +1187,7 @@ export async function handleFeishuMessage(params: {
           cfg,
           runtime,
           senderOpenId: ctx.senderOpenId,
+          accountId: account.accountId,
           dynamicCfg,
           log: (msg) => log(msg),
         });

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/feishu";
 import { describe, expect, it, vi } from "vitest";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
@@ -112,5 +115,53 @@ describe("maybeCreateDynamicAgent account-aware bindings", () => {
         },
       },
     ]);
+  });
+
+  it("creates a new agent and account-scoped binding when both are missing", async () => {
+    const writeConfigFile = vi.fn().mockResolvedValue(undefined);
+    const runtime = createRuntime(writeConfigFile);
+    const cfg: OpenClawConfig = { agents: { list: [] }, bindings: [] };
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "feishu-dynamic-agent-test-"));
+    const workspaceTemplate = path.join(tempRoot, "workspace-{agentId}");
+    const agentDirTemplate = path.join(tempRoot, "agents/{agentId}/agent");
+    const agentId = "feishu-ou_user_3";
+    const workspace = path.join(tempRoot, `workspace-${agentId}`);
+    const agentDir = path.join(tempRoot, "agents", agentId, "agent");
+
+    try {
+      const result = await maybeCreateDynamicAgent({
+        cfg,
+        runtime,
+        senderOpenId: "ou_user_3",
+        accountId: "  Router/Prod  ",
+        dynamicCfg: {
+          enabled: true,
+          workspaceTemplate,
+          agentDirTemplate,
+        },
+        log: () => {},
+      });
+
+      expect(result.created).toBe(true);
+      expect(result.agentId).toBe(agentId);
+      expect(writeConfigFile).toHaveBeenCalledTimes(1);
+      expect(result.updatedCfg.agents?.list).toContainEqual({
+        id: agentId,
+        workspace,
+        agentDir,
+      });
+      expect(result.updatedCfg.bindings).toContainEqual({
+        agentId,
+        match: {
+          channel: "feishu",
+          accountId: "router-prod",
+          peer: { kind: "direct", id: "ou_user_3" },
+        },
+      });
+      await expect(fs.access(workspace)).resolves.toBeUndefined();
+      await expect(fs.access(agentDir)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -1,0 +1,116 @@
+import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/feishu";
+import { describe, expect, it, vi } from "vitest";
+import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
+
+function createRuntime(writeConfigFile: ReturnType<typeof vi.fn>): PluginRuntime {
+  return {
+    config: {
+      writeConfigFile,
+    },
+  } as unknown as PluginRuntime;
+}
+
+describe("maybeCreateDynamicAgent account-aware bindings", () => {
+  it("adds account-scoped binding when only legacy account-less binding exists on non-default account", async () => {
+    const writeConfigFile = vi.fn().mockResolvedValue(undefined);
+    const runtime = createRuntime(writeConfigFile);
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "feishu-ou_user_1" }],
+      },
+      bindings: [
+        {
+          agentId: "feishu-ou_user_1",
+          match: {
+            channel: "feishu",
+            peer: { kind: "direct", id: "ou_user_1" },
+          },
+        },
+      ],
+    };
+
+    const result = await maybeCreateDynamicAgent({
+      cfg,
+      runtime,
+      senderOpenId: "ou_user_1",
+      accountId: "router-d",
+      dynamicCfg: { enabled: true },
+      log: () => {},
+    });
+
+    expect(result.created).toBe(true);
+    expect(writeConfigFile).toHaveBeenCalledTimes(1);
+    expect(result.updatedCfg.bindings).toContainEqual({
+      agentId: "feishu-ou_user_1",
+      match: {
+        channel: "feishu",
+        accountId: "router-d",
+        peer: { kind: "direct", id: "ou_user_1" },
+      },
+    });
+  });
+
+  it("treats legacy account-less binding as matching default account", async () => {
+    const writeConfigFile = vi.fn().mockResolvedValue(undefined);
+    const runtime = createRuntime(writeConfigFile);
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "feishu-ou_user_1" }],
+      },
+      bindings: [
+        {
+          agentId: "feishu-ou_user_1",
+          match: {
+            channel: "feishu",
+            peer: { kind: "direct", id: "ou_user_1" },
+          },
+        },
+      ],
+    };
+
+    const result = await maybeCreateDynamicAgent({
+      cfg,
+      runtime,
+      senderOpenId: "ou_user_1",
+      accountId: "default",
+      dynamicCfg: { enabled: true },
+      log: () => {},
+    });
+
+    expect(result.created).toBe(false);
+    expect(writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("writes explicit accountId when creating missing binding for existing agent", async () => {
+    const writeConfigFile = vi.fn().mockResolvedValue(undefined);
+    const runtime = createRuntime(writeConfigFile);
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "feishu-ou_user_2" }],
+      },
+      bindings: [],
+    };
+
+    const result = await maybeCreateDynamicAgent({
+      cfg,
+      runtime,
+      senderOpenId: "ou_user_2",
+      accountId: "router-d",
+      dynamicCfg: { enabled: true },
+      log: () => {},
+    });
+
+    expect(result.created).toBe(true);
+    expect(writeConfigFile).toHaveBeenCalledTimes(1);
+    expect(result.updatedCfg.bindings).toEqual([
+      {
+        agentId: "feishu-ou_user_2",
+        match: {
+          channel: "feishu",
+          accountId: "router-d",
+          peer: { kind: "direct", id: "ou_user_2" },
+        },
+      },
+    ]);
+  });
+});

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/feishu";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
@@ -136,21 +137,14 @@ function resolveUserPath(p: string): string {
   return p;
 }
 
-const DEFAULT_ACCOUNT_ID = "default";
-
-function normalizeAccountId(value: string | undefined): string {
-  const trimmed = value?.trim().toLowerCase();
-  return trimmed ? trimmed : DEFAULT_ACCOUNT_ID;
-}
-
 function bindingMatchesAccount(bindingAccountId: string | undefined, accountId: string): boolean {
-  const normalizedBindingAccountId = bindingAccountId?.trim().toLowerCase();
-  if (!normalizedBindingAccountId) {
+  const trimmedBindingAccountId = bindingAccountId?.trim();
+  if (!trimmedBindingAccountId) {
     // Legacy bindings without accountId only match the default account.
     return accountId === DEFAULT_ACCOUNT_ID;
   }
-  if (normalizedBindingAccountId === "*") {
+  if (trimmedBindingAccountId === "*") {
     return true;
   }
-  return normalizedBindingAccountId === accountId;
+  return normalizeAccountId(trimmedBindingAccountId) === accountId;
 }

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -18,10 +18,13 @@ export async function maybeCreateDynamicAgent(params: {
   cfg: OpenClawConfig;
   runtime: PluginRuntime;
   senderOpenId: string;
+  accountId: string;
   dynamicCfg: DynamicAgentCreationConfig;
   log: (msg: string) => void;
 }): Promise<MaybeCreateDynamicAgentResult> {
-  const { cfg, runtime, senderOpenId, dynamicCfg, log } = params;
+  const { cfg, runtime, senderOpenId, accountId, dynamicCfg, log } = params;
+
+  const normalizedAccountId = normalizeAccountId(accountId);
 
   // Check if there's already a binding for this user
   const existingBindings = cfg.bindings ?? [];
@@ -29,7 +32,8 @@ export async function maybeCreateDynamicAgent(params: {
     (b) =>
       b.match?.channel === "feishu" &&
       b.match?.peer?.kind === "direct" &&
-      b.match?.peer?.id === senderOpenId,
+      b.match?.peer?.id === senderOpenId &&
+      bindingMatchesAccount(b.match?.accountId, normalizedAccountId),
   );
 
   if (hasBinding) {
@@ -66,6 +70,7 @@ export async function maybeCreateDynamicAgent(params: {
           agentId,
           match: {
             channel: "feishu",
+            accountId: normalizedAccountId,
             peer: { kind: "direct", id: senderOpenId },
           },
         },
@@ -108,6 +113,7 @@ export async function maybeCreateDynamicAgent(params: {
         agentId,
         match: {
           channel: "feishu",
+          accountId: normalizedAccountId,
           peer: { kind: "direct", id: senderOpenId },
         },
       },
@@ -128,4 +134,23 @@ function resolveUserPath(p: string): string {
     return path.join(os.homedir(), p.slice(2));
   }
   return p;
+}
+
+const DEFAULT_ACCOUNT_ID = "default";
+
+function normalizeAccountId(value: string | undefined): string {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed ? trimmed : DEFAULT_ACCOUNT_ID;
+}
+
+function bindingMatchesAccount(bindingAccountId: string | undefined, accountId: string): boolean {
+  const normalizedBindingAccountId = bindingAccountId?.trim().toLowerCase();
+  if (!normalizedBindingAccountId) {
+    // Legacy bindings without accountId only match the default account.
+    return accountId === DEFAULT_ACCOUNT_ID;
+  }
+  if (normalizedBindingAccountId === "*") {
+    return true;
+  }
+  return normalizedBindingAccountId === accountId;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu `dynamicAgentCreation` created DM bindings without `match.accountId`, so named-account traffic could not match the generated binding and kept routing to `agent:main`.
- Why it matters: users with non-default Feishu account IDs cannot get isolated per-user dynamic agent sessions even though agent/binding creation appears successful.
- What changed: dynamic binding detection and creation are now account-aware (`accountId` is passed from Feishu runtime and written into new bindings), with legacy account-less bindings treated as default-account-only.
- What did NOT change (scope boundary): no behavior changes for group routing, broadcast logic, or non-Feishu channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42837
- Related #

## User-visible / Behavior Changes

- Feishu DM dynamic agent routing now works for named/non-default Feishu accounts.
- Existing legacy dynamic bindings without `accountId` continue to work for default account traffic.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu plugin
- Relevant config (redacted): `channels.feishu.dynamicAgentCreation.enabled=true`, named account ID (for example `router-d`)

### Steps

1. Configure Feishu with a named account (non-`default`) and enable `dynamicAgentCreation`.
2. Send DM from a Feishu user without existing account-scoped binding.
3. Observe generated binding and route session key.

### Expected

- Dynamic binding matches named account and DM routes to the per-user dynamic agent session.

### Actual

- Before fix, generated binding lacked `accountId` and routing stayed at `agent:main` for named accounts.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands run:

- `pnpm test extensions/feishu/src/dynamic-agent.test.ts` ✅ (3 passed)
- `pnpm test extensions/feishu/src/bot.test.ts` ✅ (52 passed)
- `pnpm format` ✅

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: account-aware dynamic binding creation for non-default Feishu accounts; legacy account-less binding behavior for default account; missing-binding add-path for existing dynamic agents.
- Edge cases checked: legacy bindings without `accountId` are treated as default-only to match router semantics.
- What you did **not** verify: live Feishu tenant end-to-end message exchange.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: disable `channels.feishu.dynamicAgentCreation.enabled` or revert this commit.
- Files/config to restore: `extensions/feishu/src/dynamic-agent.ts`, `extensions/feishu/src/bot.ts`.
- Known bad symptoms reviewers should watch for: unexpected duplicate dynamic bindings per DM user/account.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: users with pre-existing legacy bindings might accumulate an additional account-scoped binding for named accounts.
  - Mitigation: this is intentional to restore correct routing; matching logic avoids repeated writes once account-scoped binding exists.
