### PR TITLE
fix(config): add requiresOpenAiAnthropicToolPayload to ModelCompatSchema

### DIFF
--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -198,6 +198,7 @@ export const ModelCompatSchema = z
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),
     requiresMistralToolIds: z.boolean().optional(),
+    requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Background

Commit e5c06dd added this field to types.models.ts and used it in models-config.providers.ts and extra-params.ts, but forgot to add it to
   the zod validation schema. The strict() call then rejects any models.json that contains this compat key, causing onboard to fail with
  "Config validation failed: Unrecognized key".

  ## Summary

  - **Problem:** `requiresOpenAiAnthropicToolPayload` was added to `ModelCompatConfig` (types) and used in runtime code, but never
  registered in `ModelCompatSchema` (zod)
  - **Why it matters:** Any user who runs `openclaw onboard` with a Kimi provider gets a fatal config validation error and cannot start the
   gateway
  - **What changed:** Added `requiresOpenAiAnthropicToolPayload: z.boolean().optional()` to `ModelCompatSchema` in `zod-schema.core.ts`
  - **What did NOT change:** No runtime behavior, no tool logic, no compat handling code — schema only

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [x] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Related to e5c06dd

  ## User-visible / Behavior Changes

  Users who ran `openclaw onboard` for a Kimi provider can now start the gateway without a config validation error. No other behavior
  changes.

  ## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node.js
  - Model/provider: kimi-coding
  - Integration/channel (if any): N/A
  - Relevant config (redacted):
    ```json
    {
      "compat": {
        "requiresOpenAiAnthropicToolPayload": true
      }
    }

  Steps

  1. Run openclaw onboard and configure a Kimi provider

  Expected

  - Gateway starts successfully

  Actual

  - Error: Config validation failed: models.providers.kimi-coding.models.0.compat: Unrecognized key: "requiresOpenAiAnthropicToolPayload"

  Evidence

  - Failing test/log before + passing after
  - Trace/log snippets — error message above reproduces 100% before fix, gone after

  Human Verification (required)

  - Verified scenarios: config with requiresOpenAiAnthropicToolPayload: true passes validation after fix
  - Edge cases checked: requiresOpenAiAnthropicToolPayload: false and omitted both pass
  - What you did not verify: full onboard flow end-to-end with a live Kimi API key

  Review Conversations

  - I replied to or resolved every bot review conversation I addressed in this PR.
  - I left unresolved only the conversations that still need reviewer or maintainer judgment.

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: revert the one-line addition in zod-schema.core.ts
  - Files/config to restore: src/config/zod-schema.core.ts
  - Known bad symptoms: config validation errors on startup for Kimi providers

  Risks and Mitigations

  None — this is a one-line schema addition with no runtime behavior change.
  ```