### PR TITLE
Telegram: add processing indicator message

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -110,6 +110,21 @@ describe("web search provider config", () => {
   });
 });
 
+describe("telegram processing indicator config", () => {
+  it("accepts processingIndicator", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          botToken: "fake",
+          processingIndicator: "⌛️",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});
+
 describe("talk.voiceAliases", () => {
   it("accepts a string map of voice aliases", () => {
     const res = validateConfigObject({

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1464,6 +1464,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
   "channels.telegram.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
+  "channels.telegram.processingIndicator":
+    'Optional visible Telegram message sent while a request is being processed, for example "⌛️". When set, OpenClaw deletes it after a successful reply and edits it to a generic error message if processing fails.',
   "channels.telegram.streaming":
     'Unified Telegram stream preview mode: "off" | "partial" | "block" | "progress" (default: "partial"). "progress" maps to "partial" on Telegram. Legacy boolean/streamMode keys are auto-mapped.',
   "channels.discord.streaming":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -708,6 +708,7 @@ export const FIELD_LABELS: Record<string, string> = {
   ...IRC_FIELD_LABELS,
   "channels.telegram.botToken": "Telegram Bot Token",
   "channels.telegram.dmPolicy": "Telegram DM Policy",
+  "channels.telegram.processingIndicator": "Telegram Processing Indicator",
   "channels.telegram.configWrites": "Telegram Config Writes",
   "channels.telegram.commands.native": "Telegram Native Commands",
   "channels.telegram.commands.nativeSkills": "Telegram Native Skill Commands",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -121,6 +121,8 @@ export type TelegramAccountConfig = {
   dms?: Record<string, DmConfig>;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
+  /** Optional visible "working..." message sent while Telegram replies are processing. */
+  processingIndicator?: string;
   /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */
   chunkMode?: "length" | "newline";
   /**

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -183,6 +183,7 @@ export const TelegramAccountSchemaBase = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     direct: z.record(z.string(), TelegramDirectSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
+    processingIndicator: z.string().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     streaming: z.union([z.boolean(), z.enum(["off", "partial", "block", "progress"])]).optional(),
     blockStreaming: z.boolean().optional(),

--- a/src/telegram/bot-message.test.ts
+++ b/src/telegram/bot-message.test.ts
@@ -66,6 +66,27 @@ describe("telegram bot message processor", () => {
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("sends and removes processing indicator around successful dispatch", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 999 });
+    const deleteMessage = vi.fn().mockResolvedValue(true);
+    buildTelegramMessageContext.mockResolvedValue({
+      chatId: 123,
+      threadSpec: { id: 456 },
+      route: { sessionKey: "agent:main:main" },
+    });
+
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage, deleteMessage } },
+      telegramCfg: { processingIndicator: "⌛️" },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+    await processSampleMessage(processMessage);
+
+    expect(sendMessage).toHaveBeenCalledWith(123, "⌛️", { message_thread_id: 456 });
+    expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+    expect(deleteMessage).toHaveBeenCalledWith(123, 999);
+  });
+
   it("skips dispatch when no context is produced", async () => {
     buildTelegramMessageContext.mockResolvedValue(null);
     const processMessage = createTelegramMessageProcessor(baseDeps);
@@ -95,6 +116,35 @@ describe("telegram bot message processor", () => {
       "Something went wrong while processing your request. Please try again.",
       { message_thread_id: 456 },
     );
+    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("dispatch exploded"));
+  });
+
+  it("edits processing indicator when dispatch throws", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 999 });
+    const editMessageText = vi.fn().mockResolvedValue(true);
+    const runtimeError = vi.fn();
+    buildTelegramMessageContext.mockResolvedValue({
+      chatId: 123,
+      threadSpec: { id: 456 },
+      route: { sessionKey: "agent:main:main" },
+    });
+    dispatchTelegramMessage.mockRejectedValue(new Error("dispatch exploded"));
+
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage, editMessageText } },
+      telegramCfg: { processingIndicator: "⌛️" },
+      runtime: { error: runtimeError },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+    await expect(processSampleMessage(processMessage)).resolves.toBeUndefined();
+
+    expect(sendMessage).toHaveBeenCalledWith(123, "⌛️", { message_thread_id: 456 });
+    expect(editMessageText).toHaveBeenCalledWith(
+      123,
+      999,
+      "Something went wrong while processing your request. Please try again.",
+    );
+    expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("dispatch exploded"));
   });
 

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -47,6 +47,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     textLimit,
     opts,
   } = deps;
+  const processingIndicator = telegramCfg.processingIndicator?.trim();
 
   return async (
     primaryCtx: TelegramContext,
@@ -79,6 +80,19 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     if (!context) {
       return;
     }
+    let processingIndicatorMessageId: number | undefined;
+    if (processingIndicator) {
+      try {
+        const sent = await bot.api.sendMessage(
+          context.chatId,
+          processingIndicator,
+          context.threadSpec?.id != null ? { message_thread_id: context.threadSpec.id } : undefined,
+        );
+        processingIndicatorMessageId = sent?.message_id;
+      } catch {
+        // Best-effort UX only; continue processing if the indicator cannot be sent.
+      }
+    }
     try {
       await dispatchTelegramMessage({
         context,
@@ -91,8 +105,27 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         telegramCfg,
         opts,
       });
+      if (processingIndicatorMessageId != null) {
+        try {
+          await bot.api.deleteMessage(context.chatId, processingIndicatorMessageId);
+        } catch {
+          // Best-effort cleanup only.
+        }
+      }
     } catch (err) {
       runtime.error?.(danger(`telegram message processing failed: ${String(err)}`));
+      if (processingIndicatorMessageId != null) {
+        try {
+          await bot.api.editMessageText(
+            context.chatId,
+            processingIndicatorMessageId,
+            "Something went wrong while processing your request. Please try again.",
+          );
+          return;
+        } catch {
+          // Fall back to a new message if the indicator cannot be edited.
+        }
+      }
       try {
         await bot.api.sendMessage(
           context.chatId,


### PR DESCRIPTION
## Summary
- add `channels.telegram.processingIndicator` so Telegram can post a visible in-chat "working" message while a request is being processed
- delete the indicator after a successful reply
- edit the indicator to the existing generic failure text when dispatch fails, falling back to a new message only if the edit itself fails

## Root cause
For issue #6946, Telegram only exposed subtle feedback paths like typing indicators and ack reactions. The message processor had no hook to send a visible in-chat placeholder before `dispatchTelegramMessage()` started, and no lifecycle cleanup/edit path around that dispatch.

## Testing
- `pnpm test src/config/config-misc.test.ts`
- `pnpm test src/telegram/bot-message.test.ts`
