### PR TITLE
Telegram: store human-readable topic labels

### DIFF
--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -167,6 +167,10 @@ export function deriveSessionMetaPatch(params: {
   if (mergedOrigin) {
     patch.origin = mergedOrigin;
   }
+  const threadLabel = params.ctx.ThreadLabel?.trim();
+  if (threadLabel) {
+    patch.displayName = threadLabel;
+  }
 
   return Object.keys(patch).length > 0 ? patch : null;
 }

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -145,4 +145,27 @@ describe("session store key normalization", () => {
     expect(store[CANONICAL_KEY]?.updatedAt).toBe(1111);
     expect(store[CANONICAL_KEY]?.origin?.provider).toBe("webchat");
   });
+
+  it("persists inbound thread labels as display names", async () => {
+    const sessionKey = "agent:main:telegram:group:-1001234567890:topic:77";
+
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey,
+      ctx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "group",
+        From: "telegram:group:-1001234567890:topic:77",
+        To: "telegram:-1001234567890",
+        SessionKey: sessionKey,
+        OriginatingTo: "telegram:-1001234567890:topic:77",
+        GroupSubject: "Forum Group",
+        ThreadLabel: "Telegram : Forum Group : Build Updates",
+      },
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[sessionKey]?.displayName).toBe("Telegram : Forum Group : Build Updates");
+  });
 });

--- a/src/telegram/bot-message-context.implicit-mention.test.ts
+++ b/src/telegram/bot-message-context.implicit-mention.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
-import { TELEGRAM_FORUM_SERVICE_FIELDS } from "./forum-service-message.js";
+import {
+  resolveTelegramForumTopicName,
+  TELEGRAM_FORUM_SERVICE_FIELDS,
+} from "./forum-service-message.js";
 
 describe("buildTelegramMessageContext implicitMention forum service messages", () => {
   /**
@@ -61,6 +64,19 @@ describe("buildTelegramMessageContext implicitMention forum service messages", (
     // With requireMention and no explicit @mention, the message should be
     // skipped (null) because implicitMention should NOT fire.
     expect(ctx).toBeNull();
+  });
+
+  it("extracts forum topic names from service messages", async () => {
+    expect(
+      resolveTelegramForumTopicName({
+        forum_topic_created: { name: "Build Updates", icon_color: 0x6fb9f0 },
+      }),
+    ).toBe("Build Updates");
+    expect(
+      resolveTelegramForumTopicName({
+        forum_topic_edited: { name: "Roadmap", icon_custom_emoji_id: "123" },
+      }),
+    ).toBe("Roadmap");
   });
 
   it.each(TELEGRAM_FORUM_SERVICE_FIELDS)(

--- a/src/telegram/bot-message-context.session.ts
+++ b/src/telegram/bot-message-context.session.ts
@@ -33,6 +33,7 @@ import {
   type TelegramThreadSpec,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
+import { resolveTelegramForumTopicName } from "./forum-service-message.js";
 import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
 
 export async function buildTelegramInboundContextPayload(params: {
@@ -120,6 +121,11 @@ export async function buildTelegramInboundContextPayload(params: {
       }]\n`
     : "";
   const groupLabel = isGroup ? buildGroupLabel(msg, chatId, resolvedThreadId) : undefined;
+  const forumTopicName =
+    resolvedThreadId != null && isForum ? resolveTelegramForumTopicName(msg) : undefined;
+  const threadLabel = forumTopicName
+    ? ["Telegram", msg.chat.title?.trim(), forumTopicName].filter(Boolean).join(" : ")
+    : undefined;
   const senderName = buildSenderName(msg);
   const conversationLabel = isGroup
     ? (groupLabel ?? `group:${chatId}`)
@@ -241,6 +247,7 @@ export async function buildTelegramInboundContextPayload(params: {
     ...(locationData ? toLocationContext(locationData) : undefined),
     CommandAuthorized: commandAuthorized,
     MessageThreadId: threadSpec.id,
+    ThreadLabel: threadLabel,
     IsForum: isForum,
     OriginatingChannel: "telegram" as const,
     OriginatingTo: `telegram:${chatId}`,

--- a/src/telegram/forum-service-message.ts
+++ b/src/telegram/forum-service-message.ts
@@ -21,3 +21,26 @@ export function isTelegramForumServiceMessage(msg: unknown): boolean {
   const record = msg as Record<string, unknown>;
   return TELEGRAM_FORUM_SERVICE_FIELDS.some((field) => record[field] != null);
 }
+
+function readTelegramForumTopicName(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const raw = (value as { name?: unknown }).name;
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function resolveTelegramForumTopicName(msg: unknown): string | undefined {
+  if (!msg || typeof msg !== "object") {
+    return undefined;
+  }
+  const record = msg as Record<string, unknown>;
+  return (
+    readTelegramForumTopicName(record.forum_topic_created) ??
+    readTelegramForumTopicName(record.forum_topic_edited)
+  );
+}


### PR DESCRIPTION
## Summary
- extract Telegram forum topic names from topic-created/topic-edited service messages
- persist thread labels into session metadata so topic sessions keep a human-readable display name
- cover topic-name extraction and session-store persistence with regression tests

## Testing
- pnpm test src/telegram/bot-message-context.implicit-mention.test.ts
- pnpm test src/config/sessions/store.session-key-normalization.test.ts
- pnpm exec vitest run src/auto-reply/reply/session.test.ts -t "forks a new session from the parent session file"
- pnpm exec oxfmt --check src/telegram/forum-service-message.ts src/telegram/bot-message-context.session.ts src/config/sessions/metadata.ts src/telegram/bot-message-context.implicit-mention.test.ts src/config/sessions/store.session-key-normalization.test.ts

Fixes #7406
