### PR TITLE
fix(telegram): avoid polling restart hang after stall detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Docs: https://docs.openclaw.ai
 - Agents/fallback cooldown probing: cap cooldown-bypass probing to one attempt per provider per fallback run so multi-model same-provider cooldown chains can continue to cross-provider fallbacks instead of repeatedly stalling on duplicate cooldown probes. (#41711) Thanks @cgdusek.
 - Telegram/direct delivery: bridge direct delivery sends to internal `message:sent` hooks so internal hook listeners observe successful Telegram deliveries. (#40185) Thanks @vincentkoc.
 - Dependencies: refresh workspace dependencies except the pinned Carbon package, and harden ACP session-config writes against non-string SDK values so newer ACP clients fail fast instead of tripping type/runtime mismatches.
+- Telegram/polling restarts: clear bounded cleanup timeout handles after `runner.stop()` and `bot.stop()` settle so stall recovery no longer leaves stray 15-second timers behind on clean shutdown. (#43188) thanks @kyohwang.
 
 ## 2026.3.8
 

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -398,6 +398,20 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(createdBotStops[0]).toHaveBeenCalledTimes(1);
   });
 
+  it("clears bounded cleanup timers after a clean stop", async () => {
+    vi.useFakeTimers();
+    try {
+      const abort = new AbortController();
+      mockRunOnceAndAbort(abort);
+
+      await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("surfaces non-recoverable errors", async () => {
     runSpy.mockImplementationOnce(() =>
       makeRunnerStub({

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -15,6 +15,7 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
+const POLL_STOP_GRACE_MS = 15_000;
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
@@ -176,6 +177,11 @@ export class TelegramPollingSession {
     const fetchAbortController = this.#activeFetchAbort;
     let stopPromise: Promise<void> | undefined;
     let stalledRestart = false;
+    let forceCycleTimer: ReturnType<typeof setTimeout> | undefined;
+    let forceCycleResolve: (() => void) | undefined;
+    const forceCyclePromise = new Promise<void>((resolve) => {
+      forceCycleResolve = resolve;
+    });
     const stopRunner = () => {
       fetchAbortController?.abort();
       stopPromise ??= Promise.resolve(runner.stop())
@@ -209,12 +215,24 @@ export class TelegramPollingSession {
           `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
         );
         void stopRunner();
+        void stopBot();
+        if (!forceCycleTimer) {
+          forceCycleTimer = setTimeout(() => {
+            if (this.opts.abortSignal?.aborted) {
+              return;
+            }
+            this.opts.log(
+              `[telegram] Polling runner stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
+            );
+            forceCycleResolve?.();
+          }, POLL_STOP_GRACE_MS);
+        }
       }
     }, POLL_WATCHDOG_INTERVAL_MS);
 
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
     try {
-      await runner.task();
+      await Promise.race([runner.task(), forceCyclePromise]);
       if (this.opts.abortSignal?.aborted) {
         return "exit";
       }
@@ -249,9 +267,18 @@ export class TelegramPollingSession {
       return shouldRestart ? "continue" : "exit";
     } finally {
       clearInterval(watchdog);
+      if (forceCycleTimer) {
+        clearTimeout(forceCycleTimer);
+      }
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
-      await stopRunner();
-      await stopBot();
+      await Promise.race([
+        stopRunner(),
+        new Promise<void>((resolve) => setTimeout(resolve, POLL_STOP_GRACE_MS)),
+      ]);
+      await Promise.race([
+        stopBot(),
+        new Promise<void>((resolve) => setTimeout(resolve, POLL_STOP_GRACE_MS)),
+      ]);
       this.#activeRunner = undefined;
       if (this.#activeFetchAbort === fetchAbortController) {
         this.#activeFetchAbort = undefined;

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -17,6 +17,23 @@ const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
 
+const waitForGracefulStop = async (stop: () => Promise<void>) => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      stop(),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, POLL_STOP_GRACE_MS);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
+
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
 type TelegramPollingSessionOpts = {
@@ -271,14 +288,8 @@ export class TelegramPollingSession {
         clearTimeout(forceCycleTimer);
       }
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
-      await Promise.race([
-        stopRunner(),
-        new Promise<void>((resolve) => setTimeout(resolve, POLL_STOP_GRACE_MS)),
-      ]);
-      await Promise.race([
-        stopBot(),
-        new Promise<void>((resolve) => setTimeout(resolve, POLL_STOP_GRACE_MS)),
-      ]);
+      await waitForGracefulStop(stopRunner);
+      await waitForGracefulStop(stopBot);
       this.#activeRunner = undefined;
       if (this.#activeFetchAbort === fetchAbortController) {
         this.#activeFetchAbort = undefined;


### PR DESCRIPTION
Fixes #43187

## Summary
Fix a Telegram polling edge case where stall detection logs but polling does not recover, leaving inbound updates unconsumed until manual gateway restart.

## Root cause
`TelegramPollingSession` detects stall (`no getUpdates > 90s`) and calls `runner.stop()`. In some cases, stop/teardown can hang and the cycle never reaches restart logic.

## Changes
- Add `POLL_STOP_GRACE_MS = 15_000`.
- On stall detection:
  - call both `runner.stop()` and `bot.stop()`.
  - arm a grace timer; if stop still hangs, force current cycle to resolve and proceed to restart backoff.
- In `finally` teardown:
  - bound `stopRunner()` and `stopBot()` with timeout races so shutdown path cannot hang forever.

## Why this is safe
- No behavior change on healthy paths.
- Only affects stall/teardown edge cases.
- Existing backoff/retry policy remains unchanged.

## Validation
- Reproduced field evidence from issue #43187.
- Applied equivalent logic locally; pending Telegram backlog resumed consumption after restart cycle.
