### PR TITLE
fix(cron): avoid manual run self-deadlock on cron lane

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
-import { clearCommandLane, setCommandLaneConcurrency } from "../process/command-queue.js";
+import {
+  clearCommandLane,
+  enqueueCommandInLane,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import * as schedule from "./schedule.js";
 import {
@@ -1565,6 +1569,54 @@ describe("Cron issue regressions", () => {
       expect(jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("ok");
     });
 
+    clearCommandLane(CommandLane.Cron);
+  });
+
+  it("avoids cron lane self-deadlock for manual runs (#43008)", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Main);
+    clearCommandLane(CommandLane.Cron);
+    setCommandLaneConcurrency(CommandLane.Main, 1);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-03-11T09:05:00.000Z");
+    const job = createDueIsolatedJob({ id: "manual-deadlock-43008", nowMs: dueAt, nextRunAtMs: dueAt });
+    await fs.writeFile(store.storePath, JSON.stringify({ version: 1, jobs: [job] }), "utf-8");
+
+    const nestedCronWorkStarted = createDeferred<void>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      cronConfig: { maxConcurrentRuns: 1 },
+      log: createNoopLogger(),
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        return await enqueueCommandInLane(CommandLane.Cron, async () => {
+          nestedCronWorkStarted.resolve();
+          return { status: "ok", summary: "manual run finished" } as const;
+        });
+      }),
+    });
+
+    const ack = await enqueueRun(state, job.id, "force");
+    expect(ack).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    await Promise.race([
+      nestedCronWorkStarted.promise,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("timed out waiting for nested cron lane work")), 250),
+      ),
+    ]);
+
+    await vi.waitFor(() => {
+      const currentJob = state.store?.jobs.find((candidate) => candidate.id === job.id);
+      expect(currentJob?.state.lastStatus).toBe("ok");
+    });
+
+    clearCommandLane(CommandLane.Main);
     clearCommandLane(CommandLane.Cron);
   });
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -531,8 +531,11 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
   }
 
   const runId = `manual:${id}:${state.deps.nowMs()}:${nextManualRunId++}`;
+  // Use the main lane for dispatch to avoid self-deadlocking when the
+  // manual path eventually schedules isolated agent work onto the cron lane.
+  // (Manual trigger previously nested cron->cron enqueues with maxConcurrent=1.)
   void enqueueCommandInLane(
-    CommandLane.Cron,
+    CommandLane.Main,
     async () => {
       const result = await run(state, id, mode);
       if (result.ok && "ran" in result && !result.ran) {


### PR DESCRIPTION
## Summary

- Problem: `cron.run` / "Run Now" for isolated jobs can deadlock when `cron.maxConcurrentRuns` is 1 because manual dispatch enqueues work on `CommandLane.Cron`, and nested isolated execution also enqueues on the same lane.
- Why it matters: Manual runs time out and never create a session, while timer-triggered runs succeed.
- What changed: Switched manual-run dispatch in `enqueueRun` from `CommandLane.Cron` to `CommandLane.Main`, and added a regression test for issue #43008.
- What did NOT change (scope boundary): No changes to timer-driven execution, job selection logic, or delivery behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43008
- Related #42960

## User-visible / Behavior Changes

- Manual cron runs (`cron.run` / UI "Run Now") no longer self-deadlock on the cron command lane when `maxConcurrentRuns` is 1.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node.js 22 / pnpm
- Model/provider: N/A (queueing path regression)
- Integration/channel (if any): N/A
- Relevant config (redacted): `cron.maxConcurrentRuns = 1`

### Steps

1. Create an isolated cron job (`sessionTarget: "isolated"`, `payload.kind: "agentTurn"`).
2. Trigger manually via `cron.run` / UI "Run Now".
3. Observe previous behavior (timeout) versus fixed behavior (job completes).

### Expected

- Manual run should complete without lane deadlock and persist `lastStatus: "ok"`.

### Actual

- Before fix: nested cron-lane enqueue deadlocked.
- After fix: regression test confirms nested work starts and run completes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```bash
pnpm vitest run src/cron/service.issue-regressions.test.ts -t "#43008"
```

Result: `1 passed`.

## Human Verification (required)

- Verified scenarios:
  - Added regression path that reproduces nested enqueue (`cron -> cron`) under concurrency 1.
  - Confirmed manual run ack is enqueued and job state transitions to `ok`.
- Edge cases checked:
  - Maintains existing lane cleanup in test setup/teardown.
- What you did **not** verify:
  - Full end-to-end UI run in browser.
  - Multi-node/channel integrations.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/cron/service/ops.ts`
  - `src/cron/service.issue-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - Manual `cron.run` stalls before session creation.

## Risks and Mitigations

- Risk: Moving manual dispatch to `CommandLane.Main` could alter ordering relative to other main-lane work.
  - Mitigation: Change is narrowly scoped to manual trigger dispatch; nested cron execution path remains unchanged and covered by regression test.

