### PR TITLE
UI: hide relevant memories scaffolding from chat surfaces

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -14,6 +14,7 @@ import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
+import { stripAssistantInternalScaffolding } from "../../shared/text/assistant-visible-text.js";
 import {
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
@@ -272,17 +273,28 @@ function truncateChatHistoryText(text: string): { text: string; truncated: boole
   };
 }
 
-function sanitizeChatHistoryContentBlock(block: unknown): { block: unknown; changed: boolean } {
+function sanitizeAssistantHistoryTextForDisplay(text: string): { text: string; changed: boolean } {
+  const stripped = stripAssistantInternalScaffolding(text);
+  return { text: stripped, changed: stripped !== text };
+}
+
+function sanitizeChatHistoryContentBlock(
+  block: unknown,
+  options?: { stripAssistantInternal?: boolean },
+): { block: unknown; changed: boolean } {
   if (!block || typeof block !== "object") {
     return { block, changed: false };
   }
   const entry = { ...(block as Record<string, unknown>) };
   let changed = false;
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const visible = options?.stripAssistantInternal
+      ? sanitizeAssistantHistoryTextForDisplay(entry.text)
+      : { text: entry.text, changed: false };
+    const stripped = stripInlineDirectiveTagsForDisplay(visible.text);
     const res = truncateChatHistoryText(stripped.text);
     entry.text = res.text;
-    changed ||= stripped.changed || res.truncated;
+    changed ||= visible.changed || stripped.changed || res.truncated;
   }
   if (typeof entry.partialJson === "string") {
     const res = truncateChatHistoryText(entry.partialJson);
@@ -335,12 +347,20 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
   }
 
   if (typeof entry.content === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
+    const visible =
+      entry.role === "assistant"
+        ? sanitizeAssistantHistoryTextForDisplay(entry.content)
+        : { text: entry.content, changed: false };
+    const stripped = stripInlineDirectiveTagsForDisplay(visible.text);
     const res = truncateChatHistoryText(stripped.text);
     entry.content = res.text;
-    changed ||= stripped.changed || res.truncated;
+    changed ||= visible.changed || stripped.changed || res.truncated;
   } else if (Array.isArray(entry.content)) {
-    const updated = entry.content.map((block) => sanitizeChatHistoryContentBlock(block));
+    const updated = entry.content.map((block) =>
+      sanitizeChatHistoryContentBlock(block, {
+        stripAssistantInternal: entry.role === "assistant",
+      }),
+    );
     if (updated.some((item) => item.changed)) {
       entry.content = updated.map((item) => item.block);
       changed = true;
@@ -348,10 +368,14 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
   }
 
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const visible =
+      entry.role === "assistant"
+        ? sanitizeAssistantHistoryTextForDisplay(entry.text)
+        : { text: entry.text, changed: false };
+    const stripped = stripInlineDirectiveTagsForDisplay(visible.text);
     const res = truncateChatHistoryText(stripped.text);
     entry.text = res.text;
-    changed ||= stripped.changed || res.truncated;
+    changed ||= visible.changed || stripped.changed || res.truncated;
   }
 
   return { message: changed ? entry : message, changed };

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -496,6 +496,34 @@ describe("gateway server chat", () => {
     ]);
   });
 
+  test("chat.history strips assistant relevant-memories scaffolding from user-visible history", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: [
+              "Visible intro",
+              "<relevant-memories>",
+              "private memory",
+              "</relevant-memories>",
+              "Visible outro",
+            ].join("\n"),
+          },
+        ],
+        timestamp: 1,
+      },
+    ]);
+
+    const textValues = collectHistoryTextValues(historyMessages);
+    expect(textValues).toHaveLength(1);
+    expect(textValues[0]).toContain("Visible intro");
+    expect(textValues[0]).toContain("Visible outro");
+    expect(textValues[0]).not.toContain("relevant-memories");
+    expect(textValues[0]).not.toContain("private memory");
+  });
+
   test("agent.wait resolves chat.send runs that finish without lifecycle events", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     try {

--- a/src/tui/components/assistant-message.test.ts
+++ b/src/tui/components/assistant-message.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeAssistantMessageTextForDisplay } from "./assistant-message.js";
+
+describe("sanitizeAssistantMessageTextForDisplay", () => {
+  it("strips relevant-memories scaffolding before rendering", () => {
+    const out = sanitizeAssistantMessageTextForDisplay(
+      [
+        "Visible intro",
+        "<relevant-memories>",
+        "private memory",
+        "</relevant-memories>",
+        "Visible outro",
+      ].join("\n"),
+    );
+
+    expect(out).toContain("Visible intro");
+    expect(out).toContain("Visible outro");
+    expect(out).not.toContain("relevant-memories");
+    expect(out).not.toContain("private memory");
+  });
+});

--- a/src/tui/components/assistant-message.ts
+++ b/src/tui/components/assistant-message.ts
@@ -1,22 +1,33 @@
 import { Container, Spacer } from "@mariozechner/pi-tui";
+import { stripAssistantInternalScaffolding } from "../../shared/text/assistant-visible-text.js";
 import { markdownTheme, theme } from "../theme/theme.js";
 import { HyperlinkMarkdown } from "./hyperlink-markdown.js";
+
+export function sanitizeAssistantMessageTextForDisplay(text: string): string {
+  return stripAssistantInternalScaffolding(text);
+}
 
 export class AssistantMessageComponent extends Container {
   private body: HyperlinkMarkdown;
 
   constructor(text: string) {
     super();
-    this.body = new HyperlinkMarkdown(text, 1, 0, markdownTheme, {
-      // Keep assistant body text in terminal default foreground so contrast
-      // follows the user's terminal theme (dark or light).
-      color: (line) => theme.assistantText(line),
-    });
+    this.body = new HyperlinkMarkdown(
+      sanitizeAssistantMessageTextForDisplay(text),
+      1,
+      0,
+      markdownTheme,
+      {
+        // Keep assistant body text in terminal default foreground so contrast
+        // follows the user's terminal theme (dark or light).
+        color: (line) => theme.assistantText(line),
+      },
+    );
     this.addChild(new Spacer(1));
     this.addChild(this.body);
   }
 
   setText(text: string) {
-    this.body.setText(text);
+    this.body.setText(sanitizeAssistantMessageTextForDisplay(text));
   }
 }


### PR DESCRIPTION
## Summary
- fix #42203 by stripping `<relevant-memories>` scaffolding before TUI rendering
- apply the same assistant-visible sanitization to `chat.history` so Control UI/Webchat does not expose injected memory blocks
- add focused regressions for both surfaces

## Problem
The memory-lancedb plugin can inject `<relevant-memories>...</relevant-memories>` into assistant-visible text. That block is internal model context and should never be shown back to the end user.

The repo already had `stripAssistantInternalScaffolding()` for this exact markup, but TUI and `chat.history` rendering paths were not using it.

## Root cause
- `src/tui/components/assistant-message.ts` passed assistant text straight into the markdown renderer
- `src/gateway/server-methods/chat.ts` stripped directive tags and oversized payloads, but did not strip assistant internal scaffolding from history text/blocks

## Fix
- sanitize TUI assistant text with `stripAssistantInternalScaffolding()` before render/update
- sanitize assistant `chat.history` text and text blocks with the same helper before returning history to webchat/control-ui clients

## Testing
- `pnpm test src/tui/components/assistant-message.test.ts`
- `pnpm exec vitest run src/gateway/server.chat.gateway-server-chat.test.ts -t 'chat.history strips assistant relevant-memories scaffolding from user-visible history'`
