### PR TITLE
fix(googlechat): preserve DM thread context

### DIFF
--- a/extensions/googlechat/src/monitor.threading.test.ts
+++ b/extensions/googlechat/src/monitor.threading.test.ts
@@ -1,0 +1,304 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/googlechat";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockServerResponse } from "../../../src/test-utils/mock-http-response.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import { handleGoogleChatWebhookRequest, registerGoogleChatWebhookTarget } from "./monitor.js";
+
+const sendGoogleChatMessageMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/googlechat", () => ({
+  createWebhookInFlightLimiter: vi.fn(() => ({})),
+  createReplyPrefixOptions: vi.fn(() => ({})),
+  registerWebhookTargetWithPluginRoute: vi.fn(
+    ({
+      targetsByPath,
+      target,
+    }: {
+      targetsByPath: Map<string, unknown[]>;
+      target: { path: string };
+    }) => {
+      const existing = targetsByPath.get(target.path) ?? [];
+      targetsByPath.set(target.path, [...existing, target]);
+      return {
+        unregister: () => {
+          const next = (targetsByPath.get(target.path) ?? []).filter((entry) => entry !== target);
+          if (next.length > 0) {
+            targetsByPath.set(target.path, next);
+          } else {
+            targetsByPath.delete(target.path);
+          }
+        },
+      };
+    },
+  ),
+  resolveInboundRouteEnvelopeBuilderWithRuntime: vi.fn(() => ({
+    route: {
+      sessionKey: "googlechat:session",
+      accountId: "default",
+      agentId: "assistant",
+    },
+    buildEnvelope: ({ body }: { body: string }) => ({
+      storePath: "/tmp/googlechat-threading-test.md",
+      body,
+    }),
+  })),
+  resolveWebhookPath: vi.fn(() => "/googlechat"),
+}));
+
+vi.mock("./api.js", () => ({
+  downloadGoogleChatMedia: vi.fn(),
+  deleteGoogleChatMessage: vi.fn(),
+  sendGoogleChatMessage: sendGoogleChatMessageMock,
+  updateGoogleChatMessage: vi.fn(),
+}));
+
+vi.mock("./monitor-access.js", () => ({
+  applyGoogleChatInboundAccessPolicy: vi.fn(async () => ({
+    ok: true,
+    commandAuthorized: true,
+    effectiveWasMentioned: true,
+    groupSystemPrompt: undefined,
+  })),
+  isSenderAllowed: vi.fn(),
+}));
+
+vi.mock("./monitor-webhook.js", () => ({
+  createGoogleChatWebhookRequestHandler:
+    ({
+      webhookTargets,
+      processEvent,
+    }: {
+      webhookTargets: Map<string, unknown[]>;
+      processEvent: (event: unknown, target: unknown) => Promise<void>;
+    }) =>
+    async (req: IncomingMessage, res: ServerResponse) => {
+      const target = webhookTargets.get(req.url ?? "/googlechat")?.[0];
+      if (!target) {
+        res.statusCode = 404;
+        res.end("Not Found");
+        return false;
+      }
+      const body = await readRequestBody(req);
+      await processEvent(JSON.parse(body) as unknown, target);
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end("{}");
+      return true;
+    },
+}));
+
+function createWebhookRequest(payload: unknown): IncomingMessage {
+  const req = new EventEmitter() as IncomingMessage & {
+    destroyed?: boolean;
+    destroy: (error?: Error) => IncomingMessage;
+    on: (event: string, listener: (...args: unknown[]) => void) => IncomingMessage;
+  };
+  req.method = "POST";
+  req.url = "/googlechat";
+  req.headers = {
+    "content-type": "application/json",
+  };
+  req.destroyed = false;
+  req.destroy = () => {
+    req.destroyed = true;
+    return req;
+  };
+
+  const originalOn = req.on.bind(req);
+  let bodyScheduled = false;
+  req.on = ((event: string, listener: (...args: unknown[]) => void) => {
+    const result = originalOn(event, listener);
+    if (!bodyScheduled && event === "data") {
+      bodyScheduled = true;
+      void Promise.resolve().then(() => {
+        req.emit("data", Buffer.from(JSON.stringify(payload), "utf-8"));
+        if (!req.destroyed) {
+          req.emit("end");
+        }
+      });
+    }
+    return result;
+  }) as IncomingMessage["on"];
+
+  return req;
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve) => {
+    req.on("data", (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    });
+    req.on("end", () => resolve());
+  });
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function createConfig(): OpenClawConfig {
+  return {
+    channels: {
+      googlechat: {
+        enabled: true,
+        replyToMode: "off",
+        serviceAccount: {
+          type: "service_account",
+          client_email: "bot@example.com",
+          private_key: "test-key", // pragma: allowlist secret
+          token_uri: "https://oauth2.googleapis.com/token",
+        },
+      },
+    },
+  };
+}
+
+function createAccount(
+  config: Partial<ResolvedGoogleChatAccount["config"]> = {},
+): ResolvedGoogleChatAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    credentialSource: "none",
+    config,
+  } as ResolvedGoogleChatAccount;
+}
+
+function createCore(params: {
+  onRecordSessionMeta?: (args: unknown) => Promise<void> | void;
+  onDispatchReply?: (args: {
+    dispatcherOptions: {
+      deliver: (payload: { text?: string; replyToId?: string }) => Promise<void>;
+    };
+  }) => Promise<void> | void;
+}): PluginRuntime {
+  return {
+    logging: {
+      shouldLogVerbose: () => false,
+    },
+    channel: {
+      reply: {
+        finalizeInboundContext: vi.fn((ctx) => ctx),
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn(async (args) => {
+          await params.onDispatchReply?.(args);
+        }),
+      },
+      session: {
+        recordSessionMetaFromInbound: vi.fn(async (args) => {
+          await params.onRecordSessionMeta?.(args);
+        }),
+      },
+      media: {
+        fetchRemoteMedia: vi.fn(),
+        saveMediaBuffer: vi.fn(),
+      },
+      text: {
+        resolveChunkMode: vi.fn(() => "sentences"),
+        chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+      },
+    },
+  } as unknown as PluginRuntime;
+}
+
+function createMessageEvent(threadName: string) {
+  return {
+    type: "MESSAGE",
+    eventTime: "2026-03-10T00:00:00.000Z",
+    space: {
+      name: "spaces/AAA",
+      type: "DM",
+    },
+    message: {
+      name: "spaces/AAA/messages/msg-1",
+      text: "hello",
+      thread: {
+        name: threadName,
+      },
+      sender: {
+        name: "users/123",
+        displayName: "Test User",
+        email: "test@example.com",
+        type: "HUMAN",
+      },
+    },
+  };
+}
+
+describe("Google Chat monitor threading", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("records inbound MessageThreadId in session metadata", async () => {
+    const threadName = "spaces/AAA/threads/thread-1";
+    const recordSessionMetaFromInbound = vi.fn(async () => {});
+    const core = createCore({
+      onRecordSessionMeta: recordSessionMetaFromInbound,
+    });
+    const unregister = registerGoogleChatWebhookTarget({
+      account: createAccount({ typingIndicator: "none" }),
+      config: createConfig(),
+      runtime: {},
+      core,
+      path: "/googlechat",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const handled = await handleGoogleChatWebhookRequest(
+        createWebhookRequest(createMessageEvent(threadName)),
+        createMockServerResponse(),
+      );
+
+      expect(handled).toBe(true);
+      expect(recordSessionMetaFromInbound).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({
+            ReplyToId: threadName,
+            MessageThreadId: threadName,
+          }),
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+
+  it("uses the preserved inbound thread for immediate replies", async () => {
+    const threadName = "spaces/AAA/threads/thread-2";
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/reply-1",
+    });
+    const core = createCore({
+      onDispatchReply: async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "Threaded reply" });
+      },
+    });
+    const unregister = registerGoogleChatWebhookTarget({
+      account: createAccount({ typingIndicator: "none" }),
+      config: createConfig(),
+      runtime: {},
+      core,
+      path: "/googlechat",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const handled = await handleGoogleChatWebhookRequest(
+        createWebhookRequest(createMessageEvent(threadName)),
+        createMockServerResponse(),
+      );
+
+      expect(handled).toBe(true);
+      expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          space: "spaces/AAA",
+          text: "Threaded reply",
+          thread: threadName,
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/extensions/googlechat/src/monitor.threading.test.ts
+++ b/extensions/googlechat/src/monitor.threading.test.ts
@@ -170,7 +170,12 @@ function createCore(params: {
   onRecordSessionMeta?: (args: unknown) => Promise<void> | void;
   onDispatchReply?: (args: {
     dispatcherOptions: {
-      deliver: (payload: { text?: string; replyToId?: string }) => Promise<void>;
+      deliver: (payload: {
+        text?: string;
+        mediaUrl?: string;
+        mediaUrls?: string[];
+        replyToId?: string;
+      }) => Promise<void>;
     };
   }) => Promise<void> | void;
   fetchRemoteMediaResult?: { buffer: Buffer; fileName: string; contentType: string };

--- a/extensions/googlechat/src/monitor.threading.test.ts
+++ b/extensions/googlechat/src/monitor.threading.test.ts
@@ -7,6 +7,7 @@ import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { handleGoogleChatWebhookRequest, registerGoogleChatWebhookTarget } from "./monitor.js";
 
 const sendGoogleChatMessageMock = vi.hoisted(() => vi.fn());
+const uploadGoogleChatAttachmentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/googlechat", () => ({
   createWebhookInFlightLimiter: vi.fn(() => ({})),
@@ -51,6 +52,7 @@ vi.mock("./api.js", () => ({
   downloadGoogleChatMedia: vi.fn(),
   deleteGoogleChatMessage: vi.fn(),
   sendGoogleChatMessage: sendGoogleChatMessageMock,
+  uploadGoogleChatAttachment: uploadGoogleChatAttachmentMock,
   updateGoogleChatMessage: vi.fn(),
 }));
 
@@ -171,7 +173,13 @@ function createCore(params: {
       deliver: (payload: { text?: string; replyToId?: string }) => Promise<void>;
     };
   }) => Promise<void> | void;
+  fetchRemoteMediaResult?: { buffer: Buffer; fileName: string; contentType: string };
 }): PluginRuntime {
+  const fetchRemoteMediaResult = params.fetchRemoteMediaResult ?? {
+    buffer: Buffer.from("media-bytes"),
+    fileName: "attachment.png",
+    contentType: "image/png",
+  };
   return {
     logging: {
       shouldLogVerbose: () => false,
@@ -189,7 +197,7 @@ function createCore(params: {
         }),
       },
       media: {
-        fetchRemoteMedia: vi.fn(),
+        fetchRemoteMedia: vi.fn(async () => fetchRemoteMediaResult),
         saveMediaBuffer: vi.fn(),
       },
       text: {
@@ -295,6 +303,58 @@ describe("Google Chat monitor threading", () => {
           space: "spaces/AAA",
           text: "Threaded reply",
           thread: threadName,
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+
+  it("uses the preserved inbound thread for media replies", async () => {
+    const threadName = "spaces/AAA/threads/thread-3";
+    uploadGoogleChatAttachmentMock.mockResolvedValue({
+      attachmentUploadToken: "upload-token-1",
+    });
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/reply-2",
+    });
+    const core = createCore({
+      onDispatchReply: async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ mediaUrl: "https://example.com/image.png" });
+      },
+    });
+    const unregister = registerGoogleChatWebhookTarget({
+      account: createAccount({ typingIndicator: "none" }),
+      config: createConfig(),
+      runtime: {},
+      core,
+      path: "/googlechat",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const handled = await handleGoogleChatWebhookRequest(
+        createWebhookRequest(createMessageEvent(threadName)),
+        createMockServerResponse(),
+      );
+
+      expect(handled).toBe(true);
+      expect(uploadGoogleChatAttachmentMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          space: "spaces/AAA",
+          filename: "attachment.png",
+        }),
+      );
+      expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          space: "spaces/AAA",
+          thread: threadName,
+          attachments: [
+            expect.objectContaining({
+              attachmentUploadToken: "upload-token-1",
+              contentName: "attachment.png",
+            }),
+          ],
         }),
       );
     } finally {

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -230,6 +230,7 @@ async function processMessageWithPipeline(params: {
     body: rawBody,
   });
 
+  const inboundThreadId = message.thread?.name;
   const ctxPayload = core.channel.reply.finalizeInboundContext({
     Body: body,
     BodyForAgent: rawBody,
@@ -250,8 +251,9 @@ async function processMessageWithPipeline(params: {
     Surface: "googlechat",
     MessageSid: message.name,
     MessageSidFull: message.name,
-    ReplyToId: message.thread?.name,
-    ReplyToIdFull: message.thread?.name,
+    ReplyToId: inboundThreadId,
+    ReplyToIdFull: inboundThreadId,
+    MessageThreadId: inboundThreadId,
     MediaPath: mediaPath,
     MediaType: mediaType,
     MediaUrl: mediaPath,
@@ -318,6 +320,7 @@ async function processMessageWithPipeline(params: {
       deliver: async (payload) => {
         await deliverGoogleChatReply({
           payload,
+          threadId: ctxPayload.MessageThreadId ?? ctxPayload.ReplyToId,
           account,
           spaceId,
           runtime,
@@ -365,6 +368,7 @@ async function downloadAttachment(
 
 async function deliverGoogleChatReply(params: {
   payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string; replyToId?: string };
+  threadId?: string;
   account: ResolvedGoogleChatAccount;
   spaceId: string;
   runtime: GoogleChatRuntimeEnv;
@@ -373,8 +377,18 @@ async function deliverGoogleChatReply(params: {
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingMessageName?: string;
 }): Promise<void> {
-  const { payload, account, spaceId, runtime, core, config, statusSink, typingMessageName } =
-    params;
+  const {
+    payload,
+    threadId,
+    account,
+    spaceId,
+    runtime,
+    core,
+    config,
+    statusSink,
+    typingMessageName,
+  } = params;
+  const resolvedThreadId = threadId?.trim() || payload.replyToId?.trim() || undefined;
   const mediaList = payload.mediaUrls?.length
     ? payload.mediaUrls
     : payload.mediaUrl
@@ -431,7 +445,7 @@ async function deliverGoogleChatReply(params: {
           account,
           space: spaceId,
           text: caption,
-          thread: payload.replyToId,
+          thread: resolvedThreadId,
           attachments: [
             { attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName },
           ],
@@ -463,7 +477,7 @@ async function deliverGoogleChatReply(params: {
             account,
             space: spaceId,
             text: chunk,
-            thread: payload.replyToId,
+            thread: resolvedThreadId,
           });
         }
         statusSink?.({ lastOutboundAt: Date.now() });


### PR DESCRIPTION
## Summary
- Problem: Google Chat inbound messages stored the native thread on `ReplyToId`, but the shared session/follow-up pipeline persists `MessageThreadId`.
- Why it matters: DM replies could lose their original Google Chat thread target and fall back to new threads on later reply paths.
- What changed: Google Chat inbound now copies `message.thread?.name` into `MessageThreadId`, and the monitor-local reply sender prefers the preserved thread when sending text or media replies.
- What did NOT change (scope boundary): No shared threading abstraction changes, no config/schema changes, and no changes to non-Google-Chat channels.

_AI-assisted: yes. Testing: fully tested locally._

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #41788
- Related #

## User-visible / Behavior Changes
Google Chat DM replies now preserve the original conversation thread across the shared session/reply pipeline instead of falling back to new threads on later reply paths.

## Security Impact (required)
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: Node 24 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Google Chat
- Relevant config (redacted): `channels.googlechat.replyToMode=off`

### Steps
1. Receive a Google Chat DM webhook event with `message.thread.name` set.
2. Persist session metadata from the normalized inbound context.
3. Send an immediate reply through the Google Chat monitor path.

### Expected
- The session metadata preserves the Google Chat thread.
- Replies are sent into the same Google Chat thread.

### Actual
- Before this change, only `ReplyToId` was populated, so shared session/follow-up paths could lose the thread target.

## Evidence
- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
- Verified scenarios: fresh-clone `pnpm install`, `pnpm build`, `pnpm check`, `pnpm test`; targeted Google Chat regression coverage in the branch
- Edge cases checked: `replyToMode=off`, immediate reply path, session metadata persistence
- What you did **not** verify: live Google Chat end-to-end against a real Workspace-backed service account

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: revert commit `03100c5b6`
- Files/config to restore: `extensions/googlechat/src/monitor.ts`
- Known bad symptoms reviewers should watch for: Google Chat replies landing in a new thread instead of the original DM thread

## Risks and Mitigations
- Risk: Google Chat currently uses the thread name in both `ReplyToId` and `MessageThreadId`, which differs from some channels’ stricter reply/thread split.
- Mitigation: The change is intentionally scoped to the Google Chat monitor and covered by narrow regression tests for the affected paths.

Made with [Cursor](https://cursor.com)