### PR TITLE
Agents: discover Bedrock inference profile ids

### DIFF
--- a/src/agents/bedrock-discovery.test.ts
+++ b/src/agents/bedrock-discovery.test.ts
@@ -21,9 +21,13 @@ async function loadDiscovery() {
 }
 
 function mockSingleActiveSummary(overrides: Partial<typeof baseActiveAnthropicSummary> = {}): void {
-  sendMock.mockResolvedValueOnce({
-    modelSummaries: [{ ...baseActiveAnthropicSummary, ...overrides }],
-  });
+  sendMock
+    .mockResolvedValueOnce({
+      modelSummaries: [{ ...baseActiveAnthropicSummary, ...overrides }],
+    })
+    .mockResolvedValueOnce({
+      inferenceProfileSummaries: [],
+    });
 }
 
 describe("bedrock discovery", () => {
@@ -34,46 +38,50 @@ describe("bedrock discovery", () => {
   it("filters to active streaming text models and maps modalities", async () => {
     const { discoverBedrockModels } = await loadDiscovery();
 
-    sendMock.mockResolvedValueOnce({
-      modelSummaries: [
-        {
-          modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
-          modelName: "Claude 3.7 Sonnet",
-          providerName: "anthropic",
-          inputModalities: ["TEXT", "IMAGE"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-        {
-          modelId: "anthropic.claude-3-haiku-20240307-v1:0",
-          modelName: "Claude 3 Haiku",
-          providerName: "anthropic",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: false,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-        {
-          modelId: "meta.llama3-8b-instruct-v1:0",
-          modelName: "Llama 3 8B",
-          providerName: "meta",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "INACTIVE" },
-        },
-        {
-          modelId: "amazon.titan-embed-text-v1",
-          modelName: "Titan Embed",
-          providerName: "amazon",
-          inputModalities: ["TEXT"],
-          outputModalities: ["EMBEDDING"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-      ],
-    });
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [
+          {
+            modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+            modelName: "Claude 3.7 Sonnet",
+            providerName: "anthropic",
+            inputModalities: ["TEXT", "IMAGE"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+          {
+            modelId: "anthropic.claude-3-haiku-20240307-v1:0",
+            modelName: "Claude 3 Haiku",
+            providerName: "anthropic",
+            inputModalities: ["TEXT"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: false,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+          {
+            modelId: "meta.llama3-8b-instruct-v1:0",
+            modelName: "Llama 3 8B",
+            providerName: "meta",
+            inputModalities: ["TEXT"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "INACTIVE" },
+          },
+          {
+            modelId: "amazon.titan-embed-text-v1",
+            modelName: "Titan Embed",
+            providerName: "amazon",
+            inputModalities: ["TEXT"],
+            outputModalities: ["EMBEDDING"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [],
+      });
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
     expect(models).toHaveLength(1);
@@ -117,7 +125,7 @@ describe("bedrock discovery", () => {
 
     await discoverBedrockModels({ region: "us-east-1", clientFactory });
     await discoverBedrockModels({ region: "us-east-1", clientFactory });
-    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledTimes(2);
   });
 
   it("skips cache when refreshInterval is 0", async () => {
@@ -125,7 +133,9 @@ describe("bedrock discovery", () => {
 
     sendMock
       .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
-      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] });
+      .mockResolvedValueOnce({ inferenceProfileSummaries: [] })
+      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
+      .mockResolvedValueOnce({ inferenceProfileSummaries: [] });
 
     await discoverBedrockModels({
       region: "us-east-1",
@@ -137,6 +147,71 @@ describe("bedrock discovery", () => {
       config: { refreshInterval: 0 },
       clientFactory,
     });
-    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("prefers active inference profile ids over duplicate foundation model ids", async () => {
+    const { discoverBedrockModels } = await loadDiscovery();
+
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [baseActiveAnthropicSummary],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileName: "Claude 3.7 Sonnet US Profile",
+            inferenceProfileArn:
+              "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            models: [
+              {
+                modelArn:
+                  "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0",
+              },
+            ],
+            inferenceProfileId: "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        name: "Claude 3.7 Sonnet US Profile",
+        input: ["text"],
+      }),
+    ]);
+  });
+
+  it("ignores inference profiles that do not map to an allowed active foundation model", async () => {
+    const { discoverBedrockModels } = await loadDiscovery();
+
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileName: "Unknown Profile",
+            inferenceProfileArn:
+              "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.unknown.model-v1:0",
+            models: [
+              {
+                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/unknown.model-v1:0",
+              },
+            ],
+            inferenceProfileId: "us.unknown.model-v1:0",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    expect(models).toEqual([]);
   });
 });

--- a/src/agents/bedrock-discovery.ts
+++ b/src/agents/bedrock-discovery.ts
@@ -1,7 +1,9 @@
 import {
   BedrockClient,
   ListFoundationModelsCommand,
+  ListInferenceProfilesCommand,
   type ListFoundationModelsCommandOutput,
+  type ListInferenceProfilesCommandOutput,
 } from "@aws-sdk/client-bedrock";
 import type { BedrockDiscoveryConfig, ModelDefinitionConfig } from "../config/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -19,6 +21,9 @@ const DEFAULT_COST = {
 };
 
 type BedrockModelSummary = NonNullable<ListFoundationModelsCommandOutput["modelSummaries"]>[number];
+type BedrockInferenceProfileSummary = NonNullable<
+  ListInferenceProfilesCommandOutput["inferenceProfileSummaries"]
+>[number];
 
 type BedrockDiscoveryCacheEntry = {
   expiresAt: number;
@@ -124,6 +129,23 @@ function shouldIncludeSummary(summary: BedrockModelSummary, filter: string[]): b
   return true;
 }
 
+function shouldIncludeInferenceProfile(
+  summary: BedrockInferenceProfileSummary,
+  foundationSummary: BedrockModelSummary | undefined,
+  filter: string[],
+): boolean {
+  if (!summary.inferenceProfileId?.trim()) {
+    return false;
+  }
+  if (summary.status !== "ACTIVE") {
+    return false;
+  }
+  if (!foundationSummary) {
+    return false;
+  }
+  return shouldIncludeSummary(foundationSummary, filter);
+}
+
 function toModelDefinition(
   summary: BedrockModelSummary,
   defaults: { contextWindow: number; maxTokens: number },
@@ -137,6 +159,55 @@ function toModelDefinition(
     cost: DEFAULT_COST,
     contextWindow: defaults.contextWindow,
     maxTokens: defaults.maxTokens,
+  };
+}
+
+function extractModelIdFromArn(modelArn?: string): string | null {
+  const trimmed = modelArn?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const foundationIndex = trimmed.indexOf(":foundation-model/");
+  if (foundationIndex >= 0) {
+    return trimmed.slice(foundationIndex + ":foundation-model/".length).trim() || null;
+  }
+  const promptRouterIndex = trimmed.indexOf(":inference-profile/");
+  if (promptRouterIndex >= 0) {
+    return trimmed.slice(promptRouterIndex + ":inference-profile/".length).trim() || null;
+  }
+  const slash = trimmed.lastIndexOf("/");
+  return slash >= 0 ? trimmed.slice(slash + 1).trim() || null : trimmed;
+}
+
+async function listInferenceProfiles(
+  client: BedrockClient,
+): Promise<BedrockInferenceProfileSummary[]> {
+  const summaries: BedrockInferenceProfileSummary[] = [];
+  let nextToken: string | undefined;
+  do {
+    const response = await client.send(
+      new ListInferenceProfilesCommand(nextToken ? { nextToken } : {}),
+    );
+    summaries.push(...(response.inferenceProfileSummaries ?? []));
+    nextToken = response.nextToken;
+  } while (nextToken);
+  return summaries;
+}
+
+function toInferenceProfileDefinition(params: {
+  profile: BedrockInferenceProfileSummary;
+  foundationSummary: BedrockModelSummary;
+  defaults: { contextWindow: number; maxTokens: number };
+}): ModelDefinitionConfig {
+  const id = params.profile.inferenceProfileId?.trim() ?? "";
+  return {
+    id,
+    name: params.profile.inferenceProfileName?.trim() || id,
+    reasoning: inferReasoningSupport(params.foundationSummary),
+    input: mapInputModalities(params.foundationSummary),
+    cost: DEFAULT_COST,
+    contextWindow: params.defaults.contextWindow,
+    maxTokens: params.defaults.maxTokens,
   };
 }
 
@@ -181,9 +252,49 @@ export async function discoverBedrockModels(params: {
   const client = clientFactory(params.region);
 
   const discoveryPromise = (async () => {
-    const response = await client.send(new ListFoundationModelsCommand({}));
+    const [foundationResponse, inferenceProfiles] = await Promise.all([
+      client.send(new ListFoundationModelsCommand({})),
+      listInferenceProfiles(client),
+    ]);
+    const foundationSummaries = (foundationResponse.modelSummaries ?? []).filter((summary) =>
+      shouldIncludeSummary(summary, providerFilter),
+    );
+    const foundationById = new Map(
+      foundationSummaries
+        .map((summary) => [summary.modelId?.trim() ?? "", summary] as const)
+        .filter(([id]) => id.length > 0),
+    );
     const discovered: ModelDefinitionConfig[] = [];
-    for (const summary of response.modelSummaries ?? []) {
+    const coveredFoundationIds = new Set<string>();
+
+    for (const profile of inferenceProfiles) {
+      const foundationSummary = profile.models
+        ?.map((entry) => foundationById.get(extractModelIdFromArn(entry.modelArn) ?? ""))
+        .find((summary): summary is BedrockModelSummary => Boolean(summary));
+      if (!shouldIncludeInferenceProfile(profile, foundationSummary, providerFilter)) {
+        continue;
+      }
+      const foundationId = foundationSummary.modelId?.trim();
+      if (foundationId) {
+        coveredFoundationIds.add(foundationId);
+      }
+      discovered.push(
+        toInferenceProfileDefinition({
+          profile,
+          foundationSummary,
+          defaults: {
+            contextWindow: defaultContextWindow,
+            maxTokens: defaultMaxTokens,
+          },
+        }),
+      );
+    }
+
+    for (const summary of foundationSummaries) {
+      const foundationId = summary.modelId?.trim();
+      if (foundationId && coveredFoundationIds.has(foundationId)) {
+        continue;
+      }
       if (!shouldIncludeSummary(summary, providerFilter)) {
         continue;
       }


### PR DESCRIPTION
## Summary
- discover Bedrock inference profile ids alongside foundation models during autodiscovery
- prefer active inference profile ids when they map to an allowed active foundation model
- keep fallback foundation model discovery for models without an active inference profile

## Testing
- pnpm test src/agents/bedrock-discovery.test.ts
- pnpm test src/agents/model-selection.test.ts
- pnpm exec oxfmt --check src/agents/bedrock-discovery.ts src/agents/bedrock-discovery.test.ts

Fixes #5290
