### PR TITLE
feat: two-stage stall recovery for sub-agents

### DIFF
--- a/src/agents/subagent-registry.stall-recovery.test.ts
+++ b/src/agents/subagent-registry.stall-recovery.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentDefaultsSchema } from "../config/zod-schema.agent-defaults.js";
+import { AgentEntrySchema } from "../config/zod-schema.agent-runtime.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -150,14 +151,18 @@ vi.mock("./timeout.js", () => ({
   resolveAgentTimeoutMs: vi.fn(() => 600_000),
 }));
 
-vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: vi.fn(() => ({
+vi.mock("../logging/subsystem.js", () => {
+  const makeLogger = (): Record<string, unknown> => ({
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
     debug: vi.fn(),
-  })),
-}));
+    child: vi.fn(() => makeLogger()),
+  });
+  return {
+    createSubsystemLogger: vi.fn(() => makeLogger()),
+  };
+});
 
 vi.mock("../runtime.js", () => ({
   defaultRuntime: { log: vi.fn() },
@@ -599,5 +604,139 @@ describe("stall recovery detection (sweeper)", () => {
       (call: unknown[]) => (call[0] as { method?: string })?.method === "agent",
     );
     expect(agentCalls).toHaveLength(0);
+  });
+
+  it("gateway fallback includes idempotencyKey (Bug #1 fix)", async () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    queueEmbeddedPiMessageSpy.mockReturnValue(false);
+
+    registerSubagentRun({
+      runId: "run-idem-key",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "idempotency key test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 5,
+      stallKillAfterSeconds: 10,
+    });
+
+    callGatewaySpy.mockClear();
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    });
+    queueEmbeddedPiMessageSpy.mockClear();
+    queueEmbeddedPiMessageSpy.mockReturnValue(false);
+
+    // Advance past nudge threshold and trigger sweeper.
+    vi.setSystemTime(baseTime + 6_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const agentCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCalls.length).toBeGreaterThanOrEqual(1);
+    const nudgeCall = agentCalls[0][0] as {
+      params?: { idempotencyKey?: string };
+    };
+    // The gateway requires idempotencyKey — verify it's present and non-empty.
+    expect(nudgeCall.params?.idempotencyKey).toBeDefined();
+    expect(nudgeCall.params!.idempotencyKey!.length).toBeGreaterThan(0);
+    expect(nudgeCall.params!.idempotencyKey).toContain("stall-nudge");
+  });
+
+  it("nudge not marked sent when both delivery paths fail (Bug #1 fix)", async () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    // Both delivery paths will fail.
+    queueEmbeddedPiMessageSpy.mockReturnValue(false);
+
+    registerSubagentRun({
+      runId: "run-nudge-fail",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "nudge fail test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 5,
+      stallKillAfterSeconds: 10,
+    });
+
+    callGatewaySpy.mockClear();
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      // Simulate gateway failure for nudge delivery.
+      if (params?.method === "agent") {
+        throw new Error("gateway unavailable");
+      }
+      return { status: "ok" };
+    });
+    queueEmbeddedPiMessageSpy.mockClear();
+    queueEmbeddedPiMessageSpy.mockReturnValue(false);
+
+    // Advance past nudge threshold and trigger sweeper.
+    vi.setSystemTime(baseTime + 6_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Both paths failed — stallNudgedAt should NOT be set.
+    const runs = listSubagentRunsForRequester("agent:main:main");
+    const entry = runs.find((r) => r.runId === "run-nudge-fail");
+    expect(entry).toBeDefined();
+    expect(entry!.stallNudgedAt).toBeUndefined();
+
+    // On the next sweep, nudge should be retried (not skipped).
+    callGatewaySpy.mockClear();
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    });
+    queueEmbeddedPiMessageSpy.mockClear();
+    queueEmbeddedPiMessageSpy.mockReturnValue(false);
+
+    // Trigger another sweep (still past the nudge threshold).
+    vi.setSystemTime(baseTime + 12_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // The nudge should be retried via callGateway.
+    const retryCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(retryCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("stall recovery per-agent config validation (Bug #3 fix)", () => {
+  it("per-agent subagents schema accepts stallNudgeAfterSeconds", () => {
+    const result = AgentEntrySchema.safeParse({
+      id: "test",
+      subagents: { stallNudgeAfterSeconds: 120 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("per-agent subagents schema accepts stallKillAfterSeconds", () => {
+    const result = AgentEntrySchema.safeParse({
+      id: "test",
+      subagents: { stallKillAfterSeconds: 300 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("per-agent subagents schema rejects negative stall values", () => {
+    const result = AgentEntrySchema.safeParse({
+      id: "test",
+      subagents: { stallNudgeAfterSeconds: -1 },
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/src/agents/subagent-registry.stall-recovery.test.ts
+++ b/src/agents/subagent-registry.stall-recovery.test.ts
@@ -1,0 +1,603 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentDefaultsSchema } from "../config/zod-schema.agent-defaults.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { callGatewaySpy, queueEmbeddedPiMessageSpy, abortEmbeddedPiRunSpy, onAgentEventListeners } =
+  vi.hoisted(() => ({
+    callGatewaySpy: vi.fn(async (params: { method?: string }) => {
+      // agent.wait must never resolve — otherwise the run is immediately completed.
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    }),
+    queueEmbeddedPiMessageSpy: vi.fn(() => false),
+    abortEmbeddedPiRunSpy: vi.fn(() => true),
+    onAgentEventListeners: new Set<(evt: unknown) => void>(),
+  }));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: callGatewaySpy,
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn((listener: (evt: unknown) => void) => {
+    onAgentEventListeners.add(listener);
+    return () => onAgentEventListeners.delete(listener);
+  }),
+  emitAgentEvent: vi.fn((event: Record<string, unknown>) => {
+    const enriched = { ...event, seq: 1, ts: Date.now() };
+    for (const listener of onAgentEventListeners) {
+      listener(enriched);
+    }
+  }),
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  isEmbeddedPiRunActive: vi.fn(() => false),
+  isEmbeddedPiRunStreaming: vi.fn(() => false),
+  queueEmbeddedPiMessage: queueEmbeddedPiMessageSpy,
+  abortEmbeddedPiRun: abortEmbeddedPiRunSpy,
+  waitForEmbeddedPiRunEnd: vi.fn(async () => true),
+}));
+
+vi.mock("./subagent-announce.js", () => ({
+  captureSubagentCompletionReply: vi.fn(async () => "done"),
+  runSubagentAnnounceFlow: vi.fn(async () => true),
+}));
+
+vi.mock("./subagent-registry-state.js", () => ({
+  getSubagentRunsSnapshotForRead: vi.fn((runs: Map<string, unknown>) => runs),
+  persistSubagentRunsToDisk: vi.fn(),
+  restoreSubagentRunsFromDisk: vi.fn(() => 0),
+}));
+
+vi.mock("./subagent-announce-queue.js", () => ({
+  resetAnnounceQueuesForTests: vi.fn(),
+  enqueueAnnounce: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    session: { mainKey: "main", store: "/tmp/test-store" },
+    agents: {
+      defaults: {
+        subagents: {
+          stallNudgeAfterSeconds: 90,
+          stallKillAfterSeconds: 180,
+        },
+      },
+    },
+  })),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({
+    "agent:main:subagent:stall-child": {
+      sessionId: "child-session-id-stall",
+    },
+  })),
+  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
+  resolveStorePath: vi.fn(() => "/tmp/test-store/sessions.json"),
+}));
+
+vi.mock("../context-engine/init.js", () => ({
+  ensureContextEnginesInitialized: vi.fn(),
+}));
+
+vi.mock("../context-engine/registry.js", () => ({
+  resolveContextEngine: vi.fn(async () => ({})),
+}));
+
+vi.mock("./subagent-registry-cleanup.js", () => ({
+  resolveCleanupCompletionReason: vi.fn(() => "complete"),
+  resolveDeferredCleanupDecision: vi.fn(() => ({ kind: "give-up", reason: "expiry" })),
+}));
+
+vi.mock("./subagent-registry-completion.js", () => ({
+  emitSubagentEndedHookOnce: vi.fn(async () => undefined),
+  resolveLifecycleOutcomeFromRunOutcome: vi.fn(() => "completed"),
+  runOutcomesEqual: vi.fn(
+    (a: { status?: string } | undefined, b: { status?: string } | undefined) =>
+      a?.status === b?.status,
+  ),
+}));
+
+// Provide real-ish query implementations so listSubagentRunsForRequester works.
+vi.mock("./subagent-registry-queries.js", () => ({
+  countActiveDescendantRunsFromRuns: vi.fn(() => 0),
+  countActiveRunsForSessionFromRuns: vi.fn(() => 0),
+  countPendingDescendantRunsExcludingRunFromRuns: vi.fn(() => 0),
+  countPendingDescendantRunsFromRuns: vi.fn(() => 0),
+  findRunIdsByChildSessionKeyFromRuns: vi.fn(
+    (runs: Map<string, { childSessionKey?: string }>, key: string) => {
+      const ids: string[] = [];
+      for (const [runId, entry] of runs.entries()) {
+        if (entry.childSessionKey === key) {
+          ids.push(runId);
+        }
+      }
+      return ids;
+    },
+  ),
+  listDescendantRunsForRequesterFromRuns: vi.fn(() => []),
+  listRunsForRequesterFromRuns: vi.fn(
+    (runs: Map<string, { requesterSessionKey?: string }>, requesterSessionKey: string) => {
+      const result: unknown[] = [];
+      for (const entry of runs.values()) {
+        if (entry.requesterSessionKey === requesterSessionKey) {
+          result.push(entry);
+        }
+      }
+      return result;
+    },
+  ),
+  resolveRequesterForChildSessionFromRuns: vi.fn(() => null),
+  shouldIgnorePostCompletionAnnounceForSessionFromRuns: vi.fn(() => false),
+}));
+
+vi.mock("./subagent-lifecycle-events.js", async () => {
+  const actual = await vi.importActual<typeof import("./subagent-lifecycle-events.js")>(
+    "./subagent-lifecycle-events.js",
+  );
+  return actual;
+});
+
+vi.mock("./timeout.js", () => ({
+  resolveAgentTimeoutMs: vi.fn(() => 600_000),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: { log: vi.fn() },
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => ({})),
+}));
+
+// ---------------------------------------------------------------------------
+// Import SUT after mocks
+// ---------------------------------------------------------------------------
+
+import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  addSubagentRunForTests,
+  listSubagentRunsForRequester,
+  registerSubagentRun,
+  resetSubagentRegistryForTests,
+} from "./subagent-registry.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStallTestRun(overrides?: Partial<SubagentRunRecord>): SubagentRunRecord {
+  const now = Date.now();
+  return {
+    runId: "run-stall-1",
+    childSessionKey: "agent:main:subagent:stall-child",
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "stall test task",
+    cleanup: "keep" as const,
+    createdAt: now,
+    startedAt: now,
+    cleanupHandled: false,
+    stallNudgeAfterSeconds: 5,
+    stallKillAfterSeconds: 10,
+    lastToolCallAt: now,
+    ...overrides,
+  };
+}
+
+function emitToolEvent(runId: string) {
+  (emitAgentEvent as unknown as (evt: Record<string, unknown>) => void)({
+    runId,
+    stream: "tool",
+    data: { phase: "start", name: "read" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("stall recovery config validation", () => {
+  it("stallNudgeAfterSeconds accepts 0 (disabled)", () => {
+    const result = AgentDefaultsSchema.safeParse({
+      subagents: { stallNudgeAfterSeconds: 0 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("stallNudgeAfterSeconds accepts positive integers", () => {
+    const result = AgentDefaultsSchema.safeParse({
+      subagents: { stallNudgeAfterSeconds: 90 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("stallKillAfterSeconds accepts 0 (disabled)", () => {
+    const result = AgentDefaultsSchema.safeParse({
+      subagents: { stallKillAfterSeconds: 0 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("stallKillAfterSeconds accepts positive integers", () => {
+    const result = AgentDefaultsSchema.safeParse({
+      subagents: { stallKillAfterSeconds: 120 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects negative stallNudgeAfterSeconds", () => {
+    const result = AgentDefaultsSchema.safeParse({
+      subagents: { stallNudgeAfterSeconds: -1 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative stallKillAfterSeconds", () => {
+    const result = AgentDefaultsSchema.safeParse({
+      subagents: { stallKillAfterSeconds: -5 },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("stall recovery detection (sweeper)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetSubagentRegistryForTests({ persist: false });
+    callGatewaySpy.mockClear();
+    // Restore the default implementation after mockClear.
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    });
+    queueEmbeddedPiMessageSpy.mockClear();
+    queueEmbeddedPiMessageSpy.mockReturnValue(false);
+    abortEmbeddedPiRunSpy.mockClear();
+    onAgentEventListeners.clear();
+  });
+
+  afterEach(() => {
+    resetSubagentRegistryForTests({ persist: false });
+    vi.useRealTimers();
+  });
+
+  it("nudge fires after stallNudgeAfterSeconds of inactivity", async () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    registerSubagentRun({
+      runId: "run-nudge-1",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "nudge test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 5,
+      stallKillAfterSeconds: 10,
+    });
+
+    callGatewaySpy.mockClear();
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    });
+    queueEmbeddedPiMessageSpy.mockClear();
+
+    // Advance time past the nudge threshold (5s) and trigger the sweeper (60s interval).
+    vi.setSystemTime(baseTime + 6_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // The nudge should attempt queueEmbeddedPiMessage first (returns false),
+    // then fall back to callGateway with method "agent".
+    const agentCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCalls.length).toBeGreaterThanOrEqual(1);
+    const nudgeCall = agentCalls[0][0] as {
+      params?: { sessionKey?: string; message?: string };
+    };
+    expect(nudgeCall.params?.sessionKey).toBe("agent:main:subagent:stall-child");
+    expect(nudgeCall.params?.message).toContain("stalled");
+  });
+
+  it("kill fires after stallKillAfterSeconds past nudge", async () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    // Register a run to start the sweeper.
+    registerSubagentRun({
+      runId: "run-kill-1",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "kill test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 5,
+      stallKillAfterSeconds: 10,
+    });
+
+    // Now overwrite the run record with pre-set stall state
+    // (already nudged 11s ago, kill threshold is 10s).
+    addSubagentRunForTests(
+      makeStallTestRun({
+        runId: "run-kill-1",
+        createdAt: baseTime - 20_000,
+        startedAt: baseTime - 20_000,
+        lastToolCallAt: baseTime - 20_000,
+        stallNudgeAfterSeconds: 5,
+        stallKillAfterSeconds: 10,
+        stallNudgedAt: baseTime - 11_000,
+      }),
+    );
+
+    callGatewaySpy.mockClear();
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    });
+    abortEmbeddedPiRunSpy.mockClear();
+
+    // Trigger the sweeper.
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // The run should have been killed — abortEmbeddedPiRun called.
+    expect(abortEmbeddedPiRunSpy).toHaveBeenCalled();
+
+    // Verify the run is marked as ended.
+    const runs = listSubagentRunsForRequester("agent:main:main");
+    const killed = runs.find((r) => r.runId === "run-kill-1");
+    expect(killed?.endedAt).toBeDefined();
+    expect(killed?.outcome?.status).toBe("error");
+  });
+
+  it("tool activity resets stall timer", () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    registerSubagentRun({
+      runId: "run-tool-reset",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "tool reset test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 5,
+      stallKillAfterSeconds: 10,
+    });
+
+    // Advance time and emit a tool event.
+    const toolTime = baseTime + 3_000;
+    vi.setSystemTime(toolTime);
+
+    emitToolEvent("run-tool-reset");
+
+    const runs = listSubagentRunsForRequester("agent:main:main");
+    const entry = runs.find((r) => r.runId === "run-tool-reset");
+    expect(entry).toBeDefined();
+    // lastToolCallAt should be updated to the time the tool event was emitted.
+    expect(entry!.lastToolCallAt).toBe(toolTime);
+  });
+
+  it("tool activity after nudge clears stallNudgedAt", () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    registerSubagentRun({
+      runId: "run-clear-nudge",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "clear nudge test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 5,
+      stallKillAfterSeconds: 10,
+    });
+
+    // Manually set stallNudgedAt on the entry.
+    const runs = listSubagentRunsForRequester("agent:main:main");
+    const entry = runs.find((r) => r.runId === "run-clear-nudge");
+    expect(entry).toBeDefined();
+    entry!.stallNudgedAt = baseTime - 2_000;
+
+    // Emit a tool event — should clear the nudge state.
+    vi.setSystemTime(baseTime + 1_000);
+    emitToolEvent("run-clear-nudge");
+
+    const updatedRuns = listSubagentRunsForRequester("agent:main:main");
+    const updated = updatedRuns.find((r) => r.runId === "run-clear-nudge");
+    expect(updated?.stallNudgedAt).toBeUndefined();
+  });
+
+  it("disabled when both values are 0", async () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    registerSubagentRun({
+      runId: "run-disabled",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "disabled stall test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 0,
+      stallKillAfterSeconds: 0,
+    });
+
+    callGatewaySpy.mockClear();
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    });
+    queueEmbeddedPiMessageSpy.mockClear();
+    abortEmbeddedPiRunSpy.mockClear();
+
+    // Advance well past any stall threshold.
+    vi.setSystemTime(baseTime + 300_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // No nudge or kill should fire.
+    const agentCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCalls).toHaveLength(0);
+    expect(abortEmbeddedPiRunSpy).not.toHaveBeenCalled();
+  });
+
+  it("completed runs are not checked", async () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    registerSubagentRun({
+      runId: "run-completed",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "completed stall test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 5,
+      stallKillAfterSeconds: 10,
+    });
+
+    // Mark it as ended.
+    const runs = listSubagentRunsForRequester("agent:main:main");
+    const entry = runs.find((r) => r.runId === "run-completed");
+    expect(entry).toBeDefined();
+    entry!.endedAt = baseTime;
+
+    callGatewaySpy.mockClear();
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    });
+    queueEmbeddedPiMessageSpy.mockClear();
+    abortEmbeddedPiRunSpy.mockClear();
+
+    // Advance well past stall thresholds.
+    vi.setSystemTime(baseTime + 300_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // No stall actions should fire for ended runs.
+    const agentCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCalls).toHaveLength(0);
+    expect(abortEmbeddedPiRunSpy).not.toHaveBeenCalled();
+  });
+
+  it("nudge falls back to callGateway when queueEmbeddedPiMessage returns false", async () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    queueEmbeddedPiMessageSpy.mockReturnValue(false);
+
+    registerSubagentRun({
+      runId: "run-nudge-fallback",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "nudge fallback test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 5,
+      stallKillAfterSeconds: 10,
+    });
+
+    callGatewaySpy.mockClear();
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    });
+    queueEmbeddedPiMessageSpy.mockClear();
+    queueEmbeddedPiMessageSpy.mockReturnValue(false);
+
+    // Advance past nudge threshold and trigger sweeper.
+    vi.setSystemTime(baseTime + 6_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // queueEmbeddedPiMessage should have been called first.
+    expect(queueEmbeddedPiMessageSpy).toHaveBeenCalled();
+
+    // Since it returned false, callGateway should be called with method "agent".
+    const agentCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCalls.length).toBeGreaterThanOrEqual(1);
+    const nudgeCall = agentCalls[0][0] as {
+      params?: { message?: string };
+    };
+    expect(nudgeCall.params?.message).toContain("stalled");
+  });
+
+  it("nudge uses queueEmbeddedPiMessage when it returns true", async () => {
+    const baseTime = 1_000_000;
+    vi.setSystemTime(baseTime);
+
+    queueEmbeddedPiMessageSpy.mockReturnValue(true);
+
+    registerSubagentRun({
+      runId: "run-nudge-embedded",
+      childSessionKey: "agent:main:subagent:stall-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "nudge embedded test",
+      cleanup: "keep",
+      stallNudgeAfterSeconds: 5,
+      stallKillAfterSeconds: 10,
+    });
+
+    callGatewaySpy.mockClear();
+    callGatewaySpy.mockImplementation(async (params: { method?: string }) => {
+      if (params?.method === "agent.wait") {
+        return new Promise(() => {});
+      }
+      return { status: "ok" };
+    });
+    queueEmbeddedPiMessageSpy.mockClear();
+    queueEmbeddedPiMessageSpy.mockReturnValue(true);
+
+    // Advance past nudge threshold and trigger sweeper.
+    vi.setSystemTime(baseTime + 6_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // queueEmbeddedPiMessage should have succeeded.
+    expect(queueEmbeddedPiMessageSpy).toHaveBeenCalled();
+    const callArgs = queueEmbeddedPiMessageSpy.mock.calls[0] as unknown as [string, string];
+    expect(callArgs[1]).toContain("stalled");
+
+    // callGateway should NOT have been called with method "agent" for fallback.
+    const agentCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCalls).toHaveLength(0);
+  });
+});

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -16,8 +16,8 @@ import { onAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { defaultRuntime } from "../runtime.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
-import { ensureRuntimePluginsLoaded } from "./runtime-plugins.js";
 import { abortEmbeddedPiRun, queueEmbeddedPiMessage } from "./pi-embedded.js";
+import { ensureRuntimePluginsLoaded } from "./runtime-plugins.js";
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import {
   captureSubagentCompletionReply,
@@ -682,7 +682,11 @@ function restoreSubagentRunsOnce() {
     }
     // Resume pending work.
     ensureListener();
-    if ([...subagentRuns.values()].some((entry) => entry.archiveAtMs)) {
+    if (
+      [...subagentRuns.values()].some(
+        (entry) => entry.archiveAtMs || entry.stallNudgeAfterSeconds || entry.stallKillAfterSeconds,
+      )
+    ) {
       startSweeper();
     }
     for (const runId of subagentRuns.keys()) {
@@ -807,16 +811,22 @@ async function checkStallRecovery() {
             params: {
               sessionKey: entry.childSessionKey,
               message: nudgeMessage,
+              idempotencyKey: `stall-nudge:${runId}:${now}`,
             },
             timeoutMs: 10_000,
           });
+          nudged = true;
         } catch {
           log.warn(`Stall nudge delivery failed: runId=${runId}`);
         }
       }
 
-      entry.stallNudgedAt = now;
-      persistSubagentRuns();
+      // Only mark nudge as sent if at least one delivery path succeeded.
+      // If delivery failed, leave stallNudgedAt unset so the next sweep retries.
+      if (nudged) {
+        entry.stallNudgedAt = now;
+        persistSubagentRuns();
+      }
     }
   }
 }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -721,6 +721,7 @@ function startSweeper() {
     void sweepSubagentRuns();
   }, 60_000);
   sweeper.unref?.();
+  log.debug("Stall sweeper started (interval)");
 }
 
 function stopSweeper() {
@@ -729,6 +730,7 @@ function stopSweeper() {
   }
   clearInterval(sweeper);
   sweeper = null;
+  log.debug("Stall sweeper stopped");
 }
 
 /**
@@ -738,6 +740,7 @@ function stopSweeper() {
  */
 async function checkStallRecovery() {
   const now = Date.now();
+  log.debug(`Sweep: checking ${subagentRuns.size} active runs`);
   for (const [runId, entry] of subagentRuns.entries()) {
     // Only check active runs (no endedAt).
     if (typeof entry.endedAt === "number") {
@@ -760,7 +763,7 @@ async function checkStallRecovery() {
       const timeSinceNudgeMs = now - entry.stallNudgedAt;
       if (timeSinceNudgeMs >= killSeconds * 1000) {
         const idleSec = Math.round(idleMs / 1000);
-        log.info(
+        log.warn(
           `Stall kill: runId=${runId} child=${entry.childSessionKey} idle=${idleSec}s nudgedAgo=${Math.round(timeSinceNudgeMs / 1000)}s`,
         );
         // Use completeSubagentRun with stall-specific outcome for proper announce flow.
@@ -779,8 +782,8 @@ async function checkStallRecovery() {
           if (childSessionId) {
             abortEmbeddedPiRun(childSessionId);
           }
-        } catch {
-          /* best effort */
+        } catch (err) {
+          log.debug(`Stall kill: embedded abort failed (best-effort)`, { runId, err });
         }
         continue;
       }
@@ -798,9 +801,14 @@ async function checkStallRecovery() {
         const childSessionId = resolveChildSessionId(entry.childSessionKey);
         if (childSessionId) {
           nudged = queueEmbeddedPiMessage(childSessionId, nudgeMessage);
+          if (nudged) {
+            log.info(
+              `Stall nudge delivered (embedded): runId=${runId} child=${entry.childSessionKey}`,
+            );
+          }
         }
-      } catch {
-        /* best effort */
+      } catch (err) {
+        log.debug(`Stall nudge: embedded delivery failed, trying gateway fallback`, { runId, err });
       }
 
       if (!nudged) {
@@ -816,8 +824,11 @@ async function checkStallRecovery() {
             timeoutMs: 10_000,
           });
           nudged = true;
+          log.info(
+            `Stall nudge delivered (gateway fallback): runId=${runId} child=${entry.childSessionKey}`,
+          );
         } catch {
-          log.warn(`Stall nudge delivery failed: runId=${runId}`);
+          log.warn(`Stall nudge delivery failed: runId=${runId} child=${entry.childSessionKey}`);
         }
       }
 
@@ -893,6 +904,9 @@ function ensureListener() {
             entry.lastToolCallAt = evt.ts || Date.now();
             // Clear nudge state — activity detected after nudge means agent recovered.
             if (entry.stallNudgedAt) {
+              log.info(
+                `Stall recovered: runId=${evt.runId} child=${entry.childSessionKey} — tool activity resumed after nudge`,
+              );
               entry.stallNudgedAt = undefined;
             }
             persistSubagentRuns();

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -17,6 +17,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { defaultRuntime } from "../runtime.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { ensureRuntimePluginsLoaded } from "./runtime-plugins.js";
+import { abortEmbeddedPiRun, queueEmbeddedPiMessage } from "./pi-embedded.js";
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import {
   captureSubagentCompletionReply,
@@ -148,6 +149,21 @@ function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: 
     }
   }
   return undefined;
+}
+
+function resolveChildSessionId(childSessionKey: string): string | undefined {
+  try {
+    const cfg = loadConfig();
+    const agentId = resolveAgentIdFromSessionKey(childSessionKey);
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    const store = loadSessionStore(storePath);
+    const entry = findSessionEntryByKey(store, childSessionKey);
+    return typeof entry?.sessionId === "string" && entry.sessionId.trim()
+      ? entry.sessionId.trim()
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function resolveSubagentRunOrphanReason(params: {
@@ -711,7 +727,104 @@ function stopSweeper() {
   sweeper = null;
 }
 
+/**
+ * Check all active subagent runs for stall conditions and take escalating action:
+ * 1. Nudge: inject a system message after stallNudgeAfterSeconds of no tool calls
+ * 2. Kill: auto-terminate after stallKillAfterSeconds following the nudge
+ */
+async function checkStallRecovery() {
+  const now = Date.now();
+  for (const [runId, entry] of subagentRuns.entries()) {
+    // Only check active runs (no endedAt).
+    if (typeof entry.endedAt === "number") {
+      continue;
+    }
+
+    const nudgeSeconds = entry.stallNudgeAfterSeconds ?? 0;
+    const killSeconds = entry.stallKillAfterSeconds ?? 0;
+
+    // Both disabled — skip.
+    if (nudgeSeconds <= 0 && killSeconds <= 0) {
+      continue;
+    }
+
+    const lastActivity = entry.lastToolCallAt ?? entry.createdAt;
+    const idleMs = now - lastActivity;
+
+    // Check kill condition first (nudge was already sent).
+    if (entry.stallNudgedAt && killSeconds > 0) {
+      const timeSinceNudgeMs = now - entry.stallNudgedAt;
+      if (timeSinceNudgeMs >= killSeconds * 1000) {
+        const idleSec = Math.round(idleMs / 1000);
+        log.info(
+          `Stall kill: runId=${runId} child=${entry.childSessionKey} idle=${idleSec}s nudgedAgo=${Math.round(timeSinceNudgeMs / 1000)}s`,
+        );
+        // Use completeSubagentRun with stall-specific outcome for proper announce flow.
+        await completeSubagentRun({
+          runId,
+          endedAt: now,
+          outcome: { status: "error", error: `stalled (no tool activity for ${idleSec}s)` },
+          reason: SUBAGENT_ENDED_REASON_KILLED,
+          sendFarewell: true,
+          accountId: entry.requesterOrigin?.accountId,
+          triggerCleanup: true,
+        });
+        // Also abort the embedded run if it's still active.
+        try {
+          const childSessionId = resolveChildSessionId(entry.childSessionKey);
+          if (childSessionId) {
+            abortEmbeddedPiRun(childSessionId);
+          }
+        } catch {
+          /* best effort */
+        }
+        continue;
+      }
+    }
+
+    // Check nudge condition.
+    if (!entry.stallNudgedAt && nudgeSeconds > 0 && idleMs >= nudgeSeconds * 1000) {
+      const idleSec = Math.round(idleMs / 1000);
+      log.info(`Stall nudge: runId=${runId} child=${entry.childSessionKey} idle=${idleSec}s`);
+
+      const nudgeMessage = "You appear stalled — resume your task or report what's blocking you.";
+      let nudged = false;
+
+      try {
+        const childSessionId = resolveChildSessionId(entry.childSessionKey);
+        if (childSessionId) {
+          nudged = queueEmbeddedPiMessage(childSessionId, nudgeMessage);
+        }
+      } catch {
+        /* best effort */
+      }
+
+      if (!nudged) {
+        // Fallback: send via gateway as a follow-up message.
+        try {
+          await callGateway({
+            method: "agent",
+            params: {
+              sessionKey: entry.childSessionKey,
+              message: nudgeMessage,
+            },
+            timeoutMs: 10_000,
+          });
+        } catch {
+          log.warn(`Stall nudge delivery failed: runId=${runId}`);
+        }
+      }
+
+      entry.stallNudgedAt = now;
+      persistSubagentRuns();
+    }
+  }
+}
+
 async function sweepSubagentRuns() {
+  // Stall recovery check runs every sweep cycle.
+  await checkStallRecovery();
+
   const now = Date.now();
   let mutated = false;
   for (const [runId, entry] of subagentRuns.entries()) {
@@ -757,7 +870,28 @@ function ensureListener() {
   listenerStarted = true;
   listenerStop = onAgentEvent((evt) => {
     void (async () => {
-      if (!evt || evt.stream !== "lifecycle") {
+      if (!evt) {
+        return;
+      }
+
+      // Track tool activity for stall detection.
+      if (evt.stream === "tool") {
+        const entry = subagentRuns.get(evt.runId);
+        if (entry && typeof entry.endedAt !== "number") {
+          const phase = evt.data?.phase;
+          if (phase === "start" || phase === "end") {
+            entry.lastToolCallAt = evt.ts || Date.now();
+            // Clear nudge state — activity detected after nudge means agent recovered.
+            if (entry.stallNudgedAt) {
+              entry.stallNudgedAt = undefined;
+            }
+            persistSubagentRuns();
+          }
+        }
+        return;
+      }
+
+      if (evt.stream !== "lifecycle") {
         return;
       }
       const phase = evt.data?.phase;
@@ -1132,12 +1266,15 @@ export function replaceSubagentRunAfterSteer(params: {
     spawnMode,
     archiveAtMs,
     runTimeoutSeconds,
+    // Reset stall recovery state for the new run (config is preserved via ...source).
+    lastToolCallAt: now,
+    stallNudgedAt: undefined,
   };
 
   subagentRuns.set(nextRunId, next);
   ensureListener();
   persistSubagentRuns();
-  if (archiveAtMs) {
+  if (archiveAtMs || next.stallNudgeAfterSeconds || next.stallKillAfterSeconds) {
     startSweeper();
   }
   void waitForSubagentCompletion(nextRunId, waitTimeoutMs);
@@ -1162,6 +1299,9 @@ export function registerSubagentRun(params: {
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;
+  stallNudgeAfterSeconds?: number;
+  stallKillAfterSeconds?: number;
+  lastToolCallAt?: number;
 }) {
   const now = Date.now();
   const cfg = loadConfig();
@@ -1195,10 +1335,13 @@ export function registerSubagentRun(params: {
     attachmentsDir: params.attachmentsDir,
     attachmentsRootDir: params.attachmentsRootDir,
     retainAttachmentsOnKeep: params.retainAttachmentsOnKeep,
+    stallNudgeAfterSeconds: params.stallNudgeAfterSeconds,
+    stallKillAfterSeconds: params.stallKillAfterSeconds,
+    lastToolCallAt: params.lastToolCallAt ?? now,
   });
   ensureListener();
   persistSubagentRuns();
-  if (archiveAtMs) {
+  if (archiveAtMs || params.stallNudgeAfterSeconds || params.stallKillAfterSeconds) {
     startSweeper();
   }
   // Wait for subagent completion via gateway RPC (cross-process).

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -55,4 +55,12 @@ export type SubagentRunRecord = {
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;
+  /** Timestamp of the last tool call activity (start or end). Initialized to createdAt. */
+  lastToolCallAt?: number;
+  /** Timestamp when a stall nudge was delivered. Kill timer starts from this. */
+  stallNudgedAt?: number;
+  /** Resolved stall nudge threshold in seconds (0 = disabled). */
+  stallNudgeAfterSeconds?: number;
+  /** Resolved stall kill threshold in seconds (0 = disabled). */
+  stallKillAfterSeconds?: number;
 };

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -51,6 +51,8 @@ export type SpawnSubagentParams = {
   model?: string;
   thinking?: string;
   runTimeoutSeconds?: number;
+  stallNudgeAfterSeconds?: number;
+  stallKillAfterSeconds?: number;
   thread?: boolean;
   mode?: SpawnSubagentMode;
   cleanup?: "delete" | "keep";
@@ -295,6 +297,30 @@ export async function spawnSubagentDirect(
     typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
       ? Math.max(0, Math.floor(params.runTimeoutSeconds))
       : cfgSubagentTimeout;
+
+  // Resolve stall recovery thresholds (config → param override → defaults).
+  const cfgStallNudge =
+    typeof cfg?.agents?.defaults?.subagents?.stallNudgeAfterSeconds === "number" &&
+    Number.isFinite(cfg.agents.defaults.subagents.stallNudgeAfterSeconds)
+      ? Math.max(0, Math.floor(cfg.agents.defaults.subagents.stallNudgeAfterSeconds))
+      : 90; // default
+  const stallNudgeAfterSeconds =
+    typeof params.stallNudgeAfterSeconds === "number" &&
+    Number.isFinite(params.stallNudgeAfterSeconds)
+      ? Math.max(0, Math.floor(params.stallNudgeAfterSeconds))
+      : cfgStallNudge;
+
+  const cfgStallKill =
+    typeof cfg?.agents?.defaults?.subagents?.stallKillAfterSeconds === "number" &&
+    Number.isFinite(cfg.agents.defaults.subagents.stallKillAfterSeconds)
+      ? Math.max(0, Math.floor(cfg.agents.defaults.subagents.stallKillAfterSeconds))
+      : 180; // default
+  const stallKillAfterSeconds =
+    typeof params.stallKillAfterSeconds === "number" &&
+    Number.isFinite(params.stallKillAfterSeconds)
+      ? Math.max(0, Math.floor(params.stallKillAfterSeconds))
+      : cfgStallKill;
+
   let modelApplied = false;
   let threadBindingReady = false;
   const { mainKey, alias } = resolveMainSessionAlias(cfg);
@@ -667,6 +693,9 @@ export async function spawnSubagentDirect(
       attachmentsDir: attachmentAbsDir,
       attachmentsRootDir: attachmentRootDir,
       retainAttachmentsOnKeep: retainOnSessionKeep,
+      stallNudgeAfterSeconds,
+      stallKillAfterSeconds,
+      lastToolCallAt: Date.now(),
     });
   } catch (err) {
     if (attachmentAbsDir) {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -37,6 +37,8 @@ const SessionsSpawnToolSchema = Type.Object({
   runTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
   // Back-compat: older callers used timeoutSeconds for this tool.
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+  stallNudgeAfterSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+  stallKillAfterSeconds: Type.Optional(Type.Number({ minimum: 0 })),
   thread: Type.Optional(Type.Boolean()),
   mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
@@ -117,6 +119,22 @@ export function createSessionsSpawnTool(
         typeof timeoutSecondsCandidate === "number" && Number.isFinite(timeoutSecondsCandidate)
           ? Math.max(0, Math.floor(timeoutSecondsCandidate))
           : undefined;
+      const stallNudgeAfterSecondsCandidate =
+        typeof params.stallNudgeAfterSeconds === "number"
+          ? params.stallNudgeAfterSeconds
+          : undefined;
+      const stallNudgeAfterSeconds =
+        typeof stallNudgeAfterSecondsCandidate === "number" &&
+        Number.isFinite(stallNudgeAfterSecondsCandidate)
+          ? Math.max(0, Math.floor(stallNudgeAfterSecondsCandidate))
+          : undefined;
+      const stallKillAfterSecondsCandidate =
+        typeof params.stallKillAfterSeconds === "number" ? params.stallKillAfterSeconds : undefined;
+      const stallKillAfterSeconds =
+        typeof stallKillAfterSecondsCandidate === "number" &&
+        Number.isFinite(stallKillAfterSecondsCandidate)
+          ? Math.max(0, Math.floor(stallKillAfterSecondsCandidate))
+          : undefined;
       const thread = params.thread === true;
       const attachments = Array.isArray(params.attachments)
         ? (params.attachments as Array<{
@@ -181,6 +199,8 @@ export function createSessionsSpawnTool(
           model: modelOverride,
           thinking: thinkingOverrideRaw,
           runTimeoutSeconds,
+          stallNudgeAfterSeconds,
+          stallKillAfterSeconds,
           thread,
           mode,
           cleanup,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -281,6 +281,10 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
+    /** Seconds of inactivity (no tool calls) before injecting a nudge message. 0 = disabled (default: 90). */
+    stallNudgeAfterSeconds?: number;
+    /** Seconds after nudge with continued inactivity before auto-killing. 0 = disabled (default: 180). */
+    stallKillAfterSeconds?: number;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -186,6 +186,8 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        stallNudgeAfterSeconds: z.number().int().min(0).optional(),
+        stallKillAfterSeconds: z.number().int().min(0).optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -741,6 +741,8 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        stallNudgeAfterSeconds: z.number().int().min(0).optional(),
+        stallKillAfterSeconds: z.number().int().min(0).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Adds activity-based stall detection and two-stage recovery (nudge → kill) for sub-agents.

### Problem
Sub-agents can stall indefinitely — waiting on an API call that never returns, stuck in a loop, or hitting an unhandled error. The only existing protection is `runTimeoutSeconds`, which is a hard wall clock timeout that can't distinguish between a stalled agent and one that's actively working on a long task.

### Solution
Two-stage stall recovery based on **tool call activity**:

1. **Nudge** (`stallNudgeAfterSeconds`, default 90s) — If no tool calls for N seconds, send the agent a "you appear stalled" message. This gives the agent a chance to self-recover (retry the API call, try a different approach, etc.).

2. **Kill** (`stallKillAfterSeconds`, default 180s) — If still no tool calls N seconds after the nudge, forcefully terminate the run and announce timeout to the parent session.

### What's included
- Core stall detection loop in `subagent-registry.ts` (sweeper-based, checks `lastToolCallAt`)
- Two delivery paths for nudge messages (embedded Pi message → gateway RPC fallback)
- Agent recovery detection (clears nudge state when tool activity resumes)
- Per-agent and global config support (`stallNudgeAfterSeconds`, `stallKillAfterSeconds`)
- Comprehensive logging: sweeper lifecycle, nudge delivery (both paths), recovery events, kill events
- 19 tests covering detection, delivery, recovery, kill, config validation, and edge cases

### Bug fixes in this PR
- **Nudge delivery**: Added missing `idempotencyKey` to gateway fallback (was silently rejected). Fixed `stallNudgedAt` being set even when delivery failed (prevented retries).
- **Sweeper restart**: `restoreSubagentRunsOnce()` now checks stall config keys when deciding to start the sweeper (session-mode runs without `archiveAtMs` were being skipped).
- **Config schema**: Added stall keys to per-agent `subagents` schema to match `AgentDefaultsSchema` (fixes Zod strict-mode rejection).

### Production data
Running on a live deployment for 3 days:
- 24+ stall events detected across 3 agents
- 1 confirmed stall kill (agent idle 21 min)
- Multiple successful nudge → recovery cycles observed

Fixes #39305