### PR TITLE
fix(agents): enable OpenAI-style tool payloads for kimi-coding provider

### DIFF
--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -31,8 +31,8 @@ describe("resolveProviderCapabilities", () => {
       resolveProviderCapabilities("kimi-code"),
     );
     expect(resolveProviderCapabilities("kimi-code")).toEqual({
-      anthropicToolSchemaMode: "native",
-      anthropicToolChoiceMode: "native",
+      anthropicToolSchemaMode: "openai-functions",
+      anthropicToolChoiceMode: "openai-string-modes",
       providerFamily: "default",
       preserveAnthropicThinkingSignatures: false,
       openAiCompatTurnValidation: true,
@@ -73,9 +73,11 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
   });
 
-  it("treats kimi aliases as native anthropic tool payload providers", () => {
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(false);
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);
+  it("treats kimi aliases as OpenAI-compatible anthropic tool payload providers", () => {
+    // kimi-coding requires OpenAI-style tool payloads (tools[].function + string-mode tool_choice)
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(true);
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(true);
+    // anthropic native does not require OpenAI-compatible payloads
     expect(requiresOpenAiCompatibleAnthropicToolPayload("anthropic")).toBe(false);
   });
 

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -33,10 +33,12 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
   "amazon-bedrock": {
     providerFamily: "anthropic",
   },
-  // kimi-coding natively supports Anthropic tool framing (input_schema);
-  // converting to OpenAI format causes XML text fallback instead of tool_use blocks.
+  // kimi-coding uses anthropic-messages API but requires OpenAI-style tool payloads
+  // (tools[].function + string-mode tool_choice) for proper tool call support.
   "kimi-coding": {
     preserveAnthropicThinkingSignatures: false,
+    anthropicToolSchemaMode: "openai-functions",
+    anthropicToolChoiceMode: "openai-string-modes",
   },
   mistral: {
     transcriptToolCallIdMode: "strict9",


### PR DESCRIPTION
## Summary

The kimi-coding provider uses `anthropic-messages` API but requires OpenAI-style tool payloads (`tools[].function` + string-mode `tool_choice`) for proper tool call support. Without this fix, tool calls fail because the endpoint doesn't properly handle native Anthropic tool format.

## Problem

Users configuring Kimi Coding via `KIMI_API_KEY` environment variable (auto-discovered provider) experienced tool calls failing. The tool call arguments appeared as plain text in messages instead of being properly invoked.

Root cause: The provider capabilities for `kimi-coding` didn't specify OpenAI-style tool conversion, so the `requiresOpenAiCompatibleAnthropicToolPayload()` function returned `false`, and the tool payload normalization in `anthropic-stream-wrappers.ts` was never triggered.

## Changes

- Add `anthropicToolSchemaMode: "openai-functions"` to kimi-coding provider capabilities
- Add `anthropicToolChoiceMode: "openai-string-modes"` to kimi-coding provider capabilities  
- Update tests to reflect new expected behavior

## Testing

```bash
pnpm test src/agents/provider-capabilities.test.ts
```

All 6 tests pass.

## Related

This completes the fix started in PR #37038 which mentioned normalizing tool payloads for Kimi Coding but didn't properly configure the provider capabilities for auto-discovered providers.