### PR TITLE
cron: add procedural playbook memory v0

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1353,6 +1353,7 @@
                 "pages": [
                   "design/kilo-gateway-integration",
                   "experiments/onboarding-config-protocol",
+                  "experiments/plans/autonomy-upgrade-roadmap",
                   "experiments/plans/acp-thread-bound-agents",
                   "experiments/plans/acp-unified-streaming-refactor",
                   "experiments/plans/browser-evaluate-cdp-refactor",

--- a/docs/experiments/plans/autonomy-upgrade-roadmap.md
+++ b/docs/experiments/plans/autonomy-upgrade-roadmap.md
@@ -1,0 +1,547 @@
+---
+summary: "Roadmap for replayable execution graphs, memory stratification, critic gates, evaluation harnesses, and safe self-improvement"
+read_when:
+  - Planning autonomy or multi-agent execution work
+  - Deciding what ships in wave-1 versus later wave-2 work
+  - Adding memory, critic, evaluation, or self-improvement loops
+owner: "openclaw"
+status: "draft"
+last_updated: "2026-03-11"
+title: "Autonomy Upgrade Roadmap"
+---
+
+# Autonomy Upgrade Roadmap
+
+## Overview
+
+This plan captures the autonomy-upgrade direction for OpenClaw as a sequence of
+safe, reviewable deliveries instead of one large “autonomous agent” feature.
+
+The goal is not to maximize independence first.
+The goal is to make autonomous behavior:
+
+- replayable
+- inspectable
+- interruptible
+- attributable
+- cost-bounded
+- safe to expand over time
+
+Wave-1 ships the minimum substrate required to trust later autonomy work:
+
+- replayable execution graphs
+- critic gates
+- failure taxonomy
+- procedural playbook memory
+- deterministic evaluation bundles
+
+Wave-2 builds on that substrate with deeper planning, simulation, self-calibration,
+and parallel research lanes.
+
+## Why this needs a roadmap
+
+OpenClaw already has many of the primitives autonomy systems need, but they are
+still spread across separate subsystems:
+
+- routing and binding plans such as [ACP Thread Bound Agents](/experiments/plans/acp-thread-bound-agents)
+- memory research such as [Workspace Memory Research](/experiments/research/memory)
+- loop and repetition protection in [Tool-loop detection](/tools/loop-detection)
+- early procedural recovery in `src/cron/procedural-playbook-memory-v0.ts`
+
+Without an explicit roadmap, future autonomy features can drift into:
+
+- non-replayable side effects
+- opaque critic verdicts
+- memory writes without provenance
+- safety gates that exist only in prompts
+- self-improvement loops that optimize for activity instead of outcomes
+
+## North-star model
+
+The long-term system should look like a controlled execution loop:
+
+1. A planner turns an objective into a typed execution graph.
+2. Each graph node runs inside an explicit lane:
+   - research
+   - execution
+   - critic
+   - evaluation
+3. Every node emits structured artifacts:
+   - inputs
+   - outputs
+   - tool calls
+   - costs
+   - timing
+   - verdicts
+4. Critics can block, downgrade, reroute, or request human approval.
+5. Evaluation summarizes what actually happened, not what the agent claimed.
+6. Memory layers retain only evidence-backed artifacts:
+   - procedural playbooks
+   - failure clusters
+   - reusable strategy fragments
+   - calibrated expectations
+
+The system should behave more like an auditable workflow engine than a free-form
+chat loop with extra prompts.
+
+## Non-negotiable invariants
+
+All autonomy work in this roadmap should preserve these invariants:
+
+- Every autonomous run has a stable run id plus a replayable event log.
+- Every critic verdict is tied to specific evidence, not only generated prose.
+- Every high-impact action has an explicit stop path:
+  - kill switch
+  - retry policy
+  - operator-visible failure reason
+- Research lanes and execution lanes are separable and logged independently.
+- Costs and latency are measured per node, not inferred after the fact.
+- Memory writes are append-only or versioned, with provenance back to the run.
+- Self-improvement is gated by evaluation artifacts, not just successful completion.
+- No autonomous upgrade should silently widen permissions or tool reach.
+
+## Existing foundation to reuse
+
+The roadmap should extend current OpenClaw foundations instead of replacing them.
+
+### Loop and stall protection
+
+- [Tool-loop detection](/tools/loop-detection)
+- `src/agents/tool-loop-detection.ts`
+
+This already provides warning and critical thresholds plus a global circuit breaker.
+It is the first runtime-level evidence that autonomous loops need explicit guardrails.
+
+### Procedural playbook memory
+
+- `src/cron/procedural-playbook-memory-v0.ts`
+- `src/cron/service.playbook-memory-v0.test.ts`
+
+This is the first concrete memory layer for “safe defaults from prior failures”.
+It should become one input to the broader autonomy memory stack, not a dead-end sidecar.
+
+### Offline memory research
+
+- [Workspace Memory Research](/experiments/research/memory)
+
+This provides the right memory posture:
+
+- Markdown or human-readable source of truth
+- derived index for retrieval
+- retain / recall / reflect
+- confidence-bearing opinions
+
+### Thread-bound execution substrate
+
+- [ACP Thread Bound Agents](/experiments/plans/acp-thread-bound-agents)
+
+This already describes the control-plane approach OpenClaw should use for persistent,
+thread-bound, replayable agent work. The autonomy graph should reuse those lifecycle
+and persistence principles.
+
+## Wave-1: trust substrate first
+
+Wave-1 should be treated as mandatory before shipping deeper autonomous planning.
+
+### 1. Replayable execution graph and checkpoints
+
+Goal:
+
+- replace implicit “agent loop state” with typed graph nodes and explicit checkpoints
+
+Needed behaviors:
+
+- node-level inputs and outputs
+- deterministic edge transitions
+- resumable checkpoints
+- per-node timing and cost accounting
+- operator-readable run summaries
+
+Why first:
+
+- every later feature depends on trustworthy replay and attribution
+
+### 2. Failure taxonomy and decision reasons
+
+Goal:
+
+- normalize why autonomous work failed, degraded, retried, or escalated
+
+At minimum the taxonomy should distinguish:
+
+- planner failure
+- tool contract failure
+- runtime failure
+- timeout
+- low-confidence output
+- loop / stall
+- critic rejection
+- human-approval required
+- cost-budget exceeded
+- policy violation
+
+Why first:
+
+- critics, playbooks, and calibration all need consistent failure labels
+
+### 3. Procedural playbook memory
+
+Goal:
+
+- keep the current “safe default from prior failures” work as the canonical first memory layer for autonomy recovery
+
+Required properties:
+
+- evidence-backed entries
+- bounded, actionable recovery steps
+- clear signatureing for recurring failures
+- compatibility with broader memory indexing later
+
+Why first:
+
+- it turns repeated failure into reusable operator-grade guidance
+
+### 4. Critic mode with kill-switch policy
+
+Goal:
+
+- make critique an execution gate, not only a prompt pattern
+
+Required critic artifacts:
+
+- verdict: pass / warn / block / human-review
+- reasons with evidence pointers
+- severity
+- suggested mitigation
+- stop/continue recommendation
+
+Kill-switch policy should be able to stop or downgrade runs for:
+
+- repeated loop/stall evidence
+- repeated critic blocks on the same objective
+- policy boundary violations
+- cost overrun
+- missing required approvals
+
+### 5. Evaluation bundle
+
+Goal:
+
+- every autonomous run should end with a compact evaluation artifact that can be replayed and compared
+
+Bundle contents:
+
+- objective
+- execution graph summary
+- node outcomes
+- critic interventions
+- failures and retries
+- cost and latency
+- final outcome
+- “should this pattern be retained?” recommendation
+
+## Wave-1 exit criteria
+
+Wave-1 should be considered complete only when:
+
+- a run can be replayed from stored graph/checkpoint artifacts
+- loop/stall events and critic blocks are observable in one timeline
+- failure taxonomy is consistent across planner, tool, runtime, and critic paths
+- procedural playbook memory is populated from real failures, not hand-authored only
+- evaluation bundles can compare at least two runs of the same objective
+- the system can fail closed with a visible reason
+
+## Wave-2: capability expansion on top of the substrate
+
+Wave-2 tasks should be delivered on top of the wave-1 substrate, not in parallel with it.
+
+### Trading-safe simulation lane
+
+Backlog title:
+
+- `OpenClaw wave-2: trading-safe simulation lane (replay/backtest + decision logs)`
+
+Purpose:
+
+- give research-style or strategy-style autonomous work a strict non-live lane with immutable decision logs and explicit assumptions
+
+Depends on:
+
+- replayable execution graph
+- evaluation bundle
+- failure taxonomy
+
+### MCP/tool interoperability conformance harness
+
+Backlog title:
+
+- `OpenClaw wave-2: MCP/tool interoperability conformance harness`
+
+Purpose:
+
+- validate tool contracts, adapters, timeouts, and error handling against repeatable fixtures
+
+Depends on:
+
+- failure taxonomy
+- execution logs
+- evaluation harness
+
+### Risk-tiered human approval checkpoints
+
+Backlog title:
+
+- `OpenClaw wave-2: risk-tiered human-approval checkpoints (HITL)`
+
+Purpose:
+
+- route sensitive graph nodes to explicit approval gates based on risk class
+
+Depends on:
+
+- critic verdicts
+- failure taxonomy
+- operator-visible graph state
+
+### Observability and trace spans
+
+Backlog title:
+
+- `OpenClaw wave-2: observability + trace spans for agent loop stages`
+
+Purpose:
+
+- make planner, executor, critic, evaluator, and memory writes visible as one traceable flow
+
+Depends on:
+
+- execution graph as source of span boundaries
+
+### Split Research Brain versus Execution Brain
+
+Backlog title:
+
+- `OpenClaw wave-2: split Research Brain vs Execution Brain with guardrails`
+
+Purpose:
+
+- separate speculative exploration from permissioned execution
+
+Depends on:
+
+- simulation lane
+- HITL checkpoints
+- critic gate
+
+### Rolling playbook evolution
+
+Backlog title:
+
+- `OpenClaw wave-2: rolling playbook evolution with weighted selection`
+
+Purpose:
+
+- evolve playbooks from evidence, not ad-hoc prompt edits
+
+Depends on:
+
+- procedural playbook memory
+- evaluation bundle
+- failure taxonomy
+
+### Self-calibration loop
+
+Backlog title:
+
+- `OpenClaw wave-2: self-calibration loop (predicted vs realized performance)`
+
+Purpose:
+
+- compare planner/critic expectations with actual outcomes and update confidence
+
+Depends on:
+
+- trace spans
+- evaluation bundle
+- retained outcome artifacts
+
+### Async task-graph orchestrator
+
+Backlog title:
+
+- `OpenClaw wave-2: async task-graph orchestrator for parallel research lanes`
+
+Purpose:
+
+- allow parallel subgraphs without losing replayability or operator control
+
+Depends on:
+
+- execution graph and checkpoints
+- critic gate
+- observability
+
+### Autonomous hypothesis generator
+
+Backlog title:
+
+- `OpenClaw wave-2: autonomous hypothesis generator from failure clusters`
+
+Purpose:
+
+- turn repeated failures into candidate experiments instead of only retries
+
+Depends on:
+
+- failure clustering
+- evaluation bundle
+- simulation lane
+
+### Temporal credit assignment logging via ablation
+
+Backlog title:
+
+- `OpenClaw wave-2: temporal credit assignment logging via ablation`
+
+Purpose:
+
+- understand which nodes, prompts, or tools actually improved outcomes
+
+Depends on:
+
+- replayable graphs
+- trace spans
+- evaluation harness
+
+### Execution sandbox templates and import allowlist validator
+
+Backlog title:
+
+- `OpenClaw wave-2: execution sandbox templates + import allowlist validator`
+
+Purpose:
+
+- bound experimental execution lanes to known-safe tool/runtime envelopes
+
+Depends on:
+
+- simulation lane
+- HITL
+- failure taxonomy
+
+### Compute-budget-aware planner and ROI objective
+
+Backlog title:
+
+- `OpenClaw wave-2: compute-budget-aware planner + ROI objective`
+
+Purpose:
+
+- optimize for useful work under explicit cost and latency budgets
+
+Depends on:
+
+- per-node cost accounting
+- evaluation bundle
+- trace spans
+
+### Strategy genome store and mutation primitives
+
+Backlog title:
+
+- `OpenClaw wave-2: strategy genome store + mutation primitives`
+
+Purpose:
+
+- store reusable plan fragments and mutate them under controlled evaluation loops
+
+Depends on:
+
+- simulation lane
+- hypothesis generation
+- credit assignment
+
+### Tool reliability wrappers, cost routing, and self-improvement loops
+
+Backlog title:
+
+- `OpenClaw wave-2 backlog: tool reliability wrappers + cost routing + self-improvement loops`
+
+Purpose:
+
+- tie the whole system together with robust wrappers and cost-aware runtime selection
+
+Depends on:
+
+- nearly everything above
+
+This should be treated as an integration tranche, not an entry point.
+
+## Recommended delivery order
+
+Recommended order after the current in-flight autonomy work:
+
+1. Replayable execution graph + checkpoints
+2. Failure taxonomy
+3. Critic gate + kill-switch policy
+4. Evaluation bundle
+5. Observability + trace spans
+6. HITL checkpoints
+7. MCP/tool conformance harness
+8. Simulation lane
+9. Research Brain versus Execution Brain
+10. Rolling playbook evolution + self-calibration
+11. Async task-graph + hypothesis generation + credit assignment
+12. Budget-aware planner + genome store + broader self-improvement loops
+
+## What should not ship early
+
+The following should not ship before the wave-1 substrate exists:
+
+- autonomous retries that mutate plans without replay artifacts
+- memory writes that are not attributable to a run
+- self-improvement loops that only score “task completed”
+- parallel multi-agent research without checkpointed execution graphs
+- execution-policy widening without critic and approval gates
+
+## Validation model
+
+Each roadmap stage should add its own validation artifacts.
+
+### For execution graph work
+
+- deterministic replay test
+- resume-from-checkpoint test
+- duplicate-suppression test
+
+### For critic work
+
+- critic evidence artifact test
+- block / warn / pass routing tests
+- kill-switch escalation tests
+
+### For memory work
+
+- provenance checks
+- repeated-failure compaction tests
+- retrieval quality spot checks using known incidents
+
+### For evaluation and calibration work
+
+- two-run comparison fixtures
+- predicted versus realized delta reports
+- retained-artifact correctness checks
+
+## Open questions
+
+- Should graph state live entirely in gateway persistence first, or should there be a dedicated autonomy store from day one?
+- Should critics run as peer nodes in the graph or as graph-level supervisors with override authority?
+- How much of procedural playbook memory should stay cron-specific before it is generalized?
+- Which autonomy artifacts belong in user-visible docs versus operator-only internals?
+
+## Recommendation
+
+Treat the current critic, loop-detection, and procedural-playbook efforts as the start of a broader autonomy substrate, not isolated features.
+
+The next best use of engineering time is not “more intelligence”.
+It is finishing the replay, critic, failure-taxonomy, and evaluation foundations so later autonomy work has something stable to stand on.

--- a/src/cron/procedural-playbook-memory-v0.test.ts
+++ b/src/cron/procedural-playbook-memory-v0.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCronProceduralPlaybookSignature,
+  createInMemoryCronProceduralPlaybookMemoryStoreV0,
+  CronProceduralPlaybookMemoryLayerV0,
+  recordCronProceduralPlaybookSignalV0,
+  resolveCronProceduralPlaybookFailureKind,
+} from "./procedural-playbook-memory-v0.js";
+
+describe("resolveCronProceduralPlaybookFailureKind", () => {
+  it("classifies known cron failure shapes", () => {
+    expect(
+      resolveCronProceduralPlaybookFailureKind({
+        error: "delivery target is missing for telegram announce",
+      }),
+    ).toBe("delivery-target");
+    expect(
+      resolveCronProceduralPlaybookFailureKind({
+        error: "invalid cron.add params: schedule.everyMs required",
+      }),
+    ).toBe("tool-validation");
+    expect(
+      resolveCronProceduralPlaybookFailureKind({
+        error: "isolated cron jobs require payload.kind=agentTurn",
+      }),
+    ).toBe("runtime-validation");
+    expect(
+      resolveCronProceduralPlaybookFailureKind({
+        error: "job timed out after 30 seconds",
+      }),
+    ).toBe("timeout");
+  });
+});
+
+describe("CronProceduralPlaybookMemoryLayerV0", () => {
+  it("records failure entries and builds ranked prompt guidance", () => {
+    const store = createInMemoryCronProceduralPlaybookMemoryStoreV0();
+    const layer = new CronProceduralPlaybookMemoryLayerV0({
+      store,
+      nowMs: () => 1_700_000_000_000,
+    });
+
+    const entry = layer.recordSignal({
+      jobId: "job-1",
+      jobName: "notify",
+      sessionTarget: "main",
+      payloadKind: "systemEvent",
+      status: "error",
+      error: "delivery target is missing",
+    });
+
+    expect(entry).toMatchObject({
+      signature: buildCronProceduralPlaybookSignature({
+        sessionTarget: "main",
+        payloadKind: "systemEvent",
+        failureKind: "delivery-target",
+      }),
+      failureKind: "delivery-target",
+      failureCount: 1,
+      successCount: 0,
+      jobIds: ["job-1"],
+      safeDefault: true,
+    });
+
+    expect(layer.getGuidance()).toEqual([
+      expect.objectContaining({
+        failureKind: "delivery-target",
+        failureCount: 1,
+        successCount: 0,
+      }),
+    ]);
+    expect(layer.buildPromptSnippet()).toContain(
+      "Procedural playbook (safe defaults from prior failures):",
+    );
+  });
+
+  it("records recoveries against the prior failure signature", () => {
+    const store = createInMemoryCronProceduralPlaybookMemoryStoreV0();
+    const layer = new CronProceduralPlaybookMemoryLayerV0({
+      store,
+      nowMs: () => 1_700_000_000_000,
+    });
+
+    layer.recordSignal({
+      jobId: "job-1",
+      sessionTarget: "isolated",
+      payloadKind: "agentTurn",
+      status: "error",
+      error: "invalid cron.add params: payload.message required",
+    });
+
+    const recovered = layer.recordSignal({
+      jobId: "job-1",
+      sessionTarget: "isolated",
+      payloadKind: "agentTurn",
+      status: "ok",
+      error: "invalid cron.add params: payload.message required",
+    });
+
+    expect(recovered).toMatchObject({
+      failureKind: "tool-validation",
+      failureCount: 1,
+      successCount: 1,
+      jobIds: ["job-1"],
+    });
+  });
+});
+
+describe("recordCronProceduralPlaybookSignalV0", () => {
+  it("returns undefined when disabled", () => {
+    const store = createInMemoryCronProceduralPlaybookMemoryStoreV0();
+
+    const result = recordCronProceduralPlaybookSignalV0({
+      enabled: false,
+      store,
+      signal: {
+        jobId: "job-1",
+        sessionTarget: "main",
+        payloadKind: "systemEvent",
+        status: "error",
+        error: "delivery target is missing",
+      },
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/cron/procedural-playbook-memory-v0.ts
+++ b/src/cron/procedural-playbook-memory-v0.ts
@@ -1,0 +1,595 @@
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
+import type { CronPayload, CronRunStatus, CronSessionTarget } from "./types.js";
+
+export const CRON_PROCEDURAL_PLAYBOOK_MEMORY_V0_ENABLE_ENV = "OPENCLAW_CRON_PLAYBOOK_MEMORY_V0";
+export const CRON_PROCEDURAL_PLAYBOOK_MEMORY_V0_KILL_SWITCH_ENV =
+  "OPENCLAW_CRON_PLAYBOOK_MEMORY_V0_DISABLE";
+
+export type CronProceduralPlaybookFailureKind =
+  | "delivery-target"
+  | "tool-validation"
+  | "runtime-validation"
+  | "timeout"
+  | "unknown";
+
+export type CronProceduralPlaybookSignalV0 = {
+  jobId: string;
+  jobName?: string;
+  sessionTarget: CronSessionTarget;
+  payloadKind: CronPayload["kind"];
+  status: CronRunStatus;
+  error?: string;
+  errorKind?: string;
+  occurredAtMs?: number;
+};
+
+export type CronProceduralPlaybookEntryV0 = {
+  signature: string;
+  sessionTarget: CronSessionTarget;
+  payloadKind: CronPayload["kind"];
+  failureKind: CronProceduralPlaybookFailureKind;
+  rootCause: string;
+  steps: string[];
+  safeDefault: true;
+  failureCount: number;
+  successCount: number;
+  firstSeenAtMs: number;
+  lastSeenAtMs: number;
+  lastError?: string;
+  lastJobName?: string;
+  jobIds: string[];
+};
+
+export type CronProceduralPlaybookMemoryStateV0 = {
+  version: 1;
+  updatedAtMs: number;
+  entries: Record<string, CronProceduralPlaybookEntryV0>;
+};
+
+export type CronProceduralPlaybookGuidanceV0 = {
+  signature: string;
+  failureKind: CronProceduralPlaybookFailureKind;
+  rootCause: string;
+  steps: string[];
+  failureCount: number;
+  successCount: number;
+  lastSeenAtMs: number;
+};
+
+export interface CronProceduralPlaybookMemoryStoreV0 {
+  load(): CronProceduralPlaybookMemoryStateV0 | undefined;
+  save(state: CronProceduralPlaybookMemoryStateV0): void;
+  resolvePath?(): string;
+}
+
+const MAX_TRACKED_JOB_IDS = 12;
+
+const DELIVERY_TARGET_ERROR_RE =
+  /(delivery target|delivery\.to|delivery channel|delivery target is missing|delivery channel is missing|invalid telegram delivery target)/i;
+const TOOL_VALIDATION_ERROR_RE = /^invalid\s+[a-z0-9_.-]+\s+params\b/i;
+const RUNTIME_VALIDATION_ERROR_RE =
+  /(requires payload\.kind|requires non-empty|invalid model reference|main cron jobs require payload|isolated cron jobs require payload)/i;
+const TIMEOUT_ERROR_RE = /(timed out|timeout|deadline exceeded|aborterror)/i;
+
+const DEFAULT_PLAYBOOK: Record<
+  CronProceduralPlaybookFailureKind,
+  { rootCause: string; steps: string[] }
+> = {
+  "delivery-target": {
+    rootCause: "delivery-target-resolution-failed",
+    steps: [
+      "Set explicit delivery.channel and delivery.to so cron resolves one deterministic destination.",
+      "Dry-run once with `openclaw cron run <jobId>` and confirm the resolved target/account.",
+      "If delivery is optional, use delivery.bestEffort=true to avoid hard scheduling failures.",
+    ],
+  },
+  "tool-validation": {
+    rootCause: "cron-tool-input-validation-failed",
+    steps: [
+      "Validate schedule/payload/delivery fields before saving job edits.",
+      "Prefer `openclaw cron add` / `openclaw cron edit` over manual JSON patches.",
+      "Re-run the job once manually after schema-changing edits.",
+    ],
+  },
+  "runtime-validation": {
+    rootCause: "cron-runtime-validation-failed",
+    steps: [
+      "Verify sessionTarget/payload.kind pairing and non-empty message fields.",
+      "Check model and auth-profile overrides for the target agent.",
+      "Apply the smallest safe fix and validate with one isolated run before recurrence.",
+    ],
+  },
+  timeout: {
+    rootCause: "cron-job-execution-timeout",
+    steps: [
+      "Reduce prompt scope or split long work into multiple jobs.",
+      "Increase payload.timeoutSeconds only when runtime is predictably bounded.",
+      "Use retry/backoff policies instead of rapid immediate retries.",
+    ],
+  },
+  unknown: {
+    rootCause: "cron-unknown-failure",
+    steps: [
+      "Capture exact error text and recent job config changes.",
+      "Reproduce with `openclaw cron run <jobId>` to separate transient vs deterministic errors.",
+      "Ship the narrowest mitigation first; avoid broad retries until root cause is clear.",
+    ],
+  },
+};
+
+export function isCronProceduralPlaybookMemoryV0Enabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (isTruthyEnvValue(env[CRON_PROCEDURAL_PLAYBOOK_MEMORY_V0_KILL_SWITCH_ENV])) {
+    return false;
+  }
+  return isTruthyEnvValue(env[CRON_PROCEDURAL_PLAYBOOK_MEMORY_V0_ENABLE_ENV]);
+}
+
+export function resolveCronProceduralPlaybookFailureKind(params: {
+  errorKind?: string;
+  error?: string;
+}): CronProceduralPlaybookFailureKind {
+  const errorKind = normalizeToken(params.errorKind);
+  const error = params.error?.trim() ?? "";
+
+  if (
+    errorKind === "delivery-target" ||
+    errorKind === "delivery_target" ||
+    errorKind === "delivery"
+  ) {
+    return "delivery-target";
+  }
+  if (errorKind === "tool-validation" || errorKind === "tool_validation") {
+    return "tool-validation";
+  }
+  if (errorKind === "runtime-validation" || errorKind === "runtime_validation") {
+    return "runtime-validation";
+  }
+  if (errorKind === "timeout") {
+    return "timeout";
+  }
+
+  if (!error) {
+    return "unknown";
+  }
+  if (DELIVERY_TARGET_ERROR_RE.test(error)) {
+    return "delivery-target";
+  }
+  if (TOOL_VALIDATION_ERROR_RE.test(error)) {
+    return "tool-validation";
+  }
+  if (RUNTIME_VALIDATION_ERROR_RE.test(error)) {
+    return "runtime-validation";
+  }
+  if (TIMEOUT_ERROR_RE.test(error)) {
+    return "timeout";
+  }
+  return "unknown";
+}
+
+export function buildCronProceduralPlaybookSignature(params: {
+  sessionTarget: CronSessionTarget;
+  payloadKind: CronPayload["kind"];
+  failureKind: CronProceduralPlaybookFailureKind;
+}): string {
+  return `${params.sessionTarget}:${params.payloadKind}:${params.failureKind}`;
+}
+
+export function createEmptyCronProceduralPlaybookMemoryStateV0(
+  nowMs: number = Date.now(),
+): CronProceduralPlaybookMemoryStateV0 {
+  return {
+    version: 1,
+    updatedAtMs: nowMs,
+    entries: {},
+  };
+}
+
+export class CronProceduralPlaybookMemoryLayerV0 {
+  private readonly store: CronProceduralPlaybookMemoryStoreV0;
+  private readonly nowMs: () => number;
+  private state: CronProceduralPlaybookMemoryStateV0;
+
+  constructor(params: { store: CronProceduralPlaybookMemoryStoreV0; nowMs?: () => number }) {
+    this.store = params.store;
+    this.nowMs = params.nowMs ?? (() => Date.now());
+    this.state = this.loadState();
+  }
+
+  getStateSnapshot(): CronProceduralPlaybookMemoryStateV0 {
+    return cloneState(this.state);
+  }
+
+  recordSignal(signal: CronProceduralPlaybookSignalV0): CronProceduralPlaybookEntryV0 | undefined {
+    const now = signal.occurredAtMs ?? this.nowMs();
+    if (signal.status !== "error") {
+      return this.recordNonErrorSignal(signal, now);
+    }
+
+    const failureKind = resolveCronProceduralPlaybookFailureKind({
+      errorKind: signal.errorKind,
+      error: signal.error,
+    });
+    const signature = buildCronProceduralPlaybookSignature({
+      sessionTarget: signal.sessionTarget,
+      payloadKind: signal.payloadKind,
+      failureKind,
+    });
+
+    const existing = this.state.entries[signature];
+    const entry = existing
+      ? { ...existing }
+      : this.createDefaultEntry({
+          signature,
+          sessionTarget: signal.sessionTarget,
+          payloadKind: signal.payloadKind,
+          failureKind,
+          now,
+        });
+
+    entry.failureCount += 1;
+    entry.lastSeenAtMs = now;
+    entry.lastError = signal.error?.trim() || entry.lastError;
+    entry.lastJobName = signal.jobName?.trim() || entry.lastJobName;
+    entry.jobIds = appendJobId(entry.jobIds, signal.jobId);
+
+    this.state.entries[signature] = entry;
+    this.state.updatedAtMs = now;
+    this.persistState();
+    return cloneEntry(entry);
+  }
+
+  getGuidance(params?: {
+    sessionTarget?: CronSessionTarget;
+    payloadKind?: CronPayload["kind"];
+    limit?: number;
+    includeUnknown?: boolean;
+  }): CronProceduralPlaybookGuidanceV0[] {
+    const limit = clampLimit(params?.limit);
+    const includeUnknown = params?.includeUnknown ?? false;
+
+    const entries = Object.values(this.state.entries).filter((entry) => {
+      if (!includeUnknown && entry.failureKind === "unknown") {
+        return false;
+      }
+      if (params?.sessionTarget && entry.sessionTarget !== params.sessionTarget) {
+        return false;
+      }
+      if (params?.payloadKind && entry.payloadKind !== params.payloadKind) {
+        return false;
+      }
+      return true;
+    });
+
+    entries.sort((a, b) => {
+      if (b.failureCount !== a.failureCount) {
+        return b.failureCount - a.failureCount;
+      }
+      return b.lastSeenAtMs - a.lastSeenAtMs;
+    });
+
+    return entries.slice(0, limit).map((entry) => ({
+      signature: entry.signature,
+      failureKind: entry.failureKind,
+      rootCause: entry.rootCause,
+      steps: [...entry.steps],
+      failureCount: entry.failureCount,
+      successCount: entry.successCount,
+      lastSeenAtMs: entry.lastSeenAtMs,
+    }));
+  }
+
+  buildPromptSnippet(params?: {
+    sessionTarget?: CronSessionTarget;
+    payloadKind?: CronPayload["kind"];
+    limit?: number;
+  }): string | undefined {
+    const guidance = this.getGuidance({
+      sessionTarget: params?.sessionTarget,
+      payloadKind: params?.payloadKind,
+      limit: params?.limit,
+    });
+
+    if (guidance.length === 0) {
+      return undefined;
+    }
+
+    const lines: string[] = ["Procedural playbook (safe defaults from prior failures):"];
+    for (const item of guidance) {
+      lines.push(
+        `- ${item.failureKind} (${item.failureCount} failures / ${item.successCount} recoveries)`,
+      );
+      for (const step of item.steps) {
+        lines.push(`  - ${step}`);
+      }
+    }
+    return lines.join("\n");
+  }
+
+  private loadState(): CronProceduralPlaybookMemoryStateV0 {
+    const raw = this.store.load();
+    const parsed = toState(raw);
+    if (parsed) {
+      return parsed;
+    }
+    return createEmptyCronProceduralPlaybookMemoryStateV0(this.nowMs());
+  }
+
+  private createDefaultEntry(params: {
+    signature: string;
+    sessionTarget: CronSessionTarget;
+    payloadKind: CronPayload["kind"];
+    failureKind: CronProceduralPlaybookFailureKind;
+    now: number;
+  }): CronProceduralPlaybookEntryV0 {
+    const defaults = DEFAULT_PLAYBOOK[params.failureKind];
+    return {
+      signature: params.signature,
+      sessionTarget: params.sessionTarget,
+      payloadKind: params.payloadKind,
+      failureKind: params.failureKind,
+      rootCause: defaults.rootCause,
+      steps: [...defaults.steps],
+      safeDefault: true,
+      failureCount: 0,
+      successCount: 0,
+      firstSeenAtMs: params.now,
+      lastSeenAtMs: params.now,
+      jobIds: [],
+    };
+  }
+
+  private recordNonErrorSignal(
+    signal: CronProceduralPlaybookSignalV0,
+    now: number,
+  ): CronProceduralPlaybookEntryV0 | undefined {
+    if (!signal.errorKind && !signal.error) {
+      return undefined;
+    }
+    const failureKind = resolveCronProceduralPlaybookFailureKind({
+      errorKind: signal.errorKind,
+      error: signal.error,
+    });
+    const signature = buildCronProceduralPlaybookSignature({
+      sessionTarget: signal.sessionTarget,
+      payloadKind: signal.payloadKind,
+      failureKind,
+    });
+    const existing = this.state.entries[signature];
+    if (!existing) {
+      return undefined;
+    }
+    const entry = {
+      ...existing,
+      successCount: existing.successCount + 1,
+      lastSeenAtMs: now,
+      jobIds: appendJobId(existing.jobIds, signal.jobId),
+      lastJobName: signal.jobName?.trim() || existing.lastJobName,
+    } satisfies CronProceduralPlaybookEntryV0;
+    this.state.entries[signature] = entry;
+    this.state.updatedAtMs = now;
+    this.persistState();
+    return cloneEntry(entry);
+  }
+
+  private persistState() {
+    this.store.save(this.state);
+  }
+}
+
+export function resolveDefaultCronProceduralPlaybookMemoryPathV0(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return path.join(resolveStateDir(env), "cron", "playbook-memory-v0.json");
+}
+
+export class FileCronProceduralPlaybookMemoryStoreV0 implements CronProceduralPlaybookMemoryStoreV0 {
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly explicitPath?: string;
+
+  constructor(params?: { env?: NodeJS.ProcessEnv; path?: string }) {
+    this.env = params?.env ?? process.env;
+    this.explicitPath = params?.path;
+  }
+
+  resolvePath(): string {
+    if (this.explicitPath?.trim()) {
+      return path.resolve(this.explicitPath.trim());
+    }
+    return resolveDefaultCronProceduralPlaybookMemoryPathV0(this.env);
+  }
+
+  load(): CronProceduralPlaybookMemoryStateV0 | undefined {
+    const parsed = toState(loadJsonFile(this.resolvePath()));
+    return parsed ?? undefined;
+  }
+
+  save(state: CronProceduralPlaybookMemoryStateV0): void {
+    saveJsonFile(this.resolvePath(), state);
+  }
+}
+
+export function createInMemoryCronProceduralPlaybookMemoryStoreV0(
+  seed?: CronProceduralPlaybookMemoryStateV0,
+): CronProceduralPlaybookMemoryStoreV0 {
+  let state = seed ? cloneState(seed) : undefined;
+  return {
+    load() {
+      return state ? cloneState(state) : undefined;
+    },
+    save(next) {
+      state = cloneState(next);
+    },
+    resolvePath() {
+      return "in-memory://cron/playbook-memory-v0";
+    },
+  };
+}
+
+export function recordCronProceduralPlaybookSignalV0(params: {
+  signal: CronProceduralPlaybookSignalV0;
+  enabled?: boolean;
+  env?: NodeJS.ProcessEnv;
+  store?: CronProceduralPlaybookMemoryStoreV0;
+  nowMs?: () => number;
+  onError?: (error: string) => void;
+}): CronProceduralPlaybookEntryV0 | undefined {
+  const enabled = params.enabled ?? isCronProceduralPlaybookMemoryV0Enabled(params.env);
+  if (!enabled) {
+    return undefined;
+  }
+  try {
+    const layer = new CronProceduralPlaybookMemoryLayerV0({
+      store: params.store ?? new FileCronProceduralPlaybookMemoryStoreV0({ env: params.env }),
+      nowMs: params.nowMs,
+    });
+    return layer.recordSignal(params.signal);
+  } catch (err) {
+    const text = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    params.onError?.(`cron procedural playbook memory v0: ${text}`);
+    return undefined;
+  }
+}
+
+function normalizeToken(value?: string): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function appendJobId(jobIds: string[], nextJobId: string): string[] {
+  const trimmed = nextJobId.trim();
+  if (!trimmed) {
+    return jobIds.slice(0, MAX_TRACKED_JOB_IDS);
+  }
+  const deduped = [trimmed, ...jobIds.filter((value) => value !== trimmed)];
+  return deduped.slice(0, MAX_TRACKED_JOB_IDS);
+}
+
+function clampLimit(limit?: number): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) {
+    return 3;
+  }
+  const floored = Math.floor(limit);
+  if (floored <= 0) {
+    return 1;
+  }
+  return Math.min(floored, 20);
+}
+
+function cloneEntry(value: CronProceduralPlaybookEntryV0): CronProceduralPlaybookEntryV0 {
+  return {
+    ...value,
+    steps: [...value.steps],
+    jobIds: [...value.jobIds],
+  };
+}
+
+function cloneState(
+  value: CronProceduralPlaybookMemoryStateV0,
+): CronProceduralPlaybookMemoryStateV0 {
+  const entries: Record<string, CronProceduralPlaybookEntryV0> = {};
+  for (const [key, entry] of Object.entries(value.entries)) {
+    entries[key] = cloneEntry(entry);
+  }
+  return {
+    version: 1,
+    updatedAtMs: value.updatedAtMs,
+    entries,
+  };
+}
+
+function toState(value: unknown): CronProceduralPlaybookMemoryStateV0 | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const raw = value as Partial<CronProceduralPlaybookMemoryStateV0>;
+  if (raw.version !== 1) {
+    return undefined;
+  }
+  if (typeof raw.updatedAtMs !== "number" || !Number.isFinite(raw.updatedAtMs)) {
+    return undefined;
+  }
+  if (!raw.entries || typeof raw.entries !== "object") {
+    return undefined;
+  }
+
+  const entries: Record<string, CronProceduralPlaybookEntryV0> = {};
+  for (const [signature, entryRaw] of Object.entries(raw.entries)) {
+    const parsed = toEntry(signature, entryRaw);
+    if (parsed) {
+      entries[signature] = parsed;
+    }
+  }
+
+  return {
+    version: 1,
+    updatedAtMs: raw.updatedAtMs,
+    entries,
+  };
+}
+
+function toEntry(signature: string, value: unknown): CronProceduralPlaybookEntryV0 | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const raw = value as Partial<CronProceduralPlaybookEntryV0>;
+
+  if (typeof raw.signature !== "string" || raw.signature !== signature) {
+    return undefined;
+  }
+  if (raw.sessionTarget !== "main" && raw.sessionTarget !== "isolated") {
+    return undefined;
+  }
+  if (raw.payloadKind !== "systemEvent" && raw.payloadKind !== "agentTurn") {
+    return undefined;
+  }
+  if (
+    raw.failureKind !== "delivery-target" &&
+    raw.failureKind !== "tool-validation" &&
+    raw.failureKind !== "runtime-validation" &&
+    raw.failureKind !== "timeout" &&
+    raw.failureKind !== "unknown"
+  ) {
+    return undefined;
+  }
+  if (typeof raw.rootCause !== "string" || !Array.isArray(raw.steps) || raw.safeDefault !== true) {
+    return undefined;
+  }
+  if (
+    typeof raw.failureCount !== "number" ||
+    typeof raw.successCount !== "number" ||
+    typeof raw.firstSeenAtMs !== "number" ||
+    typeof raw.lastSeenAtMs !== "number"
+  ) {
+    return undefined;
+  }
+
+  const steps = raw.steps.filter(
+    (item): item is string => typeof item === "string" && Boolean(item),
+  );
+  const jobIds =
+    Array.isArray(raw.jobIds) && raw.jobIds.length > 0
+      ? raw.jobIds.filter((item): item is string => typeof item === "string" && Boolean(item))
+      : [];
+
+  return {
+    signature,
+    sessionTarget: raw.sessionTarget,
+    payloadKind: raw.payloadKind,
+    failureKind: raw.failureKind,
+    rootCause: raw.rootCause,
+    steps,
+    safeDefault: true,
+    failureCount: Math.max(0, Math.floor(raw.failureCount)),
+    successCount: Math.max(0, Math.floor(raw.successCount)),
+    firstSeenAtMs: raw.firstSeenAtMs,
+    lastSeenAtMs: raw.lastSeenAtMs,
+    lastError: typeof raw.lastError === "string" && raw.lastError ? raw.lastError : undefined,
+    lastJobName:
+      typeof raw.lastJobName === "string" && raw.lastJobName ? raw.lastJobName : undefined,
+    jobIds: jobIds.slice(0, MAX_TRACKED_JOB_IDS),
+  };
+}

--- a/src/cron/service.playbook-memory-v0.test.ts
+++ b/src/cron/service.playbook-memory-v0.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMockCronStateForJobs } from "./service.test-harness.js";
+import { executeJob } from "./service/timer.js";
+import type { CronJob } from "./types.js";
+
+function createJob(overrides?: Partial<CronJob>): CronJob {
+  return {
+    id: "job-1",
+    name: "Cron job",
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "Run task" },
+    delivery: { mode: "none" },
+    failureAlert: false,
+    createdAtMs: 1_700_000_000_000,
+    updatedAtMs: 1_700_000_000_000,
+    state: {},
+    ...overrides,
+  };
+}
+
+describe("executeJob procedural playbook memory wiring", () => {
+  it("records error signals when a cron run fails", async () => {
+    const job = createJob();
+    const recordProceduralPlaybookSignal = vi.fn();
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: 1_700_000_000_000 });
+    state.deps.recordProceduralPlaybookSignal = recordProceduralPlaybookSignal;
+    state.deps.runIsolatedAgentJob = vi.fn().mockResolvedValue({
+      status: "error",
+      error: "delivery target is missing",
+      errorKind: "delivery-target",
+    });
+
+    await executeJob(state, job, 1_700_000_000_000, { forced: false });
+
+    expect(recordProceduralPlaybookSignal).toHaveBeenCalledWith({
+      jobId: "job-1",
+      jobName: "Cron job",
+      sessionTarget: "isolated",
+      payloadKind: "agentTurn",
+      status: "error",
+      error: "delivery target is missing",
+      errorKind: "delivery-target",
+      occurredAtMs: 1_700_000_000_000,
+    });
+  });
+
+  it("records recovery signals after a prior execution error", async () => {
+    const job = createJob({
+      state: {
+        lastRunStatus: "error",
+        lastError: "delivery target is missing",
+      },
+    });
+    const recordProceduralPlaybookSignal = vi.fn();
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: 1_700_000_000_000 });
+    state.deps.recordProceduralPlaybookSignal = recordProceduralPlaybookSignal;
+    state.deps.runIsolatedAgentJob = vi.fn().mockResolvedValue({
+      status: "ok",
+      summary: "Delivered",
+    });
+
+    await executeJob(state, job, 1_700_000_000_000, { forced: false });
+
+    expect(recordProceduralPlaybookSignal).toHaveBeenCalledWith({
+      jobId: "job-1",
+      jobName: "Cron job",
+      sessionTarget: "isolated",
+      payloadKind: "agentTurn",
+      status: "ok",
+      error: "delivery target is missing",
+      occurredAtMs: 1_700_000_000_000,
+    });
+  });
+});

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -1,5 +1,6 @@
 import type { CronConfig } from "../../config/types.cron.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
+import type { CronProceduralPlaybookSignalV0 } from "../procedural-playbook-memory-v0.js";
 import type {
   CronDeliveryStatus,
   CronJob,
@@ -99,6 +100,7 @@ export type CronServiceDeps = {
     mode?: "announce" | "webhook";
     accountId?: string;
   }) => Promise<void>;
+  recordProceduralPlaybookSignal?: (signal: CronProceduralPlaybookSignalV0) => void;
   onEvent?: (evt: CronEvent) => void;
 };
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1025,6 +1025,7 @@ export async function executeJobCore(
   return {
     status: res.status,
     error: res.error,
+    errorKind: res.errorKind,
     summary: res.summary,
     delivered: res.delivered,
     deliveryAttempted: res.deliveryAttempted,
@@ -1049,6 +1050,8 @@ export async function executeJob(
   if (!job.state) {
     job.state = {};
   }
+  const previousRunStatus = job.state.lastRunStatus ?? job.state.lastStatus;
+  const previousError = job.state.lastError;
   const startedAt = state.deps.nowMs();
   job.state.runningAtMs = startedAt;
   job.state.lastError = undefined;
@@ -1063,6 +1066,29 @@ export async function executeJob(
     coreResult = await executeJobCore(state, job);
   } catch (err) {
     coreResult = { status: "error", error: String(err) };
+  }
+
+  if (coreResult.status === "error") {
+    state.deps.recordProceduralPlaybookSignal?.({
+      jobId: job.id,
+      jobName: job.name,
+      sessionTarget: job.sessionTarget,
+      payloadKind: job.payload.kind,
+      status: coreResult.status,
+      error: coreResult.error,
+      errorKind: coreResult.errorKind,
+      occurredAtMs: startedAt,
+    });
+  } else if (coreResult.status === "ok" && previousRunStatus === "error" && previousError) {
+    state.deps.recordProceduralPlaybookSignal?.({
+      jobId: job.id,
+      jobName: job.name,
+      sessionTarget: job.sessionTarget,
+      payloadKind: job.payload.kind,
+      status: coreResult.status,
+      error: previousError,
+      occurredAtMs: startedAt,
+    });
   }
 
   const endedAt = state.deps.nowMs();

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -11,6 +11,7 @@ import { resolveStorePath } from "../config/sessions/paths.js";
 import { resolveFailureDestination, sendFailureNotificationAnnounce } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { resolveDeliveryTarget } from "../cron/isolated-agent/delivery-target.js";
+import { recordCronProceduralPlaybookSignalV0 } from "../cron/procedural-playbook-memory-v0.js";
 import {
   appendCronRunLog,
   resolveCronRunLogPath,
@@ -280,6 +281,14 @@ export function buildGatewayCronService(params: {
         sessionKey,
         heartbeat: heartbeatOverride,
         deps: { ...params.deps, runtime: defaultRuntime },
+      });
+    },
+    recordProceduralPlaybookSignal: (signal) => {
+      recordCronProceduralPlaybookSignalV0({
+        signal,
+        onError: (error) => {
+          cronLogger.warn({ err: error, jobId: signal.jobId }, "cron playbook memory failed");
+        },
       });
     },
     runIsolatedAgentJob: async ({ job, message, abortSignal }) => {


### PR DESCRIPTION
## Summary
- add a procedural playbook memory layer that records recurring cron failure signatures and safe-default remediation steps
- wire cron execution to record failure and recovery signals into the new memory layer
- cover the classification, persistence, and service wiring with targeted tests

## Validation
- pnpm vitest run src/cron/procedural-playbook-memory-v0.test.ts src/cron/service.playbook-memory-v0.test.ts
- pnpm build