### PR TITLE
fix(telegram): ignore invalid reply-to ids on send

### DIFF
--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../../../src/auto-reply/types.js";
+import { telegramOutbound } from "./outbound-adapter.js";
+
+describe("telegramOutbound", () => {
+  it("passes parsed reply/thread ids for sendText", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-text-1", chatId: "123" });
+    const sendText = telegramOutbound.sendText;
+    expect(sendText).toBeDefined();
+
+    const result = await sendText!({
+      cfg: {},
+      to: "123",
+      text: "<b>hello</b>",
+      accountId: "work",
+      replyToId: "44",
+      threadId: "55",
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "123",
+      "<b>hello</b>",
+      expect.objectContaining({
+        textMode: "html",
+        verbose: false,
+        accountId: "work",
+        replyToMessageId: 44,
+        messageThreadId: 55,
+      }),
+    );
+    expect(result).toEqual({ channel: "telegram", messageId: "tg-text-1", chatId: "123" });
+  });
+
+  it("drops non-numeric reply ids for sendText", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-text-3", chatId: "123" });
+    const sendText = telegramOutbound.sendText;
+    expect(sendText).toBeDefined();
+
+    await sendText!({
+      cfg: {},
+      to: "123",
+      text: "<b>hello</b>",
+      replyToId: "2e8b4b8b-7f8c-4f7f-8db1-1186f1f9fbcc",
+      threadId: "55",
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "123",
+      "<b>hello</b>",
+      expect.objectContaining({
+        textMode: "html",
+        verbose: false,
+        messageThreadId: 55,
+      }),
+    );
+    expect(sendTelegram.mock.calls[0]?.[2]?.replyToMessageId).toBeUndefined();
+  });
+
+  it("parses scoped DM thread ids for sendText", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-text-2", chatId: "12345" });
+    const sendText = telegramOutbound.sendText;
+    expect(sendText).toBeDefined();
+
+    await sendText!({
+      cfg: {},
+      to: "12345",
+      text: "<b>hello</b>",
+      accountId: "work",
+      threadId: "12345:99",
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "12345",
+      "<b>hello</b>",
+      expect.objectContaining({
+        textMode: "html",
+        verbose: false,
+        accountId: "work",
+        messageThreadId: 99,
+      }),
+    );
+  });
+
+  it("passes media options for sendMedia", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-media-1", chatId: "123" });
+    const sendMedia = telegramOutbound.sendMedia;
+    expect(sendMedia).toBeDefined();
+
+    const result = await sendMedia!({
+      cfg: {},
+      to: "123",
+      text: "caption",
+      mediaUrl: "https://example.com/a.jpg",
+      mediaLocalRoots: ["/tmp/media"],
+      accountId: "default",
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "123",
+      "caption",
+      expect.objectContaining({
+        textMode: "html",
+        verbose: false,
+        mediaUrl: "https://example.com/a.jpg",
+        mediaLocalRoots: ["/tmp/media"],
+      }),
+    );
+    expect(result).toEqual({ channel: "telegram", messageId: "tg-media-1", chatId: "123" });
+  });
+
+  it("sends payload media list and applies buttons only to first message", async () => {
+    const sendTelegram = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "tg-1", chatId: "123" })
+      .mockResolvedValueOnce({ messageId: "tg-2", chatId: "123" });
+    const sendPayload = telegramOutbound.sendPayload;
+    expect(sendPayload).toBeDefined();
+
+    const payload: ReplyPayload = {
+      text: "caption",
+      mediaUrls: ["https://example.com/1.jpg", "https://example.com/2.jpg"],
+      channelData: {
+        telegram: {
+          quoteText: "quoted",
+          buttons: [[{ text: "Approve", callback_data: "ok" }]],
+        },
+      },
+    };
+
+    const result = await sendPayload!({
+      cfg: {},
+      to: "123",
+      text: "",
+      payload,
+      mediaLocalRoots: ["/tmp/media"],
+      accountId: "default",
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledTimes(2);
+    expect(sendTelegram).toHaveBeenNthCalledWith(
+      1,
+      "123",
+      "caption",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/1.jpg",
+        quoteText: "quoted",
+        buttons: [[{ text: "Approve", callback_data: "ok" }]],
+      }),
+    );
+    expect(sendTelegram).toHaveBeenNthCalledWith(
+      2,
+      "123",
+      "",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/2.jpg",
+        quoteText: "quoted",
+      }),
+    );
+    const secondCallOpts = sendTelegram.mock.calls[1]?.[2] as Record<string, unknown>;
+    expect(secondCallOpts?.buttons).toBeUndefined();
+    expect(result).toEqual({ channel: "telegram", messageId: "tg-2", chatId: "123" });
+  });
+});

--- a/extensions/telegram/src/outbound-params.test.ts
+++ b/extensions/telegram/src/outbound-params.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { parseTelegramReplyToMessageId } from "./outbound-params.js";
+
+describe("parseTelegramReplyToMessageId", () => {
+  it("accepts only strict positive integer strings", () => {
+    expect(parseTelegramReplyToMessageId("44")).toBe(44);
+    expect(parseTelegramReplyToMessageId(" 55 ")).toBe(55);
+    expect(parseTelegramReplyToMessageId("0012")).toBe(12);
+    expect(parseTelegramReplyToMessageId("123abc")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("9.5")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("-7")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("0")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("abc")).toBeUndefined();
+  });
+});

--- a/extensions/telegram/src/outbound-params.ts
+++ b/extensions/telegram/src/outbound-params.ts
@@ -2,8 +2,12 @@ export function parseTelegramReplyToMessageId(replyToId?: string | null): number
   if (!replyToId) {
     return undefined;
   }
-  const parsed = Number.parseInt(replyToId, 10);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  const trimmed = replyToId.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function parseIntegerId(value: string): number | undefined {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1634,6 +1634,28 @@ describe("shared send behaviors", () => {
     }
   });
 
+  it("drops invalid reply ids instead of forwarding broken threading params", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 56,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "reply text", {
+      token: "tok",
+      api,
+      replyToMessageId: Number.NaN,
+      quoteText: "quoted text",
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "reply text", {
+      parse_mode: "HTML",
+    });
+  });
+
   it("wraps chat-not-found with actionable context", async () => {
     const cases = [
       {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -383,8 +383,12 @@ function buildTelegramThreadReplyParams(params: {
   const threadIdParams = buildTelegramThreadParams(threadSpec);
   const threadParams: Record<string, unknown> = threadIdParams ? { ...threadIdParams } : {};
 
-  if (params.replyToMessageId != null) {
-    const replyToMessageId = Math.trunc(params.replyToMessageId);
+  if (
+    typeof params.replyToMessageId === "number" &&
+    Number.isSafeInteger(params.replyToMessageId) &&
+    params.replyToMessageId > 0
+  ) {
+    const replyToMessageId = params.replyToMessageId;
     if (params.quoteText?.trim()) {
       threadParams.reply_parameters = {
         message_id: replyToMessageId,


### PR DESCRIPTION
## Summary

- Problem: Telegram outbound sends could forward non-numeric or partially numeric `replyToId` values as `reply_to_message_id`, causing `400: Bad Request: message to be replied not found` failures.
- Why it matters: cross-surface routing can carry UUID-like reply ids, so a bad reply id should degrade to a normal send instead of failing delivery.
- What changed: tightened `parseTelegramReplyToMessageId` to accept only strict positive integer strings, added a defense-in-depth positive-integer guard before attaching Telegram reply threading params, and added focused regression tests for the parser, outbound adapter, and send path.
- What did NOT change (scope boundary): Telegram thread-id parsing and valid reply threading behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37222
- Related #37312

## User-visible / Behavior Changes

Telegram outbound delivery now drops invalid `replyToId` values instead of passing broken reply-threading parameters through to the Telegram API.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Darwin
- Runtime/container: local Node v25.2.1 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): N/A (unit/integration tests)

### Steps

1. Route a Telegram outbound send with a non-Telegram reply id such as a UUID or partially numeric string.
2. Observe that the previous implementation could coerce that value into `reply_to_message_id` / `reply_parameters.message_id`.
3. Run the new Telegram regression tests after the fix.

### Expected

- Invalid reply ids are ignored and the message is sent without Telegram reply-threading fields.
- Valid positive integer reply ids continue to work normally.

### Actual

- `parseTelegramReplyToMessageId` now returns `undefined` for invalid ids.
- `buildTelegramThreadReplyParams` now omits reply params unless the id is a finite positive integer.
- Added regression tests pass locally for parser, outbound adapter, and send-path coverage.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: strict parsing rejects UUID-like / partially numeric reply ids; outbound adapter leaves invalid `replyToId` unset; direct send path omits reply-threading params for invalid numeric values while preserving valid reply ids.
- Edge cases checked: whitespace-trimmed integers still parse; `0`, negative, decimal, and `NaN` values are rejected.
- What you did **not** verify: live Telegram delivery against a real bot/chat.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit fc0c308508ed41558d6fee4b247d9965e5ea9339.
- Files/config to restore: `src/telegram/outbound-params.ts`, `src/telegram/send.ts`.
- Known bad symptoms reviewers should watch for: valid numeric Telegram replies unexpectedly losing threading.

## Risks and Mitigations

- Risk: stricter parsing could drop malformed values that previously coerced into integers.
  - Mitigation: only invalid/non-Telegram ids are rejected; digit-only positive integers still thread exactly as before.
