### PR TITLE
docs(zh-CN): add Chinese translation for auth-credential-semantics.md

### DIFF
--- a/docs/zh-CN/auth-credential-semantics.md
+++ b/docs/zh-CN/auth-credential-semantics.md
@@ -1,0 +1,45 @@
+# 认证凭证语义
+
+本文档定义了以下模块中使用的规范凭证资格和解析语义：
+
+- `resolveAuthProfileOrder`
+- `resolveApiKeyForProfile`
+- `models status --probe`
+- `doctor-auth`
+
+目标是保持选择时和运行时行为一致。
+
+## 稳定的原因代码
+
+- `ok`
+- `missing_credential`
+- `invalid_expires`
+- `expired`
+- `unresolved_ref`
+
+## Token 凭证
+
+Token 凭证（`type: "token"`）支持内联 `token` 和/或 `tokenRef`。
+
+### 资格规则
+
+1. 当 `token` 和 `tokenRef` 都不存在时，token 配置文件不合格。
+2. `expires` 是可选的。
+3. 如果存在 `expires`，它必须是大于 `0` 的有限数字。
+4. 如果 `expires` 无效（`NaN`、`0`、负数、非有限数或错误类型），配置文件不合格，原因为 `invalid_expires`。
+5. 如果 `expires` 已过期，配置文件不合格，原因为 `expired`。
+6. `tokenRef` 不会绕过 `expires` 验证。
+
+### 解析规则
+
+1. 解析器对 `expires` 的语义与资格语义一致。
+2. 对于合格的配置文件，token 材料可从内联值或 `tokenRef` 解析。
+3. 不可解析的引用在 `models status --probe` 输出中产生 `unresolved_ref`。
+
+## 向后兼容的消息格式
+
+为了脚本兼容性，探测错误保持第一行不变：
+
+`Auth profile credentials are missing or expired.`
+
+人类友好的详细信息和稳定的原因代码可以添加在后续行中。


### PR DESCRIPTION
Translates `docs/auth-credential-semantics.md` → `docs/zh-CN/auth-credential-semantics.md`. Part of #43033.