### PR TITLE
Exec approvals: add denylist support

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -11,6 +11,7 @@ import {
   type ExecSecurity,
   buildEnforcedShellCommand,
   evaluateShellAllowlist,
+  evaluateShellDenylist,
   recordAllowlistUse,
   requiresExecApproval,
   resolveAllowAlwaysPatterns,
@@ -90,10 +91,20 @@ export async function processGatewayAllowlist(
     platform: process.platform,
     trustedSafeBinDirs: params.trustedSafeBinDirs,
   });
+  const denylistEval = evaluateShellDenylist({
+    command: params.command,
+    entries: approvals.denylist,
+    cwd: params.workdir,
+    env: params.env,
+    platform: process.platform,
+  });
   const allowlistMatches = allowlistEval.allowlistMatches;
   const analysisOk = allowlistEval.analysisOk;
-  const allowlistSatisfied =
-    hostSecurity === "allowlist" && analysisOk ? allowlistEval.allowlistSatisfied : false;
+  const allowlistSatisfied = analysisOk ? allowlistEval.allowlistSatisfied : false;
+  const denylistMatched =
+    denylistEval.analysisOk &&
+    denylistEval.denylistMatched &&
+    !(analysisOk && allowlistEval.allowlistSatisfied);
   let enforcedCommand: string | undefined;
   if (hostSecurity === "allowlist" && analysisOk && allowlistSatisfied) {
     const enforced = buildEnforcedShellCommand({
@@ -135,6 +146,7 @@ export async function processGatewayAllowlist(
       security: hostSecurity,
       analysisOk,
       allowlistSatisfied,
+      denylistMatched,
     }) ||
     requiresHeredocApproval ||
     obfuscation.detected;
@@ -229,11 +241,17 @@ export async function processGatewayAllowlist(
         } else {
           approvedByAsk = true;
         }
+      } else if (baseDecision.timedOut && askFallback === "denylist") {
+        if (denylistMatched) {
+          deniedReason = "approval-timeout (denylist-match)";
+        } else {
+          approvedByAsk = true;
+        }
       } else if (decision === "allow-once") {
         approvedByAsk = true;
       } else if (decision === "allow-always") {
         approvedByAsk = true;
-        if (hostSecurity === "allowlist") {
+        if (hostSecurity === "allowlist" || hostSecurity === "denylist") {
           const patterns = resolveAllowAlwaysPatterns({
             segments: allowlistEval.segments,
             cwd: params.workdir,
@@ -250,6 +268,8 @@ export async function processGatewayAllowlist(
 
       if (hostSecurity === "allowlist" && (!analysisOk || !allowlistSatisfied) && !approvedByAsk) {
         deniedReason = deniedReason ?? "allowlist-miss";
+      } else if (hostSecurity === "denylist" && denylistMatched && !approvedByAsk) {
+        deniedReason = deniedReason ?? "denylist-match";
       }
 
       if (deniedReason) {
@@ -371,6 +391,9 @@ export async function processGatewayAllowlist(
 
   if (hostSecurity === "allowlist" && (!analysisOk || !allowlistSatisfied)) {
     throw new Error("exec denied: allowlist miss");
+  }
+  if (hostSecurity === "denylist" && denylistMatched) {
+    throw new Error("exec denied: denylist match");
   }
 
   recordMatchedAllowlistUse(allowlistEval.segments[0]?.resolution?.resolvedPath);

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -11,6 +11,7 @@ import {
   type ExecAsk,
   type ExecSecurity,
   evaluateShellAllowlist,
+  evaluateShellDenylist,
   requiresExecApproval,
   resolveExecApprovalsFromFile,
 } from "../infra/exec-approvals.js";
@@ -142,7 +143,13 @@ export async function executeNodeHostCommand(
   });
   let analysisOk = baseAllowlistEval.analysisOk;
   let allowlistSatisfied = false;
-  if (hostAsk === "on-miss" && hostSecurity === "allowlist" && analysisOk) {
+  let denylistMatched = false;
+  if (
+    analysisOk &&
+    ((hostAsk === "on-miss" && hostSecurity === "allowlist") ||
+      (hostAsk === "on-match" && hostSecurity === "denylist") ||
+      hostSecurity === "denylist")
+  ) {
     try {
       const approvalsSnapshot = await callGatewayTool<{ file: string }>(
         "exec.approvals.node.get",
@@ -157,9 +164,9 @@ export async function executeNodeHostCommand(
         const resolved = resolveExecApprovalsFromFile({
           file: approvalsFile as ExecApprovalsFile,
           agentId: params.agentId,
-          overrides: { security: "allowlist" },
+          overrides: { security: hostSecurity },
         });
-        // Allowlist-only precheck; safe bins are node-local and may diverge.
+        // Safe bins are node-local and may diverge, so only use allowlist entries here.
         const allowlistEval = evaluateShellAllowlist({
           command: params.command,
           allowlist: resolved.allowlist,
@@ -169,7 +176,18 @@ export async function executeNodeHostCommand(
           platform: nodeInfo?.platform,
           trustedSafeBinDirs: params.trustedSafeBinDirs,
         });
+        const denylistEval = evaluateShellDenylist({
+          command: params.command,
+          entries: resolved.denylist,
+          cwd: params.workdir,
+          env: params.env,
+          platform: nodeInfo?.platform,
+        });
         allowlistSatisfied = allowlistEval.allowlistSatisfied;
+        denylistMatched =
+          denylistEval.analysisOk &&
+          denylistEval.denylistMatched &&
+          !allowlistEval.allowlistSatisfied;
         analysisOk = allowlistEval.analysisOk;
       }
     } catch {
@@ -189,6 +207,7 @@ export async function executeNodeHostCommand(
       security: hostSecurity,
       analysisOk,
       allowlistSatisfied,
+      denylistMatched,
     }) || obfuscation.detected;
   const invokeTimeoutMs = Math.max(
     10_000,
@@ -300,6 +319,20 @@ export async function executeNodeHostCommand(
 
       if (baseDecision.timedOut && askFallback === "full" && approvedByAsk) {
         approvalDecision = "allow-once";
+      } else if (baseDecision.timedOut && askFallback === "allowlist") {
+        if (!analysisOk || !allowlistSatisfied) {
+          deniedReason = "approval-timeout (allowlist-miss)";
+        } else {
+          approvedByAsk = true;
+          approvalDecision = "allow-once";
+        }
+      } else if (baseDecision.timedOut && askFallback === "denylist") {
+        if (denylistMatched) {
+          deniedReason = "approval-timeout (denylist-match)";
+        } else {
+          approvedByAsk = true;
+          approvalDecision = "allow-once";
+        }
       } else if (decision === "allow-once") {
         approvedByAsk = true;
         approvalDecision = "allow-once";
@@ -389,7 +422,7 @@ export async function executeNodeHostCommand(
                   warningText,
                   approvalSlug,
                   approvalId,
-                  command: prepared.plan.commandText,
+                  command: prepared.plan.commandPreview ?? prepared.plan.commandText,
                   cwd: runCwd,
                   host: "node",
                   nodeId,

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -194,6 +194,101 @@ describe("exec approvals", () => {
     expect(calls).not.toContain("exec.approval.request");
   });
 
+  it("requires approval when gateway denylist matches on-match", async () => {
+    const approvalsPath = path.join(process.env.HOME ?? "", ".openclaw", "exec-approvals.json");
+    await fs.mkdir(path.dirname(approvalsPath), { recursive: true });
+    await fs.writeFile(
+      approvalsPath,
+      JSON.stringify(
+        {
+          version: 1,
+          defaults: { security: "denylist", ask: "on-match", askFallback: "deny" },
+          agents: {
+            main: {
+              denylist: [{ pattern: process.execPath, argsMatch: "--version" }],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const calls: string[] = [];
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      calls.push(method);
+      if (method === "exec.approval.request") {
+        return { status: "accepted", id: (params as { id?: string })?.id };
+      }
+      if (method === "exec.approval.waitDecision") {
+        return { decision: "deny" };
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "off",
+      security: "full",
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call-gateway-denylist", {
+      command: `"${process.execPath}" --version`,
+    });
+    expect(result.details.status).toBe("approval-pending");
+    expect(calls).toContain("exec.approval.request");
+    expect(calls).toContain("exec.approval.waitDecision");
+  });
+
+  it("requires approval when node denylist matches on-match", async () => {
+    const approvalsFile = {
+      version: 1,
+      defaults: { security: "denylist", ask: "on-match", askFallback: "deny" },
+      agents: {
+        main: {
+          denylist: [{ pattern: process.execPath, argsMatch: "--version" }],
+        },
+      },
+    };
+
+    const calls: string[] = [];
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      calls.push(method);
+      if (method === "exec.approvals.node.get") {
+        return { file: approvalsFile };
+      }
+      if (method === "exec.approval.request") {
+        return { status: "accepted", id: (params as { id?: string })?.id };
+      }
+      if (method === "exec.approval.waitDecision") {
+        return { decision: "deny" };
+      }
+      if (method === "node.invoke") {
+        const invoke = params as { command?: string };
+        if (invoke.command === "system.run.prepare") {
+          return buildPreparedSystemRunPayload(params);
+        }
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      ask: "on-match",
+      security: "denylist",
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call-node-denylist", {
+      command: `"${process.execPath}" --version`,
+    });
+    expect(result.details.status).toBe("approval-pending");
+    expect(calls).toContain("exec.approvals.node.get");
+    expect(calls).toContain("exec.approval.request");
+    expect(calls).toContain("exec.approval.waitDecision");
+  });
+
   it("honors ask=off for elevated gateway exec without prompting", async () => {
     const calls: string[] = [];
     vi.mocked(callGatewayTool).mockImplementation(async (method) => {

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -317,6 +317,78 @@ export type ExecAllowlistAnalysis = {
   segmentSatisfiedBy: ExecSegmentSatisfiedBy[];
 };
 
+export type ExecDenylistAnalysis = {
+  analysisOk: boolean;
+  denylistMatched: boolean;
+  denylistMatches: ExecAllowlistEntry[];
+  segments: ExecCommandSegment[];
+};
+
+function evaluateExecPatternMatches(params: {
+  analysis: ExecCommandAnalysis;
+  entries: ExecAllowlistEntry[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: string | null;
+}): ExecDenylistAnalysis {
+  if (!params.analysis.ok || params.analysis.segments.length === 0) {
+    return {
+      analysisOk: false,
+      denylistMatched: false,
+      denylistMatches: [],
+      segments: [],
+    };
+  }
+
+  const matches: ExecAllowlistEntry[] = [];
+  for (const group of resolveAnalysisSegmentGroups(params.analysis)) {
+    for (const segment of group) {
+      const effectiveArgv =
+        segment.resolution?.effectiveArgv && segment.resolution.effectiveArgv.length > 0
+          ? segment.resolution.effectiveArgv
+          : segment.argv;
+      const allowlistSegment =
+        effectiveArgv === segment.argv ? segment : { ...segment, argv: effectiveArgv };
+      const candidatePath = resolveAllowlistCandidatePath(segment.resolution, params.cwd);
+      const candidateResolution =
+        candidatePath && segment.resolution
+          ? { ...segment.resolution, resolvedPath: candidatePath }
+          : segment.resolution;
+      const executableMatch = matchAllowlist(params.entries, candidateResolution, effectiveArgv);
+      const inlineCommand = extractShellWrapperInlineCommand(allowlistSegment.argv);
+      const shellScriptCandidatePath =
+        inlineCommand === null
+          ? resolveShellWrapperScriptCandidatePath({
+              segment: allowlistSegment,
+              cwd: params.cwd,
+            })
+          : undefined;
+      const shellScriptMatch = shellScriptCandidatePath
+        ? matchAllowlist(
+            params.entries,
+            {
+              rawExecutable: shellScriptCandidatePath,
+              resolvedPath: shellScriptCandidatePath,
+              executableName: path.basename(shellScriptCandidatePath),
+            },
+            effectiveArgv,
+          )
+        : null;
+      const match = executableMatch ?? shellScriptMatch;
+      if (match) {
+        matches.push(match);
+      }
+    }
+  }
+
+  return {
+    analysisOk: true,
+    denylistMatched: matches.length > 0,
+    denylistMatches: matches,
+    segments: params.analysis.segments,
+  };
+}
+
 function hasSegmentExecutableMatch(
   segment: ExecCommandSegment,
   predicate: (token: string) => boolean,
@@ -605,5 +677,81 @@ export function evaluateShellAllowlist(
     allowlistMatches,
     segments,
     segmentSatisfiedBy,
+  };
+}
+
+export function evaluateExecDenylist(params: {
+  analysis: ExecCommandAnalysis;
+  entries: ExecAllowlistEntry[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: string | null;
+}): ExecDenylistAnalysis {
+  return evaluateExecPatternMatches(params);
+}
+
+export function evaluateShellDenylist(params: {
+  command: string;
+  entries: ExecAllowlistEntry[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: string | null;
+}): ExecDenylistAnalysis {
+  const analysisFailure = (): ExecDenylistAnalysis => ({
+    analysisOk: false,
+    denylistMatched: false,
+    denylistMatches: [],
+    segments: [],
+  });
+
+  if (hasShellLineContinuation(params.command)) {
+    return analysisFailure();
+  }
+
+  const chainParts = isWindowsPlatform(params.platform) ? null : splitCommandChain(params.command);
+  if (!chainParts) {
+    const analysis = analyzeShellCommand({
+      command: params.command,
+      cwd: params.cwd,
+      env: params.env,
+      platform: params.platform,
+    });
+    return evaluateExecPatternMatches({
+      analysis,
+      entries: params.entries,
+      cwd: params.cwd,
+      env: params.env,
+      platform: params.platform,
+    });
+  }
+
+  const matches: ExecAllowlistEntry[] = [];
+  const segments: ExecCommandSegment[] = [];
+  for (const part of chainParts) {
+    const analysis = analyzeShellCommand({
+      command: part,
+      cwd: params.cwd,
+      env: params.env,
+      platform: params.platform,
+    });
+    if (!analysis.ok) {
+      return analysisFailure();
+    }
+    segments.push(...analysis.segments);
+    const evaluation = evaluateExecPatternMatches({
+      analysis,
+      entries: params.entries,
+      cwd: params.cwd,
+      env: params.env,
+      platform: params.platform,
+    });
+    matches.push(...evaluation.denylistMatches);
+  }
+
+  return {
+    analysisOk: true,
+    denylistMatched: matches.length > 0,
+    denylistMatches: matches,
+    segments,
   };
 }

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -51,6 +51,21 @@ describe("exec approvals wildcard agent", () => {
       }
     }
   });
+
+  it("merges wildcard denylist entries with agent entries", () => {
+    const file: ExecApprovalsFile = {
+      version: 1,
+      agents: {
+        "*": { denylist: [{ pattern: "/usr/bin/rm" }] },
+        main: { denylist: [{ pattern: "/bin/dd", argsMatch: "of=/dev/" }] },
+      },
+    };
+    const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
+    expect(resolved.denylist).toEqual([
+      expect.objectContaining({ pattern: "/usr/bin/rm" }),
+      expect.objectContaining({ pattern: "/bin/dd", argsMatch: "of=/dev/" }),
+    ]);
+  });
 });
 
 describe("exec approvals node host allowlist check", () => {
@@ -279,5 +294,42 @@ describe("normalizeExecApprovals handles string allowlist entries (#9790)", () =
         expectNoSpreadStringArtifacts(entries ?? []);
       }
     }
+  });
+});
+
+describe("normalizeExecApprovals denylist entries", () => {
+  it("preserves argsMatch and reason metadata", () => {
+    const normalized = normalizeExecApprovals({
+      version: 1,
+      agents: {
+        main: {
+          denylist: [
+            { pattern: "/usr/bin/rm", argsMatch: "-rf /", reason: "destructive recursive delete" },
+          ],
+        },
+      },
+    });
+    expect(normalized.agents?.main?.denylist).toEqual([
+      expect.objectContaining({
+        pattern: "/usr/bin/rm",
+        argsMatch: "-rf /",
+        reason: "destructive recursive delete",
+      }),
+    ]);
+  });
+
+  it("coerces bare string denylist entries into structured patterns", () => {
+    const normalized = normalizeExecApprovals({
+      version: 1,
+      agents: {
+        main: {
+          denylist: ["/usr/bin/rm", "/bin/dd"] as unknown as ExecAllowlistEntry[],
+        },
+      },
+    });
+    expect(normalized.agents?.main?.denylist?.map((entry) => entry.pattern)).toEqual([
+      "/usr/bin/rm",
+      "/bin/dd",
+    ]);
   });
 });

--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -128,6 +128,23 @@ describe("exec approvals allowlist matching", () => {
     });
     expect(match?.pattern).toBe(literalPattern);
   });
+
+  it("supports argsMatch as a case-insensitive argv substring filter", () => {
+    const match = matchAllowlist(
+      [{ pattern: "/opt/**/rg", argsMatch: "--glob src/**" }],
+      baseResolution,
+      ["/opt/homebrew/bin/rg", "--glob", "src/**", "needle"],
+    );
+    expect(match?.pattern).toBe("/opt/**/rg");
+    expect(match?.argsMatch).toBe("--glob src/**");
+
+    const missed = matchAllowlist(
+      [{ pattern: "/opt/**/rg", argsMatch: "--glob docs/**" }],
+      baseResolution,
+      ["/opt/homebrew/bin/rg", "--glob", "src/**", "needle"],
+    );
+    expect(missed).toBeNull();
+  });
 });
 
 describe("mergeExecApprovalsSocketDefaults", () => {
@@ -877,6 +894,7 @@ describe("exec approvals policy helpers", () => {
   it("maxAsk returns the more aggressive ask mode", () => {
     expect(maxAsk("off", "always")).toBe("always");
     expect(maxAsk("on-miss", "off")).toBe("on-miss");
+    expect(maxAsk("on-match", "on-miss")).toBe("on-match");
   });
 
   it("requiresExecApproval respects ask mode and allowlist satisfaction", () => {
@@ -918,6 +936,24 @@ describe("exec approvals policy helpers", () => {
         security: "full",
         analysisOk: false,
         allowlistSatisfied: false,
+      }),
+    ).toBe(false);
+    expect(
+      requiresExecApproval({
+        ask: "on-match",
+        security: "denylist",
+        analysisOk: true,
+        allowlistSatisfied: false,
+        denylistMatched: true,
+      }),
+    ).toBe(true);
+    expect(
+      requiresExecApproval({
+        ask: "on-match",
+        security: "denylist",
+        analysisOk: true,
+        allowlistSatisfied: false,
+        denylistMatched: false,
       }),
     ).toBe(false);
   });

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -8,8 +8,8 @@ export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
 
 export type ExecHost = "sandbox" | "gateway" | "node";
-export type ExecSecurity = "deny" | "allowlist" | "full";
-export type ExecAsk = "off" | "on-miss" | "always";
+export type ExecSecurity = "deny" | "allowlist" | "denylist" | "full";
+export type ExecAsk = "off" | "on-miss" | "on-match" | "always";
 
 export function normalizeExecHost(value?: string | null): ExecHost | null {
   const normalized = value?.trim().toLowerCase();
@@ -21,7 +21,12 @@ export function normalizeExecHost(value?: string | null): ExecHost | null {
 
 export function normalizeExecSecurity(value?: string | null): ExecSecurity | null {
   const normalized = value?.trim().toLowerCase();
-  if (normalized === "deny" || normalized === "allowlist" || normalized === "full") {
+  if (
+    normalized === "deny" ||
+    normalized === "allowlist" ||
+    normalized === "denylist" ||
+    normalized === "full"
+  ) {
     return normalized;
   }
   return null;
@@ -29,7 +34,12 @@ export function normalizeExecSecurity(value?: string | null): ExecSecurity | nul
 
 export function normalizeExecAsk(value?: string | null): ExecAsk | null {
   const normalized = value?.trim().toLowerCase();
-  if (normalized === "off" || normalized === "on-miss" || normalized === "always") {
+  if (
+    normalized === "off" ||
+    normalized === "on-miss" ||
+    normalized === "on-match" ||
+    normalized === "always"
+  ) {
     return normalized;
   }
   return null;
@@ -106,6 +116,8 @@ export type ExecApprovalsDefaults = {
 export type ExecAllowlistEntry = {
   id?: string;
   pattern: string;
+  argsMatch?: string;
+  reason?: string;
   lastUsedAt?: number;
   lastUsedCommand?: string;
   lastResolvedPath?: string;
@@ -113,6 +125,7 @@ export type ExecAllowlistEntry = {
 
 export type ExecApprovalsAgent = ExecApprovalsDefaults & {
   allowlist?: ExecAllowlistEntry[];
+  denylist?: ExecAllowlistEntry[];
 };
 
 export type ExecApprovalsFile = {
@@ -140,6 +153,7 @@ export type ExecApprovalsResolved = {
   defaults: Required<ExecApprovalsDefaults>;
   agent: Required<ExecApprovalsDefaults>;
   allowlist: ExecAllowlistEntry[];
+  denylist: ExecAllowlistEntry[];
   file: ExecApprovalsFile;
 };
 
@@ -168,7 +182,7 @@ export function resolveExecApprovalsSocketPath(): string {
   return expandHomePrefix(DEFAULT_SOCKET);
 }
 
-function normalizeAllowlistPattern(value: string | undefined): string | null {
+function normalizeExecRulePattern(value: string | undefined): string | null {
   const trimmed = value?.trim() ?? "";
   return trimmed ? trimmed.toLowerCase() : null;
 }
@@ -178,20 +192,32 @@ function mergeLegacyAgent(
   legacy: ExecApprovalsAgent,
 ): ExecApprovalsAgent {
   const allowlist: ExecAllowlistEntry[] = [];
-  const seen = new Set<string>();
-  const pushEntry = (entry: ExecAllowlistEntry) => {
-    const key = normalizeAllowlistPattern(entry.pattern);
+  const denylist: ExecAllowlistEntry[] = [];
+  const seenAllowlist = new Set<string>();
+  const seenDenylist = new Set<string>();
+  const pushEntry = (
+    entries: ExecAllowlistEntry[],
+    seen: Set<string>,
+    entry: ExecAllowlistEntry,
+  ) => {
+    const key = normalizeExecRulePattern(entry.pattern);
     if (!key || seen.has(key)) {
       return;
     }
     seen.add(key);
-    allowlist.push(entry);
+    entries.push(entry);
   };
   for (const entry of current.allowlist ?? []) {
-    pushEntry(entry);
+    pushEntry(allowlist, seenAllowlist, entry);
   }
   for (const entry of legacy.allowlist ?? []) {
-    pushEntry(entry);
+    pushEntry(allowlist, seenAllowlist, entry);
+  }
+  for (const entry of current.denylist ?? []) {
+    pushEntry(denylist, seenDenylist, entry);
+  }
+  for (const entry of legacy.denylist ?? []) {
+    pushEntry(denylist, seenDenylist, entry);
   }
 
   return {
@@ -200,6 +226,7 @@ function mergeLegacyAgent(
     askFallback: current.askFallback ?? legacy.askFallback,
     autoAllowSkills: current.autoAllowSkills ?? legacy.autoAllowSkills,
     allowlist: allowlist.length > 0 ? allowlist : undefined,
+    denylist: denylist.length > 0 ? denylist : undefined,
   };
 }
 
@@ -208,15 +235,15 @@ function ensureDir(filePath: string) {
   fs.mkdirSync(dir, { recursive: true });
 }
 
-// Coerce legacy/corrupted allowlists into `ExecAllowlistEntry[]` before we spread
+// Coerce legacy/corrupted rule lists into `ExecAllowlistEntry[]` before we spread
 // entries to add ids (spreading strings creates {"0":"l","1":"s",...}).
-function coerceAllowlistEntries(allowlist: unknown): ExecAllowlistEntry[] | undefined {
-  if (!Array.isArray(allowlist) || allowlist.length === 0) {
-    return Array.isArray(allowlist) ? (allowlist as ExecAllowlistEntry[]) : undefined;
+function coerceRuleEntries(entries: unknown): ExecAllowlistEntry[] | undefined {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return Array.isArray(entries) ? (entries as ExecAllowlistEntry[]) : undefined;
   }
   let changed = false;
   const result: ExecAllowlistEntry[] = [];
-  for (const item of allowlist) {
+  for (const item of entries) {
     if (typeof item === "string") {
       const trimmed = item.trim();
       if (trimmed) {
@@ -236,24 +263,24 @@ function coerceAllowlistEntries(allowlist: unknown): ExecAllowlistEntry[] | unde
       changed = true; // dropped invalid entry
     }
   }
-  return changed ? (result.length > 0 ? result : undefined) : (allowlist as ExecAllowlistEntry[]);
+  return changed ? (result.length > 0 ? result : undefined) : (entries as ExecAllowlistEntry[]);
 }
 
-function ensureAllowlistIds(
-  allowlist: ExecAllowlistEntry[] | undefined,
+function ensureRuleIds(
+  entries: ExecAllowlistEntry[] | undefined,
 ): ExecAllowlistEntry[] | undefined {
-  if (!Array.isArray(allowlist) || allowlist.length === 0) {
-    return allowlist;
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return entries;
   }
   let changed = false;
-  const next = allowlist.map((entry) => {
+  const next = entries.map((entry) => {
     if (entry.id) {
       return entry;
     }
     changed = true;
     return { ...entry, id: crypto.randomUUID() };
   });
-  return changed ? next : allowlist;
+  return changed ? next : entries;
 }
 
 export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
@@ -267,10 +294,10 @@ export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFi
     delete agents.default;
   }
   for (const [key, agent] of Object.entries(agents)) {
-    const coerced = coerceAllowlistEntries(agent.allowlist);
-    const allowlist = ensureAllowlistIds(coerced);
-    if (allowlist !== agent.allowlist) {
-      agents[key] = { ...agent, allowlist };
+    const allowlist = ensureRuleIds(coerceRuleEntries(agent.allowlist));
+    const denylist = ensureRuleIds(coerceRuleEntries(agent.denylist));
+    if (allowlist !== agent.allowlist || denylist !== agent.denylist) {
+      agents[key] = { ...agent, allowlist, denylist };
     }
   }
   const normalized: ExecApprovalsFile = {
@@ -389,14 +416,14 @@ export function ensureExecApprovals(): ExecApprovalsFile {
 }
 
 function normalizeSecurity(value: ExecSecurity | undefined, fallback: ExecSecurity): ExecSecurity {
-  if (value === "allowlist" || value === "full" || value === "deny") {
+  if (value === "allowlist" || value === "denylist" || value === "full" || value === "deny") {
     return value;
   }
   return fallback;
 }
 
 function normalizeAsk(value: ExecAsk | undefined, fallback: ExecAsk): ExecAsk {
-  if (value === "always" || value === "off" || value === "on-miss") {
+  if (value === "always" || value === "off" || value === "on-miss" || value === "on-match") {
     return value;
   }
   return fallback;
@@ -468,6 +495,10 @@ export function resolveExecApprovalsFromFile(params: {
     ...(Array.isArray(wildcard.allowlist) ? wildcard.allowlist : []),
     ...(Array.isArray(agent.allowlist) ? agent.allowlist : []),
   ];
+  const denylist = [
+    ...(Array.isArray(wildcard.denylist) ? wildcard.denylist : []),
+    ...(Array.isArray(agent.denylist) ? agent.denylist : []),
+  ];
   return {
     path: params.path ?? resolveExecApprovalsPath(),
     socketPath: expandHomePrefix(
@@ -477,6 +508,7 @@ export function resolveExecApprovalsFromFile(params: {
     defaults: resolvedDefaults,
     agent: resolvedAgent,
     allowlist,
+    denylist,
     file,
   };
 }
@@ -486,12 +518,14 @@ export function requiresExecApproval(params: {
   security: ExecSecurity;
   analysisOk: boolean;
   allowlistSatisfied: boolean;
+  denylistMatched?: boolean;
 }): boolean {
   return (
     params.ask === "always" ||
     (params.ask === "on-miss" &&
       params.security === "allowlist" &&
-      (!params.analysisOk || !params.allowlistSatisfied))
+      (!params.analysisOk || !params.allowlistSatisfied)) ||
+    (params.ask === "on-match" && params.security === "denylist" && params.denylistMatched === true)
   );
 }
 
@@ -545,12 +579,12 @@ export function addAllowlistEntry(
 }
 
 export function minSecurity(a: ExecSecurity, b: ExecSecurity): ExecSecurity {
-  const order: Record<ExecSecurity, number> = { deny: 0, allowlist: 1, full: 2 };
+  const order: Record<ExecSecurity, number> = { deny: 0, allowlist: 1, denylist: 2, full: 3 };
   return order[a] <= order[b] ? a : b;
 }
 
 export function maxAsk(a: ExecAsk, b: ExecAsk): ExecAsk {
-  const order: Record<ExecAsk, number> = { off: 0, "on-miss": 1, always: 2 };
+  const order: Record<ExecAsk, number> = { off: 0, "on-miss": 1, "on-match": 2, always: 3 };
   return order[a] >= order[b] ? a : b;
 }
 

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -143,14 +143,31 @@ export function resolveAllowlistCandidatePath(
 export function matchAllowlist(
   entries: ExecAllowlistEntry[],
   resolution: CommandResolution | null,
+  argv?: string[],
 ): ExecAllowlistEntry | null {
   if (!entries.length) {
     return null;
   }
+  const effectiveArgv =
+    argv && argv.length > 0
+      ? argv
+      : (resolution?.effectiveArgv ?? [resolution?.rawExecutable ?? ""]);
+  const joinedArgs = effectiveArgv
+    .slice(1)
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .join(" ");
+  const matchesArgsConstraint = (entry: ExecAllowlistEntry): boolean => {
+    const constraint = entry.argsMatch?.trim().toLowerCase();
+    if (!constraint) {
+      return true;
+    }
+    return joinedArgs.includes(constraint);
+  };
   // A bare "*" wildcard allows any parsed executable command.
   // Check it before the resolvedPath guard so unresolved PATH lookups still
   // match (for example platform-specific executables without known extensions).
-  const bareWild = entries.find((e) => e.pattern?.trim() === "*");
+  const bareWild = entries.find((e) => e.pattern?.trim() === "*" && matchesArgsConstraint(e));
   if (bareWild && resolution) {
     return bareWild;
   }
@@ -167,7 +184,7 @@ export function matchAllowlist(
     if (!hasPath) {
       continue;
     }
-    if (matchesExecAllowlistPattern(pattern, resolvedPath)) {
+    if (matchesExecAllowlistPattern(pattern, resolvedPath) && matchesArgsConstraint(entry)) {
       return entry;
     }
   }

--- a/src/node-host/exec-policy.test.ts
+++ b/src/node-host/exec-policy.test.ts
@@ -14,6 +14,7 @@ const buildPolicyParams = (overrides: Partial<EvaluatePolicyParams>): EvaluatePo
     ask: "off",
     analysisOk: true,
     allowlistSatisfied: true,
+    denylistMatched: false,
     approvalDecision: null,
     approved: false,
     isWindows: false,
@@ -139,5 +140,32 @@ describe("evaluateSystemRunPolicy", () => {
     expect(allowed.requiresAsk).toBe(false);
     expect(allowed.analysisOk).toBe(true);
     expect(allowed.allowlistSatisfied).toBe(true);
+  });
+
+  it("requires approval on denylist matches when ask=on-match", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({
+          security: "denylist",
+          ask: "on-match",
+          denylistMatched: true,
+        }),
+      ),
+    );
+    expect(denied.eventReason).toBe("approval-required");
+    expect(denied.requiresAsk).toBe(true);
+  });
+
+  it("denies denylist matches without approval", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({
+          security: "denylist",
+          denylistMatched: true,
+        }),
+      ),
+    );
+    expect(denied.eventReason).toBe("denylist-match");
+    expect(denied.errorMessage).toBe("SYSTEM_RUN_DENIED: denylist match");
   });
 });

--- a/src/node-host/exec-policy.ts
+++ b/src/node-host/exec-policy.ts
@@ -5,6 +5,7 @@ export type ExecApprovalDecision = "allow-once" | "allow-always" | null;
 export type SystemRunPolicyDecision = {
   analysisOk: boolean;
   allowlistSatisfied: boolean;
+  denylistMatched: boolean;
   shellWrapperBlocked: boolean;
   windowsShellWrapperBlocked: boolean;
   requiresAsk: boolean;
@@ -16,7 +17,7 @@ export type SystemRunPolicyDecision = {
     }
   | {
       allowed: false;
-      eventReason: "security=deny" | "approval-required" | "allowlist-miss";
+      eventReason: "security=deny" | "approval-required" | "allowlist-miss" | "denylist-match";
       errorMessage: string;
     }
 );
@@ -54,6 +55,7 @@ export function evaluateSystemRunPolicy(params: {
   ask: ExecAsk;
   analysisOk: boolean;
   allowlistSatisfied: boolean;
+  denylistMatched: boolean;
   approvalDecision: ExecApprovalDecision;
   approved?: boolean;
   isWindows: boolean;
@@ -74,6 +76,7 @@ export function evaluateSystemRunPolicy(params: {
       errorMessage: "SYSTEM_RUN_DISABLED: security=deny",
       analysisOk,
       allowlistSatisfied,
+      denylistMatched: params.denylistMatched,
       shellWrapperBlocked,
       windowsShellWrapperBlocked,
       requiresAsk: false,
@@ -87,6 +90,7 @@ export function evaluateSystemRunPolicy(params: {
     security: params.security,
     analysisOk,
     allowlistSatisfied,
+    denylistMatched: params.denylistMatched,
   });
   if (requiresAsk && !approvedByAsk) {
     return {
@@ -95,6 +99,7 @@ export function evaluateSystemRunPolicy(params: {
       errorMessage: "SYSTEM_RUN_DENIED: approval required",
       analysisOk,
       allowlistSatisfied,
+      denylistMatched: params.denylistMatched,
       shellWrapperBlocked,
       windowsShellWrapperBlocked,
       requiresAsk,
@@ -113,6 +118,23 @@ export function evaluateSystemRunPolicy(params: {
       }),
       analysisOk,
       allowlistSatisfied,
+      denylistMatched: params.denylistMatched,
+      shellWrapperBlocked,
+      windowsShellWrapperBlocked,
+      requiresAsk,
+      approvalDecision: params.approvalDecision,
+      approvedByAsk,
+    };
+  }
+
+  if (params.security === "denylist" && params.denylistMatched && !approvedByAsk) {
+    return {
+      allowed: false,
+      eventReason: "denylist-match",
+      errorMessage: "SYSTEM_RUN_DENIED: denylist match",
+      analysisOk,
+      allowlistSatisfied,
+      denylistMatched: params.denylistMatched,
       shellWrapperBlocked,
       windowsShellWrapperBlocked,
       requiresAsk,
@@ -125,6 +147,7 @@ export function evaluateSystemRunPolicy(params: {
     allowed: true,
     analysisOk,
     allowlistSatisfied,
+    denylistMatched: params.denylistMatched,
     shellWrapperBlocked,
     windowsShellWrapperBlocked,
     requiresAsk,

--- a/src/node-host/invoke-system-run-allowlist.ts
+++ b/src/node-host/invoke-system-run-allowlist.ts
@@ -1,7 +1,9 @@
 import {
   analyzeArgvCommand,
   evaluateExecAllowlist,
+  evaluateExecDenylist,
   evaluateShellAllowlist,
+  evaluateShellDenylist,
   resolvePlannedSegmentArgv,
   resolveExecApprovals,
   type ExecAllowlistEntry,
@@ -16,6 +18,8 @@ export type SystemRunAllowlistAnalysis = {
   analysisOk: boolean;
   allowlistMatches: ExecAllowlistEntry[];
   allowlistSatisfied: boolean;
+  denylistMatches: ExecAllowlistEntry[];
+  denylistMatched: boolean;
   segments: ExecCommandSegment[];
 };
 
@@ -45,13 +49,22 @@ export function evaluateSystemRunAllowlist(params: {
       autoAllowSkills: params.autoAllowSkills,
       platform: process.platform,
     });
+    const denylistEval = evaluateShellDenylist({
+      command: params.shellCommand,
+      entries: params.approvals.denylist,
+      cwd: params.cwd,
+      env: params.env,
+      platform: process.platform,
+    });
     return {
       analysisOk: allowlistEval.analysisOk,
       allowlistMatches: allowlistEval.allowlistMatches,
-      allowlistSatisfied:
-        params.security === "allowlist" && allowlistEval.analysisOk
-          ? allowlistEval.allowlistSatisfied
-          : false,
+      allowlistSatisfied: allowlistEval.analysisOk ? allowlistEval.allowlistSatisfied : false,
+      denylistMatches: denylistEval.denylistMatches,
+      denylistMatched:
+        denylistEval.analysisOk &&
+        denylistEval.denylistMatched &&
+        !(allowlistEval.analysisOk && allowlistEval.allowlistSatisfied),
       segments: allowlistEval.segments,
     };
   }
@@ -67,11 +80,22 @@ export function evaluateSystemRunAllowlist(params: {
     skillBins: params.skillBins,
     autoAllowSkills: params.autoAllowSkills,
   });
+  const denylistEval = evaluateExecDenylist({
+    analysis,
+    entries: params.approvals.denylist,
+    cwd: params.cwd,
+    env: params.env,
+    platform: process.platform,
+  });
   return {
     analysisOk: analysis.ok,
     allowlistMatches: allowlistEval.allowlistMatches,
-    allowlistSatisfied:
-      params.security === "allowlist" && analysis.ok ? allowlistEval.allowlistSatisfied : false,
+    allowlistSatisfied: analysis.ok ? allowlistEval.allowlistSatisfied : false,
+    denylistMatches: denylistEval.denylistMatches,
+    denylistMatched:
+      denylistEval.analysisOk &&
+      denylistEval.denylistMatched &&
+      !(analysis.ok && allowlistEval.allowlistSatisfied),
     segments: analysis.segments,
   };
 }

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -49,6 +49,7 @@ type SystemRunDeniedReason =
   | "security=deny"
   | "approval-required"
   | "allowlist-miss"
+  | "denylist-match"
   | "execution-plan-miss"
   | "companion-unavailable"
   | "permission:screenRecording";
@@ -89,6 +90,7 @@ type SystemRunPolicyPhase = SystemRunParsePhase & {
   allowlistMatches: ExecAllowlistEntry[];
   analysisOk: boolean;
   allowlistSatisfied: boolean;
+  denylistMatched: boolean;
   segments: ExecCommandSegment[];
   plannedAllowlistArgv: string[] | undefined;
   isWindows: boolean;
@@ -114,6 +116,7 @@ function normalizeDeniedReason(reason: string | null | undefined): SystemRunDeni
     case "security=deny":
     case "approval-required":
     case "allowlist-miss":
+    case "denylist-match":
     case "execution-plan-miss":
     case "companion-unavailable":
     case "permission:screenRecording":
@@ -271,19 +274,20 @@ async function evaluateSystemRunPolicyPhase(
     onWarning: warnWritableTrustedDirOnce,
   });
   const bins = autoAllowSkills ? await opts.skillBins.current() : [];
-  let { analysisOk, allowlistMatches, allowlistSatisfied, segments } = evaluateSystemRunAllowlist({
-    shellCommand: parsed.shellPayload,
-    argv: parsed.argv,
-    approvals,
-    security,
-    safeBins,
-    safeBinProfiles,
-    trustedSafeBinDirs,
-    cwd: parsed.cwd,
-    env: parsed.env,
-    skillBins: bins,
-    autoAllowSkills,
-  });
+  let { analysisOk, allowlistMatches, allowlistSatisfied, denylistMatched, segments } =
+    evaluateSystemRunAllowlist({
+      shellCommand: parsed.shellPayload,
+      argv: parsed.argv,
+      approvals,
+      security,
+      safeBins,
+      safeBinProfiles,
+      trustedSafeBinDirs,
+      cwd: parsed.cwd,
+      env: parsed.env,
+      skillBins: bins,
+      autoAllowSkills,
+    });
   const isWindows = process.platform === "win32";
   const cmdInvocation = parsed.shellPayload
     ? opts.isCmdExeInvocation(segments[0]?.argv ?? [])
@@ -293,6 +297,7 @@ async function evaluateSystemRunPolicyPhase(
     ask,
     analysisOk,
     allowlistSatisfied,
+    denylistMatched,
     approvalDecision: parsed.approvalDecision,
     approved: parsed.approved,
     isWindows,
@@ -301,6 +306,7 @@ async function evaluateSystemRunPolicyPhase(
   });
   analysisOk = policy.analysisOk;
   allowlistSatisfied = policy.allowlistSatisfied;
+  denylistMatched = policy.denylistMatched;
   if (!policy.allowed) {
     await sendSystemRunDenied(opts, parsed.execution, {
       reason: policy.eventReason,
@@ -363,6 +369,7 @@ async function evaluateSystemRunPolicyPhase(
     allowlistMatches,
     analysisOk,
     allowlistSatisfied,
+    denylistMatched,
     segments,
     plannedAllowlistArgv: plannedAllowlistArgv ?? undefined,
     isWindows,
@@ -451,7 +458,10 @@ async function executeSystemRunPhase(
     }
   }
 
-  if (phase.policy.approvalDecision === "allow-always" && phase.security === "allowlist") {
+  if (
+    phase.policy.approvalDecision === "allow-always" &&
+    (phase.security === "allowlist" || phase.security === "denylist")
+  ) {
     if (phase.policy.analysisOk) {
       const patterns = resolveAllowAlwaysPatterns({
         segments: phase.segments,

--- a/ui/src/ui/controllers/exec-approvals.ts
+++ b/ui/src/ui/controllers/exec-approvals.ts
@@ -11,6 +11,8 @@ export type ExecApprovalsDefaults = {
 export type ExecApprovalsAllowlistEntry = {
   id?: string;
   pattern: string;
+  argsMatch?: string;
+  reason?: string;
   lastUsedAt?: number;
   lastUsedCommand?: string;
   lastResolvedPath?: string;
@@ -18,6 +20,7 @@ export type ExecApprovalsAllowlistEntry = {
 
 export type ExecApprovalsAgent = ExecApprovalsDefaults & {
   allowlist?: ExecApprovalsAllowlistEntry[];
+  denylist?: ExecApprovalsAllowlistEntry[];
 };
 
 export type ExecApprovalsFile = {

--- a/ui/src/ui/views/nodes-exec-approvals.ts
+++ b/ui/src/ui/views/nodes-exec-approvals.ts
@@ -11,8 +11,8 @@ import {
 } from "./nodes-shared.ts";
 import type { NodesProps } from "./nodes.ts";
 
-type ExecSecurity = "deny" | "allowlist" | "full";
-type ExecAsk = "off" | "on-miss" | "always";
+type ExecSecurity = "deny" | "allowlist" | "denylist" | "full";
+type ExecAsk = "off" | "on-miss" | "on-match" | "always";
 
 type ExecApprovalsResolvedDefaults = {
   security: ExecSecurity;
@@ -41,6 +41,7 @@ type ExecApprovalsState = {
   selectedAgent: Record<string, unknown> | null;
   agents: ExecApprovalsAgentOption[];
   allowlist: ExecApprovalsAllowlistEntry[];
+  denylist: ExecApprovalsAllowlistEntry[];
   target: "gateway" | "node";
   targetNodeId: string | null;
   targetNodes: ExecApprovalsTargetNode[];
@@ -57,24 +58,26 @@ const EXEC_APPROVALS_DEFAULT_SCOPE = "__defaults__";
 const SECURITY_OPTIONS: Array<{ value: ExecSecurity; label: string }> = [
   { value: "deny", label: "Deny" },
   { value: "allowlist", label: "Allowlist" },
+  { value: "denylist", label: "Denylist" },
   { value: "full", label: "Full" },
 ];
 
 const ASK_OPTIONS: Array<{ value: ExecAsk; label: string }> = [
   { value: "off", label: "Off" },
   { value: "on-miss", label: "On miss" },
+  { value: "on-match", label: "On match" },
   { value: "always", label: "Always" },
 ];
 
 function normalizeSecurity(value?: string): ExecSecurity {
-  if (value === "allowlist" || value === "full" || value === "deny") {
+  if (value === "allowlist" || value === "denylist" || value === "full" || value === "deny") {
     return value;
   }
   return "deny";
 }
 
 function normalizeAsk(value?: string): ExecAsk {
-  if (value === "always" || value === "off" || value === "on-miss") {
+  if (value === "always" || value === "off" || value === "on-miss" || value === "on-match") {
     return value;
   }
   return "on-miss";
@@ -165,6 +168,9 @@ export function resolveExecApprovalsState(props: NodesProps): ExecApprovalsState
   const allowlist = Array.isArray((selectedAgent as { allowlist?: unknown })?.allowlist)
     ? ((selectedAgent as { allowlist?: ExecApprovalsAllowlistEntry[] }).allowlist ?? [])
     : [];
+  const denylist = Array.isArray((selectedAgent as { denylist?: unknown })?.denylist)
+    ? ((selectedAgent as { denylist?: ExecApprovalsAllowlistEntry[] }).denylist ?? [])
+    : [];
   return {
     ready,
     disabled: props.execApprovalsSaving || props.execApprovalsLoading,
@@ -177,6 +183,7 @@ export function resolveExecApprovalsState(props: NodesProps): ExecApprovalsState
     selectedAgent,
     agents,
     allowlist,
+    denylist,
     target,
     targetNodeId,
     targetNodes,
@@ -226,7 +233,18 @@ export function renderExecApprovals(state: ExecApprovalsState) {
             ${
               state.selectedScope === EXEC_APPROVALS_DEFAULT_SCOPE
                 ? nothing
-                : renderExecApprovalsAllowlist(state)
+                : html`
+                    ${renderExecApprovalsRuleList(state, {
+                      key: "allowlist",
+                      title: "Allowlist",
+                      emptyText: "No allowlist entries yet.",
+                    })}
+                    ${renderExecApprovalsRuleList(state, {
+                      key: "denylist",
+                      title: "Denylist",
+                      emptyText: "No denylist entries yet.",
+                    })}
+                  `
             }
           `
       }
@@ -528,21 +546,28 @@ function renderExecApprovalsPolicy(state: ExecApprovalsState) {
   `;
 }
 
-function renderExecApprovalsAllowlist(state: ExecApprovalsState) {
-  const allowlistPath = ["agents", state.selectedScope, "allowlist"];
-  const entries = state.allowlist;
+function renderExecApprovalsRuleList(
+  state: ExecApprovalsState,
+  params: {
+    key: "allowlist" | "denylist";
+    title: string;
+    emptyText: string;
+  },
+) {
+  const entries = params.key === "allowlist" ? state.allowlist : state.denylist;
+  const listPath = ["agents", state.selectedScope, params.key];
   return html`
     <div class="row" style="margin-top: 18px; justify-content: space-between;">
       <div>
-        <div class="card-title">Allowlist</div>
-        <div class="card-sub">Case-insensitive glob patterns.</div>
+        <div class="card-title">${params.title}</div>
+        <div class="card-sub">Case-insensitive glob patterns, plus optional argument substring.</div>
       </div>
       <button
         class="btn btn--sm"
         ?disabled=${state.disabled}
         @click=${() => {
           const next = [...entries, { pattern: "" }];
-          state.onPatch(allowlistPath, next);
+          state.onPatch(listPath, next);
         }}
       >
         Add pattern
@@ -552,16 +577,17 @@ function renderExecApprovalsAllowlist(state: ExecApprovalsState) {
       ${
         entries.length === 0
           ? html`
-              <div class="muted">No allowlist entries yet.</div>
+              <div class="muted">${params.emptyText}</div>
             `
-          : entries.map((entry, index) => renderAllowlistEntry(state, entry, index))
+          : entries.map((entry, index) => renderRuleListEntry(state, params.key, entry, index))
       }
     </div>
   `;
 }
 
-function renderAllowlistEntry(
+function renderRuleListEntry(
   state: ExecApprovalsState,
+  listKey: "allowlist" | "denylist",
   entry: ExecApprovalsAllowlistEntry,
   index: number,
 ) {
@@ -586,9 +612,26 @@ function renderAllowlistEntry(
             @input=${(event: Event) => {
               const target = event.target as HTMLInputElement;
               state.onPatch(
-                ["agents", state.selectedScope, "allowlist", index, "pattern"],
+                ["agents", state.selectedScope, listKey, index, "pattern"],
                 target.value,
               );
+            }}
+          />
+        </label>
+        <label class="field">
+          <span>Args match</span>
+          <input
+            type="text"
+            .value=${entry.argsMatch ?? ""}
+            ?disabled=${state.disabled}
+            @input=${(event: Event) => {
+              const target = event.target as HTMLInputElement;
+              const value = target.value;
+              if (value.trim()) {
+                state.onPatch(["agents", state.selectedScope, listKey, index, "argsMatch"], value);
+              } else {
+                state.onRemove(["agents", state.selectedScope, listKey, index, "argsMatch"]);
+              }
             }}
           />
         </label>
@@ -596,11 +639,12 @@ function renderAllowlistEntry(
           class="btn btn--sm danger"
           ?disabled=${state.disabled}
           @click=${() => {
-            if (state.allowlist.length <= 1) {
-              state.onRemove(["agents", state.selectedScope, "allowlist"]);
+            const entries = listKey === "allowlist" ? state.allowlist : state.denylist;
+            if (entries.length <= 1) {
+              state.onRemove(["agents", state.selectedScope, listKey]);
               return;
             }
-            state.onRemove(["agents", state.selectedScope, "allowlist", index]);
+            state.onRemove(["agents", state.selectedScope, listKey, index]);
           }}
         >
           Remove


### PR DESCRIPTION
## Summary
- add exec approval denylist rules with optional `argsMatch` support and `ask=on-match`
- enforce denylist matches across gateway exec, node exec, and `system.run`, while allowing allowlist entries to act as denylist exceptions
- extend the Control UI to edit denylist entries and `argsMatch` filters

Closes #6615.

## Testing
- `pnpm test src/node-host/exec-policy.test.ts`
- `pnpm test src/infra/exec-approvals.test.ts`
- `pnpm test src/infra/exec-approvals-config.test.ts`
- `pnpm test src/agents/bash-tools.exec.approval-id.test.ts`
- `pnpm test src/node-host/invoke-system-run.test.ts`
- `pnpm build`
