### PR TITLE
fix: serialize gateway config mutations

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -31,6 +31,7 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { loadOpenClawPlugins } from "../../plugins/loader.js";
+import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { diffConfigPaths } from "../config-reload.js";
 import {
   formatControlPlaneActor,
@@ -53,6 +54,8 @@ import { resolveBaseHashParam } from "./base-hash.js";
 import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+const CONFIG_WRITE_LANE = "config-write";
 
 function requireConfigBaseHash(
   params: unknown,
@@ -308,208 +311,214 @@ export const configHandlers: GatewayRequestHandlers = {
     respond(true, result, undefined);
   },
   "config.set": async ({ params, respond }) => {
-    if (!assertValidParams(params, validateConfigSetParams, "config.set", respond)) {
-      return;
-    }
-    const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
-    if (!requireConfigBaseHash(params, snapshot, respond)) {
-      return;
-    }
-    const parsed = parseValidateConfigFromRawOrRespond(params, "config.set", snapshot, respond);
-    if (!parsed) {
-      return;
-    }
-    await writeConfigFile(parsed.config, writeOptions);
-    respond(
-      true,
-      {
-        ok: true,
-        path: createConfigIO().configPath,
-        config: redactConfigObject(parsed.config, parsed.schema.uiHints),
-      },
-      undefined,
-    );
+    await enqueueCommandInLane(CONFIG_WRITE_LANE, async () => {
+      if (!assertValidParams(params, validateConfigSetParams, "config.set", respond)) {
+        return;
+      }
+      const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+      if (!requireConfigBaseHash(params, snapshot, respond)) {
+        return;
+      }
+      const parsed = parseValidateConfigFromRawOrRespond(params, "config.set", snapshot, respond);
+      if (!parsed) {
+        return;
+      }
+      await writeConfigFile(parsed.config, writeOptions);
+      respond(
+        true,
+        {
+          ok: true,
+          path: createConfigIO().configPath,
+          config: redactConfigObject(parsed.config, parsed.schema.uiHints),
+        },
+        undefined,
+      );
+    });
   },
   "config.patch": async ({ params, respond, client, context }) => {
-    if (!assertValidParams(params, validateConfigPatchParams, "config.patch", respond)) {
-      return;
-    }
-    const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
-    if (!requireConfigBaseHash(params, snapshot, respond)) {
-      return;
-    }
-    if (!snapshot.valid) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid config; fix before patching"),
+    await enqueueCommandInLane(CONFIG_WRITE_LANE, async () => {
+      if (!assertValidParams(params, validateConfigPatchParams, "config.patch", respond)) {
+        return;
+      }
+      const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+      if (!requireConfigBaseHash(params, snapshot, respond)) {
+        return;
+      }
+      if (!snapshot.valid) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid config; fix before patching"),
+        );
+        return;
+      }
+      const rawValue = (params as { raw?: unknown }).raw;
+      if (typeof rawValue !== "string") {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "invalid config.patch params: raw (string) required",
+          ),
+        );
+        return;
+      }
+      const parsedRes = parseConfigJson5(rawValue);
+      if (!parsedRes.ok) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, parsedRes.error));
+        return;
+      }
+      if (
+        !parsedRes.parsed ||
+        typeof parsedRes.parsed !== "object" ||
+        Array.isArray(parsedRes.parsed)
+      ) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "config.patch raw must be an object"),
+        );
+        return;
+      }
+      const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
+        mergeObjectArraysById: true,
+      });
+      const schemaPatch = loadSchemaWithPlugins();
+      const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
+      if (!restoredMerge.ok) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            restoredMerge.humanReadableMessage ?? "invalid config",
+          ),
+        );
+        return;
+      }
+      const migrated = applyLegacyMigrations(restoredMerge.result);
+      const resolved = migrated.next ?? restoredMerge.result;
+      const validated = validateConfigObjectWithPlugins(resolved);
+      if (!validated.ok) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid config", {
+            details: { issues: validated.issues },
+          }),
+        );
+        return;
+      }
+      const changedPaths = diffConfigPaths(snapshot.config, validated.config);
+      const actor = resolveControlPlaneActor(client);
+      context?.logGateway?.info(
+        `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
       );
-      return;
-    }
-    const rawValue = (params as { raw?: unknown }).raw;
-    if (typeof rawValue !== "string") {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          "invalid config.patch params: raw (string) required",
-        ),
-      );
-      return;
-    }
-    const parsedRes = parseConfigJson5(rawValue);
-    if (!parsedRes.ok) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, parsedRes.error));
-      return;
-    }
-    if (
-      !parsedRes.parsed ||
-      typeof parsedRes.parsed !== "object" ||
-      Array.isArray(parsedRes.parsed)
-    ) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "config.patch raw must be an object"),
-      );
-      return;
-    }
-    const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
-      mergeObjectArraysById: true,
-    });
-    const schemaPatch = loadSchemaWithPlugins();
-    const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
-    if (!restoredMerge.ok) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          restoredMerge.humanReadableMessage ?? "invalid config",
-        ),
-      );
-      return;
-    }
-    const migrated = applyLegacyMigrations(restoredMerge.result);
-    const resolved = migrated.next ?? restoredMerge.result;
-    const validated = validateConfigObjectWithPlugins(resolved);
-    if (!validated.ok) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid config", {
-          details: { issues: validated.issues },
-        }),
-      );
-      return;
-    }
-    const changedPaths = diffConfigPaths(snapshot.config, validated.config);
-    const actor = resolveControlPlaneActor(client);
-    context?.logGateway?.info(
-      `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
-    );
-    await writeConfigFile(validated.config, writeOptions);
+      await writeConfigFile(validated.config, writeOptions);
 
-    const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
-      resolveConfigRestartRequest(params);
-    const payload = buildConfigRestartSentinelPayload({
-      kind: "config-patch",
-      mode: "config.patch",
-      sessionKey,
-      deliveryContext,
-      threadId,
-      note,
-    });
-    const sentinelPath = await tryWriteRestartSentinelPayload(payload);
-    const restart = scheduleGatewaySigusr1Restart({
-      delayMs: restartDelayMs,
-      reason: "config.patch",
-      audit: {
-        actor: actor.actor,
-        deviceId: actor.deviceId,
-        clientIp: actor.clientIp,
-        changedPaths,
-      },
-    });
-    if (restart.coalesced) {
-      context?.logGateway?.warn(
-        `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
-      );
-    }
-    respond(
-      true,
-      {
-        ok: true,
-        path: createConfigIO().configPath,
-        config: redactConfigObject(validated.config, schemaPatch.uiHints),
-        restart,
-        sentinel: {
-          path: sentinelPath,
-          payload,
+      const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
+        resolveConfigRestartRequest(params);
+      const payload = buildConfigRestartSentinelPayload({
+        kind: "config-patch",
+        mode: "config.patch",
+        sessionKey,
+        deliveryContext,
+        threadId,
+        note,
+      });
+      const sentinelPath = await tryWriteRestartSentinelPayload(payload);
+      const restart = scheduleGatewaySigusr1Restart({
+        delayMs: restartDelayMs,
+        reason: "config.patch",
+        audit: {
+          actor: actor.actor,
+          deviceId: actor.deviceId,
+          clientIp: actor.clientIp,
+          changedPaths,
         },
-      },
-      undefined,
-    );
+      });
+      if (restart.coalesced) {
+        context?.logGateway?.warn(
+          `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+        );
+      }
+      respond(
+        true,
+        {
+          ok: true,
+          path: createConfigIO().configPath,
+          config: redactConfigObject(validated.config, schemaPatch.uiHints),
+          restart,
+          sentinel: {
+            path: sentinelPath,
+            payload,
+          },
+        },
+        undefined,
+      );
+    });
   },
   "config.apply": async ({ params, respond, client, context }) => {
-    if (!assertValidParams(params, validateConfigApplyParams, "config.apply", respond)) {
-      return;
-    }
-    const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
-    if (!requireConfigBaseHash(params, snapshot, respond)) {
-      return;
-    }
-    const parsed = parseValidateConfigFromRawOrRespond(params, "config.apply", snapshot, respond);
-    if (!parsed) {
-      return;
-    }
-    const changedPaths = diffConfigPaths(snapshot.config, parsed.config);
-    const actor = resolveControlPlaneActor(client);
-    context?.logGateway?.info(
-      `config.apply write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.apply`,
-    );
-    await writeConfigFile(parsed.config, writeOptions);
-
-    const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
-      resolveConfigRestartRequest(params);
-    const payload = buildConfigRestartSentinelPayload({
-      kind: "config-apply",
-      mode: "config.apply",
-      sessionKey,
-      deliveryContext,
-      threadId,
-      note,
-    });
-    const sentinelPath = await tryWriteRestartSentinelPayload(payload);
-    const restart = scheduleGatewaySigusr1Restart({
-      delayMs: restartDelayMs,
-      reason: "config.apply",
-      audit: {
-        actor: actor.actor,
-        deviceId: actor.deviceId,
-        clientIp: actor.clientIp,
-        changedPaths,
-      },
-    });
-    if (restart.coalesced) {
-      context?.logGateway?.warn(
-        `config.apply restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+    await enqueueCommandInLane(CONFIG_WRITE_LANE, async () => {
+      if (!assertValidParams(params, validateConfigApplyParams, "config.apply", respond)) {
+        return;
+      }
+      const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+      if (!requireConfigBaseHash(params, snapshot, respond)) {
+        return;
+      }
+      const parsed = parseValidateConfigFromRawOrRespond(params, "config.apply", snapshot, respond);
+      if (!parsed) {
+        return;
+      }
+      const changedPaths = diffConfigPaths(snapshot.config, parsed.config);
+      const actor = resolveControlPlaneActor(client);
+      context?.logGateway?.info(
+        `config.apply write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.apply`,
       );
-    }
-    respond(
-      true,
-      {
-        ok: true,
-        path: createConfigIO().configPath,
-        config: redactConfigObject(parsed.config, parsed.schema.uiHints),
-        restart,
-        sentinel: {
-          path: sentinelPath,
-          payload,
+      await writeConfigFile(parsed.config, writeOptions);
+
+      const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
+        resolveConfigRestartRequest(params);
+      const payload = buildConfigRestartSentinelPayload({
+        kind: "config-apply",
+        mode: "config.apply",
+        sessionKey,
+        deliveryContext,
+        threadId,
+        note,
+      });
+      const sentinelPath = await tryWriteRestartSentinelPayload(payload);
+      const restart = scheduleGatewaySigusr1Restart({
+        delayMs: restartDelayMs,
+        reason: "config.apply",
+        audit: {
+          actor: actor.actor,
+          deviceId: actor.deviceId,
+          clientIp: actor.clientIp,
+          changedPaths,
         },
-      },
-      undefined,
-    );
+      });
+      if (restart.coalesced) {
+        context?.logGateway?.warn(
+          `config.apply restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+        );
+      }
+      respond(
+        true,
+        {
+          ok: true,
+          path: createConfigIO().configPath,
+          config: redactConfigObject(parsed.config, parsed.schema.uiHints),
+          restart,
+          sentinel: {
+            path: sentinelPath,
+            payload,
+          },
+        },
+        undefined,
+      );
+    });
   },
 };

--- a/src/gateway/server.config-write-race.test.ts
+++ b/src/gateway/server.config-write-race.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigFileSnapshot } from "../config/types.js";
+
+const mockReadConfigFileSnapshotForWrite = vi.hoisted(() => vi.fn());
+const mockWriteConfigFile = vi.hoisted(() => vi.fn());
+const mockLoadConfig = vi.hoisted(() => vi.fn(() => ({})));
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    createConfigIO: vi.fn(() => ({ configPath: "/tmp/openclaw.json" })),
+    loadConfig: () => mockLoadConfig(),
+    readConfigFileSnapshotForWrite: (...args: unknown[]) =>
+      mockReadConfigFileSnapshotForWrite(...args),
+    writeConfigFile: (...args: unknown[]) => mockWriteConfigFile(...args),
+  };
+});
+
+vi.mock("../config/schema.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/schema.js")>("../config/schema.js");
+  return {
+    ...actual,
+    buildConfigSchema: vi.fn(() => ({ uiHints: {} })),
+    lookupConfigSchema: actual.lookupConfigSchema,
+  };
+});
+
+vi.mock("../channels/plugins/index.js", () => ({
+  listChannelPlugins: vi.fn(() => []),
+}));
+
+vi.mock("../plugins/loader.js", () => ({
+  loadOpenClawPlugins: vi.fn(() => ({ plugins: [] })),
+}));
+
+vi.mock("../config/redact-snapshot.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/redact-snapshot.js")>(
+    "../config/redact-snapshot.js",
+  );
+  return {
+    ...actual,
+    restoreRedactedValues: vi.fn((value: unknown) => ({ ok: true, result: value })),
+    redactConfigObject: actual.redactConfigObject,
+    redactConfigSnapshot: actual.redactConfigSnapshot,
+  };
+});
+
+vi.mock("../config/legacy.js", () => ({
+  applyLegacyMigrations: vi.fn((value: unknown) => ({ next: value })),
+}));
+
+vi.mock("../config/validation.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../config/validation.js")>("../config/validation.js");
+  return {
+    ...actual,
+    validateConfigObjectWithPlugins: vi.fn((value: unknown) => ({ ok: true, config: value })),
+  };
+});
+
+vi.mock("../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: vi.fn(() => ({ coalesced: false, delayMs: 2000, reason: "test" })),
+}));
+
+vi.mock("../config/sessions.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../config/sessions.js")>("../config/sessions.js");
+  return {
+    ...actual,
+    extractDeliveryInfo: vi.fn(() => ({ deliveryContext: undefined, threadId: undefined })),
+  };
+});
+
+vi.mock("../control-plane-audit.js", async () => {
+  const actual = await vi.importActual<typeof import("../control-plane-audit.js")>(
+    "../control-plane-audit.js",
+  );
+  return {
+    ...actual,
+    resolveControlPlaneActor: vi.fn(() => ({
+      actor: "test",
+      deviceId: null,
+      clientIp: null,
+    })),
+    formatControlPlaneActor: vi.fn(() => "test"),
+    summarizeChangedPaths: vi.fn(() => "gateway.auth, channels.telegram"),
+  };
+});
+
+import { configHandlers } from "./server-methods/config.js";
+
+function makeSnapshot(params: {
+  hash: string;
+  config: Record<string, unknown>;
+}): ConfigFileSnapshot {
+  return {
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: JSON.stringify(params.config),
+    parsed: params.config,
+    resolved: params.config,
+    valid: true,
+    config: params.config,
+    hash: params.hash,
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+  };
+}
+
+describe("config write race", () => {
+  beforeEach(() => {
+    mockReadConfigFileSnapshotForWrite.mockReset();
+    mockWriteConfigFile.mockReset();
+    mockLoadConfig.mockReset();
+    mockLoadConfig.mockReturnValue({});
+  });
+
+  it("serializes config.patch so stale concurrent writes are rejected", async () => {
+    let firstWriteDone = false;
+    let releaseFirstWrite!: () => void;
+    const firstWriteBlocked = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+
+    mockReadConfigFileSnapshotForWrite.mockImplementation(async () => {
+      return firstWriteDone
+        ? {
+            snapshot: makeSnapshot({
+              hash: "hash-2",
+              config: {
+                gateway: { mode: "local" },
+              },
+            }),
+            writeOptions: {},
+          }
+        : {
+            snapshot: makeSnapshot({
+              hash: "hash-1",
+              config: {
+                gateway: { mode: "local" },
+                channels: { telegram: { token: "one" } },
+              },
+            }),
+            writeOptions: {},
+          };
+    });
+
+    mockWriteConfigFile.mockImplementationOnce(async () => {
+      await firstWriteBlocked;
+      firstWriteDone = true;
+    });
+
+    const firstRespond = vi.fn();
+    const secondRespond = vi.fn();
+    const context = {
+      logGateway: {
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    };
+
+    const firstCall = configHandlers["config.patch"]({
+      params: {
+        raw: JSON.stringify({
+          channels: {
+            telegram: null,
+          },
+        }),
+        baseHash: "hash-1",
+      },
+      respond: firstRespond,
+      client: undefined,
+      context,
+      req: undefined,
+    } as never);
+
+    await vi.waitFor(() => {
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+    });
+
+    const secondCall = configHandlers["config.patch"]({
+      params: {
+        raw: JSON.stringify({
+          gateway: {
+            auth: { mode: "token", token: "two" },
+          },
+        }),
+        baseHash: "hash-1",
+      },
+      respond: secondRespond,
+      client: undefined,
+      context,
+      req: undefined,
+    } as never);
+
+    releaseFirstWrite();
+    await Promise.all([firstCall, secondCall]);
+
+    expect(firstRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true }),
+      undefined,
+    );
+    expect(secondRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: "config changed since last load; re-run config.get and retry",
+      }),
+    );
+    expect(mockReadConfigFileSnapshotForWrite).toHaveBeenCalledTimes(2);
+  });
+
+  it("serializes config.apply so stale concurrent writes are rejected", async () => {
+    let firstWriteDone = false;
+    let releaseFirstWrite!: () => void;
+    const firstWriteBlocked = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+
+    mockReadConfigFileSnapshotForWrite.mockImplementation(async () => {
+      return firstWriteDone
+        ? {
+            snapshot: makeSnapshot({
+              hash: "hash-2",
+              config: {
+                gateway: { mode: "local" },
+                features: { alpha: true },
+              },
+            }),
+            writeOptions: {},
+          }
+        : {
+            snapshot: makeSnapshot({
+              hash: "hash-1",
+              config: {
+                gateway: { mode: "local" },
+                features: { alpha: false },
+              },
+            }),
+            writeOptions: {},
+          };
+    });
+
+    mockWriteConfigFile.mockImplementationOnce(async () => {
+      await firstWriteBlocked;
+      firstWriteDone = true;
+    });
+
+    const firstRespond = vi.fn();
+    const secondRespond = vi.fn();
+    const context = {
+      logGateway: {
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    };
+
+    const firstCall = configHandlers["config.apply"]({
+      params: {
+        raw: JSON.stringify({
+          gateway: { mode: "local" },
+          features: { alpha: true },
+        }),
+        baseHash: "hash-1",
+      },
+      respond: firstRespond,
+      client: undefined,
+      context,
+      req: undefined,
+    } as never);
+
+    await vi.waitFor(() => {
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+    });
+
+    const secondCall = configHandlers["config.apply"]({
+      params: {
+        raw: JSON.stringify({
+          gateway: { mode: "local" },
+          features: { beta: true },
+        }),
+        baseHash: "hash-1",
+      },
+      respond: secondRespond,
+      client: undefined,
+      context,
+      req: undefined,
+    } as never);
+
+    releaseFirstWrite();
+    await Promise.all([firstCall, secondCall]);
+
+    expect(firstRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true }),
+      undefined,
+    );
+    expect(secondRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: "config changed since last load; re-run config.get and retry",
+      }),
+    );
+    expect(mockReadConfigFileSnapshotForWrite).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: overlapping gateway config mutations can be computed from the same stale snapshot and silently overwrite each other.
- Why it matters: Control UI and other gateway RPC config writes can lose changes without an obvious error.
- What changed: `config.set`, `config.patch`, and `config.apply` now run through a dedicated single-file write lane so each mutation re-checks the latest config state before writing.
- What did NOT change (scope boundary): this PR does not change direct non-gateway config writers outside these RPC handlers.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #43150

## User-visible / Behavior Changes

- Concurrent gateway config mutations now fail cleanly with a stale base-hash error instead of silently reviving older config state.
- `config.patch` and `config.apply` keep the existing `baseHash` contract, but the check is now protected by serialization across gateway RPC writes.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: local macOS dev environment
- Runtime/container: Node.js dev environment
- Model/provider: not required
- Integration/channel (if any): gateway config RPC
- Relevant config (redacted): not required

### Steps

1. Start two gateway config mutations from the same base hash.
2. Let the first write hold the write path long enough for the second request to begin.
3. Observe the second request after the first one completes.

### Expected

- The first write succeeds.
- The second stale write is rejected with `config changed since last load; re-run config.get and retry`.

### Actual

- Before this change, overlapping gateway config mutations could be computed from the same stale snapshot and a later write could overwrite earlier changes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/gateway/server.config-patch.test.ts src/gateway/server.config-apply.test.ts src/gateway/server.config-write-race.test.ts`
- Edge cases checked: stale concurrent `config.patch`, stale concurrent `config.apply`, existing `config.patch`/`config.apply` behavior still passing
- What you did **not** verify: direct non-gateway config writers outside these RPC handlers

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/gateway/server-methods/config.ts`
- Known bad symptoms reviewers should watch for: config RPC calls blocking unexpectedly instead of completing quickly

## Risks and Mitigations

- Risk: gateway config RPC writes are now serialized, so overlapping writes will wait instead of racing.
  - Mitigation: this is limited to `config.set`, `config.patch`, and `config.apply`, and the targeted tests prove stale concurrent writes are rejected cleanly.
