### PR TITLE
Update dev-setup.md

### DIFF
--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -21,7 +21,7 @@ Before building the app, ensure you have the following installed:
 Install the project-wide dependencies:
 
 ```bash
-pnpm install
+npm install
 ```
 
 ## 2. Build and Package the App


### PR DESCRIPTION
typo in set up

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
Copy pasting command fails due to typo.
- What changed:
pnpm install -> npm install
- What did NOT change (scope boundary):
everything else

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

