### PR TITLE
Gateway: ignore non-version service markers

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -3,6 +3,8 @@ import type { IncomingMessage } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { VERSION } from "../version.js";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "./control-ui-contract.js";
 import { handleControlUiAvatarRequest, handleControlUiHttpRequest } from "./control-ui.js";
 import { makeMockHttpResponse } from "./test-http-response.js";
@@ -27,6 +29,7 @@ describe("handleControlUiHttpRequest", () => {
       assistantName: string;
       assistantAvatar: string;
       assistantAgentId: string;
+      serverVersion: string;
     };
   }
 
@@ -170,6 +173,32 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantAgentId).toBe("main");
       },
     });
+  });
+
+  it("ignores non-version OPENCLAW_VERSION markers in bootstrap serverVersion", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_VERSION: "dev",
+        OPENCLAW_SERVICE_VERSION: "2026.3.8",
+      },
+      async () => {
+        await withControlUiRoot({
+          fn: async (tmp) => {
+            const { res, end } = makeMockHttpResponse();
+            const handled = handleControlUiHttpRequest(
+              { url: CONTROL_UI_BOOTSTRAP_CONFIG_PATH, method: "GET" } as IncomingMessage,
+              res,
+              {
+                root: { kind: "resolved", path: tmp },
+              },
+            );
+            expect(handled).toBe(true);
+            const parsed = parseBootstrapPayload(end);
+            expect(parsed.serverVersion).toBe(VERSION);
+          },
+        });
+      },
+    );
   });
 
   it("serves bootstrap config JSON under basePath", async () => {

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -149,6 +149,9 @@ describe("version resolution", () => {
     expect(resolveUsableRuntimeVersion(" \t ")).toBeUndefined();
     expect(resolveUsableRuntimeVersion("0.0.0")).toBeUndefined();
     expect(resolveUsableRuntimeVersion(" 0.0.0 ")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion("dev")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion(" stable ")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion("unknown")).toBeUndefined();
     expect(resolveUsableRuntimeVersion("2026.3.2")).toBe("2026.3.2");
     expect(resolveUsableRuntimeVersion(" 2026.3.2 ")).toBe("2026.3.2");
   });
@@ -176,6 +179,27 @@ describe("version resolution", () => {
           OPENCLAW_VERSION: "",
           OPENCLAW_SERVICE_VERSION: " ",
           npm_package_version: "",
+        },
+        "fallback",
+      ),
+    ).toBe(VERSION);
+  });
+
+  it("ignores non-version OPENCLAW_VERSION markers and falls back to concrete versions", () => {
+    expect(
+      resolveRuntimeServiceVersion({
+        OPENCLAW_VERSION: "dev",
+        OPENCLAW_SERVICE_VERSION: "2.4.6-service",
+        npm_package_version: "1.0.0-package",
+      }),
+    ).toBe(VERSION);
+
+    expect(
+      resolveRuntimeServiceVersion(
+        {
+          OPENCLAW_VERSION: "stable",
+          OPENCLAW_SERVICE_VERSION: " ",
+          npm_package_version: "1.0.0-package",
         },
         "fallback",
       ),

--- a/src/version.ts
+++ b/src/version.ts
@@ -91,6 +91,7 @@ export type RuntimeVersionEnv = {
 };
 
 export const RUNTIME_SERVICE_VERSION_FALLBACK = "unknown";
+const NON_VERSION_RUNTIME_MARKERS = new Set(["beta", "dev", "latest", "stable", "unknown"]);
 
 export function resolveUsableRuntimeVersion(version: string | undefined): string | undefined {
   const trimmed = version?.trim();
@@ -99,7 +100,20 @@ export function resolveUsableRuntimeVersion(version: string | undefined): string
   if (!trimmed || trimmed === "0.0.0") {
     return undefined;
   }
+  if (NON_VERSION_RUNTIME_MARKERS.has(trimmed.toLowerCase())) {
+    return undefined;
+  }
   return trimmed;
+}
+
+function firstUsableRuntimeVersion(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const usable = resolveUsableRuntimeVersion(value);
+    if (usable) {
+      return usable;
+    }
+  }
+  return undefined;
 }
 
 export function resolveRuntimeServiceVersion(
@@ -109,7 +123,7 @@ export function resolveRuntimeServiceVersion(
   const runtimeVersion = resolveUsableRuntimeVersion(VERSION);
 
   return (
-    firstNonEmpty(
+    firstUsableRuntimeVersion(
       env["OPENCLAW_VERSION"],
       runtimeVersion,
       env["OPENCLAW_SERVICE_VERSION"],


### PR DESCRIPTION
## Summary
- ignore non-version runtime markers like `dev` and `stable` when resolving the gateway service version
- keep falling back to the concrete runtime or service version for Control UI/bootstrap responses
- add regression coverage for version resolution and Control UI bootstrap payloads

## Testing
- pnpm test src/version.test.ts
- pnpm test src/gateway/control-ui.http.test.ts
- pnpm test src/gateway/server.auth.default-token.test.ts

Closes #42205.
