### PR TITLE
feat(routing): support per-agent dmScope override

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -375,7 +375,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.list[].sandbox.browser.cdpSourceRange":
     "Per-agent override for CDP source CIDR allowlist.",
   "agents.list[].dmScope":
-    'Per-agent DM session scope override. When set, overrides the global session.dmScope for this agent.',
+    "Per-agent DM session scope override. When set, overrides the global session.dmScope for this agent.",
   "gateway.controlUi.basePath":
     "Optional URL prefix where the Control UI is served (e.g. /openclaw).",
   "gateway.controlUi.root":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -374,6 +374,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional CIDR allowlist for container-edge CDP ingress (for example 172.21.0.1/32).",
   "agents.list[].sandbox.browser.cdpSourceRange":
     "Per-agent override for CDP source CIDR allowlist.",
+  "agents.list[].dmScope":
+    'Per-agent DM session scope override. When set, overrides the global session.dmScope for this agent.',
   "gateway.controlUi.basePath":
     "Optional URL prefix where the Control UI is served (e.g. /openclaw).",
   "gateway.controlUi.root":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -821,6 +821,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.list[].sandbox.browser.cdpSourceRange": "Agent Sandbox Browser CDP Source Port Range",
   "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Agent Sandbox Docker Allow Container Namespace Join",
+  "agents.list[].dmScope": "Agent DM Session Scope",
   "discovery.mdns.mode": "mDNS Discovery Mode",
   plugins: "Plugins",
   "plugins.enabled": "Enable Plugins",

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,7 +1,7 @@
 import type { ChatType } from "../channels/chat-type.js";
 import type { AgentDefaultsConfig } from "./types.agent-defaults.js";
 import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared.js";
-import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
+import type { DmScope, HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
@@ -80,6 +80,8 @@ export type AgentConfig = {
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
   };
+  /** Optional per-agent DM session scope override. */
+  dmScope?: DmScope;
   /** Optional per-agent sandbox overrides. */
   sandbox?: AgentSandboxConfig;
   /** Optional per-agent stream params (e.g. cacheRetention, temperature). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -744,6 +744,14 @@ export const AgentEntrySchema = z
       })
       .strict()
       .optional(),
+    dmScope: z
+      .union([
+        z.literal("main"),
+        z.literal("per-peer"),
+        z.literal("per-channel-peer"),
+        z.literal("per-account-channel-peer"),
+      ])
+      .optional(),
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -712,6 +712,13 @@ const AgentRuntimeSchema = z
   ])
   .optional();
 
+export const DmScopeSchema = z.union([
+  z.literal("main"),
+  z.literal("per-peer"),
+  z.literal("per-channel-peer"),
+  z.literal("per-account-channel-peer"),
+]);
+
 export const AgentEntrySchema = z
   .object({
     id: z.string(),
@@ -744,14 +751,7 @@ export const AgentEntrySchema = z
       })
       .strict()
       .optional(),
-    dmScope: z
-      .union([
-        z.literal("main"),
-        z.literal("per-peer"),
-        z.literal("per-channel-peer"),
-        z.literal("per-account-channel-peer"),
-      ])
-      .optional(),
+    dmScope: DmScopeSchema.optional(),
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { parseByteSize } from "../cli/parse-bytes.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
-import { ElevatedAllowFromSchema } from "./zod-schema.agent-runtime.js";
+import { DmScopeSchema, ElevatedAllowFromSchema } from "./zod-schema.agent-runtime.js";
 import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
 import {
   GroupChatSchema,
@@ -26,14 +26,7 @@ export const SessionSendPolicySchema = createAllowDenyChannelRulesSchema();
 export const SessionSchema = z
   .object({
     scope: z.union([z.literal("per-sender"), z.literal("global")]).optional(),
-    dmScope: z
-      .union([
-        z.literal("main"),
-        z.literal("per-peer"),
-        z.literal("per-channel-peer"),
-        z.literal("per-account-channel-peer"),
-      ])
-      .optional(),
+    dmScope: DmScopeSchema.optional(),
     identityLinks: z.record(z.string(), z.array(z.string())).optional(),
     resetTriggers: z.array(z.string()).optional(),
     idleMinutes: z.number().int().positive().optional(),

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -60,10 +60,7 @@ describe("resolveAgentRoute", () => {
     const cfg: OpenClawConfig = {
       session: { dmScope: "per-channel-peer" },
       agents: {
-        list: [
-          { id: "main", dmScope: "main" },
-          { id: "dm" },
-        ],
+        list: [{ id: "main", dmScope: "main" }, { id: "dm" }],
       },
       bindings: [
         {

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -56,6 +56,48 @@ describe("resolveAgentRoute", () => {
     }
   });
 
+  test("per-agent dmScope overrides global session.dmScope", () => {
+    const cfg: OpenClawConfig = {
+      session: { dmScope: "per-channel-peer" },
+      agents: {
+        list: [
+          { id: "main", dmScope: "main" },
+          { id: "dm" },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "feishu", peer: { kind: "direct", id: "owner-uid" } },
+        },
+        {
+          agentId: "dm",
+          match: { channel: "feishu", peer: { kind: "direct", id: "other-user" } },
+        },
+      ],
+    };
+
+    // main agent has per-agent dmScope="main" → collapses to main session key
+    const mainRoute = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "direct", id: "owner-uid" },
+    });
+    expect(mainRoute.agentId).toBe("main");
+    expect(mainRoute.sessionKey).toBe("agent:main:main");
+
+    // dm agent has no per-agent dmScope → falls back to global "per-channel-peer"
+    const dmRoute = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "direct", id: "other-user" },
+    });
+    expect(dmRoute.agentId).toBe("dm");
+    expect(dmRoute.sessionKey).toBe("agent:dm:feishu:direct:other-user");
+  });
+
   test("resolveInboundLastRouteSessionKey follows route policy", () => {
     expect(
       resolveInboundLastRouteSessionKey({

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -660,12 +660,16 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
+    const agentCfg = listAgents(input.cfg).find(
+      (a) => normalizeAgentId(a.id) === normalizeAgentId(resolvedAgentId),
+    );
+    const effectiveDmScope = agentCfg?.dmScope ?? dmScope;
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
       channel,
       accountId,
       peer,
-      dmScope,
+      dmScope: effectiveDmScope,
       identityLinks,
     }).toLowerCase();
     const mainSessionKey = buildAgentMainSessionKey({


### PR DESCRIPTION
## Summary

- Add optional `dmScope` field to `AgentConfig`, allowing each agent to override the global `session.dmScope`
- When set, the per-agent `dmScope` takes precedence over `session.dmScope` during session key resolution
- Falls back to the global `session.dmScope` when no per-agent override is configured

### Use case

When running multiple agents with different isolation needs:
- **Personal agent** (`dmScope: "main"`): all DMs collapse to a single shared session
- **DM agent** (inherits global `per-channel-peer`): each user gets an isolated session
- **Group agent**: unaffected by dmScope (groups always get their own session key)

```jsonc
{
  "session": { "dmScope": "per-channel-peer" },
  "agents": {
    "list": [
      { "id": "main", "dmScope": "main" },
      { "id": "dm" },
      { "id": "group" }
    ]
  }
}
```

### Files changed

| File | Change |
|------|--------|
| `src/config/types.agents.ts` | Add `dmScope?: DmScope` to `AgentConfig` |
| `src/config/zod-schema.agent-runtime.ts` | Add zod validation for `dmScope` |
| `src/routing/resolve-route.ts` | Look up per-agent `dmScope` in `choose()` |
| `src/config/schema.help.ts` | Add help text |
| `src/config/schema.labels.ts` | Add label |
| `src/routing/resolve-route.test.ts` | Add test for per-agent override |

## Test plan

- [x] `npx vitest run src/routing/resolve-route.test.ts` — all 42 tests pass
- [ ] Manual: configure two agents with different `dmScope` values, verify session keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)