### PR TITLE
Hooks: fix bundled hook discovery in pnpm install layouts

### DIFF
--- a/src/hooks/bundled-dir.test.ts
+++ b/src/hooks/bundled-dir.test.ts
@@ -19,19 +19,28 @@ async function writeBundledHook(params: { hooksDir: string; name: string }): Pro
 
 describe("resolveBundledHooksDir", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
+  let tempDirs: string[];
+
+  async function createTempDir(prefix: string): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
 
   beforeEach(() => {
     envSnapshot = captureEnv(["OPENCLAW_BUNDLED_HOOKS_DIR"]);
+    tempDirs = [];
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     envSnapshot.restore();
+    for (const dir of tempDirs.toReversed()) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("returns OPENCLAW_BUNDLED_HOOKS_DIR override when set", async () => {
-    const overrideDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-bundled-hooks-override-"),
-    );
+    const overrideDir = await createTempDir("openclaw-bundled-hooks-override-");
     process.env.OPENCLAW_BUNDLED_HOOKS_DIR = ` ${overrideDir} `;
     expect(resolveBundledHooksDir()).toBe(overrideDir);
   });
@@ -39,7 +48,7 @@ describe("resolveBundledHooksDir", () => {
   it("resolves bundled hooks under a flattened dist layout", async () => {
     delete process.env.OPENCLAW_BUNDLED_HOOKS_DIR;
 
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bundled-hooks-"));
+    const root = await createTempDir("openclaw-bundled-hooks-");
     await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
 
     const distBundled = path.join(root, "dist", "bundled");
@@ -67,7 +76,7 @@ describe("resolveBundledHooksDir", () => {
   it("skips non-hook exec sibling dirs and falls back to package dist hooks", async () => {
     delete process.env.OPENCLAW_BUNDLED_HOOKS_DIR;
 
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bundled-hooks-fallback-"));
+    const root = await createTempDir("openclaw-bundled-hooks-fallback-");
     await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
 
     const execPath = path.join(root, "runtime", "node");
@@ -91,5 +100,35 @@ describe("resolveBundledHooksDir", () => {
     });
 
     expect(resolved).toBe(distBundled);
+  });
+
+  it("does not walk up past package root when package-root candidates are absent", async () => {
+    delete process.env.OPENCLAW_BUNDLED_HOOKS_DIR;
+
+    const root = await createTempDir("openclaw-bundled-hooks-root-");
+    const packageRoot = path.join(root, "package");
+    await fs.mkdir(packageRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw" }),
+    );
+
+    const unrelatedBundled = path.join(root, "bundled");
+    await writeBundledHook({ hooksDir: unrelatedBundled, name: "unrelated-hook" });
+
+    const moduleDir = path.join(packageRoot, "dist", "nested");
+    await fs.mkdir(moduleDir, { recursive: true });
+    const moduleUrl = pathToFileURL(path.join(moduleDir, "workspace.js")).href;
+    const argv1 = path.join(packageRoot, "dist", "entry.js");
+    await fs.writeFile(argv1, "// stub", "utf-8");
+
+    const resolved = resolveBundledHooksDir({
+      argv1,
+      moduleUrl,
+      cwd: moduleDir,
+      execPath: path.join(root, "runtime", "node"),
+    });
+
+    expect(resolved).toBeUndefined();
   });
 });

--- a/src/hooks/bundled-dir.test.ts
+++ b/src/hooks/bundled-dir.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { resolveBundledHooksDir } from "./bundled-dir.js";
+
+async function writeBundledHook(params: { hooksDir: string; name: string }): Promise<void> {
+  const hookDir = path.join(params.hooksDir, params.name);
+  await fs.mkdir(hookDir, { recursive: true });
+  await fs.writeFile(path.join(hookDir, "HOOK.md"), `---\nname: ${params.name}\n---\n`, "utf-8");
+  await fs.writeFile(
+    path.join(hookDir, "handler.js"),
+    "export default async function() {}\n",
+    "utf-8",
+  );
+}
+
+describe("resolveBundledHooksDir", () => {
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["OPENCLAW_BUNDLED_HOOKS_DIR"]);
+  });
+
+  afterEach(() => {
+    envSnapshot.restore();
+  });
+
+  it("returns OPENCLAW_BUNDLED_HOOKS_DIR override when set", async () => {
+    const overrideDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-bundled-hooks-override-"),
+    );
+    process.env.OPENCLAW_BUNDLED_HOOKS_DIR = ` ${overrideDir} `;
+    expect(resolveBundledHooksDir()).toBe(overrideDir);
+  });
+
+  it("resolves bundled hooks under a flattened dist layout", async () => {
+    delete process.env.OPENCLAW_BUNDLED_HOOKS_DIR;
+
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bundled-hooks-"));
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+
+    const distBundled = path.join(root, "dist", "bundled");
+    await writeBundledHook({ hooksDir: distBundled, name: "session-memory" });
+
+    const distDir = path.join(root, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    const argv1 = path.join(distDir, "entry.js");
+    await fs.writeFile(argv1, "// stub", "utf-8");
+
+    const moduleUrl = pathToFileURL(path.join(distDir, "workspace.js")).href;
+    const execPath = path.join(root, "bin", "node");
+    await fs.mkdir(path.dirname(execPath), { recursive: true });
+
+    const resolved = resolveBundledHooksDir({
+      argv1,
+      moduleUrl,
+      cwd: distDir,
+      execPath,
+    });
+
+    expect(resolved).toBe(distBundled);
+  });
+
+  it("skips non-hook exec sibling dirs and falls back to package dist hooks", async () => {
+    delete process.env.OPENCLAW_BUNDLED_HOOKS_DIR;
+
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bundled-hooks-fallback-"));
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+
+    const execPath = path.join(root, "runtime", "node");
+    const execSiblingHooks = path.join(path.dirname(execPath), "hooks", "bundled");
+    await fs.mkdir(execSiblingHooks, { recursive: true });
+
+    const distBundled = path.join(root, "dist", "bundled");
+    await writeBundledHook({ hooksDir: distBundled, name: "command-logger" });
+
+    const distDir = path.join(root, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    const argv1 = path.join(distDir, "entry.js");
+    await fs.writeFile(argv1, "// stub", "utf-8");
+    const moduleUrl = pathToFileURL(path.join(distDir, "workspace.js")).href;
+
+    const resolved = resolveBundledHooksDir({
+      argv1,
+      moduleUrl,
+      cwd: distDir,
+      execPath,
+    });
+
+    expect(resolved).toBe(distBundled);
+  });
+});

--- a/src/hooks/bundled-dir.ts
+++ b/src/hooks/bundled-dir.ts
@@ -5,6 +5,11 @@ import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 
 const HOOK_HANDLER_CANDIDATES = ["handler.js", "handler.ts", "index.js", "index.ts"];
 
+function isSameOrDescendantPath(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
 function isDirectoryLike(entry: fs.Dirent, fullPath: string): boolean {
   if (entry.isDirectory()) {
     return true;
@@ -73,7 +78,7 @@ export function resolveBundledHooksDir(opts: BundledHooksResolveOptions = {}): s
   // npm/dev: prefer package-root relative lookup so pnpm/global symlink layouts resolve reliably.
   try {
     const moduleUrl = opts.moduleUrl ?? import.meta.url;
-    const moduleDir = path.dirname(fileURLToPath(moduleUrl));
+    const moduleDir = path.resolve(path.dirname(fileURLToPath(moduleUrl)));
     const argv1 = opts.argv1 ?? process.argv[1];
     const cwd = opts.cwd ?? process.cwd();
     const packageRoot = resolveOpenClawPackageRootSync({
@@ -81,6 +86,7 @@ export function resolveBundledHooksDir(opts: BundledHooksResolveOptions = {}): s
       moduleUrl,
       cwd,
     });
+    const normalizedPackageRoot = packageRoot ? path.resolve(packageRoot) : null;
     if (packageRoot) {
       const distBundled = path.join(packageRoot, "dist", "bundled");
       if (looksLikeBundledHooksDir(distBundled)) {
@@ -93,14 +99,23 @@ export function resolveBundledHooksDir(opts: BundledHooksResolveOptions = {}): s
     }
 
     // Fallback: walk up from the module location for layouts where package-root discovery fails.
-    let current = moduleDir;
+    let current =
+      normalizedPackageRoot && !isSameOrDescendantPath(moduleDir, normalizedPackageRoot)
+        ? normalizedPackageRoot
+        : moduleDir;
     for (let depth = 0; depth < 6; depth += 1) {
+      if (normalizedPackageRoot && !isSameOrDescendantPath(current, normalizedPackageRoot)) {
+        break;
+      }
       const candidate = path.join(current, "bundled");
       if (looksLikeBundledHooksDir(candidate)) {
         return candidate;
       }
       const parent = path.dirname(current);
-      if (parent === current) {
+      if (
+        parent === current ||
+        (normalizedPackageRoot && !isSameOrDescendantPath(parent, normalizedPackageRoot))
+      ) {
         break;
       }
       current = parent;

--- a/src/hooks/bundled-dir.ts
+++ b/src/hooks/bundled-dir.ts
@@ -1,8 +1,58 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 
-export function resolveBundledHooksDir(): string | undefined {
+const HOOK_HANDLER_CANDIDATES = ["handler.js", "handler.ts", "index.js", "index.ts"];
+
+function isDirectoryLike(entry: fs.Dirent, fullPath: string): boolean {
+  if (entry.isDirectory()) {
+    return true;
+  }
+  if (!entry.isSymbolicLink()) {
+    return false;
+  }
+  try {
+    return fs.statSync(fullPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function looksLikeBundledHooksDir(dir: string): boolean {
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) {
+        continue;
+      }
+      const hookDir = path.join(dir, entry.name);
+      if (!isDirectoryLike(entry, hookDir)) {
+        continue;
+      }
+      if (!fs.existsSync(path.join(hookDir, "HOOK.md"))) {
+        continue;
+      }
+      if (
+        HOOK_HANDLER_CANDIDATES.some((candidate) => fs.existsSync(path.join(hookDir, candidate)))
+      ) {
+        return true;
+      }
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+export type BundledHooksResolveOptions = {
+  argv1?: string;
+  moduleUrl?: string;
+  cwd?: string;
+  execPath?: string;
+};
+
+export function resolveBundledHooksDir(opts: BundledHooksResolveOptions = {}): string | undefined {
   const override = process.env.OPENCLAW_BUNDLED_HOOKS_DIR?.trim();
   if (override) {
     return override;
@@ -10,35 +60,50 @@ export function resolveBundledHooksDir(): string | undefined {
 
   // bun --compile: ship a sibling `hooks/bundled/` next to the executable.
   try {
-    const execDir = path.dirname(process.execPath);
+    const execPath = opts.execPath ?? process.execPath;
+    const execDir = path.dirname(execPath);
     const sibling = path.join(execDir, "hooks", "bundled");
-    if (fs.existsSync(sibling)) {
+    if (looksLikeBundledHooksDir(sibling)) {
       return sibling;
     }
   } catch {
     // ignore
   }
 
-  // npm: resolve `<packageRoot>/dist/hooks/bundled` relative to this module (compiled hooks).
-  // This path works when installed via npm: node_modules/openclaw/dist/hooks/bundled-dir.js
+  // npm/dev: prefer package-root relative lookup so pnpm/global symlink layouts resolve reliably.
   try {
-    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-    const distBundled = path.join(moduleDir, "bundled");
-    if (fs.existsSync(distBundled)) {
-      return distBundled;
+    const moduleUrl = opts.moduleUrl ?? import.meta.url;
+    const moduleDir = path.dirname(fileURLToPath(moduleUrl));
+    const argv1 = opts.argv1 ?? process.argv[1];
+    const cwd = opts.cwd ?? process.cwd();
+    const packageRoot = resolveOpenClawPackageRootSync({
+      argv1,
+      moduleUrl,
+      cwd,
+    });
+    if (packageRoot) {
+      const distBundled = path.join(packageRoot, "dist", "bundled");
+      if (looksLikeBundledHooksDir(distBundled)) {
+        return distBundled;
+      }
+      const srcBundled = path.join(packageRoot, "src", "hooks", "bundled");
+      if (looksLikeBundledHooksDir(srcBundled)) {
+        return srcBundled;
+      }
     }
-  } catch {
-    // ignore
-  }
 
-  // dev: resolve `<packageRoot>/src/hooks/bundled` relative to dist/hooks/bundled-dir.js
-  // This path works in dev: dist/hooks/bundled-dir.js -> ../../src/hooks/bundled
-  try {
-    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-    const root = path.resolve(moduleDir, "..", "..");
-    const srcBundled = path.join(root, "src", "hooks", "bundled");
-    if (fs.existsSync(srcBundled)) {
-      return srcBundled;
+    // Fallback: walk up from the module location for layouts where package-root discovery fails.
+    let current = moduleDir;
+    for (let depth = 0; depth < 6; depth += 1) {
+      const candidate = path.join(current, "bundled");
+      if (looksLikeBundledHooksDir(candidate)) {
+        return candidate;
+      }
+      const parent = path.dirname(current);
+      if (parent === current) {
+        break;
+      }
+      current = parent;
     }
   } catch {
     // ignore


### PR DESCRIPTION
## Summary

- Problem: `openclaw hooks list` can return `No hooks found` on Windows when installed via `pnpm add -g`.
- Why it matters: built-in hooks (for example `session-memory`) cannot be discovered/enabled, so the hooks CLI appears broken.
- What changed: hardened bundled-hook directory resolution to prefer package-root based paths and validate that candidate directories actually contain hook metadata + handlers.
- What changed: added focused tests for override handling, flattened dist layouts, and fallback behavior when exec sibling directories are present but not valid hooks.
- What did NOT change (scope boundary): hook enable/disable logic, hook config schema, and runtime hook handler behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43180
- Related #

## User-visible / Behavior Changes

- `openclaw hooks list` now reliably discovers bundled hooks in pnpm/global install layouts where path resolution previously missed them.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local validation)
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Run `pnpm test src/hooks/bundled-dir.test.ts src/hooks/loader.test.ts`.
2. Verify all tests pass.

### Expected

- Hook resolver tests pass and existing hook loader tests remain green.

### Actual

- Passed: `2` files, `16` tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Exact commands and outcomes:

- `pnpm test src/hooks/bundled-dir.test.ts src/hooks/loader.test.ts`
  - Initial run failed due missing deps: `vitest not found` (node_modules absent).
- `pnpm install`
  - Installed workspace dependencies successfully.
- `pnpm exec oxfmt --check src/hooks/bundled-dir.ts src/hooks/bundled-dir.test.ts`
  - Reported format issues in `src/hooks/bundled-dir.test.ts`.
- `pnpm exec oxfmt --write src/hooks/bundled-dir.ts src/hooks/bundled-dir.test.ts`
  - Formatting applied.
- `pnpm exec oxfmt --check src/hooks/bundled-dir.ts src/hooks/bundled-dir.test.ts`
  - Passed.
- `pnpm test src/hooks/bundled-dir.test.ts src/hooks/loader.test.ts`
  - Passed: `2` files, `16` tests.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: bundled hooks resolver returns expected directories for override, flattened dist layout, and fallback path selection.
- Edge cases checked: ignored exec sibling `hooks/bundled` directory when it does not contain valid hook structure.
- What you did **not** verify: direct manual reproduction on Windows host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/hooks/bundled-dir.ts`.
- Known bad symptoms reviewers should watch for: bundled hooks not appearing in `openclaw hooks list`.

## Risks and Mitigations

- Risk: resolver could pick an unexpected directory in non-standard runtimes.
  - Mitigation: candidate directories are now validated to contain both `HOOK.md` and handler files before being accepted, and tests cover fallback ordering.
