### PR TITLE
Models: allow Responses prompt_cache_key opt-out

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1706,6 +1706,32 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("store");
   });
 
+  it("strips prompt_cache_key from payload for responses models that declare supportsPromptCacheKey=false", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-openai-responses",
+      applyModelId: "doubao-seed-2-0-pro-260215",
+      model: {
+        api: "openai-responses",
+        provider: "custom-openai-responses",
+        id: "doubao-seed-2-0-pro-260215",
+        name: "doubao-seed-2-0-pro-260215",
+        baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 16_384,
+        compat: { supportsPromptCacheKey: false },
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-123",
+      },
+    });
+    expect(payload.store).toBe(false);
+    expect(payload).not.toHaveProperty("prompt_cache_key");
+  });
+
   it("keeps existing context_management when stripping store for supportsStore=false models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "custom-openai-responses",

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -44,7 +44,7 @@ function shouldForceResponsesStore(model: {
   api?: unknown;
   provider?: unknown;
   baseUrl?: unknown;
-  compat?: { supportsStore?: boolean };
+  compat?: { supportsStore?: boolean; supportsPromptCacheKey?: boolean };
 }): boolean {
   if (model.compat?.supportsStore === false) {
     return false;
@@ -87,7 +87,7 @@ function shouldEnableOpenAIResponsesServerCompaction(
     api?: unknown;
     provider?: unknown;
     baseUrl?: unknown;
-    compat?: { supportsStore?: boolean };
+    compat?: { supportsStore?: boolean; supportsPromptCacheKey?: boolean };
   },
   extraParams: Record<string, unknown> | undefined,
 ): boolean {
@@ -105,7 +105,10 @@ function shouldEnableOpenAIResponsesServerCompaction(
 }
 
 function shouldStripResponsesStore(
-  model: { api?: unknown; compat?: { supportsStore?: boolean } },
+  model: {
+    api?: unknown;
+    compat?: { supportsStore?: boolean; supportsPromptCacheKey?: boolean };
+  },
   forceStore: boolean,
 ): boolean {
   if (forceStore) {
@@ -117,10 +120,21 @@ function shouldStripResponsesStore(
   return OPENAI_RESPONSES_APIS.has(model.api) && model.compat?.supportsStore === false;
 }
 
+function shouldStripResponsesPromptCacheKey(model: {
+  api?: unknown;
+  compat?: { supportsStore?: boolean; supportsPromptCacheKey?: boolean };
+}): boolean {
+  if (typeof model.api !== "string") {
+    return false;
+  }
+  return OPENAI_RESPONSES_APIS.has(model.api) && model.compat?.supportsPromptCacheKey === false;
+}
+
 function applyOpenAIResponsesPayloadOverrides(params: {
   payloadObj: Record<string, unknown>;
   forceStore: boolean;
   stripStore: boolean;
+  stripPromptCacheKey: boolean;
   useServerCompaction: boolean;
   compactThreshold: number;
 }): void {
@@ -129,6 +143,9 @@ function applyOpenAIResponsesPayloadOverrides(params: {
   }
   if (params.stripStore) {
     delete params.payloadObj.store;
+  }
+  if (params.stripPromptCacheKey) {
+    delete params.payloadObj.prompt_cache_key;
   }
   if (params.useServerCompaction && params.payloadObj.context_management === undefined) {
     params.payloadObj.context_management = [
@@ -177,7 +194,8 @@ export function createOpenAIResponsesContextManagementWrapper(
     const forceStore = shouldForceResponsesStore(model);
     const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(model, extraParams);
     const stripStore = shouldStripResponsesStore(model, forceStore);
-    if (!forceStore && !useServerCompaction && !stripStore) {
+    const stripPromptCacheKey = shouldStripResponsesPromptCacheKey(model);
+    if (!forceStore && !useServerCompaction && !stripStore && !stripPromptCacheKey) {
       return underlying(model, context, options);
     }
 
@@ -193,6 +211,7 @@ export function createOpenAIResponsesContextManagementWrapper(
             payloadObj: payload as Record<string, unknown>,
             forceStore,
             stripStore,
+            stripPromptCacheKey,
             useServerCompaction,
             compactThreshold,
           });

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -44,6 +44,31 @@ describe("plugins.slots.contextEngine", () => {
   });
 });
 
+describe("models.providers.*.models.*.compat.supportsPromptCacheKey", () => {
+  it("accepts boolean values", () => {
+    const result = OpenClawSchema.safeParse({
+      models: {
+        providers: {
+          volcengine: {
+            baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+            api: "openai-responses",
+            models: [
+              {
+                id: "doubao-seed-2-0-pro-260215",
+                name: "doubao-seed-2-0-pro-260215",
+                compat: {
+                  supportsPromptCacheKey: false,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("ui.seamColor", () => {
   it("accepts hex colors", () => {
     const res = validateConfigObject({ ui: { seamColor: "#FF4500" } });

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -15,6 +15,7 @@ export type ModelApi = (typeof MODEL_APIS)[number];
 
 export type ModelCompatConfig = {
   supportsStore?: boolean;
+  supportsPromptCacheKey?: boolean;
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
   supportsUsageInStreaming?: boolean;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -183,6 +183,7 @@ export const ModelApiSchema = z.enum(MODEL_APIS);
 export const ModelCompatSchema = z
   .object({
     supportsStore: z.boolean().optional(),
+    supportsPromptCacheKey: z.boolean().optional(),
     supportsDeveloperRole: z.boolean().optional(),
     supportsReasoningEffort: z.boolean().optional(),
     supportsUsageInStreaming: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- add `compat.supportsPromptCacheKey` for Responses models that reject `prompt_cache_key`
- strip `prompt_cache_key` in the OpenAI Responses payload wrapper when that compat flag is false
- cover the new compat flag in config validation and payload mutation tests

## Testing
- `pnpm test src/agents/pi-embedded-runner-extraparams.test.ts`
- `pnpm test src/config/config-misc.test.ts`

## Issues
- Closes #1691
- Fixes #42614
