### PR TITLE
infra: globalize unhandled rejection state (AI-assisted)

### DIFF
--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -8,6 +8,12 @@ import {
 
 type UnhandledRejectionHandler = (reason: unknown) => boolean;
 
+const unhandledRejectionsInstallKey = Symbol.for("openclaw.unhandled-rejections.installed");
+
+type UnhandledRejectionsInstallState = {
+  installed: boolean;
+};
+
 const handlers = new Set<UnhandledRejectionHandler>();
 
 const FATAL_ERROR_CODES = new Set([
@@ -217,6 +223,13 @@ export function isUnhandledRejectionHandled(reason: unknown): boolean {
 }
 
 export function installUnhandledRejectionHandler(): void {
+  const globalState = globalThis as typeof globalThis & {
+    [unhandledRejectionsInstallKey]?: UnhandledRejectionsInstallState;
+  };
+  if (globalState[unhandledRejectionsInstallKey]?.installed) {
+    return;
+  }
+
   process.on("unhandledRejection", (reason, _promise) => {
     if (isUnhandledRejectionHandled(reason)) {
       return;
@@ -252,4 +265,8 @@ export function installUnhandledRejectionHandler(): void {
     console.error("[openclaw] Unhandled promise rejection:", formatUncaughtError(reason));
     process.exit(1);
   });
+
+  globalState[unhandledRejectionsInstallKey] = {
+    installed: true,
+  };
 }

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -8,25 +8,25 @@ import {
 
 type UnhandledRejectionHandler = (reason: unknown) => boolean;
 
-const unhandledRejectionsInstallKey = Symbol.for("openclaw.unhandled-rejections.installed");
+const unhandledRejectionsStateKey = Symbol.for("openclaw.unhandled-rejections.state");
 
-type UnhandledRejectionsInstallState = {
+type UnhandledRejectionsState = {
   installed: boolean;
   handlers: Set<UnhandledRejectionHandler>;
 };
 
-function getUnhandledRejectionsState(): UnhandledRejectionsInstallState {
+function getUnhandledRejectionsState(): UnhandledRejectionsState {
   const globalState = globalThis as typeof globalThis & {
-    [unhandledRejectionsInstallKey]?: UnhandledRejectionsInstallState;
+    [unhandledRejectionsStateKey]?: UnhandledRejectionsState;
   };
 
-  let state = globalState[unhandledRejectionsInstallKey];
+  let state = globalState[unhandledRejectionsStateKey];
   if (!state) {
     state = {
       installed: false,
       handlers: new Set<UnhandledRejectionHandler>(),
     };
-    globalState[unhandledRejectionsInstallKey] = state;
+    globalState[unhandledRejectionsStateKey] = state;
   }
 
   return state;
@@ -246,6 +246,8 @@ export function installUnhandledRejectionHandler(): void {
     return;
   }
 
+  state.installed = true;
+
   process.on("unhandledRejection", (reason, _promise) => {
     if (isUnhandledRejectionHandled(reason)) {
       return;
@@ -281,6 +283,4 @@ export function installUnhandledRejectionHandler(): void {
     console.error("[openclaw] Unhandled promise rejection:", formatUncaughtError(reason));
     process.exit(1);
   });
-
-  state.installed = true;
 }

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -12,9 +12,25 @@ const unhandledRejectionsInstallKey = Symbol.for("openclaw.unhandled-rejections.
 
 type UnhandledRejectionsInstallState = {
   installed: boolean;
+  handlers: Set<UnhandledRejectionHandler>;
 };
 
-const handlers = new Set<UnhandledRejectionHandler>();
+function getUnhandledRejectionsState(): UnhandledRejectionsInstallState {
+  const globalState = globalThis as typeof globalThis & {
+    [unhandledRejectionsInstallKey]?: UnhandledRejectionsInstallState;
+  };
+
+  let state = globalState[unhandledRejectionsInstallKey];
+  if (!state) {
+    state = {
+      installed: false,
+      handlers: new Set<UnhandledRejectionHandler>(),
+    };
+    globalState[unhandledRejectionsInstallKey] = state;
+  }
+
+  return state;
+}
 
 const FATAL_ERROR_CODES = new Set([
   "ERR_OUT_OF_MEMORY",
@@ -200,6 +216,7 @@ export function isTransientNetworkError(err: unknown): boolean {
 }
 
 export function registerUnhandledRejectionHandler(handler: UnhandledRejectionHandler): () => void {
+  const { handlers } = getUnhandledRejectionsState();
   handlers.add(handler);
   return () => {
     handlers.delete(handler);
@@ -207,6 +224,7 @@ export function registerUnhandledRejectionHandler(handler: UnhandledRejectionHan
 }
 
 export function isUnhandledRejectionHandled(reason: unknown): boolean {
+  const { handlers } = getUnhandledRejectionsState();
   for (const handler of handlers) {
     try {
       if (handler(reason)) {
@@ -223,10 +241,8 @@ export function isUnhandledRejectionHandled(reason: unknown): boolean {
 }
 
 export function installUnhandledRejectionHandler(): void {
-  const globalState = globalThis as typeof globalThis & {
-    [unhandledRejectionsInstallKey]?: UnhandledRejectionsInstallState;
-  };
-  if (globalState[unhandledRejectionsInstallKey]?.installed) {
+  const state = getUnhandledRejectionsState();
+  if (state.installed) {
     return;
   }
 
@@ -266,7 +282,5 @@ export function installUnhandledRejectionHandler(): void {
     process.exit(1);
   });
 
-  globalState[unhandledRejectionsInstallKey] = {
-    installed: true,
-  };
+  state.installed = true;
 }


### PR DESCRIPTION
## What
- Make installUnhandledRejectionHandler() idempotent so repeated calls do not attach multiple process.on("unhandledRejection", …) listeners.
- Move the unhandled rejection install flag and handler registry into a shared globalThis state keyed by Symbol.for("openclaw.unhandled-rejections.state"), and route registerUnhandledRejectionHandler / isUnhandledRejectionHandled through that shared state.

## Why
- Prevent double-installing unhandled rejection listeners, which can otherwise cause duplicated logs and confusing “why did it exit twice?” behavior if the handler is wired up more than once (tests, embedding, future refactors).
- Centralize unhandled rejection state so different entrypoints share a single source of truth, keeping behavior consistent while remaining a behavior-preserving change in the common case.
​
## AI Assistance
- AI-assisted: Codex
- Testing degree: fully tested
- Screenshots: N/A (non-UI change)

## Validation
- `pnpm build`
- `pnpm check`
- `pnpm test`
- `codex review --base origin/main` (no actionable findings)

## Prompts / Session Context
- Prompt summary: "Use above contribution guidelines as reference and create a PR."
- Work done: analyzed the existing diff, validated gates, and prepared this PR.

## Understanding Confirmation
- This change only refactors unhandled-rejection state ownership and access.
- The existing fatal/transient error classification and process-level listener behavior remain the same.
