### PR TITLE
fix(ui): show full tool command in sidebar details

### DIFF
--- a/src/ui.tool-cards-sidebar-content.test.ts
+++ b/src/ui.tool-cards-sidebar-content.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildToolSidebarContent } from "../ui/src/ui/chat/tool-cards.ts";
+
+describe("buildToolSidebarContent", () => {
+  it("includes full command and output", () => {
+    const command =
+      "with python3 ~/.openclaw/workspace/skills/node-cluster-3.connector/scripts/main.py invoke wangjx-node-host system.run --raw-command='echo hello'";
+    const content = buildToolSidebarContent({
+      title: "Exec",
+      detail: command,
+      outputText: "line1\nline2",
+    });
+
+    expect(content).toContain("## Exec");
+    expect(content).toContain("### Command");
+    expect(content).toContain(command);
+    expect(content).toContain("### Output");
+    expect(content).toContain("line1\nline2");
+  });
+
+  it("shows completion text when output missing", () => {
+    const content = buildToolSidebarContent({ title: "Exec", detail: "with ls -la" });
+    expect(content).toContain("No output — tool completed successfully");
+  });
+});

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildToolSidebarContent } from "../ui/src/ui/chat/tool-cards.ts";
+import { buildToolSidebarContent } from "./tool-cards.js";
 
 describe("buildToolSidebarContent", () => {
   it("includes full command and output", () => {

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -48,6 +48,27 @@ export function extractToolCards(message: unknown): ToolCard[] {
   return cards;
 }
 
+export function buildToolSidebarContent(params: {
+  title: string;
+  detail?: string;
+  outputText?: string;
+}): string {
+  const sections: string[] = [`## ${params.title}`];
+  const detailText = params.detail?.trim();
+  if (detailText) {
+    sections.push(`### Command\n\`\`\`sh\n${detailText}\n\`\`\``);
+  }
+
+  const outputText = params.outputText?.trim();
+  if (outputText) {
+    sections.push(`### Output\n${formatToolOutputForSidebar(params.outputText)}`);
+  } else {
+    sections.push("*No output — tool completed successfully.*");
+  }
+
+  return sections.join("\n\n");
+}
+
 export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: string) => void) {
   const display = resolveToolDisplay({ name: card.name, args: card.args });
   const detail = formatToolDetail(display);
@@ -56,13 +77,11 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
   const canClick = Boolean(onOpenSidebar);
   const handleClick = canClick
     ? () => {
-        if (hasText) {
-          onOpenSidebar!(formatToolOutputForSidebar(card.text!));
-          return;
-        }
-        const info = `## ${display.label}\n\n${
-          detail ? `**Command:** \`${detail}\`\n\n` : ""
-        }*No output — tool completed successfully.*`;
+        const info = buildToolSidebarContent({
+          title: display.label,
+          detail,
+          outputText: hasText ? card.text : undefined,
+        });
         onOpenSidebar!(info);
       }
     : undefined;

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -61,7 +61,7 @@ export function buildToolSidebarContent(params: {
 
   const outputText = params.outputText?.trim();
   if (outputText) {
-    sections.push(`### Output\n${formatToolOutputForSidebar(params.outputText)}`);
+    sections.push(`### Output\n${formatToolOutputForSidebar(outputText)}`);
   } else {
     sections.push("*No output — tool completed successfully.*");
   }


### PR DESCRIPTION
## Summary
Fixes #43153 by making the Chat tool-card sidebar show both:
- full command (detail line, untruncated)
- full output (formatted as before)

The tool card list preview remains truncated for readability, but clicking a card now opens a complete detail view.

## Changes
- add `buildToolSidebarContent(...)` helper in `ui/src/ui/chat/tool-cards.ts`
- sidebar click handler now always opens a structured markdown view:
  - `## <Tool>`
  - `### Command` (shell code block, full command/detail)
  - `### Output` (full output; JSON still pretty-printed)
- add targeted regression test: `src/ui.tool-cards-sidebar-content.test.ts`

## Validation
- `pnpm vitest run src/ui.tool-cards-sidebar-content.test.ts`

## AI Transparency
This patch was prepared with AI assistance and manually validated with targeted tests.
