### PR TITLE
fix(cron): add null check for payload.text/message in normalizePayloadToSystemText

### DIFF
--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -79,9 +79,9 @@ export function inferLegacyName(job: {
   return "Cron job";
 }
 
-export function normalizePayloadToSystemText(payload: CronPayload) {
+export function normalizePayloadToSystemText(payload: CronPayload): string {
   if (payload.kind === "systemEvent") {
-    return payload.text.trim();
+    return typeof payload.text === "string" ? payload.text.trim() : "";
   }
-  return payload.message.trim();
+  return typeof payload.message === "string" ? payload.message.trim() : "";
 }


### PR DESCRIPTION
## Summary

Cron jobs with `payload.kind: systemEvent` would fail with `TypeError: Cannot read properties of undefined (reading 'trim')` when `payload.text` or `payload.message` is undefined.

## Root Cause

The `normalizePayloadToSystemText` function in `src/cron/service/normalize.ts` directly called `.trim()` on `payload.text` and `payload.message` without null checks:

```typescript
export function normalizePayloadToSystemText(payload: CronPayload) {
  if (payload.kind === "systemEvent") {
    return payload.text.trim();  // ❌ TypeError if undefined
  }
  return payload.message.trim();  // ❌ TypeError if undefined
}
```

## Fix

Added typeof checks before calling `.trim()`:

```typescript
export function normalizePayloadToSystemText(payload: CronPayload): string {
  if (payload.kind === "systemEvent") {
    return typeof payload.text === "string" ? payload.text.trim() : "";
  }
  return typeof payload.message === "string" ? payload.message.trim() : "";
}
```

## Testing

- Change is minimal and surgical
- No tests exist for this specific function, but the fix follows the same pattern used elsewhere in the codebase (e.g., `normalizeOptionalText`)

Fixes #43163