### PR TITLE
fix(chat): stop advertising /subagents spawn in UI/help

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -287,15 +287,15 @@ function buildChatCommands(): ChatCommandDefinition[] {
     defineChatCommand({
       key: "subagents",
       nativeName: "subagents",
-      description: "List, kill, log, spawn, or steer subagent runs for this session.",
+      description: "List, kill, log, info, send, or steer subagent runs for this session.",
       textAlias: "/subagents",
       category: "management",
       args: [
         {
           name: "action",
-          description: "list | kill | log | info | send | steer | spawn",
+          description: "list | kill | log | info | send | steer",
           type: "string",
-          choices: ["list", "kill", "log", "info", "send", "steer", "spawn"],
+          choices: ["list", "kill", "log", "info", "send", "steer"],
         },
         {
           name: "target",

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -409,7 +409,6 @@ export function buildSubagentsHelp() {
     "- /subagents info <id|#>",
     "- /subagents send <id|#> <message>",
     "- /subagents steer <id|#> <message>",
-    "- /subagents spawn <agentId> <task> [--model <model>] [--thinking <level>]",
     "- /focus <subagent-label|session-key|session-id|session-label>",
     "- /unfocus",
     "- /agents",


### PR DESCRIPTION
## Summary
- remove `/subagents spawn` from user-facing `/subagents` help text so chat users are not prompted into a commonly failing flow
- update the command registry metadata for `/subagents` to advertise only the supported day-to-day actions (`list`, `kill`, `log`, `info`, `send`, `steer`)
- keep backend `/subagents spawn` handling unchanged for explicit/manual usage paths

## Issue linkage
Fixes #42944

## Validation
- `pnpm vitest run src/auto-reply/commands-registry.test.ts src/auto-reply/reply/commands.test.ts src/auto-reply/reply/commands-subagents-spawn.test.ts`
