### PR TITLE
WhatsApp: support channel systemPrompt overrides

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -75,6 +75,23 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts channels.whatsapp.systemPrompt at root and account scope", () => {
+    const res = validateConfigObject({
+      channels: {
+        whatsapp: {
+          systemPrompt: "Reply directly.",
+          accounts: {
+            work: {
+              systemPrompt: "Reply as work.",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects unsafe iMessage remoteHost", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1498,6 +1498,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow ACP spawns with thread=true to auto-bind Telegram current conversations when supported.",
   "channels.whatsapp.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.whatsapp.allowFrom=["*"].',
+  "channels.whatsapp.systemPrompt":
+    "Optional system prompt snippet prepended to inbound WhatsApp turns. Account-level values override the root WhatsApp prompt.",
   "channels.whatsapp.selfChatMode": "Same-phone setup (bot uses your personal WhatsApp number).",
   "channels.whatsapp.debounceMs":
     "Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -731,6 +731,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.telegram.threadBindings.spawnSubagentSessions": "Telegram Thread-Bound Subagent Spawn",
   "channels.telegram.threadBindings.spawnAcpSessions": "Telegram Thread-Bound ACP Spawn",
   "channels.whatsapp.dmPolicy": "WhatsApp DM Policy",
+  "channels.whatsapp.systemPrompt": "WhatsApp System Prompt",
   "channels.whatsapp.selfChatMode": "WhatsApp Self-Phone Mode",
   "channels.whatsapp.debounceMs": "WhatsApp Message Debounce (ms)",
   "channels.whatsapp.configWrites": "WhatsApp Config Writes",

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -93,6 +93,8 @@ type WhatsAppConfigCore = {
   messagePrefix?: string;
   /** Outbound response prefix override. */
   responsePrefix?: string;
+  /** Optional system prompt snippet applied to inbound WhatsApp turns. */
+  systemPrompt?: string;
 };
 
 export type WhatsAppConfig = WhatsAppConfigCore &

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -39,6 +39,7 @@ const WhatsAppSharedSchema = z.object({
   sendReadReceipts: z.boolean().optional(),
   messagePrefix: z.string().optional(),
   responsePrefix: z.string().optional(),
+  systemPrompt: z.string().optional(),
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -15,6 +15,7 @@ export type ResolvedWhatsAppAccount = {
   enabled: boolean;
   sendReadReceipts: boolean;
   messagePrefix?: string;
+  systemPrompt?: string;
   authDir: string;
   isLegacyAuthDir: boolean;
   selfChatMode?: boolean;
@@ -132,6 +133,7 @@ export function resolveWhatsAppAccount(params: {
     sendReadReceipts: accountCfg?.sendReadReceipts ?? rootCfg?.sendReadReceipts ?? true,
     messagePrefix:
       accountCfg?.messagePrefix ?? rootCfg?.messagePrefix ?? params.cfg.messages?.messagePrefix,
+    systemPrompt: accountCfg?.systemPrompt ?? rootCfg?.systemPrompt,
     authDir,
     isLegacyAuthDir: isLegacy,
     selfChatMode: accountCfg?.selfChatMode ?? rootCfg?.selfChatMode,

--- a/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -236,6 +236,42 @@ describe("web processMessage inbound contract", () => {
     expect(getDispatcherResponsePrefix()).toBeUndefined();
   });
 
+  it("passes account-level WhatsApp systemPrompt into the inbound context", async () => {
+    capturedCtx = undefined;
+
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+1555",
+        groupHistoryKey: "+1555",
+        cfg: {
+          channels: {
+            whatsapp: {
+              systemPrompt: "Reply casually.",
+              accounts: {
+                default: {
+                  systemPrompt: "Reply directly with text.",
+                },
+              },
+            },
+          },
+          messages: {},
+          session: { store: sessionStorePath },
+        } as unknown as ReturnType<typeof import("../../../config/config.js").loadConfig>,
+        msg: {
+          id: "msg-system-prompt",
+          from: "+1555",
+          to: "+2000",
+          chatType: "direct",
+          body: "hi",
+        },
+      }),
+    );
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const ctx = capturedCtx as any;
+    expect(ctx?.GroupSystemPrompt).toBe("Reply directly with text.");
+  });
+
   it("clears pending group history when the dispatcher does not queue a final reply", async () => {
     capturedCtx = undefined;
     const groupHistories = new Map<string, Array<{ sender: string; body: string }>>([

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -257,6 +257,11 @@ export async function processMessage(params: {
 
   const textLimit = params.maxMediaTextChunkLimit ?? resolveTextChunkLimit(params.cfg, "whatsapp");
   const chunkMode = resolveChunkMode(params.cfg, "whatsapp", params.route.accountId);
+  const account = resolveWhatsAppAccount({
+    cfg: params.cfg,
+    accountId: params.route.accountId,
+  });
+  const groupSystemPrompt = account.systemPrompt?.trim() || undefined;
   const tableMode = resolveMarkdownTableMode({
     cfg: params.cfg,
     channel: "whatsapp",
@@ -316,6 +321,7 @@ export async function processMessage(params: {
     ChatType: params.msg.chatType,
     ConversationLabel: params.msg.chatType === "group" ? conversationId : params.msg.from,
     GroupSubject: params.msg.groupSubject,
+    GroupSystemPrompt: groupSystemPrompt,
     GroupMembers: formatGroupMembers({
       participants: params.msg.groupParticipants,
       roster: params.groupMemberNames.get(params.groupHistoryKey),


### PR DESCRIPTION
## Summary

- Problem: WhatsApp channel config supported message/response prefix overrides, but not a channel-level `systemPrompt`, unlike Telegram/Slack/Discord.
- Why it matters: WhatsApp users had no clean channel-specific way to steer reply behavior, including discouraging `message` tool usage for normal direct replies.
- What changed: added `systemPrompt` to WhatsApp root/account config, threaded it through `resolveWhatsAppAccount()`, and injected it into inbound WhatsApp context so agent runs receive the prompt.
- What did NOT change (scope boundary): no per-contact `dms` prompt support, no Signal/iMessage parity work, and no outbound delivery behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #7011
- Related #7010

## User-visible / Behavior Changes

`channels.whatsapp.systemPrompt` and `channels.whatsapp.accounts.<id>.systemPrompt` are now accepted and included in inbound WhatsApp agent context. Account-level values override the root WhatsApp prompt.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: local dev checkout
- Runtime/container: pnpm + vitest
- Model/provider: N/A
- Integration/channel (if any): WhatsApp web auto-reply inbound pipeline
- Relevant config (redacted): `channels.whatsapp.systemPrompt` and `channels.whatsapp.accounts.default.systemPrompt`

### Steps

1. Configure `channels.whatsapp.systemPrompt` or an account-level `systemPrompt`.
2. Process an inbound WhatsApp message.
3. Inspect the finalized inbound context passed to the dispatcher.

### Expected

- The inbound context contains the configured WhatsApp system prompt, with account-level override taking precedence.

### Actual

- After the patch, `GroupSystemPrompt` is populated from WhatsApp config and reaches the auto-reply pipeline.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:

```bash
pnpm test src/config/config.schema-regressions.test.ts src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
pnpm exec oxfmt --check src/config/types.whatsapp.ts src/config/zod-schema.providers-whatsapp.ts src/web/accounts.ts src/web/auto-reply/monitor/process-message.ts src/config/config.schema-regressions.test.ts src/web/auto-reply/monitor/process-message.inbound-contract.test.ts src/config/schema.help.ts src/config/schema.labels.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - WhatsApp config validation accepts root/account `systemPrompt` keys.
  - Inbound WhatsApp processing passes account-level prompt through to the dispatcher context.
- Edge cases checked:
  - Account-level `systemPrompt` overrides the root WhatsApp prompt.
- What you did **not** verify:
  - End-to-end live WhatsApp traffic against a real Baileys session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f99c5ef37`.
- Files/config to restore:
  - `src/config/types.whatsapp.ts`
  - `src/config/zod-schema.providers-whatsapp.ts`
  - `src/web/accounts.ts`
  - `src/web/auto-reply/monitor/process-message.ts`
- Known bad symptoms reviewers should watch for:
  - WhatsApp inbound context missing `GroupSystemPrompt` despite config.
  - Unexpected root prompt winning over account-level prompt.

## Risks and Mitigations

- Risk: prompt precedence could drift from other per-account WhatsApp overrides.
  - Mitigation: reuse `resolveWhatsAppAccount()` merge precedence and cover account override in regression test.
