### PR TITLE
fix(agents): respect workspace config for sub-agent sessions

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -423,6 +423,7 @@ export async function spawnSubagentDirect(
     spawnDepth: childDepth,
     subagentRole: childCapabilities.role === "main" ? null : childCapabilities.role,
     subagentControlScope: childCapabilities.controlScope,
+    workspace: targetAgentConfig?.workspace,
   });
   if (spawnDepthPatchError) {
     return {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -631,8 +631,11 @@ async function prepareAgentCommandExecution(
     sessionKey,
   });
   // Internal callers (for example subagent spawns) may pin workspace inheritance.
+  // Session entry workspace override takes precedence over config and spawned metadata.
   const workspaceDirRaw =
-    normalizedSpawned.workspaceDir ?? resolveAgentWorkspaceDir(cfg, sessionAgentId);
+    sessionEntryRaw?.workspace ??
+    normalizedSpawned.workspaceDir ??
+    resolveAgentWorkspaceDir(cfg, sessionAgentId);
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -67,6 +67,7 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
+  cwd?: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
@@ -77,7 +78,7 @@ async function ensureSessionHeader(params: {
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: process.cwd(),
+    cwd: params.cwd ?? process.cwd(),
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
@@ -177,7 +178,11 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  await ensureSessionHeader({
+    sessionFile,
+    sessionId: entry.sessionId,
+    cwd: entry.workspace,
+  });
 
   const sessionManager = SessionManager.open(sessionFile);
   sessionManager.appendMessage({

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -78,7 +78,7 @@ async function ensureSessionHeader(params: {
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: params.cwd ?? process.cwd(),
+    cwd: params.cwd ? resolveUserPath(params.cwd) : process.cwd(),
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -86,6 +86,8 @@ export type SessionEntry = {
   subagentRole?: "orchestrator" | "leaf";
   /** Explicit control scope assigned at spawn time for subagent control decisions. */
   subagentControlScope?: "children" | "none";
+  /** Workspace override for this session (respects agents.list[].workspace). */
+  workspace?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
   /**

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -65,6 +65,8 @@ export const SessionsPatchParamsSchema = Type.Object(
       ]),
     ),
     elevatedLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    // Workspace override for sub-agent sessions (per-agent workspace).
+    workspace: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     execHost: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     execSecurity: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     execAsk: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -192,6 +192,24 @@ export async function applySessionsPatchToStore(params: {
     }
   }
 
+  if ("workspace" in patch) {
+    const raw = patch.workspace;
+    if (raw === null) {
+      if (existing?.workspace) {
+        return invalid("workspace cannot be cleared once set");
+      }
+    } else if (raw !== undefined) {
+      const trimmed = String(raw).trim();
+      if (!trimmed) {
+        return invalid("invalid workspace: empty");
+      }
+      if (existing?.workspace && existing.workspace !== trimmed) {
+        return invalid("workspace cannot be changed once set");
+      }
+      next.workspace = trimmed;
+    }
+  }
+
   if ("label" in patch) {
     const raw = patch.label;
     if (raw === null) {


### PR DESCRIPTION
## Summary

- **Problem:** Sub-agents spawned via sessions_spawn ignored the workspace path configured in agents.list[].workspace, defaulting to parent's or global workspace instead
- **Why it matters:** Files written to wrong directory, memory_search indexed wrong directory, and workspace isolation was broken for configured agents
- **What changed:** Added workspace field to session entry, pass workspace from targetAgentConfig during spawn, and prioritize session workspace in resolution chain
- **What did NOT change:** Existing workspace resolution logic for main sessions and agents without explicit workspace config remains unchanged

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17698
- Related #

## User-visible / Behavior Changes

- Sub-agents now respect workspace configured in agents.list[].workspace
- Session jsonl transcript correctly shows configured workspace in cwd field
- exec commands run in the correct workspace directory for configured agents

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (Yes - sub-agents now access configured workspace directory instead of default workspace)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22.20.0
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: agents.list[].workspace configured to /Users/admin/.openclaw/workspaces/k8s-sre

### Steps

1. Configure agent with explicit workspace in agents.list
2. Spawn sub-agent via sessions_spawn tool
3. Check session jsonl transcript first line
4. Run exec command in sub-agent to verify working directory

### Expected

- Session jsonl shows: {"cwd":"/Users/admin/.openclaw/workspaces/k8s-sre"}
- exec commands run in /Users/admin/.openclaw/workspaces/k8s-sre

### Actual

- ✅ Session jsonl correctly shows configured workspace
- ✅ exec commands run in the correct workspace directory

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets: Session jsonl first line shows correct cwd
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

Verified scenarios:
- Sub-agent session correctly shows configured workspace in session header
- exec commands run in the correct workspace directory
- Main session and agents without workspace config unaffected

What you did **not** verify:
- Memory search indexing behavior
- Multi-level sub-agent nesting scenarios

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert: Remove workspace field from agents.list config or revert commit
- Files/config to restore: None (config change only)
- Known bad symptoms: Sub-agents default to parent/global workspace

## Risks and Mitigations

- Risk: Sub-agents may access different workspace directory than before, potentially breaking workflows that depended on previous behavior
  - Mitigation: This is a bug fix to honor configured workspace; previous behavior was incorrect
- Risk: Existing sessions may need to be restarted to pick up new workspace path
  - Mitigation: Workspace is set at session creation time; new sessions will use correct path
