### PR TITLE
Fix env proxy bootstrap for model traffic

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
@@ -79,6 +79,7 @@ vi.mock("../../../infra/machine-name.js", () => ({
 }));
 
 vi.mock("../../../infra/net/undici-global-dispatcher.js", () => ({
+  ensureGlobalUndiciEnvProxyDispatcher: () => {},
   ensureGlobalUndiciStreamTimeouts: () => {},
 }));
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -752,6 +752,8 @@ export async function runEmbeddedAttempt(
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   const prevCwd = process.cwd();
   const runAbortController = new AbortController();
+  // Proxy bootstrap must happen before timeout tuning so the timeouts wrap the
+  // active EnvHttpProxyAgent instead of being replaced by a bare proxy dispatcher.
   ensureGlobalUndiciEnvProxyDispatcher();
   ensureGlobalUndiciStreamTimeouts();
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -11,7 +11,10 @@ import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
-import { ensureGlobalUndiciStreamTimeouts } from "../../../infra/net/undici-global-dispatcher.js";
+import {
+  ensureGlobalUndiciEnvProxyDispatcher,
+  ensureGlobalUndiciStreamTimeouts,
+} from "../../../infra/net/undici-global-dispatcher.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import type {
@@ -749,6 +752,7 @@ export async function runEmbeddedAttempt(
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   const prevCwd = process.cwd();
   const runAbortController = new AbortController();
+  ensureGlobalUndiciEnvProxyDispatcher();
   ensureGlobalUndiciStreamTimeouts();
 
   log.debug(

--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { hasEnvHttpProxyConfigured, resolveEnvHttpProxyUrl } from "./proxy-env.js";
+
+describe("resolveEnvHttpProxyUrl", () => {
+  it("uses lower-case https_proxy before upper-case HTTPS_PROXY", () => {
+    const env = {
+      https_proxy: "http://lower.test:8080",
+      HTTPS_PROXY: "http://upper.test:8080",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveEnvHttpProxyUrl("https", env)).toBe("http://lower.test:8080");
+  });
+
+  it("treats empty lower-case https_proxy as authoritative over upper-case HTTPS_PROXY", () => {
+    const env = {
+      https_proxy: "",
+      HTTPS_PROXY: "http://upper.test:8080",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveEnvHttpProxyUrl("https", env)).toBeUndefined();
+    expect(hasEnvHttpProxyConfigured("https", env)).toBe(false);
+  });
+
+  it("treats empty lower-case http_proxy as authoritative over upper-case HTTP_PROXY", () => {
+    const env = {
+      http_proxy: "   ",
+      HTTP_PROXY: "http://upper-http.test:8080",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveEnvHttpProxyUrl("http", env)).toBeUndefined();
+    expect(hasEnvHttpProxyConfigured("http", env)).toBe(false);
+  });
+
+  it("falls back from HTTPS proxy vars to HTTP proxy vars for https requests", () => {
+    const env = {
+      HTTP_PROXY: "http://upper-http.test:8080",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveEnvHttpProxyUrl("https", env)).toBe("http://upper-http.test:8080");
+    expect(hasEnvHttpProxyConfigured("https", env)).toBe(true);
+  });
+});

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -16,3 +16,36 @@ export function hasProxyEnvConfigured(env: NodeJS.ProcessEnv = process.env): boo
   }
   return false;
 }
+
+function trimNonEmpty(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Match undici EnvHttpProxyAgent semantics for env-based HTTP/S proxy selection:
+ * - lower-case vars take precedence over upper-case
+ * - HTTPS requests prefer https_proxy/HTTPS_PROXY, then fall back to http_proxy/HTTP_PROXY
+ * - ALL_PROXY is ignored by EnvHttpProxyAgent
+ */
+export function resolveEnvHttpProxyUrl(
+  protocol: "http" | "https",
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const httpProxy = trimNonEmpty(env.http_proxy) ?? trimNonEmpty(env.HTTP_PROXY);
+  const httpsProxy = trimNonEmpty(env.https_proxy) ?? trimNonEmpty(env.HTTPS_PROXY);
+  if (protocol === "https") {
+    return httpsProxy ?? httpProxy;
+  }
+  return httpProxy;
+}
+
+export function hasEnvHttpProxyConfigured(
+  protocol: "http" | "https" = "https",
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return resolveEnvHttpProxyUrl(protocol, env) !== undefined;
+}

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -17,12 +17,12 @@ export function hasProxyEnvConfigured(env: NodeJS.ProcessEnv = process.env): boo
   return false;
 }
 
-function trimNonEmpty(value: string | undefined): string | undefined {
+function normalizeProxyEnvValue(value: string | undefined): string | null | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
   const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 /**
@@ -35,12 +35,16 @@ export function resolveEnvHttpProxyUrl(
   protocol: "http" | "https",
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
-  const httpProxy = trimNonEmpty(env.http_proxy) ?? trimNonEmpty(env.HTTP_PROXY);
-  const httpsProxy = trimNonEmpty(env.https_proxy) ?? trimNonEmpty(env.HTTPS_PROXY);
+  const lowerHttpProxy = normalizeProxyEnvValue(env.http_proxy);
+  const lowerHttpsProxy = normalizeProxyEnvValue(env.https_proxy);
+  const httpProxy =
+    lowerHttpProxy !== undefined ? lowerHttpProxy : normalizeProxyEnvValue(env.HTTP_PROXY);
+  const httpsProxy =
+    lowerHttpsProxy !== undefined ? lowerHttpsProxy : normalizeProxyEnvValue(env.HTTPS_PROXY);
   if (protocol === "https") {
-    return httpsProxy ?? httpProxy;
+    return httpsProxy ?? httpProxy ?? undefined;
   }
-  return httpProxy;
+  return httpProxy ?? undefined;
 }
 
 export function hasEnvHttpProxyConfigured(

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -73,11 +73,7 @@ describe("resolveProxyFetchFromEnv", () => {
   });
 
   it("returns proxy fetch using EnvHttpProxyAgent when HTTPS_PROXY is set", async () => {
-    // Stub empty vars first — on Windows, process.env is case-insensitive so
-    // HTTPS_PROXY and https_proxy share the same slot. Value must be set LAST.
     vi.stubEnv("HTTP_PROXY", "");
-    vi.stubEnv("https_proxy", "");
-    vi.stubEnv("http_proxy", "");
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
     undiciFetch.mockResolvedValue({ ok: true });
 
@@ -94,8 +90,6 @@ describe("resolveProxyFetchFromEnv", () => {
 
   it("returns proxy fetch when HTTP_PROXY is set", () => {
     vi.stubEnv("HTTPS_PROXY", "");
-    vi.stubEnv("https_proxy", "");
-    vi.stubEnv("http_proxy", "");
     vi.stubEnv("HTTP_PROXY", "http://fallback.test:3128");
 
     const fetchFn = resolveProxyFetchFromEnv();

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -1,5 +1,6 @@
 import { EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import { logWarn } from "../../logger.js";
+import { hasEnvHttpProxyConfigured } from "./proxy-env.js";
 
 export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
 type ProxyFetchWithMetadata = typeof fetch & {
@@ -51,12 +52,7 @@ export function getProxyUrlFromFetch(fetchImpl?: typeof fetch): string | undefin
  * Gracefully returns undefined if the proxy URL is malformed.
  */
 export function resolveProxyFetchFromEnv(): typeof fetch | undefined {
-  const proxyUrl =
-    process.env.HTTPS_PROXY ||
-    process.env.HTTP_PROXY ||
-    process.env.https_proxy ||
-    process.env.http_proxy;
-  if (!proxyUrl?.trim()) {
+  if (!hasEnvHttpProxyConfigured("https")) {
     return undefined;
   }
   try {

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -192,4 +192,17 @@ describe("ensureGlobalUndiciEnvProxyDispatcher", () => {
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
+
+  it("reinstalls env proxy if an external change later reverts the dispatcher to Agent", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+
+    setCurrentDispatcher(new Agent());
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+  });
 });

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -57,8 +57,14 @@ vi.mock("node:net", () => ({
   getDefaultAutoSelectFamily,
 }));
 
+vi.mock("./proxy-env.js", () => ({
+  hasEnvHttpProxyConfigured: vi.fn(() => false),
+}));
+
+import { hasEnvHttpProxyConfigured } from "./proxy-env.js";
 import {
   DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+  ensureGlobalUndiciEnvProxyDispatcher,
   ensureGlobalUndiciStreamTimeouts,
   resetGlobalUndiciStreamTimeoutsForTests,
 } from "./undici-global-dispatcher.js";
@@ -69,6 +75,7 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     resetGlobalUndiciStreamTimeoutsForTests();
     setCurrentDispatcher(new Agent());
     getDefaultAutoSelectFamily.mockReturnValue(undefined);
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(false);
   });
 
   it("replaces default Agent dispatcher with extended stream timeouts", () => {
@@ -134,5 +141,55 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
       autoSelectFamily: false,
       autoSelectFamilyAttemptTimeout: 300,
     });
+  });
+});
+
+describe("ensureGlobalUndiciEnvProxyDispatcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGlobalUndiciStreamTimeoutsForTests();
+    setCurrentDispatcher(new Agent());
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(false);
+  });
+
+  it("installs EnvHttpProxyAgent when env HTTP proxy is configured on a default Agent", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("does not override unsupported custom proxy dispatcher types", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+    setCurrentDispatcher(new ProxyAgent("http://proxy.test:8080"));
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("retries proxy bootstrap after an unsupported dispatcher later becomes a default Agent", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+    setCurrentDispatcher(new ProxyAgent("http://proxy.test:8080"));
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+
+    setCurrentDispatcher(new Agent());
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("is idempotent after proxy bootstrap succeeds", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -75,8 +75,14 @@ function resolveCurrentDispatcherKind(): DispatcherKind | null {
 
 export function ensureGlobalUndiciEnvProxyDispatcher(): void {
   const shouldUseEnvProxy = hasEnvHttpProxyConfigured("https");
-  if (!shouldUseEnvProxy || lastAppliedProxyBootstrap) {
+  if (!shouldUseEnvProxy) {
     return;
+  }
+  if (lastAppliedProxyBootstrap) {
+    if (resolveCurrentDispatcherKind() === "env-proxy") {
+      return;
+    }
+    lastAppliedProxyBootstrap = false;
   }
   const currentKind = resolveCurrentDispatcherKind();
   if (currentKind === null) {

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -1,11 +1,13 @@
 import * as net from "node:net";
 import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { hasEnvHttpProxyConfigured } from "./proxy-env.js";
 
 export const DEFAULT_UNDICI_STREAM_TIMEOUT_MS = 30 * 60 * 1000;
 
 const AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 300;
 
-let lastAppliedDispatcherKey: string | null = null;
+let lastAppliedTimeoutKey: string | null = null;
+let lastAppliedProxyBootstrap = false;
 
 type DispatcherKind = "agent" | "env-proxy" | "unsupported";
 
@@ -59,28 +61,53 @@ function resolveDispatcherKey(params: {
   return `${params.kind}:${params.timeoutMs}:${autoSelectToken}`;
 }
 
+function resolveCurrentDispatcherKind(): DispatcherKind | null {
+  let dispatcher: unknown;
+  try {
+    dispatcher = getGlobalDispatcher();
+  } catch {
+    return null;
+  }
+
+  const currentKind = resolveDispatcherKind(dispatcher);
+  return currentKind === "unsupported" ? null : currentKind;
+}
+
+export function ensureGlobalUndiciEnvProxyDispatcher(): void {
+  const shouldUseEnvProxy = hasEnvHttpProxyConfigured("https");
+  if (!shouldUseEnvProxy || lastAppliedProxyBootstrap) {
+    return;
+  }
+  const currentKind = resolveCurrentDispatcherKind();
+  if (currentKind === null) {
+    return;
+  }
+  if (currentKind === "env-proxy") {
+    lastAppliedProxyBootstrap = true;
+    return;
+  }
+  try {
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+    lastAppliedProxyBootstrap = true;
+  } catch {
+    // Best-effort bootstrap only.
+  }
+}
+
 export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }): void {
   const timeoutMsRaw = opts?.timeoutMs ?? DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
   const timeoutMs = Math.max(1, Math.floor(timeoutMsRaw));
   if (!Number.isFinite(timeoutMsRaw)) {
     return;
   }
-
-  let dispatcher: unknown;
-  try {
-    dispatcher = getGlobalDispatcher();
-  } catch {
-    return;
-  }
-
-  const kind = resolveDispatcherKind(dispatcher);
-  if (kind === "unsupported") {
+  const kind = resolveCurrentDispatcherKind();
+  if (kind === null) {
     return;
   }
 
   const autoSelectFamily = resolveAutoSelectFamily();
   const nextKey = resolveDispatcherKey({ kind, timeoutMs, autoSelectFamily });
-  if (lastAppliedDispatcherKey === nextKey) {
+  if (lastAppliedTimeoutKey === nextKey) {
     return;
   }
 
@@ -102,12 +129,13 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
         }),
       );
     }
-    lastAppliedDispatcherKey = nextKey;
+    lastAppliedTimeoutKey = nextKey;
   } catch {
     // Best-effort hardening only.
   }
 }
 
 export function resetGlobalUndiciStreamTimeoutsForTests(): void {
-  lastAppliedDispatcherKey = null;
+  lastAppliedTimeoutKey = null;
+  lastAppliedProxyBootstrap = false;
 }

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -2,6 +2,7 @@ import * as dns from "node:dns";
 import { Agent, EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
+import { hasEnvHttpProxyConfigured } from "../infra/net/proxy-env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
@@ -177,13 +178,7 @@ function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env
 }
 
 function hasEnvHttpProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
-  // Match EnvHttpProxyAgent behavior (undici) for HTTPS requests:
-  // - lower-case env vars take precedence over upper-case
-  // - HTTPS requests use https_proxy/HTTPS_PROXY first, then fall back to http_proxy/HTTP_PROXY
-  // - ALL_PROXY is ignored by EnvHttpProxyAgent
-  const httpProxy = env.http_proxy ?? env.HTTP_PROXY;
-  const httpsProxy = env.https_proxy ?? env.HTTPS_PROXY;
-  return Boolean(httpProxy) || Boolean(httpsProxy);
+  return hasEnvHttpProxyConfigured("https", env);
 }
 
 function createTelegramDispatcher(params: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: generic model traffic (including `minimax-portal` on `anthropic-messages`) could ignore `HTTP_PROXY` / `HTTPS_PROXY` because the embedded runner only tuned undici timeouts and only preserved env-proxy mode if an `EnvHttpProxyAgent` was already installed.
- Why it matters: MiniMax/Anthropic-style model calls could bypass mitm or other configured HTTP(S) proxies even while Telegram and `web_search` still routed through proxy-aware paths.
- What changed: split global undici proxy bootstrap from timeout tuning, install env-proxy dispatch explicitly in the embedded runner, and centralize EnvHttpProxyAgent-style HTTP/HTTPS env resolution in shared net helpers reused by proxy fetch and Telegram.
- What did NOT change (scope boundary): this does not change model selection, provider auth, request payloads, or OpenAI WebSocket transport behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Generic model HTTP traffic now honors `HTTP_PROXY` / `HTTPS_PROXY` via the shared undici dispatcher bootstrap, including `minimax-portal` / `anthropic-messages` runs.
- Env-proxy precedence for shared net helpers is aligned with `EnvHttpProxyAgent` semantics (`https_proxy` / `HTTPS_PROXY` first for HTTPS, then `http_proxy` / `HTTP_PROXY`; `ALL_PROXY` is not treated as EnvHttpProxyAgent support).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local gateway / embedded runner
- Model/provider: `minimax-portal/MiniMax-M2.5` (`anthropic-messages`)
- Integration/channel (if any): generic embedded agent run, plus Telegram/web-search proxy regression coverage
- Relevant config (redacted): `HTTP_PROXY` / `HTTPS_PROXY` set; `minimax-portal` configured on `api.minimax.io/anthropic`

### Steps

1. Configure a generic model provider that uses the embedded runner HTTP path (for example `minimax-portal` on `anthropic-messages`) and set `HTTP_PROXY` / `HTTPS_PROXY`.
2. Start the gateway / embedded runner and execute a model request.
3. Verify the global undici dispatcher bootstraps env-proxy mode and that sibling proxy-aware paths still preserve their existing semantics.

### Expected

- Generic model HTTP traffic installs `EnvHttpProxyAgent` when HTTP(S) proxy env is configured.
- Later timeout tuning preserves the active dispatcher mode instead of silently reverting proxy routing.
- Shared net helpers agree on which env vars count for `EnvHttpProxyAgent` semantics.

### Actual

- Before this change, generic model traffic could stay on a plain undici `Agent`, bypassing configured HTTP(S) proxies, while Telegram and `web_search` still used their proxy-aware paths.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - env-proxy bootstrap installs `EnvHttpProxyAgent` for the generic model path
  - unsupported dispatcher state does not permanently suppress later proxy bootstrap
  - Telegram and shared proxy fetch helpers still honor the aligned HTTP/HTTPS proxy env semantics
- Edge cases checked:
  - proxy bootstrap is idempotent after success
  - timeout tuning still preserves env-proxy mode with autoSelectFamily settings
  - `ALL_PROXY`-only Telegram behavior remains direct/non-env-proxy
- What you did **not** verify:
  - a live end-to-end mitm capture after this code change

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `01fc0f596c`
- Files/config to restore: `src/infra/net/undici-global-dispatcher.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`, shared proxy helper files under `src/infra/net/`
- Known bad symptoms reviewers should watch for: generic model traffic unexpectedly bypassing proxy env again, or Telegram/web tool proxy behavior diverging from model-path proxy env detection

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: shared env-proxy helper changes could alter sibling path interpretation of proxy env precedence.
  - Mitigation: aligned Telegram and proxy-fetch to the same helper and kept focused tests green.
- Risk: proxy bootstrap could interfere with later undici tuning or custom dispatchers.
  - Mitigation: proxy bootstrap is explicit, best-effort, idempotent, and leaves unsupported/custom dispatcher types untouched.
