### PR TITLE
Agents: add first-class workspace ls tool

### DIFF
--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -21,6 +21,7 @@ describe("Agent-specific tool filtering", () => {
       containerPath: "/workspace",
     }),
     readFile: async () => Buffer.from(""),
+    readdir: async () => [],
     writeFile: async () => {},
     mkdirp: async () => {},
     remove: async () => {},

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-b.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-b.test.ts
@@ -54,6 +54,7 @@ describe("createOpenClawCodingTools", () => {
   it("enforces apply_patch availability and canonical names across model/provider constraints", () => {
     expect(defaultTools.some((tool) => tool.name === "exec")).toBe(true);
     expect(defaultTools.some((tool) => tool.name === "process")).toBe(true);
+    expect(defaultTools.some((tool) => tool.name === "ls")).toBe(true);
     expect(defaultTools.some((tool) => tool.name === "apply_patch")).toBe(false);
 
     const enabledConfig: OpenClawConfig = {
@@ -105,6 +106,7 @@ describe("createOpenClawCodingTools", () => {
     const names = new Set(oauthTools.map((tool) => tool.name));
     expect(names.has("exec")).toBe(true);
     expect(names.has("read")).toBe(true);
+    expect(names.has("ls")).toBe(true);
     expect(names.has("write")).toBe(true);
     expect(names.has("edit")).toBe(true);
     expect(names.has("apply_patch")).toBe(false);

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -12,6 +12,8 @@ describe("createOpenClawCodingTools", () => {
     try {
       const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
       const { readTool, writeTool, editTool } = expectReadWriteEditTools(tools);
+      const lsTool = tools.find((tool) => tool.name === "ls");
+      expect(lsTool).toBeDefined();
 
       const filePath = "alias-test.txt";
       await writeTool?.execute("tool-alias-1", {
@@ -34,6 +36,13 @@ describe("createOpenClawCodingTools", () => {
         | undefined;
       const combinedText = textBlocks?.map((block) => block.text ?? "").join("\n");
       expect(combinedText).toContain("hello universe");
+
+      const lsResult = await lsTool?.execute("tool-alias-ls", { file_path: "." });
+      const lsTextBlocks = lsResult?.content?.filter((block) => block.type === "text") as
+        | Array<{ text?: string }>
+        | undefined;
+      const listed = lsTextBlocks?.map((block) => block.text ?? "").join("\n") ?? "";
+      expect(listed).toContain(filePath);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -414,6 +414,7 @@ describe("createOpenClawCodingTools", () => {
     });
     const names = new Set(tools.map((tool) => tool.name));
     expect(names.has("read")).toBe(true);
+    expect(names.has("ls")).toBe(true);
     expect(names.has("write")).toBe(true);
     expect(names.has("edit")).toBe(true);
     expect(names.has("exec")).toBe(false);
@@ -425,6 +426,7 @@ describe("createOpenClawCodingTools", () => {
     });
     const names = new Set(tools.map((tool) => tool.name));
     expect(names.has("read")).toBe(false);
+    expect(names.has("ls")).toBe(false);
     expect(names.has("write")).toBe(false);
     expect(names.has("edit")).toBe(false);
     expect(names.has("exec")).toBe(true);

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -573,10 +573,8 @@ function createSandboxLsOperations(params: SandboxToolParams) {
         isDirectory: () => stat.type === "directory",
       };
     },
-    readdir: async (absolutePath: string) => {
-      const resolved = params.bridge.resolvePath({ filePath: absolutePath, cwd: params.root });
-      return await fs.readdir(resolved.hostPath);
-    },
+    readdir: (absolutePath: string) =>
+      params.bridge.readdir({ filePath: absolutePath, cwd: params.root }),
   } as const;
 }
 

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
+import {
+  createEditTool,
+  createLsTool,
+  createReadTool,
+  createWriteTool,
+} from "@mariozechner/pi-coding-agent";
 import {
   SafeOpenError,
   openFileWithinRoot,
@@ -458,6 +463,13 @@ export function createSandboxedWriteTool(params: SandboxToolParams) {
   return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.write);
 }
 
+export function createSandboxedLsTool(params: SandboxToolParams) {
+  const base = createLsTool(params.root, {
+    operations: createSandboxLsOperations(params),
+  }) as unknown as AnyAgentTool;
+  return wrapToolParamNormalization(base);
+}
+
 export function createSandboxedEditTool(params: SandboxToolParams) {
   const base = createEditTool(params.root, {
     operations: createSandboxEditOperations(params),
@@ -470,6 +482,13 @@ export function createHostWorkspaceWriteTool(root: string, options?: { workspace
     operations: createHostWriteOperations(root, options),
   }) as unknown as AnyAgentTool;
   return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.write);
+}
+
+export function createHostWorkspaceLsTool(root: string, options?: { workspaceOnly?: boolean }) {
+  const base = createLsTool(root, {
+    operations: createHostLsOperations(root, options),
+  }) as unknown as AnyAgentTool;
+  return wrapToolParamNormalization(base);
 }
 
 export function createHostWorkspaceEditTool(root: string, options?: { workspaceOnly?: boolean }) {
@@ -541,6 +560,26 @@ function createSandboxWriteOperations(params: SandboxToolParams) {
   } as const;
 }
 
+function createSandboxLsOperations(params: SandboxToolParams) {
+  return {
+    exists: async (absolutePath: string) =>
+      (await params.bridge.stat({ filePath: absolutePath, cwd: params.root })) !== null,
+    stat: async (absolutePath: string) => {
+      const stat = await params.bridge.stat({ filePath: absolutePath, cwd: params.root });
+      if (!stat) {
+        throw createFsAccessError("ENOENT", absolutePath);
+      }
+      return {
+        isDirectory: () => stat.type === "directory",
+      };
+    },
+    readdir: async (absolutePath: string) => {
+      const resolved = params.bridge.resolvePath({ filePath: absolutePath, cwd: params.root });
+      return await fs.readdir(resolved.hostPath);
+    },
+  } as const;
+}
+
 function createSandboxEditOperations(params: SandboxToolParams) {
   return {
     readFile: (absolutePath: string) =>
@@ -560,6 +599,21 @@ async function writeHostFile(absolutePath: string, content: string) {
   const resolved = path.resolve(absolutePath);
   await fs.mkdir(path.dirname(resolved), { recursive: true });
   await fs.writeFile(resolved, content, "utf-8");
+}
+
+async function resolveHostWorkspacePath(
+  root: string,
+  absolutePath: string,
+  options?: { workspaceOnly?: boolean },
+) {
+  const resolved = path.resolve(absolutePath);
+  if (options?.workspaceOnly !== true) {
+    return resolved;
+  }
+  const relative = toRelativeWorkspacePath(root, resolved, { allowRoot: true });
+  const workspaceResolved = relative ? path.resolve(root, relative) : path.resolve(root);
+  await assertSandboxPath({ filePath: workspaceResolved, cwd: root, root });
+  return workspaceResolved;
 }
 
 function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {
@@ -592,6 +646,31 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
         data: content,
         mkdir: true,
       });
+    },
+  } as const;
+}
+
+function createHostLsOperations(root: string, options?: { workspaceOnly?: boolean }) {
+  return {
+    exists: async (absolutePath: string) => {
+      try {
+        const resolved = await resolveHostWorkspacePath(root, absolutePath, options);
+        await fs.access(resolved);
+        return true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return false;
+        }
+        throw error;
+      }
+    },
+    stat: async (absolutePath: string) => {
+      const resolved = await resolveHostWorkspacePath(root, absolutePath, options);
+      return await fs.stat(resolved);
+    },
+    readdir: async (absolutePath: string) => {
+      const resolved = await resolveHostWorkspacePath(root, absolutePath, options);
+      return await fs.readdir(resolved);
     },
   } as const;
 }

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -1,4 +1,4 @@
-import { codingTools, createReadTool, readTool } from "@mariozechner/pi-coding-agent";
+import { codingTools, createLsTool, createReadTool, readTool } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
@@ -29,9 +29,11 @@ import {
 import {
   assertRequiredParams,
   createHostWorkspaceEditTool,
+  createHostWorkspaceLsTool,
   createHostWorkspaceWriteTool,
   createOpenClawReadTool,
   createSandboxedEditTool,
+  createSandboxedLsTool,
   createSandboxedReadTool,
   createSandboxedWriteTool,
   normalizeToolParams,
@@ -347,7 +349,12 @@ export function createOpenClawCodingTools(options?: {
   }
   const imageSanitization = resolveImageSanitizationLimits(options?.config);
 
-  const base = (codingTools as unknown as AnyAgentTool[]).flatMap((tool) => {
+  const codingBaseTools = [...(codingTools as unknown as AnyAgentTool[])];
+  if (!codingBaseTools.some((tool) => tool.name === "ls")) {
+    codingBaseTools.push(createLsTool(workspaceRoot) as unknown as AnyAgentTool);
+  }
+
+  const base = codingBaseTools.flatMap((tool) => {
     if (tool.name === readTool.name) {
       if (sandboxRoot) {
         const sandboxed = createSandboxedReadTool({
@@ -369,6 +376,23 @@ export function createOpenClawCodingTools(options?: {
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,
       });
+      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+    }
+    if (tool.name === "ls") {
+      if (sandboxRoot) {
+        const sandboxed = createSandboxedLsTool({
+          root: sandboxRoot,
+          bridge: sandboxFsBridge!,
+        });
+        return [
+          workspaceOnly
+            ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
+                containerWorkdir: sandbox.containerWorkdir,
+              })
+            : sandboxed,
+        ];
+      }
+      const wrapped = createHostWorkspaceLsTool(workspaceRoot, { workspaceOnly });
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
     }
     if (tool.name === "bash" || tool.name === execToolName) {

--- a/src/agents/pi-tools.workspace-paths.test.ts
+++ b/src/agents/pi-tools.workspace-paths.test.ts
@@ -249,4 +249,31 @@ describe("sandboxed workspace paths", () => {
       });
     });
   });
+
+  it("routes sandbox ls directory reads through bridge.readdir", async () => {
+    await withTempDir("openclaw-sandbox-", async (sandboxDir) => {
+      const marker = "bridge readdir blocked";
+      const hostBridge = createHostSandboxFsBridge(sandboxDir);
+      const sandbox = createPiToolsSandboxContext({
+        workspaceDir: sandboxDir,
+        workspaceAccess: "rw" as const,
+        fsBridge: {
+          ...hostBridge,
+          readdir: async () => {
+            throw new Error(marker);
+          },
+        },
+        tools: { allow: [], deny: [] },
+      });
+
+      const tools = createOpenClawCodingTools({ workspaceDir: sandboxDir, sandbox });
+      const lsTool = tools.find((tool) => tool.name === "ls");
+      expect(lsTool).toBeDefined();
+      if (!lsTool) {
+        throw new Error("ls tool missing");
+      }
+
+      await expect(lsTool.execute("sbx-ls-bridge-readdir", { path: "." })).rejects.toThrow(marker);
+    });
+  });
 });

--- a/src/agents/pi-tools.workspace-paths.test.ts
+++ b/src/agents/pi-tools.workspace-paths.test.ts
@@ -58,11 +58,17 @@ describe("workspace path resolution", () => {
         try {
           const tools = createOpenClawCodingTools({ workspaceDir });
           const { readTool, writeTool, editTool } = expectReadWriteEditTools(tools);
+          const lsTool = tools.find((tool) => tool.name === "ls");
+          expect(lsTool).toBeDefined();
 
           const readFile = "read.txt";
           await fs.writeFile(path.join(workspaceDir, readFile), "workspace read ok", "utf8");
           const readResult = await readTool.execute("ws-read", { path: readFile });
           expect(getTextContent(readResult)).toContain("workspace read ok");
+
+          await fs.mkdir(path.join(workspaceDir, "list-dir"), { recursive: true });
+          const lsResult = await lsTool?.execute("ws-ls", { path: "." });
+          expect(getTextContent(lsResult)).toContain("list-dir/");
 
           const writeFile = "write.txt";
           await writeTool.execute("ws-write", {
@@ -141,10 +147,15 @@ describe("workspace path resolution", () => {
       const cfg: OpenClawConfig = { tools: { fs: { workspaceOnly: true } } };
       const tools = createOpenClawCodingTools({ workspaceDir, config: cfg });
       const { readTool } = expectReadWriteEditTools(tools);
+      const lsTool = tools.find((tool) => tool.name === "ls");
+      expect(lsTool).toBeDefined();
 
       const outsideAbsolute = path.resolve(path.parse(workspaceDir).root, "outside-openclaw.txt");
       await expect(
         readTool.execute("ws-read-at-prefix", { path: `@${outsideAbsolute}` }),
+      ).rejects.toThrow(/Path escapes sandbox root/i);
+      await expect(
+        lsTool?.execute("ws-ls-at-prefix", { path: `@${outsideAbsolute}` }),
       ).rejects.toThrow(/Path escapes sandbox root/i);
     });
   });
@@ -208,6 +219,8 @@ describe("sandboxed workspace paths", () => {
 
         const tools = createOpenClawCodingTools({ workspaceDir, sandbox });
         const { readTool, writeTool, editTool } = expectReadWriteEditTools(tools);
+        const lsTool = tools.find((tool) => tool.name === "ls");
+        expect(lsTool).toBeDefined();
 
         const result = await readTool?.execute("sbx-read", { path: testFile });
         expect(getTextContent(result)).toContain("sandbox read");
@@ -226,6 +239,13 @@ describe("sandboxed workspace paths", () => {
         });
         const edited = await fs.readFile(path.join(sandboxDir, "new.txt"), "utf8");
         expect(edited).toBe("sandbox edit");
+
+        await fs.writeFile(path.join(sandboxDir, "sandbox-only.txt"), "sandbox only", "utf8");
+        await fs.writeFile(path.join(workspaceDir, "workspace-only.txt"), "workspace only", "utf8");
+        const lsResult = await lsTool?.execute("sbx-ls", { path: "." });
+        const listed = getTextContent(lsResult);
+        expect(listed).toContain("sandbox-only.txt");
+        expect(listed).not.toContain("workspace-only.txt");
       });
     });
   });

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -39,6 +39,7 @@ export type SandboxFsStat = {
 export type SandboxFsBridge = {
   resolvePath(params: { filePath: string; cwd?: string }): SandboxResolvedPath;
   readFile(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<Buffer>;
+  readdir(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<string[]>;
   writeFile(params: {
     filePath: string;
     cwd?: string;
@@ -100,6 +101,19 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   }): Promise<Buffer> {
     const target = this.resolveResolvedPath(params);
     return this.readPinnedFile(target);
+  }
+
+  async readdir(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<string[]> {
+    const target = this.resolveResolvedPath(params);
+    await this.pathGuard.assertPathSafety(target, {
+      action: "list directories",
+      allowedType: "directory",
+    });
+    return await fs.promises.readdir(target.hostPath);
   }
 
   async writeFile(params: {

--- a/src/agents/test-helpers/host-sandbox-fs-bridge.ts
+++ b/src/agents/test-helpers/host-sandbox-fs-bridge.ts
@@ -12,6 +12,10 @@ export function createSandboxFsBridgeFromResolver(
       const target = resolvePath(filePath, cwd);
       return fs.readFile(target.hostPath);
     },
+    readdir: async ({ filePath, cwd }) => {
+      const target = resolvePath(filePath, cwd);
+      return fs.readdir(target.hostPath);
+    },
     writeFile: async ({ filePath, cwd, data, mkdir = true }) => {
       const target = resolvePath(filePath, cwd);
       if (mkdir) {

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -47,6 +47,13 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     profiles: ["coding"],
   },
   {
+    id: "ls",
+    label: "ls",
+    description: "List directory contents",
+    sectionId: "fs",
+    profiles: ["coding"],
+  },
+  {
     id: "write",
     label: "write",
     description: "Create or overwrite files",

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -49,6 +49,7 @@ describe("tool-policy", () => {
     expect(set.has("bash")).toBe(false);
     expect(set.has("apply_patch")).toBe(true);
     expect(set.has("read")).toBe(true);
+    expect(set.has("ls")).toBe(true);
     expect(set.has("write")).toBe(true);
     expect(set.has("edit")).toBe(true);
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw coding tools exposed `read`/`write`/`edit` but had no first-class directory listing tool.
- Why it matters: agents had to fall back to `exec` for basic directory navigation.
- What changed: added a first-class `ls` tool to OpenClaw coding tools, with the same host/sandbox + `tools.fs.workspaceOnly` boundary behavior used by file tools.
- What changed: added `ls` to the core tool catalog `group:fs`/`coding` profile and updated tests.
- What did NOT change (scope boundary): no shell/exec permission expansion and no workspace boundary relaxation.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43099
- Related #N/A

## User-visible / Behavior Changes

- `createOpenClawCodingTools()` now includes `ls`.
- `ls` is now included in `group:fs` and the `coding` tool profile.
- In sandbox and/or `tools.fs.workspaceOnly=true` mode, `ls` now follows the same workspace-root guard model as `read`/`write`/`edit`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes (new read-only listing capability)
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes (`ls` tool is now exposed)
- Data access scope changed? (`Yes/No`) No (still gated by existing host/sandbox + workspace guards)
- If any `Yes`, explain risk + mitigation:
  - Risk: additional filesystem visibility.
  - Mitigation: `ls` is read-only and wrapped with existing workspace root guards (`tools.fs.workspaceOnly`) and sandbox path mapping, matching existing file tool boundary behavior.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default + `tools.fs.workspaceOnly` cases in tests

### Steps

1. Add `ls` into OpenClaw coding tool construction with host/sandbox wrappers.
2. Add `ls` to core tool catalog `group:fs`/`coding` profile.
3. Validate with targeted test suites.

### Expected

- `ls` is available as a first-class coding tool.
- `group:fs` allow/deny includes `ls`.
- `ls` respects workspace-only and sandbox path boundaries.

### Actual

- All expected behaviors are present and covered by passing tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands and outcomes:

1. `pnpm vitest src/agents/pi-tools.workspace-paths.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-b.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts src/agents/tool-policy.test.ts`
- Result: 5 files passed, 58 tests passed.

2. `pnpm vitest src/agents/pi-tools-agent-config.test.ts src/gateway/server-methods/tools-catalog.test.ts`
- Result: 2 files passed, 25 tests passed.

3. `pnpm format`
- Result: success.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `ls` exists in default coding tools, `group:fs` policy expansion/deny includes `ls`, alias path normalization works with `file_path`, host and sandbox workspace routing for `ls` is correct.
- Edge cases checked: workspace-only guard rejection for outside `@` path, sandbox listing resolves against sandbox workspace not host workspace.
- What you did **not** verify: live channel-runtime/manual UI session execution.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: deny `ls` in tool policy (e.g., `tools.deny: ["ls"]`) or revert commit c37b4e8ee.
- Files/config to restore: `src/agents/pi-tools.ts`, `src/agents/pi-tools.read.ts`, `src/agents/tool-catalog.ts`.
- Known bad symptoms reviewers should watch for: unexpected `ls` availability when explicit tool allowlists are intended to exclude filesystem group entries.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: exposing extra filesystem discovery data in contexts that previously only used read/write/edit.
  - Mitigation: keep `ls` in existing `group:fs` policy bucket and enforce same workspace/sandbox guards.
