### PR TITLE
feat(podman): support custom image via OPENCLAW_IMAGE and fix env loading

### DIFF
--- a/scripts/podman/openclaw.container.in
+++ b/scripts/podman/openclaw.container.in
@@ -6,7 +6,7 @@
 Description=OpenClaw gateway (rootless Podman)
 
 [Container]
-Image=openclaw:local
+Image={{IMAGE_NAME}}
 ContainerName=openclaw
 UserNS=keep-id
 # Keep container UID/GID aligned with the invoking user so mounted config is readable.

--- a/scripts/run-openclaw-podman.sh
+++ b/scripts/run-openclaw-podman.sh
@@ -70,11 +70,6 @@ fi
 CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$EFFECTIVE_HOME/.openclaw}"
 ENV_FILE="${OPENCLAW_PODMAN_ENV:-$CONFIG_DIR/.env}"
 WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$CONFIG_DIR/workspace}"
-CONTAINER_NAME="${OPENCLAW_PODMAN_CONTAINER:-openclaw}"
-OPENCLAW_IMAGE="${OPENCLAW_PODMAN_IMAGE:-openclaw:local}"
-PODMAN_PULL="${OPENCLAW_PODMAN_PULL:-never}"
-HOST_GATEWAY_PORT="${OPENCLAW_PODMAN_GATEWAY_HOST_PORT:-${OPENCLAW_GATEWAY_PORT:-18789}}"
-HOST_BRIDGE_PORT="${OPENCLAW_PODMAN_BRIDGE_HOST_PORT:-${OPENCLAW_BRIDGE_PORT:-18790}}"
 
 # Safe cwd for podman (openclaw is nologin; avoid inherited cwd from sudo)
 cd "$EFFECTIVE_HOME" 2>/dev/null || cd /tmp 2>/dev/null || true
@@ -96,6 +91,12 @@ if [[ -f "$ENV_FILE" ]]; then
   source "$ENV_FILE" 2>/dev/null || true
   set +a
 fi
+
+CONTAINER_NAME="${OPENCLAW_PODMAN_CONTAINER:-openclaw}"
+OPENCLAW_IMAGE="${OPENCLAW_PODMAN_IMAGE:-openclaw:local}"
+PODMAN_PULL="${OPENCLAW_PODMAN_PULL:-never}"
+HOST_GATEWAY_PORT="${OPENCLAW_PODMAN_GATEWAY_HOST_PORT:-${OPENCLAW_GATEWAY_PORT:-18789}}"
+HOST_BRIDGE_PORT="${OPENCLAW_PODMAN_BRIDGE_HOST_PORT:-${OPENCLAW_BRIDGE_PORT:-18790}}"
 
 # Keep Podman default local-only unless explicitly overridden.
 # Non-loopback binds require gateway.controlUi.allowedOrigins (security hardening).

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -19,6 +19,7 @@ OPENCLAW_USER="${OPENCLAW_PODMAN_USER:-openclaw}"
 REPO_PATH="${OPENCLAW_REPO_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 RUN_SCRIPT_SRC="$REPO_PATH/scripts/run-openclaw-podman.sh"
 QUADLET_TEMPLATE="$REPO_PATH/scripts/podman/openclaw.container.in"
+IMAGE_NAME="${OPENCLAW_IMAGE:-openclaw:local}"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -238,13 +239,22 @@ if run_as_openclaw test -f "$ENV_FILE"; then
     printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$TOKEN" | run_as_openclaw tee -a "$ENV_FILE" >/dev/null
     echo "Added OPENCLAW_GATEWAY_TOKEN to $ENV_FILE."
   fi
-  run_as_openclaw chmod 600 "$ENV_FILE" 2>/dev/null || true
 else
   TOKEN="$(generate_token_hex_32)"
   printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$TOKEN" | run_as_openclaw tee "$ENV_FILE" >/dev/null
-  run_as_openclaw chmod 600 "$ENV_FILE" 2>/dev/null || true
   echo "Created $ENV_FILE with new token."
 fi
+
+# Upsert OPENCLAW_PODMAN_IMAGE to ensure it loads the correct image on startup
+TMP_ENV_FILE="$OPENCLAW_CONFIG/.env.tmp"
+run_as_openclaw awk -v img="$IMAGE_NAME" '
+  BEGIN { found = 0 }
+  /^OPENCLAW_PODMAN_IMAGE=/ { print "OPENCLAW_PODMAN_IMAGE=" img; found = 1; next }
+  { print }
+  END { if (!found) print "OPENCLAW_PODMAN_IMAGE=" img }
+' "$ENV_FILE" | run_as_openclaw tee "$TMP_ENV_FILE" >/dev/null
+run_as_openclaw mv "$TMP_ENV_FILE" "$ENV_FILE"
+run_as_openclaw chmod 600 "$ENV_FILE" 2>/dev/null || true
 
 # The gateway refuses to start unless gateway.mode=local is set in config.
 # Make first-run non-interactive; users can run the wizard later to configure channels/providers.
@@ -255,26 +265,33 @@ if ! run_as_openclaw test -f "$OPENCLAW_JSON"; then
   echo "Created $OPENCLAW_JSON (minimal gateway.mode=local)."
 fi
 
-echo "Building image from $REPO_PATH..."
-BUILD_ARGS=()
-[[ -n "${OPENCLAW_DOCKER_APT_PACKAGES:-}" ]] && BUILD_ARGS+=(--build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}")
-[[ -n "${OPENCLAW_EXTENSIONS:-}" ]] && BUILD_ARGS+=(--build-arg "OPENCLAW_EXTENSIONS=${OPENCLAW_EXTENSIONS}")
-podman build ${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"} -t openclaw:local -f "$REPO_PATH/Dockerfile" "$REPO_PATH"
+if [[ "$IMAGE_NAME" == "openclaw:local" ]]; then
+  echo "Building image from $REPO_PATH..."
+  BUILD_ARGS=()
+  [[ -n "${OPENCLAW_DOCKER_APT_PACKAGES:-}" ]] && BUILD_ARGS+=(--build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}")
+  [[ -n "${OPENCLAW_EXTENSIONS:-}" ]] && BUILD_ARGS+=(--build-arg "OPENCLAW_EXTENSIONS=${OPENCLAW_EXTENSIONS}")
+  podman build ${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"} -t "$IMAGE_NAME" -f "$REPO_PATH/Dockerfile" "$REPO_PATH"
 
-echo "Loading image into $OPENCLAW_USER's Podman store..."
-TMP_IMAGE_DIR="$(resolve_image_tmp_dir)"
-echo "Using temporary image dir: $TMP_IMAGE_DIR"
-TMP_STAGE_DIR="$(mktemp -d -p "$TMP_IMAGE_DIR" openclaw-image.XXXXXX)"
-TMP_IMAGE="$TMP_STAGE_DIR/image.tar"
-chmod 700 "$TMP_STAGE_DIR"
-trap 'rm -rf "$TMP_STAGE_DIR"' EXIT
-podman save openclaw:local -o "$TMP_IMAGE"
-chmod 600 "$TMP_IMAGE"
-# Stream the image into the target user's podman load so private temp directories
-# do not need to be traversable by $OPENCLAW_USER.
-cat "$TMP_IMAGE" | run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load
-rm -rf "$TMP_STAGE_DIR"
-trap - EXIT
+  # Transfer image from current user's store to openclaw's rootless store.
+  echo "Loading image into $OPENCLAW_USER's Podman store..."
+  TMP_IMAGE_DIR="$(resolve_image_tmp_dir)"
+  echo "Using temporary image dir: $TMP_IMAGE_DIR"
+  TMP_STAGE_DIR="$(mktemp -d -p "$TMP_IMAGE_DIR" openclaw-image.XXXXXX)"
+  TMP_IMAGE="$TMP_STAGE_DIR/image.tar"
+  chmod 700 "$TMP_STAGE_DIR"
+  trap 'rm -rf "$TMP_STAGE_DIR"' EXIT
+  podman save "$IMAGE_NAME" -o "$TMP_IMAGE"
+  chmod 600 "$TMP_IMAGE"
+  cat "$TMP_IMAGE" | run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load
+  rm -rf "$TMP_STAGE_DIR"
+  trap - EXIT
+else
+  echo "Pulling image $IMAGE_NAME into $OPENCLAW_USER's Podman store..."
+  if ! run_as_openclaw podman pull "$IMAGE_NAME"; then
+    echo "ERROR: Failed to pull image $IMAGE_NAME." >&2
+    exit 1
+  fi
+fi
 
 echo "Copying launch script to $LAUNCH_SCRIPT_DST..."
 run_root cat "$RUN_SCRIPT_SRC" | run_as_openclaw tee "$LAUNCH_SCRIPT_DST" >/dev/null
@@ -286,7 +303,8 @@ if [[ "$INSTALL_QUADLET" == true && -f "$QUADLET_TEMPLATE" ]]; then
   echo "Installing systemd quadlet for $OPENCLAW_USER..."
   run_as_openclaw mkdir -p "$QUADLET_DIR"
   OPENCLAW_HOME_SED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_HOME")"
-  sed "s|{{OPENCLAW_HOME}}|$OPENCLAW_HOME_SED|g" "$QUADLET_TEMPLATE" | run_as_openclaw tee "$QUADLET_DIR/openclaw.container" >/dev/null
+  IMAGE_NAME_SED="$(escape_sed_replacement_pipe_delim "$IMAGE_NAME")"
+  sed "s|{{OPENCLAW_HOME}}|$OPENCLAW_HOME_SED|g; s|{{IMAGE_NAME}}|$IMAGE_NAME_SED|g" "$QUADLET_TEMPLATE" | run_as_openclaw tee "$QUADLET_DIR/openclaw.container" >/dev/null
   run_as_openclaw chmod 700 "$OPENCLAW_HOME/.config" "$OPENCLAW_HOME/.config/containers" "$QUADLET_DIR" 2>/dev/null || true
   run_as_openclaw chmod 600 "$QUADLET_DIR/openclaw.container" 2>/dev/null || true
   if command -v systemctl &>/dev/null; then

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -128,7 +128,7 @@ require_cmd podman
 if ! is_root; then
   require_cmd sudo
 fi
-if [[ ! -f "$REPO_PATH/Dockerfile" ]]; then
+if [[ "$IMAGE_NAME" == "openclaw:local" && ! -f "$REPO_PATH/Dockerfile" ]]; then
   echo "Dockerfile not found at $REPO_PATH. Set OPENCLAW_REPO_PATH to the repo root." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The podman setup script strictly built and used the `openclaw:local` image, lacking support for custom images. Furthermore, `run-openclaw-podman.sh` assigned container variables before evaluating the `.env` file, causing custom settings to be ignored.
- Why it matters: Adding custom image support aligns the Podman installation flow with the Docker one (using `OPENCLAW_IMAGE`), giving users the flexibility to pull instead of build. Fixing the `.env` evaluation sequence ensures that environment overrides work correctly across restarts.
- What changed: 
  - `setup-podman.sh` now reads `OPENCLAW_IMAGE` and skips building if a custom image is provided, performing a `podman pull` instead.
  - Sourcing of the `.env` file in `run-openclaw-podman.sh` has been moved up to precede variable initialization.
  - The Podman quadlet template now natively supports dynamically injecting the image name (`{{IMAGE_NAME}}`).
- What did NOT change (scope boundary): The default image remains `openclaw:local`. No changes were made to Docker flows or the core gateway application logic.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

Users can now specify an external image using `OPENCLAW_IMAGE=my/custom-image ./setup-podman.sh` instead of being forced to build locally. Runtime `OPENCLAW_PODMAN_*` config variables now properly override script defaults.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Evaluated custom image fetching and quadlet template matching. Evaluated variable precedence via `.env` in `run-openclaw-podman.sh`.
- Edge cases checked: Empty or undefined `OPENCLAW_IMAGE` falls back safely to building `openclaw:local`.
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
