### PR TITLE
Auto-reply: expose resolved OpenRouter auto model in usage footer

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -6,6 +6,7 @@ import { normalizeAnyChannelId, normalizeChannelId } from "../../channels/regist
 import type { OpenClawConfig } from "../../config/config.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { estimateUsageCost, formatTokenCount, formatUsd } from "../../utils/usage-format.js";
+import { formatProviderModelRef } from "../model-runtime.js";
 import type { TemplateContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
@@ -126,6 +127,23 @@ export const formatResponseUsageLine = (params: {
   const costLabel = params.showCost ? formatUsd(cost) : undefined;
   const suffix = costLabel ? ` · est ${costLabel}` : "";
   return `Usage: ${inputLabel} in / ${outputLabel} out${suffix}`;
+};
+
+export const formatResolvedOpenRouterAutoUsageSuffix = (params: {
+  selectedProvider: string;
+  selectedModel: string;
+  activeProvider: string;
+  activeModel: string;
+}): string | null => {
+  const selectedRef = formatProviderModelRef(params.selectedProvider, params.selectedModel).trim();
+  if (selectedRef.toLowerCase() !== "openrouter/auto") {
+    return null;
+  }
+  const activeRef = formatProviderModelRef(params.activeProvider, params.activeModel).trim();
+  if (!activeRef || activeRef.toLowerCase() === selectedRef.toLowerCase()) {
+    return null;
+  }
+  return ` · model ${activeRef}`;
 };
 
 export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPayload[] => {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1547,6 +1547,86 @@ describe("runReplyAgent response usage footer", () => {
     expect(String(payload?.text ?? "")).toContain("Usage:");
     expect(String(payload?.text ?? "")).not.toContain("· session ");
   });
+
+  it("shows the resolved OpenRouter model when selected model is openrouter/auto", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "openrouter",
+          model: "google/gemini-2.5-flash",
+          usage: { input: 12, output: 3 },
+        },
+      },
+    });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "whatsapp",
+      OriginatingTo: "+15550001111",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const sessionKey = "agent:main:whatsapp:dm:+1000";
+
+    const res = await runReplyAgent({
+      commandBody: "hello",
+      followupRun: {
+        prompt: "hello",
+        summaryLine: "hello",
+        enqueuedAt: Date.now(),
+        run: {
+          agentId: "main",
+          agentDir: "/tmp/agent",
+          sessionId: "session",
+          sessionKey,
+          messageProvider: "whatsapp",
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/tmp",
+          config: {},
+          skillsSnapshot: {},
+          provider: "openrouter",
+          model: "openrouter/auto",
+          thinkLevel: "low",
+          verboseLevel: "off",
+          elevatedLevel: "off",
+          bashElevated: {
+            enabled: false,
+            allowed: false,
+            defaultLevel: "off",
+          },
+          timeoutMs: 1_000,
+          blockReplyBreak: "message_end",
+        },
+      } as unknown as FollowupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry: {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        responseUsage: "tokens",
+      },
+      sessionKey,
+      defaultModel: "openrouter/openrouter/auto",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    const payload = Array.isArray(res) ? res[0] : res;
+    expect(String(payload?.text ?? "")).toContain("Usage:");
+    expect(String(payload?.text ?? "")).toContain("· model openrouter/google/gemini-2.5-flash");
+  });
 });
 
 describe("runReplyAgent transient HTTP retry", () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -44,7 +44,11 @@ import {
   hasSessionRelatedCronJobs,
   hasUnbackedReminderCommitment,
 } from "./agent-runner-reminder-guard.js";
-import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
+import {
+  appendUsageLine,
+  formatResolvedOpenRouterAutoUsageSuffix,
+  formatResponseUsageLine,
+} from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
@@ -594,6 +598,15 @@ export async function runReplyAgent(params: {
         showCost,
         costConfig,
       });
+      const resolvedModelSuffix = formatResolvedOpenRouterAutoUsageSuffix({
+        selectedProvider,
+        selectedModel,
+        activeProvider: providerUsed,
+        activeModel: modelUsed,
+      });
+      if (formatted && resolvedModelSuffix) {
+        formatted += resolvedModelSuffix;
+      }
       if (formatted && responseUsageMode === "full" && sessionKey) {
         formatted = `${formatted} · session \`${sessionKey}\``;
       }


### PR DESCRIPTION
## Summary

- Problem: replies using `openrouter/auto` only showed the generic usage footer, so users could not see which model OpenRouter actually routed to.
- Why it matters: `openrouter/auto` hides real routing decisions; without surfacing the resolved model, cost and behavior are harder to audit.
- What changed: the response usage footer now appends the resolved runtime model when the selected model is `openrouter/auto` and OpenRouter returned a concrete routed model.
- What did NOT change (scope boundary): no status command changes, no fallback notices changes, and no broader model-selection UI changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #7006

## User-visible / Behavior Changes

Replies that use `openrouter/auto` now include the resolved routed model in the usage footer, for example `Usage: ... · model openrouter/google/gemini-2.5-flash`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: local dev checkout
- Runtime/container: pnpm + vitest
- Model/provider: `openrouter/auto`
- Integration/channel (if any): auto-reply response footer
- Relevant config (redacted): `responseUsage=tokens`

### Steps

1. Run an agent turn with selected model `openrouter/auto`.
2. Return usage metadata plus a concrete runtime model from OpenRouter.
3. Inspect the final reply payload text.

### Expected

- The usage footer shows the concrete routed model, not just generic usage numbers.

### Actual

- After the patch, the footer includes `· model openrouter/...` when OpenRouter resolved `auto` to a concrete model.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:

```bash
pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
pnpm exec oxfmt --check src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner-utils.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `openrouter/auto` replies now append the resolved model when runtime metadata differs from the selected model.
  - Existing response usage footer tests still pass.
- Edge cases checked:
  - No suffix is added when the runtime model is still `openrouter/auto`.
  - Non-OpenRouter-auto selections are left unchanged by the helper guard.
- What you did **not** verify:
  - End-to-end live OpenRouter traffic against a real gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `0042bcc9f`.
- Files/config to restore:
  - `src/auto-reply/reply/agent-runner.ts`
  - `src/auto-reply/reply/agent-runner-utils.ts`
  - `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- Known bad symptoms reviewers should watch for:
  - Usage footer showing an unexpected `model ...` suffix for non-`openrouter/auto` runs.

## Risks and Mitigations

- Risk: footer could become noisy if the guard misidentifies non-auto selections.
  - Mitigation: the suffix is gated strictly on `openrouter/auto` and covered by regression test.
