### PR TITLE
fix(feishu): preserve UTF-8 filenames in file uploads

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -381,7 +381,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageResourceGetMock).not.toHaveBeenCalled();
   });
 
-  it("encodes Chinese filenames for file uploads", async () => {
+  it("preserves Chinese filenames for file uploads", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -390,8 +390,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     const createCall = fileCreateMock.mock.calls[0][0];
-    expect(createCall.data.file_name).not.toBe("测试文档.pdf");
-    expect(createCall.data.file_name).toBe(encodeURIComponent("测试文档") + ".pdf");
+    expect(createCall.data.file_name).toBe("测试文档.pdf");
   });
 
   it("preserves ASCII filenames unchanged for file uploads", async () => {
@@ -406,7 +405,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(createCall.data.file_name).toBe("report-2026.pdf");
   });
 
-  it("encodes special characters (em-dash, full-width brackets) in filenames", async () => {
+  it("preserves non-ASCII characters (em-dash, full-width brackets) in filenames", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -415,9 +414,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     const createCall = fileCreateMock.mock.calls[0][0];
-    expect(createCall.data.file_name).toMatch(/\.md$/);
-    expect(createCall.data.file_name).not.toContain("—");
-    expect(createCall.data.file_name).not.toContain("（");
+    expect(createCall.data.file_name).toBe("报告—详情（2026）.md");
   });
 });
 
@@ -427,56 +424,47 @@ describe("sanitizeFileNameForUpload", () => {
     expect(sanitizeFileNameForUpload("my-file_v2.txt")).toBe("my-file_v2.txt");
   });
 
-  it("encodes Chinese characters in basename, preserves extension", () => {
-    const result = sanitizeFileNameForUpload("测试文件.md");
-    expect(result).toBe(encodeURIComponent("测试文件") + ".md");
-    expect(result).toMatch(/\.md$/);
+  it("preserves Chinese characters (UTF-8 passed through to Feishu API)", () => {
+    expect(sanitizeFileNameForUpload("测试文件.md")).toBe("测试文件.md");
+    expect(sanitizeFileNameForUpload("支出报销明细表.xlsx")).toBe("支出报销明细表.xlsx");
   });
 
-  it("encodes em-dash and full-width brackets", () => {
-    const result = sanitizeFileNameForUpload("文件—说明（v2）.pdf");
-    expect(result).toMatch(/\.pdf$/);
-    expect(result).not.toContain("—");
-    expect(result).not.toContain("（");
-    expect(result).not.toContain("）");
+  it("preserves em-dash and full-width brackets", () => {
+    expect(sanitizeFileNameForUpload("文件—说明（v2）.pdf")).toBe("文件—说明（v2）.pdf");
   });
 
-  it("encodes single quotes and parentheses per RFC 5987", () => {
-    const result = sanitizeFileNameForUpload("文件'(test).txt");
-    expect(result).toContain("%27");
-    expect(result).toContain("%28");
-    expect(result).toContain("%29");
-    expect(result).toMatch(/\.txt$/);
+  it("preserves single quotes and parentheses", () => {
+    expect(sanitizeFileNameForUpload("file'(test).txt")).toBe("file'(test).txt");
   });
 
   it("handles filenames without extension", () => {
-    const result = sanitizeFileNameForUpload("测试文件");
-    expect(result).toBe(encodeURIComponent("测试文件"));
+    expect(sanitizeFileNameForUpload("测试文件")).toBe("测试文件");
   });
 
-  it("handles mixed ASCII and non-ASCII", () => {
-    const result = sanitizeFileNameForUpload("Report_报告_2026.xlsx");
-    expect(result).toMatch(/\.xlsx$/);
-    expect(result).not.toContain("报告");
+  it("preserves mixed ASCII and non-ASCII", () => {
+    expect(sanitizeFileNameForUpload("Report_报告_2026.xlsx")).toBe("Report_报告_2026.xlsx");
   });
 
-  it("encodes non-ASCII extensions", () => {
-    const result = sanitizeFileNameForUpload("报告.文档");
-    expect(result).toContain("%E6%96%87%E6%A1%A3");
-    expect(result).not.toContain("文档");
+  it("preserves non-ASCII extensions", () => {
+    expect(sanitizeFileNameForUpload("报告.文档")).toBe("报告.文档");
   });
 
-  it("encodes emoji filenames", () => {
-    const result = sanitizeFileNameForUpload("report_😀.txt");
-    expect(result).toContain("%F0%9F%98%80");
-    expect(result).toMatch(/\.txt$/);
+  it("preserves emoji filenames", () => {
+    expect(sanitizeFileNameForUpload("report_😀.txt")).toBe("report_😀.txt");
   });
 
-  it("encodes mixed ASCII and non-ASCII extensions", () => {
-    const result = sanitizeFileNameForUpload("notes_总结.v测试");
-    expect(result).toContain("notes_");
-    expect(result).toContain("%E6%B5%8B%E8%AF%95");
-    expect(result).not.toContain("测试");
+  it("strips control characters", () => {
+    expect(sanitizeFileNameForUpload("bad\x00name\x1f.txt")).toBe("bad_name_.txt");
+  });
+
+  it("replaces path separators and shell-unsafe chars", () => {
+    expect(sanitizeFileNameForUpload('file/with\\slashes:"stars*?.txt')).toBe(
+      "file_with_slashes__stars__.txt",
+    );
+  });
+
+  it("replaces angle brackets and pipe", () => {
+    expect(sanitizeFileNameForUpload("file<>|test.txt")).toBe("file___test.txt");
   });
 });
 

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -219,21 +219,20 @@ export async function uploadImageFeishu(params: {
 }
 
 /**
- * Encode a filename for safe use in Feishu multipart/form-data uploads.
- * Non-ASCII characters (Chinese, em-dash, full-width brackets, etc.) cause
- * the upload to silently fail when passed raw through the SDK's form-data
- * serialization.  RFC 5987 percent-encoding keeps headers 7-bit clean while
- * Feishu's server decodes and preserves the original display name.
+ * Sanitize a filename for safe use in Feishu multipart/form-data uploads.
+ *
+ * Previous approach used encodeURIComponent() on non-ASCII filenames, assuming
+ * Feishu's server would decode them.  In practice, Feishu stores the encoded
+ * string verbatim, so Chinese filenames like "报表.xlsx" appeared as
+ * "%E6%8A%A5%E8%A1%A8.xlsx" to users.
+ *
+ * The Feishu SDK (v1.30+) and the underlying im.file.create API handle UTF-8
+ * filenames correctly in multipart form-data.  We only need to strip characters
+ * that are genuinely unsafe in Content-Disposition headers or filesystem paths:
+ * control characters (0x00-0x1F), path separators, and shell-special quotes.
  */
 export function sanitizeFileNameForUpload(fileName: string): string {
-  const ASCII_ONLY = /^[\x20-\x7E]+$/;
-  if (ASCII_ONLY.test(fileName)) {
-    return fileName;
-  }
-  return encodeURIComponent(fileName)
-    .replace(/'/g, "%27")
-    .replace(/\(/g, "%28")
-    .replace(/\)/g, "%29");
+  return fileName.replace(/[\x00-\x1f\\/:*?"<>|]/g, "_");
 }
 
 /**


### PR DESCRIPTION
## Problem

`sanitizeFileNameForUpload()` applied `encodeURIComponent()` to all non-ASCII filenames, assuming Feishu's server would decode them back. In practice, **Feishu stores the encoded string verbatim**, so Chinese filenames like `支出报销明细表.xlsx` appeared as `%E6%94%AF%E5%87%BA%E6%8A%A5%E9%94%80%E6%98%8E%E7%BB%86%E8%A1%A8.xlsx` to users.

## Fix

The Feishu SDK (v1.30+) and the `im.file.create` API handle UTF-8 filenames correctly in multipart form-data. We only need to strip characters that are genuinely unsafe in Content-Disposition headers:

- Control characters (0x00-0x1F)
- Path separators (`\` `/`)
- Shell-special characters (`:` `*` `?` `"` `<` `>` `|`)

All CJK characters, emoji, em-dash, full-width brackets etc. are now passed through as-is.

## Testing

- All 29 tests in `media.test.ts` pass
- Verified in production Docker deployment — Chinese filenames now display correctly in Feishu