### PR TITLE
Windows: relaunch gateway scheduled tasks via restart helper

### DIFF
--- a/src/daemon/schtasks.restart.test.ts
+++ b/src/daemon/schtasks.restart.test.ts
@@ -1,0 +1,117 @@
+import { PassThrough } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const execSchtasksMock = vi.hoisted(() => vi.fn());
+const relaunchGatewayScheduledTaskMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./schtasks-exec.js", () => ({
+  execSchtasks: (...args: unknown[]) => execSchtasksMock(...args),
+}));
+
+vi.mock("../infra/windows-task-restart.js", () => ({
+  relaunchGatewayScheduledTask: (...args: unknown[]) => relaunchGatewayScheduledTaskMock(...args),
+}));
+
+import { restartScheduledTask } from "./schtasks.js";
+
+describe("restartScheduledTask", () => {
+  const env = {
+    USERPROFILE: "C:\\Users\\tester",
+    OPENCLAW_PROFILE: "default",
+  };
+
+  beforeEach(() => {
+    execSchtasksMock.mockReset();
+    relaunchGatewayScheduledTaskMock.mockReset();
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/Run") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    relaunchGatewayScheduledTaskMock.mockReturnValue({
+      ok: true,
+      method: "schtasks",
+      tried: ['schtasks /Run /TN "OpenClaw Gateway"'],
+    });
+  });
+
+  it("uses the detached relaunch helper after ending the task", async () => {
+    const stdout = new PassThrough();
+    const chunks: string[] = [];
+    stdout.on("data", (chunk) => chunks.push(String(chunk)));
+
+    await restartScheduledTask({ env, stdout });
+
+    expect(execSchtasksMock.mock.calls.map((call) => call[0])).toEqual([
+      ["/Query"],
+      ["/End", "/TN", "OpenClaw Gateway"],
+    ]);
+    expect(relaunchGatewayScheduledTaskMock).toHaveBeenCalledWith(env);
+    expect(chunks.join("")).toContain("Restarted Scheduled Task");
+  });
+
+  it("falls back to direct /Run when the relaunch helper fails", async () => {
+    relaunchGatewayScheduledTaskMock.mockReturnValue({
+      ok: false,
+      method: "schtasks",
+      detail: "spawn failed",
+      tried: ['schtasks /Run /TN "OpenClaw Gateway"'],
+    });
+
+    await restartScheduledTask({ env, stdout: new PassThrough() });
+
+    expect(execSchtasksMock.mock.calls.map((call) => call[0])).toEqual([
+      ["/Query"],
+      ["/End", "/TN", "OpenClaw Gateway"],
+      ["/Run", "/TN", "OpenClaw Gateway"],
+    ]);
+  });
+
+  it("ignores not-running /End errors before relaunching", async () => {
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 1, stdout: "", stderr: "ERROR: The task is not running." };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await restartScheduledTask({ env, stdout: new PassThrough() });
+
+    expect(relaunchGatewayScheduledTaskMock).toHaveBeenCalledWith(env);
+  });
+
+  it("throws when both helper relaunch and direct /Run fail", async () => {
+    relaunchGatewayScheduledTaskMock.mockReturnValue({
+      ok: false,
+      method: "schtasks",
+      detail: "spawn failed",
+      tried: ['schtasks /Run /TN "OpenClaw Gateway"'],
+    });
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/Run") {
+        return { code: 1, stdout: "", stderr: "Last Result: 1" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await expect(restartScheduledTask({ env, stdout: new PassThrough() })).rejects.toThrow(
+      "schtasks run failed: helper=spawn failed; Last Result: 1",
+    );
+  });
+});

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { relaunchGatewayScheduledTask } from "../infra/windows-task-restart.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
@@ -318,11 +319,20 @@ export async function restartScheduledTask({
   env,
 }: GatewayServiceControlArgs): Promise<void> {
   await assertSchtasksAvailable();
-  const taskName = resolveTaskName(env ?? (process.env as GatewayServiceEnv));
-  await execSchtasks(["/End", "/TN", taskName]);
-  const res = await execSchtasks(["/Run", "/TN", taskName]);
-  if (res.code !== 0) {
-    throw new Error(`schtasks run failed: ${res.stderr || res.stdout}`.trim());
+  const resolvedEnv = env ?? (process.env as GatewayServiceEnv);
+  const taskName = resolveTaskName(resolvedEnv);
+  const end = await execSchtasks(["/End", "/TN", taskName]);
+  if (end.code !== 0 && !isTaskNotRunning(end)) {
+    throw new Error(`schtasks end failed: ${end.stderr || end.stdout}`.trim());
+  }
+
+  const relaunch = relaunchGatewayScheduledTask(resolvedEnv);
+  if (!relaunch.ok) {
+    const res = await execSchtasks(["/Run", "/TN", taskName]);
+    if (res.code !== 0) {
+      const relaunchDetail = relaunch.detail ? `helper=${relaunch.detail}; ` : "";
+      throw new Error(`schtasks run failed: ${relaunchDetail}${res.stderr || res.stdout}`.trim());
+    }
   }
   stdout.write(`${formatLine("Restarted Scheduled Task", taskName)}\n`);
 }


### PR DESCRIPTION
Closes #5065.

## Summary
- route Windows scheduled-task restarts through the detached restart helper after `/End` instead of immediately calling `/Run`
- ignore benign "task is not running" `/End` errors during restart
- keep a direct `/Run` fallback if the helper cannot be spawned, with regression coverage for both paths

## Testing
- pnpm test src/daemon/schtasks.restart.test.ts
- pnpm test src/infra/windows-task-restart.test.ts
- pnpm test src/infra/process-respawn.test.ts
