### PR TITLE
agents: cap broad home find exec scans

### DIFF
--- a/src/agents/bash-tools.exec.broad-find-guard.test.ts
+++ b/src/agents/bash-tools.exec.broad-find-guard.test.ts
@@ -19,6 +19,46 @@ describe("exec broad find guard", () => {
     expect(result.warning).toContain("20s");
   });
 
+  it("caps broad filesystem-root scans when the path appears after leading options", () => {
+    const workspace = path.join(os.homedir(), "clawdbot-workspace");
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: "find -maxdepth 5 / -type d -iname '*homedaddy*'",
+      workdir: workspace,
+      explicitTimeoutSec: null,
+    });
+
+    expect(result.timeoutSec).toBe(20);
+    expect(result.warning).toContain("broad find");
+  });
+
+  it("caps relative broad scans when workdir is the filesystem root", () => {
+    const filesystemRoot = path.parse(os.homedir()).root;
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: "find . -type d -iname '*homedaddy*'",
+      workdir: filesystemRoot,
+      explicitTimeoutSec: null,
+    });
+
+    expect(result.timeoutSec).toBe(20);
+    expect(result.warning).toContain("broad find");
+  });
+
+  it("caps broad home-directory scans when find uses leading -L", () => {
+    const home = os.homedir();
+    const workspace = path.join(home, "clawdbot-workspace");
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: "find -L $HOME -type d -iname '*homedaddy*'",
+      workdir: workspace,
+      explicitTimeoutSec: null,
+    });
+
+    expect(result.timeoutSec).toBe(20);
+    expect(result.warning).toContain("broad find");
+  });
+
   it("does not cap workspace-scoped find scans", () => {
     const home = os.homedir();
     const workspace = path.join(home, "clawdbot-workspace");
@@ -26,6 +66,21 @@ describe("exec broad find guard", () => {
     const result = maybeCapBroadFindTimeoutSec({
       command: `find ${workspace} -maxdepth 5 -type d -iname '*homedaddy*'`,
       workdir: workspace,
+      explicitTimeoutSec: null,
+    });
+
+    expect(result.timeoutSec).toBeNull();
+    expect(result.warning).toBeUndefined();
+  });
+
+  it("does not cap relative scans that resolve inside the workspace", () => {
+    const home = os.homedir();
+    const workspace = path.join(home, "clawdbot-workspace");
+    const nestedWorkdir = path.join(workspace, "src", "agents");
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: "find ../.. -maxdepth 5 -type d -iname '*homedaddy*'",
+      workdir: nestedWorkdir,
       explicitTimeoutSec: null,
     });
 
@@ -59,5 +114,33 @@ describe("exec broad find guard", () => {
 
     expect(result.timeoutSec).toBeNull();
     expect(result.warning).toBeUndefined();
+  });
+
+  it("does not treat -prune inside -exec as a real traversal escape hatch", () => {
+    const home = os.homedir();
+    const workspace = path.join(home, "clawdbot-workspace");
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: `find ${home} -type f -exec grep --no-filename -prune {} \\;`,
+      workdir: workspace,
+      explicitTimeoutSec: null,
+    });
+
+    expect(result.timeoutSec).toBe(20);
+    expect(result.warning).toContain("broad find");
+  });
+
+  it("does not let flags after shell chaining suppress the cap", () => {
+    const home = os.homedir();
+    const workspace = path.join(home, "clawdbot-workspace");
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: `find ${home} -type f && echo -prune`,
+      workdir: workspace,
+      explicitTimeoutSec: null,
+    });
+
+    expect(result.timeoutSec).toBe(20);
+    expect(result.warning).toContain("broad find");
   });
 });

--- a/src/agents/bash-tools.exec.broad-find-guard.test.ts
+++ b/src/agents/bash-tools.exec.broad-find-guard.test.ts
@@ -1,0 +1,63 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { maybeCapBroadFindTimeoutSec } from "./bash-tools.exec.js";
+
+describe("exec broad find guard", () => {
+  it("caps broad home-directory find scans when no explicit timeout is set", () => {
+    const home = os.homedir();
+    const workspace = path.join(home, "clawdbot-workspace");
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: `find ${home} -maxdepth 5 -type d -iname '*homedaddy*'`,
+      workdir: workspace,
+      explicitTimeoutSec: null,
+    });
+
+    expect(result.timeoutSec).toBe(20);
+    expect(result.warning).toContain("broad find");
+    expect(result.warning).toContain("20s");
+  });
+
+  it("does not cap workspace-scoped find scans", () => {
+    const home = os.homedir();
+    const workspace = path.join(home, "clawdbot-workspace");
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: `find ${workspace} -maxdepth 5 -type d -iname '*homedaddy*'`,
+      workdir: workspace,
+      explicitTimeoutSec: null,
+    });
+
+    expect(result.timeoutSec).toBeNull();
+    expect(result.warning).toBeUndefined();
+  });
+
+  it("does not cap broad finds that already specify an explicit timeout", () => {
+    const home = os.homedir();
+    const workspace = path.join(home, "clawdbot-workspace");
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: `find ${home} -maxdepth 5 -type d -iname '*homedaddy*'`,
+      workdir: workspace,
+      explicitTimeoutSec: 300,
+    });
+
+    expect(result.timeoutSec).toBeNull();
+    expect(result.warning).toBeUndefined();
+  });
+
+  it("does not cap broad finds that already prune noisy trees", () => {
+    const home = os.homedir();
+    const workspace = path.join(home, "clawdbot-workspace");
+
+    const result = maybeCapBroadFindTimeoutSec({
+      command: `find ${home} -path '${home}/Library' -prune -o -type d -iname '*homedaddy*'`,
+      workdir: workspace,
+      explicitTimeoutSec: null,
+    });
+
+    expect(result.timeoutSec).toBeNull();
+    expect(result.warning).toBeUndefined();
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -150,10 +150,130 @@ async function validateScriptFileForShellBleed(params: {
 }
 
 const BROAD_FIND_TIMEOUT_SEC = 20;
-const BROAD_FIND_GUARD_RE = /^\s*find\s+(?:"([^"]+)"|'([^']+)'|([^\s|&;]+))/;
-const BROAD_FIND_ESCAPE_HATCH_RE = /\s-(?:prune|xdev|mount)\b/;
+const BROAD_FIND_ESCAPE_HATCHES = new Set(["-prune", "-xdev", "-mount"]);
+const FIND_GLOBAL_OPTIONS_NO_ARG = new Set(["-H", "-L", "-P"]);
+const FIND_PREDICATES_WITH_ARG = new Set([
+  "-amin",
+  "-anewer",
+  "-atime",
+  "-cmin",
+  "-cnewer",
+  "-context",
+  "-ctime",
+  "-fstype",
+  "-gid",
+  "-group",
+  "-iname",
+  "-inum",
+  "-ipath",
+  "-iregex",
+  "-iwholename",
+  "-links",
+  "-maxdepth",
+  "-mindepth",
+  "-mmin",
+  "-mtime",
+  "-name",
+  "-newer",
+  "-path",
+  "-perm",
+  "-regex",
+  "-samefile",
+  "-size",
+  "-type",
+  "-uid",
+  "-user",
+  "-wholename",
+]);
+const FIND_SEGMENT_TERMINATORS = new Set(["&", "&&", ";", ";;", "|", "||"]);
+const FIND_EXEC_TOKENS = new Set(["-exec", "-execdir", "-ok", "-okdir"]);
 
-function resolveFindRootToken(rootToken: string, homeDir: string): string {
+function tokenizeShellWords(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escaping = false;
+  for (const char of command) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'") {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (quote === '"') {
+      if (char === '"') {
+        quote = null;
+        continue;
+      }
+      if (char === "\\") {
+        escaping = true;
+        continue;
+      }
+      current += char;
+      continue;
+    }
+    if (char === "\\") {
+      escaping = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    if (char === ";" || char === "|") {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      tokens.push(char);
+      continue;
+    }
+    if (char === "&") {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      tokens.push(char);
+      continue;
+    }
+    current += char;
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+function extractFindTraversalTokens(command: string): string[] {
+  const tokens = tokenizeShellWords(command);
+  if (tokens[0] !== "find") {
+    return [];
+  }
+  const findTokens: string[] = [];
+  for (const token of tokens.slice(1)) {
+    if (FIND_SEGMENT_TERMINATORS.has(token) || FIND_EXEC_TOKENS.has(token)) {
+      break;
+    }
+    findTokens.push(token);
+  }
+  return findTokens;
+}
+
+function resolveFindRootToken(rootToken: string, homeDir: string, workdir: string): string {
   if (rootToken === "~") {
     return homeDir;
   }
@@ -166,7 +286,25 @@ function resolveFindRootToken(rootToken: string, homeDir: string): string {
   if (rootToken.startsWith("$HOME/")) {
     return path.resolve(homeDir, rootToken.slice("$HOME/".length));
   }
-  return path.resolve(rootToken);
+  return path.resolve(workdir, rootToken);
+}
+
+function tokenLooksLikePath(token: string): boolean {
+  if (!token) {
+    return false;
+  }
+  if (token === "." || token === ".." || token === "/" || token === "~" || token === "$HOME") {
+    return true;
+  }
+  if (
+    token.startsWith("./") ||
+    token.startsWith("../") ||
+    token.startsWith("~/") ||
+    token.startsWith("$HOME/")
+  ) {
+    return true;
+  }
+  return !token.startsWith("-");
 }
 
 export function maybeCapBroadFindTimeoutSec(params: {
@@ -177,24 +315,49 @@ export function maybeCapBroadFindTimeoutSec(params: {
   if (params.explicitTimeoutSec !== null) {
     return { timeoutSec: null };
   }
-  if (BROAD_FIND_ESCAPE_HATCH_RE.test(params.command)) {
+  const findTokens = extractFindTraversalTokens(params.command);
+  if (findTokens.length === 0) {
     return { timeoutSec: null };
   }
-  const match = params.command.match(BROAD_FIND_GUARD_RE);
-  const rootToken = match?.[1] ?? match?.[2] ?? match?.[3];
-  if (!rootToken) {
+  let rootToken: string | null = null;
+  let hasEscapeHatch = false;
+  for (let i = 0; i < findTokens.length; i += 1) {
+    const token = findTokens[i];
+    if (FIND_GLOBAL_OPTIONS_NO_ARG.has(token)) {
+      continue;
+    }
+    if (token === "-D" || token === "-O") {
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("-D") || token.startsWith("-O")) {
+      continue;
+    }
+    if (BROAD_FIND_ESCAPE_HATCHES.has(token)) {
+      hasEscapeHatch = true;
+      continue;
+    }
+    if (FIND_PREDICATES_WITH_ARG.has(token)) {
+      i += 1;
+      continue;
+    }
+    if (!rootToken && tokenLooksLikePath(token)) {
+      rootToken = token;
+    }
+  }
+  if (hasEscapeHatch) {
     return { timeoutSec: null };
   }
   const homeDir = path.resolve(os.homedir());
-  const resolvedRoot = resolveFindRootToken(rootToken, homeDir);
+  const resolvedRoot = resolveFindRootToken(rootToken ?? ".", homeDir, params.workdir);
   const resolvedWorkdir = path.resolve(params.workdir);
+  const filesystemRoot = path.parse(homeDir).root;
   if (
-    resolvedRoot === resolvedWorkdir ||
-    resolvedRoot.startsWith(`${resolvedWorkdir}${path.sep}`)
+    resolvedWorkdir !== filesystemRoot &&
+    (resolvedRoot === resolvedWorkdir || resolvedRoot.startsWith(`${resolvedWorkdir}${path.sep}`))
   ) {
     return { timeoutSec: null };
   }
-  const filesystemRoot = path.parse(homeDir).root;
   const isBroadRoot = resolvedRoot === homeDir || resolvedRoot === filesystemRoot;
   if (!isBroadRoot) {
     return { timeoutSec: null };

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { type ExecHost, loadExecApprovals, maxAsk, minSecurity } from "../infra/exec-approvals.js";
@@ -146,6 +147,64 @@ async function validateScriptFileForShellBleed(params: {
       );
     }
   }
+}
+
+const BROAD_FIND_TIMEOUT_SEC = 20;
+const BROAD_FIND_GUARD_RE = /^\s*find\s+(?:"([^"]+)"|'([^']+)'|([^\s|&;]+))/;
+const BROAD_FIND_ESCAPE_HATCH_RE = /\s-(?:prune|xdev|mount)\b/;
+
+function resolveFindRootToken(rootToken: string, homeDir: string): string {
+  if (rootToken === "~") {
+    return homeDir;
+  }
+  if (rootToken.startsWith("~/")) {
+    return path.resolve(homeDir, rootToken.slice(2));
+  }
+  if (rootToken === "$HOME") {
+    return homeDir;
+  }
+  if (rootToken.startsWith("$HOME/")) {
+    return path.resolve(homeDir, rootToken.slice("$HOME/".length));
+  }
+  return path.resolve(rootToken);
+}
+
+export function maybeCapBroadFindTimeoutSec(params: {
+  command: string;
+  workdir: string;
+  explicitTimeoutSec: number | null;
+}): { timeoutSec: number | null; warning?: string } {
+  if (params.explicitTimeoutSec !== null) {
+    return { timeoutSec: null };
+  }
+  if (BROAD_FIND_ESCAPE_HATCH_RE.test(params.command)) {
+    return { timeoutSec: null };
+  }
+  const match = params.command.match(BROAD_FIND_GUARD_RE);
+  const rootToken = match?.[1] ?? match?.[2] ?? match?.[3];
+  if (!rootToken) {
+    return { timeoutSec: null };
+  }
+  const homeDir = path.resolve(os.homedir());
+  const resolvedRoot = resolveFindRootToken(rootToken, homeDir);
+  const resolvedWorkdir = path.resolve(params.workdir);
+  if (
+    resolvedRoot === resolvedWorkdir ||
+    resolvedRoot.startsWith(`${resolvedWorkdir}${path.sep}`)
+  ) {
+    return { timeoutSec: null };
+  }
+  const filesystemRoot = path.parse(homeDir).root;
+  const isBroadRoot = resolvedRoot === homeDir || resolvedRoot === filesystemRoot;
+  if (!isBroadRoot) {
+    return { timeoutSec: null };
+  }
+  return {
+    timeoutSec: BROAD_FIND_TIMEOUT_SEC,
+    warning:
+      "Warning: broad find scans over $HOME or / without pruning are capped at 20s. " +
+      "Narrow the base path, scope to the workspace, or pass an explicit timeout if the long scan is intentional.",
+  };
 }
 
 export function createExecTool(
@@ -457,11 +516,19 @@ export function createExecTool(
       }
 
       const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;
+      const broadFindTimeout = maybeCapBroadFindTimeoutSec({
+        command: params.command,
+        workdir,
+        explicitTimeoutSec,
+      });
+      if (broadFindTimeout.warning) {
+        warnings.push(broadFindTimeout.warning);
+      }
       const backgroundTimeoutBypass =
         allowBackground && explicitTimeoutSec === null && (backgroundRequested || yieldRequested);
-      const effectiveTimeout = backgroundTimeoutBypass
-        ? null
-        : (explicitTimeoutSec ?? defaultTimeoutSec);
+      const effectiveTimeout =
+        broadFindTimeout.timeoutSec ??
+        (backgroundTimeoutBypass ? null : (explicitTimeoutSec ?? defaultTimeoutSec));
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -226,6 +226,9 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
     );
+    expect(prompt).toContain(
+      "For file or directory discovery, prefer scoped searches under the workspace; avoid broad shell `find` scans over $HOME or / without an explicit timeout.",
+    );
   });
 
   it("lists available tools when provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -447,6 +447,7 @@ export function buildAgentSystemPrompt(params: {
         ].join("\n"),
     "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
     `For long waits, avoid rapid poll loops: use ${execToolName} with enough yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
+    "For file or directory discovery, prefer scoped searches under the workspace; avoid broad shell `find` scans over $HOME or / without an explicit timeout.",
     "If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.",
     ...(acpHarnessSpawnAllowed
       ? [


### PR DESCRIPTION
## Summary

When a request triggers a broad shell `find` over `$HOME` or `/` without an explicit tool timeout, the command can consume the entire embedded run budget and fall through to the generic 600s run timeout.

This change adds a narrow guard for that failure mode:

- cap broad home/root `find` scans at 20s when no explicit exec timeout is provided
- keep explicit operator intent intact when the command already sets `timeout`, `-prune`, `-xdev`, or `-mount`
- add system prompt guidance to prefer scoped workspace searches over broad shell scans

## Why

A recent timeout investigation showed an agent trying to locate a project directory by running a command equivalent to:

```bash
find $HOME -maxdepth 5 -type d -iname '*target*'
```

That search walked into noisy, permission-heavy trees and lasted until the embedded run hit its global 600s timeout. The user request itself was reasonable; the pathological part was letting an unbounded home-directory discovery command inherit the full run budget.

## Testing

- `pnpm test src/agents/bash-tools.exec.broad-find-guard.test.ts`
- `pnpm test src/agents/bash-tools.exec.script-preflight.test.ts`
- `pnpm test src/agents/system-prompt.test.ts -t "guides subagent workflows to avoid polling loops"`
