### PR TITLE
fix(telegram): deliver verbose tool summaries in forum topic sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: deliver verbose tool summaries inside forum topic sessions again, so threaded topic chats now match DM verbose behavior. (#43236) Thanks @frankbuild.
 - Agents/sandbox: honor `tools.sandbox.tools.alsoAllow`, let explicit sandbox re-allows remove matching built-in default-deny tools, and keep sandbox explain/error guidance aligned with the effective sandbox tool policy. (#54492) Thanks @ngutman.
 - Agents/sandbox: make blocked-tool guidance glob-aware again, redact/sanitize session-specific explain hints for safer copy-paste, and avoid leaking control-character session keys in those hints. (#54684) Thanks @ngutman.
 - Feishu: close WebSocket connections on monitor stop/abort so ghost connections no longer persist, preventing duplicate event processing and resource leaks across restart cycles. (#52844) Thanks @schumilin.

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -779,6 +779,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendToolResult).toHaveBeenCalledWith(
       expect.objectContaining({ text: "🔧 exec: ls" }),
     );
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -755,6 +755,33 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("delivers tool summaries in forum topic sessions (group + IsForum)", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "group",
+      IsForum: true,
+      MessageThreadId: 99,
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.({ text: "🔧 exec: ls" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "🔧 exec: ls" }),
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
   it("delivers deterministic exec approval tool payloads in groups", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -587,7 +587,10 @@ export async function dispatchReplyFromConfig(params: {
       }
     }
 
-    const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
+    // Forum topics are threaded conversations within a group — verbose tool
+    // summaries should be delivered into the topic thread, same as DMs.
+    const shouldSendToolSummaries =
+      (ctx.ChatType !== "group" || ctx.IsForum === true) && ctx.CommandSource !== "native";
     const acpDispatch = await dispatchAcpRuntime.tryDispatchAcpReply({
       ctx,
       cfg,


### PR DESCRIPTION
## Summary

Fixes #43206 — verbose tool output messages (Read, Exec, etc.) were not delivered to Telegram forum topic sessions, even when `verboseLevel` was set to `on` or `full`.

## Root Cause

In `src/auto-reply/reply/dispatch-from-config.ts`, the gate `ctx.ChatType !== "group"` blocked **all** tool summaries in group chats — including forum topics, which are threaded conversations that should behave like DMs.

## Fix

Changed the condition to:
```ts
(ctx.ChatType !== "group" || ctx.IsForum === true)
```

Forum topics now receive verbose tool summaries, same as DM sessions. The delivery pipeline already correctly propagates the thread context via `threadSpec` in `deliveryBaseOptions`, so `message_thread_id` is included automatically.

## Tests

Added test in `src/auto-reply/reply/dispatch-from-config.test.ts`:
- **"delivers tool summaries in forum topic sessions (group + IsForum)"** — verifies that `onToolResult` payloads reach `sendToolResult` when `ChatType=group` + `IsForum=true` + `MessageThreadId` is set.

## Changes

- `src/auto-reply/reply/dispatch-from-config.ts` — 5 lines (gate condition + comment)
- `src/auto-reply/reply/dispatch-from-config.test.ts` — 27 lines (new test)