### PR TITLE
Browser: align /start timeout with launch budget

### DIFF
--- a/src/browser/client.test.ts
+++ b/src/browser/client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CHROME_LAUNCH_READY_WINDOW_MS } from "./cdp-timeouts.js";
 import {
   browserAct,
   browserArmDialog,
@@ -8,7 +9,15 @@ import {
   browserPdfSave,
   browserScreenshotAction,
 } from "./client-actions.js";
-import { browserOpenTab, browserSnapshot, browserStatus, browserTabs } from "./client.js";
+import {
+  BROWSER_START_TIMEOUT_MS,
+  browserOpenTab,
+  browserSnapshot,
+  browserStart,
+  browserStatus,
+  browserTabs,
+} from "./client.js";
+import { CDP_READY_AFTER_LAUNCH_WINDOW_MS } from "./server-context.constants.js";
 
 describe("browser client", () => {
   function stubSnapshotFetch(calls: string[]) {
@@ -31,6 +40,7 @@ describe("browser client", () => {
   }
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -50,6 +60,45 @@ describe("browser client", () => {
   it("adds useful timeout messaging for abort-like failures", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("aborted")));
     await expect(browserStatus("http://127.0.0.1:18791")).rejects.toThrow(/timed out/i);
+  });
+
+  it("keeps browser start timeout ahead of the synchronous server launch budget (#3941)", async () => {
+    expect(BROWSER_START_TIMEOUT_MS).toBeGreaterThan(
+      CHROME_LAUNCH_READY_WINDOW_MS + CDP_READY_AFTER_LAUNCH_WINDOW_MS,
+    );
+
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            if (!signal) {
+              return;
+            }
+            if (signal.aborted) {
+              reject(signal.reason ?? new Error("aborted"));
+              return;
+            }
+            signal.addEventListener("abort", () => reject(signal.reason ?? new Error("aborted")), {
+              once: true,
+            });
+          }),
+      ),
+    );
+
+    let settled = false;
+    const promise = browserStart("http://127.0.0.1:18791").finally(() => {
+      settled = true;
+    });
+    const rejected = expect(promise).rejects.toThrow(new RegExp(`${BROWSER_START_TIMEOUT_MS}ms`));
+
+    await vi.advanceTimersByTimeAsync(BROWSER_START_TIMEOUT_MS - 1);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await rejected;
   });
 
   it("surfaces non-2xx responses with body text", async () => {

--- a/src/browser/client.ts
+++ b/src/browser/client.ts
@@ -1,4 +1,6 @@
+import { CHROME_LAUNCH_READY_WINDOW_MS } from "./cdp-timeouts.js";
 import { fetchBrowserJson } from "./client-fetch.js";
+import { CDP_READY_AFTER_LAUNCH_WINDOW_MS } from "./server-context.constants.js";
 
 export type BrowserStatus = {
   enabled: boolean;
@@ -100,6 +102,12 @@ function withBaseUrl(baseUrl: string | undefined, path: string): string {
   return `${trimmed.replace(/\/$/, "")}${path}`;
 }
 
+// /start waits synchronously for managed Chrome launch + post-launch CDP readiness.
+// Keep the client timeout ahead of that combined server-side window so the request
+// does not abort first on slower Linux hosts.
+export const BROWSER_START_TIMEOUT_MS =
+  CHROME_LAUNCH_READY_WINDOW_MS + CDP_READY_AFTER_LAUNCH_WINDOW_MS + 7000;
+
 export async function browserStatus(
   baseUrl?: string,
   opts?: { profile?: string },
@@ -124,7 +132,7 @@ export async function browserStart(baseUrl?: string, opts?: { profile?: string }
   const q = buildProfileQuery(opts?.profile);
   await fetchBrowserJson(withBaseUrl(baseUrl, `/start${q}`), {
     method: "POST",
-    timeoutMs: 15000,
+    timeoutMs: BROWSER_START_TIMEOUT_MS,
   });
 }
 


### PR DESCRIPTION
## Summary

- Problem: `browserStart()` timed out after 15000ms even though `POST /start` can synchronously spend longer than that waiting for managed Chrome launch plus post-launch CDP readiness.
- Why it matters: slower Linux hosts hit a client-side timeout race first, so browser control looks hung even when the server is still inside its normal startup path.
- What changed: derive a dedicated `BROWSER_START_TIMEOUT_MS` from the server-side launch windows and use it for `/start`; add a regression test that keeps the client timeout ahead of the combined synchronous server budget.
- What did NOT change (scope boundary): this PR does not redesign `/start` into an async background job or change browser stop/status semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #3941
- Related #2702

## User-visible / Behavior Changes

- Browser control start requests now wait up to 30000ms before surfacing the existing timeout error, which matches the current synchronous managed-Chrome startup flow more closely on slower hosts.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local verification)
- Runtime/container: Node 22 / pnpm test
- Model/provider: N/A
- Integration/channel (if any): browser control service
- Relevant config (redacted): N/A

### Steps

1. Inspect the managed browser `/start` path and confirm it blocks through `launchOpenClawChrome()` plus `waitForCdpReadyAfterLaunch()`.
2. Compare that combined server-side budget to the client-side `browserStart()` timeout.
3. Update the client timeout budget and add a regression test that proves the timeout remains ahead of the synchronous server launch path.

### Expected

- `browserStart()` should not abort before the current synchronous server startup budget has elapsed.

### Actual

- Before this change, `browserStart()` aborted after 15000ms, which could happen before the server completed its normal launch + CDP readiness wait path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `src/browser/client.test.ts`, `src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts`, and `src/agents/tools/browser-tool.test.ts` all pass locally after the timeout-budget change.
- Edge cases checked: the new test asserts the `/start` timeout stays ahead of the combined server-side launch windows and only rejects once that longer timeout actually elapses.
- What you did **not** verify: I did not run a live Ubuntu/x64 browser session in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ed0972196`.
- Files/config to restore: `src/browser/client.ts`, `src/browser/client.test.ts`
- Known bad symptoms reviewers should watch for: browser start requests taking unexpectedly longer than 30s without a more specific launch error.

## Risks and Mitigations

- Risk: the longer client timeout could delay failure reporting when Chrome launch is truly wedged.
  - Mitigation: the budget is still tied to the existing synchronous server launch windows, and the PR intentionally leaves the server-side launch errors unchanged so real launch failures still bubble once those windows expire.
