### PR TITLE
Docs: fix Render blueprint gateway bind

### DIFF
--- a/docs/install/render.mdx
+++ b/docs/install/render.mdx
@@ -33,6 +33,7 @@ services:
     runtime: docker
     plan: starter
     healthCheckPath: /health
+    dockerCommand: node openclaw.mjs gateway --allow-unconfigured --bind lan --port 8080
     envVars:
       - key: PORT
         value: "8080"
@@ -52,13 +53,18 @@ services:
 
 Key Blueprint features used:
 
-| Feature               | Purpose                                                    |
-| --------------------- | ---------------------------------------------------------- |
-| `runtime: docker`     | Builds from the repo's Dockerfile                          |
-| `healthCheckPath`     | Render monitors `/health` and restarts unhealthy instances |
-| `sync: false`         | Prompts for value during deploy (secrets)                  |
-| `generateValue: true` | Auto-generates a cryptographically secure value            |
-| `disk`                | Persistent storage that survives redeploys                 |
+| Feature               | Purpose                                                                   |
+| --------------------- | ------------------------------------------------------------------------- |
+| `runtime: docker`     | Builds from the repo's Dockerfile                                         |
+| `dockerCommand`       | Overrides the Dockerfile default so Render listens on its public web port |
+| `healthCheckPath`     | Render monitors `/health` and restarts unhealthy instances                |
+| `sync: false`         | Prompts for value during deploy (secrets)                                 |
+| `generateValue: true` | Auto-generates a cryptographically secure value                           |
+| `disk`                | Persistent storage that survives redeploys                                |
+
+The Dockerfile intentionally defaults to a safer local-only launch (`127.0.0.1:18789`). Render web
+services need the process to listen on the public service port instead, so the Blueprint overrides
+the command to bind LAN (`0.0.0.0`) on port `8080`.
 
 ## Choosing a plan
 
@@ -140,7 +146,7 @@ This downloads a portable backup you can restore on any OpenClaw host.
 Check the deploy logs in the Render Dashboard. Common issues:
 
 - Missing `SETUP_PASSWORD` — the Blueprint prompts for this, but verify it's set
-- Port mismatch — ensure `PORT=8080` matches the Dockerfile's exposed port
+- Blueprint drift — ensure `render.yaml` still sets `dockerCommand: node openclaw.mjs gateway --allow-unconfigured --bind lan --port 8080`
 
 ### Slow cold starts (free tier)
 

--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,7 @@ services:
     runtime: docker
     plan: starter
     healthCheckPath: /health
+    dockerCommand: node openclaw.mjs gateway --allow-unconfigured --bind lan --port 8080
     envVars:
       - key: PORT
         value: "8080"

--- a/test/render-blueprint.test.ts
+++ b/test/render-blueprint.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+type RenderEnvVar = {
+  key?: string;
+  value?: string;
+};
+
+type RenderService = {
+  type?: string;
+  runtime?: string;
+  healthCheckPath?: string;
+  dockerCommand?: string;
+  envVars?: RenderEnvVar[];
+};
+
+describe("render blueprint", () => {
+  it("overrides the Dockerfile defaults with a Render-compatible gateway command", () => {
+    const renderYamlPath = fileURLToPath(new URL("../render.yaml", import.meta.url));
+    const parsed = parse(fs.readFileSync(renderYamlPath, "utf8")) as {
+      services?: RenderService[];
+    };
+    const service = parsed.services?.[0];
+
+    expect(service?.type).toBe("web");
+    expect(service?.runtime).toBe("docker");
+    expect(service?.healthCheckPath).toBe("/health");
+    expect(service?.dockerCommand).toBe(
+      "node openclaw.mjs gateway --allow-unconfigured --bind lan --port 8080",
+    );
+
+    const env = new Map((service?.envVars ?? []).map((entry) => [entry.key, entry.value]));
+    expect(env.get("PORT")).toBe("8080");
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: the repo's Render Blueprint only set Render's platform `PORT=8080`, but the container still booted OpenClaw with the Dockerfile default command (`127.0.0.1:18789`).
- Why it matters: Render scans the public web-service port, so the stock Blueprint could deploy a container that never exposed a reachable listener and then fail health checks with "No open ports detected".
- What changed: add an explicit Render `dockerCommand` that starts the gateway on `0.0.0.0:8080`, document why the Blueprint must override the Dockerfile default, and add a regression test that locks this contract.
- What did NOT change (scope boundary): this PR does not tune Render memory plans or change the generic Dockerfile defaults for non-Render deployments.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #2334
- Related #3754

## User-visible / Behavior Changes

- Fresh Render Blueprint deployments now start OpenClaw on Render's public web port instead of relying on the Dockerfile's local-only default command.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local verification)
- Runtime/container: Node 22 / pnpm test
- Model/provider: N/A
- Integration/channel (if any): Render Blueprint / Docker deployment
- Relevant config (redacted): `render.yaml`

### Steps

1. Inspect `render.yaml` and compare it with the Dockerfile default command.
2. Confirm that Render only sets `PORT=8080`, while OpenClaw itself reads `OPENCLAW_GATEWAY_PORT` or explicit CLI `--port`, and the Dockerfile default still binds loopback on `18789`.
3. Override the Blueprint command to `--bind lan --port 8080` and lock that behavior with a test.

### Expected

- The stock Render Blueprint should start a listener on Render's public web-service port.

### Actual

- Before this change, the Blueprint relied on the Dockerfile default (`127.0.0.1:18789`), which does not satisfy Render's public port scanner.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `test/render-blueprint.test.ts` passes locally and asserts the Blueprint now runs `node openclaw.mjs gateway --allow-unconfigured --bind lan --port 8080`.
- Edge cases checked: the test also verifies the Blueprint still declares `PORT=8080` and keeps the `/health` check path aligned with the public listener.
- What you did **not** verify: I did not perform a live Render deploy in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `870f0388c`.
- Files/config to restore: `render.yaml`, `docs/install/render.mdx`, `test/render-blueprint.test.ts`
- Known bad symptoms reviewers should watch for: Render deployments still reporting no open ports or failing `/health` immediately after startup.

## Risks and Mitigations

- Risk: this only fixes the Blueprint contract and not every possible Render OOM scenario users reported later in the thread.
  - Mitigation: the PR is intentionally scoped to the reproducible port/bind misconfiguration in the repo-owned deployment path, and leaves room for separate memory tuning once there is a concrete reproducer.
