### PR TITLE
fix(infra): derive home directory from PREFIX on Android/Termux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Infra/Termux: derive the OpenClaw home directory from a genuine Termux `PREFIX` when `HOME` is unset, while preserving `OPENCLAW_HOME`, `HOME`, and `USERPROFILE` precedence for normal path resolution and tilde expansion. Fixes #42828; carries forward #42895. Thanks @Hopotta and @VibhorGautam.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -119,7 +119,7 @@ Both resolve from process env at activation time. SecretRef details are document
 
 When set, `OPENCLAW_HOME` replaces the system home directory (`$HOME` / `os.homedir()`) for all internal path resolution. This enables full filesystem isolation for headless service accounts.
 
-**Precedence:** `OPENCLAW_HOME` > `$HOME` > `USERPROFILE` > `os.homedir()`
+**Precedence:** `OPENCLAW_HOME` > `$HOME` > `USERPROFILE` > Termux `PREFIX` home fallback on Android > `os.homedir()`
 
 **Example** (macOS LaunchDaemon):
 
@@ -131,7 +131,7 @@ When set, `OPENCLAW_HOME` replaces the system home directory (`$HOME` / `os.home
 </dict>
 ```
 
-`OPENCLAW_HOME` can also be set to a tilde path (e.g. `~/svc`), which gets expanded using `$HOME` before use.
+`OPENCLAW_HOME` can also be set to a tilde path (e.g. `~/svc`), which gets expanded using the same OS home fallback chain before use.
 
 ## nvm users: web_fetch TLS failures
 

--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -58,6 +58,7 @@ describe("resolveEffectiveHomeDir", () => {
     expect(resolveEffectiveHomeDir(env, homedir)).toBe(path.resolve(expected));
   });
 
+<<<<<<< HEAD
   it.each([
     {
       name: "expands ~/ using HOME",
@@ -78,6 +79,48 @@ describe("resolveEffectiveHomeDir", () => {
     },
   ])("$name", ({ env, expected }) => {
     expect(resolveEffectiveHomeDir(env)).toBe(path.resolve(expected));
+=======
+  it("falls back to HOME then USERPROFILE then homedir", () => {
+    expect(resolveEffectiveHomeDir({ HOME: "/home/alice" } as NodeJS.ProcessEnv)).toBe(
+      path.resolve("/home/alice"),
+    );
+    expect(resolveEffectiveHomeDir({ USERPROFILE: "C:/Users/alice" } as NodeJS.ProcessEnv)).toBe(
+      path.resolve("C:/Users/alice"),
+    );
+    expect(resolveEffectiveHomeDir({} as NodeJS.ProcessEnv, () => "/fallback")).toBe(
+      path.resolve("/fallback"),
+    );
+  });
+
+  it("derives home from PREFIX on Android/Termux when HOME is unset", () => {
+    const env = {
+      PREFIX: "/data/data/com.termux/files/usr",
+      ANDROID_DATA: "/data",
+    } as NodeJS.ProcessEnv;
+    expect(resolveEffectiveHomeDir(env, () => "/home")).toBe(
+      path.resolve("/data/data/com.termux/files/home"),
+    );
+  });
+
+  it("prefers HOME over PREFIX-derived path on Termux", () => {
+    const env = {
+      HOME: "/data/data/com.termux/files/home",
+      PREFIX: "/data/data/com.termux/files/usr",
+      ANDROID_DATA: "/data",
+    } as NodeJS.ProcessEnv;
+    expect(resolveEffectiveHomeDir(env)).toBe(
+      path.resolve("/data/data/com.termux/files/home"),
+    );
+  });
+
+  it("expands OPENCLAW_HOME when set to ~", () => {
+    const env = {
+      OPENCLAW_HOME: "~/svc",
+      HOME: "/home/alice",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveEffectiveHomeDir(env)).toBe(path.resolve("/home/alice/svc"));
+>>>>>>> 9215bb9bdf (fix(infra): derive home directory from PREFIX on Android/Termux)
   });
 });
 

--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -107,6 +107,14 @@ describe("resolveEffectiveHomeDir", () => {
     expect(resolveEffectiveHomeDir(env, () => "/fallback")).toBe(path.resolve("/fallback"));
   });
 
+  it("ignores PREFIX values that only mention com.termux outside the Termux app root", () => {
+    const env = {
+      PREFIX: "/tmp/com.termux/usr",
+      ANDROID_DATA: "/data",
+    } as NodeJS.ProcessEnv;
+    expect(resolveEffectiveHomeDir(env, () => "/fallback")).toBe(path.resolve("/fallback"));
+  });
+
   it("uses Termux PREFIX for tilde expansion when HOME is unset", () => {
     const env = {
       OPENCLAW_HOME: "~/workspace",

--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -58,7 +58,6 @@ describe("resolveEffectiveHomeDir", () => {
     expect(resolveEffectiveHomeDir(env, homedir)).toBe(path.resolve(expected));
   });
 
-<<<<<<< HEAD
   it.each([
     {
       name: "expands ~/ using HOME",
@@ -79,17 +78,6 @@ describe("resolveEffectiveHomeDir", () => {
     },
   ])("$name", ({ env, expected }) => {
     expect(resolveEffectiveHomeDir(env)).toBe(path.resolve(expected));
-=======
-  it("falls back to HOME then USERPROFILE then homedir", () => {
-    expect(resolveEffectiveHomeDir({ HOME: "/home/alice" } as NodeJS.ProcessEnv)).toBe(
-      path.resolve("/home/alice"),
-    );
-    expect(resolveEffectiveHomeDir({ USERPROFILE: "C:/Users/alice" } as NodeJS.ProcessEnv)).toBe(
-      path.resolve("C:/Users/alice"),
-    );
-    expect(resolveEffectiveHomeDir({} as NodeJS.ProcessEnv, () => "/fallback")).toBe(
-      path.resolve("/fallback"),
-    );
   });
 
   it("derives home from PREFIX on Android/Termux when HOME is unset", () => {
@@ -108,9 +96,28 @@ describe("resolveEffectiveHomeDir", () => {
       PREFIX: "/data/data/com.termux/files/usr",
       ANDROID_DATA: "/data",
     } as NodeJS.ProcessEnv;
-    expect(resolveEffectiveHomeDir(env)).toBe(
-      path.resolve("/data/data/com.termux/files/home"),
-    );
+    expect(resolveEffectiveHomeDir(env)).toBe(path.resolve("/data/data/com.termux/files/home"));
+  });
+
+  it("ignores PREFIX without com.termux to avoid false positives in generic chroots", () => {
+    const env = {
+      PREFIX: "/usr",
+      ANDROID_DATA: "/data",
+    } as NodeJS.ProcessEnv;
+    expect(resolveEffectiveHomeDir(env, () => "/fallback")).toBe(path.resolve("/fallback"));
+  });
+
+  it("uses Termux PREFIX for tilde expansion when HOME is unset", () => {
+    const env = {
+      OPENCLAW_HOME: "~/workspace",
+      PREFIX: "/data/data/com.termux/files/usr",
+      ANDROID_DATA: "/data",
+    } as NodeJS.ProcessEnv;
+    expect(
+      resolveEffectiveHomeDir(env, () => {
+        throw new Error("no homedir");
+      }),
+    ).toBe(path.resolve("/data/data/com.termux/files/home/workspace"));
   });
 
   it("expands OPENCLAW_HOME when set to ~", () => {
@@ -120,7 +127,6 @@ describe("resolveEffectiveHomeDir", () => {
     } as NodeJS.ProcessEnv;
 
     expect(resolveEffectiveHomeDir(env)).toBe(path.resolve("/home/alice/svc"));
->>>>>>> 9215bb9bdf (fix(infra): derive home directory from PREFIX on Android/Termux)
   });
 });
 

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -29,6 +29,21 @@ export function resolveOsHomeDir(
   return raw ? path.resolve(raw) : undefined;
 }
 
+/** Derive a Termux home from PREFIX when running on Android. */
+function resolveTermuxHome(env: NodeJS.ProcessEnv): string | undefined {
+  const prefix = normalize(env.PREFIX);
+  if (!prefix || !normalize(env.ANDROID_DATA)) {
+    return undefined;
+  }
+  // Only trust PREFIX values that look like a real Termux installation
+  // (e.g. /data/data/com.termux/files/usr) to avoid misfires in generic
+  // Android chroots where PREFIX may be something like /usr.
+  if (!prefix.includes("com.termux")) {
+    return undefined;
+  }
+  return path.resolve(prefix, "..", "home");
+}
+
 function resolveRawHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): string | undefined {
   const explicitHome = normalize(env.OPENCLAW_HOME);
   if (explicitHome) {
@@ -54,18 +69,15 @@ function resolveRawOsHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): str
   if (userProfile) {
     return userProfile;
   }
-<<<<<<< HEAD
-=======
 
   // On Android/Termux, os.homedir() reads /etc/passwd and returns /home which
   // does not exist. Derive a usable home from Termux's PREFIX before falling
   // back to os.homedir().
-  const prefix = normalize(env.PREFIX);
-  if (prefix && normalize(env.ANDROID_DATA)) {
-    return path.resolve(prefix, "..", "home");
+  const termuxHome = resolveTermuxHome(env);
+  if (termuxHome) {
+    return termuxHome;
   }
 
->>>>>>> 9215bb9bdf (fix(infra): derive home directory from PREFIX on Android/Termux)
   return normalizeSafe(homedir);
 }
 

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -54,6 +54,18 @@ function resolveRawOsHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): str
   if (userProfile) {
     return userProfile;
   }
+<<<<<<< HEAD
+=======
+
+  // On Android/Termux, os.homedir() reads /etc/passwd and returns /home which
+  // does not exist. Derive a usable home from Termux's PREFIX before falling
+  // back to os.homedir().
+  const prefix = normalize(env.PREFIX);
+  if (prefix && normalize(env.ANDROID_DATA)) {
+    return path.resolve(prefix, "..", "home");
+  }
+
+>>>>>>> 9215bb9bdf (fix(infra): derive home directory from PREFIX on Android/Termux)
   return normalizeSafe(homedir);
 }
 

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -38,7 +38,7 @@ function resolveTermuxHome(env: NodeJS.ProcessEnv): string | undefined {
   // Only trust PREFIX values that look like a real Termux installation
   // (e.g. /data/data/com.termux/files/usr) to avoid misfires in generic
   // Android chroots where PREFIX may be something like /usr.
-  if (!prefix.includes("com.termux")) {
+  if (!/(?:^|\/)com\.termux\/files\/usr\/?$/u.test(prefix.replace(/\\/gu, "/"))) {
     return undefined;
   }
   return path.resolve(prefix, "..", "home");


### PR DESCRIPTION
## Summary

- Problem: On Android/Termux, `os.homedir()` reads `/etc/passwd` and returns `/home` which does not exist. OpenClaw crashes at startup because it cannot create its config directory.
- Why it matters: Termux is the primary way to run Node on Android. Without this fix, OpenClaw is unusable there unless the user manually sets HOME.
- What changed: Added a `resolveTermuxHome()` helper that derives `/data/data/com.termux/files/home` from the PREFIX env var. Wired it into both the main fallback chain and the tilde-expansion chain for OPENCLAW_HOME.
- What did NOT change (scope boundary): No changes to non-Android platforms. HOME/USERPROFILE still take priority when set.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #42828

## User-visible / Behavior Changes

OpenClaw now starts correctly on Termux without requiring the user to manually export HOME.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Android (Termux)

### Steps

1. Install Termux, install Node via `pkg install nodejs`
2. Run `openclaw` without setting HOME
3. Observe crash trying to create config in `/home`

### Expected

- OpenClaw resolves home to `/data/data/com.termux/files/home` and starts normally

### Actual (before fix)

- Crashes with ENOENT or writes to nonexistent `/home`

## Evidence

- [x] Failing test/log before + passing after
- [x] 4 new tests covering: PREFIX derivation, HOME priority over PREFIX, non-Termux PREFIX rejection, and tilde expansion with PREFIX fallback

## Human Verification (required)

- Verified scenarios: PREFIX fallback, HOME taking priority, tilde expansion chain, non-Termux PREFIX rejection
- Edge cases checked: generic Android chroots with PREFIX=/usr (rejected by com.termux check), OPENCLAW_HOME=~/workspace on Termux without HOME
- What I did not verify: real Termux device (verified via unit tests matching Termux env layout)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert the `resolveTermuxHome()` helper and restore the inline PREFIX check
- Only affects Android/Termux - no impact on other platforms

## Risks and Mitigations

- Risk: Custom Android environments with PREFIX containing "com.termux" but unusual directory layouts
  - Mitigation: The parent-of-PREFIX + "home" pattern matches Termux's documented layout. Non-standard setups can still override with HOME or OPENCLAW_HOME.