### PR TITLE
feat(acp): extend persistent bindings to feishu and qqbot channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 - **[Multi-agent routing](https://docs.openclaw.ai/gateway/configuration)** — route inbound channels/accounts/peers to isolated agents (workspaces + per-agent sessions).
 - **[Voice Wake](https://docs.openclaw.ai/nodes/voicewake) + [Talk Mode](https://docs.openclaw.ai/nodes/talk)** — wake words on macOS/iOS and continuous voice on Android (ElevenLabs + system TTS fallback).
 - **[Live Canvas](https://docs.openclaw.ai/platforms/mac/canvas)** — agent-driven visual workspace with [A2UI](https://docs.openclaw.ai/platforms/mac/canvas#canvas-a2ui).
+- **[ACP agent runtime](https://docs.openclaw.ai/tools/acp-agents)** — use Claude Code, Codex, OpenCode, or Gemini CLI as the agent engine. Reuse your existing subscriptions with a single config change (`acp.defaultChannels`).
 - **[First-class tools](https://docs.openclaw.ai/tools)** — browser, canvas, nodes, cron, sessions, and Discord/Slack actions.
 - **[Companion apps](https://docs.openclaw.ai/platforms/macos)** — macOS menu bar app + iOS/Android [nodes](https://docs.openclaw.ai/nodes).
 - **[Onboarding](https://docs.openclaw.ai/start/wizard) + [skills](https://docs.openclaw.ai/tools/skills)** — wizard-driven setup with bundled/managed/workspace skills.
@@ -144,7 +145,7 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 
 - [Gateway WS control plane](https://docs.openclaw.ai/gateway) with sessions, presence, config, cron, webhooks, [Control UI](https://docs.openclaw.ai/web), and [Canvas host](https://docs.openclaw.ai/platforms/mac/canvas#canvas-a2ui).
 - [CLI surface](https://docs.openclaw.ai/tools/agent-send): gateway, agent, send, [wizard](https://docs.openclaw.ai/start/wizard), and [doctor](https://docs.openclaw.ai/gateway/doctor).
-- [Pi agent runtime](https://docs.openclaw.ai/concepts/agent) in RPC mode with tool streaming and block streaming.
+- [Pi agent runtime](https://docs.openclaw.ai/concepts/agent) in RPC mode with tool streaming and block streaming. [ACP agent runtime](https://docs.openclaw.ai/tools/acp-agents) for external agent CLIs (Claude Code, Codex, OpenCode, Gemini CLI).
 - [Session model](https://docs.openclaw.ai/concepts/session): `main` for direct chats, group isolation, activation modes, queue modes, reply-back. Group rules: [Groups](https://docs.openclaw.ai/channels/groups).
 - [Media pipeline](https://docs.openclaw.ai/nodes/images): images/audio/video, transcription hooks, size caps, temp file lifecycle. Audio details: [Audio](https://docs.openclaw.ai/nodes/audio).
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -140,6 +140,22 @@ This is useful when you want every message on a channel to route through an ACP 
 
 When a specific peer binding and a catch-all binding both match, the specific peer binding takes priority.
 
+### Quick start: route all Feishu/QQ messages through ACP
+
+Add this to your `openclaw.json` to make all Feishu and QQ conversations use your paid agent CLI (Claude Code, Codex, etc.) instead of the built-in PI agent:
+
+```json5
+{
+  acp: { enabled: true, backend: "acpx", defaultAgent: "claude" },
+  bindings: [
+    { type: "acp", agentId: "main", match: { channel: "feishu", accountId: "*" } },
+    { type: "acp", agentId: "main", match: { channel: "qqbot", accountId: "*" } },
+  ],
+}
+```
+
+Replace `"claude"` with `"codex"` or another ACP agent id to use a different harness. The `accountId: "*"` wildcard matches all bot accounts on that channel.
+
 ### Runtime defaults per agent
 
 Use `agents.list[].runtime` to define ACP defaults once per agent:

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -147,9 +147,7 @@ This is useful when you want every message on a channel to route through an ACP 
     },
   ],
   acp: {
-    enabled: true,
-    backend: "acpx",
-    defaultAgent: "claude",
+    defaultAgent: "claude", // or "codex", "opencode", "gemini"
   },
 }
 ```
@@ -158,23 +156,22 @@ When a specific peer binding and a catch-all binding both match, the specific pe
 
 ### Quick start: route all channel messages through ACP
 
-Use `acp.defaultChannels` to make all conversations on a channel use ACP automatically. No `bindings[]` entries needed. Each conversation gets its own isolated ACP session.
+Use `acp.defaultChannels` to make all conversations on a channel use ACP automatically. No `bindings[]` entries needed. Each conversation gets its own isolated ACP session. This lets you reuse your existing Claude Code or Codex subscription as the agent engine.
 
-This lets you reuse your existing Claude Code or Codex subscription as the agent engine with a single config change.
-
-**CLI (one command):**
+**CLI (two commands):**
 
 ```sh
+openclaw config set acp.defaultAgent claude
 openclaw config set acp.defaultChannels '["feishu","qqbot"]'
 ```
+
+Replace `claude` with `codex`, `opencode`, or `gemini` to use a different agent CLI. The `acpx` backend plugin auto-enables when `defaultChannels` is set.
 
 **Config file (`openclaw.json`):**
 
 ```json5
 {
   acp: {
-    enabled: true,
-    backend: "acpx",
     defaultAgent: "claude", // or "codex", "opencode", "gemini"
     defaultChannels: ["feishu", "qqbot"],
   },

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -160,7 +160,7 @@ When a specific peer binding and a catch-all binding both match, the specific pe
 
 Use `acp.defaultChannels` to make all conversations on a channel use ACP automatically. No `bindings[]` entries needed. Each conversation gets its own isolated ACP session.
 
-This lets you reuse your existing Claude Code or Codex subscription as the core agent engine, replacing the built-in PI agent with a single config change.
+This lets you reuse your existing Claude Code or Codex subscription as the agent engine with a single config change.
 
 **CLI (one command):**
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -62,6 +62,22 @@ Use ACP when you want an external harness runtime. Use sub-agents when you want 
 
 See also [Sub-agents](/tools/subagents).
 
+### ACP versus embedded Pi agent
+
+ACP sessions use an external agent CLI (Claude Code, Codex, etc.) as the core agent engine. When ACP is active for a session, the agent CLI fully handles thinking, tool execution, and context management. OpenClaw serves as the orchestration layer — routing messages, managing session lifecycle, and delivering responses back to channels.
+
+| Feature            | Embedded Pi                                               | ACP session                                               |
+| ------------------ | --------------------------------------------------------- | --------------------------------------------------------- |
+| Tool execution     | OpenClaw tools (browser, canvas, nodes, cron)             | Agent CLI native tools (file edit, terminal, search, web) |
+| Context/compaction | OpenClaw session store + memory flush                     | Agent CLI native context management                       |
+| Skills             | OpenClaw skills platform                                  | Agent CLI native capabilities (AGENTS.md, MCP, etc.)      |
+| Media              | Images, audio, video, documents                           | Images (audio/video/documents forwarded as text context)  |
+| Group messages     | Activation gating, lurking, group context injection       | All messages forwarded to agent CLI                       |
+| Model              | Per-message directives, channel overrides, failover chain | Controlled by agent CLI subscription                      |
+| Streaming          | OpenClaw block streaming                                  | ACP projector with configurable delivery modes            |
+
+For coding and development workflows, agent CLIs like Claude Code and Codex provide a more capable tool set (file editing, terminal execution, code search, git operations) than the embedded Pi runtime.
+
 ## Thread-bound sessions (channel-agnostic)
 
 When thread bindings are enabled for a channel adapter, ACP sessions can be bound to threads:
@@ -140,21 +156,34 @@ This is useful when you want every message on a channel to route through an ACP 
 
 When a specific peer binding and a catch-all binding both match, the specific peer binding takes priority.
 
-### Quick start: route all Feishu/QQ messages through ACP
+### Quick start: route all channel messages through ACP
 
-Add this to your `openclaw.json` to make all Feishu and QQ conversations use your paid agent CLI (Claude Code, Codex, etc.) instead of the built-in PI agent:
+Use `acp.defaultChannels` to make all conversations on a channel use ACP automatically. No `bindings[]` entries needed. Each conversation gets its own isolated ACP session.
+
+This lets you reuse your existing Claude Code or Codex subscription as the core agent engine, replacing the built-in PI agent with a single config change.
+
+**CLI (one command):**
+
+```sh
+openclaw config set acp.defaultChannels '["feishu","qqbot"]'
+```
+
+**Config file (`openclaw.json`):**
 
 ```json5
 {
-  acp: { enabled: true, backend: "acpx", defaultAgent: "claude" },
-  bindings: [
-    { type: "acp", agentId: "main", match: { channel: "feishu", accountId: "*" } },
-    { type: "acp", agentId: "main", match: { channel: "qqbot", accountId: "*" } },
-  ],
+  acp: {
+    enabled: true,
+    backend: "acpx",
+    defaultAgent: "claude", // or "codex", "opencode", "gemini"
+    defaultChannels: ["feishu", "qqbot"],
+  },
 }
 ```
 
-Replace `"claude"` with `"codex"` or another ACP agent id to use a different harness. The `accountId: "*"` wildcard matches all bot accounts on that channel.
+Supported values: `"discord"`, `"telegram"`, `"feishu"`, `"qqbot"`.
+
+Explicit `bindings[]` entries always take priority over `defaultChannels` when both match the same conversation, so you can still use fine-grained bindings for specific conversations while using `defaultChannels` as the catch-all.
 
 ### Runtime defaults per agent
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -99,12 +99,46 @@ For non-ephemeral workflows, configure persistent ACP bindings in top-level `bin
 - `bindings[].match` identifies the target conversation:
   - Discord channel or thread: `match.channel="discord"` + `match.peer.id="<channelOrThreadId>"`
   - Telegram forum topic: `match.channel="telegram"` + `match.peer.id="<chatId>:topic:<topicId>"`
+  - Feishu conversation: `match.channel="feishu"` + optional `match.peer.id="<openId>"`
+  - QQ bot conversation: `match.channel="qqbot"` + optional `match.peer.id="<senderId>"`
 - `bindings[].agentId` is the owning OpenClaw agent id.
 - Optional ACP overrides live under `bindings[].acp`:
   - `mode` (`persistent` or `oneshot`)
   - `label`
   - `cwd`
   - `backend`
+
+### Channel-wide catch-all bindings
+
+Feishu and QQ bot support catch-all ACP bindings where `match.peer` is omitted. When peer is omitted, the binding matches all conversations on that channel/account. Each conversation still gets its own isolated ACP session.
+
+This is useful when you want every message on a channel to route through an ACP harness agent (for example Claude Code or Codex) instead of the embedded PI agent.
+
+```json5
+{
+  bindings: [
+    // All Feishu conversations -> ACP with Claude Code
+    {
+      type: "acp",
+      agentId: "main",
+      match: { channel: "feishu", accountId: "*" },
+    },
+    // All QQ bot conversations -> ACP with Claude Code
+    {
+      type: "acp",
+      agentId: "main",
+      match: { channel: "qqbot", accountId: "*" },
+    },
+  ],
+  acp: {
+    enabled: true,
+    backend: "acpx",
+    defaultAgent: "claude",
+  },
+}
+```
+
+When a specific peer binding and a catch-all binding both match, the specific peer binding takes priority.
 
 ### Runtime defaults per agent
 
@@ -169,6 +203,18 @@ Example:
         peer: { kind: "group", id: "-1001234567890:topic:42" },
       },
       acp: { cwd: "/workspace/repo-b" },
+    },
+    // Feishu catch-all: all conversations on this account use ACP
+    {
+      type: "acp",
+      agentId: "claude",
+      match: { channel: "feishu", accountId: "*" },
+    },
+    // QQ catch-all
+    {
+      type: "acp",
+      agentId: "claude",
+      match: { channel: "qqbot", accountId: "*" },
     },
     {
       type: "route",

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -5,10 +5,12 @@ import {
   clearHistoryEntriesIfEnabled,
   createScopedPairingAccess,
   DEFAULT_GROUP_HISTORY_LIMIT,
+  ensureConfiguredAcpRouteReady,
   type HistoryEntry,
   issuePairingChallenge,
   normalizeAgentId,
   recordPendingHistoryEntryIfEnabled,
+  resolveConfiguredAcpRoute,
   resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
@@ -1203,6 +1205,26 @@ export async function handleFeishuMessage(params: {
             `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
           );
         }
+      }
+    }
+
+    // ACP persistent binding resolution
+    const configuredRoute = resolveConfiguredAcpRoute({
+      cfg: effectiveCfg,
+      route,
+      channel: "feishu",
+      accountId: account.accountId,
+      conversationId: peerId,
+    });
+    const configuredBinding = configuredRoute.configuredBinding;
+    route = configuredRoute.route;
+    if (configuredBinding) {
+      const ensured = await ensureConfiguredAcpRouteReady({
+        cfg: effectiveCfg,
+        configuredBinding,
+      });
+      if (!ensured.ok) {
+        log(`feishu[${account.accountId}]: acp binding session init failed: ${ensured.error}`);
       }
     }
 

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -423,6 +423,22 @@ export function resolveConfiguredAcpBindingRecord(params: {
   if (defaultChannels.includes(channel)) {
     const bindingChannel = normalizeBindingChannel(channel);
     if (bindingChannel) {
+      // Telegram requires topic normalization so the session key hash stays
+      // consistent with explicit binding paths.
+      let effectiveConversationId = conversationId;
+      let effectiveParentConversationId = parentConversationId;
+      if (bindingChannel === "telegram") {
+        const parsed = parseTelegramTopicConversation({
+          conversationId,
+          parentConversationId,
+        });
+        if (!parsed || !parsed.chatId.startsWith("-")) {
+          return null;
+        }
+        effectiveConversationId = parsed.canonicalConversationId;
+        effectiveParentConversationId = parsed.chatId;
+      }
+
       const agentId = pickFirstExistingAgentId(params.cfg, "main");
       const runtimeDefaults = resolveAgentRuntimeAcpDefaults({
         cfg: params.cfg,
@@ -431,8 +447,8 @@ export function resolveConfiguredAcpBindingRecord(params: {
       const spec: ConfiguredAcpBindingSpec = {
         channel: bindingChannel,
         accountId,
-        conversationId,
-        parentConversationId,
+        conversationId: effectiveConversationId,
+        parentConversationId: effectiveParentConversationId,
         agentId,
         acpAgentId: normalizeText(runtimeDefaults.acpAgentId),
         mode: normalizeMode(runtimeDefaults.mode),

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -366,8 +366,13 @@ export function resolveConfiguredAcpBindingRecord(params: {
 
   // Feishu and QQ use direct conversationId matching.
   // When a binding omits peer.id it acts as a catch-all for the channel/account.
+  // Peer-specific bindings always take priority over catch-all bindings,
+  // regardless of declaration order.
   if (channel === "feishu" || channel === "qqbot") {
-    let wildcardMatch: AgentAcpBinding | null = null;
+    let peerExactMatch: AgentAcpBinding | null = null;
+    let peerWildcardMatch: AgentAcpBinding | null = null;
+    let catchAllExactMatch: AgentAcpBinding | null = null;
+    let catchAllWildcardMatch: AgentAcpBinding | null = null;
     for (const binding of listAcpBindings(params.cfg)) {
       if (normalizeBindingChannel(binding.match.channel) !== channel) {
         continue;
@@ -377,33 +382,35 @@ export function resolveConfiguredAcpBindingRecord(params: {
         continue;
       }
       const bindingConversationId = resolveBindingConversationId(binding);
-      if (bindingConversationId && bindingConversationId !== conversationId) {
-        continue;
-      }
-      if (accountMatchPriority === 2) {
-        const spec = toConfiguredBindingSpec({
-          cfg: params.cfg,
-          channel,
-          accountId,
-          conversationId,
-          binding,
-        });
-        return {
-          spec,
-          record: toConfiguredAcpBindingRecord(spec),
-        };
-      }
-      if (!wildcardMatch) {
-        wildcardMatch = binding;
+      if (bindingConversationId) {
+        // Peer-specific binding — must match conversationId exactly.
+        if (bindingConversationId !== conversationId) {
+          continue;
+        }
+        if (accountMatchPriority === 2 && !peerExactMatch) {
+          peerExactMatch = binding;
+        } else if (!peerWildcardMatch) {
+          peerWildcardMatch = binding;
+        }
+      } else {
+        // Catch-all binding (no peer.id).
+        if (accountMatchPriority === 2 && !catchAllExactMatch) {
+          catchAllExactMatch = binding;
+        } else if (!catchAllWildcardMatch) {
+          catchAllWildcardMatch = binding;
+        }
       }
     }
-    if (wildcardMatch) {
+    // Priority: peer exact > peer wildcard > catch-all exact > catch-all wildcard.
+    const bestMatch =
+      peerExactMatch ?? peerWildcardMatch ?? catchAllExactMatch ?? catchAllWildcardMatch;
+    if (bestMatch) {
       const spec = toConfiguredBindingSpec({
         cfg: params.cfg,
         channel,
         accountId,
         conversationId,
-        binding: wildcardMatch,
+        binding: bestMatch,
       });
       return {
         spec,

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -147,6 +147,10 @@ export function resolveConfiguredAcpBindingSpecBySessionKey(params: {
     if (accountMatchPriority === 0) {
       continue;
     }
+    // Reverse lookup requires a concrete conversationId to rebuild the session
+    // key hash. Catch-all bindings (no peer.id) cannot be matched here because
+    // the hash is one-way; those sessions rely on stored session meta instead
+    // (see resetAcpSessionInPlace).
     const targetConversationId = resolveBindingConversationId(binding);
     if (!targetConversationId) {
       continue;

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -296,7 +296,7 @@ export function resolveConfiguredAcpBindingRecord(params: {
         return inheritedMatch;
       }
     }
-    return null;
+    // No explicit binding matched; fall through to defaultChannels check.
   }
 
   if (channel === "telegram") {
@@ -361,7 +361,7 @@ export function resolveConfiguredAcpBindingRecord(params: {
         record: toConfiguredAcpBindingRecord(spec),
       };
     }
-    return null;
+    // No explicit binding matched; fall through to defaultChannels check.
   }
 
   // Feishu and QQ use direct conversationId matching.
@@ -410,7 +410,40 @@ export function resolveConfiguredAcpBindingRecord(params: {
         record: toConfiguredAcpBindingRecord(spec),
       };
     }
-    return null;
+    // No explicit binding matched; fall through to defaultChannels check.
+  }
+
+  // Implicit ACP binding via acp.defaultChannels — when no explicit binding
+  // matched but the channel is listed in defaultChannels, synthesize a
+  // catch-all binding spec on the fly. This lets users enable ACP for entire
+  // channels with a single config line instead of writing bindings[] entries.
+  const defaultChannels = (params.cfg.acp?.defaultChannels ?? []).map((c) =>
+    c.trim().toLowerCase(),
+  );
+  if (defaultChannels.includes(channel)) {
+    const bindingChannel = normalizeBindingChannel(channel);
+    if (bindingChannel) {
+      const agentId = pickFirstExistingAgentId(params.cfg, "main");
+      const runtimeDefaults = resolveAgentRuntimeAcpDefaults({
+        cfg: params.cfg,
+        ownerAgentId: agentId,
+      });
+      const spec: ConfiguredAcpBindingSpec = {
+        channel: bindingChannel,
+        accountId,
+        conversationId,
+        parentConversationId,
+        agentId,
+        acpAgentId: normalizeText(runtimeDefaults.acpAgentId),
+        mode: normalizeMode(runtimeDefaults.mode),
+        cwd: runtimeDefaults.cwd,
+        backend: runtimeDefaults.backend,
+      };
+      return {
+        spec,
+        record: toConfiguredAcpBindingRecord(spec),
+      };
+    }
   }
 
   return null;

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -21,7 +21,12 @@ import {
 
 function normalizeBindingChannel(value: string | undefined): ConfiguredAcpBindingChannel | null {
   const normalized = (value ?? "").trim().toLowerCase();
-  if (normalized === "discord" || normalized === "telegram") {
+  if (
+    normalized === "discord" ||
+    normalized === "telegram" ||
+    normalized === "feishu" ||
+    normalized === "qqbot"
+  ) {
     return normalized;
   }
   return null;
@@ -150,6 +155,24 @@ export function resolveConfiguredAcpBindingSpecBySessionKey(params: {
       const spec = toConfiguredBindingSpec({
         cfg: params.cfg,
         channel: "discord",
+        accountId: parsedSessionKey.accountId,
+        conversationId: targetConversationId,
+        binding,
+      });
+      if (buildConfiguredAcpSessionKey(spec) === sessionKey) {
+        if (accountMatchPriority === 2) {
+          return spec;
+        }
+        if (!wildcardMatch) {
+          wildcardMatch = spec;
+        }
+      }
+      continue;
+    }
+    if (channel === "feishu" || channel === "qqbot") {
+      const spec = toConfiguredBindingSpec({
+        cfg: params.cfg,
+        channel,
         accountId: parsedSessionKey.accountId,
         conversationId: targetConversationId,
         binding,
@@ -327,6 +350,55 @@ export function resolveConfiguredAcpBindingRecord(params: {
         accountId,
         conversationId: parsed.canonicalConversationId,
         parentConversationId: parsed.chatId,
+        binding: wildcardMatch,
+      });
+      return {
+        spec,
+        record: toConfiguredAcpBindingRecord(spec),
+      };
+    }
+    return null;
+  }
+
+  // Feishu and QQ use direct conversationId matching.
+  // When a binding omits peer.id it acts as a catch-all for the channel/account.
+  if (channel === "feishu" || channel === "qqbot") {
+    let wildcardMatch: AgentAcpBinding | null = null;
+    for (const binding of listAcpBindings(params.cfg)) {
+      if (normalizeBindingChannel(binding.match.channel) !== channel) {
+        continue;
+      }
+      const accountMatchPriority = resolveAccountMatchPriority(binding.match.accountId, accountId);
+      if (accountMatchPriority === 0) {
+        continue;
+      }
+      const bindingConversationId = resolveBindingConversationId(binding);
+      if (bindingConversationId && bindingConversationId !== conversationId) {
+        continue;
+      }
+      if (accountMatchPriority === 2) {
+        const spec = toConfiguredBindingSpec({
+          cfg: params.cfg,
+          channel,
+          accountId,
+          conversationId,
+          binding,
+        });
+        return {
+          spec,
+          record: toConfiguredAcpBindingRecord(spec),
+        };
+      }
+      if (!wildcardMatch) {
+        wildcardMatch = binding;
+      }
+    }
+    if (wildcardMatch) {
+      const spec = toConfiguredBindingSpec({
+        cfg: params.cfg,
+        channel,
+        accountId,
+        conversationId,
         binding: wildcardMatch,
       });
       return {

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -564,6 +564,41 @@ describe("resolveConfiguredAcpBindingSpecBySessionKey", () => {
     expect(spec?.conversationId).toBe("ou_abc123");
     expect(spec?.agentId).toBe("claude");
   });
+
+  it("returns null for catch-all feishu binding reverse lookup (hash is one-way)", () => {
+    const cfg = {
+      ...baseCfg,
+      bindings: [
+        {
+          type: "acp",
+          agentId: "claude",
+          match: {
+            channel: "feishu",
+            accountId: "*",
+          },
+        },
+      ],
+    } satisfies OpenClawConfig;
+
+    // Forward resolution works — catch-all matches any conversation.
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "main",
+      conversationId: "ou_xyz789",
+    });
+    expect(resolved?.spec.channel).toBe("feishu");
+
+    // Reverse lookup returns null because the session key hash is one-way
+    // and catch-all bindings have no peer.id to rebuild the hash from.
+    // Sessions created via catch-all rely on stored session meta for
+    // re-initialization (see resetAcpSessionInPlace).
+    const spec = resolveConfiguredAcpBindingSpecBySessionKey({
+      cfg,
+      sessionKey: resolved?.record.targetSessionKey ?? "",
+    });
+    expect(spec).toBeNull();
+  });
 });
 
 describe("buildConfiguredAcpSessionKey", () => {

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -688,6 +688,41 @@ describe("acp.defaultChannels implicit binding", () => {
     expect(resolved?.spec.acpAgentId).toBe("claude");
     expect(resolved?.spec.backend).toBe("acpx");
   });
+
+  it("normalizes telegram topic conversationId when synthesizing via defaultChannels", () => {
+    const cfg = {
+      ...baseCfg,
+      acp: { defaultChannels: ["telegram"] },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "telegram",
+      accountId: "main",
+      conversationId: "-1001234567890:topic:42",
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.spec.channel).toBe("telegram");
+    expect(resolved?.spec.conversationId).toBe("-1001234567890:topic:42");
+    expect(resolved?.spec.parentConversationId).toBe("-1001234567890");
+  });
+
+  it("returns null for telegram DMs even when telegram is in defaultChannels", () => {
+    const cfg = {
+      ...baseCfg,
+      acp: { defaultChannels: ["telegram"] },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "telegram",
+      accountId: "main",
+      conversationId: "123456789",
+    });
+
+    expect(resolved).toBeNull();
+  });
 });
 
 describe("buildConfiguredAcpSessionKey", () => {

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -601,6 +601,95 @@ describe("resolveConfiguredAcpBindingSpecBySessionKey", () => {
   });
 });
 
+describe("acp.defaultChannels implicit binding", () => {
+  it("synthesizes an ACP binding when channel is in defaultChannels and no explicit binding exists", () => {
+    const cfg = {
+      ...baseCfg,
+      acp: { defaultChannels: ["feishu"] },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "main",
+      conversationId: "ou_abc123",
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.spec.channel).toBe("feishu");
+    expect(resolved?.spec.conversationId).toBe("ou_abc123");
+    expect(resolved?.spec.agentId).toBe("codex");
+    expect(resolved?.spec.mode).toBe("persistent");
+  });
+
+  it("explicit binding takes priority over defaultChannels", () => {
+    const cfg = {
+      ...baseCfg,
+      acp: { defaultChannels: ["feishu"] },
+      bindings: [
+        {
+          type: "acp",
+          agentId: "claude",
+          match: { channel: "feishu", accountId: "*" },
+        },
+      ],
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "main",
+      conversationId: "ou_abc123",
+    });
+
+    expect(resolved?.spec.agentId).toBe("claude");
+  });
+
+  it("does not synthesize binding for channels not in defaultChannels", () => {
+    const cfg = {
+      ...baseCfg,
+      acp: { defaultChannels: ["feishu"] },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "qqbot",
+      accountId: "main",
+      conversationId: "group123",
+    });
+
+    expect(resolved).toBeNull();
+  });
+
+  it("uses agent runtime ACP defaults when synthesizing binding", () => {
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        list: [
+          {
+            id: "main",
+            runtime: {
+              type: "acp",
+              acp: { agent: "claude", backend: "acpx", mode: "persistent" },
+            },
+          },
+        ],
+      },
+      acp: { defaultChannels: ["qqbot"] },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "qqbot",
+      accountId: "default",
+      conversationId: "group456",
+    });
+
+    expect(resolved?.spec.acpAgentId).toBe("claude");
+    expect(resolved?.spec.backend).toBe("acpx");
+  });
+});
+
 describe("buildConfiguredAcpSessionKey", () => {
   it("is deterministic for the same conversation binding", () => {
     const sessionKeyA = buildConfiguredAcpSessionKey({

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -320,6 +320,127 @@ describe("resolveConfiguredAcpBindingRecord", () => {
     expect(resolved?.spec.cwd).toBe("/workspace/repo-a");
     expect(resolved?.spec.backend).toBe("acpx");
   });
+  it("resolves feishu catch-all ACP binding when peer is omitted", () => {
+    const cfg = {
+      ...baseCfg,
+      bindings: [
+        {
+          type: "acp",
+          agentId: "claude",
+          match: {
+            channel: "feishu",
+            accountId: "*",
+          },
+        },
+      ],
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "main",
+      conversationId: "ou_abc123",
+    });
+
+    expect(resolved?.spec.channel).toBe("feishu");
+    expect(resolved?.spec.conversationId).toBe("ou_abc123");
+    expect(resolved?.spec.agentId).toBe("claude");
+    expect(resolved?.record.targetSessionKey).toContain("agent:claude:acp:binding:feishu:");
+  });
+
+  it("resolves feishu binding with specific peer over catch-all", () => {
+    const cfg = {
+      ...baseCfg,
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "feishu",
+            accountId: "*",
+          },
+        },
+        {
+          type: "acp",
+          agentId: "claude",
+          match: {
+            channel: "feishu",
+            accountId: "main",
+            peer: { kind: "direct", id: "ou_specific" },
+          },
+        },
+      ],
+    } satisfies OpenClawConfig;
+
+    const specific = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "main",
+      conversationId: "ou_specific",
+    });
+    const other = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "main",
+      conversationId: "ou_other",
+    });
+
+    expect(specific?.spec.agentId).toBe("claude");
+    expect(other?.spec.agentId).toBe("codex");
+  });
+
+  it("resolves qqbot catch-all ACP binding", () => {
+    const cfg = {
+      ...baseCfg,
+      bindings: [
+        {
+          type: "acp",
+          agentId: "claude",
+          match: {
+            channel: "qqbot",
+            accountId: "*",
+          },
+        },
+      ],
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "qqbot",
+      accountId: "default",
+      conversationId: "sender-123",
+    });
+
+    expect(resolved?.spec.channel).toBe("qqbot");
+    expect(resolved?.spec.conversationId).toBe("sender-123");
+    expect(resolved?.spec.agentId).toBe("claude");
+  });
+
+  it("returns null for feishu when no binding matches", () => {
+    const cfg = {
+      ...baseCfg,
+      bindings: [
+        {
+          type: "acp",
+          agentId: "claude",
+          match: {
+            channel: "discord",
+            accountId: "*",
+            peer: { kind: "channel", id: "some-channel" },
+          },
+        },
+      ],
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "main",
+      conversationId: "ou_abc123",
+    });
+
+    expect(resolved).toBeNull();
+  });
 });
 
 describe("resolveConfiguredAcpBindingSpecBySessionKey", () => {
@@ -410,6 +531,38 @@ describe("resolveConfiguredAcpBindingSpecBySessionKey", () => {
     });
 
     expect(spec?.backend).toBe("exact");
+  });
+
+  it("maps a feishu binding session key back to its spec when peer is specified", () => {
+    const cfg = {
+      ...baseCfg,
+      bindings: [
+        {
+          type: "acp",
+          agentId: "claude",
+          match: {
+            channel: "feishu",
+            accountId: "main",
+            peer: { kind: "direct", id: "ou_abc123" },
+          },
+        },
+      ],
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "main",
+      conversationId: "ou_abc123",
+    });
+    const spec = resolveConfiguredAcpBindingSpecBySessionKey({
+      cfg,
+      sessionKey: resolved?.record.targetSessionKey ?? "",
+    });
+
+    expect(spec?.channel).toBe("feishu");
+    expect(spec?.conversationId).toBe("ou_abc123");
+    expect(spec?.agentId).toBe("claude");
   });
 });
 

--- a/src/acp/persistent-bindings.types.ts
+++ b/src/acp/persistent-bindings.types.ts
@@ -3,7 +3,7 @@ import type { SessionBindingRecord } from "../infra/outbound/session-binding-ser
 import { sanitizeAgentId } from "../routing/session-key.js";
 import type { AcpRuntimeSessionMode } from "./runtime/types.js";
 
-export type ConfiguredAcpBindingChannel = "discord" | "telegram";
+export type ConfiguredAcpBindingChannel = "discord" | "telegram" | "feishu" | "qqbot";
 
 export type ConfiguredAcpBindingSpec = {
   channel: ConfiguredAcpBindingChannel;

--- a/src/auto-reply/reply/commands-subagents/action-agents.ts
+++ b/src/auto-reply/reply/commands-subagents/action-agents.ts
@@ -64,9 +64,12 @@ export function handleSubagentsAgentsAction(ctx: SubagentsCommandContext): Comma
             channel,
             conversationId: binding.conversation.conversationId,
           })
-        : channel === "discord" || channel === "telegram"
+        : channel === "discord" ||
+            channel === "telegram" ||
+            channel === "feishu" ||
+            channel === "qqbot"
           ? "unbound"
-          : "bindings available on discord/telegram";
+          : "bindings available on supported channels";
       lines.push(`${index}. ${formatRunLabel(entry)} (${bindingText})`);
       index += 1;
     }

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -328,6 +328,38 @@ describe("applyPluginAutoEnable", () => {
     expect(result.changes.join("\n")).toContain("ACP runtime configured, enabled automatically.");
   });
 
+  it("auto-enables acpx plugin when acp.defaultChannels is set", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        acp: {
+          defaultChannels: ["feishu", "qqbot"],
+        },
+      },
+      env: {},
+    });
+
+    expect(result.config.plugins?.entries?.acpx?.enabled).toBe(true);
+    expect(result.changes.join("\n")).toContain("ACP runtime configured, enabled automatically.");
+  });
+
+  it("auto-enables acpx plugin when ACP bindings exist", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        bindings: [
+          {
+            type: "acp",
+            agentId: "main",
+            match: { channel: "feishu", accountId: "*" },
+          },
+        ],
+      },
+      env: {},
+    });
+
+    expect(result.config.plugins?.entries?.acpx?.enabled).toBe(true);
+    expect(result.changes.join("\n")).toContain("ACP runtime configured, enabled automatically.");
+  });
+
   it("does not auto-enable acpx when a different ACP backend is configured", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -358,8 +358,15 @@ function resolveConfiguredPlugins(
   }
   const backendRaw =
     typeof cfg.acp?.backend === "string" ? cfg.acp.backend.trim().toLowerCase() : "";
+  const hasDefaultChannels =
+    Array.isArray(cfg.acp?.defaultChannels) && cfg.acp.defaultChannels.length > 0;
+  const hasAcpBindings = Array.isArray(cfg.bindings) && cfg.bindings.some((b) => b?.type === "acp");
   const acpConfigured =
-    cfg.acp?.enabled === true || cfg.acp?.dispatch?.enabled === true || backendRaw === "acpx";
+    cfg.acp?.enabled === true ||
+    cfg.acp?.dispatch?.enabled === true ||
+    backendRaw === "acpx" ||
+    hasDefaultChannels ||
+    hasAcpBindings;
   if (acpConfigured && (!backendRaw || backendRaw === "acpx")) {
     changes.push({
       pluginId: "acpx",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -176,6 +176,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Fallback ACP target agent id used when ACP spawns do not specify an explicit target.",
   "acp.allowedAgents":
     "Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.",
+  "acp.defaultChannels":
+    'Channels that implicitly use ACP for all conversations when no explicit binding matches. Supported: "discord", "telegram", "feishu", "qqbot". Each conversation gets its own ACP session using the defaultAgent.',
   "acp.maxConcurrentSessions":
     "Maximum concurrently active ACP sessions across this gateway process.",
   "acp.stream":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -409,6 +409,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "acp.dispatch.enabled": "ACP Dispatch Enabled",
   "acp.backend": "ACP Backend",
   "acp.defaultAgent": "ACP Default Agent",
+  "acp.defaultChannels": "ACP Default Channels",
   "acp.allowedAgents": "ACP Allowed Agents",
   "acp.maxConcurrentSessions": "ACP Max Concurrent Sessions",
   "acp.stream": "ACP Stream",

--- a/src/config/types.acp.ts
+++ b/src/config/types.acp.ts
@@ -42,6 +42,12 @@ export type AcpConfig = {
   backend?: string;
   defaultAgent?: string;
   allowedAgents?: string[];
+  /**
+   * Channels that implicitly use ACP for all conversations when no explicit
+   * binding matches. Supported values: "discord", "telegram", "feishu", "qqbot".
+   * Each conversation gets its own ACP session using the defaultAgent.
+   */
+  defaultChannels?: string[];
   maxConcurrentSessions?: number;
   stream?: AcpStreamConfig;
   runtime?: AcpRuntimeConfig;

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -85,6 +85,17 @@ const AcpBindingSchema = z
       });
       return;
     }
+    // Feishu/QQ allow omitting peer entirely (catch-all), but if peer is
+    // provided its id must be non-empty to avoid accidental catch-all.
+    if ((channel === "feishu" || channel === "qqbot") && value.match.peer && !peerId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["match", "peer", "id"],
+        message:
+          "Feishu/QQ ACP bindings require a non-empty peer.id when match.peer is specified. Omit peer entirely for catch-all.",
+      });
+      return;
+    }
     if (channel === "telegram" && !/^-\d+:topic:\d+$/.test(peerId)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -62,20 +62,26 @@ const AcpBindingSchema = z
   .strict()
   .superRefine((value, ctx) => {
     const peerId = value.match.peer?.id?.trim() ?? "";
-    if (!peerId) {
+    const channel = value.match.channel.trim().toLowerCase();
+    if (
+      channel !== "discord" &&
+      channel !== "telegram" &&
+      channel !== "feishu" &&
+      channel !== "qqbot"
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["match", "channel"],
+        message:
+          'ACP bindings currently support only "discord", "telegram", "feishu", and "qqbot" channels.',
+      });
+      return;
+    }
+    if ((channel === "discord" || channel === "telegram") && !peerId) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["match", "peer"],
         message: "ACP bindings require match.peer.id to target a concrete conversation.",
-      });
-      return;
-    }
-    const channel = value.match.channel.trim().toLowerCase();
-    if (channel !== "discord" && channel !== "telegram") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["match", "channel"],
-        message: 'ACP bindings currently support only "discord" and "telegram" channels.',
       });
       return;
     }

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -429,7 +429,7 @@ export const OpenClawSchema = z
         backend: z.string().optional(),
         defaultAgent: z.string().optional(),
         allowedAgents: z.array(z.string()).optional(),
-        defaultChannels: z.array(z.string()).optional(),
+        defaultChannels: z.array(z.enum(["discord", "telegram", "feishu", "qqbot"])).optional(),
         maxConcurrentSessions: z.number().int().positive().optional(),
         stream: z
           .object({

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -429,6 +429,7 @@ export const OpenClawSchema = z
         backend: z.string().optional(),
         defaultAgent: z.string().optional(),
         allowedAgents: z.array(z.string()).optional(),
+        defaultChannels: z.array(z.string()).optional(),
         maxConcurrentSessions: z.number().int().positive().optional(),
         stream: z
           .object({

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -80,3 +80,7 @@ export {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "./webhook-memory-guards.js";
 export { applyBasicWebhookRequestGuards } from "./webhook-request-guards.js";
+export {
+  resolveConfiguredAcpRoute,
+  ensureConfiguredAcpRouteReady,
+} from "../acp/persistent-bindings.route.js";

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -850,3 +850,9 @@ export {
 
 // Security utilities
 export { redactSensitiveText } from "../logging/redact.js";
+
+// ACP persistent binding route helpers (for channel plugins that support ACP bindings)
+export {
+  resolveConfiguredAcpRoute,
+  ensureConfiguredAcpRouteReady,
+} from "../acp/persistent-bindings.route.js";


### PR DESCRIPTION
## Summary

Extend ACP persistent bindings to Feishu and QQ bot channels, and add `acp.defaultChannels` for implicit catch-all ACP binding synthesis. This lets users route all messages on a channel through an external agent CLI (Claude Code, Codex, OpenCode, Gemini CLI) with minimal config, reusing their existing subscriptions.

Closes #40097
Closes #41988

### Quick start

```sh
openclaw config set acp.defaultAgent claude
openclaw config set acp.defaultChannels '["feishu","qqbot"]'
```

The `acpx` backend plugin now auto-enables when `defaultChannels` is set or ACP bindings are configured.

### Changes

1. **`ConfiguredAcpBindingChannel`** extended: `"discord" | "telegram"` -> `"discord" | "telegram" | "feishu" | "qqbot"`

2. **Feishu/QQ binding resolution** with four-bucket priority: peer exact > peer wildcard > catch-all exact > catch-all wildcard. Catch-all bindings (omit `match.peer`) match all conversations on a channel/account.

3. **`acp.defaultChannels`** config: array of channels that implicitly use ACP for all conversations when no explicit binding matches. Synthesizes binding specs on the fly using agent runtime ACP defaults.

4. **Zod validation**: feishu/qqbot allow omitting `match.peer` (catch-all), but reject empty `peer.id` when `match.peer` is specified.

5. **Plugin auto-enable**: `acpx` plugin now auto-enables when `acp.defaultChannels` is set or `bindings[].type="acp"` exists (previously required explicit `acp.enabled: true`).

6. **Feishu integration**: ACP route resolution + session init in `extensions/feishu/src/bot.ts`.

7. **Plugin SDK exports**: ACP route helpers exported from both `plugin-sdk/feishu.ts` and `plugin-sdk/index.ts` for external channel plugins (e.g., qqbot).

8. **README**: ACP agent runtime added to highlights and core platform sections.

### Commits

- `e521cd8d9` feat(acp): extend persistent bindings to feishu and qqbot channels
- `17810f408` fix(acp): document catch-all reverse lookup limitation and add test
- `7dfeb1ea3` feat(acp): export ACP route helpers from generic plugin SDK and improve docs
- `a75f4fd2a` feat(acp): add defaultChannels config for implicit ACP binding synthesis
- `9b69ef3d6` fix(acp): validate defaultChannels values and normalize telegram topic IDs in fallback
- `3599f5440` fix(acp): add missing label for defaultChannels and soften doc wording
- `09fde0060` fix(acp): prioritize peer-specific bindings over catch-all and reject empty peer IDs
- `814030815` feat(acp): auto-enable acpx plugin for defaultChannels and ACP bindings, add README highlight

### Test plan

- [x] 32 unit tests for binding resolution (feishu/qqbot explicit, catch-all, priority, reverse lookup, defaultChannels synthesis/priority/exclusion/runtime defaults, telegram normalization)
- [x] 2 new plugin-auto-enable tests for defaultChannels and ACP binding triggers
- [x] 20 schema quality tests (labels, help text)
- [x] `pnpm build` passes (TypeScript + rolldown)
- [x] `pnpm check` passes (oxlint + oxfmt)
- [ ] Manual: send Feishu message -> verify ACP session created with `acp:binding:feishu:` key
- [ ] Manual: qqbot plugin integration (companion PR: sliverp/qqbot#156)