### PR TITLE
UI: hide subagent spawn from chat command help

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -287,15 +287,15 @@ function buildChatCommands(): ChatCommandDefinition[] {
     defineChatCommand({
       key: "subagents",
       nativeName: "subagents",
-      description: "List, kill, log, spawn, or steer subagent runs for this session.",
+      description: "List, kill, log, or steer subagent runs for this session.",
       textAlias: "/subagents",
       category: "management",
       args: [
         {
           name: "action",
-          description: "list | kill | log | info | send | steer | spawn",
+          description: "list | kill | log | info | send | steer",
           type: "string",
-          choices: ["list", "kill", "log", "info", "send", "steer", "spawn"],
+          choices: ["list", "kill", "log", "info", "send", "steer"],
         },
         {
           name: "target",

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -43,6 +43,14 @@ describe("commands registry", () => {
     expect(specs.find((spec) => spec.name === "compact")).toBeTruthy();
   });
 
+  it("does not advertise subagent spawn in command metadata", () => {
+    const subagents = listChatCommands().find((spec) => spec.key === "subagents");
+    expect(subagents).toBeTruthy();
+    expect(subagents?.description).not.toContain("spawn");
+    const actionArg = subagents?.args?.find((arg) => arg.name === "action");
+    expect(actionArg?.choices).toEqual(["list", "kill", "log", "info", "send", "steer"]);
+  });
+
   it("filters commands based on config flags", () => {
     const disabled = listChatCommandsForConfig({
       commands: { config: false, debug: false },

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -409,7 +409,6 @@ export function buildSubagentsHelp() {
     "- /subagents info <id|#>",
     "- /subagents send <id|#> <message>",
     "- /subagents steer <id|#> <message>",
-    "- /subagents spawn <agentId> <task> [--model <model>] [--thinking <level>]",
     "- /focus <subagent-label|session-key|session-id|session-label>",
     "- /unfocus",
     "- /agents",

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1637,6 +1637,17 @@ describe("handleCommands subagents", () => {
     }
   });
 
+  it("does not advertise spawn in generic subagents help", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/subagents foo", cfg);
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).not.toContain("/subagents spawn");
+  });
+
   it("returns info for a subagent", async () => {
     const now = Date.now();
     addSubagentRunForTests({


### PR DESCRIPTION
## Summary

- Problem: `/subagents` advertised `spawn` in shared chat command metadata and generic help, so Telegram/chat users were shown a flow that commonly fails with policy/internal errors.
- Why it matters: this is misleading UX for normal chat users and makes subagent delegation feel broken even though natural-language delegation still works.
- What changed: removed `spawn` from advertised `/subagents` action choices and from generic `/subagents` help text.
- What did NOT change (scope boundary): the underlying manual `/subagents spawn ...` implementation was not removed or changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42944
- Related #42944

## User-visible / Behavior Changes

`/subagents` no longer advertises `spawn` in shared command metadata or generic help, so Telegram/chat users only see the supported control actions.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: local dev checkout
- Model/provider: N/A
- Integration/channel (if any): command metadata shared with Telegram/chat command surfaces
- Relevant config (redacted): default local test config

### Steps

1. Run `/subagents` on a chat surface such as Telegram.
2. Observe that `spawn` is offered in the menu/help.
3. Try `/subagents spawn <agentId> <task>` on a session without allowed targets.

### Expected

- `/subagents` should only advertise the normal user-facing control actions.

### Actual

- `/subagents` advertised `spawn`, which led users into a commonly failing flow.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: updated command metadata/help and ran focused tests covering command registry, generic subagents help, and manual `/subagents spawn` behavior.
- Edge cases checked: manual `/subagents spawn` tests still pass, so this stays a UI-only change.
- What you did **not** verify: live Telegram interaction against a running bot.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `dc49cf8a8`.
- Files/config to restore: `src/auto-reply/commands-registry.data.ts`, `src/auto-reply/reply/commands-subagents/shared.ts`
- Known bad symptoms reviewers should watch for: `spawn` still appearing in `/subagents` menus/help on chat surfaces.

## Risks and Mitigations

- Risk: advanced users may miss the manually typed `/subagents spawn` path in generic help.
- Mitigation: this PR intentionally keeps the implementation intact and limits the change to misleading advertised UI.
