### PR TITLE
Agents: stop persisting inline image payloads in transcripts

### DIFF
--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -1,7 +1,10 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+import {
+  installSessionToolResultGuard,
+  PERSISTED_IMAGE_BLOCK_MARKER,
+} from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 
 type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
@@ -460,6 +463,37 @@ describe("installSessionToolResultGuard", () => {
       kind: "inter_session",
       sourceTool: "sessions_send",
     });
+  });
+
+  it("replaces persisted user image blocks with transcript-safe markers", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+    const base64 = Buffer.from("discord-image-secret").toString("base64");
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: [
+          { type: "text", text: "[media attached: /tmp/image.png (image/png)]" },
+          { type: "image", data: base64, mimeType: "image/png" },
+        ],
+        timestamp: Date.now(),
+      }),
+    );
+
+    const persisted = getPersistedMessages(sm)[0] as Extract<AgentMessage, { role: "user" }>;
+    expect(Array.isArray(persisted.content)).toBe(true);
+    const content = persisted.content as Array<{ type: string; text?: string; data?: string }>;
+    expect(content[0]).toMatchObject({
+      type: "text",
+      text: "[media attached: /tmp/image.png (image/png)]",
+    });
+    expect(content[1]).toMatchObject({
+      type: "text",
+      text: `${PERSISTED_IMAGE_BLOCK_MARKER} (image/png)`,
+    });
+    expect(JSON.stringify(persisted)).not.toContain(base64);
+    expect(JSON.stringify(persisted)).not.toContain("discord-image-secret");
   });
 
   // When an assistant message with toolCalls is aborted, no synthetic toolResult

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -16,6 +16,8 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 const GUARD_TRUNCATION_SUFFIX =
   "\n\n⚠️ [Content truncated during persistence — original exceeded size limit. " +
   "Use offset/limit parameters or request specific sections for large content.]";
+export const PERSISTED_IMAGE_BLOCK_MARKER =
+  "[image omitted from persisted transcript; original bytes stay out-of-band]";
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -68,6 +70,33 @@ function normalizePersistedToolResultName(
   return toolResult;
 }
 
+function redactPersistedUserImageBlocks(message: AgentMessage): AgentMessage {
+  if ((message as { role?: unknown }).role !== "user") {
+    return message;
+  }
+  const userMessage = message as Extract<AgentMessage, { role: "user" }>;
+  if (!Array.isArray(userMessage.content)) {
+    return message;
+  }
+
+  let changed = false;
+  const nextContent = userMessage.content.map((block) => {
+    if (!block || typeof block !== "object" || (block as { type?: unknown }).type !== "image") {
+      return block;
+    }
+    changed = true;
+    const mimeType = (block as { mimeType?: unknown }).mimeType;
+    const mimeLabel =
+      typeof mimeType === "string" && mimeType.trim().length > 0 ? ` (${mimeType.trim()})` : "";
+    return {
+      type: "text",
+      text: `${PERSISTED_IMAGE_BLOCK_MARKER}${mimeLabel}`,
+    } as (typeof userMessage.content)[number];
+  });
+
+  return changed ? { ...userMessage, content: nextContent } : message;
+}
+
 export function installSessionToolResultGuard(
   sessionManager: SessionManager,
   opts?: {
@@ -111,7 +140,8 @@ export function installSessionToolResultGuard(
   const pendingState = createPendingToolCallState();
   const persistMessage = (message: AgentMessage) => {
     const transformer = opts?.transformMessageForPersistence;
-    return transformer ? transformer(message) : message;
+    const transformed = transformer ? transformer(message) : message;
+    return redactPersistedUserImageBlocks(transformed);
   };
 
   const persistToolResult = (


### PR DESCRIPTION
## Summary
- fix #1210 by redacting inline user image blocks before session transcript persistence
- keep the text/media-note context in transcripts while replacing `type: "image"` blocks with a small text marker
- add a regression test proving the original base64 never lands in the persisted transcript

## Problem
Discord and similar channels can pass inbound images to the agent as `params.images`, while the prompt text already includes a `[media attached: ...]` note with the saved media path.

The same user turn was still being persisted through `SessionManager.appendMessage()` with the full inline `type: "image"` block, so session JSONL files could accumulate large base64 payloads even though the model input already had an out-of-band media path/reference.

## Root cause
The transcript persistence guard in `src/agents/session-tool-result-guard.ts` sanitized tool calls and tool results, but it did not sanitize user message image blocks before writing them to the session transcript.

## Fix
Apply a persistence-only transform in `src/agents/session-tool-result-guard.ts` that rewrites user `type: "image"` blocks into a small text marker before JSONL append.

That keeps the user-visible/media-note text context in history without storing the original base64 bytes in the transcript.

## Testing
- `pnpm test src/agents/session-tool-result-guard.test.ts`
- `pnpm test src/agents/pi-embedded-runner.guard.test.ts`
- `pnpm test src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts`

## Notes
While exploring adjacent coverage, `pnpm test src/agents/pi-embedded-runner.sanitize-session-history.test.ts` still failed on an existing unrelated expectation mismatch around `sanitizeSessionMessagesImages` for Mistral `strict9` handling. This PR does not touch that path.
