### PR TITLE
feat(web-search): make Brave Search base URL configurable

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -468,3 +468,48 @@ describe("mapBraveLlmContextResults", () => {
     expect(results[0].siteName).toBeUndefined();
   });
 });
+
+describe("resolveBraveBaseUrl", () => {
+  const { resolveBraveBaseUrl } = __testing;
+  const DEFAULT = "https://api.search.brave.com";
+
+  it("returns default when brave config is empty", () => {
+    expect(resolveBraveBaseUrl({})).toBe(DEFAULT);
+  });
+
+  it("returns default when baseUrl is not set", () => {
+    expect(resolveBraveBaseUrl({ mode: "web" })).toBe(DEFAULT);
+  });
+
+  it("returns config baseUrl when set", () => {
+    expect(resolveBraveBaseUrl({ baseUrl: "https://my-proxy.example.com" })).toBe(
+      "https://my-proxy.example.com",
+    );
+  });
+
+  it("trims whitespace from config baseUrl", () => {
+    expect(resolveBraveBaseUrl({ baseUrl: "  https://my-proxy.example.com  " })).toBe(
+      "https://my-proxy.example.com",
+    );
+  });
+
+  it("returns BRAVE_BASE_URL env var when config baseUrl is not set", () => {
+    withEnv({ BRAVE_BASE_URL: "https://env-proxy.example.com" }, () => {
+      expect(resolveBraveBaseUrl({})).toBe("https://env-proxy.example.com");
+    });
+  });
+
+  it("config baseUrl takes precedence over env var", () => {
+    withEnv({ BRAVE_BASE_URL: "https://env-proxy.example.com" }, () => {
+      expect(resolveBraveBaseUrl({ baseUrl: "https://config-proxy.example.com" })).toBe(
+        "https://config-proxy.example.com",
+      );
+    });
+  });
+
+  it("falls back to default when env var is empty string", () => {
+    withEnv({ BRAVE_BASE_URL: "" }, () => {
+      expect(resolveBraveBaseUrl({})).toBe(DEFAULT);
+    });
+  });
+});

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -29,9 +29,6 @@ const MAX_SEARCH_COUNT = 10;
 const BRAVE_DEFAULT_BASE_URL = "https://api.search.brave.com";
 const BRAVE_SEARCH_PATH = "/res/v1/web/search";
 const BRAVE_LLM_CONTEXT_PATH = "/res/v1/llm/context";
-// Keep full-URL constants for backward-compatibility (used as fallback strings).
-const BRAVE_SEARCH_ENDPOINT = `${BRAVE_DEFAULT_BASE_URL}${BRAVE_SEARCH_PATH}`;
-const BRAVE_LLM_CONTEXT_ENDPOINT = `${BRAVE_DEFAULT_BASE_URL}${BRAVE_LLM_CONTEXT_PATH}`;
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
@@ -1632,7 +1629,7 @@ async function runWebSearch(params: {
               : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
-      ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
+      ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}:${providerSpecificKey}`
       : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -26,8 +26,12 @@ const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as co
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
-const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
-const BRAVE_LLM_CONTEXT_ENDPOINT = "https://api.search.brave.com/res/v1/llm/context";
+const BRAVE_DEFAULT_BASE_URL = "https://api.search.brave.com";
+const BRAVE_SEARCH_PATH = "/res/v1/web/search";
+const BRAVE_LLM_CONTEXT_PATH = "/res/v1/llm/context";
+// Keep full-URL constants for backward-compatibility (used as fallback strings).
+const BRAVE_SEARCH_ENDPOINT = `${BRAVE_DEFAULT_BASE_URL}${BRAVE_SEARCH_PATH}`;
+const BRAVE_LLM_CONTEXT_ENDPOINT = `${BRAVE_DEFAULT_BASE_URL}${BRAVE_LLM_CONTEXT_PATH}`;
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
@@ -309,6 +313,7 @@ type BraveLlmContextResponse = {
 
 type BraveConfig = {
   mode?: string;
+  baseUrl?: string;
 };
 
 type PerplexityConfig = {
@@ -682,6 +687,12 @@ function resolveBraveConfig(search?: WebSearchConfig): BraveConfig {
 
 function resolveBraveMode(brave: BraveConfig): "web" | "llm-context" {
   return brave.mode === "llm-context" ? "llm-context" : "web";
+}
+
+function resolveBraveBaseUrl(brave: BraveConfig): string {
+  const fromConfig = brave?.baseUrl?.trim();
+  const fromEnv = process.env.BRAVE_BASE_URL?.trim();
+  return fromConfig || fromEnv || BRAVE_DEFAULT_BASE_URL;
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
@@ -1529,6 +1540,7 @@ async function runBraveLlmContextSearch(params: {
   country?: string;
   search_lang?: string;
   freshness?: string;
+  baseUrl?: string;
 }): Promise<{
   results: Array<{
     url: string;
@@ -1538,7 +1550,7 @@ async function runBraveLlmContextSearch(params: {
   }>;
   sources?: BraveLlmContextResponse["sources"];
 }> {
-  const url = new URL(BRAVE_LLM_CONTEXT_ENDPOINT);
+  const url = new URL(BRAVE_LLM_CONTEXT_PATH, params.baseUrl ?? BRAVE_DEFAULT_BASE_URL);
   url.searchParams.set("q", params.query);
   if (params.country) {
     url.searchParams.set("country", params.country);
@@ -1603,6 +1615,7 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   braveMode?: "web" | "llm-context";
+  braveBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
   const providerSpecificKey =
@@ -1614,7 +1627,9 @@ async function runWebSearch(params: {
           ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-            : "";
+            : params.provider === "brave"
+              ? (params.braveBaseUrl ?? BRAVE_DEFAULT_BASE_URL)
+              : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
       ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
@@ -1781,6 +1796,7 @@ async function runWebSearch(params: {
       country: params.country,
       search_lang: params.search_lang,
       freshness: params.freshness,
+      baseUrl: params.braveBaseUrl,
     });
 
     const mapped = llmResults.map((entry) => ({
@@ -1809,7 +1825,7 @@ async function runWebSearch(params: {
     return payload;
   }
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  const url = new URL(BRAVE_SEARCH_PATH, params.braveBaseUrl ?? BRAVE_DEFAULT_BASE_URL);
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {
@@ -2186,6 +2202,7 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         braveMode,
+        braveBaseUrl: resolveBraveBaseUrl(braveConfig),
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -2232,5 +2232,6 @@ export const __testing = {
   extractKimiCitations,
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,
+  resolveBraveBaseUrl,
   mapBraveLlmContextResults,
 } as const;

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -455,6 +455,8 @@ export type ToolsConfig = {
       brave?: {
         /** Brave Search mode: "web" (standard results) or "llm-context" (pre-extracted page content). Default: "web". */
         mode?: "web" | "llm-context";
+        /** Base URL for Brave API requests. Defaults to "https://api.search.brave.com". Useful for pointing at a proxy. Can also be set via BRAVE_BASE_URL env var. */
+        baseUrl?: string;
       };
       /** Gemini-specific configuration (used when provider="gemini"). */
       gemini?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -311,6 +311,7 @@ export const ToolsWebSearchSchema = z
     brave: z
       .object({
         mode: z.union([z.literal("web"), z.literal("llm-context")]).optional(),
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Allow the Brave Search API base URL to be customised, so users can point requests at a reverse proxy or internal mirror instead of `https://api.search.brave.com`.

## Changes

### `src/config/types.tools.ts`
Added `baseUrl?: string` to the `brave` config object (JSDoc documents the env-var fallback).

### `src/config/zod-schema.agent-runtime.ts`
Added `baseUrl: z.string().optional()` to the Brave Zod schema so the new field passes validation.

### `src/agents/tools/web-search.ts`
- Extracted `BRAVE_DEFAULT_BASE_URL`, `BRAVE_SEARCH_PATH`, `BRAVE_LLM_CONTEXT_PATH` constants; removed the old full-URL constants (dead code).
- Added `baseUrl?: string` to `BraveConfig` type.
- Added `resolveBraveBaseUrl(brave)`: config `baseUrl` takes precedence, then `BRAVE_BASE_URL` env var, then default.
- `runBraveLlmContextSearch` now accepts and uses `baseUrl`.
- `runWebSearch` params extended with `braveBaseUrl`; both Brave search branches use it.
- `providerSpecificKey` for the cache includes `braveBaseUrl` in **both** the web and llm-context branches to avoid cross-origin cache hits.
- `createWebSearchTool` passes `resolveBraveBaseUrl(braveConfig)` into `runWebSearch`.

## Config example

```yaml
tools:
  web:
    search:
      provider: brave
      brave:
        baseUrl: "https://my-brave-proxy.example.com"  # optional; defaults to https://api.search.brave.com
```

Or via environment variable:
```
BRAVE_BASE_URL=https://my-brave-proxy.example.com
```

## Behaviour

- **No config, no env var** → identical to current behaviour (uses `https://api.search.brave.com`).
- URL replaces only the *origin*; the API paths (`/res/v1/web/search`, `/res/v1/llm/context`) are unchanged.
- Config value takes precedence over the env var.