### PR TITLE
Control UI/Sessions: avoid "device identity required" disconnect when opening a session

### DIFF
--- a/test/ui/session-chat-navigation.test.ts
+++ b/test/ui/session-chat-navigation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { navigateToSessionChat } from "../../ui/src/ui/session-chat-navigation.ts";
+import type { UiSettings } from "../../ui/src/ui/storage.ts";
+
+function buildSettings(): UiSettings {
+  return {
+    gatewayUrl: "ws://localhost/ui",
+    token: "abc123",
+    sessionKey: "main",
+    lastActiveSessionKey: "main",
+    theme: "system",
+    chatFocusMode: false,
+    chatShowThinking: true,
+    splitRatio: 0.6,
+    navCollapsed: false,
+    navGroupsCollapsed: {},
+  };
+}
+
+describe("navigateToSessionChat", () => {
+  it("switches to the requested chat session without clearing the gateway token", () => {
+    const applySettings = vi.fn();
+    const loadAssistantIdentity = vi.fn(async () => undefined);
+    const setTab = vi.fn();
+    const state = {
+      sessionKey: "main",
+      chatMessage: "draft message",
+      chatStream: "streaming",
+      chatStreamStartedAt: 123,
+      chatRunId: "run-1",
+      settings: buildSettings(),
+      resetToolStream: vi.fn(),
+      resetChatScroll: vi.fn(),
+      applySettings: vi.fn((next: UiSettings) => {
+        applySettings(next);
+        state.settings = next;
+      }),
+      loadAssistantIdentity,
+      setTab,
+    };
+
+    navigateToSessionChat(state, "agent:main:session-123");
+
+    expect(state.sessionKey).toBe("agent:main:session-123");
+    expect(state.chatMessage).toBe("");
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBeNull();
+    expect(state.chatRunId).toBeNull();
+    expect(state.resetToolStream).toHaveBeenCalledOnce();
+    expect(state.resetChatScroll).toHaveBeenCalledOnce();
+    expect(applySettings).toHaveBeenCalledWith({
+      ...buildSettings(),
+      token: "abc123",
+      sessionKey: "agent:main:session-123",
+      lastActiveSessionKey: "agent:main:session-123",
+    });
+    expect(state.settings.token).toBe("abc123");
+    expect(loadAssistantIdentity).toHaveBeenCalledOnce();
+    expect(setTab).toHaveBeenCalledWith("chat");
+  });
+});

--- a/test/ui/session-chat-navigation.test.ts
+++ b/test/ui/session-chat-navigation.test.ts
@@ -25,6 +25,10 @@ describe("navigateToSessionChat", () => {
     const state = {
       sessionKey: "main",
       chatMessage: "draft message",
+      chatAttachments: [
+        { id: "att-1", dataUrl: "data:image/png;base64,abc", mimeType: "image/png" },
+      ],
+      chatQueue: [{ id: "queued-1", text: "queued", createdAt: 123 }],
       chatStream: "streaming",
       chatStreamStartedAt: 123,
       chatRunId: "run-1",
@@ -43,6 +47,8 @@ describe("navigateToSessionChat", () => {
 
     expect(state.sessionKey).toBe("agent:main:session-123");
     expect(state.chatMessage).toBe("");
+    expect(state.chatAttachments).toEqual([]);
+    expect(state.chatQueue).toEqual([]);
     expect(state.chatStream).toBeNull();
     expect(state.chatStreamStartedAt).toBeNull();
     expect(state.chatRunId).toBeNull();

--- a/test/ui/session-link-click.test.ts
+++ b/test/ui/session-link-click.test.ts
@@ -19,11 +19,7 @@ describe("handleSessionLinkClick", () => {
     const event = buildEvent();
     const onSelectSession = vi.fn();
 
-    const handled = handleSessionLinkClick(
-      event,
-      onSelectSession,
-      "agent:main:session-123",
-    );
+    const handled = handleSessionLinkClick(event, onSelectSession, "agent:main:session-123");
 
     expect(handled).toBe(true);
     expect(event.preventDefault).toHaveBeenCalledOnce();
@@ -34,11 +30,7 @@ describe("handleSessionLinkClick", () => {
     const event = buildEvent({ ctrlKey: true });
     const onSelectSession = vi.fn();
 
-    const handled = handleSessionLinkClick(
-      event,
-      onSelectSession,
-      "agent:main:session-123",
-    );
+    const handled = handleSessionLinkClick(event, onSelectSession, "agent:main:session-123");
 
     expect(handled).toBe(false);
     expect(event.preventDefault).not.toHaveBeenCalled();

--- a/test/ui/session-link-click.test.ts
+++ b/test/ui/session-link-click.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleSessionLinkClick } from "../../ui/src/ui/session-link-click.ts";
+
+function buildEvent(overrides: Partial<Parameters<typeof handleSessionLinkClick>[0]> = {}) {
+  return {
+    defaultPrevented: false,
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    preventDefault: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("handleSessionLinkClick", () => {
+  it("prevents default navigation and routes plain left-clicks through the app", () => {
+    const event = buildEvent();
+    const onSelectSession = vi.fn();
+
+    const handled = handleSessionLinkClick(
+      event,
+      onSelectSession,
+      "agent:main:session-123",
+    );
+
+    expect(handled).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(onSelectSession).toHaveBeenCalledWith("agent:main:session-123");
+  });
+
+  it("leaves modified clicks alone so opening in a new tab still uses native browser behavior", () => {
+    const event = buildEvent({ ctrlKey: true });
+    const onSelectSession = vi.fn();
+
+    const handled = handleSessionLinkClick(
+      event,
+      onSelectSession,
+      "agent:main:session-123",
+    );
+
+    expect(handled).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(onSelectSession).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -68,6 +68,7 @@ import {
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import { navigateToSessionChat } from "./session-chat-navigation.ts";
 import {
   resolveAgentConfig,
   resolveConfiguredCronModelSuggestions,
@@ -445,6 +446,7 @@ export function renderApp(state: AppViewState) {
                   state.sessionsIncludeUnknown = next.includeUnknown;
                 },
                 onRefresh: () => loadSessions(state),
+                onSelectSession: (key) => navigateToSessionChat(state, key),
                 onPatch: (key, patch) => patchSession(state, key, patch),
                 onDelete: (key) => deleteSessionAndRefresh(state, key),
               })

--- a/ui/src/ui/session-chat-navigation.ts
+++ b/ui/src/ui/session-chat-navigation.ts
@@ -1,0 +1,35 @@
+import type { UiSettings } from "./storage.ts";
+
+export type SessionChatNavigationState = {
+  sessionKey: string;
+  chatMessage: string;
+  chatStream: string | null;
+  chatStreamStartedAt: number | null;
+  chatRunId: string | null;
+  settings: UiSettings;
+  resetToolStream: () => void;
+  resetChatScroll: () => void;
+  applySettings: (next: UiSettings) => void;
+  loadAssistantIdentity: () => Promise<void>;
+  setTab: (tab: "chat") => void;
+};
+
+export function navigateToSessionChat(
+  state: SessionChatNavigationState,
+  sessionKey: string,
+) {
+  state.sessionKey = sessionKey;
+  state.chatMessage = "";
+  state.chatStream = null;
+  state.chatStreamStartedAt = null;
+  state.chatRunId = null;
+  state.resetToolStream();
+  state.resetChatScroll();
+  state.applySettings({
+    ...state.settings,
+    sessionKey,
+    lastActiveSessionKey: sessionKey,
+  });
+  void state.loadAssistantIdentity();
+  state.setTab("chat");
+}

--- a/ui/src/ui/session-chat-navigation.ts
+++ b/ui/src/ui/session-chat-navigation.ts
@@ -1,8 +1,11 @@
 import type { UiSettings } from "./storage.ts";
+import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 
 export type SessionChatNavigationState = {
   sessionKey: string;
   chatMessage: string;
+  chatAttachments: ChatAttachment[];
+  chatQueue: ChatQueueItem[];
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
@@ -14,12 +17,11 @@ export type SessionChatNavigationState = {
   setTab: (tab: "chat") => void;
 };
 
-export function navigateToSessionChat(
-  state: SessionChatNavigationState,
-  sessionKey: string,
-) {
+export function navigateToSessionChat(state: SessionChatNavigationState, sessionKey: string) {
   state.sessionKey = sessionKey;
   state.chatMessage = "";
+  state.chatAttachments = [];
+  state.chatQueue = [];
   state.chatStream = null;
   state.chatStreamStartedAt = null;
   state.chatRunId = null;

--- a/ui/src/ui/session-link-click.ts
+++ b/ui/src/ui/session-link-click.ts
@@ -1,0 +1,29 @@
+export type SessionLinkClickEvent = {
+  defaultPrevented: boolean;
+  button: number;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  preventDefault: () => void;
+};
+
+export function handleSessionLinkClick(
+  event: SessionLinkClickEvent,
+  onSelectSession: (key: string) => void,
+  sessionKey: string,
+): boolean {
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  ) {
+    return false;
+  }
+  event.preventDefault();
+  onSelectSession(sessionKey);
+  return true;
+}

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -25,6 +25,7 @@ function buildProps(result: SessionsListResult): SessionsProps {
     basePath: "",
     onFiltersChange: () => undefined,
     onRefresh: () => undefined,
+    onSelectSession: () => undefined,
     onPatch: () => undefined,
     onDelete: () => undefined,
   };

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { formatRelativeTimestamp } from "../format.ts";
 import { pathForTab } from "../navigation.ts";
 import { formatSessionTokens } from "../presenter.ts";
+import { handleSessionLinkClick } from "../session-link-click.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../types.ts";
 
 export type SessionsProps = {
@@ -20,6 +21,7 @@ export type SessionsProps = {
     includeUnknown: boolean;
   }) => void;
   onRefresh: () => void;
+  onSelectSession: (key: string) => void;
   onPatch: (
     key: string,
     patch: {
@@ -206,7 +208,14 @@ export function renderSessions(props: SessionsProps) {
                 <div class="muted">No sessions found.</div>
               `
             : rows.map((row) =>
-                renderRow(row, props.basePath, props.onPatch, props.onDelete, props.loading),
+                renderRow(
+                  row,
+                  props.basePath,
+                  props.onSelectSession,
+                  props.onPatch,
+                  props.onDelete,
+                  props.loading,
+                ),
               )
         }
       </div>
@@ -217,6 +226,7 @@ export function renderSessions(props: SessionsProps) {
 function renderRow(
   row: GatewaySessionRow,
   basePath: string,
+  onSelectSession: SessionsProps["onSelectSession"],
   onPatch: SessionsProps["onPatch"],
   onDelete: SessionsProps["onDelete"],
   disabled: boolean,
@@ -244,7 +254,16 @@ function renderRow(
   return html`
     <div class="table-row">
       <div class="mono session-key-cell">
-        ${canLink ? html`<a href=${chatUrl} class="session-link">${row.key}</a>` : row.key}
+        ${
+          canLink
+            ? html`<a
+              href=${chatUrl}
+              class="session-link"
+              @click=${(event: MouseEvent) =>
+                handleSessionLinkClick(event, onSelectSession, row.key)}
+            >${row.key}</a>`
+            : row.key
+        }
         ${showDisplayName ? html`<span class="muted session-key-display-name">${displayName}</span>` : nothing}
       </div>
       <div>


### PR DESCRIPTION
## Summary

- Problem: Clicking a session row in Control UI used a normal anchor navigation, which triggered a full page transition instead of an in-app tab/session switch.
- Why it matters: That navigation drops the current WebUI gateway connection and can lose the active tab-scoped auth context, leading to disconnects such as `device identity required` after opening a session.
- What changed: Intercept plain left-clicks on session-row links, route them through in-app chat/session navigation, and keep the current token/session state intact while switching to the selected session.
- What did NOT change (scope boundary): This PR does not change gateway auth rules, device identity requirements, or server-side token validation behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43186
- Related: None

## User-visible / Behavior Changes

- Clicking a session entry from the Control UI Sessions table now switches to that chat session in-app instead of causing a full page navigation.
- Existing Control UI auth/token state is preserved during that session switch.
- Modified clicks such as Ctrl+Click still keep native browser behavior.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local dev workspace, Node.js 24.11.1, pnpm
- Model/provider: N/A
- Integration/channel (if any): Control UI / WebUI
- Relevant config (redacted): token-authenticated Control UI session navigation

### Steps

1. Open Control UI with a valid gateway token.
2. Go to the `Sessions` tab.
3. Click a non-global session row to open it in chat.

### Expected

- The UI switches to the selected chat session without dropping the current auth/session context.
- No disconnect caused by a full page reload.
- No `device identity required` error triggered by opening the session.

### Actual

- Before this change, clicking the session row could perform a full navigation and disconnect the gateway client, leading to auth loss and `device identity required`.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
pnpm exec vitest run test/ui/session-link-click.test.ts test/ui/session-chat-navigation.test.ts

Test Files  2 passed (2)
Tests       3 passed (3)

pnpm exec tsc -p tsconfig.json --noEmit --pretty false

exit 0
