### PR TITLE
Usage: include reset and deleted session archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Matrix: durably dedupe inbound room events across gateway restarts so previously handled Matrix messages are not replayed as new, while preserving clean-restart backlog delivery for unseen events. (#50922) thanks @gumadeiras
 - Agents/media replies: migrate the remaining browser, canvas, and nodes snapshot outputs onto `details.media` so generated media keeps attaching to assistant replies after the collect-then-attach refactor. (#51731) Thanks @christianklotz.
 - Android/contacts search: escape literal `%` and `_` in contact-name queries so searches like `100%` or `_id` no longer match unrelated contacts through SQL `LIKE` wildcards. (#41891) Thanks @Kaneki-x.
+- Gateway/usage: include reset and deleted archived session transcripts in usage totals, session discovery, and archived-only session detail fallback so the Usage view no longer undercounts rotated sessions. (#43215) Thanks @rcrick.
 
 ## 2026.3.13
 

--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -3,6 +3,8 @@ import {
   formatSessionArchiveTimestamp,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
+  isUsageCountedSessionTranscriptFileName,
+  parseUsageCountedSessionIdFromFileName,
   parseSessionArchiveTimestamp,
 } from "./artifacts.js";
 
@@ -23,6 +25,32 @@ describe("session artifact helpers", () => {
       false,
     );
     expect(isPrimarySessionTranscriptFileName("sessions.json")).toBe(false);
+  });
+
+  it("classifies usage-counted transcript files", () => {
+    expect(isUsageCountedSessionTranscriptFileName("abc.jsonl")).toBe(true);
+    expect(
+      isUsageCountedSessionTranscriptFileName("abc.jsonl.reset.2026-01-01T00-00-00.000Z"),
+    ).toBe(true);
+    expect(
+      isUsageCountedSessionTranscriptFileName("abc.jsonl.deleted.2026-01-01T00-00-00.000Z"),
+    ).toBe(true);
+    expect(isUsageCountedSessionTranscriptFileName("abc.jsonl.bak.2026-01-01T00-00-00.000Z")).toBe(
+      false,
+    );
+  });
+
+  it("parses usage-counted session ids from file names", () => {
+    expect(parseUsageCountedSessionIdFromFileName("abc.jsonl")).toBe("abc");
+    expect(parseUsageCountedSessionIdFromFileName("abc.jsonl.reset.2026-01-01T00-00-00.000Z")).toBe(
+      "abc",
+    );
+    expect(
+      parseUsageCountedSessionIdFromFileName("abc.jsonl.deleted.2026-01-01T00-00-00.000Z"),
+    ).toBe("abc");
+    expect(parseUsageCountedSessionIdFromFileName("abc.jsonl.bak.2026-01-01T00-00-00.000Z")).toBe(
+      null,
+    );
   });
 
   it("formats and parses archive timestamps", () => {

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -34,6 +34,27 @@ export function isPrimarySessionTranscriptFileName(fileName: string): boolean {
   return !isSessionArchiveArtifactName(fileName);
 }
 
+export function isUsageCountedSessionTranscriptFileName(fileName: string): boolean {
+  if (isPrimarySessionTranscriptFileName(fileName)) {
+    return true;
+  }
+  return hasArchiveSuffix(fileName, "reset") || hasArchiveSuffix(fileName, "deleted");
+}
+
+export function parseUsageCountedSessionIdFromFileName(fileName: string): string | null {
+  if (isPrimarySessionTranscriptFileName(fileName)) {
+    return fileName.slice(0, -".jsonl".length);
+  }
+  for (const reason of ["reset", "deleted"] as const) {
+    const marker = `.jsonl.${reason}.`;
+    const index = fileName.lastIndexOf(marker);
+    if (index > 0 && hasArchiveSuffix(fileName, reason)) {
+      return fileName.slice(0, index);
+    }
+  }
+  return null;
+}
+
 export function formatSessionArchiveTimestamp(nowMs = Date.now()): string {
   return new Date(nowMs).toISOString().replaceAll(":", "-");
 }

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -17,6 +17,7 @@ import {
   loadSessionCostSummary,
   loadSessionUsageTimeSeries,
   discoverAllSessions,
+  resolveExistingUsageSessionFile,
   type DiscoveredSession,
 } from "../../infra/session-cost-usage.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
@@ -425,13 +426,18 @@ export const usageHandlers: GatewayRequestHandlers = {
       const sessionId = storeEntry?.sessionId ?? keyRest;
 
       // Resolve the session file path
-      let sessionFile: string;
+      let sessionFile: string | undefined;
       try {
         const pathOpts = resolveSessionFilePathOptions({
           storePath: storePath !== "(multiple)" ? storePath : undefined,
           agentId: agentIdFromKey,
         });
-        sessionFile = resolveSessionFilePath(sessionId, storeEntry, pathOpts);
+        sessionFile = resolveExistingUsageSessionFile({
+          sessionId,
+          sessionEntry: storeEntry,
+          sessionFile: resolveSessionFilePath(sessionId, storeEntry, pathOpts),
+          agentId: agentIdFromKey,
+        });
       } catch {
         respond(
           false,
@@ -441,20 +447,22 @@ export const usageHandlers: GatewayRequestHandlers = {
         return;
       }
 
-      try {
-        const stats = fs.statSync(sessionFile);
-        if (stats.isFile()) {
-          mergedEntries.push({
-            key: resolvedStoreKey,
-            sessionId,
-            sessionFile,
-            label: storeEntry?.label,
-            updatedAt: storeEntry?.updatedAt ?? stats.mtimeMs,
-            storeEntry,
-          });
+      if (sessionFile) {
+        try {
+          const stats = fs.statSync(sessionFile);
+          if (stats.isFile()) {
+            mergedEntries.push({
+              key: resolvedStoreKey,
+              sessionId,
+              sessionFile,
+              label: storeEntry?.label,
+              updatedAt: storeEntry?.updatedAt ?? stats.mtimeMs,
+              storeEntry,
+            });
+          }
+        } catch {
+          // File doesn't exist - no results for this key
         }
-      } catch {
-        // File doesn't exist - no results for this key
       }
     } else {
       // Full discovery for list view

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -322,15 +322,56 @@ describe("session cost usage", () => {
 
     await withStateDir(root, async () => {
       const sessions = await discoverAllSessions();
-      expect(sessions.map((session) => session.sessionId).toSorted()).toEqual([
-        "sess-deleted",
-        "sess-reset",
-      ]);
+      expect(sessions.map((session) => session.sessionId)).toEqual(["sess-deleted", "sess-reset"]);
       expect(
         sessions
           .map((session) => session.firstUserMessage)
           .toSorted((a, b) => String(a).localeCompare(String(b))),
       ).toEqual(["deleted transcript", "reset transcript"]);
+    });
+  });
+
+  it("deduplicates discovered sessions by sessionId and keeps the newest archive", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-dedupe-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const resetPath = path.join(sessionsDir, "sess-shared.jsonl.reset.2026-02-12T11-00-00.000Z");
+    const deletedPath = path.join(
+      sessionsDir,
+      "sess-shared.jsonl.deleted.2026-02-12T12-00-00.000Z",
+    );
+
+    await fs.writeFile(
+      resetPath,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T10:00:00.000Z",
+        message: { role: "user", content: "older archive" },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      deletedPath,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T10:05:00.000Z",
+        message: { role: "user", content: "newer archive" },
+      }),
+      "utf-8",
+    );
+
+    const older = Date.UTC(2026, 1, 12, 11, 0, 0) / 1000;
+    const newer = Date.UTC(2026, 1, 12, 12, 0, 0) / 1000;
+    await fs.utimes(resetPath, older, older);
+    await fs.utimes(deletedPath, newer, newer);
+
+    await withStateDir(root, async () => {
+      const sessions = await discoverAllSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.sessionId).toBe("sess-shared");
+      expect(sessions[0]?.sessionFile).toContain(".jsonl.deleted.");
+      expect(sessions[0]?.firstUserMessage).toBe("newer archive");
     });
   });
 
@@ -363,6 +404,48 @@ describe("session cost usage", () => {
       expect(timeseries?.points[0]?.totalTokens).toBe(10);
       expect(logs).toHaveLength(1);
       expect(logs?.[0]?.content).toContain("archived answer");
+    });
+  });
+
+  it("picks the newest archive by timestamp when reset and deleted archives coexist", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-archive-order-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-mixed.jsonl.reset.2026-02-12T11-00-00.000Z"),
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T11:00:00.000Z",
+        message: {
+          role: "assistant",
+          content: "older reset archive",
+          usage: { input: 6, output: 4, totalTokens: 10, cost: { total: 0.01 } },
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-mixed.jsonl.deleted.2026-02-12T12-00-00.000Z"),
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T12:00:00.000Z",
+        message: {
+          role: "assistant",
+          content: "newer deleted archive",
+          usage: { input: 12, output: 8, totalTokens: 20, cost: { total: 0.02 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const summary = await loadSessionCostSummary({ sessionId: "sess-mixed" });
+      const logs = await loadSessionLogs({ sessionId: "sess-mixed" });
+
+      expect(summary?.totalTokens).toBe(20);
+      expect(summary?.sessionFile).toContain(".jsonl.deleted.");
+      expect(logs?.[0]?.content).toContain("newer deleted archive");
     });
   });
 

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -231,6 +231,141 @@ describe("session cost usage", () => {
     });
   });
 
+  it("counts reset and deleted transcripts in global usage summary, but excludes bak archives", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-usage-archives-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const timestamp = "2026-02-12T10:00:00.000Z";
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-active.jsonl"),
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: { input: 1, output: 2, totalTokens: 3, cost: { total: 0.003 } },
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-reset.jsonl.reset.2026-02-12T11-00-00.000Z"),
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: { input: 10, output: 20, totalTokens: 30, cost: { total: 0.03 } },
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-deleted.jsonl.deleted.2026-02-12T12-00-00.000Z"),
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: { input: 4, output: 5, totalTokens: 9, cost: { total: 0.009 } },
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-bak.jsonl.bak.2026-02-12T13-00-00.000Z"),
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: { input: 100, output: 200, totalTokens: 300, cost: { total: 0.3 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({
+        startMs: Date.UTC(2026, 1, 12),
+        endMs: Date.UTC(2026, 1, 12, 23, 59, 59, 999),
+      });
+      expect(summary.totals.totalTokens).toBe(42);
+      expect(summary.totals.totalCost).toBeCloseTo(0.042, 8);
+    });
+  });
+
+  it("discovers reset and deleted transcripts as usage sessions", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-archives-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-reset.jsonl.reset.2026-02-12T11-00-00.000Z"),
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T10:00:00.000Z",
+        message: { role: "user", content: "reset transcript" },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-deleted.jsonl.deleted.2026-02-12T12-00-00.000Z"),
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T10:00:00.000Z",
+        message: { role: "user", content: "deleted transcript" },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const sessions = await discoverAllSessions();
+      expect(sessions.map((session) => session.sessionId).toSorted()).toEqual([
+        "sess-deleted",
+        "sess-reset",
+      ]);
+      expect(
+        sessions
+          .map((session) => session.firstUserMessage)
+          .toSorted((a, b) => String(a).localeCompare(String(b))),
+      ).toEqual(["deleted transcript", "reset transcript"]);
+    });
+  });
+
+  it("falls back to archived reset transcripts for per-session detail queries", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-archive-fallback-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-reset.jsonl.reset.2026-02-12T11-00-00.000Z"),
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T10:00:00.000Z",
+        message: {
+          role: "assistant",
+          content: "archived answer",
+          usage: { input: 6, output: 4, totalTokens: 10, cost: { total: 0.01 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const summary = await loadSessionCostSummary({ sessionId: "sess-reset" });
+      const timeseries = await loadSessionUsageTimeSeries({ sessionId: "sess-reset" });
+      const logs = await loadSessionLogs({ sessionId: "sess-reset" });
+
+      expect(summary?.totalTokens).toBe(10);
+      expect(summary?.sessionFile).toContain(".jsonl.reset.");
+      expect(timeseries?.points[0]?.totalTokens).toBe(10);
+      expect(logs).toHaveLength(1);
+      expect(logs?.[0]?.content).toContain("archived answer");
+    });
+  });
+
   it("resolves non-main absolute sessionFile using explicit agentId for cost summary", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-agent-"));
     const workerSessionsDir = path.join(root, "agents", "worker1", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -375,6 +375,47 @@ describe("session cost usage", () => {
     });
   });
 
+  it("prefers the active transcript over archives during discovery dedupe", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-active-preferred-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const activePath = path.join(sessionsDir, "sess-live.jsonl");
+    const archivePath = path.join(sessionsDir, "sess-live.jsonl.deleted.2026-02-12T12-00-00.000Z");
+
+    await fs.writeFile(
+      activePath,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T10:00:00.000Z",
+        message: { role: "user", content: "active transcript" },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      archivePath,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T10:05:00.000Z",
+        message: { role: "user", content: "archive transcript" },
+      }),
+      "utf-8",
+    );
+
+    const older = Date.UTC(2026, 1, 12, 10, 0, 0) / 1000;
+    const newer = Date.UTC(2026, 1, 12, 12, 0, 0) / 1000;
+    await fs.utimes(activePath, older, older);
+    await fs.utimes(archivePath, newer, newer);
+
+    await withStateDir(root, async () => {
+      const sessions = await discoverAllSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.sessionId).toBe("sess-live");
+      expect(sessions[0]?.sessionFile).toBe(activePath);
+      expect(sessions[0]?.firstUserMessage).toBe("active transcript");
+    });
+  });
+
   it("falls back to archived reset transcripts for per-session detail queries", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-archive-fallback-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -448,6 +448,45 @@ describe("session cost usage", () => {
     });
   });
 
+  it("uses the candidate session directory for archived fallback lookups", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-custom-archive-"));
+    const customSessionsDir = path.join(root, "custom-store", "sessions");
+    await fs.mkdir(customSessionsDir, { recursive: true });
+
+    const activePath = path.join(customSessionsDir, "sess-custom.jsonl");
+    const archivePath = path.join(
+      customSessionsDir,
+      "sess-custom.jsonl.deleted.2026-02-12T12-00-00.000Z",
+    );
+
+    await fs.writeFile(
+      archivePath,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-12T12:00:00.000Z",
+        message: {
+          role: "assistant",
+          content: "custom archived answer",
+          usage: { input: 9, output: 3, totalTokens: 12, cost: { total: 0.012 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    const summary = await loadSessionCostSummary({
+      sessionId: "sess-custom",
+      sessionFile: activePath,
+    });
+    const logs = await loadSessionLogs({
+      sessionId: "sess-custom",
+      sessionFile: activePath,
+    });
+
+    expect(summary?.totalTokens).toBe(12);
+    expect(summary?.sessionFile).toBe(archivePath);
+    expect(logs?.[0]?.content).toContain("custom archived answer");
+  });
+
   it("picks the newest archive by timestamp when reset and deleted archives coexist", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-archive-order-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -6,6 +6,7 @@ import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
   parseSessionArchiveTimestamp,
@@ -480,6 +481,7 @@ export async function discoverAllSessions(params?: {
     if (!sessionId) {
       continue;
     }
+    const isPrimaryTranscript = isPrimarySessionTranscriptFileName(entry.name);
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;
@@ -517,7 +519,15 @@ export async function discoverAllSessions(params?: {
     }
 
     const existing = discovered.get(sessionId);
-    if (!existing || stats.mtimeMs >= existing.mtime) {
+    const existingIsPrimary = existing
+      ? isPrimarySessionTranscriptFileName(path.basename(existing.sessionFile))
+      : false;
+    const shouldReplace =
+      !existing ||
+      (isPrimaryTranscript && !existingIsPrimary) ||
+      (isPrimaryTranscript === existingIsPrimary && stats.mtimeMs >= existing.mtime);
+
+    if (shouldReplace) {
       discovered.set(sessionId, {
         sessionId,
         sessionFile: filePath,

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -6,6 +6,11 @@ import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  isSessionArchiveArtifactName,
+  isUsageCountedSessionTranscriptFileName,
+  parseUsageCountedSessionIdFromFileName,
+} from "../config/sessions/artifacts.js";
+import {
   resolveSessionFilePath,
   resolveSessionTranscriptsDirForAgent,
 } from "../config/sessions/paths.js";
@@ -287,6 +292,57 @@ async function scanUsageFile(params: {
   });
 }
 
+export function resolveExistingUsageSessionFile(params: {
+  sessionId?: string;
+  sessionEntry?: SessionEntry;
+  sessionFile?: string;
+  agentId?: string;
+}): string | undefined {
+  const candidate =
+    params.sessionFile ??
+    (params.sessionId
+      ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
+          agentId: params.agentId,
+        })
+      : undefined);
+
+  if (candidate && fs.existsSync(candidate)) {
+    return candidate;
+  }
+
+  const sessionId = params.sessionId?.trim();
+  if (!sessionId) {
+    return candidate;
+  }
+
+  try {
+    const sessionsDir = resolveSessionTranscriptsDirForAgent(params.agentId);
+    const baseFileName = `${sessionId}.jsonl`;
+    const entries = fs.readdirSync(sessionsDir, { withFileTypes: true }).filter((entry) => {
+      return (
+        entry.isFile() &&
+        (entry.name === baseFileName ||
+          entry.name.startsWith(`${baseFileName}.reset.`) ||
+          entry.name.startsWith(`${baseFileName}.deleted.`))
+      );
+    });
+
+    const primary = entries.find((entry) => entry.name === baseFileName);
+    if (primary) {
+      return path.join(sessionsDir, primary.name);
+    }
+
+    const latestArchive = entries
+      .filter((entry) => isSessionArchiveArtifactName(entry.name))
+      .map((entry) => entry.name)
+      .toSorted((a, b) => b.localeCompare(a))[0];
+
+    return latestArchive ? path.join(sessionsDir, latestArchive) : candidate;
+  } catch {
+    return candidate;
+  }
+}
+
 export async function loadCostUsageSummary(params?: {
   startMs?: number;
   endMs?: number;
@@ -318,7 +374,7 @@ export async function loadCostUsageSummary(params?: {
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter((entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name))
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);
@@ -393,7 +449,7 @@ export async function discoverAllSessions(params?: {
   const discovered: DiscoveredSession[] = [];
 
   for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+    if (!entry.isFile() || !isUsageCountedSessionTranscriptFileName(entry.name)) {
       continue;
     }
 
@@ -409,8 +465,10 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    // Extract session ID from filename (remove .jsonl)
-    const sessionId = entry.name.slice(0, -6);
+    const sessionId = parseUsageCountedSessionIdFromFileName(entry.name);
+    if (!sessionId) {
+      continue;
+    }
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;
@@ -468,13 +526,7 @@ export async function loadSessionCostSummary(params: {
   startMs?: number;
   endMs?: number;
 }): Promise<SessionCostSummary | null> {
-  const sessionFile =
-    params.sessionFile ??
-    (params.sessionId
-      ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
-          agentId: params.agentId,
-        })
-      : undefined);
+  const sessionFile = resolveExistingUsageSessionFile(params);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
     return null;
   }
@@ -745,13 +797,7 @@ export async function loadSessionUsageTimeSeries(params: {
   agentId?: string;
   maxPoints?: number;
 }): Promise<SessionUsageTimeSeries | null> {
-  const sessionFile =
-    params.sessionFile ??
-    (params.sessionId
-      ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
-          agentId: params.agentId,
-        })
-      : undefined);
+  const sessionFile = resolveExistingUsageSessionFile(params);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
     return null;
   }
@@ -854,13 +900,7 @@ export async function loadSessionLogs(params: {
   agentId?: string;
   limit?: number;
 }): Promise<SessionLogEntry[] | null> {
-  const sessionFile =
-    params.sessionFile ??
-    (params.sessionId
-      ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
-          agentId: params.agentId,
-        })
-      : undefined);
+  const sessionFile = resolveExistingUsageSessionFile(params);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
     return null;
   }

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
+  parseSessionArchiveTimestamp,
   parseUsageCountedSessionIdFromFileName,
 } from "../config/sessions/artifacts.js";
 import {
@@ -335,7 +336,17 @@ export function resolveExistingUsageSessionFile(params: {
     const latestArchive = entries
       .filter((entry) => isSessionArchiveArtifactName(entry.name))
       .map((entry) => entry.name)
-      .toSorted((a, b) => b.localeCompare(a))[0];
+      .toSorted((a, b) => {
+        const tsA =
+          parseSessionArchiveTimestamp(a, "deleted") ??
+          parseSessionArchiveTimestamp(a, "reset") ??
+          0;
+        const tsB =
+          parseSessionArchiveTimestamp(b, "deleted") ??
+          parseSessionArchiveTimestamp(b, "reset") ??
+          0;
+        return tsB - tsA || b.localeCompare(a);
+      })[0];
 
     return latestArchive ? path.join(sessionsDir, latestArchive) : candidate;
   } catch {
@@ -446,7 +457,7 @@ export async function discoverAllSessions(params?: {
   const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
 
-  const discovered: DiscoveredSession[] = [];
+  const discovered = new Map<string, DiscoveredSession>();
 
   for (const entry of entries) {
     if (!entry.isFile() || !isUsageCountedSessionTranscriptFileName(entry.name)) {
@@ -505,16 +516,25 @@ export async function discoverAllSessions(params?: {
       // Ignore read errors
     }
 
-    discovered.push({
-      sessionId,
-      sessionFile: filePath,
-      mtime: stats.mtimeMs,
-      firstUserMessage,
-    });
+    const existing = discovered.get(sessionId);
+    if (!existing || stats.mtimeMs >= existing.mtime) {
+      discovered.set(sessionId, {
+        sessionId,
+        sessionFile: filePath,
+        mtime: stats.mtimeMs,
+        firstUserMessage: firstUserMessage ?? existing?.firstUserMessage,
+      });
+      continue;
+    }
+
+    if (!existing.firstUserMessage && firstUserMessage) {
+      existing.firstUserMessage = firstUserMessage;
+      discovered.set(sessionId, existing);
+    }
   }
 
   // Sort by mtime descending (most recent first)
-  return discovered.toSorted((a, b) => b.mtime - a.mtime);
+  return Array.from(discovered.values()).toSorted((a, b) => b.mtime - a.mtime);
 }
 
 export async function loadSessionCostSummary(params: {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -318,7 +318,9 @@ export function resolveExistingUsageSessionFile(params: {
   }
 
   try {
-    const sessionsDir = resolveSessionTranscriptsDirForAgent(params.agentId);
+    const sessionsDir = candidate
+      ? path.dirname(candidate)
+      : resolveSessionTranscriptsDirForAgent(params.agentId);
     const baseFileName = `${sessionId}.jsonl`;
     const entries = fs.readdirSync(sessionsDir, { withFileTypes: true }).filter((entry) => {
       return (


### PR DESCRIPTION
## Summary

- Problem: Usage aggregation only counted active `*.jsonl` session transcripts and skipped archived `*.jsonl.reset.*` / `*.jsonl.deleted.*` transcripts.
- Why it matters: Usage page totals become much lower than actual spend after `/new`, session reset, or deleting old sessions.
- What changed: usage scanning and session discovery now include `reset` and `deleted` transcript archives, and per-session usage detail falls back to archived transcripts when the active file no longer exists.
- What did NOT change (scope boundary): `*.jsonl.bak.*` archives are still excluded to avoid double-counting backup copies.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage
- [x] API / contracts
- [x] UI / DX
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Integrations
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42032
- Related #

## User-visible / Behavior Changes

- Usage totals now include spend from archived reset and deleted session transcripts.
- Session usage listing can discover archived reset/deleted sessions.
- Per-session usage detail can still load logs/timeseries/summary after the active transcript has been rotated away.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Control UI usage aggregation
- Relevant config (redacted): `OPENCLAW_STATE_DIR` pointed at temp test state dirs

### Steps

1. Create session transcripts for active `*.jsonl`, archived `*.jsonl.reset.*`, archived `*.jsonl.deleted.*`, and backup `*.jsonl.bak.*`.
2. Run usage aggregation and session discovery against that state directory.
3. Query per-session usage detail for a session that only exists as an archived reset transcript.

### Expected

- Active, reset, and deleted transcripts are counted in usage totals.
- Backup `bak` archives are not counted.
- Per-session usage detail still works when only the archived transcript remains.

### Actual

- Before this change, only active `*.jsonl` transcripts were counted, so reset/deleted usage was omitted.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted tests run:

```bash
corepack pnpm vitest run src/config/sessions/artifacts.test.ts src/infra/session-cost-usage.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts
```

Result: 23 tests passed.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: counted active/reset/deleted transcripts in aggregate usage; excluded `bak`; loaded summary/timeseries/logs from archived reset transcript fallback.
- Edge cases checked: archived session discovery still derives the original session id; specific session usage lookup still resolves when the active file is gone.
- What you did **not** verify: full manual Control UI click-through against a live local gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit to restore the previous active-transcript-only behavior.
- Files/config to restore: `src/config/sessions/artifacts.ts`, `src/infra/session-cost-usage.ts`, `src/gateway/server-methods/usage.ts`
- Known bad symptoms reviewers should watch for: usage totals unexpectedly jumping from counting backup archives, or archived session detail lookups returning duplicate/incorrect sessions.

## Risks and Mitigations

- Risk: counting archived files could accidentally include backup copies and double-count usage.
  - Mitigation: only `reset` and `deleted` archives are included; `bak` remains excluded, with test coverage for that boundary.
