### PR TITLE
fix: persist outbound messages to unified session transcript

### DIFF
--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -11,6 +11,10 @@ import { resolveMessageChannelSelection } from "../../infra/outbound/channel-sel
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import { buildOutboundResultEnvelope } from "../../infra/outbound/envelope.js";
 import {
+  ensureOutboundSessionEntry,
+  resolveOutboundSessionRoute,
+} from "../../infra/outbound/outbound-session.js";
+import {
   formatOutboundPayloadLog,
   type NormalizedOutboundPayload,
   normalizeOutboundPayloads,
@@ -219,6 +223,49 @@ export async function deliverAgentCommandResult(params: {
   }
   if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {
     if (deliveryTarget) {
+      // Resolve session route from delivery target (channel/to/accountId) to prevent IDOR.
+      // This ensures mirror writes only to the session associated with the outbound route,
+      // not an arbitrary sessionKey supplied by the caller.
+      const route = await resolveOutboundSessionRoute({
+        cfg,
+        channel: deliveryChannel,
+        target: deliveryTarget,
+        accountId: resolvedAccountId ?? null,
+        threadId: resolvedThreadTarget ?? null,
+        agentId: opts.agentId ?? "main",
+      }).catch(() => null);
+
+      if (route) {
+        await ensureOutboundSessionEntry({
+          cfg,
+          agentId: route.agentId,
+          channel: deliveryChannel,
+          accountId: resolvedAccountId ?? null,
+          route,
+        }).catch(() => {});
+      }
+
+      // Build mirror context with hard limits to prevent resource exhaustion.
+      // This ensures cross-channel visibility when dmScope: "main" is configured.
+      const MAX_MIRROR_CHARS = 10_000;
+      const MAX_MIRROR_MEDIA_URLS = 25;
+
+      const rawMirrorText = payloads
+        .map((p) => p.text)
+        .filter((t): t is string => Boolean(t && t.trim()))
+        .join("\n\n");
+
+      const mirrorText =
+        rawMirrorText.length > MAX_MIRROR_CHARS
+          ? rawMirrorText.slice(0, MAX_MIRROR_CHARS) + "\n\n[truncated]"
+          : rawMirrorText;
+
+      const mirrorMediaUrls = payloads
+        .flatMap((p) => p.mediaUrls ?? (p.mediaUrl ? [p.mediaUrl] : []))
+        .map((u) => u?.trim())
+        .filter((url): url is string => Boolean(url))
+        .slice(0, MAX_MIRROR_MEDIA_URLS);
+
       await deliverOutboundPayloads({
         cfg,
         channel: deliveryChannel,
@@ -232,6 +279,14 @@ export async function deliverAgentCommandResult(params: {
         onError: (err) => logDeliveryError(err),
         onPayload: logPayload,
         deps: createOutboundSendDeps(deps),
+        mirror: route?.sessionKey
+          ? {
+              sessionKey: route.sessionKey,
+              agentId: opts.agentId,
+              text: mirrorText || undefined,
+              mediaUrls: mirrorMediaUrls.length > 0 ? mirrorMediaUrls : undefined,
+            }
+          : undefined,
       });
     }
   }


### PR DESCRIPTION
Fixes #42974

## Summary

- **Problem**: Outbound messages sent to channels (Telegram, WhatsApp, etc.) are not persisted to the unified session transcript when dmScope: main is configured
- **Impact**: Agent loses context of its own replies when users switch channels
- **Root Cause**: deliverOutboundPayloads called without mirror parameter
- **Fix**: Pass mirror context with sessionKey, agentId, text, and mediaUrls

## Change Type

- [x] Bug fix

## Test

Manual testing required:
1. Configure session.dmScope: main
2. Send message from Telegram
3. Agent replies on Telegram
4. Ask agent in webchat: What did you just say on Telegram
5. Verify agent can recall its own reply

---

Draft: Still testing locally. Will mark ready after verification.