### PR TITLE
fix: gate Google thinkingLevel injection on model.reasoning

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.live.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.live.test.ts
@@ -152,7 +152,7 @@ describeGeminiLive("pi embedded extra params (gemini live)", () => {
     return { sawDone, stopReason, errorMessage };
   }
 
-  it("sanitizes Gemini 3.1 thinking payload and keeps image parts with reasoning enabled", async () => {
+  it("sanitizes Gemini thinking payload and keeps image parts with reasoning enabled", async () => {
     const model = getModel("google", "gemini-2.5-pro") as unknown as Model<"google-generative-ai">;
 
     const agent = { streamFn: streamSimple };

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -871,7 +871,7 @@ describe("applyExtraParamsToAgent", () => {
     ]);
   });
 
-  it("removes invalid negative Google thinkingBudget and maps Gemini 3.1 to thinkingLevel", () => {
+  it("removes invalid negative Google thinkingBudget and maps reasoning-capable Gemini models to thinkingLevel", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {
@@ -908,6 +908,7 @@ describe("applyExtraParamsToAgent", () => {
       api: "google-generative-ai",
       provider: "atproxy",
       id: "gemini-3.1-pro-high",
+      reasoning: true,
     } as Model<"google-generative-ai">;
     const context: Context = { messages: [] };
     void agent.streamFn?.(model, context, {});
@@ -929,6 +930,79 @@ describe("applyExtraParamsToAgent", () => {
     ).toEqual({
       mimeType: "image/png",
       data: "ZmFrZQ==",
+    });
+  });
+
+  it("maps Gemini 2.5 Flash to Google thinkingLevel when reasoning is enabled", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        config: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingBudget: -1,
+          },
+        },
+      };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "google", "gemini-2.5-flash", undefined, "low");
+
+    const model = {
+      api: "google-generative-ai",
+      provider: "google",
+      id: "gemini-2.5-flash",
+      reasoning: true,
+    } as Model<"google-generative-ai">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.config).toEqual({
+      thinkingConfig: {
+        includeThoughts: true,
+        thinkingLevel: "LOW",
+      },
+    });
+  });
+
+  it("does not inject Google thinkingLevel for non-reasoning models", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        config: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingBudget: -1,
+          },
+        },
+      };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "google", "gemini-2.5-flash-lite", undefined, "low");
+
+    const model = {
+      api: "google-generative-ai",
+      provider: "google",
+      id: "gemini-2.5-flash-lite",
+      reasoning: false,
+    } as Model<"google-generative-ai">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.config).toEqual({
+      thinkingConfig: {
+        includeThoughts: true,
+      },
     });
   });
 
@@ -955,6 +1029,7 @@ describe("applyExtraParamsToAgent", () => {
       api: "google-generative-ai",
       provider: "atproxy",
       id: "gemini-3.1-pro-high",
+      reasoning: true,
     } as Model<"google-generative-ai">;
     const context: Context = { messages: [] };
     void agent.streamFn?.(model, context, {});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -147,11 +147,6 @@ function createStreamFnWithExtraParams(
   return wrappedStreamFn;
 }
 
-function isGemini31Model(modelId: string): boolean {
-  const normalized = modelId.toLowerCase();
-  return normalized.includes("gemini-3.1-pro") || normalized.includes("gemini-3.1-flash");
-}
-
 function mapThinkLevelToGoogleThinkingLevel(
   thinkingLevel: ThinkLevel,
 ): "MINIMAL" | "LOW" | "MEDIUM" | "HIGH" | undefined {
@@ -173,7 +168,7 @@ function mapThinkLevelToGoogleThinkingLevel(
 
 function sanitizeGoogleThinkingPayload(params: {
   payload: unknown;
-  modelId?: string;
+  modelReasoning?: boolean;
   thinkingLevel?: ThinkLevel;
 }): void {
   if (!params.payload || typeof params.payload !== "object") {
@@ -195,13 +190,13 @@ function sanitizeGoogleThinkingPayload(params: {
     return;
   }
 
-  // pi-ai can emit thinkingBudget=-1 for some Gemini 3.1 IDs; a negative budget
-  // is invalid for Google-compatible backends and can lead to malformed handling.
+  // pi-ai can emit thinkingBudget=-1 for some reasoning-capable Gemini IDs; a
+  // negative budget is invalid for Google-compatible backends and can lead to
+  // malformed handling.
   delete thinkingConfigObj.thinkingBudget;
 
   if (
-    typeof params.modelId === "string" &&
-    isGemini31Model(params.modelId) &&
+    params.modelReasoning === true &&
     params.thinkingLevel &&
     params.thinkingLevel !== "off" &&
     thinkingConfigObj.thinkingLevel === undefined
@@ -226,7 +221,7 @@ function createGoogleThinkingPayloadWrapper(
         if (model.api === "google-generative-ai") {
           sanitizeGoogleThinkingPayload({
             payload,
-            modelId: model.id,
+            modelReasoning: model.reasoning,
             thinkingLevel,
           });
         }
@@ -433,7 +428,7 @@ export function applyExtraParamsToAgent(
   }
 
   // Guard Google payloads against invalid negative thinking budgets emitted by
-  // upstream model-ID heuristics for Gemini 3.1 variants.
+  // upstream model-ID heuristics for reasoning-capable Gemini models.
   agent.streamFn = createGoogleThinkingPayloadWrapper(agent.streamFn, thinkingLevel);
 
   const openAIServiceTier = resolveOpenAIServiceTier(merged);


### PR DESCRIPTION
## Summary

**Problem**: `sanitizeGoogleThinkingPayload()` gated Google `thinkingLevel` injection on `isGemini31Model()`, which only matched `gemini-3.1-*` IDs. As a result, reasoning-capable Gemini models outside that pattern (for example `gemini-2.5-flash`) did not receive `thinkingLevel` when sanitizing payloads with an invalid negative `thinkingBudget`.

Without API-level thinking enabled, Gemini can emit planning text inline in the assistant response instead of a separate thinking block, which leaks reasoning to the end user.

**Fix**:
- Remove `isGemini31Model()`
- Change `sanitizeGoogleThinkingPayload()` to use the resolved model's reasoning capability (`model.reasoning`) instead of model ID pattern matching
- Keep the existing negative `thinkingBudget` sanitization, but inject `thinkingLevel` for any reasoning-capable Gemini model in that path
- This covers Gemini models whose resolved metadata reports reasoning support, including `gemini-2.5-flash`

**What did NOT change**: The sanitization logic itself (`thinkingBudget` deletion, `thinkingLevel` injection conditions) is unchanged. Only the gating condition changed from string-based model ID matching to the resolved model's `reasoning` flag.

## Change Type
Bug fix

## Scope
Agents (pi-embedded-runner)

## User-visible / Behavior Changes
Reasoning-capable Gemini models outside the `gemini-3.1-*` family (e.g. `gemini-2.5-flash`) will now correctly receive `thinkingLevel` in the Google API payload during the negative `thinkingBudget` sanitization path, enabling proper thinking behavior.

## Security Impact
1. Does this change how users authenticate or how sessions/tokens are managed? **No**
2. Does this change what data users can access or modify? **No**
3. Does this modify, read, or write to the filesystem, network, or exec commands? **No**
4. Does this change input validation, sanitization, or escaping? **No** (payload sanitization logic unchanged, only gating condition)
5. Does this affect rate limiting, permissions, or access control? **No**

## Repro + Verification
**Environment**: Any OpenClaw instance using Gemini 2.5 Flash with thinking enabled (`thinkingLevel` != `"off"`)
**Steps**: Send a message with `thinkingLevel=low` using `gemini-2.5-flash` → observe `rawThinking` and `rawText` in raw-stream log
**Expected**: Thinking content in dedicated thinking block (`rawThinking` populated), clean answer in `rawText`
**Actual (before fix)**: Empty `rawThinking`, reasoning/planning text leaked into `rawText`

## Evidence
- Unit tests: 69 passing (`pnpm vitest run src/agents/pi-embedded-runner-extraparams.test.ts`)
- Added regression test: `gemini-2.5-flash` (`reasoning: true`) → `thinkingLevel` injected
- Added negative test: non-reasoning model (`reasoning: false`) → `thinkingLevel` not injected

## Human Verification
- Verified via production logs (`raw-stream.jsonl`) that `rawThinking` is populated and `rawText` is clean after deploying the fix
- **NOT verified**: Gemini live test (requires API key with access to `gemini-2.5-flash`)

## Compatibility / Migration
No migration needed. `model.reasoning` is already populated in the resolved model metadata for all models.

## Failure Recovery
Revert the single commit. No data migration involved.

## Risks and Mitigations
- **Risk**: `model.reasoning` could be `undefined` for custom model configs → **Mitigated**: condition uses strict `=== true`, so `undefined`/`false` safely skip injection (same behavior as before for non-reasoning models)