### PR TITLE
Pi: add tool adapter conformance harness

### DIFF
--- a/docs/pi-dev.md
+++ b/docs/pi-dev.md
@@ -46,6 +46,8 @@ This covers the main Pi unit suites:
 - `src/agents/pi-tool-definition-adapter.test.ts`
 - `src/agents/pi-extensions/*.test.ts`
 
+The tool-adapter interoperability contract lives in `src/agents/pi-tool-definition-adapter.conformance.test.ts` and is covered by the existing `src/agents/pi-tool-definition-adapter*.test.ts` glob.
+
 ## Manual Testing
 
 Recommended flow:

--- a/src/agents/pi-tool-definition-adapter.conformance.test.ts
+++ b/src/agents/pi-tool-definition-adapter.conformance.test.ts
@@ -1,0 +1,364 @@
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE } from "./pi-tool-definition-adapter.conformance.js";
+import { toClientToolDefinitions, toToolDefinitions } from "./pi-tool-definition-adapter.js";
+
+vi.mock("../plugins/hook-runner-global.js");
+
+type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
+type LegacyToolExecute = (
+  toolCallId: string,
+  params: unknown,
+  onUpdate: Parameters<ToolExecute>[3],
+  extensionContext: Parameters<ToolExecute>[4],
+  signal?: AbortSignal,
+) => Promise<AgentToolResult<unknown>>;
+type ExecuteLayout =
+  (typeof PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.agentToolAdapter.executeArgLayouts)[number];
+type HookRunnerMock = {
+  hasHooks: ReturnType<typeof vi.fn>;
+  runBeforeToolCall: ReturnType<typeof vi.fn>;
+};
+
+const extensionContext = {} as Parameters<ToolExecute>[4];
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+function createHookRunnerMock(params?: {
+  hasHooksReturn?: boolean;
+  runBeforeToolCallImpl?: (...args: unknown[]) => unknown;
+}): HookRunnerMock {
+  const hookRunner: HookRunnerMock = {
+    hasHooks: vi.fn(() => params?.hasHooksReturn ?? false),
+    runBeforeToolCall: params?.runBeforeToolCallImpl
+      ? vi.fn(params.runBeforeToolCallImpl)
+      : vi.fn(),
+  };
+  // oxlint-disable-next-line typescript/no-explicit-any
+  mockGetGlobalHookRunner.mockReturnValue(hookRunner as any);
+  return hookRunner;
+}
+
+function getToolDefinition(tool: AgentTool) {
+  const [definition] = toToolDefinitions([tool]);
+  if (!definition) {
+    throw new Error("missing tool definition");
+  }
+  return definition;
+}
+
+function getClientToolDefinition(
+  onClientToolCall?: (toolName: string, params: Record<string, unknown>) => void,
+) {
+  const [definition] = toClientToolDefinitions(
+    [
+      {
+        type: "function",
+        function: {
+          name: "client_tool",
+          description: "Client tool",
+          parameters: { type: "object", properties: { value: { type: "string" } } },
+        },
+      },
+    ],
+    onClientToolCall,
+  );
+  if (!definition) {
+    throw new Error("missing client tool definition");
+  }
+  return definition;
+}
+
+async function executeWithLayout<T>(
+  definition: { execute: ToolExecute },
+  layout: ExecuteLayout,
+  params: unknown,
+  options?: {
+    signal?: AbortSignal;
+    onUpdate?: Parameters<ToolExecute>[3];
+  },
+): Promise<T> {
+  if (layout === "legacy") {
+    const executeLegacy = definition.execute as unknown as LegacyToolExecute;
+    return (await executeLegacy(
+      `call-${layout}`,
+      params,
+      options?.onUpdate,
+      extensionContext,
+      options?.signal,
+    )) as T;
+  }
+  return (await definition.execute(
+    `call-${layout}`,
+    params,
+    options?.signal,
+    options?.onUpdate,
+    extensionContext,
+  )) as T;
+}
+
+function createStandardResult(toolName: string): AgentToolResult<unknown> {
+  return {
+    content: [{ type: "text", text: `${toolName}:ok` }],
+    details: { tool: toolName, ok: true },
+  };
+}
+
+describe("PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE", () => {
+  it("is JSON-serializable and lists both adapter surfaces", () => {
+    expect(() => JSON.stringify(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE)).not.toThrow();
+    expect(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.agentToolAdapter.executeArgLayouts).toEqual([
+      "current",
+      "legacy",
+    ]);
+    expect(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.clientToolAdapter.outputModes).toEqual([
+      "pending_result",
+    ]);
+  });
+});
+
+describe("agent tool adapter conformance", () => {
+  beforeEach(() => {
+    resetDiagnosticSessionStateForTest();
+    createHookRunnerMock();
+  });
+
+  it.each(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.agentToolAdapter.executeArgLayouts)(
+    "passes standard results through for %s layout",
+    async (layout) => {
+      const signal = new AbortController().signal;
+      const onUpdate = vi.fn();
+      const execute = vi.fn().mockResolvedValue(createStandardResult("memory_query"));
+      const tool = {
+        name: "memory_query",
+        label: "Memory Query",
+        description: "returns standard results",
+        parameters: Type.Object({}),
+        execute,
+      } satisfies AgentTool;
+
+      const definition = getToolDefinition(tool);
+      const result = await executeWithLayout<AgentToolResult<unknown>>(
+        definition,
+        layout,
+        {},
+        {
+          signal,
+          onUpdate,
+        },
+      );
+
+      expect(result).toEqual(createStandardResult("memory_query"));
+      expect(execute).toHaveBeenCalledWith(expect.any(String), {}, signal, onUpdate);
+    },
+  );
+
+  it.each(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.agentToolAdapter.executeArgLayouts)(
+    "normalizes details-only, plain-object, and primitive results for %s layout",
+    async (layout) => {
+      const detailsOnly = getToolDefinition({
+        name: "details_only",
+        label: "Details Only",
+        description: "details only",
+        parameters: Type.Object({}),
+        execute: (async () => ({
+          details: { hits: [{ id: "a1", score: 0.9 }] },
+        })) as unknown as AgentTool["execute"],
+      } satisfies AgentTool);
+      const plainObject = getToolDefinition({
+        name: "plain_object",
+        label: "Plain Object",
+        description: "plain object",
+        parameters: Type.Object({}),
+        execute: (async () => ({
+          count: 2,
+          ids: ["m1", "m2"],
+        })) as unknown as AgentTool["execute"],
+      } satisfies AgentTool);
+      const primitive = getToolDefinition({
+        name: "primitive_value",
+        label: "Primitive Value",
+        description: "primitive",
+        parameters: Type.Object({}),
+        execute: (async () => "done") as unknown as AgentTool["execute"],
+      } satisfies AgentTool);
+
+      const detailsResult = await executeWithLayout<AgentToolResult<unknown>>(
+        detailsOnly,
+        layout,
+        {},
+      );
+      const plainObjectResult = await executeWithLayout<AgentToolResult<unknown>>(
+        plainObject,
+        layout,
+        {},
+      );
+      const primitiveResult = await executeWithLayout<AgentToolResult<unknown>>(
+        primitive,
+        layout,
+        {},
+      );
+
+      expect(detailsResult.details).toEqual({ hits: [{ id: "a1", score: 0.9 }] });
+      expect(detailsResult.content[0]).toMatchObject({ type: "text" });
+      expect((detailsResult.content[0] as { text?: string }).text).toContain('"hits"');
+
+      expect(plainObjectResult.details).toEqual({ count: 2, ids: ["m1", "m2"] });
+      expect(plainObjectResult.content[0]).toMatchObject({ type: "text" });
+      expect((plainObjectResult.content[0] as { text?: string }).text).toContain('"count"');
+
+      expect(primitiveResult.details).toBe("done");
+      expect(primitiveResult.content[0]).toMatchObject({ type: "text", text: "done" });
+    },
+  );
+
+  it.each(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.agentToolAdapter.executeArgLayouts)(
+    "wraps non-abort tool failures for %s layout",
+    async (layout) => {
+      const definition = getToolDefinition({
+        name: "bash",
+        label: "Bash",
+        description: "throws",
+        parameters: Type.Object({}),
+        execute: async () => {
+          throw new Error("nope");
+        },
+      } satisfies AgentTool);
+
+      const result = await executeWithLayout<AgentToolResult<unknown>>(definition, layout, {});
+      expect(result.details).toMatchObject({
+        status: "error",
+        tool: "exec",
+        error: "nope",
+      });
+      expect(JSON.stringify(result.details)).not.toContain("\n    at ");
+    },
+  );
+
+  it.each(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.agentToolAdapter.executeArgLayouts)(
+    "passes abort errors through for %s layout",
+    async (layout) => {
+      const definition = getToolDefinition({
+        name: "read",
+        label: "Read",
+        description: "aborts",
+        parameters: Type.Object({}),
+        execute: async () => {
+          const error = new Error("timed out");
+          error.name = "AbortError";
+          throw error;
+        },
+      } satisfies AgentTool);
+
+      await expect(executeWithLayout(definition, layout, {})).rejects.toMatchObject({
+        name: "AbortError",
+        message: "timed out",
+      });
+    },
+  );
+
+  it.each(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.agentToolAdapter.executeArgLayouts)(
+    "rejects already-aborted calls before tool execution for %s layout",
+    async (layout) => {
+      const controller = new AbortController();
+      controller.abort();
+      const execute = vi.fn().mockResolvedValue(createStandardResult("read"));
+      const definition = getToolDefinition({
+        name: "read",
+        label: "Read",
+        description: "should not execute",
+        parameters: Type.Object({}),
+        execute,
+      } satisfies AgentTool);
+
+      await expect(
+        executeWithLayout(definition, layout, {}, { signal: controller.signal }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(execute).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe("client tool adapter conformance", () => {
+  beforeEach(() => {
+    resetDiagnosticSessionStateForTest();
+    createHookRunnerMock();
+  });
+
+  it.each(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.clientToolAdapter.executeArgLayouts)(
+    "returns a pending result for %s layout",
+    async (layout) => {
+      const onClientToolCall = vi.fn();
+      const definition = getClientToolDefinition(onClientToolCall);
+
+      const result = await executeWithLayout<AgentToolResult<unknown>>(definition, layout, {
+        value: "ok",
+      });
+
+      expect(onClientToolCall).toHaveBeenCalledWith("client_tool", { value: "ok" });
+      expect(result.details).toEqual({
+        status: "pending",
+        tool: "client_tool",
+        message: "Tool execution delegated to client",
+      });
+      expect(result.content[0]).toMatchObject({ type: "text" });
+    },
+  );
+
+  it.each(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.clientToolAdapter.executeArgLayouts)(
+    "passes hook-adjusted params through for %s layout",
+    async (layout) => {
+      const hookRunner = createHookRunnerMock({
+        hasHooksReturn: true,
+        runBeforeToolCallImpl: async () => ({ params: { extra: true } }),
+      });
+      const onClientToolCall = vi.fn();
+      const definition = getClientToolDefinition(onClientToolCall);
+
+      await executeWithLayout(definition, layout, { value: "ok" });
+
+      expect(hookRunner.runBeforeToolCall).toHaveBeenCalledTimes(1);
+      expect(onClientToolCall).toHaveBeenCalledWith("client_tool", {
+        value: "ok",
+        extra: true,
+      });
+    },
+  );
+
+  it.each(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.clientToolAdapter.executeArgLayouts)(
+    "surfaces blocked hooks for %s layout",
+    async (layout) => {
+      createHookRunnerMock({
+        hasHooksReturn: true,
+        runBeforeToolCallImpl: async () => ({
+          block: true,
+          blockReason: "blocked by policy",
+        }),
+      });
+      const onClientToolCall = vi.fn();
+      const definition = getClientToolDefinition(onClientToolCall);
+
+      await expect(executeWithLayout(definition, layout, { value: "ok" })).rejects.toThrow(
+        "blocked by policy",
+      );
+      expect(onClientToolCall).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE.clientToolAdapter.executeArgLayouts)(
+    "rejects already-aborted calls before delegation for %s layout",
+    async (layout) => {
+      const controller = new AbortController();
+      controller.abort();
+      const onClientToolCall = vi.fn();
+      const definition = getClientToolDefinition(onClientToolCall);
+
+      await expect(
+        executeWithLayout(definition, layout, { value: "ok" }, { signal: controller.signal }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(onClientToolCall).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/agents/pi-tool-definition-adapter.conformance.ts
+++ b/src/agents/pi-tool-definition-adapter.conformance.ts
@@ -1,0 +1,16 @@
+export const PI_TOOL_DEFINITION_ADAPTER_CONFORMANCE = {
+  agentToolAdapter: {
+    executeArgLayouts: ["current", "legacy"],
+    outputModes: ["standard_result", "details_only_object", "plain_object", "primitive_value"],
+    errorModes: [
+      "structured_error_result",
+      "abort_error_passthrough",
+      "already_aborted_signal_passthrough",
+    ],
+  },
+  clientToolAdapter: {
+    executeArgLayouts: ["current", "legacy"],
+    outputModes: ["pending_result"],
+    errorModes: ["blocked_hook_passthrough", "already_aborted_signal_passthrough"],
+  },
+} as const;

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -49,6 +49,18 @@ function isLegacyToolExecuteArgs(args: ToolExecuteArgsAny): args is ToolExecuteA
   return isAbortSignal(fifth);
 }
 
+function throwIfExecutionAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  if (typeof signal.throwIfAborted === "function") {
+    signal.throwIfAborted();
+  }
+  const error = new Error("This operation was aborted.");
+  error.name = "AbortError";
+  throw error;
+}
+
 function describeToolExecutionError(err: unknown): {
   message: string;
   stack?: string;
@@ -146,6 +158,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
       parameters: tool.parameters,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
+        throwIfExecutionAborted(signal);
         let executeParams = params;
         try {
           if (!beforeHookWrapped) {
@@ -159,7 +172,9 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
             }
             executeParams = hookOutcome.params;
           }
+          throwIfExecutionAborted(signal);
           const rawResult = await tool.execute(toolCallId, executeParams, signal, onUpdate);
+          throwIfExecutionAborted(signal);
           const result = normalizeToolExecutionResult({
             toolName: normalizedName,
             result: rawResult,
@@ -208,7 +223,8 @@ export function toClientToolDefinitions(
       description: func.description ?? "",
       parameters: func.parameters as ToolDefinition["parameters"],
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
-        const { toolCallId, params } = splitToolExecuteArgs(args);
+        const { toolCallId, params, signal } = splitToolExecuteArgs(args);
+        throwIfExecutionAborted(signal);
         const outcome = await runBeforeToolCallHook({
           toolName: func.name,
           params,
@@ -218,12 +234,14 @@ export function toClientToolDefinitions(
         if (outcome.blocked) {
           throw new Error(outcome.reason);
         }
+        throwIfExecutionAborted(signal);
         const adjustedParams = outcome.params;
         const paramsRecord = isPlainObject(adjustedParams) ? adjustedParams : {};
         // Notify handler that a client tool was called
         if (onClientToolCall) {
           onClientToolCall(func.name, paramsRecord);
         }
+        throwIfExecutionAborted(signal);
         // Return a pending result - the client will execute this tool
         return jsonResult({
           status: "pending",


### PR DESCRIPTION
## Summary
- add a machine-readable compatibility matrix for Pi agent/client tool adapters
- cover current + legacy execute layouts, normalized outputs, wrapped errors, hook blocking, and pending delegation in a dedicated conformance suite
- fail fast on already-aborted signals before tool execution or client-tool delegation and document the harness in the Pi workflow guide

## Why
The Pi tool definition adapter is the boundary that normalizes OpenClaw tool execution into Pi `ToolDefinition` semantics. Existing tests covered a few happy-path and error cases, but they did not pin down layout compatibility, output coercion, or abort semantics across both agent and client tool adapters. This adds a cheap regression harness so drift shows up in CI instead of at runtime.

## Testing
- `pnpm test -- src/agents/pi-tool-definition-adapter*.test.ts`
- `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts`
- `pnpm build`
- `pnpm tsgo`
- `pnpm check`

## Risk
- low: adapter-boundary tests plus a narrow abort guard on already-aborted signals
