### PR TITLE
UI: soften webchat gateway seq gaps

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -119,24 +119,31 @@ describe("connectGateway", () => {
     gatewayClientInstances.length = 0;
   });
 
-  it("ignores stale client onGap callbacks after reconnect", () => {
+  it("treats seq gaps as soft warnings and ignores stale client callbacks", () => {
     const host = createHost();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    connectGateway(host);
-    const firstClient = gatewayClientInstances[0];
-    expect(firstClient).toBeDefined();
+    try {
+      connectGateway(host);
+      const firstClient = gatewayClientInstances[0];
+      expect(firstClient).toBeDefined();
 
-    connectGateway(host);
-    const secondClient = gatewayClientInstances[1];
-    expect(secondClient).toBeDefined();
+      connectGateway(host);
+      const secondClient = gatewayClientInstances[1];
+      expect(secondClient).toBeDefined();
 
-    firstClient.emitGap(10, 13);
-    expect(host.lastError).toBeNull();
+      firstClient.emitGap(10, 13);
+      expect(host.lastError).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
 
-    secondClient.emitGap(20, 24);
-    expect(host.lastError).toBe(
-      "event gap detected (expected seq 20, got 24); refresh recommended",
-    );
+      secondClient.emitGap(20, 24);
+      expect(host.lastError).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[gateway] seq gap: expected 20, got 24 (continuing with latest state)",
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("ignores stale client onEvent callbacks after reconnect", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -259,8 +259,12 @@ export function connectGateway(host: GatewayHost) {
       if (host.client !== client) {
         return;
       }
-      host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refresh recommended`;
-      host.lastErrorCode = null;
+      // Sequence gaps can happen during high-churn chat flows like attachment
+      // uploads. The client already advances lastSeq, so treat them as a soft
+      // resync hint instead of blocking the whole UI with a fatal banner.
+      console.warn(
+        `[gateway] seq gap: expected ${expected}, got ${received} (continuing with latest state)`,
+      );
     },
   });
   host.client = client;


### PR DESCRIPTION
## Summary
- stop surfacing gateway sequence gaps as fatal control-ui errors
- keep stale-client gap callbacks ignored after reconnects
- cover the softer gap handling with a node-side UI regression test

## Root cause
When the browser client observed a seq gap, `ui/src/ui/app-gateway.ts` unconditionally set `lastError` to `event gap detected ...`. During webchat attachment flows that meant a transient resync hint turned into a blocking UI error even though the client had already advanced `lastSeq` and continued processing newer events.

## Testing
- `pnpm exec vitest run ui/src/ui/controllers/chat.test.ts`
- `cd ui && NODE_OPTIONS='--localstorage-file=/tmp/openclaw-vitest-localstorage.json' pnpm exec vitest run --config vitest.node.config.ts src/ui/app-gateway.node.test.ts`

Closes #5422.
