### PR TITLE
fix(agents): respect workspace config for sub-agent sessions

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1330,6 +1330,7 @@ public struct SessionsPatchParams: Codable, Sendable {
     public let reasoninglevel: AnyCodable?
     public let responseusage: AnyCodable?
     public let elevatedlevel: AnyCodable?
+    public let workspace: AnyCodable?
     public let exechost: AnyCodable?
     public let execsecurity: AnyCodable?
     public let execask: AnyCodable?
@@ -1350,6 +1351,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         reasoninglevel: AnyCodable?,
         responseusage: AnyCodable?,
         elevatedlevel: AnyCodable?,
+        workspace: AnyCodable?,
         exechost: AnyCodable?,
         execsecurity: AnyCodable?,
         execask: AnyCodable?,
@@ -1369,6 +1371,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         self.reasoninglevel = reasoninglevel
         self.responseusage = responseusage
         self.elevatedlevel = elevatedlevel
+        self.workspace = workspace
         self.exechost = exechost
         self.execsecurity = execsecurity
         self.execask = execask
@@ -1390,6 +1393,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         case reasoninglevel = "reasoningLevel"
         case responseusage = "responseUsage"
         case elevatedlevel = "elevatedLevel"
+        case workspace
         case exechost = "execHost"
         case execsecurity = "execSecurity"
         case execask = "execAsk"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1330,6 +1330,7 @@ public struct SessionsPatchParams: Codable, Sendable {
     public let reasoninglevel: AnyCodable?
     public let responseusage: AnyCodable?
     public let elevatedlevel: AnyCodable?
+    public let workspace: AnyCodable?
     public let exechost: AnyCodable?
     public let execsecurity: AnyCodable?
     public let execask: AnyCodable?
@@ -1350,6 +1351,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         reasoninglevel: AnyCodable?,
         responseusage: AnyCodable?,
         elevatedlevel: AnyCodable?,
+        workspace: AnyCodable?,
         exechost: AnyCodable?,
         execsecurity: AnyCodable?,
         execask: AnyCodable?,
@@ -1369,6 +1371,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         self.reasoninglevel = reasoninglevel
         self.responseusage = responseusage
         self.elevatedlevel = elevatedlevel
+        self.workspace = workspace
         self.exechost = exechost
         self.execsecurity = execsecurity
         self.execask = execask
@@ -1390,6 +1393,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         case reasoninglevel = "reasoningLevel"
         case responseusage = "responseUsage"
         case elevatedlevel = "elevatedLevel"
+        case workspace
         case exechost = "execHost"
         case execsecurity = "execSecurity"
         case execask = "execAsk"

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -16,7 +16,7 @@ import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 const log = createSubsystemLogger("agent-scope");
 
 /** Strip null bytes from paths to prevent ENOTDIR errors. */
-function stripNullBytes(s: string): string {
+export function stripNullBytes(s: string): string {
   // eslint-disable-next-line no-control-regex
   return s.replace(/\0/g, "");
 }

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -423,7 +423,7 @@ export async function spawnSubagentDirect(
     spawnDepth: childDepth,
     subagentRole: childCapabilities.role === "main" ? null : childCapabilities.role,
     subagentControlScope: childCapabilities.controlScope,
-    workspace: targetAgentConfig?.workspace,
+    workspace: targetAgentConfig?.workspace?.trim() || undefined,
   });
   if (spawnDepthPatchError) {
     return {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -423,6 +423,7 @@ export async function spawnSubagentDirect(
     spawnDepth: childDepth,
     subagentRole: childCapabilities.role === "main" ? null : childCapabilities.role,
     subagentControlScope: childCapabilities.controlScope,
+    workspace: targetAgentConfig?.workspace,
   });
   if (spawnDepthPatchError) {
     return {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -11,8 +11,9 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { resolveUserPath } from "../utils.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig, stripNullBytes } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
@@ -419,11 +420,17 @@ export async function spawnSubagentDirect(
     }
   };
 
+  // Normalize workspace path (~/ expansion, relative-to-absolute, null byte stripping)
+  // to ensure session metadata matches the real execution directory.
+  const normalizedTargetWorkspace = targetAgentConfig?.workspace
+    ? stripNullBytes(resolveUserPath(targetAgentConfig.workspace.trim()))
+    : undefined;
+
   const spawnDepthPatchError = await patchChildSession({
     spawnDepth: childDepth,
     subagentRole: childCapabilities.role === "main" ? null : childCapabilities.role,
     subagentControlScope: childCapabilities.controlScope,
-    workspace: targetAgentConfig?.workspace?.trim() || undefined,
+    workspace: normalizedTargetWorkspace,
   });
   if (spawnDepthPatchError) {
     return {
@@ -555,7 +562,7 @@ export async function spawnSubagentDirect(
   });
   // Prefer target agent's configured workspace to keep spawned metadata
   // aligned with the actual execution cwd used by the child session.
-  const targetWorkspace = targetAgentConfig?.workspace?.trim();
+  const targetWorkspace = normalizedTargetWorkspace;
   const spawnedMetadata = normalizeSpawnedRunMetadata({
     spawnedBy: spawnedByKey,
     ...toolSpawnMetadata,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -553,14 +553,19 @@ export async function spawnSubagentDirect(
     agentGroupSpace: ctx.agentGroupSpace,
     workspaceDir: ctx.workspaceDir,
   });
+  // Prefer target agent's configured workspace to keep spawned metadata
+  // aligned with the actual execution cwd used by the child session.
+  const targetWorkspace = targetAgentConfig?.workspace?.trim();
   const spawnedMetadata = normalizeSpawnedRunMetadata({
     spawnedBy: spawnedByKey,
     ...toolSpawnMetadata,
-    workspaceDir: resolveSpawnedWorkspaceInheritance({
-      config: cfg,
-      requesterSessionKey: requesterInternalKey,
-      explicitWorkspaceDir: toolSpawnMetadata.workspaceDir,
-    }),
+    workspaceDir:
+      targetWorkspace ||
+      resolveSpawnedWorkspaceInheritance({
+        config: cfg,
+        requesterSessionKey: requesterInternalKey,
+        explicitWorkspaceDir: toolSpawnMetadata.workspaceDir,
+      }),
   });
 
   const childIdem = crypto.randomUUID();

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -422,9 +422,8 @@ export async function spawnSubagentDirect(
 
   // Normalize workspace path (~/ expansion, relative-to-absolute, null byte stripping)
   // to ensure session metadata matches the real execution directory.
-  const normalizedTargetWorkspace = targetAgentConfig?.workspace
-    ? stripNullBytes(resolveUserPath(targetAgentConfig.workspace.trim()))
-    : undefined;
+  const trimmed = targetAgentConfig?.workspace?.trim();
+  const normalizedTargetWorkspace = trimmed ? stripNullBytes(resolveUserPath(trimmed)) : undefined;
 
   const spawnDepthPatchError = await patchChildSession({
     spawnDepth: childDepth,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -631,8 +631,11 @@ async function prepareAgentCommandExecution(
     sessionKey,
   });
   // Internal callers (for example subagent spawns) may pin workspace inheritance.
+  // Session entry workspace override takes precedence over config and spawned metadata.
   const workspaceDirRaw =
-    normalizedSpawned.workspaceDir ?? resolveAgentWorkspaceDir(cfg, sessionAgentId);
+    sessionEntryRaw?.workspace ??
+    normalizedSpawned.workspaceDir ??
+    resolveAgentWorkspaceDir(cfg, sessionAgentId);
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { resolveUserPath } from "../../utils.js";
 import { parseSessionThreadInfo } from "./delivery-info.js";
 import {
   resolveDefaultSessionStorePath,
@@ -78,7 +79,7 @@ async function ensureSessionHeader(params: {
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: params.cwd ?? process.cwd(),
+    cwd: params.cwd ? resolveUserPath(params.cwd) : process.cwd(),
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -67,6 +67,7 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
+  cwd?: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
@@ -77,7 +78,7 @@ async function ensureSessionHeader(params: {
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: process.cwd(),
+    cwd: params.cwd ?? process.cwd(),
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
@@ -177,7 +178,11 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  await ensureSessionHeader({
+    sessionFile,
+    sessionId: entry.sessionId,
+    cwd: entry.workspace,
+  });
 
   const sessionManager = SessionManager.open(sessionFile);
   sessionManager.appendMessage({

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -86,6 +86,8 @@ export type SessionEntry = {
   subagentRole?: "orchestrator" | "leaf";
   /** Explicit control scope assigned at spawn time for subagent control decisions. */
   subagentControlScope?: "children" | "none";
+  /** Workspace override for this session (respects agents.list[].workspace). */
+  workspace?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
   /**

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -65,6 +65,8 @@ export const SessionsPatchParamsSchema = Type.Object(
       ]),
     ),
     elevatedLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    // Workspace override for sub-agent sessions (per-agent workspace).
+    workspace: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     execHost: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     execSecurity: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     execAsk: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -192,6 +192,24 @@ export async function applySessionsPatchToStore(params: {
     }
   }
 
+  if ("workspace" in patch) {
+    const raw = patch.workspace;
+    if (raw === null) {
+      if (existing?.workspace) {
+        return invalid("workspace cannot be cleared once set");
+      }
+    } else if (raw !== undefined) {
+      const trimmed = String(raw).trim();
+      if (!trimmed) {
+        return invalid("invalid workspace: empty");
+      }
+      if (existing?.workspace && existing.workspace !== trimmed) {
+        return invalid("workspace cannot be changed once set");
+      }
+      next.workspace = trimmed;
+    }
+  }
+
   if ("label" in patch) {
     const raw = patch.label;
     if (raw === null) {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -199,6 +199,9 @@ export async function applySessionsPatchToStore(params: {
         return invalid("workspace cannot be cleared once set");
       }
     } else if (raw !== undefined) {
+      if (!supportsSpawnLineage(storeKey)) {
+        return invalid("workspace is only supported for subagent:* or acp:* sessions");
+      }
       const trimmed = String(raw).trim();
       if (!trimmed) {
         return invalid("invalid workspace: empty");


### PR DESCRIPTION
## Summary

- **Problem:** Sub-agents spawned via sessions_spawn ignored the workspace path configured in agents.list[].workspace, defaulting to parent's or global workspace instead
- **Why it matters:** Files written to wrong directory, memory_search indexed wrong directory, and workspace isolation was broken for configured agents
- **What changed:** Added workspace field to session entry, pass workspace from targetAgentConfig during spawn, and prioritize session workspace in resolution chain
- **What did NOT change:** Existing workspace resolution logic for main sessions and agents without explicit workspace config remains unchanged

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17698
- Closes #42712
- Related #

## User-visible / Behavior Changes

- Sub-agents now respect workspace configured in agents.list[].workspace
- Session jsonl transcript correctly shows configured workspace in cwd field
- exec commands run in the correct workspace directory for configured agents

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (Yes - sub-agents now access configured workspace directory instead of default workspace)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22.20.0
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: agents.list[].workspace configured to /Users/admin/.openclaw/workspaces/k8s-sre

### Steps

1. Configure agent with explicit workspace in agents.list
2. Spawn sub-agent via sessions_spawn tool
3. Check session jsonl transcript first line
4. Run exec command in sub-agent to verify working directory

### Expected

- Session jsonl shows: {"cwd":"/Users/admin/.openclaw/workspaces/k8s-sre"}
- exec commands run in /Users/admin/.openclaw/workspaces/k8s-sre

### Actual

- ✅ Session jsonl correctly shows configured workspace
- ✅ exec commands run in the correct workspace directory

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets: Session jsonl first line shows correct cwd
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

Verified scenarios:
- Sub-agent session correctly shows configured workspace in session header
- exec commands run in the correct workspace directory
- Main session and agents without workspace config unaffected

What you did **not** verify:
- Memory search indexing behavior
- Multi-level sub-agent nesting scenarios

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert: Remove workspace field from agents.list config or revert commit
- Files/config to restore: None (config change only)
- Known bad symptoms: Sub-agents default to parent/global workspace

## Risks and Mitigations

- Risk: Sub-agents may access different workspace directory than before, potentially breaking workflows that depended on previous behavior
  - Mitigation: This is a bug fix to honor configured workspace; previous behavior was incorrect
- Risk: Existing sessions may need to be restarted to pick up new workspace path
  - Mitigation: Workspace is set at session creation time; new sessions will use correct path
