### PR TITLE
fix(agent): canonicalize bare CLI session-id before session_status lookup

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -36,6 +36,7 @@ import {
 import type { AnyAgentTool } from "./common.js";
 import { readStringParam } from "./common.js";
 import {
+  looksLikeSessionKey,
   shouldResolveSessionIdInput,
   resolveInternalSessionKey,
   resolveMainSessionAlias,
@@ -189,8 +190,20 @@ export function createSessionStatusTool(opts?: {
       const a2aPolicy = createAgentToAgentPolicy(cfg);
 
       const requestedKeyParam = readStringParam(params, "sessionKey");
-      let requestedKeyRaw = requestedKeyParam ?? opts?.agentSessionKey;
-      if (!requestedKeyRaw?.trim()) {
+      // When no explicit sessionKey is provided by the model and the implicit fallback
+      // from opts.agentSessionKey is not key-shaped (e.g. a bare CLI --session-id like
+      // "local-status-probe"), canonicalize to the agent's main session key so local
+      // embedded runs don't fail with "Unknown sessionId: <raw-cli-id>".
+      const fallbackRaw = opts?.agentSessionKey?.trim();
+      let requestedKeyRaw: string;
+      if (requestedKeyParam) {
+        requestedKeyRaw = requestedKeyParam;
+      } else if (fallbackRaw && looksLikeSessionKey(fallbackRaw)) {
+        requestedKeyRaw = fallbackRaw;
+      } else if (fallbackRaw) {
+        // Bare CLI id – derive the canonical main session key for the default agent.
+        requestedKeyRaw = buildAgentMainSessionKey({ agentId: DEFAULT_AGENT_ID, mainKey });
+      } else {
         throw new Error("sessionKey required");
       }
 


### PR DESCRIPTION
## Summary

Fixes #42692

When `openclaw agent --local` passes a bare CLI `--session-id` (e.g. `local-status-probe`) into embedded tool opts as `agentSessionKey`, the `session_status` tool was using that raw value as the session lookup key. Since the value isn't key-shaped (doesn't match `agent:*`, `main`, etc.), `resolveSessionEntry` returned null and the tool threw `Unknown sessionId: local-status-probe`.

## Root cause

In `createSessionStatusTool`, the fallback `opts?.agentSessionKey` was used directly as `requestedKeyRaw` without checking if it's a canonical key shape. A bare CLI transcript ID slips through as a non-resolvable value.

## Fix

When no explicit `sessionKey` is provided by the model and the `opts.agentSessionKey` fallback is **not** key-shaped (per `looksLikeSessionKey`), canonicalize it to `buildAgentMainSessionKey({ agentId: DEFAULT_AGENT_ID, mainKey })` instead of passing the raw CLI id through. Key-shaped fallbacks (e.g. `agent:main:main`) continue to work as before.

## Changes

- `src/agents/tools/session-status-tool.ts`: add `looksLikeSessionKey` import; replace `requestedKeyParam ?? opts?.agentSessionKey` with explicit canonicalization when the fallback is not key-shaped.

## Test

```bash
openclaw agent --local --json \
  --session-id local-status-probe \
  --message "You must call session_status before answering and return exactly the active model key and nothing else."
```

Before: `[tools] session_status failed: Unknown sessionId: local-status-probe`
After: tool resolves the main session entry and returns the model key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)