### PR TITLE
Agents: strip historical tool-result images for OpenAI replay

### DIFF
--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -98,7 +98,8 @@ external end-user instructions.
 
 **OpenAI / OpenAI Codex**
 
-- Image sanitization only.
+- Image sanitization only for replayed user/assistant content.
+- Historical `toolResult.image` blocks are downgraded to text markers before replay so persisted browser/tool snapshots do not get resent as inline image history.
 - Drop orphaned reasoning signatures (standalone reasoning items without a following content block) for OpenAI Responses/Codex transcripts.
 - No tool call id sanitization.
 - No tool result pairing repair.
@@ -148,4 +149,5 @@ Before the 2026.1.22 release, OpenClaw applied multiple layers of transcript hyg
 
 This complexity caused cross-provider regressions (notably `openai-responses`
 `call_id|fc_id` pairing). The 2026.1.22 cleanup removed the extension, centralized
-logic in the runner, and made OpenAI **no-touch** beyond image sanitization.
+logic in the runner, and made OpenAI mostly **no-touch** beyond image sanitization
+and historical tool-result image downgrading.

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
+  HISTORICAL_TOOL_RESULT_IMAGE_MARKER,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
 } from "./pi-embedded-helpers.js";
@@ -286,6 +287,38 @@ describe("sanitizeSessionMessagesImages", () => {
     expect(out).toHaveLength(2);
     expect(out[0]?.role).toBe("user");
     expect(out[1]?.role).toBe("toolResult");
+  });
+
+  it("textifies historical tool-result image blocks when requested", async () => {
+    const onePixelPng =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+wP9KobjigAAAABJRU5ErkJggg==";
+    const input = castAgentMessages([
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "browser.snapshot",
+        isError: false,
+        content: [
+          { type: "text", text: "snapshot summary" },
+          { type: "image", data: onePixelPng, mimeType: "image/png" },
+        ],
+        timestamp: nextTimestamp(),
+      } satisfies ToolResultMessage,
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test", {
+      sanitizeMode: "images-only",
+      textifyHistoricalToolResultImages: true,
+    });
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("toolResult");
+    const toolResult = out[0] as Extract<AgentMessage, { role: "toolResult" }>;
+    expect(toolResult.content).toEqual([
+      { type: "text", text: "snapshot summary" },
+      { type: "text", text: `${HISTORICAL_TOOL_RESULT_IMAGE_MARKER} (image/png)` },
+    ]);
+    expect(JSON.stringify(toolResult)).not.toContain(onePixelPng);
   });
 
   describe("thought_signature stripping", () => {

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -50,6 +50,7 @@ export {
   downgradeOpenAIReasoningBlocks,
 } from "./pi-embedded-helpers/openai.js";
 export {
+  HISTORICAL_TOOL_RESULT_IMAGE_MARKER,
   isEmptyAssistantMessageContent,
   sanitizeSessionMessagesImages,
 } from "./pi-embedded-helpers/images.js";

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -6,6 +6,8 @@ import { sanitizeContentBlocksImages } from "../tool-images.js";
 import { stripThoughtSignatures } from "./bootstrap.js";
 
 type ContentBlock = AgentToolResult<unknown>["content"][number];
+export const HISTORICAL_TOOL_RESULT_IMAGE_MARKER =
+  "[historical tool-result image omitted from replay]";
 
 export function isEmptyAssistantMessageContent(
   message: Extract<AgentMessage, { role: "assistant" }>,
@@ -35,6 +37,7 @@ export async function sanitizeSessionMessagesImages(
   options?: {
     sanitizeMode?: "full" | "images-only";
     sanitizeToolCallIds?: boolean;
+    textifyHistoricalToolResultImages?: boolean;
     /**
      * Mode for tool call ID sanitization:
      * - "strict" (alphanumeric only)
@@ -55,6 +58,8 @@ export async function sanitizeSessionMessagesImages(
     maxBytes: options?.maxBytes,
   };
   const shouldSanitizeToolCallIds = options?.sanitizeToolCallIds === true;
+  const shouldTextifyHistoricalToolResultImages =
+    options?.textifyHistoricalToolResultImages === true;
   // We sanitize historical session messages because Anthropic can reject a request
   // if the transcript contains oversized base64 images (default max side 1200px).
   const sanitizedIds = shouldSanitizeToolCallIds
@@ -71,11 +76,27 @@ export async function sanitizeSessionMessagesImages(
     if (role === "toolResult") {
       const toolMsg = msg as Extract<AgentMessage, { role: "toolResult" }>;
       const content = Array.isArray(toolMsg.content) ? toolMsg.content : [];
-      const nextContent = (await sanitizeContentBlocksImages(
-        content,
-        label,
-        imageSanitization,
-      )) as unknown as typeof toolMsg.content;
+      const sanitizedContent = await sanitizeContentBlocksImages(content, label, imageSanitization);
+      const nextContent = (shouldTextifyHistoricalToolResultImages
+        ? sanitizedContent.map((block) => {
+            if (
+              !block ||
+              typeof block !== "object" ||
+              (block as { type?: unknown }).type !== "image"
+            ) {
+              return block;
+            }
+            const mimeType = (block as { mimeType?: unknown }).mimeType;
+            const mimeLabel =
+              typeof mimeType === "string" && mimeType.trim().length > 0
+                ? ` (${mimeType.trim()})`
+                : "";
+            return {
+              type: "text",
+              text: `${HISTORICAL_TOOL_RESULT_IMAGE_MARKER}${mimeLabel}`,
+            } satisfies ContentBlock;
+          })
+        : sanitizedContent) as unknown as typeof toolMsg.content;
       out.push({ ...toolMsg, content: nextContent });
       continue;
     }

--- a/src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts
@@ -49,6 +49,7 @@ describe("sanitizeSessionHistory e2e smoke", () => {
       expect.objectContaining({
         sanitizeMode: "images-only",
         sanitizeToolCallIds: false,
+        textifyHistoricalToolResultImages: true,
       }),
     );
   });

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -543,6 +543,7 @@ export async function sanitizeSessionHistory(params: {
     {
       sanitizeMode: policy.sanitizeMode,
       sanitizeToolCallIds: policy.sanitizeToolCallIds,
+      textifyHistoricalToolResultImages: policy.textifyHistoricalToolResultImages,
       toolCallIdMode: policy.toolCallIdMode,
       preserveSignatures: policy.preserveSignatures,
       sanitizeThoughtSignatures: policy.sanitizeThoughtSignatures,

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -1,7 +1,10 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+import {
+  installSessionToolResultGuard,
+  PERSISTED_IMAGE_BLOCK_MARKER,
+} from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 
 type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
@@ -460,6 +463,37 @@ describe("installSessionToolResultGuard", () => {
       kind: "inter_session",
       sourceTool: "sessions_send",
     });
+  });
+
+  it("replaces persisted user image blocks with transcript-safe markers", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+    const base64 = Buffer.from("discord-image-secret").toString("base64");
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: [
+          { type: "text", text: "[media attached: /tmp/image.png (image/png)]" },
+          { type: "image", data: base64, mimeType: "image/png" },
+        ],
+        timestamp: Date.now(),
+      }),
+    );
+
+    const persisted = getPersistedMessages(sm)[0] as Extract<AgentMessage, { role: "user" }>;
+    expect(Array.isArray(persisted.content)).toBe(true);
+    const content = persisted.content as Array<{ type: string; text?: string; data?: string }>;
+    expect(content[0]).toMatchObject({
+      type: "text",
+      text: "[media attached: /tmp/image.png (image/png)]",
+    });
+    expect(content[1]).toMatchObject({
+      type: "text",
+      text: `${PERSISTED_IMAGE_BLOCK_MARKER} (image/png)`,
+    });
+    expect(JSON.stringify(persisted)).not.toContain(base64);
+    expect(JSON.stringify(persisted)).not.toContain("discord-image-secret");
   });
 
   // When an assistant message with toolCalls is aborted, no synthetic toolResult

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -16,6 +16,8 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 const GUARD_TRUNCATION_SUFFIX =
   "\n\n⚠️ [Content truncated during persistence — original exceeded size limit. " +
   "Use offset/limit parameters or request specific sections for large content.]";
+export const PERSISTED_IMAGE_BLOCK_MARKER =
+  "[image omitted from persisted transcript; original bytes stay out-of-band]";
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -68,6 +70,33 @@ function normalizePersistedToolResultName(
   return toolResult;
 }
 
+function redactPersistedUserImageBlocks(message: AgentMessage): AgentMessage {
+  if ((message as { role?: unknown }).role !== "user") {
+    return message;
+  }
+  const userMessage = message as Extract<AgentMessage, { role: "user" }>;
+  if (!Array.isArray(userMessage.content)) {
+    return message;
+  }
+
+  let changed = false;
+  const nextContent = userMessage.content.map((block) => {
+    if (!block || typeof block !== "object" || (block as { type?: unknown }).type !== "image") {
+      return block;
+    }
+    changed = true;
+    const mimeType = (block as { mimeType?: unknown }).mimeType;
+    const mimeLabel =
+      typeof mimeType === "string" && mimeType.trim().length > 0 ? ` (${mimeType.trim()})` : "";
+    return {
+      type: "text",
+      text: `${PERSISTED_IMAGE_BLOCK_MARKER}${mimeLabel}`,
+    } as (typeof userMessage.content)[number];
+  });
+
+  return changed ? { ...userMessage, content: nextContent } : message;
+}
+
 export function installSessionToolResultGuard(
   sessionManager: SessionManager,
   opts?: {
@@ -111,7 +140,8 @@ export function installSessionToolResultGuard(
   const pendingState = createPendingToolCallState();
   const persistMessage = (message: AgentMessage) => {
     const transformer = opts?.transformMessageForPersistence;
-    return transformer ? transformer(message) : message;
+    const transformed = transformer ? transformer(message) : message;
+    return redactPersistedUserImageBlocks(transformed);
   };
 
   const persistToolResult = (

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -16,6 +16,7 @@ export type TranscriptSanitizeMode = "full" | "images-only";
 export type TranscriptPolicy = {
   sanitizeMode: TranscriptSanitizeMode;
   sanitizeToolCallIds: boolean;
+  textifyHistoricalToolResultImages: boolean;
   toolCallIdMode?: ToolCallIdMode;
   repairToolUseResultPairing: boolean;
   preserveSignatures: boolean;
@@ -110,6 +111,7 @@ export function resolveTranscriptPolicy(params: {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
     sanitizeToolCallIds:
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
+    textifyHistoricalToolResultImages: isOpenAi,
     toolCallIdMode,
     repairToolUseResultPairing,
     preserveSignatures: isAnthropic && preservesAnthropicThinkingSignatures(provider),


### PR DESCRIPTION
## Summary
- fix #42171 by downgrading historical `toolResult.image` blocks before OpenAI/Codex transcript replay
- keep current-turn image behavior intact by applying the change only in `sanitizeSessionHistory()`
- document the new OpenAI/Codex replay rule in transcript hygiene docs

## Problem
`browser.snapshot(snapshotFormat="ai")` can persist a `toolResult` containing both text and image blocks.

On later runs, OpenClaw rebuilds provider history from the stored transcript. For OpenAI/Codex paths, replaying those historical inline image blocks can leave the session in repeated `server_error` failures.

## Root cause
`sanitizeSessionHistory()` already routed OpenAI/Codex transcripts through `sanitizeSessionMessagesImages()`, but that helper only resized/sanitized historical image payloads. It did not downgrade historical `toolResult.image` blocks, so replay history could still contain inline tool-result images.

## Fix
- add `textifyHistoricalToolResultImages` to the transcript policy
- enable it for OpenAI/OpenAI Codex replay
- in `sanitizeSessionMessagesImages()`, replace historical `toolResult.image` blocks with a small text marker during replay sanitization

This keeps the textual summary of the tool result while avoiding replaying the historical image bytes back to OpenAI/Codex.

## Testing
- `pnpm exec vitest run src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts -t 'textifies historical tool-result image blocks when requested'`
- `pnpm test src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts`
- `pnpm test src/agents/transcript-policy.policy.test.ts`

## Notes
While exploring adjacent coverage, the full `src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts` file still contains a pre-existing unrelated failure in `does not synthesize tool call input when missing`. This PR does not touch that behavior.
