### PR TITLE
fix(web-search): strip accidental /chat/completions suffix from Kimi baseUrl

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1416,7 +1416,12 @@ async function runKimiSearch(params: {
   model: string;
   timeoutSeconds: number;
 }): Promise<{ content: string; citations: string[] }> {
-  const baseUrl = params.baseUrl.trim().replace(/\/$/, "");
+  // Strip a stray trailing /chat/completions so users who copy the full endpoint
+  // URL into baseUrl don't end up with a doubled path like /v1/chat/completions/chat/completions.
+  const baseUrl = params.baseUrl
+    .trim()
+    .replace(/\/$/, "")
+    .replace(/\/chat\/completions$/, "");
   const endpoint = `${baseUrl}/chat/completions`;
   const messages: Array<Record<string, unknown>> = [
     {


### PR DESCRIPTION
## Summary

Fixes #42676

When users configure `tools.web.search.kimi.baseUrl` with a value that already includes the `/chat/completions` path (e.g. `https://api.moonshot.ai/v1/chat/completions`), the URL construction appended another `/chat/completions`, resulting in a doubled path:

```
/v1/chat/completions/chat/completions  →  404
```

## Root cause

`runKimiSearch` builds the endpoint as:
```ts
const baseUrl = params.baseUrl.trim().replace(/\/$/, "");
const endpoint = `${baseUrl}/chat/completions`;
```

There is no guard against a baseUrl that already ends with `/chat/completions`.

## Fix

Strip a trailing `/chat/completions` from `baseUrl` before appending it:

```ts
const baseUrl = params.baseUrl.trim().replace(/\/$/, "").replace(/\/chat\/completions$/, "");
const endpoint = `${baseUrl}/chat/completions`;
```

This is safe for the default value (`https://api.moonshot.ai/v1`) and for any correctly configured base URL — it only affects the misconfigured case.

## Changes

- `src/agents/tools/web-search.ts`: add `.replace(/\/chat\/completions$/, "")` step in `runKimiSearch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)