### PR TITLE
GoogleChat: respect replyToMode for thread replies

### DIFF
--- a/extensions/googlechat/src/monitor.threading.test.ts
+++ b/extensions/googlechat/src/monitor.threading.test.ts
@@ -1,0 +1,343 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/googlechat";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockServerResponse } from "../../../src/test-utils/mock-http-response.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import { handleGoogleChatWebhookRequest, registerGoogleChatWebhookTarget } from "./monitor.js";
+
+const sendGoogleChatMessageMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/googlechat", () => ({
+  createWebhookInFlightLimiter: vi.fn(() => ({})),
+  createReplyPrefixOptions: vi.fn(() => ({})),
+  registerWebhookTargetWithPluginRoute: vi.fn(
+    ({
+      targetsByPath,
+      target,
+    }: {
+      targetsByPath: Map<string, unknown[]>;
+      target: { path: string };
+    }) => {
+      const existing = targetsByPath.get(target.path) ?? [];
+      targetsByPath.set(target.path, [...existing, target]);
+      return {
+        unregister: () => {
+          const next = (targetsByPath.get(target.path) ?? []).filter((entry) => entry !== target);
+          if (next.length > 0) {
+            targetsByPath.set(target.path, next);
+          } else {
+            targetsByPath.delete(target.path);
+          }
+        },
+      };
+    },
+  ),
+  resolveInboundRouteEnvelopeBuilderWithRuntime: vi.fn(() => ({
+    route: {
+      sessionKey: "googlechat:session",
+      accountId: "default",
+      agentId: "assistant",
+    },
+    buildEnvelope: ({ body }: { body: string }) => ({
+      storePath: "/tmp/googlechat-threading-test.md",
+      body,
+    }),
+  })),
+  resolveWebhookPath: vi.fn(() => "/googlechat"),
+}));
+
+vi.mock("./api.js", () => ({
+  downloadGoogleChatMedia: vi.fn(),
+  deleteGoogleChatMessage: vi.fn(),
+  sendGoogleChatMessage: sendGoogleChatMessageMock,
+  updateGoogleChatMessage: vi.fn(),
+}));
+
+vi.mock("./monitor-access.js", () => ({
+  applyGoogleChatInboundAccessPolicy: vi.fn(async () => ({
+    ok: true,
+    commandAuthorized: true,
+    effectiveWasMentioned: true,
+    groupSystemPrompt: undefined,
+  })),
+  isSenderAllowed: vi.fn(),
+}));
+
+vi.mock("./monitor-webhook.js", () => ({
+  createGoogleChatWebhookRequestHandler:
+    ({
+      webhookTargets,
+      processEvent,
+    }: {
+      webhookTargets: Map<string, unknown[]>;
+      processEvent: (event: unknown, target: unknown) => Promise<void>;
+    }) =>
+    async (req: IncomingMessage, res: ServerResponse) => {
+      const target = webhookTargets.get(req.url ?? "/googlechat")?.[0];
+      if (!target) {
+        res.statusCode = 404;
+        res.end("Not Found");
+        return false;
+      }
+      const body = await readRequestBody(req);
+      await processEvent(JSON.parse(body) as unknown, target);
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end("{}");
+      return true;
+    },
+}));
+
+function createWebhookRequest(payload: unknown): IncomingMessage {
+  const req = new EventEmitter() as IncomingMessage & {
+    destroyed?: boolean;
+    destroy: (error?: Error) => IncomingMessage;
+    on: (event: string, listener: (...args: unknown[]) => void) => IncomingMessage;
+  };
+  req.method = "POST";
+  req.url = "/googlechat";
+  req.headers = {
+    "content-type": "application/json",
+  };
+  req.destroyed = false;
+  req.destroy = () => {
+    req.destroyed = true;
+    return req;
+  };
+
+  const originalOn = req.on.bind(req);
+  let bodyScheduled = false;
+  req.on = ((event: string, listener: (...args: unknown[]) => void) => {
+    const result = originalOn(event, listener);
+    if (!bodyScheduled && event === "data") {
+      bodyScheduled = true;
+      void Promise.resolve().then(() => {
+        req.emit("data", Buffer.from(JSON.stringify(payload), "utf-8"));
+        if (!req.destroyed) {
+          req.emit("end");
+        }
+      });
+    }
+    return result;
+  }) as IncomingMessage["on"];
+
+  return req;
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve) => {
+    req.on("data", (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    });
+    req.on("end", () => resolve());
+  });
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function createConfig(): OpenClawConfig {
+  return {
+    channels: {
+      googlechat: {
+        enabled: true,
+        replyToMode: "off",
+        serviceAccount: {
+          type: "service_account",
+          client_email: "bot@example.com",
+          private_key: "test-key", // pragma: allowlist secret
+          token_uri: "https://oauth2.googleapis.com/token",
+        },
+      },
+    },
+  };
+}
+
+function createAccount(
+  config: Partial<ResolvedGoogleChatAccount["config"]> = {},
+): ResolvedGoogleChatAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    credentialSource: "none",
+    config,
+  } as ResolvedGoogleChatAccount;
+}
+
+function createCore(params: {
+  onRecordSessionMeta?: (args: unknown) => Promise<void> | void;
+  onDispatchReply?: (args: {
+    dispatcherOptions: {
+      deliver: (payload: { text?: string; replyToId?: string }) => Promise<void>;
+    };
+  }) => Promise<void> | void;
+}): PluginRuntime {
+  return {
+    logging: {
+      shouldLogVerbose: () => false,
+    },
+    channel: {
+      reply: {
+        finalizeInboundContext: vi.fn((ctx) => ctx),
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn(async (args) => {
+          await params.onDispatchReply?.(args);
+        }),
+      },
+      session: {
+        recordSessionMetaFromInbound: vi.fn(async (args) => {
+          await params.onRecordSessionMeta?.(args);
+        }),
+      },
+      media: {
+        fetchRemoteMedia: vi.fn(),
+        saveMediaBuffer: vi.fn(),
+      },
+      text: {
+        resolveChunkMode: vi.fn(() => "sentences"),
+        chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+      },
+    },
+  } as unknown as PluginRuntime;
+}
+
+function createMessageEvent(threadName: string) {
+  return {
+    type: "MESSAGE",
+    eventTime: "2026-03-10T00:00:00.000Z",
+    space: {
+      name: "spaces/AAA",
+      type: "DM",
+    },
+    message: {
+      name: "spaces/AAA/messages/msg-1",
+      text: "hello",
+      thread: {
+        name: threadName,
+      },
+      sender: {
+        name: "users/123",
+        displayName: "Test User",
+        email: "test@example.com",
+        type: "HUMAN",
+      },
+    },
+  };
+}
+
+describe("Google Chat monitor threading", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("records inbound MessageThreadId in session metadata", async () => {
+    const threadName = "spaces/AAA/threads/thread-1";
+    const recordSessionMetaFromInbound = vi.fn(async () => {});
+    const core = createCore({
+      onRecordSessionMeta: recordSessionMetaFromInbound,
+    });
+    const unregister = registerGoogleChatWebhookTarget({
+      account: createAccount({ typingIndicator: "none" }),
+      config: createConfig(),
+      runtime: {},
+      core,
+      path: "/googlechat",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const handled = await handleGoogleChatWebhookRequest(
+        createWebhookRequest(createMessageEvent(threadName)),
+        createMockServerResponse(),
+      );
+
+      expect(handled).toBe(true);
+      expect(recordSessionMetaFromInbound).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({
+            CurrentMessageId: threadName,
+            ReplyToId: threadName,
+            MessageThreadId: threadName,
+          }),
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+
+  it("uses the preserved inbound thread for immediate replies", async () => {
+    const threadName = "spaces/AAA/threads/thread-2";
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/reply-1",
+    });
+    const core = createCore({
+      onDispatchReply: async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "Threaded reply", replyToId: threadName });
+      },
+    });
+    const unregister = registerGoogleChatWebhookTarget({
+      account: createAccount({ typingIndicator: "none" }),
+      config: createConfig(),
+      runtime: {},
+      core,
+      path: "/googlechat",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const handled = await handleGoogleChatWebhookRequest(
+        createWebhookRequest(createMessageEvent(threadName)),
+        createMockServerResponse(),
+      );
+
+      expect(handled).toBe(true);
+      expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          space: "spaces/AAA",
+          text: "Threaded reply",
+          thread: threadName,
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does not force threading when the shared reply flow strips replyToId", async () => {
+    const threadName = "spaces/AAA/threads/thread-3";
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/reply-2",
+    });
+    const core = createCore({
+      onDispatchReply: async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "Root reply" });
+      },
+    });
+    const unregister = registerGoogleChatWebhookTarget({
+      account: createAccount({ typingIndicator: "none" }),
+      config: createConfig(),
+      runtime: {},
+      core,
+      path: "/googlechat",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const handled = await handleGoogleChatWebhookRequest(
+        createWebhookRequest(createMessageEvent(threadName)),
+        createMockServerResponse(),
+      );
+
+      expect(handled).toBe(true);
+      expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          space: "spaces/AAA",
+          text: "Root reply",
+          thread: undefined,
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -230,6 +230,7 @@ async function processMessageWithPipeline(params: {
     body: rawBody,
   });
 
+  const inboundThreadId = message.thread?.name;
   const ctxPayload = core.channel.reply.finalizeInboundContext({
     Body: body,
     BodyForAgent: rawBody,
@@ -250,8 +251,10 @@ async function processMessageWithPipeline(params: {
     Surface: "googlechat",
     MessageSid: message.name,
     MessageSidFull: message.name,
-    ReplyToId: message.thread?.name,
-    ReplyToIdFull: message.thread?.name,
+    CurrentMessageId: inboundThreadId ?? message.name,
+    ReplyToId: inboundThreadId,
+    ReplyToIdFull: inboundThreadId,
+    MessageThreadId: inboundThreadId,
     MediaPath: mediaPath,
     MediaType: mediaType,
     MediaUrl: mediaPath,
@@ -295,7 +298,6 @@ async function processMessageWithPipeline(params: {
         account,
         space: spaceId,
         text: `_${botName} is typing..._`,
-        thread: message.thread?.name,
       });
       typingMessageName = result?.messageName;
     } catch (err) {
@@ -375,6 +377,8 @@ async function deliverGoogleChatReply(params: {
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink, typingMessageName } =
     params;
+  const resolvedThreadId = payload.replyToId?.trim() || undefined;
+  let typingPlaceholderName = typingMessageName;
   const mediaList = payload.mediaUrls?.length
     ? payload.mediaUrls
     : payload.mediaUrl
@@ -383,28 +387,37 @@ async function deliverGoogleChatReply(params: {
 
   if (mediaList.length > 0) {
     let suppressCaption = false;
-    if (typingMessageName) {
+    if (typingPlaceholderName) {
       try {
         await deleteGoogleChatMessage({
           account,
-          messageName: typingMessageName,
+          messageName: typingPlaceholderName,
         });
+        typingPlaceholderName = undefined;
       } catch (err) {
         runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
-        const fallbackText = payload.text?.trim()
-          ? payload.text
-          : mediaList.length > 1
-            ? "Sent attachments."
-            : "Sent attachment.";
-        try {
-          await updateGoogleChatMessage({
-            account,
-            messageName: typingMessageName,
-            text: fallbackText,
-          });
-          suppressCaption = Boolean(payload.text?.trim());
-        } catch (updateErr) {
-          runtime.error?.(`Google Chat typing update failed: ${String(updateErr)}`);
+        if (resolvedThreadId) {
+          // Avoid updating the root-level typing placeholder when the real reply belongs in a thread.
+          typingPlaceholderName = undefined;
+        } else {
+          const placeholderName = typingPlaceholderName;
+          if (placeholderName) {
+            const fallbackText = payload.text?.trim()
+              ? payload.text
+              : mediaList.length > 1
+                ? "Sent attachments."
+                : "Sent attachment.";
+            try {
+              await updateGoogleChatMessage({
+                account,
+                messageName: placeholderName,
+                text: fallbackText,
+              });
+              suppressCaption = Boolean(payload.text?.trim());
+            } catch (updateErr) {
+              runtime.error?.(`Google Chat typing update failed: ${String(updateErr)}`);
+            }
+          }
         }
       }
     }
@@ -431,7 +444,7 @@ async function deliverGoogleChatReply(params: {
           account,
           space: spaceId,
           text: caption,
-          thread: payload.replyToId,
+          thread: resolvedThreadId,
           attachments: [
             { attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName },
           ],
@@ -448,14 +461,26 @@ async function deliverGoogleChatReply(params: {
     const chunkLimit = account.config.textChunkLimit ?? 4000;
     const chunkMode = core.channel.text.resolveChunkMode(config, "googlechat", account.accountId);
     const chunks = core.channel.text.chunkMarkdownTextWithMode(payload.text, chunkLimit, chunkMode);
+    let editableTypingMessageName = typingMessageName;
+    if (editableTypingMessageName && resolvedThreadId) {
+      try {
+        await deleteGoogleChatMessage({
+          account,
+          messageName: editableTypingMessageName,
+        });
+      } catch (err) {
+        runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
+      }
+      editableTypingMessageName = undefined;
+    }
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
       try {
         // Edit typing message with first chunk if available
-        if (i === 0 && typingMessageName) {
+        if (i === 0 && editableTypingMessageName) {
           await updateGoogleChatMessage({
             account,
-            messageName: typingMessageName,
+            messageName: editableTypingMessageName,
             text: chunk,
           });
         } else {
@@ -463,7 +488,7 @@ async function deliverGoogleChatReply(params: {
             account,
             space: spaceId,
             text: chunk,
-            thread: payload.replyToId,
+            thread: resolvedThreadId,
           });
         }
         statusSink?.({ lastOutboundAt: Date.now() });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -40,6 +40,7 @@ import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunContexts,
+  resolveCurrentReplyReferenceId,
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
@@ -405,8 +406,7 @@ export async function runAgentTurnWithFallback(params: {
               onBlockReply: params.opts?.onBlockReply
                 ? createBlockReplyDeliveryHandler({
                     onBlockReply: params.opts.onBlockReply,
-                    currentMessageId:
-                      params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
+                    currentMessageId: resolveCurrentReplyReferenceId(params.sessionCtx),
                     normalizeStreamingText,
                     applyReplyToMode: params.applyReplyToMode,
                     normalizeMediaPaths: normalizeReplyMediaPaths,

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -191,4 +191,56 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(1);
     expect(replyPayloads[0]?.text).toBe("hello world!");
   });
+
+  it("uses CurrentMessageId for Google Chat threading when replyToMode is all", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "thread me" }],
+      replyToMode: "all",
+      replyToChannel: "googlechat",
+      currentMessageId: "spaces/AAA/threads/thread-1",
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]).toMatchObject({
+      text: "thread me",
+      replyToId: "spaces/AAA/threads/thread-1",
+    });
+  });
+
+  it("threads only the first Google Chat payload when replyToMode is first", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "one" }, { text: "two" }],
+      replyToMode: "first",
+      replyToChannel: "googlechat",
+      currentMessageId: "spaces/AAA/threads/thread-2",
+    });
+
+    expect(replyPayloads).toHaveLength(2);
+    expect(replyPayloads[0]).toMatchObject({
+      text: "one",
+      replyToId: "spaces/AAA/threads/thread-2",
+    });
+    expect(replyPayloads[1]).toMatchObject({
+      text: "two",
+      replyToId: undefined,
+    });
+  });
+
+  it("suppresses implicit Google Chat threading when replyToMode is off", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "root reply" }],
+      replyToMode: "off",
+      replyToChannel: "googlechat",
+      currentMessageId: "spaces/AAA/threads/thread-3",
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]).toMatchObject({
+      text: "root reply",
+      replyToId: undefined,
+    });
+  });
 });

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -22,7 +22,7 @@ export function buildThreadingToolContext(params: {
   hasRepliedRef: { value: boolean } | undefined;
 }): ChannelThreadingToolContext {
   const { sessionCtx, config, hasRepliedRef } = params;
-  const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+  const currentMessageId = resolveCurrentReplyReferenceId(sessionCtx);
   const originProvider = resolveOriginMessageProvider({
     originatingChannel: sessionCtx.OriginatingChannel,
     provider: sessionCtx.Provider,
@@ -75,6 +75,17 @@ export function buildThreadingToolContext(params: {
     currentChannelProvider: provider!, // guaranteed non-null since dock exists
     currentMessageId: context.currentMessageId ?? currentMessageId,
   };
+}
+
+export function resolveCurrentReplyReferenceId(
+  sessionCtx: Pick<TemplateContext, "CurrentMessageId" | "MessageSidFull" | "MessageSid">,
+): string | undefined {
+  const currentMessageIdRaw = sessionCtx.CurrentMessageId;
+  const currentMessageId =
+    typeof currentMessageIdRaw === "number"
+      ? String(currentMessageIdRaw)
+      : currentMessageIdRaw?.trim() || undefined;
+  return currentMessageId ?? sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
 }
 
 export const isBunFetchSocketError = (message?: string) =>

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -44,7 +44,11 @@ import {
   hasSessionRelatedCronJobs,
   hasUnbackedReminderCommitment,
 } from "./agent-runner-reminder-guard.js";
-import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
+import {
+  appendUsageLine,
+  formatResponseUsageLine,
+  resolveCurrentReplyReferenceId,
+} from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
@@ -494,7 +498,7 @@ export async function runReplyAgent(params: {
       directlySentBlockKeys,
       replyToMode,
       replyToChannel,
-      currentMessageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
+      currentMessageId: resolveCurrentReplyReferenceId(sessionCtx),
       messageProvider: followupRun.run.messageProvider,
       messagingToolSentTexts: runResult.messagingToolSentTexts,
       messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -88,6 +88,23 @@ const createMSTeamsOutbound = (): ChannelOutboundAdapter => ({
   },
 });
 
+const createGoogleChatOutbound = (): ChannelOutboundAdapter => ({
+  deliveryMode: "direct",
+  sendText: async ({ to, text }) => ({
+    channel: "googlechat",
+    messageId: "g1",
+    chatId: to,
+    text,
+  }),
+  sendMedia: async ({ to, text, mediaUrl }) => ({
+    channel: "googlechat",
+    messageId: "g1",
+    chatId: to,
+    text,
+    mediaUrl,
+  }),
+});
+
 const createMSTeamsPlugin = (params: { outbound: ChannelOutboundAdapter }): ChannelPlugin => ({
   id: "msteams",
   meta: {
@@ -98,6 +115,23 @@ const createMSTeamsPlugin = (params: { outbound: ChannelOutboundAdapter }): Chan
     blurb: "Bot Framework; enterprise support.",
   },
   capabilities: { chatTypes: ["direct"] },
+  config: {
+    listAccountIds: () => [],
+    resolveAccount: () => ({}),
+  },
+  outbound: params.outbound,
+});
+
+const createGoogleChatPlugin = (params: { outbound: ChannelOutboundAdapter }): ChannelPlugin => ({
+  id: "googlechat",
+  meta: {
+    id: "googlechat",
+    label: "Google Chat",
+    selectionLabel: "Google Chat",
+    docsPath: "/channels/googlechat",
+    blurb: "Workspace chat",
+  },
+  capabilities: { chatTypes: ["direct", "group", "thread"] },
   config: {
     listAccountIds: () => [],
     resolveAccount: () => ({}),
@@ -253,6 +287,71 @@ describe("routeReply", () => {
       "telegram:123",
       "hi",
       expect.objectContaining({ messageThreadId: 42 }),
+    );
+  });
+
+  it("does not forward implicit Google Chat threadId as an explicit thread target", async () => {
+    setActivePluginRegistry(
+      createRegistry([
+        ...defaultRegistry.channels,
+        {
+          pluginId: "googlechat",
+          plugin: createGoogleChatPlugin({
+            outbound: createGoogleChatOutbound(),
+          }),
+          source: "test",
+        },
+      ]),
+    );
+    mocks.deliverOutboundPayloads.mockClear();
+    mocks.deliverOutboundPayloads.mockResolvedValue([]);
+    await routeReply({
+      payload: { text: "hi" },
+      channel: "googlechat",
+      to: "spaces/AAA",
+      threadId: "spaces/AAA/threads/thread-1",
+      cfg: {} as never,
+    });
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "googlechat",
+        replyToId: null,
+        threadId: null,
+      }),
+    );
+  });
+
+  it("preserves payload-level Google Chat reply references without passing threadId", async () => {
+    setActivePluginRegistry(
+      createRegistry([
+        ...defaultRegistry.channels,
+        {
+          pluginId: "googlechat",
+          plugin: createGoogleChatPlugin({
+            outbound: createGoogleChatOutbound(),
+          }),
+          source: "test",
+        },
+      ]),
+    );
+    mocks.deliverOutboundPayloads.mockClear();
+    mocks.deliverOutboundPayloads.mockResolvedValue([]);
+    await routeReply({
+      payload: {
+        text: "hi",
+        replyToId: "spaces/AAA/threads/thread-2",
+      },
+      channel: "googlechat",
+      to: "spaces/AAA",
+      threadId: "spaces/AAA/threads/thread-2",
+      cfg: {} as never,
+    });
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "googlechat",
+        replyToId: "spaces/AAA/threads/thread-2",
+        threadId: null,
+      }),
     );
   });
 

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -130,7 +130,8 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
   const resolvedReplyToId =
     replyToId ??
     (channelId === "slack" && threadId != null && threadId !== "" ? String(threadId) : undefined);
-  const resolvedThreadId = channelId === "slack" ? null : (threadId ?? null);
+  const resolvedThreadId =
+    channelId === "slack" || channelId === "googlechat" ? null : (threadId ?? null);
 
   try {
     // Provider docking: this is an execution boundary (we're about to send).

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -51,6 +51,11 @@ export type MsgContext = {
   MessageSid?: string;
   /** Provider-specific full message id when MessageSid is a shortened alias. */
   MessageSidFull?: string;
+  /**
+   * Provider-specific reply/reference id for the current turn.
+   * Some channels reply to thread ids instead of message ids.
+   */
+  CurrentMessageId?: string | number;
   MessageSids?: string[];
   MessageSidFirst?: string;
   MessageSidLast?: string;


### PR DESCRIPTION
## Summary

- Problem: Google Chat threaded replies were carrying the inbound thread through a separate implicit `threadId` path, so `replyToMode` filtering on `replyToId` did not actually disable or limit threading.
- Why it matters: `channels.googlechat.replyToMode: \"off\"` still threaded replies, and `\"first\"` could keep threading follow-up payloads after the first reply.
- What changed: Google Chat now stores the thread name as the provider-specific current reply reference, the shared reply pipeline uses that reference for Google Chat payload threading, and routing no longer forwards Google Chat session `threadId` as an unconditional explicit thread target.
- What did NOT change (scope boundary): No config/schema changes for users, no non-Google-Chat behavior changes beyond the shared reply-reference plumbing needed to support provider-specific current reply IDs.

_AI-assisted: yes. Testing: fully tested locally._

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42510
- Related #43076

## User-visible / Behavior Changes

Google Chat now respects `channels.googlechat.replyToMode` in the shared reply pipeline:
- `off` keeps replies in the root conversation
- `first` only threads the first reply
- `all` preserves threaded replies consistently

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Google Chat
- Relevant config (redacted): `channels.googlechat.replyToMode=off|first|all`

### Steps

1. Receive a Google Chat inbound event with `message.thread.name` set.
2. Persist session metadata and build reply payloads through the shared reply pipeline.
3. Send immediate and routed replies for `replyToMode=off`, `first`, and `all`.

### Expected

- `off` strips implicit threading.
- `first` uses the thread only once.
- `all` preserves the Google Chat thread reference consistently.

### Actual

- Before this change, Google Chat could still thread replies through a preserved `threadId` path even after `replyToId` had been filtered out.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: fresh real git clone of the PR branch, `pnpm install`, `pnpm build`, `pnpm check`, `pnpm test`
- Edge cases checked: `replyToMode=off`, `replyToMode=first`, immediate monitor replies, routed shared-pipeline replies, typing-placeholder behavior for threaded replies
- What you did **not** verify: live Google Chat end-to-end against a real service account

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `1bbbf961`
- Files/config to restore: `extensions/googlechat/src/monitor.ts`, `src/auto-reply/reply/route-reply.ts`, `src/auto-reply/reply/agent-runner-utils.ts`
- Known bad symptoms reviewers should watch for: Google Chat replies threading when `replyToMode=off`, or later replies continuing to thread when `replyToMode=first`

## Risks and Mitigations

- Risk: shared reply plumbing now honors provider-specific `CurrentMessageId` for Google Chat, so regressions would show up as incorrect implicit threading rather than explicit send failures.
- Mitigation: added coverage at the monitor layer, shared payload builder, and route-reply boundary.

Made with [Cursor](https://cursor.com)