### PR TITLE
Fix session-link reload dropping Control UI token

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -447,6 +447,22 @@ export function renderApp(state: AppViewState) {
                 onRefresh: () => loadSessions(state),
                 onPatch: (key, patch) => patchSession(state, key, patch),
                 onDelete: (key) => deleteSessionAndRefresh(state, key),
+                onOpenSession: (sessionKey) => {
+                  state.sessionKey = sessionKey;
+                  state.chatMessage = "";
+                  state.chatStream = null;
+                  state.chatStreamStartedAt = null;
+                  state.chatRunId = null;
+                  state.resetToolStream();
+                  state.resetChatScroll();
+                  state.applySettings({
+                    ...state.settings,
+                    sessionKey,
+                    lastActiveSessionKey: sessionKey,
+                  });
+                  void state.loadAssistantIdentity();
+                  state.setTab("chat");
+                },
               })
             : nothing
         }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -450,9 +450,11 @@ export function renderApp(state: AppViewState) {
                 onOpenSession: (sessionKey) => {
                   state.sessionKey = sessionKey;
                   state.chatMessage = "";
+                  state.chatAttachments = [];
                   state.chatStream = null;
                   state.chatStreamStartedAt = null;
                   state.chatRunId = null;
+                  state.chatQueue = [];
                   state.resetToolStream();
                   state.resetChatScroll();
                   state.applySettings({

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -448,21 +448,26 @@ export function renderApp(state: AppViewState) {
                 onPatch: (key, patch) => patchSession(state, key, patch),
                 onDelete: (key) => deleteSessionAndRefresh(state, key),
                 onOpenSession: (sessionKey) => {
-                  state.sessionKey = sessionKey;
-                  state.chatMessage = "";
-                  state.chatAttachments = [];
-                  state.chatStream = null;
-                  state.chatStreamStartedAt = null;
-                  state.chatRunId = null;
-                  state.chatQueue = [];
-                  state.resetToolStream();
-                  state.resetChatScroll();
+                  const isSessionSwitch = state.sessionKey !== sessionKey;
+                  if (isSessionSwitch) {
+                    state.sessionKey = sessionKey;
+                    state.chatMessage = "";
+                    state.chatAttachments = [];
+                    state.chatStream = null;
+                    state.chatStreamStartedAt = null;
+                    state.chatRunId = null;
+                    state.chatQueue = [];
+                    state.resetToolStream();
+                    state.resetChatScroll();
+                  }
                   state.applySettings({
                     ...state.settings,
                     sessionKey,
                     lastActiveSessionKey: sessionKey,
                   });
-                  void state.loadAssistantIdentity();
+                  if (isSessionSwitch) {
+                    void state.loadAssistantIdentity();
+                  }
                   state.setTab("chat");
                 },
               })

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -84,6 +84,21 @@ describe("control UI routing", () => {
     await app.updateComplete;
 
     app.applySettings({ ...app.settings, token: "abc123" });
+    app.chatAttachments = [
+      {
+        id: "a1",
+        dataUrl: "data:text/plain;base64,QQ==",
+        mimeType: "text/plain",
+      },
+    ];
+    app.chatQueue = [
+      {
+        id: "q1",
+        text: "queued message",
+        createdAt: Date.now(),
+      },
+    ];
+    app.chatRunId = "run-123";
     app.sessionsResult = {
       ts: Date.now(),
       path: "(multiple)",
@@ -107,6 +122,9 @@ describe("control UI routing", () => {
     expect(app.settings.token).toBe("abc123");
     expect(app.tab).toBe("chat");
     expect(app.sessionKey).toBe("agent:main:subagent:task-123");
+    expect(app.chatAttachments).toEqual([]);
+    expect(app.chatQueue).toEqual([]);
+    expect(app.chatRunId).toBeNull();
     expect(window.location.pathname).toBe("/chat");
     expect(window.location.search).toBe("?session=agent%3Amain%3Asubagent%3Atask-123");
   });

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -79,6 +79,38 @@ describe("control UI routing", () => {
     expect(window.location.search).toBe("?session=main");
   });
 
+  it("opens session table links in-app without dropping in-memory token state", async () => {
+    const app = mountApp("/sessions");
+    await app.updateComplete;
+
+    app.applySettings({ ...app.settings, token: "abc123" });
+    app.sessionsResult = {
+      ts: Date.now(),
+      path: "(multiple)",
+      count: 1,
+      defaults: { model: null, contextTokens: null },
+      sessions: [
+        {
+          key: "agent:main:subagent:task-123",
+          kind: "direct",
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+    await app.updateComplete;
+
+    const link = app.querySelector<HTMLAnchorElement>(".session-key-cell a.session-link");
+    expect(link).not.toBeNull();
+    link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }));
+
+    await app.updateComplete;
+    expect(app.settings.token).toBe("abc123");
+    expect(app.tab).toBe("chat");
+    expect(app.sessionKey).toBe("agent:main:subagent:task-123");
+    expect(window.location.pathname).toBe("/chat");
+    expect(window.location.search).toBe("?session=agent%3Amain%3Asubagent%3Atask-123");
+  });
+
   it("keeps chat and nav usable on narrow viewports", async () => {
     const app = mountApp("/chat");
     await app.updateComplete;

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -129,6 +129,76 @@ describe("control UI routing", () => {
     expect(window.location.search).toBe("?session=agent%3Amain%3Asubagent%3Atask-123");
   });
 
+  it("keeps active chat state when opening the current session from the table", async () => {
+    const app = mountApp("/sessions");
+    await app.updateComplete;
+
+    const currentSession = "agent:main:subagent:task-123";
+    const queuedAt = Date.now();
+    app.sessionKey = currentSession;
+    app.applySettings({
+      ...app.settings,
+      token: "abc123",
+      sessionKey: currentSession,
+      lastActiveSessionKey: currentSession,
+    });
+    app.chatAttachments = [
+      {
+        id: "a1",
+        dataUrl: "data:text/plain;base64,QQ==",
+        mimeType: "text/plain",
+      },
+    ];
+    app.chatQueue = [
+      {
+        id: "q1",
+        text: "queued message",
+        createdAt: queuedAt,
+      },
+    ];
+    app.chatRunId = "run-123";
+    app.sessionsResult = {
+      ts: Date.now(),
+      path: "(multiple)",
+      count: 1,
+      defaults: { model: null, contextTokens: null },
+      sessions: [
+        {
+          key: currentSession,
+          kind: "direct",
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+    await app.updateComplete;
+
+    const link = app.querySelector<HTMLAnchorElement>(".session-key-cell a.session-link");
+    expect(link).not.toBeNull();
+    link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }));
+
+    await app.updateComplete;
+    expect(app.settings.token).toBe("abc123");
+    expect(app.tab).toBe("chat");
+    expect(app.sessionKey).toBe(currentSession);
+    expect(app.chatAttachments).toEqual([
+      {
+        id: "a1",
+        dataUrl: "data:text/plain;base64,QQ==",
+        mimeType: "text/plain",
+      },
+    ]);
+    expect(app.chatQueue).toEqual([
+      {
+        id: "q1",
+        text: "queued message",
+        createdAt: queuedAt,
+      },
+    ]);
+    expect(app.chatRunId).toBe("run-123");
+    expect(window.location.pathname).toBe("/chat");
+    expect(window.location.search).toBe("?session=agent%3Amain%3Asubagent%3Atask-123");
+  });
+
   it("keeps chat and nav usable on narrow viewports", async () => {
     const app = mountApp("/chat");
     await app.updateComplete;

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -27,6 +27,7 @@ function buildProps(result: SessionsListResult): SessionsProps {
     onRefresh: () => undefined,
     onPatch: () => undefined,
     onDelete: () => undefined,
+    onOpenSession: () => undefined,
   };
 }
 

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -30,6 +30,7 @@ export type SessionsProps = {
     },
   ) => void;
   onDelete: (key: string) => void;
+  onOpenSession: (key: string) => void;
 };
 
 const THINK_LEVELS = ["", "off", "minimal", "low", "medium", "high", "xhigh"] as const;
@@ -206,7 +207,14 @@ export function renderSessions(props: SessionsProps) {
                 <div class="muted">No sessions found.</div>
               `
             : rows.map((row) =>
-                renderRow(row, props.basePath, props.onPatch, props.onDelete, props.loading),
+                renderRow(
+                  row,
+                  props.basePath,
+                  props.onPatch,
+                  props.onDelete,
+                  props.onOpenSession,
+                  props.loading,
+                ),
               )
         }
       </div>
@@ -219,6 +227,7 @@ function renderRow(
   basePath: string,
   onPatch: SessionsProps["onPatch"],
   onDelete: SessionsProps["onDelete"],
+  onOpenSession: SessionsProps["onOpenSession"],
   disabled: boolean,
 ) {
   const updated = row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "n/a";
@@ -244,7 +253,28 @@ function renderRow(
   return html`
     <div class="table-row">
       <div class="mono session-key-cell">
-        ${canLink ? html`<a href=${chatUrl} class="session-link">${row.key}</a>` : row.key}
+        ${
+          canLink
+            ? html`<a
+              href=${chatUrl}
+              class="session-link"
+              @click=${(event: MouseEvent) => {
+                if (
+                  event.defaultPrevented ||
+                  event.button !== 0 ||
+                  event.metaKey ||
+                  event.ctrlKey ||
+                  event.shiftKey ||
+                  event.altKey
+                ) {
+                  return;
+                }
+                event.preventDefault();
+                onOpenSession(row.key);
+              }}
+            >${row.key}</a>`
+            : row.key
+        }
         ${showDisplayName ? html`<span class="muted session-key-display-name">${displayName}</span>` : nothing}
       </div>
       <div>


### PR DESCRIPTION
## Summary
- prevent full-page navigation when clicking session keys in the Sessions table
- route normal left-clicks through in-app navigation to Chat with the selected session key
- keep modifier clicks (`cmd/ctrl/shift/alt` or non-left clicks) as normal link behavior
- add a browser routing test that verifies session-link navigation keeps in-memory token state

## Root cause
Session rows used plain anchor navigation (`/chat?session=...`). That triggers a page reload, and Control UI tokens are intentionally in-memory only, so the reload dropped auth and disconnected the gateway.

## Validation
- `pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/views/sessions.test.ts src/ui/navigation.browser.test.ts` ✅ (2 files, 15 tests passed)
- `pnpm exec oxfmt --check ui/src/ui/views/sessions.ts ui/src/ui/app-render.ts ui/src/ui/views/sessions.test.ts ui/src/ui/navigation.browser.test.ts` ✅

Closes #43186
