### PR TITLE
fix(skills): skill-creator quote YAML-sensitive description values

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -324,6 +324,7 @@ Write the YAML frontmatter with `name` and `description`:
 - `description`: This is the primary triggering mechanism for your skill, and helps Codex understand when to use the skill.
   - Include both what the Skill does and specific triggers/contexts for when to use it.
   - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Codex.
+  - Quote the `description` value if it contains `:`, `#`, brackets, or other YAML-sensitive punctuation. Keep `name` and `description` as simple YAML scalars.
   - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Codex needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
 
 Do not include any other fields in YAML frontmatter.

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -22,7 +22,7 @@ ALLOWED_RESOURCES = {"scripts", "references", "assets"}
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
-description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+description: "[TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]"
 ---
 
 # {skill_title}


### PR DESCRIPTION
Document the YAML frontmatter footgun where unquoted descriptions containing ':' can be rejected by stricter skill loaders, and update the generated SKILL.md template to quote description by default.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `skills/skill-creator` did not warn that unquoted YAML `description` values containing `:` can be rejected by stricter skill loaders, causing otherwise valid-looking skills to be skipped.
- Why it matters: skill authors can create a skill that passes a casual read but never loads into agent context because frontmatter parsing fails.
- What changed: added a short YAML-safety note to `skills/skill-creator/SKILL.md` and changed `skills/skill-creator/scripts/init_skill.py` so generated skills quote `description` by default.
- What did NOT change (scope boundary): no runtime skill loading logic, validation logic, limits, config defaults, or execution behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New `skill-creator` guidance explicitly tells authors to quote `description` when it contains YAML-sensitive punctuation like `:`, `#`, or brackets.
- Newly generated skills from `skills/skill-creator/scripts/init_skill.py` now use a quoted `description` placeholder by default.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux server where the skill was authored and loaded
- Runtime/container: OpenClaw 2026.3.8
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default `skills.limits.*`; no custom runtime limit causing the issue

### Steps

1. Create a skill with YAML frontmatter where `description` is unquoted and contains a second `:`, for example `Triggers on:`.
2. Place it in the skills directory and run `openclaw skills check`.
3. Observe that the skill is skipped and does not appear in the ready skill list.
4. Quote the `description` value and re-run the same check.

### Expected

- The skill should load normally, or the authoring guidance/template should prevent creating the broken frontmatter shape by default.

### Actual

- The unquoted `description` containing `:` was rejected by a stricter YAML parser in the skill-loading path, so the skill did not load into context.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the failure mode with a real skill whose unquoted `description` contained `Triggers on:`; confirmed that quoting the `description` fixed loading.
- Edge cases checked: reviewed repo tests for `skills/skill-creator` and did not find existing fixtures that depend on the unquoted template placeholder.
- What you did **not** verify: full test suite was not run.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two changed files in this PR.
- Files/config to restore: `skills/skill-creator/SKILL.md`, `skills/skill-creator/scripts/init_skill.py`
- Known bad symptoms reviewers should watch for: unexpected tests or tooling that assert the exact old `SKILL.md` template string.

## Risks and Mitigations

- Risk: a hidden test or downstream tool may assert the exact previous template text from `init_skill.py`.
  - Mitigation: the change is limited to quoting the placeholder value, which remains valid YAML and preserves the same semantics.
