### PR TITLE
fix(auth): clear stale expiry display for auto-renewable OAuth profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/allowlist store account scoping: keep `/allowlist ... --store` writes scoped to the selected account and clear legacy unscoped entries when removing default-account store access, preventing cross-account default allowlist bleed-through from legacy pairing-store reads. Thanks @tdjackey for reporting and @vincentkoc for the fix.
 - Security/Nostr: harden profile mutation/import loopback guards by failing closed on non-loopback forwarded client headers (`x-forwarded-for` / `x-real-ip`) and rejecting `sec-fetch-site: cross-site`; adds regression coverage for proxy-forwarded and browser cross-site mutation attempts.
 - CLI/bootstrap Node version hint maintenance: replace hardcoded nvm `22` instructions in `openclaw.mjs` with `MIN_NODE_MAJOR` interpolation so future minimum-Node bumps keep startup guidance in sync automatically. (#39056) Thanks @onstash.
+- Auth/status display: clear stale access-token expiry values from auto-renewable OAuth profiles so `openclaw models auth status` no longer shows misleading "ok — expires in 0m" for credentials with a valid refresh token. (#43122, fixes #42721)
 
 ## 2026.3.2
 

--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -63,6 +63,11 @@ describe("buildAuthHealthSummary", () => {
     expect(statuses["anthropic:expired"]).toBe("ok");
     expect(statuses["anthropic:api"]).toBe("static");
 
+    // Genuinely valid "ok" profile preserves its real expiry values
+    const okProfile = summary.profiles.find((p) => p.profileId === "anthropic:ok");
+    expect(okProfile?.expiresAt).toBe(now + DEFAULT_OAUTH_WARN_MS + 60_000);
+    expect(okProfile?.remainingMs).toBe(DEFAULT_OAUTH_WARN_MS + 60_000);
+
     const provider = summary.providers.find((entry) => entry.provider === "anthropic");
     expect(provider?.status).toBe("ok");
   });
@@ -90,6 +95,41 @@ describe("buildAuthHealthSummary", () => {
     const statuses = profileStatuses(summary);
 
     expect(statuses["google:no-refresh"]).toBe("expired");
+  });
+
+  it("clears stale expiry for refreshable expired/expiring OAuth profiles", () => {
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:expired-refreshable": {
+          type: "oauth" as const,
+          provider: "anthropic",
+          access: "access",
+          refresh: "refresh",
+          expires: now - 86_400_000,
+        },
+        "anthropic:expiring-refreshable": {
+          type: "oauth" as const,
+          provider: "anthropic",
+          access: "access",
+          refresh: "refresh",
+          expires: now + 10_000,
+        },
+      },
+    };
+    const summary = buildAuthHealthSummary({
+      store,
+      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    });
+    const expired = summary.profiles.find((p) => p.profileId === "anthropic:expired-refreshable");
+    expect(expired?.status).toBe("ok");
+    expect(expired?.expiresAt).toBeUndefined();
+    expect(expired?.remainingMs).toBeUndefined();
+    const expiring = summary.profiles.find((p) => p.profileId === "anthropic:expiring-refreshable");
+    expect(expiring?.status).toBe("ok");
+    expect(expiring?.expiresAt).toBeUndefined();
+    expect(expiring?.remainingMs).toBeUndefined();
   });
 
   it("marks token profiles with invalid expires as missing with reason code", () => {

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -170,15 +170,17 @@ function buildProfileHealth(params: {
   );
   // OAuth credentials with a valid refresh token auto-renew on first API call,
   // so don't warn about access token expiration.
-  const status =
-    hasRefreshToken && (rawStatus === "expired" || rawStatus === "expiring") ? "ok" : rawStatus;
+  const refreshOverride = hasRefreshToken && (rawStatus === "expired" || rawStatus === "expiring");
+  const status = refreshOverride ? "ok" : rawStatus;
   return {
     profileId,
     provider: credential.provider,
     type: "oauth",
     status,
-    expiresAt: credential.expires,
-    remainingMs,
+    // When the status is overridden to "ok" because auto-refresh will handle it,
+    // clear the stale access-token expiry so callers don't display misleading values.
+    expiresAt: refreshOverride ? undefined : credential.expires,
+    remainingMs: refreshOverride ? undefined : remainingMs,
     source,
     label,
   };

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -618,7 +618,9 @@ export async function modelsStatusCommand(
             ? ""
             : profile.expiresAt
               ? ` expires in ${formatRemainingShort(profile.remainingMs)}`
-              : " expires unknown";
+              : profile.status !== "ok"
+                ? " expires unknown"
+                : "";
         runtime.log(`  - ${label} ${status}${expiry}`);
       }
     }


### PR DESCRIPTION
Fixes #42721

`buildProfileHealth` already overrides the status of refreshable OAuth profiles to `"ok"` (they auto-renew on next API call), but it was still passing through the stale access-token `expiresAt` and `remainingMs` values. Downstream renderers like `models auth status` then displayed contradictory "ok — expires in 0m". This clears both fields when the refresh override fires and suppresses "expires unknown" for profiles already classified as healthy.

### Testing

- `npx vitest run src/agents/auth-health.test.ts` passes (5/5 including new regression test)
- New test covers both expired and expiring refreshable OAuth profiles, asserts `expiresAt` and `remainingMs` are `undefined`
- Existing "ok" profile assertions verify genuinely valid credentials still preserve their real expiry values

### Changelog

Updated.