### PR TITLE
Reply: show Copilot usage in response footer

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -99,6 +99,7 @@ export const formatResponseUsageLine = (params: {
     cacheRead: number;
     cacheWrite: number;
   };
+  providerUsageSummary?: string;
 }): string | null => {
   const usage = params.usage;
   if (!usage) {
@@ -124,7 +125,11 @@ export const formatResponseUsageLine = (params: {
         })
       : undefined;
   const costLabel = params.showCost ? formatUsd(cost) : undefined;
-  const suffix = costLabel ? ` · est ${costLabel}` : "";
+  const suffixParts = [
+    costLabel ? `est ${costLabel}` : null,
+    params.providerUsageSummary?.trim() ? params.providerUsageSummary.trim() : null,
+  ].filter(Boolean);
+  const suffix = suffixParts.length > 0 ? ` · ${suffixParts.join(" · ")}` : "";
   return `Usage: ${inputLabel} in / ${outputLabel} out${suffix}`;
 };
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -15,6 +15,8 @@ const runEmbeddedPiAgentMock = vi.fn();
 const runCliAgentMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
 const runtimeErrorMock = vi.fn();
+const loadProviderUsageSummaryMock = vi.fn();
+const formatUsageWindowSummaryMock = vi.fn();
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -58,6 +60,17 @@ vi.mock("../../runtime.js", async () => {
   };
 });
 
+vi.mock("../../infra/provider-usage.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/provider-usage.js")>(
+    "../../infra/provider-usage.js",
+  );
+  return {
+    ...actual,
+    loadProviderUsageSummary: (...args: unknown[]) => loadProviderUsageSummaryMock(...args),
+    formatUsageWindowSummary: (...args: unknown[]) => formatUsageWindowSummaryMock(...args),
+  };
+});
+
 vi.mock("./queue.js", async () => {
   const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
   return {
@@ -90,8 +103,12 @@ beforeEach(() => {
   runWithModelFallbackMock.mockClear();
   runtimeErrorMock.mockClear();
   loadCronStoreMock.mockClear();
+  loadProviderUsageSummaryMock.mockClear();
+  formatUsageWindowSummaryMock.mockClear();
   // Default: no cron jobs in store.
   loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+  loadProviderUsageSummaryMock.mockResolvedValue({ updatedAt: Date.now(), providers: [] });
+  formatUsageWindowSummaryMock.mockReturnValue(null);
   resetSystemEventsForTest();
 
   // Default: no provider switch; execute the chosen provider+model.
@@ -1527,6 +1544,107 @@ describe("runReplyAgent response usage footer", () => {
     const payload = Array.isArray(res) ? res[0] : res;
     expect(String(payload?.text ?? "")).toContain("Usage:");
     expect(String(payload?.text ?? "")).toContain(`· session \`${sessionKey}\``);
+  });
+
+  it("appends Copilot premium usage when available", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "github-copilot",
+          model: "gpt-4.1",
+          usage: { input: 12, output: 3 },
+        },
+      },
+    });
+    loadProviderUsageSummaryMock.mockResolvedValueOnce({
+      updatedAt: Date.now(),
+      providers: [
+        {
+          provider: "github-copilot",
+          displayName: "GitHub Copilot",
+          windows: [
+            { label: "Premium", usedPercent: 14 },
+            { label: "Chat", usedPercent: 0 },
+          ],
+        },
+      ],
+    });
+    formatUsageWindowSummaryMock.mockReturnValueOnce("Premium 86% left · Chat 100% left");
+
+    const sessionKey = "agent:main:whatsapp:dm:+1000";
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "whatsapp",
+      OriginatingTo: "+15550001111",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      responseUsage: "full",
+    };
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        agentDir: "/tmp/agent",
+        sessionId: "session",
+        sessionKey,
+        messageProvider: "whatsapp",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "github-copilot",
+        model: "gpt-4.1",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const res = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionKey,
+      defaultModel: "github-copilot/gpt-4.1",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    const payload = Array.isArray(res) ? res[0] : res;
+    expect(String(payload?.text ?? "")).toContain("Premium 86% left · Chat 100% left");
+    expect(loadProviderUsageSummaryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: ["github-copilot"],
+        agentDir: "/tmp/agent",
+      }),
+    );
   });
 
   it("does not append session key when responseUsage=tokens", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -17,6 +17,11 @@ import {
 import type { TypingMode } from "../../config/types.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import {
+  formatUsageWindowSummary,
+  loadProviderUsageSummary,
+  resolveUsageProviderId,
+} from "../../infra/provider-usage.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -59,6 +64,43 @@ import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
+const USAGE_SUMMARY_TIMEOUT_MS = 3_500;
+
+async function loadCopilotUsageFooterSummary(params: {
+  provider: string;
+  agentDir?: string;
+  now: number;
+}): Promise<string | null> {
+  let usageProvider: ReturnType<typeof resolveUsageProviderId> | undefined;
+  try {
+    usageProvider = resolveUsageProviderId(params.provider);
+  } catch {
+    return null;
+  }
+  if (usageProvider !== "github-copilot") {
+    return null;
+  }
+
+  try {
+    const usageSummary = await loadProviderUsageSummary({
+      timeoutMs: USAGE_SUMMARY_TIMEOUT_MS,
+      providers: [usageProvider],
+      agentDir: params.agentDir,
+      now: params.now,
+    });
+    const usageEntry = usageSummary.providers[0];
+    if (!usageEntry || usageEntry.error || usageEntry.windows.length === 0) {
+      return null;
+    }
+    return formatUsageWindowSummary(usageEntry, {
+      now: params.now,
+      maxWindows: 2,
+      includeResets: false,
+    });
+  } catch {
+    return null;
+  }
+}
 
 export async function runReplyAgent(params: {
   commandBody: string;
@@ -589,10 +631,16 @@ export async function runReplyAgent(params: {
             config: cfg,
           })
         : undefined;
+      const providerUsageSummary = await loadCopilotUsageFooterSummary({
+        provider: providerUsed,
+        agentDir: followupRun.run.agentDir,
+        now: Date.now(),
+      });
       let formatted = formatResponseUsageLine({
         usage,
         showCost,
         costConfig,
+        providerUsageSummary: providerUsageSummary ?? undefined,
       });
       if (formatted && responseUsageMode === "full" && sessionKey) {
         formatted = `${formatted} · session \`${sessionKey}\``;


### PR DESCRIPTION
## Summary
- append GitHub Copilot premium/chat quota details to the per-response usage footer
- reuse the existing provider usage summary formatting so the footer matches `/status`
- cover the new footer behavior with a Copilot regression test

## Testing
- pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
- pnpm test src/auto-reply/status.test.ts
- pnpm exec oxfmt --check src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner-utils.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts

Fixes #7379
