### PR TITLE
Chat UI: show full exec commands in sidebar

### DIFF
--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { extractToolCards } from "./tool-cards.ts";
+
+describe("extractToolCards", () => {
+  it("reuses the matching call args for tool results in the same message", () => {
+    const command =
+      "python3 ~/.openclaw/workspace/skills/node-cluster-3.connector/scripts/main.py invoke " +
+      'wangjx-node-host system.run --raw-command "echo sidebar"';
+    const cards = extractToolCards({
+      content: [
+        {
+          type: "tool_call",
+          name: "exec",
+          arguments: { command },
+        },
+        {
+          type: "tool_result",
+          name: "exec",
+          text: "done",
+        },
+      ],
+    });
+
+    expect(cards).toHaveLength(2);
+    expect(cards[1]).toEqual(
+      expect.objectContaining({
+        kind: "result",
+        name: "exec",
+        args: { command },
+        text: "done",
+      }),
+    );
+  });
+});

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -5,7 +5,7 @@ import type { ToolCard } from "../types/chat-types.ts";
 import { TOOL_INLINE_THRESHOLD } from "./constants.ts";
 import { extractTextCached } from "./message-extract.ts";
 import { isToolResultMessage } from "./message-normalizer.ts";
-import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
+import { formatToolSidebarContent, getTruncatedPreview } from "./tool-helpers.ts";
 
 export function extractToolCards(message: unknown): ToolCard[] {
   const m = message as Record<string, unknown>;
@@ -33,7 +33,11 @@ export function extractToolCards(message: unknown): ToolCard[] {
     }
     const text = extractToolText(item);
     const name = typeof item.name === "string" ? item.name : "tool";
-    cards.push({ kind: "result", name, text });
+    const explicitArgs = coerceArgs(item.arguments ?? item.args);
+    const inheritedArgs =
+      explicitArgs ??
+      [...cards].toReversed().find((card) => card.kind === "call" && card.name === name)?.args;
+    cards.push({ kind: "result", name, args: inheritedArgs, text });
   }
 
   if (isToolResultMessage(message) && !cards.some((card) => card.kind === "result")) {
@@ -56,14 +60,7 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
   const canClick = Boolean(onOpenSidebar);
   const handleClick = canClick
     ? () => {
-        if (hasText) {
-          onOpenSidebar!(formatToolOutputForSidebar(card.text!));
-          return;
-        }
-        const info = `## ${display.label}\n\n${
-          detail ? `**Command:** \`${detail}\`\n\n` : ""
-        }*No output — tool completed successfully.*`;
-        onOpenSidebar!(info);
+        onOpenSidebar!(formatToolSidebarContent(card));
       }
     : undefined;
 

--- a/ui/src/ui/chat/tool-helpers.test.ts
+++ b/ui/src/ui/chat/tool-helpers.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
+import { describe, expect, it } from "vitest";
+import {
+  formatToolOutputForSidebar,
+  formatToolSidebarContent,
+  getTruncatedPreview,
+} from "./tool-helpers.ts";
 
 describe("tool-helpers", () => {
   describe("formatToolOutputForSidebar", () => {
@@ -74,6 +78,26 @@ describe("tool-helpers", () => {
     it("handles whitespace-only string", () => {
       const result = formatToolOutputForSidebar("   ");
       expect(result).toBe("   ");
+    });
+  });
+
+  describe("formatToolSidebarContent", () => {
+    it("shows the full exec command above sidebar output", () => {
+      const command =
+        "python3 ~/.openclaw/workspace/skills/node-cluster-3.connector/scripts/main.py invoke " +
+        'wangjx-node-host system.run --raw-command "echo this is a deliberately long command ' +
+        'that should never be truncated in the sidebar"';
+
+      const content = formatToolSidebarContent({
+        name: "exec",
+        args: { command },
+        text: "done",
+      });
+
+      expect(content).toContain("**Command:**");
+      expect(content).toContain(command);
+      expect(content).not.toContain("…");
+      expect(content).toContain("done");
     });
   });
 

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -2,6 +2,7 @@
  * Helper functions for tool card rendering.
  */
 
+import { formatToolDetail, resolveToolDisplay } from "../tool-display.ts";
 import { PREVIEW_MAX_CHARS, PREVIEW_MAX_LINES } from "./constants.ts";
 
 /**
@@ -20,6 +21,40 @@ export function formatToolOutputForSidebar(text: string): string {
     }
   }
   return text;
+}
+
+function resolveExecCommandForSidebar(args: unknown): string | undefined {
+  if (!args || typeof args !== "object") {
+    return undefined;
+  }
+  const command = (args as Record<string, unknown>).command;
+  return typeof command === "string" && command.trim() ? command.trim() : undefined;
+}
+
+export function formatToolSidebarContent(card: {
+  name: string;
+  args?: unknown;
+  text?: string;
+}): string {
+  const display = resolveToolDisplay({ name: card.name, args: card.args });
+  const detail = formatToolDetail(display);
+  const fullExecCommand =
+    card.name === "exec" ? resolveExecCommandForSidebar(card.args) : undefined;
+  const sections: string[] = [`## ${display.label}`];
+
+  if (fullExecCommand) {
+    sections.push("", "**Command:**", "```sh", fullExecCommand, "```");
+  } else if (detail) {
+    sections.push("", `**Details:** ${detail}`);
+  }
+
+  if (card.text?.trim()) {
+    sections.push("", formatToolOutputForSidebar(card.text));
+  } else {
+    sections.push("", "*No output — tool completed successfully.*");
+  }
+
+  return sections.join("\n");
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep the full exec command in tool sidebar content instead of showing output-only markdown
- let tool result cards inherit the matching tool-call args within the same message so the sidebar can reconstruct the command
- add UI regression coverage for sidebar formatting and tool-call/result pairing

Closes #43153.

## Testing
- `pnpm exec vitest run --config vitest.config.ts src/ui/chat/tool-helpers.test.ts`
- `pnpm exec vitest run --config vitest.config.ts src/ui/chat/tool-cards.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/chat/tool-helpers.ts ui/src/ui/chat/tool-cards.ts ui/src/ui/chat/tool-helpers.test.ts ui/src/ui/chat/tool-cards.test.ts`
