### PR TITLE
Thinking: allow xhigh for openai-codex gpt-5.2

### DIFF
--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatXHighModelHint,
   listThinkingLevelLabels,
   listThinkingLevels,
   normalizeReasoningLevel,
@@ -54,7 +55,8 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("openai", "gpt-5.4-pro")).toContain("xhigh");
   });
 
-  it("includes xhigh for openai-codex gpt-5.4", () => {
+  it("includes xhigh for openai-codex gpt-5.2 and gpt-5.4", () => {
+    expect(listThinkingLevels("openai-codex", "gpt-5.2")).toContain("xhigh");
     expect(listThinkingLevels("openai-codex", "gpt-5.4")).toContain("xhigh");
   });
 
@@ -70,6 +72,10 @@ describe("listThinkingLevels", () => {
   it("always includes adaptive", () => {
     expect(listThinkingLevels(undefined, "gpt-4.1-mini")).toContain("adaptive");
     expect(listThinkingLevels("anthropic", "claude-opus-4-6")).toContain("adaptive");
+  });
+
+  it("includes openai-codex/gpt-5.2 in the xhigh model hint", () => {
+    expect(formatXHighModelHint()).toContain("openai-codex/gpt-5.2");
   });
 });
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -26,6 +26,7 @@ export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.4-pro",
   "openai/gpt-5.2",
   "openai-codex/gpt-5.4",
+  "openai-codex/gpt-5.2",
   "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",


### PR DESCRIPTION
## Summary

- Problem: `thinking="xhigh"` rejected `openai-codex/gpt-5.2` even though nearby OpenAI/OpenAI Codex GPT-5.2 variants were already supported.
- Why it matters: Codex users hit a confusing mismatch where `gpt-5.2` worked as a model selection but `xhigh` was denied for the same provider/model pairing.
- What changed: added `openai-codex/gpt-5.2` to the xhigh allowlist and extended the direct thinking tests to cover both support and hint text.
- What did NOT change (scope boundary): no broader thinking-policy changes, no provider auth changes, and no CLI/TUI selection changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #6820

## User-visible / Behavior Changes

`openai-codex/gpt-5.2` now accepts `xhigh` thinking, and the supported-model hint text includes it.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: local dev checkout
- Runtime/container: pnpm + vitest
- Model/provider: `openai-codex/gpt-5.2`
- Integration/channel (if any): thinking-level validation
- Relevant config (redacted): `thinking=xhigh`

### Steps

1. Select model `openai-codex/gpt-5.2`.
2. Request `thinking="xhigh"`.
3. Inspect the support matrix and xhigh hint text.

### Expected

- `openai-codex/gpt-5.2` is treated as xhigh-capable.

### Actual

- After the patch, `listThinkingLevels("openai-codex", "gpt-5.2")` includes `xhigh`, and the supported-model hint lists the new ref.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:

```bash
pnpm test src/auto-reply/thinking.test.ts
pnpm exec oxfmt --check src/auto-reply/thinking.ts src/auto-reply/thinking.test.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `openai-codex/gpt-5.2` is now xhigh-capable in the direct thinking-level matrix.
  - The xhigh help text now mentions `openai-codex/gpt-5.2`.
- Edge cases checked:
  - Existing nearby refs like `openai/gpt-5.2` and `openai-codex/gpt-5.2-codex` remain supported.
- What you did **not** verify:
  - End-to-end TUI interaction against a live provider.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `923772f16`.
- Files/config to restore:
  - `src/auto-reply/thinking.ts`
  - `src/auto-reply/thinking.test.ts`
- Known bad symptoms reviewers should watch for:
  - xhigh support matrix unexpectedly growing beyond the intended provider/model ref.

## Risks and Mitigations

- Risk: the allowlist could drift from provider-side support if OpenAI Codex changes capabilities.
  - Mitigation: the change is isolated to the explicit allowlist and covered by a focused regression test.
