### PR TITLE
fix(macos): use foundationValue when serializing browser proxy POST body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@ Docs: https://docs.openclaw.ai
 - Auth/profile resolution: log debug details when auto-discovered auth profiles fail during provider API-key resolution, so `--debug` output surfaces the real refresh/keychain/credential-store failure instead of only the generic missing-key message. (#41271) thanks @he-yufeng.
 - ACP/cancel scoping: scope `chat.abort` and shared-session ACP event routing by `runId` so one session cannot cancel or consume another session's run when they share the same gateway session key. (#41331) Thanks @pejmanjohn.
 - SecretRef/models: harden custom/provider secret persistence and reuse across models.json snapshots, merge behavior, runtime headers, and secret audits. (#42554) Thanks @joshavant.
+- macOS/browser proxy: serialize non-GET browser proxy request bodies through `AnyCodable.foundationValue` so nested JSON bodies no longer crash the macOS app with `Invalid type in JSON write (__SwiftValue)`. (#43069) Thanks @Effet.
 
 ## 2026.3.7
 

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
@@ -146,8 +146,8 @@ actor MacNodeBrowserProxy {
             request.setValue(password, forHTTPHeaderField: "x-openclaw-password")
         }
 
-        if method != "GET", let body = params.body?.value {
-            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [.fragmentsAllowed])
+        if method != "GET", let body = params.body {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body.foundationValue, options: [.fragmentsAllowed])
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
 

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeBrowserProxyTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeBrowserProxyTests.swift
@@ -39,9 +39,21 @@ struct MacNodeBrowserProxyTests {
         #expect(tabs[0]["id"] as? String == "tab-1")
     }
 
-    // Regression test: POST body with nested AnyCodable must not crash with __SwiftValue
+    // Regression test: nested POST bodies must serialize without __SwiftValue crashes.
     @Test func postRequestSerializesNestedBodyWithoutCrash() async throws {
-        var capturedBody: Data?
+        actor BodyCapture {
+            private var body: Data?
+
+            func set(_ body: Data?) {
+                self.body = body
+            }
+
+            func get() -> Data? {
+                self.body
+            }
+        }
+
+        let capturedBody = BodyCapture()
         let proxy = MacNodeBrowserProxy(
             endpointProvider: {
                 MacNodeBrowserProxy.Endpoint(
@@ -50,7 +62,7 @@ struct MacNodeBrowserProxyTests {
                     password: nil)
             },
             performRequest: { request in
-                capturedBody = request.httpBody
+                await capturedBody.set(request.httpBody)
                 let url = try #require(request.url)
                 let response = try #require(
                     HTTPURLResponse(
@@ -64,7 +76,7 @@ struct MacNodeBrowserProxyTests {
         _ = try await proxy.request(
             paramsJSON: #"{"method":"POST","path":"/action","body":{"nested":{"key":"val"},"arr":[1,2]}}"#)
 
-        let bodyData = try #require(capturedBody)
+        let bodyData = try #require(await capturedBody.get())
         let parsed = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
         let nested = try #require(parsed["nested"] as? [String: Any])
         #expect(nested["key"] as? String == "val")

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeBrowserProxyTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeBrowserProxyTests.swift
@@ -38,4 +38,37 @@ struct MacNodeBrowserProxyTests {
         #expect(tabs.count == 1)
         #expect(tabs[0]["id"] as? String == "tab-1")
     }
+
+    // Regression test: POST body with nested AnyCodable must not crash with __SwiftValue
+    @Test func postRequestSerializesNestedBodyWithoutCrash() async throws {
+        var capturedBody: Data?
+        let proxy = MacNodeBrowserProxy(
+            endpointProvider: {
+                MacNodeBrowserProxy.Endpoint(
+                    baseURL: URL(string: "http://127.0.0.1:18791")!,
+                    token: nil,
+                    password: nil)
+            },
+            performRequest: { request in
+                capturedBody = request.httpBody
+                let url = try #require(request.url)
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: nil))
+                return (Data(#"{"ok":true}"#.utf8), response)
+            })
+
+        _ = try await proxy.request(
+            paramsJSON: #"{"method":"POST","path":"/action","body":{"nested":{"key":"val"},"arr":[1,2]}}"#)
+
+        let bodyData = try #require(capturedBody)
+        let parsed = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        let nested = try #require(parsed["nested"] as? [String: Any])
+        #expect(nested["key"] as? String == "val")
+        let arr = try #require(parsed["arr"] as? [Any])
+        #expect(arr.count == 2)
+    }
 }


### PR DESCRIPTION
Replacement for #41635.

Original contributor: @Effet

This PR preserves the exact original contributor commit on a maintainer-owned rescue branch after the prior rescue PR was removed.

## Summary

- **Problem:** `MacNodeBrowserProxy.makeRequest` passes `params.body?.value` directly to `JSONSerialization.data(withJSONObject:)`. `AnyCodable.init(from:)` stores decoded JSON objects as `[String: AnyCodable]` internally — a pure Swift struct (`__SwiftValue`) that `NSJSONSerialization` can't handle, causing an `NSInvalidArgumentException` crash (SIGABRT) on every non-GET request with a JSON body.
- **Why it matters:** Any POST/PUT/PATCH request routed through the Mac browser proxy crashes the app. The crash is deterministic and not edge-case.
- **What changed:** Use `params.body?.foundationValue` instead of `params.body?.value`. `foundationValue` (already defined in `AnyCodable+Helpers.swift`) recursively converts `[String: AnyCodable]` → `[String: Any]` so `JSONSerialization` receives only Foundation-compatible types.
- **What did NOT change:** No behavior change for GET requests or response parsing; no new dependencies.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #40957
- Replaces #41635

## User-visible / Behavior Changes

Mac app no longer crashes when making POST/PUT/PATCH requests through the browser proxy.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (latest)
- Runtime: Mac app (MacNodeRuntime)

### Steps

1. Open Mac app with gateway running
2. Trigger any browser proxy call that uses a non-GET method with a JSON body (e.g. a POST via `MacNodeBrowserProxy.request`)
3. App crashes with `NSInvalidArgumentException: Invalid type in JSON write (__SwiftValue)`

### Expected

- Request serializes and sends successfully

### Actual

- SIGABRT crash in `MacNodeBrowserProxy.makeRequest` at `JSONSerialization.data(withJSONObject:)`

## Evidence

- [x] Regression test added: `postRequestSerializesNestedBodyWithoutCrash` in `MacNodeBrowserProxyTests.swift` — covers nested dict + array body, was impossible to add before the fix (would crash)

## Human Verification (required)

- Verified scenarios: read crash stack trace, identified root cause in source, confirmed `foundationValue` is the correct converter, added failing→passing test
- Edge cases checked: nested objects, arrays, null values all handled by existing `foundationValue` recursion
- What you did **not** verify: live end-to-end POST request through running gateway (no Mac build in this session)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert: restore `params.body?.value` in `MacNodeBrowserProxy.swift:149`
- Known bad symptom: app crashes on any browser proxy POST request (same as before fix)

## Risks and Mitigations

- Risk: `foundationValue` on an unrecognized type falls through to `self.value` (the default case) — same behavior as before, so no regression risk.
