### PR TITLE
Fix misleading tool failure warning after successful retries

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -488,3 +488,53 @@ describe("messaging tool media URL tracking", () => {
     expect(ctx.state.pendingMessagingMediaUrls.has("tool-m3")).toBe(false);
   });
 });
+
+describe("handleToolExecutionEnd retry clearing", () => {
+  it("clears last mutating tool error after same-tool retry succeeds on a different path", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "write",
+        toolCallId: "tool-write-1",
+        args: { path: "/usr/local/bin/demo", content: "echo hi" },
+      } as never,
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "write",
+        toolCallId: "tool-write-1",
+        isError: true,
+        result: { error: "permission denied" },
+      } as never,
+    );
+
+    expect(ctx.state.lastToolError?.toolName).toBe("write");
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "write",
+        toolCallId: "tool-write-2",
+        args: { path: "/tmp/demo", content: "echo hi" },
+      } as never,
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "write",
+        toolCallId: "tool-write-2",
+        isError: false,
+        result: { details: { status: "ok" } },
+      } as never,
+    );
+
+    expect(ctx.state.lastToolError).toBeUndefined();
+  });
+});

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -44,7 +44,7 @@ describe("tool mutation helpers", () => {
     expect(buildToolMutationState("browser", { action: "list" }).mutatingAction).toBe(false);
   });
 
-  it("matches tool actions by fingerprint and fails closed on asymmetric data", () => {
+  it("matches retries by tool/action intent while keeping asymmetric data fail-closed", () => {
     expect(
       isSameToolMutationAction(
         { toolName: "write", actionFingerprint: "tool=write|path=/tmp/a" },
@@ -55,6 +55,18 @@ describe("tool mutation helpers", () => {
       isSameToolMutationAction(
         { toolName: "write", actionFingerprint: "tool=write|path=/tmp/a" },
         { toolName: "write", actionFingerprint: "tool=write|path=/tmp/b" },
+      ),
+    ).toBe(true);
+    expect(
+      isSameToolMutationAction(
+        {
+          toolName: "message",
+          actionFingerprint: "tool=message|action=send|target=slack:c123",
+        },
+        {
+          toolName: "message",
+          actionFingerprint: "tool=message|action=react|target=slack:c123",
+        },
       ),
     ).toBe(false);
     expect(

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -193,14 +193,36 @@ export function buildToolMutationState(
   };
 }
 
-export function isSameToolMutationAction(existing: ToolActionRef, next: ToolActionRef): boolean {
-  if (existing.actionFingerprint != null || next.actionFingerprint != null) {
-    // For mutating flows, fail closed: only clear when both fingerprints exist and match.
-    return (
-      existing.actionFingerprint != null &&
-      next.actionFingerprint != null &&
-      existing.actionFingerprint === next.actionFingerprint
-    );
+function extractActionFromFingerprint(fingerprint: string | undefined): string | undefined {
+  if (!fingerprint) {
+    return undefined;
   }
+  const match = fingerprint.match(/(?:^|\|)action=([^|]+)/);
+  return match?.[1];
+}
+
+export function isSameToolMutationAction(existing: ToolActionRef, next: ToolActionRef): boolean {
+  if (existing.actionFingerprint && next.actionFingerprint) {
+    if (existing.actionFingerprint === next.actionFingerprint) {
+      return true;
+    }
+
+    // Allow recovery retries that target a different resource but keep the same
+    // tool/action intent (for example write retrying to a fallback path).
+    if (existing.toolName !== next.toolName) {
+      return false;
+    }
+    const existingAction = extractActionFromFingerprint(existing.actionFingerprint);
+    const nextAction = extractActionFromFingerprint(next.actionFingerprint);
+    if (existingAction && nextAction) {
+      return existingAction === nextAction;
+    }
+    return !existingAction && !nextAction;
+  }
+
+  if (existing.actionFingerprint || next.actionFingerprint) {
+    return false;
+  }
+
   return existing.toolName === next.toolName && (existing.meta ?? "") === (next.meta ?? "");
 }


### PR DESCRIPTION
## Summary
- relax mutating retry matching so a successful retry with the same tool/action intent clears prior tool failure warnings even when the target changes (for example `write` to fallback path)
- keep stricter behavior for action-specific tools (`message action=send` does not clear a prior `message action=react` failure)
- add regression coverage for both matcher behavior and handler-level `lastToolError` clearing

## Validation
- `pnpm vitest src/agents/tool-mutation.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts`

Fixes #42912