### PR TITLE
fix(usage): show balance-only providers in summary line and report [AI]

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -384,6 +384,9 @@ export function createSessionStatusTool(opts?: {
             });
             if (formatted && !formatted.startsWith("error:")) {
               usageLine = `📊 Usage: ${formatted}`;
+            } else if (!snapshot.error && snapshot.plan) {
+              // Balance-only provider (no quota windows) — show plan label directly.
+              usageLine = `📊 Usage: ${snapshot.displayName} ${snapshot.plan}`;
             }
           }
         } catch {

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -94,7 +94,7 @@ export async function buildStatusReply(params: {
         agentDir: statusAgentDir,
       });
       const usageEntry = usageSummary.providers[0];
-      if (usageEntry && !usageEntry.error && usageEntry.windows.length > 0) {
+      if (usageEntry && !usageEntry.error) {
         const summaryLine = formatUsageWindowSummary(usageEntry, {
           now: Date.now(),
           maxWindows: 2,
@@ -102,6 +102,9 @@ export async function buildStatusReply(params: {
         });
         if (summaryLine) {
           usageLine = `📊 Usage: ${summaryLine}`;
+        } else if (usageEntry.plan) {
+          // Balance-only provider (no quota windows) — show plan label directly.
+          usageLine = `📊 Usage: ${usageEntry.displayName} ${usageEntry.plan}`;
         }
       }
     } catch {

--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -48,7 +48,8 @@ describe("fetchCodexUsage", () => {
     const result = await fetchCodexUsage("token", "acct-1", 5000, mockFetch);
 
     expect(result.provider).toBe("openai-codex");
-    expect(result.plan).toBe("Plus ($12.50)");
+    expect(result.plan).toBe("Plus");
+    expect(result.balance).toBe("$12.50");
     expect(result.windows).toEqual([
       { label: "3h", usedPercent: 35.5, resetAt: 1_700_000_000_000 },
       { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },

--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -134,7 +134,7 @@ describe("fetchCodexUsage", () => {
     expect(result.windows).toEqual([{ label: "6h", usedPercent: 11, resetAt: undefined }]);
   });
 
-  it("builds a balance-only plan when credits exist without a plan type", async () => {
+  it("sets balance (not plan) when credits exist without a plan type", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(200, {
         credits: { balance: "7.5" },
@@ -142,11 +142,12 @@ describe("fetchCodexUsage", () => {
     );
 
     const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
-    expect(result.plan).toBe("$7.50");
+    expect(result.plan).toBeUndefined();
+    expect(result.balance).toBe("$7.50");
     expect(result.windows).toEqual([]);
   });
 
-  it("falls back invalid credit strings to a zero balance", async () => {
+  it("does not set balance for unparseable credit strings", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(200, {
         plan_type: "Plus",
@@ -155,6 +156,7 @@ describe("fetchCodexUsage", () => {
     );
 
     const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
-    expect(result.plan).toBe("Plus ($0.00)");
+    expect(result.plan).toBe("Plus");
+    expect(result.balance).toBeUndefined();
   });
 });

--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -56,6 +56,15 @@ describe("fetchCodexUsage", () => {
     ]);
   });
 
+  it("does not set balance for malformed credit strings", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, { plan_type: "Plus", credits: { balance: "" } }),
+    );
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.balance).toBeUndefined();
+    expect(result.plan).toBe("Plus");
+  });
+
   it("labels weekly secondary window as Week", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(200, {

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -102,13 +102,14 @@ export async function fetchCodexUsage(
     });
   }
 
-  let plan = data.plan_type;
+  const plan = data.plan_type;
+  let balance: string | undefined;
   if (data.credits?.balance !== undefined && data.credits.balance !== null) {
-    const balance =
+    const raw =
       typeof data.credits.balance === "number"
         ? data.credits.balance
         : parseFloat(data.credits.balance) || 0;
-    plan = plan ? `${plan} ($${balance.toFixed(2)})` : `$${balance.toFixed(2)}`;
+    balance = `$${raw.toFixed(2)}`;
   }
 
   return {
@@ -116,5 +117,6 @@ export async function fetchCodexUsage(
     displayName: PROVIDER_LABELS["openai-codex"],
     windows,
     plan,
+    balance,
   };
 }

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -108,8 +108,13 @@ export async function fetchCodexUsage(
     const raw =
       typeof data.credits.balance === "number"
         ? data.credits.balance
-        : parseFloat(data.credits.balance) || 0;
-    balance = `$${raw.toFixed(2)}`;
+        : parseFloat(data.credits.balance);
+    // Only expose balance when the parse actually produced a finite number;
+    // malformed strings (e.g. "") become NaN via parseFloat and must not be
+    // treated as valid usage data.
+    if (Number.isFinite(raw)) {
+      balance = `$${raw.toFixed(2)}`;
+    }
   }
 
   return {

--- a/src/infra/provider-usage.format.test.ts
+++ b/src/infra/provider-usage.format.test.ts
@@ -112,7 +112,7 @@ describe("provider-usage.format", () => {
     ).toBeNull();
   });
 
-  it("includes plan-only providers in summary line and omits errored ones", () => {
+  it("includes balance-only providers in summary line and omits errored ones", () => {
     const summary: UsageSummary = {
       updatedAt: now,
       providers: [
@@ -120,13 +120,13 @@ describe("provider-usage.format", () => {
           provider: "zai",
           displayName: "Kilo",
           windows: [],
-          plan: "$5.00",
+          balance: "$5.00",
         },
         {
           provider: "anthropic",
           displayName: "Claude",
           windows: [],
-          plan: "$0.00",
+          plan: "business",
           error: "Depleted",
         },
         {
@@ -137,7 +137,7 @@ describe("provider-usage.format", () => {
       ],
     };
 
-    // Kilo appears with its plan label; errored Claude is excluded; windowless+planless Xiaomi is excluded
+    // Kilo appears with its balance; errored Claude is excluded; windowless+balanceless Xiaomi is excluded
     expect(formatUsageSummaryLine(summary, { now })).toBe("📊 Usage: Kilo $5.00");
   });
 
@@ -160,19 +160,21 @@ describe("provider-usage.format", () => {
           provider: "xiaomi",
           displayName: "Xiaomi",
           windows: [],
+          // plan without balance: tier metadata only — still signals "no data"
+          plan: "business",
         },
         {
           provider: "zai",
           displayName: "Kilo",
           windows: [],
-          plan: "$5.00",
+          balance: "$5.00",
         },
       ],
     };
     expect(formatUsageReportLines(summary)).toEqual([
       "Usage:",
       "  Codex (Plus): Token expired",
-      "  Xiaomi: no data",
+      "  Xiaomi (business): no data",
       "  Kilo ($5.00)",
     ]);
   });

--- a/src/infra/provider-usage.format.test.ts
+++ b/src/infra/provider-usage.format.test.ts
@@ -117,7 +117,7 @@ describe("provider-usage.format", () => {
       updatedAt: now,
       providers: [
         {
-          provider: "kilocode",
+          provider: "zai",
           displayName: "Kilo",
           windows: [],
           plan: "$5.00",
@@ -162,7 +162,7 @@ describe("provider-usage.format", () => {
           windows: [],
         },
         {
-          provider: "kilocode",
+          provider: "zai",
           displayName: "Kilo",
           windows: [],
           plan: "$5.00",

--- a/src/infra/provider-usage.format.test.ts
+++ b/src/infra/provider-usage.format.test.ts
@@ -112,6 +112,35 @@ describe("provider-usage.format", () => {
     ).toBeNull();
   });
 
+  it("includes plan-only providers in summary line and omits errored ones", () => {
+    const summary: UsageSummary = {
+      updatedAt: now,
+      providers: [
+        {
+          provider: "kilocode",
+          displayName: "Kilo",
+          windows: [],
+          plan: "$5.00",
+        },
+        {
+          provider: "anthropic",
+          displayName: "Claude",
+          windows: [],
+          plan: "$0.00",
+          error: "Depleted",
+        },
+        {
+          provider: "xiaomi",
+          displayName: "Xiaomi",
+          windows: [],
+        },
+      ],
+    };
+
+    // Kilo appears with its plan label; errored Claude is excluded; windowless+planless Xiaomi is excluded
+    expect(formatUsageSummaryLine(summary, { now })).toBe("📊 Usage: Kilo $5.00");
+  });
+
   it("formats report output for empty, error, no-data, and plan entries", () => {
     expect(formatUsageReportLines({ updatedAt: now, providers: [] })).toEqual([
       "Usage: no provider usage available.",
@@ -132,12 +161,19 @@ describe("provider-usage.format", () => {
           displayName: "Xiaomi",
           windows: [],
         },
+        {
+          provider: "kilocode",
+          displayName: "Kilo",
+          windows: [],
+          plan: "$5.00",
+        },
       ],
     };
     expect(formatUsageReportLines(summary)).toEqual([
       "Usage:",
       "  Codex (Plus): Token expired",
       "  Xiaomi: no data",
+      "  Kilo ($5.00)",
     ]);
   });
 

--- a/src/infra/provider-usage.format.ts
+++ b/src/infra/provider-usage.format.ts
@@ -71,16 +71,16 @@ export function formatUsageSummaryLine(
   opts?: { now?: number; maxProviders?: number },
 ): string | null {
   const providers = summary.providers
-    .filter((entry) => !entry.error && (entry.windows.length > 0 || entry.plan))
+    .filter((entry) => !entry.error && (entry.windows.length > 0 || entry.balance))
     .slice(0, opts?.maxProviders ?? summary.providers.length);
   if (providers.length === 0) {
     return null;
   }
 
   const parts = providers.map((entry) => {
-    // Plan-only providers (e.g. credit-balance APIs with no quota windows)
+    // Balance-only providers (credit-balance APIs with no quota windows)
     if (entry.windows.length === 0) {
-      return `${entry.displayName} ${entry.plan}`;
+      return `${entry.displayName} ${entry.balance}`;
     }
     const window = entry.windows.reduce((best, next) =>
       next.usedPercent > best.usedPercent ? next : best,
@@ -97,15 +97,16 @@ export function formatUsageReportLines(summary: UsageSummary, opts?: { now?: num
 
   const lines: string[] = ["Usage:"];
   for (const entry of summary.providers) {
-    const planSuffix = entry.plan ? ` (${entry.plan})` : "";
+    const metaParts = [entry.plan, entry.balance].filter(Boolean);
+    const planSuffix = metaParts.length > 0 ? ` (${metaParts.join(" · ")})` : "";
     if (entry.error) {
       lines.push(`  ${entry.displayName}${planSuffix}: ${entry.error}`);
       continue;
     }
     if (entry.windows.length === 0) {
-      // If the plan field carries the data (e.g. credit balance), it's already
-      // shown via planSuffix — don't append ": no data" in that case.
-      const suffix = entry.plan ? "" : ": no data";
+      // Preserve "no data" unless the snapshot explicitly carries a credit
+      // balance — plan alone is tier metadata and does not confirm usage data.
+      const suffix = entry.balance ? "" : ": no data";
       lines.push(`  ${entry.displayName}${planSuffix}${suffix}`);
       continue;
     }

--- a/src/infra/provider-usage.format.ts
+++ b/src/infra/provider-usage.format.ts
@@ -71,13 +71,17 @@ export function formatUsageSummaryLine(
   opts?: { now?: number; maxProviders?: number },
 ): string | null {
   const providers = summary.providers
-    .filter((entry) => entry.windows.length > 0 && !entry.error)
+    .filter((entry) => !entry.error && (entry.windows.length > 0 || entry.plan))
     .slice(0, opts?.maxProviders ?? summary.providers.length);
   if (providers.length === 0) {
     return null;
   }
 
   const parts = providers.map((entry) => {
+    // Plan-only providers (e.g. credit-balance APIs with no quota windows)
+    if (entry.windows.length === 0) {
+      return `${entry.displayName} ${entry.plan}`;
+    }
     const window = entry.windows.reduce((best, next) =>
       next.usedPercent > best.usedPercent ? next : best,
     );
@@ -99,7 +103,10 @@ export function formatUsageReportLines(summary: UsageSummary, opts?: { now?: num
       continue;
     }
     if (entry.windows.length === 0) {
-      lines.push(`  ${entry.displayName}${planSuffix}: no data`);
+      // If the plan field carries the data (e.g. credit balance), it's already
+      // shown via planSuffix — don't append ": no data" in that case.
+      const suffix = entry.plan ? "" : ": no data";
+      lines.push(`  ${entry.displayName}${planSuffix}${suffix}`);
       continue;
     }
     lines.push(`  ${entry.displayName}${planSuffix}`);

--- a/src/infra/provider-usage.types.ts
+++ b/src/infra/provider-usage.types.ts
@@ -9,6 +9,10 @@ export type ProviderUsageSnapshot = {
   displayName: string;
   windows: UsageWindow[];
   plan?: string;
+  /** Credit-balance string (e.g. "$5.00"). When set, the snapshot carries
+   *  usage data even if windows is empty; format functions use this to
+   *  suppress the "no data" marker and include the provider in summaries. */
+  balance?: string;
   error?: string;
 };
 


### PR DESCRIPTION
## Summary

- **Problem:** Providers that return a credit balance but no quota windows are
  silently dropped from the compact `📊 Usage:` summary line, and the full
  report appends `: no data` even when a balance was fetched successfully.
- **Why it matters:** Users see no feedback for a configured provider, or
  misleading "no data" when the balance was fetched successfully.
- **What changed:**
  - Added a `balance` field to `ProviderUsageSnapshot` to carry credit-balance
    strings (e.g. `"$5.00"`). `plan` remains for plan-tier metadata only (e.g.
    `"Pro"`, `"business"`).
  - `formatUsageSummaryLine` now includes balance-only providers
    (`windows.length === 0 && balance`), rendering them as `<Name> <balance>`
    (e.g. `Kilo $5.00`). Providers with neither windows nor a balance are still
    excluded.
  - `formatUsageReportLines` omits `: no data` when `entry.balance` is set;
    `plan`-only entries (no balance, no windows) still show `: no data` because
    plan alone is tier metadata and does not confirm usage data was returned.
  - `fetchCodexUsage` now populates `balance` from the API credit-balance
    response instead of folding the value into `plan`.
- **What did NOT change:** Window-based formatting, error display, and providers
  with neither windows nor a balance are unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Linked Issue/PR

- Related #

## User-visible / Behavior Changes

- Usage summary line now shows balance-only providers (e.g. `📊 Usage: Kilo $5.00`)
  instead of silently omitting them.
- Full usage report no longer shows `<Provider> (<balance>): no data` when a
  credit balance was returned — it shows `<Provider> (<balance>)`.
- Plan-tier-only entries (no balance, no windows) still show `: no data` as before.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Configure a provider whose usage endpoint returns a credit balance with no
   quota windows.
2. Run `openclaw status` or the equivalent usage command.

### Expected

- Compact line: `📊 Usage: Kilo $5.00`
- Full report: `  Kilo ($5.00)` (no `: no data` suffix)

### Actual (before fix)

- Compact line: provider absent entirely
- Full report: `  Kilo ($5.00): no data`

## Evidence

- New test `"includes balance-only providers in summary line and omits errored ones"`
  and updated `"formats report output …"` assert the corrected output; all 9 tests pass.

## Human Verification

- Verified scenarios: balance-only included, errored excluded,
  windowless+balanceless excluded, mixed-provider ordering, `maxProviders` cap.
- Edge cases checked: `balance: undefined` + plan-only still renders `: no data`;
  error + balance still excluded from summary.
- What I did **not** verify: live end-to-end with a real credit-balance provider
  (no provider uses this path on main yet — `fetchCodexUsage` is the first).

## AI-Assisted

This PR was created with AI assistance (Claude Code).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — `balance` is an optional field; existing snapshots without it behave identically.
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert `src/infra/provider-usage.format.ts` to prior filter/branch logic and
  remove the `balance` field from `provider-usage.types.ts`.
- Bad symptoms: balance-only providers appear in summary when they shouldn't.

## Risks and Mitigations

- Risk: a snapshot with an incorrect `balance` string could appear in the summary.
  - Mitigation: `balance` is set only by each provider's fetch function after a
    successful credit-balance check; only `fetchCodexUsage` sets it on main.