### PR TITLE
fix: allow same-group message tool usage for media/file sends

### DIFF
--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { buildGroupChatContext } from "./groups.js";
+
+describe("buildGroupChatContext", () => {
+  it("allows message tool usage for same-group media/file sends", () => {
+    const context = buildGroupChatContext({
+      sessionCtx: {
+        Provider: "telegram",
+        GroupSubject: "Release Ops",
+        GroupMembers: "alice, bob",
+      },
+    } as Parameters<typeof buildGroupChatContext>[0]);
+
+    expect(context).toContain('You are in the Telegram group chat "Release Ops".');
+    expect(context).toContain("Participants: alice, bob.");
+    expect(context).toContain("Reply normally for text.");
+    expect(context).toContain("You may use the message tool when you need to send media/files");
+    expect(context).toContain("to this same group/topic");
+  });
+});

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -133,7 +133,7 @@ export function buildGroupChatContext(params: { sessionCtx: TemplateContext }): 
     lines.push(`Participants: ${members}.`);
   }
   lines.push(
-    "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group — just reply normally.",
+    "Your text replies are automatically sent to this group chat. Reply normally for text. You may use the message tool when you need to send media/files (images, documents, audio, video) to this same group/topic or when intentionally targeting a different chat.",
   );
   return lines.join(" ");
 }


### PR DESCRIPTION
## Summary
- relax the persistent group-chat prompt guidance so same-chat `message` tool sends are allowed for media/files while keeping normal text replies on the direct reply path
- keep the existing anti-pattern guard for text sends ("reply normally for text")
- add a unit test covering the updated guidance text

## Repro linkage
Fixes #43146.

Issue repro says Telegram topic sessions are blocked from sending attachments because the injected guidance forbids same-group `message` sends outright. This patch updates `buildGroupChatContext()` in `src/auto-reply/reply/groups.ts` to explicitly allow `message` for media/files in the same group/topic.

## Validation
- `git diff --check`

## Notes on tests
- Attempted: `pnpm exec vitest run --config vitest.unit.config.ts src/auto-reply/reply/groups.test.ts`
- In this runner, `vitest` is not available (`Command "vitest" not found`) because project dependencies are not installed in the temp checkout.
