### PR TITLE
macOS/onboarding: prompt for remote gateway auth tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - OpenCode/onboarding: add new OpenCode Go provider, treat Zen and Go as one OpenCode setup in the wizard/docs while keeping the runtime providers split, store one shared OpenCode key for both profiles, and stop overriding the built-in `opencode-go` catalog routing. (#42313) Thanks @ImLukeF and @vincentkoc.
 - macOS/chat UI: add a chat model picker, persist explicit thinking-level selections across relaunch, and harden provider-aware session model sync for the shared chat composer. (#42314) Thanks @ImLukeF.
 - iOS/TestFlight: add a local beta release flow with Fastlane prepare/archive/upload support, canonical beta bundle IDs, and watch-app archive fixes. (#42991) Thanks @ngutman.
+- macOS/onboarding: detect when remote gateways need a shared auth token, explain where to find it on the gateway host, and clarify when a successful check used paired-device auth instead. (#43100) Thanks @ngutman.
 
 ### Breaking
 

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -600,28 +600,26 @@ final class AppState {
     private func syncGatewayConfigIfNeeded() {
         guard !self.isPreview, !self.isInitializing else { return }
 
-        let connectionMode = self.connectionMode
-        let remoteTarget = self.remoteTarget
-        let remoteIdentity = self.remoteIdentity
-        let remoteTransport = self.remoteTransport
-        let remoteUrl = self.remoteUrl
-        let remoteToken = self.remoteToken
-        let remoteTokenDirty = self.remoteTokenDirty
-
         Task { @MainActor in
-            // Keep app-only connection settings local to avoid overwriting remote gateway config.
-            let synced = Self.syncedGatewayRoot(
-                currentRoot: OpenClawConfigFile.loadDict(),
-                connectionMode: connectionMode,
-                remoteTransport: remoteTransport,
-                remoteTarget: remoteTarget,
-                remoteIdentity: remoteIdentity,
-                remoteUrl: remoteUrl,
-                remoteToken: remoteToken,
-                remoteTokenDirty: remoteTokenDirty)
-            guard synced.changed else { return }
-            OpenClawConfigFile.saveDict(synced.root)
+            self.syncGatewayConfigNow()
         }
+    }
+
+    func syncGatewayConfigNow() {
+        guard !self.isPreview, !self.isInitializing else { return }
+
+        // Keep app-only connection settings local to avoid overwriting remote gateway config.
+        let synced = Self.syncedGatewayRoot(
+            currentRoot: OpenClawConfigFile.loadDict(),
+            connectionMode: self.connectionMode,
+            remoteTransport: self.remoteTransport,
+            remoteTarget: self.remoteTarget,
+            remoteIdentity: self.remoteIdentity,
+            remoteUrl: self.remoteUrl,
+            remoteToken: self.remoteToken,
+            remoteTokenDirty: self.remoteTokenDirty)
+        guard synced.changed else { return }
+        OpenClawConfigFile.saveDict(synced.root)
     }
 
     func triggerVoiceEars(ttl: TimeInterval? = 5) {

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -605,6 +605,7 @@ final class AppState {
         }
     }
 
+    @MainActor
     func syncGatewayConfigNow() {
         guard !self.isPreview, !self.isInitializing else { return }
 

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -188,6 +188,10 @@ final class ControlChannel {
             return desc
         }
 
+        if let authIssue = RemoteGatewayAuthIssue(error: error) {
+            return authIssue.statusMessage
+        }
+
         // If the gateway explicitly rejects the hello (e.g., auth/token mismatch), surface it.
         if let urlErr = error as? URLError,
            urlErr.code == .dataNotAllowed // used for WS close 1008 auth failures

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -348,10 +348,18 @@ struct GeneralSettings: View {
             Text("Testing…")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-        case .ok:
-            Label("Ready", systemImage: "checkmark.circle.fill")
-                .font(.caption)
-                .foregroundStyle(.green)
+        case let .ok(success):
+            VStack(alignment: .leading, spacing: 2) {
+                Label(success.title, systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                if let detail = success.detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         case let .failed(message):
             Text(message)
                 .font(.caption)
@@ -518,7 +526,7 @@ struct GeneralSettings: View {
 private enum RemoteStatus: Equatable {
     case idle
     case checking
-    case ok
+    case ok(RemoteGatewayProbeSuccess)
     case failed(String)
 }
 
@@ -558,114 +566,14 @@ extension GeneralSettings {
     @MainActor
     func testRemote() async {
         self.remoteStatus = .checking
-        let settings = CommandResolver.connectionSettings()
-        if self.state.remoteTransport == .direct {
-            let trimmedUrl = self.state.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedUrl.isEmpty else {
-                self.remoteStatus = .failed("Set a gateway URL first")
-                return
-            }
-            guard Self.isValidWsUrl(trimmedUrl) else {
-                self.remoteStatus = .failed(
-                    "Gateway URL must use wss:// for remote hosts (ws:// only for localhost)")
-                return
-            }
-        } else {
-            guard !settings.target.isEmpty else {
-                self.remoteStatus = .failed("Set an SSH target first")
-                return
-            }
-
-            // Step 1: basic SSH reachability check
-            guard let sshCommand = Self.sshCheckCommand(
-                target: settings.target,
-                identity: settings.identity)
-            else {
-                self.remoteStatus = .failed("SSH target is invalid")
-                return
-            }
-            let sshResult = await ShellExecutor.run(
-                command: sshCommand,
-                cwd: nil,
-                env: nil,
-                timeout: 8)
-
-            guard sshResult.ok else {
-                self.remoteStatus = .failed(self.formatSSHFailure(sshResult, target: settings.target))
-                return
-            }
+        switch await RemoteGatewayProbe.run() {
+        case let .ready(success):
+            self.remoteStatus = .ok(success)
+        case let .authIssue(issue):
+            self.remoteStatus = .failed(issue.statusMessage)
+        case let .failed(message):
+            self.remoteStatus = .failed(message)
         }
-
-        // Step 2: control channel health check
-        let originalMode = AppStateStore.shared.connectionMode
-        do {
-            try await ControlChannel.shared.configure(mode: .remote(
-                target: settings.target,
-                identity: settings.identity))
-            let data = try await ControlChannel.shared.health(timeout: 10)
-            if decodeHealthSnapshot(from: data) != nil {
-                self.remoteStatus = .ok
-            } else {
-                self.remoteStatus = .failed("Control channel returned invalid health JSON")
-            }
-        } catch {
-            self.remoteStatus = .failed(error.localizedDescription)
-        }
-
-        // Restore original mode if we temporarily switched
-        switch originalMode {
-        case .remote:
-            break
-        case .local:
-            try? await ControlChannel.shared.configure(mode: .local)
-        case .unconfigured:
-            await ControlChannel.shared.disconnect()
-        }
-    }
-
-    private static func isValidWsUrl(_ raw: String) -> Bool {
-        GatewayRemoteConfig.normalizeGatewayUrl(raw) != nil
-    }
-
-    private static func sshCheckCommand(target: String, identity: String) -> [String]? {
-        guard let parsed = CommandResolver.parseSSHTarget(target) else { return nil }
-        let options = [
-            "-o", "BatchMode=yes",
-            "-o", "ConnectTimeout=5",
-            "-o", "StrictHostKeyChecking=accept-new",
-            "-o", "UpdateHostKeys=yes",
-        ]
-        let args = CommandResolver.sshArguments(
-            target: parsed,
-            identity: identity,
-            options: options,
-            remoteCommand: ["echo", "ok"])
-        return ["/usr/bin/ssh"] + args
-    }
-
-    private func formatSSHFailure(_ response: Response, target: String) -> String {
-        let payload = response.payload.flatMap { String(data: $0, encoding: .utf8) }
-        let trimmed = payload?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .split(whereSeparator: \.isNewline)
-            .joined(separator: " ")
-        if let trimmed,
-           trimmed.localizedCaseInsensitiveContains("host key verification failed")
-        {
-            let host = CommandResolver.parseSSHTarget(target)?.host ?? target
-            return "SSH check failed: Host key verification failed. Remove the old key with " +
-                "`ssh-keygen -R \(host)` and try again."
-        }
-        if let trimmed, !trimmed.isEmpty {
-            if let message = response.message, message.hasPrefix("exit ") {
-                return "SSH check failed: \(trimmed) (\(message))"
-            }
-            return "SSH check failed: \(trimmed)"
-        }
-        if let message = response.message {
-            return "SSH check failed (\(message))"
-        }
-        return "SSH check failed"
     }
 
     private func revealLogs() {

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -9,6 +9,13 @@ enum UIStrings {
     static let welcomeTitle = "Welcome to OpenClaw"
 }
 
+enum RemoteOnboardingProbeState: Equatable {
+    case idle
+    case checking
+    case ok(RemoteGatewayProbeSuccess)
+    case failed(String)
+}
+
 @MainActor
 final class OnboardingController {
     static let shared = OnboardingController()
@@ -72,6 +79,8 @@ struct OnboardingView: View {
     @State var didAutoKickoff = false
     @State var showAdvancedConnection = false
     @State var preferredGatewayID: String?
+    @State var remoteProbeState: RemoteOnboardingProbeState = .idle
+    @State var remoteAuthIssue: RemoteGatewayAuthIssue?
     @State var gatewayDiscovery: GatewayDiscoveryModel
     @State var onboardingChatModel: OpenClawChatViewModel
     @State var onboardingSkillsModel = SkillsSettingsModel()

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -81,6 +81,7 @@ struct OnboardingView: View {
     @State var preferredGatewayID: String?
     @State var remoteProbeState: RemoteOnboardingProbeState = .idle
     @State var remoteAuthIssue: RemoteGatewayAuthIssue?
+    @State var suppressRemoteProbeReset = false
     @State var gatewayDiscovery: GatewayDiscoveryModel
     @State var onboardingChatModel: OpenClawChatViewModel
     @State var onboardingSkillsModel = SkillsSettingsModel()

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -2,6 +2,7 @@ import AppKit
 import OpenClawChatUI
 import OpenClawDiscovery
 import OpenClawIPC
+import OpenClawKit
 import SwiftUI
 
 extension OnboardingView {
@@ -97,6 +98,11 @@ extension OnboardingView {
 
                     self.gatewayDiscoverySection()
 
+                    if self.shouldShowRemoteConnectionSection {
+                        Divider().padding(.vertical, 4)
+                        self.remoteConnectionSection()
+                    }
+
                     self.connectionChoiceButton(
                         title: "Configure later",
                         subtitle: "Don’t start the Gateway yet.",
@@ -108,6 +114,19 @@ extension OnboardingView {
                     self.advancedConnectionSection()
                 }
             }
+        }
+        .onChange(of: self.state.connectionMode) { _, newValue in
+            guard newValue != .remote else { return }
+            self.resetRemoteProbeFeedback()
+        }
+        .onChange(of: self.state.remoteTransport) { _, _ in
+            self.resetRemoteProbeFeedback()
+        }
+        .onChange(of: self.state.remoteTarget) { _, _ in
+            self.resetRemoteProbeFeedback()
+        }
+        .onChange(of: self.state.remoteUrl) { _, _ in
+            self.resetRemoteProbeFeedback()
         }
     }
 
@@ -199,25 +218,6 @@ extension OnboardingView {
                         .pickerStyle(.segmented)
                         .frame(width: fieldWidth)
                     }
-                    GridRow {
-                        Text("Gateway token")
-                            .font(.callout.weight(.semibold))
-                            .frame(width: labelWidth, alignment: .leading)
-                        SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: fieldWidth)
-                    }
-                    if self.state.remoteTokenUnsupported {
-                        GridRow {
-                            Text("")
-                                .frame(width: labelWidth, alignment: .leading)
-                            Text(
-                                "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.")
-                                .font(.caption)
-                                .foregroundStyle(.orange)
-                                .frame(width: fieldWidth, alignment: .leading)
-                        }
-                    }
                     if self.state.remoteTransport == .direct {
                         GridRow {
                             Text("Gateway URL")
@@ -287,6 +287,227 @@ extension OnboardingView {
             }
             .transition(.opacity.combined(with: .move(edge: .top)))
         }
+    }
+
+    private var shouldShowRemoteConnectionSection: Bool {
+        self.state.connectionMode == .remote ||
+            self.showAdvancedConnection ||
+            self.remoteProbeState != .idle ||
+            self.remoteAuthIssue != nil ||
+            Self.shouldShowRemoteTokenField(
+                showAdvancedConnection: self.showAdvancedConnection,
+                remoteToken: self.state.remoteToken,
+                remoteTokenUnsupported: self.state.remoteTokenUnsupported,
+                authIssue: self.remoteAuthIssue)
+    }
+
+    private var shouldShowRemoteTokenField: Bool {
+        guard self.shouldShowRemoteConnectionSection else { return false }
+        return Self.shouldShowRemoteTokenField(
+            showAdvancedConnection: self.showAdvancedConnection,
+            remoteToken: self.state.remoteToken,
+            remoteTokenUnsupported: self.state.remoteTokenUnsupported,
+            authIssue: self.remoteAuthIssue)
+    }
+
+    private var remoteProbePreflightMessage: String? {
+        switch self.state.remoteTransport {
+        case .direct:
+            let trimmedUrl = self.state.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedUrl.isEmpty {
+                return "Select a nearby gateway or open Advanced to enter a gateway URL."
+            }
+            if GatewayRemoteConfig.normalizeGatewayUrl(trimmedUrl) == nil {
+                return "Gateway URL must use wss:// for remote hosts (ws:// only for localhost)."
+            }
+            return nil
+        case .ssh:
+            let trimmedTarget = self.state.remoteTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedTarget.isEmpty {
+                return "Select a nearby gateway or open Advanced to enter an SSH target."
+            }
+            return CommandResolver.sshTargetValidationMessage(trimmedTarget)
+        }
+    }
+
+    private var canProbeRemoteConnection: Bool {
+        self.remoteProbePreflightMessage == nil && self.remoteProbeState != .checking
+    }
+
+    @ViewBuilder
+    private func remoteConnectionSection() -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Remote connection")
+                        .font(.callout.weight(.semibold))
+                    Text("Checks the real remote websocket and auth handshake.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                Button {
+                    Task { await self.probeRemoteConnection() }
+                } label: {
+                    if self.remoteProbeState == .checking {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(minWidth: 120)
+                    } else {
+                        Text("Check connection")
+                            .frame(minWidth: 120)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!self.canProbeRemoteConnection)
+            }
+
+            if self.shouldShowRemoteTokenField {
+                self.remoteTokenField()
+            }
+
+            if let message = self.remoteProbePreflightMessage, self.remoteProbeState != .checking {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            self.remoteProbeStatusView()
+
+            if let issue = self.remoteAuthIssue {
+                self.remoteAuthPromptView(issue: issue)
+            }
+        }
+    }
+
+    private func remoteTokenField() -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 12) {
+                Text("Gateway token")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: 110, alignment: .leading)
+                SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 320)
+            }
+            Text("Used when the remote gateway requires token auth.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if self.state.remoteTokenUnsupported {
+                Text(
+                    "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func remoteProbeStatusView() -> some View {
+        switch self.remoteProbeState {
+        case .idle:
+            EmptyView()
+        case .checking:
+            Text("Checking remote gateway…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case let .ok(success):
+            VStack(alignment: .leading, spacing: 2) {
+                Label(success.title, systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                if let detail = success.detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        case let .failed(message):
+            if self.remoteAuthIssue == nil {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func remoteAuthPromptView(issue: RemoteGatewayAuthIssue) -> some View {
+        let promptStyle = Self.remoteAuthPromptStyle(for: issue)
+        return HStack(alignment: .top, spacing: 10) {
+            Image(systemName: promptStyle.systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(promptStyle.tint)
+                .frame(width: 16, alignment: .center)
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(issue.title)
+                    .font(.caption.weight(.semibold))
+                Text(.init(issue.body))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let footnote = issue.footnote {
+                    Text(.init(footnote))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func probeRemoteConnection() async {
+        self.state.connectionMode = .remote
+        self.remoteProbeState = .checking
+        self.remoteAuthIssue = nil
+
+        switch await RemoteGatewayProbe.run() {
+        case let .ready(success):
+            self.remoteProbeState = .ok(success)
+        case let .authIssue(issue):
+            self.remoteAuthIssue = issue
+            self.remoteProbeState = .failed(issue.statusMessage)
+        case let .failed(message):
+            self.remoteProbeState = .failed(message)
+        }
+    }
+
+    private func resetRemoteProbeFeedback() {
+        self.remoteProbeState = .idle
+        self.remoteAuthIssue = nil
+    }
+
+    static func remoteAuthPromptStyle(
+        for issue: RemoteGatewayAuthIssue)
+        -> (systemImage: String, tint: Color)
+    {
+        switch issue {
+        case .tokenRequired:
+            return ("key.fill", .orange)
+        case .tokenMismatch:
+            return ("exclamationmark.triangle.fill", .orange)
+        case .gatewayTokenNotConfigured:
+            return ("wrench.and.screwdriver.fill", .orange)
+        case .passwordRequired:
+            return ("lock.slash.fill", .orange)
+        }
+    }
+
+    static func shouldShowRemoteTokenField(
+        showAdvancedConnection: Bool,
+        remoteToken: String,
+        remoteTokenUnsupported: Bool,
+        authIssue: RemoteGatewayAuthIssue?) -> Bool
+    {
+        showAdvancedConnection ||
+            remoteTokenUnsupported ||
+            !remoteToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            authIssue?.showsTokenField == true
     }
 
     func gatewaySubtitle(for gateway: GatewayDiscoveryModel.DiscoveredGateway) -> String? {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -510,6 +510,8 @@ extension OnboardingView {
             return ("wrench.and.screwdriver.fill", .orange)
         case .passwordRequired:
             return ("lock.slash.fill", .orange)
+        case .pairingRequired:
+            return ("link.badge.plus", .orange)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -116,7 +116,10 @@ extension OnboardingView {
             }
         }
         .onChange(of: self.state.connectionMode) { _, newValue in
-            guard newValue != .remote else { return }
+            guard Self.shouldResetRemoteProbeFeedback(
+                for: newValue,
+                suppressReset: self.suppressRemoteProbeReset)
+            else { return }
             self.resetRemoteProbeFeedback()
         }
         .onChange(of: self.state.remoteTransport) { _, _ in
@@ -462,9 +465,21 @@ extension OnboardingView {
 
     @MainActor
     private func probeRemoteConnection() async {
-        self.state.connectionMode = .remote
+        let originalMode = self.state.connectionMode
+        let shouldRestoreMode = originalMode != .remote
+        if shouldRestoreMode {
+            // Reuse the shared remote endpoint stack for probing without committing the user's mode choice.
+            self.state.connectionMode = .remote
+        }
         self.remoteProbeState = .checking
         self.remoteAuthIssue = nil
+        defer {
+            if shouldRestoreMode {
+                self.suppressRemoteProbeReset = true
+                self.state.connectionMode = originalMode
+                self.suppressRemoteProbeReset = false
+            }
+        }
 
         switch await RemoteGatewayProbe.run() {
         case let .ready(success):
@@ -508,6 +523,13 @@ extension OnboardingView {
             remoteTokenUnsupported ||
             !remoteToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
             authIssue?.showsTokenField == true
+    }
+
+    static func shouldResetRemoteProbeFeedback(
+        for connectionMode: AppState.ConnectionMode,
+        suppressReset: Bool) -> Bool
+    {
+        !suppressReset && connectionMode != .remote
     }
 
     func gatewaySubtitle(for gateway: GatewayDiscoveryModel.DiscoveredGateway) -> String? {

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -1,0 +1,211 @@
+import Foundation
+import OpenClawIPC
+import OpenClawKit
+
+enum RemoteGatewayAuthIssue: Equatable {
+    case tokenRequired
+    case tokenMismatch
+    case gatewayTokenNotConfigured
+    case passwordRequired
+
+    init?(error: Error) {
+        guard let authError = error as? GatewayConnectAuthError else {
+            return nil
+        }
+        switch authError.detail {
+        case .authTokenMissing:
+            self = .tokenRequired
+        case .authTokenMismatch:
+            self = .tokenMismatch
+        case .authTokenNotConfigured:
+            self = .gatewayTokenNotConfigured
+        case .authPasswordMissing, .authPasswordMismatch, .authPasswordNotConfigured:
+            self = .passwordRequired
+        default:
+            return nil
+        }
+    }
+
+    var showsTokenField: Bool {
+        switch self {
+        case .tokenRequired, .tokenMismatch:
+            true
+        case .gatewayTokenNotConfigured, .passwordRequired:
+            false
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .tokenRequired:
+            "This gateway requires an auth token"
+        case .tokenMismatch:
+            "That token did not match the gateway"
+        case .gatewayTokenNotConfigured:
+            "This gateway host needs token setup"
+        case .passwordRequired:
+            "This gateway is using unsupported auth"
+        }
+    }
+
+    var body: String {
+        switch self {
+        case .tokenRequired:
+            "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
+        case .tokenMismatch:
+            "Check `gateway.auth.token` or `OPENCLAW_GATEWAY_TOKEN` on the gateway host and try again."
+        case .gatewayTokenNotConfigured:
+            "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
+        case .passwordRequired:
+            "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
+        }
+    }
+
+    var footnote: String? {
+        switch self {
+        case .tokenRequired, .gatewayTokenNotConfigured:
+            "No token yet? Generate one on the gateway host with `openclaw doctor --generate-gateway-token`, then set it as `gateway.auth.token`."
+        case .tokenMismatch, .passwordRequired:
+            nil
+        }
+    }
+
+    var statusMessage: String {
+        switch self {
+        case .tokenRequired:
+            "This gateway requires an auth token from the gateway host."
+        case .tokenMismatch:
+            "Gateway token mismatch. Check gateway.auth.token or OPENCLAW_GATEWAY_TOKEN on the gateway host."
+        case .gatewayTokenNotConfigured:
+            "This gateway has token auth enabled, but no gateway.auth.token is configured on the host."
+        case .passwordRequired:
+            "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet."
+        }
+    }
+}
+
+enum RemoteGatewayProbeResult: Equatable {
+    case ready(RemoteGatewayProbeSuccess)
+    case authIssue(RemoteGatewayAuthIssue)
+    case failed(String)
+}
+
+struct RemoteGatewayProbeSuccess: Equatable {
+    let authSource: GatewayAuthSource?
+
+    var title: String {
+        switch self.authSource {
+        case .some(.deviceToken):
+            "Connected via paired device"
+        case .some(.sharedToken):
+            "Connected with gateway token"
+        case .some(.password):
+            "Connected with password"
+        case .some(GatewayAuthSource.none), nil:
+            "Remote gateway ready"
+        }
+    }
+
+    var detail: String? {
+        switch self.authSource {
+        case .some(.deviceToken):
+            "This Mac used a stored device token. New or unpaired devices may still need the gateway token."
+        case .some(.sharedToken), .some(.password), .some(GatewayAuthSource.none), nil:
+            nil
+        }
+    }
+}
+
+enum RemoteGatewayProbe {
+    @MainActor
+    static func run() async -> RemoteGatewayProbeResult {
+        AppStateStore.shared.syncGatewayConfigNow()
+        let settings = CommandResolver.connectionSettings()
+        let transport = AppStateStore.shared.remoteTransport
+
+        if transport == .direct {
+            let trimmedUrl = AppStateStore.shared.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedUrl.isEmpty else {
+                return .failed("Set a gateway URL first")
+            }
+            guard self.isValidWsUrl(trimmedUrl) else {
+                return .failed("Gateway URL must use wss:// for remote hosts (ws:// only for localhost)")
+            }
+        } else {
+            let trimmedTarget = settings.target.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedTarget.isEmpty else {
+                return .failed("Set an SSH target first")
+            }
+            if let validationMessage = CommandResolver.sshTargetValidationMessage(trimmedTarget) {
+                return .failed(validationMessage)
+            }
+            guard let sshCommand = self.sshCheckCommand(target: settings.target, identity: settings.identity) else {
+                return .failed("SSH target is invalid")
+            }
+
+            let sshResult = await ShellExecutor.run(
+                command: sshCommand,
+                cwd: nil,
+                env: nil,
+                timeout: 8)
+            guard sshResult.ok else {
+                return .failed(self.formatSSHFailure(sshResult, target: settings.target))
+            }
+        }
+
+        do {
+            _ = try await GatewayConnection.shared.healthSnapshot(timeoutMs: 10_000)
+            let authSource = await GatewayConnection.shared.authSource()
+            return .ready(RemoteGatewayProbeSuccess(authSource: authSource))
+        } catch {
+            if let authIssue = RemoteGatewayAuthIssue(error: error) {
+                return .authIssue(authIssue)
+            }
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    private static func isValidWsUrl(_ raw: String) -> Bool {
+        GatewayRemoteConfig.normalizeGatewayUrl(raw) != nil
+    }
+
+    private static func sshCheckCommand(target: String, identity: String) -> [String]? {
+        guard let parsed = CommandResolver.parseSSHTarget(target) else { return nil }
+        let options = [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=5",
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "UpdateHostKeys=yes",
+        ]
+        let args = CommandResolver.sshArguments(
+            target: parsed,
+            identity: identity,
+            options: options,
+            remoteCommand: ["echo", "ok"])
+        return ["/usr/bin/ssh"] + args
+    }
+
+    private static func formatSSHFailure(_ response: Response, target: String) -> String {
+        let payload = response.payload.flatMap { String(data: $0, encoding: .utf8) }
+        let trimmed = payload?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isNewline)
+            .joined(separator: " ")
+        if let trimmed,
+           trimmed.localizedCaseInsensitiveContains("host key verification failed")
+        {
+            let host = CommandResolver.parseSSHTarget(target)?.host ?? target
+            return "SSH check failed: Host key verification failed. Remove the old key with ssh-keygen -R \(host) and try again."
+        }
+        if let trimmed, !trimmed.isEmpty {
+            if let message = response.message, message.hasPrefix("exit ") {
+                return "SSH check failed: \(trimmed) (\(message))"
+            }
+            return "SSH check failed: \(trimmed)"
+        }
+        if let message = response.message {
+            return "SSH check failed (\(message))"
+        }
+        return "SSH check failed"
+    }
+}

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -7,6 +7,7 @@ enum RemoteGatewayAuthIssue: Equatable {
     case tokenMismatch
     case gatewayTokenNotConfigured
     case passwordRequired
+    case pairingRequired
 
     init?(error: Error) {
         guard let authError = error as? GatewayConnectAuthError else {
@@ -21,6 +22,8 @@ enum RemoteGatewayAuthIssue: Equatable {
             self = .gatewayTokenNotConfigured
         case .authPasswordMissing, .authPasswordMismatch, .authPasswordNotConfigured:
             self = .passwordRequired
+        case .pairingRequired:
+            self = .pairingRequired
         default:
             return nil
         }
@@ -30,7 +33,7 @@ enum RemoteGatewayAuthIssue: Equatable {
         switch self {
         case .tokenRequired, .tokenMismatch:
             true
-        case .gatewayTokenNotConfigured, .passwordRequired:
+        case .gatewayTokenNotConfigured, .passwordRequired, .pairingRequired:
             false
         }
     }
@@ -45,6 +48,8 @@ enum RemoteGatewayAuthIssue: Equatable {
             "This gateway host needs token setup"
         case .passwordRequired:
             "This gateway is using unsupported auth"
+        case .pairingRequired:
+            "This device needs pairing approval"
         }
     }
 
@@ -58,6 +63,8 @@ enum RemoteGatewayAuthIssue: Equatable {
             "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
         case .passwordRequired:
             "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
+        case .pairingRequired:
+            "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
         }
     }
 
@@ -65,6 +72,8 @@ enum RemoteGatewayAuthIssue: Equatable {
         switch self {
         case .tokenRequired, .gatewayTokenNotConfigured:
             "No token yet? Generate one on the gateway host with `openclaw doctor --generate-gateway-token`, then set it as `gateway.auth.token`."
+        case .pairingRequired:
+            "If you do not have another paired OpenClaw client yet, approve the pending request on the gateway host with `openclaw devices approve`."
         case .tokenMismatch, .passwordRequired:
             nil
         }
@@ -80,6 +89,8 @@ enum RemoteGatewayAuthIssue: Equatable {
             "This gateway has token auth enabled, but no gateway.auth.token is configured on the host."
         case .passwordRequired:
             "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet."
+        case .pairingRequired:
+            "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
@@ -7,6 +7,11 @@ struct GatewayChannelConnectTests {
     private enum FakeResponse {
         case helloOk(delayMs: Int)
         case invalid(delayMs: Int)
+        case authFailed(
+            delayMs: Int,
+            detailCode: String,
+            canRetryWithDeviceToken: Bool,
+            recommendedNextStep: String?)
     }
 
     private func makeSession(response: FakeResponse) -> GatewayTestWebSocketSession {
@@ -27,6 +32,14 @@ struct GatewayChannelConnectTests {
                         case let .invalid(ms):
                             delayMs = ms
                             message = .string("not json")
+                        case let .authFailed(ms, detailCode, canRetryWithDeviceToken, recommendedNextStep):
+                            delayMs = ms
+                            let id = task.snapshotConnectRequestID() ?? "connect"
+                            message = .data(GatewayWebSocketTestSupport.connectAuthFailureData(
+                                id: id,
+                                detailCode: detailCode,
+                                canRetryWithDeviceToken: canRetryWithDeviceToken,
+                                recommendedNextStep: recommendedNextStep))
                         }
                         try await Task.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
                         return message
@@ -70,5 +83,30 @@ struct GatewayChannelConnectTests {
             if case .failure = r2 { true } else { false }
         }())
         #expect(session.snapshotMakeCount() == 1)
+    }
+
+    @Test func `connect surfaces structured auth failure`() async throws {
+        let session = self.makeSession(response: .authFailed(
+            delayMs: 0,
+            detailCode: GatewayConnectAuthDetailCode.authTokenMissing.rawValue,
+            canRetryWithDeviceToken: true,
+            recommendedNextStep: GatewayConnectRecoveryNextStep.updateAuthConfiguration.rawValue))
+        let channel = try GatewayChannelActor(
+            url: #require(URL(string: "ws://example.invalid")),
+            token: nil,
+            session: WebSocketSessionBox(session: session))
+
+        do {
+            try await channel.connect()
+            Issue.record("expected GatewayConnectAuthError")
+        } catch let error as GatewayConnectAuthError {
+            #expect(error.detail == .authTokenMissing)
+            #expect(error.detailCode == GatewayConnectAuthDetailCode.authTokenMissing.rawValue)
+            #expect(error.canRetryWithDeviceToken)
+            #expect(error.recommendedNextStep == .updateAuthConfiguration)
+            #expect(error.recommendedNextStepCode == GatewayConnectRecoveryNextStep.updateAuthConfiguration.rawValue)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -52,6 +52,40 @@ enum GatewayWebSocketTestSupport {
         return Data(json.utf8)
     }
 
+    static func connectAuthFailureData(
+        id: String,
+        detailCode: String,
+        message: String = "gateway auth rejected",
+        canRetryWithDeviceToken: Bool = false,
+        recommendedNextStep: String? = nil) -> Data
+    {
+        let recommendedNextStepJson: String
+        if let recommendedNextStep {
+            recommendedNextStepJson = """
+            ,
+                          "recommendedNextStep": "\(recommendedNextStep)"
+            """
+        } else {
+            recommendedNextStepJson = ""
+        }
+        let json = """
+        {
+          "type": "res",
+          "id": "\(id)",
+          "ok": false,
+          "error": {
+            "message": "\(message)",
+            "details": {
+              "code": "\(detailCode)",
+              "canRetryWithDeviceToken": \(canRetryWithDeviceToken ? "true" : "false")
+              \(recommendedNextStepJson)
+            }
+          }
+        }
+        """
+        return Data(json.utf8)
+    }
+
     static func requestID(from message: URLSessionWebSocketTask.Message) -> String? {
         guard let obj = self.requestFrameObject(from: message) else { return nil }
         guard (obj["type"] as? String) == "req" else {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
@@ -21,6 +21,10 @@ struct OnboardingRemoteAuthPromptTests {
             message: "password missing",
             detailCode: GatewayConnectAuthDetailCode.authPasswordMissing.rawValue,
             canRetryWithDeviceToken: false)
+        let pairingRequired = GatewayConnectAuthError(
+            message: "pairing required",
+            detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
+            canRetryWithDeviceToken: false)
         let unknown = GatewayConnectAuthError(
             message: "other",
             detailCode: "SOMETHING_ELSE",
@@ -30,6 +34,7 @@ struct OnboardingRemoteAuthPromptTests {
         #expect(RemoteGatewayAuthIssue(error: tokenMismatch) == .tokenMismatch)
         #expect(RemoteGatewayAuthIssue(error: tokenNotConfigured) == .gatewayTokenNotConfigured)
         #expect(RemoteGatewayAuthIssue(error: passwordMissing) == .passwordRequired)
+        #expect(RemoteGatewayAuthIssue(error: pairingRequired) == .pairingRequired)
         #expect(RemoteGatewayAuthIssue(error: unknown) == nil)
     }
 
@@ -83,6 +88,20 @@ struct OnboardingRemoteAuthPromptTests {
             remoteToken: "",
             remoteTokenUnsupported: false,
             authIssue: .gatewayTokenNotConfigured) == false)
+        #expect(OnboardingView.shouldShowRemoteTokenField(
+            showAdvancedConnection: false,
+            remoteToken: "",
+            remoteTokenUnsupported: false,
+            authIssue: .pairingRequired) == false)
+    }
+
+    @Test func `pairing required copy points users to pair approve`() {
+        let issue = RemoteGatewayAuthIssue.pairingRequired
+
+        #expect(issue.title == "This device needs pairing approval")
+        #expect(issue.body.contains("`/pair approve`"))
+        #expect(issue.statusMessage.contains("/pair approve"))
+        #expect(issue.footnote?.contains("`openclaw devices approve`") == true)
     }
 
     @Test func `paired device success copy explains auth source`() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
@@ -1,0 +1,100 @@
+import OpenClawKit
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct OnboardingRemoteAuthPromptTests {
+    @Test func `auth detail codes map to remote auth issues`() {
+        let tokenMissing = GatewayConnectAuthError(
+            message: "token missing",
+            detailCode: GatewayConnectAuthDetailCode.authTokenMissing.rawValue,
+            canRetryWithDeviceToken: false)
+        let tokenMismatch = GatewayConnectAuthError(
+            message: "token mismatch",
+            detailCode: GatewayConnectAuthDetailCode.authTokenMismatch.rawValue,
+            canRetryWithDeviceToken: false)
+        let tokenNotConfigured = GatewayConnectAuthError(
+            message: "token not configured",
+            detailCode: GatewayConnectAuthDetailCode.authTokenNotConfigured.rawValue,
+            canRetryWithDeviceToken: false)
+        let passwordMissing = GatewayConnectAuthError(
+            message: "password missing",
+            detailCode: GatewayConnectAuthDetailCode.authPasswordMissing.rawValue,
+            canRetryWithDeviceToken: false)
+        let unknown = GatewayConnectAuthError(
+            message: "other",
+            detailCode: "SOMETHING_ELSE",
+            canRetryWithDeviceToken: false)
+
+        #expect(RemoteGatewayAuthIssue(error: tokenMissing) == .tokenRequired)
+        #expect(RemoteGatewayAuthIssue(error: tokenMismatch) == .tokenMismatch)
+        #expect(RemoteGatewayAuthIssue(error: tokenNotConfigured) == .gatewayTokenNotConfigured)
+        #expect(RemoteGatewayAuthIssue(error: passwordMissing) == .passwordRequired)
+        #expect(RemoteGatewayAuthIssue(error: unknown) == nil)
+    }
+
+    @Test func `password detail family maps to password required issue`() {
+        let mismatch = GatewayConnectAuthError(
+            message: "password mismatch",
+            detailCode: GatewayConnectAuthDetailCode.authPasswordMismatch.rawValue,
+            canRetryWithDeviceToken: false)
+        let notConfigured = GatewayConnectAuthError(
+            message: "password not configured",
+            detailCode: GatewayConnectAuthDetailCode.authPasswordNotConfigured.rawValue,
+            canRetryWithDeviceToken: false)
+
+        #expect(RemoteGatewayAuthIssue(error: mismatch) == .passwordRequired)
+        #expect(RemoteGatewayAuthIssue(error: notConfigured) == .passwordRequired)
+    }
+
+    @Test func `token field visibility follows onboarding rules`() {
+        #expect(OnboardingView.shouldShowRemoteTokenField(
+            showAdvancedConnection: false,
+            remoteToken: "",
+            remoteTokenUnsupported: false,
+            authIssue: nil) == false)
+        #expect(OnboardingView.shouldShowRemoteTokenField(
+            showAdvancedConnection: true,
+            remoteToken: "",
+            remoteTokenUnsupported: false,
+            authIssue: nil))
+        #expect(OnboardingView.shouldShowRemoteTokenField(
+            showAdvancedConnection: false,
+            remoteToken: "secret",
+            remoteTokenUnsupported: false,
+            authIssue: nil))
+        #expect(OnboardingView.shouldShowRemoteTokenField(
+            showAdvancedConnection: false,
+            remoteToken: "",
+            remoteTokenUnsupported: true,
+            authIssue: nil))
+        #expect(OnboardingView.shouldShowRemoteTokenField(
+            showAdvancedConnection: false,
+            remoteToken: "",
+            remoteTokenUnsupported: false,
+            authIssue: .tokenRequired))
+        #expect(OnboardingView.shouldShowRemoteTokenField(
+            showAdvancedConnection: false,
+            remoteToken: "",
+            remoteTokenUnsupported: false,
+            authIssue: .tokenMismatch))
+        #expect(OnboardingView.shouldShowRemoteTokenField(
+            showAdvancedConnection: false,
+            remoteToken: "",
+            remoteTokenUnsupported: false,
+            authIssue: .gatewayTokenNotConfigured) == false)
+    }
+
+    @Test func `paired device success copy explains auth source`() {
+        let pairedDevice = RemoteGatewayProbeSuccess(authSource: .deviceToken)
+        let sharedToken = RemoteGatewayProbeSuccess(authSource: .sharedToken)
+        let noAuth = RemoteGatewayProbeSuccess(authSource: GatewayAuthSource.none)
+
+        #expect(pairedDevice.title == "Connected via paired device")
+        #expect(pairedDevice.detail == "This Mac used a stored device token. New or unpaired devices may still need the gateway token.")
+        #expect(sharedToken.title == "Connected with gateway token")
+        #expect(sharedToken.detail == nil)
+        #expect(noAuth.title == "Remote gateway ready")
+        #expect(noAuth.detail == nil)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
@@ -97,4 +97,11 @@ struct OnboardingRemoteAuthPromptTests {
         #expect(noAuth.title == "Remote gateway ready")
         #expect(noAuth.detail == nil)
     }
+
+    @Test func `transient probe mode restore does not clear probe feedback`() {
+        #expect(OnboardingView.shouldResetRemoteProbeFeedback(for: .local, suppressReset: false))
+        #expect(OnboardingView.shouldResetRemoteProbeFeedback(for: .unconfigured, suppressReset: false))
+        #expect(OnboardingView.shouldResetRemoteProbeFeedback(for: .remote, suppressReset: false) == false)
+        #expect(OnboardingView.shouldResetRemoteProbeFeedback(for: .local, suppressReset: true) == false)
+    }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -132,38 +132,17 @@ private let defaultOperatorConnectScopes: [String] = [
 ]
 
 private enum GatewayConnectErrorCodes {
-    static let authTokenMismatch = "AUTH_TOKEN_MISMATCH"
-    static let authDeviceTokenMismatch = "AUTH_DEVICE_TOKEN_MISMATCH"
-    static let authTokenMissing = "AUTH_TOKEN_MISSING"
-    static let authPasswordMissing = "AUTH_PASSWORD_MISSING"
-    static let authPasswordMismatch = "AUTH_PASSWORD_MISMATCH"
-    static let authRateLimited = "AUTH_RATE_LIMITED"
-    static let pairingRequired = "PAIRING_REQUIRED"
-    static let controlUiDeviceIdentityRequired = "CONTROL_UI_DEVICE_IDENTITY_REQUIRED"
-    static let deviceIdentityRequired = "DEVICE_IDENTITY_REQUIRED"
-}
-
-private struct GatewayConnectAuthError: LocalizedError {
-    let message: String
-    let detailCode: String?
-    let canRetryWithDeviceToken: Bool
-
-    var errorDescription: String? { self.message }
-
-    var isNonRecoverable: Bool {
-        switch self.detailCode {
-        case GatewayConnectErrorCodes.authTokenMissing,
-            GatewayConnectErrorCodes.authPasswordMissing,
-            GatewayConnectErrorCodes.authPasswordMismatch,
-            GatewayConnectErrorCodes.authRateLimited,
-            GatewayConnectErrorCodes.pairingRequired,
-            GatewayConnectErrorCodes.controlUiDeviceIdentityRequired,
-            GatewayConnectErrorCodes.deviceIdentityRequired:
-            return true
-        default:
-            return false
-        }
-    }
+    static let authTokenMismatch = GatewayConnectAuthDetailCode.authTokenMismatch.rawValue
+    static let authDeviceTokenMismatch = GatewayConnectAuthDetailCode.authDeviceTokenMismatch.rawValue
+    static let authTokenMissing = GatewayConnectAuthDetailCode.authTokenMissing.rawValue
+    static let authTokenNotConfigured = GatewayConnectAuthDetailCode.authTokenNotConfigured.rawValue
+    static let authPasswordMissing = GatewayConnectAuthDetailCode.authPasswordMissing.rawValue
+    static let authPasswordMismatch = GatewayConnectAuthDetailCode.authPasswordMismatch.rawValue
+    static let authPasswordNotConfigured = GatewayConnectAuthDetailCode.authPasswordNotConfigured.rawValue
+    static let authRateLimited = GatewayConnectAuthDetailCode.authRateLimited.rawValue
+    static let pairingRequired = GatewayConnectAuthDetailCode.pairingRequired.rawValue
+    static let controlUiDeviceIdentityRequired = GatewayConnectAuthDetailCode.controlUiDeviceIdentityRequired.rawValue
+    static let deviceIdentityRequired = GatewayConnectAuthDetailCode.deviceIdentityRequired.rawValue
 }
 
 public actor GatewayChannelActor {
@@ -278,8 +257,7 @@ public actor GatewayChannelActor {
                 if self.shouldPauseReconnectAfterAuthFailure(error) {
                     self.reconnectPausedForAuthFailure = true
                     self.logger.error(
-                        "gateway watchdog reconnect paused for non-recoverable auth failure " +
-                            "\(error.localizedDescription, privacy: .public)"
+                        "gateway watchdog reconnect paused for non-recoverable auth failure \(error.localizedDescription, privacy: .public)"
                     )
                     continue
                 }
@@ -522,10 +500,12 @@ public actor GatewayChannelActor {
             let details = res.error?["details"]?.value as? [String: ProtoAnyCodable]
             let detailCode = details?["code"]?.value as? String
             let canRetryWithDeviceToken = details?["canRetryWithDeviceToken"]?.value as? Bool ?? false
+            let recommendedNextStep = details?["recommendedNextStep"]?.value as? String
             throw GatewayConnectAuthError(
                 message: msg,
-                detailCode: detailCode,
-                canRetryWithDeviceToken: canRetryWithDeviceToken)
+                detailCodeRaw: detailCode,
+                canRetryWithDeviceToken: canRetryWithDeviceToken,
+                recommendedNextStepRaw: recommendedNextStep)
         }
         guard let payload = res.payload else {
             throw NSError(
@@ -710,8 +690,7 @@ public actor GatewayChannelActor {
             if self.shouldPauseReconnectAfterAuthFailure(error) {
                 self.reconnectPausedForAuthFailure = true
                 self.logger.error(
-                    "gateway reconnect paused for non-recoverable auth failure " +
-                        "\(error.localizedDescription, privacy: .public)"
+                    "gateway reconnect paused for non-recoverable auth failure \(error.localizedDescription, privacy: .public)"
                 )
                 return
             }
@@ -743,7 +722,7 @@ public actor GatewayChannelActor {
             return false
         }
         return authError.canRetryWithDeviceToken ||
-            authError.detailCode == GatewayConnectErrorCodes.authTokenMismatch
+            authError.detail == .authTokenMismatch
     }
 
     private func shouldPauseReconnectAfterAuthFailure(_ error: Error) -> Bool {
@@ -753,7 +732,7 @@ public actor GatewayChannelActor {
         if authError.isNonRecoverable {
             return true
         }
-        if authError.detailCode == GatewayConnectErrorCodes.authTokenMismatch &&
+        if authError.detail == .authTokenMismatch &&
             self.deviceTokenRetryBudgetUsed && !self.pendingDeviceTokenRetry
         {
             return true
@@ -765,7 +744,7 @@ public actor GatewayChannelActor {
         guard let authError = error as? GatewayConnectAuthError else {
             return false
         }
-        return authError.detailCode == GatewayConnectErrorCodes.authDeviceTokenMismatch
+        return authError.detail == .authDeviceTokenMismatch
     }
 
     private func isTrustedDeviceRetryEndpoint() -> Bool {
@@ -867,6 +846,9 @@ public actor GatewayChannelActor {
 
     // Wrap low-level URLSession/WebSocket errors with context so UI can surface them.
     private func wrap(_ error: Error, context: String) -> Error {
+        if error is GatewayConnectAuthError || error is GatewayResponseError || error is GatewayDecodingError {
+            return error
+        }
         if let urlError = error as? URLError {
             let desc = urlError.localizedDescription.isEmpty ? "cancelled" : urlError.localizedDescription
             return NSError(
@@ -910,8 +892,7 @@ public actor GatewayChannelActor {
             return (id: id, data: data)
         } catch {
             self.logger.error(
-                "gateway \(kind) encode failed \(method, privacy: .public) " +
-                    "error=\(error.localizedDescription, privacy: .public)")
+                "gateway \(kind) encode failed \(method, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             throw error
         }
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
@@ -1,6 +1,112 @@
 import OpenClawProtocol
 import Foundation
 
+public enum GatewayConnectAuthDetailCode: String, Sendable {
+    case authRequired = "AUTH_REQUIRED"
+    case authUnauthorized = "AUTH_UNAUTHORIZED"
+    case authTokenMismatch = "AUTH_TOKEN_MISMATCH"
+    case authDeviceTokenMismatch = "AUTH_DEVICE_TOKEN_MISMATCH"
+    case authTokenMissing = "AUTH_TOKEN_MISSING"
+    case authTokenNotConfigured = "AUTH_TOKEN_NOT_CONFIGURED"
+    case authPasswordMissing = "AUTH_PASSWORD_MISSING"
+    case authPasswordMismatch = "AUTH_PASSWORD_MISMATCH"
+    case authPasswordNotConfigured = "AUTH_PASSWORD_NOT_CONFIGURED"
+    case authRateLimited = "AUTH_RATE_LIMITED"
+    case authTailscaleIdentityMissing = "AUTH_TAILSCALE_IDENTITY_MISSING"
+    case authTailscaleProxyMissing = "AUTH_TAILSCALE_PROXY_MISSING"
+    case authTailscaleWhoisFailed = "AUTH_TAILSCALE_WHOIS_FAILED"
+    case authTailscaleIdentityMismatch = "AUTH_TAILSCALE_IDENTITY_MISMATCH"
+    case pairingRequired = "PAIRING_REQUIRED"
+    case controlUiDeviceIdentityRequired = "CONTROL_UI_DEVICE_IDENTITY_REQUIRED"
+    case deviceIdentityRequired = "DEVICE_IDENTITY_REQUIRED"
+    case deviceAuthInvalid = "DEVICE_AUTH_INVALID"
+    case deviceAuthDeviceIdMismatch = "DEVICE_AUTH_DEVICE_ID_MISMATCH"
+    case deviceAuthSignatureExpired = "DEVICE_AUTH_SIGNATURE_EXPIRED"
+    case deviceAuthNonceRequired = "DEVICE_AUTH_NONCE_REQUIRED"
+    case deviceAuthNonceMismatch = "DEVICE_AUTH_NONCE_MISMATCH"
+    case deviceAuthSignatureInvalid = "DEVICE_AUTH_SIGNATURE_INVALID"
+    case deviceAuthPublicKeyInvalid = "DEVICE_AUTH_PUBLIC_KEY_INVALID"
+}
+
+public enum GatewayConnectRecoveryNextStep: String, Sendable {
+    case retryWithDeviceToken = "retry_with_device_token"
+    case updateAuthConfiguration = "update_auth_configuration"
+    case updateAuthCredentials = "update_auth_credentials"
+    case waitThenRetry = "wait_then_retry"
+    case reviewAuthConfiguration = "review_auth_configuration"
+}
+
+/// Structured websocket connect-auth rejection surfaced before the channel is usable.
+public struct GatewayConnectAuthError: LocalizedError, Sendable {
+    public let message: String
+    public let detailCodeRaw: String?
+    public let recommendedNextStepRaw: String?
+    public let canRetryWithDeviceToken: Bool
+
+    public init(
+        message: String,
+        detailCodeRaw: String?,
+        canRetryWithDeviceToken: Bool,
+        recommendedNextStepRaw: String? = nil)
+    {
+        let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDetailCode = detailCodeRaw?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedRecommendedNextStep =
+            recommendedNextStepRaw?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.message = trimmedMessage.isEmpty ? "gateway connect failed" : trimmedMessage
+        self.detailCodeRaw = trimmedDetailCode?.isEmpty == false ? trimmedDetailCode : nil
+        self.canRetryWithDeviceToken = canRetryWithDeviceToken
+        self.recommendedNextStepRaw =
+            trimmedRecommendedNextStep?.isEmpty == false ? trimmedRecommendedNextStep : nil
+    }
+
+    public init(
+        message: String,
+        detailCode: String?,
+        canRetryWithDeviceToken: Bool,
+        recommendedNextStep: String? = nil)
+    {
+        self.init(
+            message: message,
+            detailCodeRaw: detailCode,
+            canRetryWithDeviceToken: canRetryWithDeviceToken,
+            recommendedNextStepRaw: recommendedNextStep)
+    }
+
+    public var detailCode: String? { self.detailCodeRaw }
+
+    public var recommendedNextStepCode: String? { self.recommendedNextStepRaw }
+
+    public var detail: GatewayConnectAuthDetailCode? {
+        guard let detailCodeRaw else { return nil }
+        return GatewayConnectAuthDetailCode(rawValue: detailCodeRaw)
+    }
+
+    public var recommendedNextStep: GatewayConnectRecoveryNextStep? {
+        guard let recommendedNextStepRaw else { return nil }
+        return GatewayConnectRecoveryNextStep(rawValue: recommendedNextStepRaw)
+    }
+
+    public var errorDescription: String? { self.message }
+
+    public var isNonRecoverable: Bool {
+        switch self.detail {
+        case .authTokenMissing,
+            .authTokenNotConfigured,
+            .authPasswordMissing,
+            .authPasswordMismatch,
+            .authPasswordNotConfigured,
+            .authRateLimited,
+            .pairingRequired,
+            .controlUiDeviceIdentityRequired,
+            .deviceIdentityRequired:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 /// Structured error surfaced when the gateway responds with `{ ok: false }`.
 public struct GatewayResponseError: LocalizedError, @unchecked Sendable {
     public let method: String


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: macOS onboarding did not explain when a remote gateway actually needed a shared auth token, and it showed a generic success state even when the connection succeeded via a paired-device token.
- Why it matters: users could not tell when to enter `gateway.remote.token`, where to find the gateway token on the host, or why one Mac connected while a fresh client would still be rejected.
- What changed: added a shared remote probe that surfaces structured connect-auth failures and successful auth source, shows onboarding/settings token guidance when the gateway requires token auth, and labels paired-device success explicitly.
- What did NOT change (scope boundary): this PR does not add password-auth UI, and it does not change gateway auth semantics on the server.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

- Remote onboarding now shows a token-required prompt only when the gateway handshake reports token auth is required.
- The prompt explains that the token comes from the gateway host and points users to `openclaw config get gateway.auth.token`, `OPENCLAW_GATEWAY_TOKEN`, and `openclaw doctor --generate-gateway-token`.
- Successful remote checks now distinguish `Connected via paired device` from generic gateway readiness.
- macOS Settings reuses the same remote probe result so onboarding and Settings show consistent auth messaging.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  The PR changes only how macOS classifies and presents existing gateway auth outcomes. Shared tokens are still stored/resolved through existing config paths, and the new UI copy is explicit about the token living on the gateway host.

## Repro + Verification

### Environment

- OS: macOS 14 arm64
- Runtime/container: SwiftPM debug build for `apps/macos`
- Model/provider: N/A
- Integration/channel (if any): Remote gateway over direct `wss://` and SSH tunnel
- Relevant config (redacted): gateway host configured with `gateway.auth.mode=token`; local macOS app tested both with and without stored device-token state

### Steps

1. Configure a remote gateway in macOS onboarding or Settings without a `gateway.remote.token` value.
2. Probe a gateway that requires shared token auth.
3. Probe again from a Mac/device that already has paired-device auth available.

### Expected

- Token-required gateways show a targeted prompt that explains where to find or generate the gateway token.
- Token mismatch and host-misconfigured cases show different messages.
- Successful paired-device auth is labeled explicitly instead of looking like “token not needed”.

### Actual

- With this PR, onboarding/settings now surface the expected token guidance and auth-source-specific success copy.
- Without this PR, the UI showed a generic ready state and did not explain why an already-paired Mac could connect.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `swift test --package-path apps/macos --filter OnboardingRemoteAuthPromptTests`
  - `swift test --package-path apps/macos --filter GatewayChannelConnectTests`
  - Relaunched the macOS app in onboarding mode after clearing local app prefs and device-auth state.
  - Confirmed the direct Tailscale Serve path could still authenticate this Mac without a shared token, which is why the new paired-device success label is needed.
  - Verified the SSH-tunneled path with a fresh `OPENCLAW_STATE_DIR` and no stored device token returns `unauthorized: gateway token missing (provide gateway auth token)`.
- Edge cases checked:
  - token missing
  - token mismatch
  - gateway token not configured on host
  - password-auth gateway classification
  - paired-device success copy
- What you did **not** verify:
  - full end-to-end SwiftUI UI automation for the onboarding flow
  - settings UI snapshot coverage for every auth-source variant

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this branch or restore the previous onboarding/settings probe/UI behavior.
- Files/config to restore: `apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift`, onboarding/settings auth prompt handling, and the structured connect-auth plumbing in `apps/shared/OpenClawKit`.
- Known bad symptoms reviewers should watch for: onboarding shows the token field too aggressively, or success labels misclassify shared-token vs paired-device auth.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: remote auth behavior differs between direct Tailscale endpoints and SSH-tunneled loopback endpoints, so reviewers may misread a direct success as “token not required”.
  - Mitigation: the probe now surfaces paired-device success explicitly, and the manual verification above exercises the SSH path with fresh auth state to confirm the true token-required case.
