### PR TITLE
fix(auto-reply): retry inbound debounce flush after lock contention

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -12,7 +12,7 @@ type BlueBubblesDebounceEntry = {
 };
 
 export type BlueBubblesDebouncer = {
-  enqueue: (item: BlueBubblesDebounceEntry) => Promise<void>;
+  enqueue: (item: BlueBubblesDebounceEntry) => Promise<boolean>;
   flushKey: (key: string) => Promise<boolean>;
 };
 

--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -13,7 +13,7 @@ type BlueBubblesDebounceEntry = {
 
 export type BlueBubblesDebouncer = {
   enqueue: (item: BlueBubblesDebounceEntry) => Promise<void>;
-  flushKey: (key: string) => Promise<void>;
+  flushKey: (key: string) => Promise<boolean>;
 };
 
 export type BlueBubblesDebounceRegistry = {

--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -161,6 +161,8 @@ export function createBlueBubblesDebounceRegistry(params: {
           // (e.g., text+image arriving as separate webhooks for the same messageId)
           return true;
         },
+        shouldFlushDirectWhenPending: (entry) =>
+          core.channel.text.hasControlCommand(entry.message.text, config),
         onFlush: async (entries) => {
           if (entries.length === 0) {
             return;

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -336,6 +336,7 @@ function registerEventHandlers(
       return !core.channel.text.hasControlCommand(text, cfg);
     },
     shouldFlushDirectWhenPending: (event) =>
+      event.message.message_type !== "text" ||
       core.channel.text.hasControlCommand(resolveDebounceText(event), cfg),
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -335,6 +335,8 @@ function registerEventHandlers(
       }
       return !core.channel.text.hasControlCommand(text, cfg);
     },
+    shouldFlushDirectWhenPending: (event) =>
+      core.channel.text.hasControlCommand(resolveDebounceText(event), cfg),
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {

--- a/extensions/feishu/src/monitor.test-mocks.ts
+++ b/extensions/feishu/src/monitor.test-mocks.ts
@@ -16,7 +16,7 @@ export function createFeishuRuntimeMockModule(): {
       debounce: {
         resolveInboundDebounceMs: () => number;
         createInboundDebouncer: () => {
-          enqueue: () => Promise<void>;
+          enqueue: () => Promise<boolean>;
           flushKey: () => Promise<void>;
         };
       };
@@ -32,7 +32,7 @@ export function createFeishuRuntimeMockModule(): {
         debounce: {
           resolveInboundDebounceMs: () => 0,
           createInboundDebouncer: () => ({
-            enqueue: async () => {},
+            enqueue: async () => false,
             flushKey: async () => {},
           }),
         },

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1900,6 +1900,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       return !core.channel.text.hasControlCommand(text, cfg);
     },
     shouldFlushDirectWhenPending: (entry) =>
+      Boolean(entry.post.file_ids?.length) ||
       core.channel.text.hasControlCommand(entry.post.message?.trim() ?? "", cfg),
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1899,6 +1899,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       }
       return !core.channel.text.hasControlCommand(text, cfg);
     },
+    shouldFlushDirectWhenPending: (entry) =>
+      core.channel.text.hasControlCommand(entry.post.message?.trim() ?? "", cfg),
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -14,9 +14,10 @@ describe("msteams monitor handler authz", () => {
           resolveInboundDebounceMs: () => 0,
           createInboundDebouncer: <T>(params: {
             onFlush: (entries: T[]) => Promise<void>;
-          }): { enqueue: (entry: T) => Promise<void> } => ({
+          }): { enqueue: (entry: T) => Promise<boolean> } => ({
             enqueue: async (entry: T) => {
               await params.onFlush([entry]);
+              return false;
             },
           }),
         },

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -634,6 +634,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       }
       return !core.channel.text.hasControlCommand(entry.text, cfg);
     },
+    shouldFlushDirectWhenPending: (entry) => core.channel.text.hasControlCommand(entry.text, cfg),
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -634,7 +634,8 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       }
       return !core.channel.text.hasControlCommand(entry.text, cfg);
     },
-    shouldFlushDirectWhenPending: (entry) => core.channel.text.hasControlCommand(entry.text, cfg),
+    shouldFlushDirectWhenPending: (entry) =>
+      entry.attachments.length > 0 || core.channel.text.hasControlCommand(entry.text, cfg),
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -276,7 +276,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { model: "deepseek/deepseek-r1" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -308,7 +308,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -332,7 +332,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "high" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -357,7 +357,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning: { max_tokens: 256 } };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -381,7 +381,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "medium" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -588,7 +588,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { thinking: "off" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -619,7 +619,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { thinking: "off" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -650,7 +650,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -674,7 +674,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { tool_choice: "required" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -726,7 +726,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -855,7 +855,7 @@ describe("applyExtraParamsToAgent", () => {
         ],
         tool_choice: { type: "tool", name: "read" },
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -899,7 +899,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         ],
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -938,7 +938,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         ],
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -1002,7 +1002,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         },
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -1049,7 +1049,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         },
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -173,7 +173,7 @@ describe("resolveExtraParams", () => {
 describe("applyExtraParamsToAgent", () => {
   function createOptionsCaptureAgent() {
     const calls: Array<(SimpleStreamOptions & { openaiWsWarmup?: boolean }) | undefined> = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       calls.push(options as (SimpleStreamOptions & { openaiWsWarmup?: boolean }) | undefined);
       return {} as ReturnType<StreamFn>;
     };
@@ -274,7 +274,7 @@ describe("applyExtraParamsToAgent", () => {
     // reasoning: { effort: "none" }, causing a 400 on models that require
     // reasoning (e.g. deepseek/deepseek-r1).
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { model: "deepseek/deepseek-r1" };
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -306,7 +306,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("injects reasoning.effort when thinkingLevel is non-off for OpenRouter", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {};
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -330,7 +330,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("removes legacy reasoning_effort and keeps reasoning unset when thinkingLevel is off", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "high" };
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -355,7 +355,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("does not inject effort when payload already has reasoning.max_tokens", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning: { max_tokens: 256 } };
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -379,7 +379,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("does not inject reasoning.effort for x-ai/grok models on OpenRouter (#32039)", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "medium" };
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -586,7 +586,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("normalizes thinking=off to null for SiliconFlow Pro models", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { thinking: "off" };
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -617,7 +617,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("keeps thinking=off unchanged for non-Pro SiliconFlow model IDs", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { thinking: "off" };
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -648,7 +648,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("maps thinkingLevel=off to Moonshot thinking.type=disabled", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {};
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -672,7 +672,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("maps non-off thinking levels to Moonshot thinking.type=enabled and normalizes tool_choice", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = { tool_choice: "required" };
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -724,7 +724,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("respects explicit Moonshot thinking param from model config", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {};
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
@@ -840,7 +840,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("does not rewrite tool schema for kimi-coding (native Anthropic format)", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {
         tools: [
           {
@@ -889,7 +889,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("does not rewrite anthropic tool schema for non-kimi endpoints", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {
         tools: [
           {
@@ -928,7 +928,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("uses explicit compat metadata for anthropic tool payload normalization", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {
         tools: [
           {
@@ -979,7 +979,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("removes invalid negative Google thinkingBudget and maps Gemini 3.1 to thinkingLevel", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {
         contents: [
           {
@@ -1040,7 +1040,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("keeps valid Google thinkingBudget unchanged", () => {
     const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       const payload: Record<string, unknown> = {
         config: {
           thinkingConfig: {
@@ -1469,7 +1469,7 @@ describe("applyExtraParamsToAgent", () => {
 
   it("skips context1m beta for OAuth tokens but preserves OAuth-required betas", () => {
     const calls: Array<SimpleStreamOptions | undefined> = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const baseStreamFn: StreamFn = (model, _context, options) => {
       calls.push(options);
       return {} as ReturnType<StreamFn>;
     };

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -350,8 +350,6 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
 
   return {
     enqueue,
-    flushKey: async (key: string) => {
-      await flushKeyInternal(key);
-    },
+    flushKey: (key: string) => flushKeyInternal(key),
   };
 }

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -201,6 +201,17 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     return Math.min(maxRetryDelayMs, Math.max(buffer.debounceMs, Math.trunc(delay)));
   };
 
+  const hasPendingWork = (buffer: DebounceBuffer<T>) => buffer.flushing || buffer.items.length > 0;
+
+  const deleteCurrentBuffer = (key: string, buffer: DebounceBuffer<T>) => {
+    clearScheduledFlush(buffer);
+    if (buffers.get(key) !== buffer) {
+      return false;
+    }
+    buffers.delete(key);
+    return true;
+  };
+
   const flushDirect = async (items: T[]) => {
     try {
       await params.onFlush(items);
@@ -217,16 +228,20 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     clearScheduledFlush(buffer);
     const delayMs = reason === "retry" ? resolveRetryDelayMs(buffer) : buffer.debounceMs;
     buffer.timeout = setTimeout(() => {
-      void flushBuffer(key, buffer);
+      void flushKeyInternal(key);
     }, delayMs);
     buffer.timeout.unref?.();
   };
 
   const scheduleBufferedFlush = (key: string, buffer: DebounceBuffer<T>) => {
+    if (buffer.items.length === 0) {
+      clearScheduledFlush(buffer);
+      return;
+    }
     scheduleFlush(key, buffer, buffer.consecutiveFailures > 0 ? "retry" : "debounce");
   };
 
-  const flushBuffer = async (key: string, buffer: DebounceBuffer<T>): Promise<boolean> => {
+  async function flushBuffer(key: string, buffer: DebounceBuffer<T>): Promise<boolean> {
     clearScheduledFlush(buffer);
     if (buffer.flushing) {
       if (buffer.items.length > 0) {
@@ -235,7 +250,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       return false;
     }
     if (buffer.items.length === 0) {
-      buffers.delete(key);
+      deleteCurrentBuffer(key, buffer);
       return true;
     }
     const items = buffer.items.splice(0);
@@ -262,7 +277,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       clearScheduledFlush(buffer);
       const droppedItems = buffer.items.splice(0);
       decrementBufferedTotal(droppedItems.length);
-      buffers.delete(key);
+      deleteCurrentBuffer(key, buffer);
       params.onError?.(
         createDebounceError("INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED", key, {
           maxFlushRetries,
@@ -272,21 +287,21 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       );
       return true;
     }
-    if (flushFailed || buffer.items.length > 0) {
+    if (buffer.items.length > 0) {
       scheduleFlush(key, buffer, flushFailed ? "retry" : "debounce");
       return false;
     }
-    buffers.delete(key);
+    deleteCurrentBuffer(key, buffer);
     return true;
-  };
+  }
 
-  const flushKeyInternal = async (key: string) => {
+  async function flushKeyInternal(key: string) {
     const buffer = buffers.get(key);
     if (!buffer) {
       return true;
     }
     return flushBuffer(key, buffer);
-  };
+  }
 
   const enqueue = async (item: T) => {
     const key = params.buildKey(item);
@@ -301,24 +316,28 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
           if (params.shouldFlushDirectWhenPending?.(item)) {
             // Priority items like control commands should not be trapped behind a failing buffer.
             await flushDirect([item]);
-            return;
+            return false;
           }
           // Preserve ordering by appending non-debounced items behind unresolved buffered work.
           pushBufferedItem(key, pending, item);
           scheduleBufferedFlush(key, pending);
-          return;
+          return hasPendingWork(pending);
         }
       }
       await flushDirect([item]);
-      return;
+      return false;
     }
 
     const existing = buffers.get(key);
     if (existing) {
       existing.debounceMs = debounceMs;
       pushBufferedItem(key, existing, item);
+      if (existing.items.length === 0 && !existing.flushing) {
+        deleteCurrentBuffer(key, existing);
+        return false;
+      }
       scheduleBufferedFlush(key, existing);
-      return;
+      return hasPendingWork(existing);
     }
 
     if (buffers.size >= maxKeys) {
@@ -329,7 +348,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
         [item],
       );
       await flushDirect([item]);
-      return;
+      return false;
     }
 
     const buffer: DebounceBuffer<T> = {
@@ -342,10 +361,11 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     buffers.set(key, buffer);
     pushBufferedItem(key, buffer, item);
     if (buffer.items.length === 0) {
-      buffers.delete(key);
-      return;
+      deleteCurrentBuffer(key, buffer);
+      return false;
     }
     scheduleFlush(key, buffer);
+    return true;
   };
 
   return {

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -51,6 +51,7 @@ export type InboundDebounceCreateParams<T> = {
   maxKeys?: number;
   maxFlushRetries?: number;
   maxBufferedItems?: number;
+  maxTotalBufferedItems?: number;
   maxRetryDelayMs?: number;
   retryBackoffFactor?: number;
   onFlush: (items: T[]) => Promise<void>;
@@ -63,12 +64,14 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
   const maxKeys = Math.max(1, Math.trunc(params.maxKeys ?? 1000));
   const maxFlushRetries = Math.max(0, Math.trunc(params.maxFlushRetries ?? 20));
   const maxBufferedItems = Math.max(1, Math.trunc(params.maxBufferedItems ?? 500));
+  const maxTotalBufferedItems = Math.max(1, Math.trunc(params.maxTotalBufferedItems ?? 10_000));
   const retryBackoffFactor = Number.isFinite(params.retryBackoffFactor)
     ? Math.max(1, params.retryBackoffFactor ?? 2)
     : 2;
   const maxRetryDelayMs = Number.isFinite(params.maxRetryDelayMs)
     ? Math.max(defaultDebounceMs, Math.trunc(params.maxRetryDelayMs ?? 30_000))
     : Math.max(defaultDebounceMs, 30_000);
+  let totalBufferedItems = 0;
 
   const resolveDebounceMs = (item: T) => {
     const resolved = params.resolveDebounceMs?.(item);
@@ -83,17 +86,20 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
   const createDebounceError = (
     code:
       | "INBOUND_DEBOUNCE_BUFFER_OVERFLOW"
+      | "INBOUND_DEBOUNCE_TOTAL_BUFFER_OVERFLOW"
       | "INBOUND_DEBOUNCE_MAX_KEYS_EXCEEDED"
       | "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
     key: string,
-    extra: Record<string, number> = {},
+    extra: Record<string, unknown> = {},
   ) => {
     const message =
       code === "INBOUND_DEBOUNCE_BUFFER_OVERFLOW"
         ? "inbound debounce buffer overflow"
-        : code === "INBOUND_DEBOUNCE_MAX_KEYS_EXCEEDED"
-          ? "inbound debounce key capacity exceeded"
-          : "inbound debounce flush retries exceeded";
+        : code === "INBOUND_DEBOUNCE_TOTAL_BUFFER_OVERFLOW"
+          ? "inbound debounce total buffer overflow"
+          : code === "INBOUND_DEBOUNCE_MAX_KEYS_EXCEEDED"
+            ? "inbound debounce key capacity exceeded"
+            : "inbound debounce flush retries exceeded";
     return Object.assign(new Error(message), {
       code,
       debounceKeyHash: buildKeyHash(key),
@@ -121,14 +127,69 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     );
   };
 
+  const emitTotalOverflowError = (key: string, droppedItems: T[]) => {
+    if (droppedItems.length === 0) {
+      return;
+    }
+    params.onError?.(
+      createDebounceError("INBOUND_DEBOUNCE_TOTAL_BUFFER_OVERFLOW", key, {
+        maxTotalBufferedItems,
+      }),
+      droppedItems,
+    );
+  };
+
+  const decrementBufferedTotal = (count: number) => {
+    if (count <= 0) {
+      return;
+    }
+    totalBufferedItems = Math.max(0, totalBufferedItems - count);
+  };
+
+  const takeNewestItems = (buffer: DebounceBuffer<T>, count: number): T[] => {
+    if (count <= 0 || buffer.items.length === 0) {
+      return [];
+    }
+    const droppedItems = buffer.items.splice(Math.max(0, buffer.items.length - count), count);
+    decrementBufferedTotal(droppedItems.length);
+    return droppedItems;
+  };
+
   const trimBufferToLimit = (key: string, buffer: DebounceBuffer<T>) => {
     const overflow = buffer.items.length - maxBufferedItems;
     if (overflow <= 0) {
       return;
     }
     // Drop newest items to preserve ordering for already-buffered work.
-    const droppedItems = buffer.items.splice(maxBufferedItems, overflow);
+    const droppedItems = takeNewestItems(buffer, overflow);
     emitOverflowError(key, droppedItems);
+  };
+
+  const trimTotalBufferedItemsToLimit = (key: string, buffer: DebounceBuffer<T>) => {
+    const overflow = totalBufferedItems - maxTotalBufferedItems;
+    if (overflow <= 0) {
+      return;
+    }
+    // Drop newest items from the active buffer first to cap aggregate memory growth.
+    const droppedItems = takeNewestItems(buffer, overflow);
+    emitTotalOverflowError(key, droppedItems);
+  };
+
+  const pushBufferedItem = (key: string, buffer: DebounceBuffer<T>, item: T) => {
+    buffer.items.push(item);
+    totalBufferedItems += 1;
+    trimBufferToLimit(key, buffer);
+    trimTotalBufferedItemsToLimit(key, buffer);
+  };
+
+  const requeueBufferedItems = (key: string, buffer: DebounceBuffer<T>, items: T[]) => {
+    if (items.length === 0) {
+      return;
+    }
+    buffer.items.unshift(...items);
+    totalBufferedItems += items.length;
+    trimBufferToLimit(key, buffer);
+    trimTotalBufferedItemsToLimit(key, buffer);
   };
 
   const resolveRetryDelayMs = (buffer: DebounceBuffer<T>) => {
@@ -178,19 +239,21 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       return true;
     }
     const items = buffer.items.splice(0);
+    decrementBufferedTotal(items.length);
     buffer.flushing = true;
     let flushFailed = false;
     let retriesExceeded = false;
+    let flushError: unknown;
     try {
       await params.onFlush(items);
       buffer.consecutiveFailures = 0;
     } catch (err) {
       flushFailed = true;
+      flushError = err;
       // Preserve ordering when retrying the failed batch.
-      buffer.items.unshift(...items);
+      requeueBufferedItems(key, buffer, items);
       buffer.consecutiveFailures += 1;
-      params.onError?.(err, items);
-      trimBufferToLimit(key, buffer);
+      // Recoverable retries stay quiet so channel handlers do not surface repeated user-visible errors.
       retriesExceeded = buffer.consecutiveFailures > maxFlushRetries;
     } finally {
       buffer.flushing = false;
@@ -198,10 +261,12 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     if (retriesExceeded) {
       clearScheduledFlush(buffer);
       const droppedItems = buffer.items.splice(0);
+      decrementBufferedTotal(droppedItems.length);
       buffers.delete(key);
       params.onError?.(
         createDebounceError("INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED", key, {
           maxFlushRetries,
+          cause: flushError,
         }),
         droppedItems,
       );
@@ -239,8 +304,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
             return;
           }
           // Preserve ordering by appending non-debounced items behind unresolved buffered work.
-          pending.items.push(item);
-          trimBufferToLimit(key, pending);
+          pushBufferedItem(key, pending, item);
           scheduleBufferedFlush(key, pending);
           return;
         }
@@ -251,9 +315,8 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
 
     const existing = buffers.get(key);
     if (existing) {
-      existing.items.push(item);
       existing.debounceMs = debounceMs;
-      trimBufferToLimit(key, existing);
+      pushBufferedItem(key, existing, item);
       scheduleBufferedFlush(key, existing);
       return;
     }
@@ -270,13 +333,18 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     }
 
     const buffer: DebounceBuffer<T> = {
-      items: [item],
+      items: [],
       timeout: null,
       debounceMs,
       flushing: false,
       consecutiveFailures: 0,
     };
     buffers.set(key, buffer);
+    pushBufferedItem(key, buffer, item);
+    if (buffer.items.length === 0) {
+      buffers.delete(key);
+      return;
+    }
     scheduleFlush(key, buffer);
   };
 

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { OpenClawConfig } from "../config/config.js";
 import type { InboundDebounceByProvider } from "../config/types.messages.js";
 
@@ -46,6 +47,7 @@ export type InboundDebounceCreateParams<T> = {
   buildKey: (item: T) => string | null | undefined;
   shouldDebounce?: (item: T) => boolean;
   resolveDebounceMs?: (item: T) => number | undefined;
+  maxKeys?: number;
   maxFlushRetries?: number;
   maxBufferedItems?: number;
   maxRetryDelayMs?: number;
@@ -57,6 +59,7 @@ export type InboundDebounceCreateParams<T> = {
 export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>) {
   const buffers = new Map<string, DebounceBuffer<T>>();
   const defaultDebounceMs = Math.max(0, Math.trunc(params.debounceMs));
+  const maxKeys = Math.max(1, Math.trunc(params.maxKeys ?? 1000));
   const maxFlushRetries = Math.max(0, Math.trunc(params.maxFlushRetries ?? 20));
   const maxBufferedItems = Math.max(1, Math.trunc(params.maxBufferedItems ?? 500));
   const retryBackoffFactor = Number.isFinite(params.retryBackoffFactor)
@@ -74,13 +77,44 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     return Math.max(0, Math.trunc(resolved));
   };
 
+  const buildKeyHash = (key: string) => createHash("sha256").update(key).digest("hex").slice(0, 12);
+
+  const createDebounceError = (
+    code:
+      | "INBOUND_DEBOUNCE_BUFFER_OVERFLOW"
+      | "INBOUND_DEBOUNCE_MAX_KEYS_EXCEEDED"
+      | "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
+    key: string,
+    extra: Record<string, number> = {},
+  ) => {
+    const message =
+      code === "INBOUND_DEBOUNCE_BUFFER_OVERFLOW"
+        ? "inbound debounce buffer overflow"
+        : code === "INBOUND_DEBOUNCE_MAX_KEYS_EXCEEDED"
+          ? "inbound debounce key capacity exceeded"
+          : "inbound debounce flush retries exceeded";
+    return Object.assign(new Error(message), {
+      code,
+      debounceKeyHash: buildKeyHash(key),
+      ...extra,
+    });
+  };
+
+  const clearScheduledFlush = (buffer: DebounceBuffer<T>) => {
+    if (!buffer.timeout) {
+      return;
+    }
+    clearTimeout(buffer.timeout);
+    buffer.timeout = null;
+  };
+
   const emitOverflowError = (key: string, droppedItems: T[]) => {
     if (droppedItems.length === 0) {
       return;
     }
     params.onError?.(
-      Object.assign(new Error(`inbound debounce buffer overflow for key "${key}"`), {
-        code: "INBOUND_DEBOUNCE_BUFFER_OVERFLOW",
+      createDebounceError("INBOUND_DEBOUNCE_BUFFER_OVERFLOW", key, {
+        maxBufferedItems,
       }),
       droppedItems,
     );
@@ -105,14 +139,36 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     return Math.min(maxRetryDelayMs, Math.max(buffer.debounceMs, Math.trunc(delay)));
   };
 
-  const flushBuffer = async (key: string, buffer: DebounceBuffer<T>): Promise<boolean> => {
-    if (buffer.timeout) {
-      clearTimeout(buffer.timeout);
-      buffer.timeout = null;
+  const flushDirect = async (items: T[]) => {
+    try {
+      await params.onFlush(items);
+    } catch (err) {
+      params.onError?.(err, items);
     }
+  };
+
+  const scheduleFlush = (
+    key: string,
+    buffer: DebounceBuffer<T>,
+    reason: "debounce" | "retry" = "debounce",
+  ) => {
+    clearScheduledFlush(buffer);
+    const delayMs = reason === "retry" ? resolveRetryDelayMs(buffer) : buffer.debounceMs;
+    buffer.timeout = setTimeout(() => {
+      void flushBuffer(key, buffer);
+    }, delayMs);
+    buffer.timeout.unref?.();
+  };
+
+  const scheduleBufferedFlush = (key: string, buffer: DebounceBuffer<T>) => {
+    scheduleFlush(key, buffer, buffer.consecutiveFailures > 0 ? "retry" : "debounce");
+  };
+
+  const flushBuffer = async (key: string, buffer: DebounceBuffer<T>): Promise<boolean> => {
+    clearScheduledFlush(buffer);
     if (buffer.flushing) {
       if (buffer.items.length > 0) {
-        scheduleFlush(key, buffer);
+        scheduleBufferedFlush(key, buffer);
       }
       return false;
     }
@@ -139,15 +195,13 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       buffer.flushing = false;
     }
     if (retriesExceeded) {
+      clearScheduledFlush(buffer);
       const droppedItems = buffer.items.splice(0);
       buffers.delete(key);
       params.onError?.(
-        Object.assign(
-          new Error(
-            `inbound debounce flush retries exceeded for key "${key}" (${maxFlushRetries})`,
-          ),
-          { code: "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED" },
-        ),
+        createDebounceError("INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED", key, {
+          maxFlushRetries,
+        }),
         droppedItems,
       );
       return true;
@@ -168,21 +222,6 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     return flushBuffer(key, buffer);
   };
 
-  const scheduleFlush = (
-    key: string,
-    buffer: DebounceBuffer<T>,
-    reason: "debounce" | "retry" = "debounce",
-  ) => {
-    if (buffer.timeout) {
-      clearTimeout(buffer.timeout);
-    }
-    const delayMs = reason === "retry" ? resolveRetryDelayMs(buffer) : buffer.debounceMs;
-    buffer.timeout = setTimeout(() => {
-      void flushBuffer(key, buffer);
-    }, delayMs);
-    buffer.timeout.unref?.();
-  };
-
   const enqueue = async (item: T) => {
     const key = params.buildKey(item);
     const debounceMs = resolveDebounceMs(item);
@@ -196,15 +235,11 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
           // Preserve ordering by appending non-debounced items behind unresolved buffered work.
           pending.items.push(item);
           trimBufferToLimit(key, pending);
-          scheduleFlush(key, pending, pending.consecutiveFailures > 0 ? "retry" : "debounce");
+          scheduleBufferedFlush(key, pending);
           return;
         }
       }
-      try {
-        await params.onFlush([item]);
-      } catch (err) {
-        params.onError?.(err, [item]);
-      }
+      await flushDirect([item]);
       return;
     }
 
@@ -213,7 +248,18 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       existing.items.push(item);
       existing.debounceMs = debounceMs;
       trimBufferToLimit(key, existing);
-      scheduleFlush(key, existing);
+      scheduleBufferedFlush(key, existing);
+      return;
+    }
+
+    if (buffers.size >= maxKeys) {
+      params.onError?.(
+        createDebounceError("INBOUND_DEBOUNCE_MAX_KEYS_EXCEEDED", key, {
+          maxKeys,
+        }),
+        [item],
+      );
+      await flushDirect([item]);
       return;
     }
 

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -38,6 +38,7 @@ type DebounceBuffer<T> = {
   timeout: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
   flushing: boolean;
+  consecutiveFailures: number;
 };
 
 export type InboundDebounceCreateParams<T> = {
@@ -45,6 +46,10 @@ export type InboundDebounceCreateParams<T> = {
   buildKey: (item: T) => string | null | undefined;
   shouldDebounce?: (item: T) => boolean;
   resolveDebounceMs?: (item: T) => number | undefined;
+  maxFlushRetries?: number;
+  maxBufferedItems?: number;
+  maxRetryDelayMs?: number;
+  retryBackoffFactor?: number;
   onFlush: (items: T[]) => Promise<void>;
   onError?: (err: unknown, items: T[]) => void;
 };
@@ -52,6 +57,14 @@ export type InboundDebounceCreateParams<T> = {
 export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>) {
   const buffers = new Map<string, DebounceBuffer<T>>();
   const defaultDebounceMs = Math.max(0, Math.trunc(params.debounceMs));
+  const maxFlushRetries = Math.max(0, Math.trunc(params.maxFlushRetries ?? 20));
+  const maxBufferedItems = Math.max(1, Math.trunc(params.maxBufferedItems ?? 500));
+  const retryBackoffFactor = Number.isFinite(params.retryBackoffFactor)
+    ? Math.max(1, params.retryBackoffFactor ?? 2)
+    : 2;
+  const maxRetryDelayMs = Number.isFinite(params.maxRetryDelayMs)
+    ? Math.max(defaultDebounceMs, Math.trunc(params.maxRetryDelayMs ?? 30_000))
+    : Math.max(defaultDebounceMs, 30_000);
 
   const resolveDebounceMs = (item: T) => {
     const resolved = params.resolveDebounceMs?.(item);
@@ -59,6 +72,37 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       return defaultDebounceMs;
     }
     return Math.max(0, Math.trunc(resolved));
+  };
+
+  const emitOverflowError = (key: string, droppedItems: T[]) => {
+    if (droppedItems.length === 0) {
+      return;
+    }
+    params.onError?.(
+      Object.assign(new Error(`inbound debounce buffer overflow for key "${key}"`), {
+        code: "INBOUND_DEBOUNCE_BUFFER_OVERFLOW",
+      }),
+      droppedItems,
+    );
+  };
+
+  const trimBufferToLimit = (key: string, buffer: DebounceBuffer<T>) => {
+    const overflow = buffer.items.length - maxBufferedItems;
+    if (overflow <= 0) {
+      return;
+    }
+    // Drop newest items to preserve ordering for already-buffered work.
+    const droppedItems = buffer.items.splice(maxBufferedItems, overflow);
+    emitOverflowError(key, droppedItems);
+  };
+
+  const resolveRetryDelayMs = (buffer: DebounceBuffer<T>) => {
+    const exponent = Math.max(0, buffer.consecutiveFailures - 1);
+    const delay = buffer.debounceMs * retryBackoffFactor ** exponent;
+    if (!Number.isFinite(delay)) {
+      return maxRetryDelayMs;
+    }
+    return Math.min(maxRetryDelayMs, Math.max(buffer.debounceMs, Math.trunc(delay)));
   };
 
   const flushBuffer = async (key: string, buffer: DebounceBuffer<T>) => {
@@ -79,18 +123,37 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     const items = buffer.items.splice(0);
     buffer.flushing = true;
     let flushFailed = false;
+    let retriesExceeded = false;
     try {
       await params.onFlush(items);
+      buffer.consecutiveFailures = 0;
     } catch (err) {
       flushFailed = true;
       // Preserve ordering when retrying the failed batch.
       buffer.items.unshift(...items);
+      buffer.consecutiveFailures += 1;
       params.onError?.(err, items);
+      trimBufferToLimit(key, buffer);
+      retriesExceeded = buffer.consecutiveFailures > maxFlushRetries;
     } finally {
       buffer.flushing = false;
     }
+    if (retriesExceeded) {
+      const droppedItems = buffer.items.splice(0);
+      buffers.delete(key);
+      params.onError?.(
+        Object.assign(
+          new Error(
+            `inbound debounce flush retries exceeded for key "${key}" (${maxFlushRetries})`,
+          ),
+          { code: "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED" },
+        ),
+        droppedItems,
+      );
+      return;
+    }
     if (flushFailed || buffer.items.length > 0) {
-      scheduleFlush(key, buffer);
+      scheduleFlush(key, buffer, flushFailed ? "retry" : "debounce");
       return;
     }
     buffers.delete(key);
@@ -104,13 +167,18 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     await flushBuffer(key, buffer);
   };
 
-  const scheduleFlush = (key: string, buffer: DebounceBuffer<T>) => {
+  const scheduleFlush = (
+    key: string,
+    buffer: DebounceBuffer<T>,
+    reason: "debounce" | "retry" = "debounce",
+  ) => {
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
     }
+    const delayMs = reason === "retry" ? resolveRetryDelayMs(buffer) : buffer.debounceMs;
     buffer.timeout = setTimeout(() => {
       void flushBuffer(key, buffer);
-    }, buffer.debounceMs);
+    }, delayMs);
     buffer.timeout.unref?.();
   };
 
@@ -135,11 +203,18 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     if (existing) {
       existing.items.push(item);
       existing.debounceMs = debounceMs;
+      trimBufferToLimit(key, existing);
       scheduleFlush(key, existing);
       return;
     }
 
-    const buffer: DebounceBuffer<T> = { items: [item], timeout: null, debounceMs, flushing: false };
+    const buffer: DebounceBuffer<T> = {
+      items: [item],
+      timeout: null,
+      debounceMs,
+      flushing: false,
+      consecutiveFailures: 0,
+    };
     buffers.set(key, buffer);
     scheduleFlush(key, buffer);
   };

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -46,6 +46,7 @@ export type InboundDebounceCreateParams<T> = {
   debounceMs: number;
   buildKey: (item: T) => string | null | undefined;
   shouldDebounce?: (item: T) => boolean;
+  shouldFlushDirectWhenPending?: (item: T) => boolean;
   resolveDebounceMs?: (item: T) => number | undefined;
   maxKeys?: number;
   maxFlushRetries?: number;
@@ -232,6 +233,11 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
         const fullyFlushed = await flushKeyInternal(key);
         const pending = buffers.get(key);
         if (!fullyFlushed && pending) {
+          if (params.shouldFlushDirectWhenPending?.(item)) {
+            // Priority items like control commands should not be trapped behind a failing buffer.
+            await flushDirect([item]);
+            return;
+          }
           // Preserve ordering by appending non-debounced items behind unresolved buffered work.
           pending.items.push(item);
           trimBufferToLimit(key, pending);

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -37,6 +37,7 @@ type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
+  flushing: boolean;
 };
 
 export type InboundDebounceCreateParams<T> = {
@@ -61,19 +62,38 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
   };
 
   const flushBuffer = async (key: string, buffer: DebounceBuffer<T>) => {
-    buffers.delete(key);
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
       buffer.timeout = null;
     }
-    if (buffer.items.length === 0) {
+    if (buffer.flushing) {
+      if (buffer.items.length > 0) {
+        scheduleFlush(key, buffer);
+      }
       return;
     }
-    try {
-      await params.onFlush(buffer.items);
-    } catch (err) {
-      params.onError?.(err, buffer.items);
+    if (buffer.items.length === 0) {
+      buffers.delete(key);
+      return;
     }
+    const items = buffer.items.splice(0);
+    buffer.flushing = true;
+    let flushFailed = false;
+    try {
+      await params.onFlush(items);
+    } catch (err) {
+      flushFailed = true;
+      // Preserve ordering when retrying the failed batch.
+      buffer.items.unshift(...items);
+      params.onError?.(err, items);
+    } finally {
+      buffer.flushing = false;
+    }
+    if (flushFailed || buffer.items.length > 0) {
+      scheduleFlush(key, buffer);
+      return;
+    }
+    buffers.delete(key);
   };
 
   const flushKey = async (key: string) => {
@@ -119,7 +139,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       return;
     }
 
-    const buffer: DebounceBuffer<T> = { items: [item], timeout: null, debounceMs };
+    const buffer: DebounceBuffer<T> = { items: [item], timeout: null, debounceMs, flushing: false };
     buffers.set(key, buffer);
     scheduleFlush(key, buffer);
   };

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -105,7 +105,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     return Math.min(maxRetryDelayMs, Math.max(buffer.debounceMs, Math.trunc(delay)));
   };
 
-  const flushBuffer = async (key: string, buffer: DebounceBuffer<T>) => {
+  const flushBuffer = async (key: string, buffer: DebounceBuffer<T>): Promise<boolean> => {
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
       buffer.timeout = null;
@@ -114,11 +114,11 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       if (buffer.items.length > 0) {
         scheduleFlush(key, buffer);
       }
-      return;
+      return false;
     }
     if (buffer.items.length === 0) {
       buffers.delete(key);
-      return;
+      return true;
     }
     const items = buffer.items.splice(0);
     buffer.flushing = true;
@@ -150,21 +150,22 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
         ),
         droppedItems,
       );
-      return;
+      return true;
     }
     if (flushFailed || buffer.items.length > 0) {
       scheduleFlush(key, buffer, flushFailed ? "retry" : "debounce");
-      return;
+      return false;
     }
     buffers.delete(key);
+    return true;
   };
 
-  const flushKey = async (key: string) => {
+  const flushKeyInternal = async (key: string) => {
     const buffer = buffers.get(key);
     if (!buffer) {
-      return;
+      return true;
     }
-    await flushBuffer(key, buffer);
+    return flushBuffer(key, buffer);
   };
 
   const scheduleFlush = (
@@ -189,7 +190,15 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
 
     if (!canDebounce || !key) {
       if (key && buffers.has(key)) {
-        await flushKey(key);
+        const fullyFlushed = await flushKeyInternal(key);
+        const pending = buffers.get(key);
+        if (!fullyFlushed && pending) {
+          // Preserve ordering by appending non-debounced items behind unresolved buffered work.
+          pending.items.push(item);
+          trimBufferToLimit(key, pending);
+          scheduleFlush(key, pending, pending.consecutiveFailures > 0 ? "retry" : "debounce");
+          return;
+        }
       }
       try {
         await params.onFlush([item]);
@@ -219,5 +228,10 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     scheduleFlush(key, buffer);
   };
 
-  return { enqueue, flushKey };
+  return {
+    enqueue,
+    flushKey: async (key: string) => {
+      await flushKeyInternal(key);
+    },
+  };
 }

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -841,6 +841,65 @@ describe("createInboundDebouncer", () => {
       vi.useRealTimers();
     }
   });
+
+  it("does not let an empty scheduled flush delete a newer buffer for the same key", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: Array<string[]> = [];
+      const errors: Array<{ err: unknown; items: string[] }> = [];
+      const firstFlush = { resolve: null as (() => void) | null };
+      let holdFirstFlush = true;
+
+      const debouncer = createInboundDebouncer<{
+        key: string;
+        id: string;
+        windowMs: number;
+      }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        resolveDebounceMs: (item) => item.windowMs,
+        maxTotalBufferedItems: 1,
+        onFlush: async (items) => {
+          const ids = items.map((entry) => entry.id);
+          if (ids.includes("1") && holdFirstFlush) {
+            holdFirstFlush = false;
+            await new Promise<void>((resolve) => {
+              firstFlush.resolve = resolve;
+            });
+          }
+          delivered.push(ids);
+        },
+        onError: (err, items) => {
+          errors.push({ err, items: items.map((entry) => entry.id) });
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1", windowMs: 10 });
+      await vi.advanceTimersByTimeAsync(10); // Start the first flush and keep it in flight.
+
+      await debouncer.enqueue({ key: "b", id: "keep", windowMs: 1 });
+      await debouncer.enqueue({ key: "a", id: "dropped", windowMs: 10 }); // This item is trimmed immediately.
+      firstFlush.resolve?.();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1); // Flush the other key so the cap is free again.
+
+      await debouncer.enqueue({ key: "a", id: "new", windowMs: 10 });
+      await vi.advanceTimersByTimeAsync(9); // The stale timer fires here if it still exists.
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(errors.at(-1)?.err).toMatchObject({
+        code: "INBOUND_DEBOUNCE_TOTAL_BUFFER_OVERFLOW",
+      });
+      expect(errors.at(-1)?.items).toEqual(["dropped"]);
+      expect(delivered).toContainEqual(["1"]);
+      expect(delivered).toContainEqual(["keep"]);
+      expect(delivered).toContainEqual(["new"]);
+      expect(delivered.flat()).not.toContain("dropped");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("initSessionState BodyStripped", () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -347,7 +347,7 @@ describe("createInboundDebouncer", () => {
     vi.useRealTimers();
   });
 
-  it("retries a failed flush without dropping buffered items", async () => {
+  it("retries a failed flush without dropping buffered items or surfacing a recoverable error", async () => {
     vi.useFakeTimers();
     try {
       let shouldFailFirstFlush = true;
@@ -371,7 +371,7 @@ describe("createInboundDebouncer", () => {
 
       await debouncer.enqueue({ key: "a", id: "1" });
       await vi.advanceTimersByTimeAsync(10); // First flush fails.
-      expect(errors).toHaveLength(1);
+      expect(errors).toHaveLength(0);
       expect(delivered).toEqual([]);
 
       // A subsequent message should not cause the failed buffered item to be lost.
@@ -379,6 +379,7 @@ describe("createInboundDebouncer", () => {
       await vi.advanceTimersByTimeAsync(10);
 
       expect(delivered).toEqual([["1", "2"]]);
+      expect(errors).toHaveLength(0);
     } finally {
       vi.useRealTimers();
     }
@@ -388,7 +389,6 @@ describe("createInboundDebouncer", () => {
     vi.useFakeTimers();
     try {
       const delivered: Array<string[]> = [];
-      const errors: unknown[] = [];
       let attempts = 0;
 
       const debouncer = createInboundDebouncer<{ key: string; id: string }>({
@@ -401,21 +401,15 @@ describe("createInboundDebouncer", () => {
           }
           delivered.push(items.map((entry) => entry.id));
         },
-        onError: (err) => {
-          errors.push(err);
-        },
       });
 
       await debouncer.enqueue({ key: "a", id: "1" });
       await vi.advanceTimersByTimeAsync(10); // First flush failure.
       expect(delivered).toEqual([]);
-      expect(errors).toHaveLength(1);
 
       await vi.advanceTimersByTimeAsync(9); // Retry delay is still 10ms for first failure.
-      expect(errors).toHaveLength(1);
 
       await vi.advanceTimersByTimeAsync(1); // Second flush failure at t=20ms.
-      expect(errors).toHaveLength(2);
 
       await vi.advanceTimersByTimeAsync(19); // Backoff doubles to 20ms before third attempt.
       expect(delivered).toEqual([]);
@@ -482,12 +476,9 @@ describe("createInboundDebouncer", () => {
       await debouncer.enqueue({ key: "a", id: "1" });
       await vi.advanceTimersByTimeAsync(60);
 
-      expect(errors).toHaveLength(4);
+      expect(errors).toHaveLength(1);
       expect(errors[0]?.items).toEqual(["1"]);
-      expect(errors[1]?.items).toEqual(["1"]);
-      expect(errors[2]?.items).toEqual(["1"]);
-      expect(errors[3]?.items).toEqual(["1"]);
-      expect(errors[3]?.err).toMatchObject({
+      expect(errors[0]?.err).toMatchObject({
         code: "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
       });
       expect(vi.getTimerCount()).toBe(0);
@@ -529,6 +520,43 @@ describe("createInboundDebouncer", () => {
       });
       expect(String(errors[0]?.err)).toBe("Error: inbound debounce buffer overflow");
       expect(String(errors[0]?.err)).not.toContain(rawKey);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("caps total buffered items across keys and reports dropped overflow", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: Array<string[]> = [];
+      const errors: Array<{ err: unknown; items: string[] }> = [];
+
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        maxTotalBufferedItems: 2,
+        onFlush: async (items) => {
+          delivered.push(items.map((entry) => entry.id));
+        },
+        onError: (err, items) => {
+          errors.push({ err, items: items.map((entry) => entry.id) });
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1" });
+      await debouncer.enqueue({ key: "b", id: "2" });
+      await debouncer.enqueue({ key: "c", id: "3" });
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(delivered).toEqual([["1"], ["2"]]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.items).toEqual(["3"]);
+      expect(errors[0]?.err).toMatchObject({
+        code: "INBOUND_DEBOUNCE_TOTAL_BUFFER_OVERFLOW",
+        debounceKeyHash: expect.any(String),
+        maxTotalBufferedItems: 2,
+      });
+      expect(String(errors[0]?.err)).toBe("Error: inbound debounce total buffer overflow");
     } finally {
       vi.useRealTimers();
     }
@@ -603,13 +631,13 @@ describe("createInboundDebouncer", () => {
 
       await debouncer.enqueue({ key: "a", id: "1", debounce: true });
       await vi.advanceTimersByTimeAsync(10); // First flush fails.
-      expect(errors).toHaveLength(1);
+      expect(errors).toHaveLength(0);
       expect(delivered).toEqual([]);
 
       // A non-debounced follow-up should not bypass older buffered work.
       await debouncer.enqueue({ key: "a", id: "2", debounce: false });
       expect(delivered).toEqual([]);
-      expect(errors).toHaveLength(2);
+      expect(errors).toHaveLength(0);
 
       await vi.advanceTimersByTimeAsync(20);
       expect(delivered).toEqual([["1", "2"]]);

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -427,6 +427,41 @@ describe("createInboundDebouncer", () => {
     }
   });
 
+  it("keeps retry backoff when new debounced items arrive on a failed key", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: Array<string[]> = [];
+      let attempts = 0;
+
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        onFlush: async (items) => {
+          attempts += 1;
+          if (attempts < 3) {
+            throw new Error("temporary flush failure");
+          }
+          delivered.push(items.map((entry) => entry.id));
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1" });
+      await vi.advanceTimersByTimeAsync(20); // First two attempts fail at t=10ms and t=20ms.
+      expect(attempts).toBe(2);
+
+      await debouncer.enqueue({ key: "a", id: "2" });
+      await vi.advanceTimersByTimeAsync(10);
+      expect(attempts).toBe(2);
+      expect(delivered).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(attempts).toBe(3);
+      expect(delivered).toEqual([["1", "2"]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("drops buffered items after max retry ceiling is exceeded", async () => {
     vi.useFakeTimers();
     try {
@@ -466,6 +501,7 @@ describe("createInboundDebouncer", () => {
     try {
       const delivered: Array<string[]> = [];
       const errors: Array<{ err: unknown; items: string[] }> = [];
+      const rawKey = 'sender:"alice"\n+15550001111';
 
       const debouncer = createInboundDebouncer<{ key: string; id: string }>({
         debounceMs: 10,
@@ -479,9 +515,9 @@ describe("createInboundDebouncer", () => {
         },
       });
 
-      await debouncer.enqueue({ key: "a", id: "1" });
-      await debouncer.enqueue({ key: "a", id: "2" });
-      await debouncer.enqueue({ key: "a", id: "3" });
+      await debouncer.enqueue({ key: rawKey, id: "1" });
+      await debouncer.enqueue({ key: rawKey, id: "2" });
+      await debouncer.enqueue({ key: rawKey, id: "3" });
       await vi.advanceTimersByTimeAsync(10);
 
       expect(delivered).toEqual([["1", "2"]]);
@@ -489,7 +525,50 @@ describe("createInboundDebouncer", () => {
       expect(errors[0]?.items).toEqual(["3"]);
       expect(errors[0]?.err).toMatchObject({
         code: "INBOUND_DEBOUNCE_BUFFER_OVERFLOW",
+        debounceKeyHash: expect.any(String),
       });
+      expect(String(errors[0]?.err)).toBe("Error: inbound debounce buffer overflow");
+      expect(String(errors[0]?.err)).not.toContain(rawKey);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to direct flush when active debounce key capacity is exceeded", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: Array<string[]> = [];
+      const errors: Array<{ err: unknown; items: string[] }> = [];
+
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        maxKeys: 2,
+        onFlush: async (items) => {
+          delivered.push(items.map((entry) => entry.id));
+        },
+        onError: (err, items) => {
+          errors.push({ err, items: items.map((entry) => entry.id) });
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1" });
+      await debouncer.enqueue({ key: "b", id: "2" });
+      await debouncer.enqueue({ key: "c", id: "3" });
+
+      expect(delivered).toEqual([["3"]]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.items).toEqual(["3"]);
+      expect(errors[0]?.err).toMatchObject({
+        code: "INBOUND_DEBOUNCE_MAX_KEYS_EXCEEDED",
+        debounceKeyHash: expect.any(String),
+        maxKeys: 2,
+      });
+      expect(String(errors[0]?.err)).toBe("Error: inbound debounce key capacity exceeded");
+      expect(vi.getTimerCount()).toBe(2);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(delivered).toEqual([["3"], ["1"], ["2"]]);
     } finally {
       vi.useRealTimers();
     }
@@ -534,6 +613,56 @@ describe("createInboundDebouncer", () => {
 
       await vi.advanceTimersByTimeAsync(20);
       expect(delivered).toEqual([["1", "2"]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears stale retry timers before dropping an exhausted key", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: Array<string[]> = [];
+      const firstFlush = { reject: null as ((reason?: unknown) => void) | null };
+      let holdFirstFlush = true;
+
+      const debouncer = createInboundDebouncer<{
+        key: string;
+        id: string;
+        debounce: boolean;
+      }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        shouldDebounce: (item) => item.debounce,
+        maxFlushRetries: 0,
+        onFlush: async (items) => {
+          if (holdFirstFlush) {
+            holdFirstFlush = false;
+            await new Promise<void>((_resolve, reject) => {
+              firstFlush.reject = reject;
+            });
+            return;
+          }
+          delivered.push(items.map((entry) => entry.id));
+        },
+        onError: () => {},
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1", debounce: true });
+      await vi.advanceTimersByTimeAsync(10); // Start the first flush and keep it in flight.
+
+      await debouncer.enqueue({ key: "a", id: "2", debounce: true });
+      firstFlush.reject?.(new Error("persistent failure"));
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await debouncer.enqueue({ key: "a", id: "3", debounce: true });
+      await vi.advanceTimersByTimeAsync(9); // A stale timer would fire here and delete the new buffer.
+
+      expect(delivered).toEqual([]);
+
+      await debouncer.enqueue({ key: "a", id: "4", debounce: false });
+      expect(delivered).toEqual([["3"], ["4"]]);
+      expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();
     }

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -383,6 +383,117 @@ describe("createInboundDebouncer", () => {
       vi.useRealTimers();
     }
   });
+
+  it("applies exponential backoff before retrying failed flushes", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: Array<string[]> = [];
+      const errors: unknown[] = [];
+      let attempts = 0;
+
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        onFlush: async (items) => {
+          attempts += 1;
+          if (attempts < 3) {
+            throw new Error("temporary flush failure");
+          }
+          delivered.push(items.map((entry) => entry.id));
+        },
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1" });
+      await vi.advanceTimersByTimeAsync(10); // First flush failure.
+      expect(delivered).toEqual([]);
+      expect(errors).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(9); // Retry delay is still 10ms for first failure.
+      expect(errors).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(1); // Second flush failure at t=20ms.
+      expect(errors).toHaveLength(2);
+
+      await vi.advanceTimersByTimeAsync(19); // Backoff doubles to 20ms before third attempt.
+      expect(delivered).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(delivered).toEqual([["1"]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops buffered items after max retry ceiling is exceeded", async () => {
+    vi.useFakeTimers();
+    try {
+      const errors: Array<{ err: unknown; items: string[] }> = [];
+
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        maxFlushRetries: 2,
+        onFlush: async () => {
+          throw new Error("persistent flush failure");
+        },
+        onError: (err, items) => {
+          errors.push({ err, items: items.map((entry) => entry.id) });
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1" });
+      await vi.advanceTimersByTimeAsync(60);
+
+      expect(errors).toHaveLength(4);
+      expect(errors[0]?.items).toEqual(["1"]);
+      expect(errors[1]?.items).toEqual(["1"]);
+      expect(errors[2]?.items).toEqual(["1"]);
+      expect(errors[3]?.items).toEqual(["1"]);
+      expect(errors[3]?.err).toMatchObject({
+        code: "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("caps buffered items and reports dropped overflow", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: Array<string[]> = [];
+      const errors: Array<{ err: unknown; items: string[] }> = [];
+
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        maxBufferedItems: 2,
+        onFlush: async (items) => {
+          delivered.push(items.map((entry) => entry.id));
+        },
+        onError: (err, items) => {
+          errors.push({ err, items: items.map((entry) => entry.id) });
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1" });
+      await debouncer.enqueue({ key: "a", id: "2" });
+      await debouncer.enqueue({ key: "a", id: "3" });
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(delivered).toEqual([["1", "2"]]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.items).toEqual(["3"]);
+      expect(errors[0]?.err).toMatchObject({
+        code: "INBOUND_DEBOUNCE_BUFFER_OVERFLOW",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("initSessionState BodyStripped", () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -646,6 +646,38 @@ describe("createInboundDebouncer", () => {
     }
   });
 
+  it("reports whether flushKey drained the key or rescheduled it for retry", async () => {
+    vi.useFakeTimers();
+    try {
+      let shouldFail = true;
+      const delivered: Array<string[]> = [];
+
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        onFlush: async (items) => {
+          if (shouldFail) {
+            throw new Error("temporary lock contention");
+          }
+          delivered.push(items.map((entry) => entry.id));
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1" });
+
+      expect(await debouncer.flushKey("a")).toBe(false);
+      expect(delivered).toEqual([]);
+
+      shouldFail = false;
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(delivered).toEqual([["1"]]);
+      expect(await debouncer.flushKey("a")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("flushes priority non-debounced items directly when a key is stuck retrying", async () => {
     vi.useFakeTimers();
     try {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -618,6 +618,63 @@ describe("createInboundDebouncer", () => {
     }
   });
 
+  it("flushes priority non-debounced items directly when a key is stuck retrying", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: Array<string[]> = [];
+      const errors: Array<{ err: unknown; items: string[] }> = [];
+
+      const debouncer = createInboundDebouncer<{
+        key: string;
+        id: string;
+        debounce: boolean;
+        priority: boolean;
+      }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        shouldDebounce: (item) => item.debounce,
+        shouldFlushDirectWhenPending: (item) => item.priority,
+        maxFlushRetries: 3,
+        retryBackoffFactor: 1,
+        maxRetryDelayMs: 10,
+        onFlush: async (items) => {
+          const ids = items.map((entry) => entry.id);
+          if (ids.includes("buffered")) {
+            throw new Error("temporary lock contention");
+          }
+          delivered.push(ids);
+        },
+        onError: (err, items) => {
+          errors.push({ err, items: items.map((entry) => entry.id) });
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "buffered", debounce: true, priority: false });
+      await vi.advanceTimersByTimeAsync(10); // First buffered flush fails.
+
+      await debouncer.enqueue({ key: "a", id: "/stop", debounce: false, priority: true });
+
+      expect(delivered).toEqual([["/stop"]]);
+      expect(
+        errors.some(
+          (entry) =>
+            entry.items.includes("/stop") ||
+            (entry.err as { code?: string }).code === "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
+        ),
+      ).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(20); // Remaining buffered retries exhaust and drop only the old batch.
+
+      expect(errors.at(-1)?.items).toEqual(["buffered"]);
+      expect(errors.at(-1)?.err).toMatchObject({
+        code: "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
+      });
+      expect(delivered).toEqual([["/stop"]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clears stale retry timers before dropping an exhausted key", async () => {
     vi.useFakeTimers();
     try {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -494,6 +494,50 @@ describe("createInboundDebouncer", () => {
       vi.useRealTimers();
     }
   });
+
+  it("preserves order when a non-debounced item arrives after a retryable flush failure", async () => {
+    vi.useFakeTimers();
+    try {
+      let remainingFailures = 2;
+      const delivered: Array<string[]> = [];
+      const errors: unknown[] = [];
+
+      const debouncer = createInboundDebouncer<{
+        key: string;
+        id: string;
+        debounce: boolean;
+      }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        shouldDebounce: (item) => item.debounce,
+        onFlush: async (items) => {
+          if (remainingFailures > 0) {
+            remainingFailures -= 1;
+            throw new Error("temporary lock contention");
+          }
+          delivered.push(items.map((entry) => entry.id));
+        },
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1", debounce: true });
+      await vi.advanceTimersByTimeAsync(10); // First flush fails.
+      expect(errors).toHaveLength(1);
+      expect(delivered).toEqual([]);
+
+      // A non-debounced follow-up should not bypass older buffered work.
+      await debouncer.enqueue({ key: "a", id: "2", debounce: false });
+      expect(delivered).toEqual([]);
+      expect(errors).toHaveLength(2);
+
+      await vi.advanceTimersByTimeAsync(20);
+      expect(delivered).toEqual([["1", "2"]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("initSessionState BodyStripped", () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -675,6 +675,63 @@ describe("createInboundDebouncer", () => {
     }
   });
 
+  it("flushes structured non-debounced followers directly when a key is stuck retrying", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: Array<string[]> = [];
+      const errors: Array<{ err: unknown; items: string[] }> = [];
+
+      const debouncer = createInboundDebouncer<{
+        key: string;
+        id: string;
+        debounce: boolean;
+        directFlush: boolean;
+      }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        shouldDebounce: (item) => item.debounce,
+        shouldFlushDirectWhenPending: (item) => item.directFlush,
+        maxFlushRetries: 3,
+        retryBackoffFactor: 1,
+        maxRetryDelayMs: 10,
+        onFlush: async (items) => {
+          const ids = items.map((entry) => entry.id);
+          if (ids.includes("buffered")) {
+            throw new Error("temporary lock contention");
+          }
+          delivered.push(ids);
+        },
+        onError: (err, items) => {
+          errors.push({ err, items: items.map((entry) => entry.id) });
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "buffered", debounce: true, directFlush: false });
+      await vi.advanceTimersByTimeAsync(10); // First buffered flush fails.
+
+      await debouncer.enqueue({ key: "a", id: "media", debounce: false, directFlush: true });
+
+      expect(delivered).toEqual([["media"]]);
+      expect(
+        errors.some(
+          (entry) =>
+            entry.items.includes("media") ||
+            (entry.err as { code?: string }).code === "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
+        ),
+      ).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(20); // Remaining buffered retries exhaust and drop only the old batch.
+
+      expect(errors.at(-1)?.items).toEqual(["buffered"]);
+      expect(errors.at(-1)?.err).toMatchObject({
+        code: "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
+      });
+      expect(delivered).toEqual([["media"]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clears stale retry timers before dropping an exhausted key", async () => {
     vi.useFakeTimers();
     try {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -346,6 +346,43 @@ describe("createInboundDebouncer", () => {
 
     vi.useRealTimers();
   });
+
+  it("retries a failed flush without dropping buffered items", async () => {
+    vi.useFakeTimers();
+    try {
+      let shouldFailFirstFlush = true;
+      const delivered: Array<string[]> = [];
+      const errors: unknown[] = [];
+
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 10,
+        buildKey: (item) => item.key,
+        onFlush: async (items) => {
+          if (shouldFailFirstFlush) {
+            shouldFailFirstFlush = false;
+            throw new Error("timeout acquiring session store lock");
+          }
+          delivered.push(items.map((entry) => entry.id));
+        },
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1" });
+      await vi.advanceTimersByTimeAsync(10); // First flush fails.
+      expect(errors).toHaveLength(1);
+      expect(delivered).toEqual([]);
+
+      // A subsequent message should not cause the failed buffered item to be lost.
+      await debouncer.enqueue({ key: "a", id: "2" });
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(delivered).toEqual([["1", "2"]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("initSessionState BodyStripped", () => {

--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -24,10 +24,11 @@ describe("shouldDebounceTextInbound", () => {
 });
 
 describe("shouldFlushDirectTextInbound", () => {
-  it("marks control commands as priority even when debounce is otherwise disabled", () => {
+  it("marks control commands and structured payloads as priority", () => {
     const cfg = {} as Parameters<typeof shouldFlushDirectTextInbound>[0]["cfg"];
 
     expect(shouldFlushDirectTextInbound({ text: "/stop", cfg })).toBe(true);
+    expect(shouldFlushDirectTextInbound({ text: "", cfg, requiresDirectFlush: true })).toBe(true);
     expect(shouldFlushDirectTextInbound({ text: "hello there", cfg })).toBe(false);
     expect(shouldFlushDirectTextInbound({ text: "   ", cfg })).toBe(false);
   });

--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createChannelInboundDebouncer,
+  shouldFlushDirectTextInbound,
   shouldDebounceTextInbound,
 } from "./inbound-debounce-policy.js";
 
@@ -19,6 +20,16 @@ describe("shouldDebounceTextInbound", () => {
     expect(shouldDebounceTextInbound({ text: "hello there", cfg, allowDebounce: false })).toBe(
       false,
     );
+  });
+});
+
+describe("shouldFlushDirectTextInbound", () => {
+  it("marks control commands as priority even when debounce is otherwise disabled", () => {
+    const cfg = {} as Parameters<typeof shouldFlushDirectTextInbound>[0]["cfg"];
+
+    expect(shouldFlushDirectTextInbound({ text: "/stop", cfg })).toBe(true);
+    expect(shouldFlushDirectTextInbound({ text: "hello there", cfg })).toBe(false);
+    expect(shouldFlushDirectTextInbound({ text: "   ", cfg })).toBe(false);
   });
 });
 

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -27,6 +27,18 @@ export function shouldDebounceTextInbound(params: {
   return !hasControlCommand(text, params.cfg, params.commandOptions);
 }
 
+export function shouldFlushDirectTextInbound(params: {
+  text: string | null | undefined;
+  cfg: OpenClawConfig;
+  commandOptions?: CommandNormalizeOptions;
+}): boolean {
+  const text = params.text?.trim() ?? "";
+  if (!text) {
+    return false;
+  }
+  return hasControlCommand(text, params.cfg, params.commandOptions);
+}
+
 export function createChannelInboundDebouncer<T>(
   params: Omit<InboundDebounceCreateParams<T>, "debounceMs"> & {
     cfg: OpenClawConfig;

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -31,7 +31,11 @@ export function shouldFlushDirectTextInbound(params: {
   text: string | null | undefined;
   cfg: OpenClawConfig;
   commandOptions?: CommandNormalizeOptions;
+  requiresDirectFlush?: boolean;
 }): boolean {
+  if (params.requiresDirectFlush) {
+    return true;
+  }
   const text = params.text?.trim() ?? "";
   if (!text) {
     return false;

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -1,6 +1,7 @@
 import type { Client } from "@buape/carbon";
 import {
   createChannelInboundDebouncer,
+  shouldFlushDirectTextInbound,
   shouldDebounceTextInbound,
 } from "../../channels/inbound-debounce-policy.js";
 import { resolveOpenProviderRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
@@ -84,6 +85,16 @@ export function createDiscordMessageHandler(
           (message.attachments && message.attachments.length > 0) ||
           hasDiscordMessageStickers(message),
         ),
+      });
+    },
+    shouldFlushDirectWhenPending: (entry) => {
+      const message = entry.data.message;
+      if (!message) {
+        return false;
+      }
+      return shouldFlushDirectTextInbound({
+        text: resolveDiscordMessageText(message, { includeForwarded: false }),
+        cfg: params.cfg,
       });
     },
     onFlush: async (entries) => {

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -95,6 +95,10 @@ export function createDiscordMessageHandler(
       return shouldFlushDirectTextInbound({
         text: resolveDiscordMessageText(message, { includeForwarded: false }),
         cfg: params.cfg,
+        requiresDirectFlush: Boolean(
+          (message.attachments && message.attachments.length > 0) ||
+          hasDiscordMessageStickers(message),
+        ),
       });
     },
     onFlush: async (entries) => {

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -184,6 +184,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       shouldFlushDirectTextInbound({
         text: entry.message.text,
         cfg,
+        requiresDirectFlush: Boolean(entry.message.attachments && entry.message.attachments.length),
       }),
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -10,6 +10,7 @@ import {
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import {
   createChannelInboundDebouncer,
+  shouldFlushDirectTextInbound,
   shouldDebounceTextInbound,
 } from "../../channels/inbound-debounce-policy.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
@@ -179,6 +180,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         hasMedia: Boolean(entry.message.attachments && entry.message.attachments.length > 0),
       });
     },
+    shouldFlushDirectWhenPending: (entry) =>
+      shouldFlushDirectTextInbound({
+        text: entry.message.text,
+        cfg,
+      }),
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {

--- a/src/shared/global-singleton.ts
+++ b/src/shared/global-singleton.ts
@@ -1,8 +1,7 @@
 export function resolveGlobalSingleton<T>(key: symbol, create: () => T): T {
   const globalStore = globalThis as Record<PropertyKey, unknown>;
-  const existing = globalStore[key] as T | undefined;
   if (Object.prototype.hasOwnProperty.call(globalStore, key)) {
-    return existing;
+    return globalStore[key] as T;
   }
   const created = create();
   globalStore[key] = created;

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -17,6 +17,7 @@ import { createReplyDispatcherWithTyping } from "../../auto-reply/reply/reply-di
 import { resolveControlCommandGate } from "../../channels/command-gating.js";
 import {
   createChannelInboundDebouncer,
+  shouldFlushDirectTextInbound,
   shouldDebounceTextInbound,
 } from "../../channels/inbound-debounce-policy.js";
 import { logInboundDrop, logTypingFailure } from "../../channels/logging.js";
@@ -339,6 +340,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         hasMedia: Boolean(entry.mediaPath || entry.mediaType || entry.mediaPaths?.length),
       });
     },
+    shouldFlushDirectWhenPending: (entry) =>
+      shouldFlushDirectTextInbound({
+        text: entry.bodyText,
+        cfg: deps.cfg,
+      }),
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -344,6 +344,12 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       shouldFlushDirectTextInbound({
         text: entry.bodyText,
         cfg: deps.cfg,
+        requiresDirectFlush: Boolean(
+          entry.mediaPath ||
+          entry.mediaType ||
+          entry.mediaPaths?.length ||
+          entry.mediaTypes?.length,
+        ),
       }),
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/src/slack/monitor/message-handler.app-mention-race.test.ts
+++ b/src/slack/monitor/message-handler.app-mention-race.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../channels/inbound-debounce-policy.js", () => ({
         opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
       }) => {
         await params.onFlush([entry]);
+        return false;
       },
       flushKey: async (_key: string) => true,
     },

--- a/src/slack/monitor/message-handler.app-mention-race.test.ts
+++ b/src/slack/monitor/message-handler.app-mention-race.test.ts
@@ -10,6 +10,7 @@ const dispatchPreparedSlackMessageMock = vi.fn<(prepared: unknown) => Promise<vo
 
 vi.mock("../../channels/inbound-debounce-policy.js", () => ({
   shouldDebounceTextInbound: () => false,
+  shouldFlushDirectTextInbound: () => false,
   createChannelInboundDebouncer: (params: {
     onFlush: (
       entries: Array<{
@@ -26,7 +27,7 @@ vi.mock("../../channels/inbound-debounce-policy.js", () => ({
       }) => {
         await params.onFlush([entry]);
       },
-      flushKey: async (_key: string) => {},
+      flushKey: async (_key: string) => true,
     },
   }),
 }));

--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -176,7 +176,7 @@ describe("createSlackMessageHandler", () => {
     expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
   });
 
-  it("queues immediate top-level follow-ups until pending buffered keys fully flush", async () => {
+  it("queues non-priority top-level follow-ups until pending buffered keys fully flush", async () => {
     flushKeyMock.mockResolvedValue(false);
     const handler = createSlackMessageHandler({
       ctx: createContext(),
@@ -192,20 +192,18 @@ describe("createSlackMessageHandler", () => {
       ts: "1709000000.000100",
       text: "first buffered text",
     } as SlackMessageEvent;
-    const fileMessage = {
+    const immediateMessage = {
       type: "message",
-      subtype: "file_share",
       channel: "C111",
       user: "U111",
       ts: "1709000000.000200",
-      text: "file follows",
-      files: [{ id: "F1" }],
+      text: "",
     } as SlackMessageEvent;
 
     await handler(bufferedMessage as never, { source: "message" });
     enqueueMock.mockClear();
 
-    await handler(fileMessage as never, { source: "message" });
+    await handler(immediateMessage as never, { source: "message" });
 
     expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
     expect(enqueueMock).not.toHaveBeenCalled();
@@ -240,20 +238,18 @@ describe("createSlackMessageHandler", () => {
       ts: "1709000000.000100",
       text: "first buffered text",
     } as SlackMessageEvent;
-    const fileMessage = {
+    const immediateMessage = {
       type: "message",
-      subtype: "file_share",
       channel: "C111",
       user: "U111",
       ts: "1709000000.000200",
-      text: "file follows",
-      files: [{ id: "F1" }],
+      text: "",
     } as SlackMessageEvent;
 
     await handler(bufferedMessage as never, { source: "message" });
     enqueueMock.mockClear();
 
-    await handler(fileMessage as never, { source: "message" });
+    await handler(immediateMessage as never, { source: "message" });
 
     capturedDebouncerParams?.onError?.(
       Object.assign(new Error("inbound debounce flush retries exceeded"), {
@@ -268,6 +264,47 @@ describe("createSlackMessageHandler", () => {
       message: expect.objectContaining({
         ts: "1709000000.000200",
         channel: "C111",
+      }),
+      opts: { source: "message" },
+    });
+  });
+
+  it("flushes priority top-level followers immediately while older keys are still retrying", async () => {
+    flushKeyMock.mockResolvedValue(false);
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    const bufferedMessage = {
+      type: "message",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000100",
+      text: "first buffered text",
+    } as SlackMessageEvent;
+    const priorityMessage = {
+      type: "message",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000200",
+      text: "/stop",
+    } as SlackMessageEvent;
+
+    await handler(bufferedMessage as never, { source: "message" });
+    enqueueMock.mockClear();
+
+    await handler(priorityMessage as never, { source: "message" });
+
+    expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledWith({
+      message: expect.objectContaining({
+        ts: "1709000000.000200",
+        channel: "C111",
+        text: "/stop",
       }),
       opts: { source: "message" },
     });

--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { InboundDebounceCreateParams } from "../../auto-reply/inbound-debounce.js";
 import type { SlackMessageEvent } from "../types.js";
-import { createSlackMessageHandler } from "./message-handler.js";
+import {
+  createSlackMessageHandler,
+  MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION,
+  MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_TOTAL,
+} from "./message-handler.js";
 
 const enqueueMock = vi.fn(async (_entry: unknown) => {});
 const flushKeyMock = vi.fn(async (_key: string) => true);
@@ -45,6 +49,7 @@ vi.mock("./message-handler/dispatch.js", () => ({
 
 function createContext(overrides?: {
   markMessageSeen?: (channel: string | undefined, ts: string | undefined) => boolean;
+  runtimeError?: (message: string) => void;
 }) {
   return {
     cfg: {},
@@ -52,7 +57,9 @@ function createContext(overrides?: {
     app: {
       client: {},
     },
-    runtime: {},
+    runtime: {
+      error: overrides?.runtimeError,
+    },
     markMessageSeen: (channel: string | undefined, ts: string | undefined) =>
       overrides?.markMessageSeen?.(channel, ts) ?? false,
   } as Parameters<typeof createSlackMessageHandler>[0]["ctx"];
@@ -305,6 +312,156 @@ describe("createSlackMessageHandler", () => {
         ts: "1709000000.000200",
         channel: "C111",
         text: "/stop",
+      }),
+      opts: { source: "message" },
+    });
+  });
+
+  it("bypasses the per-conversation immediate queue when it reaches the backlog cap", async () => {
+    flushKeyMock.mockResolvedValue(false);
+    const runtimeError = vi.fn();
+    const handler = createSlackMessageHandler({
+      ctx: createContext({ runtimeError }),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    const bufferedMessage = {
+      type: "message",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000100",
+      text: "first buffered text",
+    } as SlackMessageEvent;
+
+    await handler(bufferedMessage as never, { source: "message" });
+    enqueueMock.mockClear();
+
+    for (
+      let index = 0;
+      index < MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION;
+      index += 1
+    ) {
+      await handler(
+        {
+          type: "message",
+          channel: "C111",
+          user: "U111",
+          ts: `1709000000.${String(200 + index).padStart(6, "0")}`,
+          text: "",
+        } as never,
+        { source: "message" },
+      );
+    }
+
+    expect(enqueueMock).not.toHaveBeenCalled();
+
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.999999",
+        text: "",
+      } as never,
+      { source: "message" },
+    );
+
+    expect(runtimeError).toHaveBeenCalledWith(
+      "slack inbound immediate backlog overflow; bypassing queue to cap memory growth",
+    );
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenLastCalledWith({
+      message: expect.objectContaining({
+        ts: "1709000000.999999",
+        channel: "C111",
+      }),
+      opts: { source: "message" },
+    });
+
+    capturedDebouncerParams?.onError?.(
+      Object.assign(new Error("inbound debounce flush retries exceeded"), {
+        code: "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
+      }),
+      [{ message: bufferedMessage, opts: { source: "message" } }],
+    );
+    await vi.waitFor(() => {
+      expect(enqueueMock).toHaveBeenCalledTimes(
+        MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION + 1,
+      );
+    });
+
+    expect(enqueueMock).toHaveBeenCalledTimes(
+      MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION + 1,
+    );
+  });
+
+  it("bypasses the immediate queue when the global backlog cap is reached", async () => {
+    flushKeyMock.mockResolvedValue(false);
+    const runtimeError = vi.fn();
+    const handler = createSlackMessageHandler({
+      ctx: createContext({ runtimeError }),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    const conversations = [
+      { channel: "C111", user: "U111", baseTs: 100_000 },
+      { channel: "C222", user: "U222", baseTs: 200_000 },
+      { channel: "C333", user: "U333", baseTs: 300_000 },
+    ] as const;
+
+    for (const [index, conversation] of conversations.entries()) {
+      await handler(
+        {
+          type: "message",
+          channel: conversation.channel,
+          user: conversation.user,
+          ts: `1709000000.${String(conversation.baseTs + index).padStart(6, "0")}`,
+          text: "first buffered text",
+        } as never,
+        { source: "message" },
+      );
+    }
+    enqueueMock.mockClear();
+
+    for (let index = 0; index < MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_TOTAL; index += 1) {
+      const conversation = conversations[index % 2];
+      await handler(
+        {
+          type: "message",
+          channel: conversation.channel,
+          user: conversation.user,
+          ts: `1709000000.${String(conversation.baseTs + 1000 + index).padStart(6, "0")}`,
+          text: "",
+        } as never,
+        { source: "message" },
+      );
+    }
+
+    expect(enqueueMock).not.toHaveBeenCalled();
+
+    await handler(
+      {
+        type: "message",
+        channel: conversations[2].channel,
+        user: conversations[2].user,
+        ts: "1709000000.999998",
+        text: "",
+      } as never,
+      { source: "message" },
+    );
+
+    expect(runtimeError).toHaveBeenCalledWith(
+      "slack inbound immediate backlog overflow; bypassing queue to cap memory growth",
+    );
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenLastCalledWith({
+      message: expect.objectContaining({
+        ts: "1709000000.999998",
+        channel: "C333",
       }),
       opts: { source: "message" },
     });

--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -1,24 +1,46 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InboundDebounceCreateParams } from "../../auto-reply/inbound-debounce.js";
+import type { SlackMessageEvent } from "../types.js";
 import { createSlackMessageHandler } from "./message-handler.js";
 
 const enqueueMock = vi.fn(async (_entry: unknown) => {});
-const flushKeyMock = vi.fn(async (_key: string) => {});
+const flushKeyMock = vi.fn(async (_key: string) => true);
 const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
   ...message,
 }));
+const prepareSlackMessageMock = vi.fn(async (_args: unknown) => ({ ctxPayload: {} }));
+const dispatchPreparedSlackMessageMock = vi.fn(async (_prepared: unknown) => {});
+
+type SlackInboundEntry = {
+  message: SlackMessageEvent;
+  opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
+};
+
+let capturedDebouncerParams: InboundDebounceCreateParams<SlackInboundEntry> | null = null;
 
 vi.mock("../../auto-reply/inbound-debounce.js", () => ({
   resolveInboundDebounceMs: () => 10,
-  createInboundDebouncer: () => ({
-    enqueue: (entry: unknown) => enqueueMock(entry),
-    flushKey: (key: string) => flushKeyMock(key),
-  }),
+  createInboundDebouncer: (params: InboundDebounceCreateParams<SlackInboundEntry>) => {
+    capturedDebouncerParams = params;
+    return {
+      enqueue: (entry: unknown) => enqueueMock(entry),
+      flushKey: (key: string) => flushKeyMock(key),
+    };
+  },
 }));
 
 vi.mock("./thread-resolution.js", () => ({
   createSlackThreadTsResolver: () => ({
     resolve: (entry: { message: Record<string, unknown> }) => resolveThreadTsMock(entry),
   }),
+}));
+
+vi.mock("./message-handler/prepare.js", () => ({
+  prepareSlackMessage: (args: unknown) => prepareSlackMessageMock(args),
+}));
+
+vi.mock("./message-handler/dispatch.js", () => ({
+  dispatchPreparedSlackMessage: (prepared: unknown) => dispatchPreparedSlackMessageMock(prepared),
 }));
 
 function createContext(overrides?: {
@@ -52,7 +74,12 @@ describe("createSlackMessageHandler", () => {
   beforeEach(() => {
     enqueueMock.mockClear();
     flushKeyMock.mockClear();
+    flushKeyMock.mockResolvedValue(true);
     resolveThreadTsMock.mockClear();
+    prepareSlackMessageMock.mockClear();
+    prepareSlackMessageMock.mockResolvedValue({ ctxPayload: {} });
+    dispatchPreparedSlackMessageMock.mockClear();
+    capturedDebouncerParams = null;
   });
 
   it("does not track invalid non-message events from the message stream", async () => {
@@ -147,5 +174,102 @@ describe("createSlackMessageHandler", () => {
     );
 
     expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
+  });
+
+  it("queues immediate top-level follow-ups until pending buffered keys fully flush", async () => {
+    flushKeyMock.mockResolvedValue(false);
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    const bufferedMessage = {
+      type: "message",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000100",
+      text: "first buffered text",
+    } as SlackMessageEvent;
+    const fileMessage = {
+      type: "message",
+      subtype: "file_share",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000200",
+      text: "file follows",
+      files: [{ id: "F1" }],
+    } as SlackMessageEvent;
+
+    await handler(bufferedMessage as never, { source: "message" });
+    enqueueMock.mockClear();
+
+    await handler(fileMessage as never, { source: "message" });
+
+    expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
+    expect(enqueueMock).not.toHaveBeenCalled();
+
+    await capturedDebouncerParams?.onFlush?.([
+      { message: bufferedMessage, opts: { source: "message" } },
+    ]);
+
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledWith({
+      message: expect.objectContaining({
+        ts: "1709000000.000200",
+        channel: "C111",
+      }),
+      opts: { source: "message" },
+    });
+  });
+
+  it("releases queued top-level follow-ups when a pending buffered key exhausts retries", async () => {
+    flushKeyMock.mockResolvedValue(false);
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    const bufferedMessage = {
+      type: "message",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000100",
+      text: "first buffered text",
+    } as SlackMessageEvent;
+    const fileMessage = {
+      type: "message",
+      subtype: "file_share",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000200",
+      text: "file follows",
+      files: [{ id: "F1" }],
+    } as SlackMessageEvent;
+
+    await handler(bufferedMessage as never, { source: "message" });
+    enqueueMock.mockClear();
+
+    await handler(fileMessage as never, { source: "message" });
+
+    capturedDebouncerParams?.onError?.(
+      Object.assign(new Error("inbound debounce flush retries exceeded"), {
+        code: "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
+      }),
+      [{ message: bufferedMessage, opts: { source: "message" } }],
+    );
+    await Promise.resolve();
+
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledWith({
+      message: expect.objectContaining({
+        ts: "1709000000.000200",
+        channel: "C111",
+      }),
+      opts: { source: "message" },
+    });
   });
 });

--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -7,7 +7,7 @@ import {
   MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_TOTAL,
 } from "./message-handler.js";
 
-const enqueueMock = vi.fn(async (_entry: unknown) => {});
+const enqueueMock = vi.fn(async (_entry: unknown) => true);
 const flushKeyMock = vi.fn(async (_key: string) => true);
 const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
   ...message,
@@ -80,6 +80,7 @@ function createHandlerWithTracker(overrides?: {
 describe("createSlackMessageHandler", () => {
   beforeEach(() => {
     enqueueMock.mockClear();
+    enqueueMock.mockResolvedValue(true);
     flushKeyMock.mockClear();
     flushKeyMock.mockResolvedValue(true);
     resolveThreadTsMock.mockClear();
@@ -367,14 +368,25 @@ describe("createSlackMessageHandler", () => {
       } as never,
       { source: "message" },
     );
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.999998",
+        text: "",
+      } as never,
+      { source: "message" },
+    );
 
     expect(runtimeError).toHaveBeenCalledWith(
       "slack inbound immediate backlog overflow; bypassing queue to cap memory growth",
     );
-    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(runtimeError).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledTimes(2);
     expect(enqueueMock).toHaveBeenLastCalledWith({
       message: expect.objectContaining({
-        ts: "1709000000.999999",
+        ts: "1709000000.999998",
         channel: "C111",
       }),
       opts: { source: "message" },
@@ -388,12 +400,12 @@ describe("createSlackMessageHandler", () => {
     );
     await vi.waitFor(() => {
       expect(enqueueMock).toHaveBeenCalledTimes(
-        MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION + 1,
+        MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION + 2,
       );
     });
 
     expect(enqueueMock).toHaveBeenCalledTimes(
-      MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION + 1,
+      MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION + 2,
     );
   });
 
@@ -462,6 +474,64 @@ describe("createSlackMessageHandler", () => {
       message: expect.objectContaining({
         ts: "1709000000.999998",
         channel: "C333",
+      }),
+      opts: { source: "message" },
+    });
+  });
+
+  it("releases top-level pending keys when a debounced message cannot remain buffered", async () => {
+    enqueueMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false).mockResolvedValue(true);
+    flushKeyMock.mockResolvedValue(false);
+
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    const firstBufferedMessage = {
+      type: "message",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000100",
+      text: "first buffered text",
+    } as SlackMessageEvent;
+    const overflowedBufferedMessage = {
+      type: "message",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000200",
+      text: "second buffered text",
+    } as SlackMessageEvent;
+    const queuedImmediateMessage = {
+      type: "message",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000300",
+      text: "",
+    } as SlackMessageEvent;
+
+    await handler(firstBufferedMessage as never, { source: "message" });
+    await handler(overflowedBufferedMessage as never, { source: "message" });
+    enqueueMock.mockClear();
+
+    await handler(queuedImmediateMessage as never, { source: "message" });
+    expect(enqueueMock).not.toHaveBeenCalled();
+
+    capturedDebouncerParams?.onError?.(
+      Object.assign(new Error("inbound debounce flush retries exceeded"), {
+        code: "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED",
+      }),
+      [{ message: firstBufferedMessage, opts: { source: "message" } }],
+    );
+    await Promise.resolve();
+
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledWith({
+      message: expect.objectContaining({
+        ts: "1709000000.000300",
+        channel: "C111",
       }),
       opts: { source: "message" },
     });

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -24,6 +24,7 @@ type SlackInboundEntry = {
 const APP_MENTION_RETRY_TTL_MS = 60_000;
 export const MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION = 50;
 export const MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_TOTAL = 100;
+const PENDING_TOP_LEVEL_IMMEDIATE_OVERFLOW_LOG_COOLDOWN_MS = 10_000;
 
 function resolveSlackSenderId(message: SlackMessageEvent): string | null {
   return message.user ?? message.bot_id ?? null;
@@ -115,6 +116,7 @@ export function createSlackMessageHandler(params: {
   const { ctx, account, trackEvent } = params;
   const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
   const pendingTopLevelImmediateEntries = new Map<string, SlackInboundEntry[]>();
+  const pendingTopLevelImmediateOverflowLogAt = new Map<string, number>();
   const drainingTopLevelImmediateEntries = new Set<string>();
   let totalPendingTopLevelImmediateEntries = 0;
   let debouncer!: ReturnType<typeof createChannelInboundDebouncer<SlackInboundEntry>>["debouncer"];
@@ -137,15 +139,25 @@ export function createSlackMessageHandler(params: {
     return conversationKey;
   };
 
+  const logImmediateOverflow = (conversationKey: string) => {
+    const now = Date.now();
+    const lastLogAt = pendingTopLevelImmediateOverflowLogAt.get(conversationKey) ?? 0;
+    if (now - lastLogAt < PENDING_TOP_LEVEL_IMMEDIATE_OVERFLOW_LOG_COOLDOWN_MS) {
+      return;
+    }
+    pendingTopLevelImmediateOverflowLogAt.set(conversationKey, now);
+    ctx.runtime.error?.(
+      "slack inbound immediate backlog overflow; bypassing queue to cap memory growth",
+    );
+  };
+
   const queueTopLevelImmediateEntry = (conversationKey: string, entry: SlackInboundEntry) => {
     const queuedEntries = pendingTopLevelImmediateEntries.get(conversationKey) ?? [];
     if (
       queuedEntries.length >= MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION ||
       totalPendingTopLevelImmediateEntries >= MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_TOTAL
     ) {
-      ctx.runtime.error?.(
-        "slack inbound immediate backlog overflow; bypassing queue to cap memory growth",
-      );
+      logImmediateOverflow(conversationKey);
       return false;
     }
     queuedEntries.push(entry);
@@ -162,11 +174,13 @@ export function createSlackMessageHandler(params: {
     const nextEntry = queuedEntries.shift();
     if (!nextEntry) {
       pendingTopLevelImmediateEntries.delete(conversationKey);
+      pendingTopLevelImmediateOverflowLogAt.delete(conversationKey);
       return null;
     }
     totalPendingTopLevelImmediateEntries = Math.max(0, totalPendingTopLevelImmediateEntries - 1);
     if (queuedEntries.length === 0) {
       pendingTopLevelImmediateEntries.delete(conversationKey);
+      pendingTopLevelImmediateOverflowLogAt.delete(conversationKey);
     }
     return nextEntry;
   };
@@ -379,6 +393,12 @@ export function createSlackMessageHandler(params: {
       pendingKeys.add(debounceKey);
       pendingTopLevelDebounceKeys.set(conversationKey, pendingKeys);
     }
-    await debouncer.enqueue({ message: resolvedMessage, opts });
+    const remainsPending = await debouncer.enqueue({ message: resolvedMessage, opts });
+    if (canDebounce && debounceKey && conversationKey && !remainsPending) {
+      const conversationKeyToDrain = releaseTopLevelPendingKey({ message: resolvedMessage, opts });
+      if (conversationKeyToDrain) {
+        await drainTopLevelImmediateEntries(conversationKeyToDrain);
+      }
+    }
   };
 }

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -22,6 +22,8 @@ type SlackInboundEntry = {
 };
 
 const APP_MENTION_RETRY_TTL_MS = 60_000;
+export const MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION = 50;
+export const MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_TOTAL = 100;
 
 function resolveSlackSenderId(message: SlackMessageEvent): string | null {
   return message.user ?? message.bot_id ?? null;
@@ -114,6 +116,7 @@ export function createSlackMessageHandler(params: {
   const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
   const pendingTopLevelImmediateEntries = new Map<string, SlackInboundEntry[]>();
   const drainingTopLevelImmediateEntries = new Set<string>();
+  let totalPendingTopLevelImmediateEntries = 0;
   let debouncer!: ReturnType<typeof createChannelInboundDebouncer<SlackInboundEntry>>["debouncer"];
 
   const releaseTopLevelPendingKey = (entry: SlackInboundEntry): string | null => {
@@ -136,8 +139,36 @@ export function createSlackMessageHandler(params: {
 
   const queueTopLevelImmediateEntry = (conversationKey: string, entry: SlackInboundEntry) => {
     const queuedEntries = pendingTopLevelImmediateEntries.get(conversationKey) ?? [];
+    if (
+      queuedEntries.length >= MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_PER_CONVERSATION ||
+      totalPendingTopLevelImmediateEntries >= MAX_PENDING_TOP_LEVEL_IMMEDIATE_ENTRIES_TOTAL
+    ) {
+      ctx.runtime.error?.(
+        "slack inbound immediate backlog overflow; bypassing queue to cap memory growth",
+      );
+      return false;
+    }
     queuedEntries.push(entry);
     pendingTopLevelImmediateEntries.set(conversationKey, queuedEntries);
+    totalPendingTopLevelImmediateEntries += 1;
+    return true;
+  };
+
+  const shiftTopLevelImmediateEntry = (conversationKey: string) => {
+    const queuedEntries = pendingTopLevelImmediateEntries.get(conversationKey);
+    if (!queuedEntries) {
+      return null;
+    }
+    const nextEntry = queuedEntries.shift();
+    if (!nextEntry) {
+      pendingTopLevelImmediateEntries.delete(conversationKey);
+      return null;
+    }
+    totalPendingTopLevelImmediateEntries = Math.max(0, totalPendingTopLevelImmediateEntries - 1);
+    if (queuedEntries.length === 0) {
+      pendingTopLevelImmediateEntries.delete(conversationKey);
+    }
+    return nextEntry;
   };
 
   const drainTopLevelImmediateEntries = async (conversationKey: string) => {
@@ -153,17 +184,9 @@ export function createSlackMessageHandler(params: {
     drainingTopLevelImmediateEntries.add(conversationKey);
     try {
       while ((pendingTopLevelDebounceKeys.get(conversationKey)?.size ?? 0) === 0) {
-        const queuedEntries = pendingTopLevelImmediateEntries.get(conversationKey);
-        if (!queuedEntries) {
-          return;
-        }
-        const nextEntry = queuedEntries.shift();
+        const nextEntry = shiftTopLevelImmediateEntry(conversationKey);
         if (!nextEntry) {
-          pendingTopLevelImmediateEntries.delete(conversationKey);
           return;
-        }
-        if (queuedEntries.length === 0) {
-          pendingTopLevelImmediateEntries.delete(conversationKey);
         }
         await debouncer.enqueue(nextEntry);
       }
@@ -342,7 +365,11 @@ export function createSlackMessageHandler(params: {
             return;
           }
           // Keep immediate top-level followers behind older buffered keys until those keys resolve.
-          queueTopLevelImmediateEntry(conversationKey, { message: resolvedMessage, opts });
+          if (queueTopLevelImmediateEntry(conversationKey, { message: resolvedMessage, opts })) {
+            return;
+          }
+          // Once the backlog cap is hit, bypass the queue so pending memory stays bounded.
+          await debouncer.enqueue({ message: resolvedMessage, opts });
           return;
         }
       }

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -16,6 +16,11 @@ export type SlackMessageHandler = (
   opts: { source: "message" | "app_mention"; wasMentioned?: boolean },
 ) => Promise<void>;
 
+type SlackInboundEntry = {
+  message: SlackMessageEvent;
+  opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
+};
+
 const APP_MENTION_RETRY_TTL_MS = 60_000;
 
 function resolveSlackSenderId(message: SlackMessageEvent): string | null {
@@ -95,92 +100,163 @@ export function createSlackMessageHandler(params: {
   trackEvent?: () => void;
 }): SlackMessageHandler {
   const { ctx, account, trackEvent } = params;
-  const { debounceMs, debouncer } = createChannelInboundDebouncer<{
-    message: SlackMessageEvent;
-    opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
-  }>({
-    cfg: ctx.cfg,
-    channel: "slack",
-    buildKey: (entry) => buildSlackDebounceKey(entry.message, ctx.accountId),
-    shouldDebounce: (entry) => shouldDebounceSlackMessage(entry.message, ctx.cfg),
-    shouldFlushDirectWhenPending: (entry) =>
-      shouldFlushDirectTextInbound({
-        text: stripSlackMentionsForCommandDetection(entry.message.text ?? ""),
-        cfg: ctx.cfg,
-        requiresDirectFlush: Boolean(entry.message.files && entry.message.files.length > 0),
-      }),
-    onFlush: async (entries) => {
-      const last = entries.at(-1);
-      if (!last) {
-        return;
-      }
-      const flushedKey = buildSlackDebounceKey(last.message, ctx.accountId);
-      const topLevelConversationKey = buildTopLevelSlackConversationKey(
-        last.message,
-        ctx.accountId,
-      );
-      if (flushedKey && topLevelConversationKey) {
-        const pendingKeys = pendingTopLevelDebounceKeys.get(topLevelConversationKey);
-        if (pendingKeys) {
-          pendingKeys.delete(flushedKey);
-          if (pendingKeys.size === 0) {
-            pendingTopLevelDebounceKeys.delete(topLevelConversationKey);
-          }
-        }
-      }
-      const combinedText =
-        entries.length === 1
-          ? (last.message.text ?? "")
-          : entries
-              .map((entry) => entry.message.text ?? "")
-              .filter(Boolean)
-              .join("\n");
-      const combinedMentioned = entries.some((entry) => Boolean(entry.opts.wasMentioned));
-      const syntheticMessage: SlackMessageEvent = {
-        ...last.message,
-        text: combinedText,
-      };
-      const prepared = await prepareSlackMessage({
-        ctx,
-        account,
-        message: syntheticMessage,
-        opts: {
-          ...last.opts,
-          wasMentioned: combinedMentioned || last.opts.wasMentioned,
-        },
-      });
-      const seenMessageKey = buildSeenMessageKey(last.message.channel, last.message.ts);
-      if (!prepared) {
-        return;
-      }
-      if (seenMessageKey) {
-        pruneAppMentionRetryKeys(Date.now());
-        if (last.opts.source === "app_mention") {
-          // If app_mention wins the race and dispatches first, drop the later message dispatch.
-          appMentionDispatchedKeys.set(seenMessageKey, Date.now() + APP_MENTION_RETRY_TTL_MS);
-        } else if (last.opts.source === "message" && appMentionDispatchedKeys.has(seenMessageKey)) {
-          appMentionDispatchedKeys.delete(seenMessageKey);
-          appMentionRetryKeys.delete(seenMessageKey);
+  const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
+  const pendingTopLevelImmediateEntries = new Map<string, SlackInboundEntry[]>();
+  const drainingTopLevelImmediateEntries = new Set<string>();
+  let debouncer!: ReturnType<typeof createChannelInboundDebouncer<SlackInboundEntry>>["debouncer"];
+
+  const releaseTopLevelPendingKey = (entry: SlackInboundEntry): string | null => {
+    const flushedKey = buildSlackDebounceKey(entry.message, ctx.accountId);
+    const conversationKey = buildTopLevelSlackConversationKey(entry.message, ctx.accountId);
+    if (!flushedKey || !conversationKey) {
+      return null;
+    }
+    const pendingKeys = pendingTopLevelDebounceKeys.get(conversationKey);
+    if (!pendingKeys) {
+      return null;
+    }
+    pendingKeys.delete(flushedKey);
+    if (pendingKeys.size > 0) {
+      return null;
+    }
+    pendingTopLevelDebounceKeys.delete(conversationKey);
+    return conversationKey;
+  };
+
+  const queueTopLevelImmediateEntry = (conversationKey: string, entry: SlackInboundEntry) => {
+    const queuedEntries = pendingTopLevelImmediateEntries.get(conversationKey) ?? [];
+    queuedEntries.push(entry);
+    pendingTopLevelImmediateEntries.set(conversationKey, queuedEntries);
+  };
+
+  const drainTopLevelImmediateEntries = async (conversationKey: string) => {
+    if (drainingTopLevelImmediateEntries.has(conversationKey)) {
+      return;
+    }
+    if ((pendingTopLevelDebounceKeys.get(conversationKey)?.size ?? 0) > 0) {
+      return;
+    }
+    if ((pendingTopLevelImmediateEntries.get(conversationKey)?.length ?? 0) === 0) {
+      return;
+    }
+    drainingTopLevelImmediateEntries.add(conversationKey);
+    try {
+      while ((pendingTopLevelDebounceKeys.get(conversationKey)?.size ?? 0) === 0) {
+        const queuedEntries = pendingTopLevelImmediateEntries.get(conversationKey);
+        if (!queuedEntries) {
           return;
         }
-        appMentionRetryKeys.delete(seenMessageKey);
-      }
-      if (entries.length > 1) {
-        const ids = entries.map((entry) => entry.message.ts).filter(Boolean) as string[];
-        if (ids.length > 0) {
-          prepared.ctxPayload.MessageSids = ids;
-          prepared.ctxPayload.MessageSidFirst = ids[0];
-          prepared.ctxPayload.MessageSidLast = ids[ids.length - 1];
+        const nextEntry = queuedEntries.shift();
+        if (!nextEntry) {
+          pendingTopLevelImmediateEntries.delete(conversationKey);
+          return;
         }
+        if (queuedEntries.length === 0) {
+          pendingTopLevelImmediateEntries.delete(conversationKey);
+        }
+        await debouncer.enqueue(nextEntry);
       }
-      await dispatchPreparedSlackMessage(prepared);
-    },
-    onError: (err) => {
-      ctx.runtime.error?.(`slack inbound debounce flush failed: ${String(err)}`);
-    },
-  });
+    } finally {
+      drainingTopLevelImmediateEntries.delete(conversationKey);
+    }
+  };
+
+  const { debounceMs, debouncer: createdDebouncer } =
+    createChannelInboundDebouncer<SlackInboundEntry>({
+      cfg: ctx.cfg,
+      channel: "slack",
+      buildKey: (entry) => buildSlackDebounceKey(entry.message, ctx.accountId),
+      shouldDebounce: (entry) => shouldDebounceSlackMessage(entry.message, ctx.cfg),
+      shouldFlushDirectWhenPending: (entry) =>
+        shouldFlushDirectTextInbound({
+          text: stripSlackMentionsForCommandDetection(entry.message.text ?? ""),
+          cfg: ctx.cfg,
+          requiresDirectFlush: Boolean(entry.message.files && entry.message.files.length > 0),
+        }),
+      onFlush: async (entries) => {
+        const last = entries.at(-1);
+        if (!last) {
+          return;
+        }
+        const combinedText =
+          entries.length === 1
+            ? (last.message.text ?? "")
+            : entries
+                .map((entry) => entry.message.text ?? "")
+                .filter(Boolean)
+                .join("\n");
+        const combinedMentioned = entries.some((entry) => Boolean(entry.opts.wasMentioned));
+        const syntheticMessage: SlackMessageEvent = {
+          ...last.message,
+          text: combinedText,
+        };
+        const prepared = await prepareSlackMessage({
+          ctx,
+          account,
+          message: syntheticMessage,
+          opts: {
+            ...last.opts,
+            wasMentioned: combinedMentioned || last.opts.wasMentioned,
+          },
+        });
+        const seenMessageKey = buildSeenMessageKey(last.message.channel, last.message.ts);
+        if (!prepared) {
+          const conversationKeyToDrain = releaseTopLevelPendingKey(last);
+          if (conversationKeyToDrain) {
+            await drainTopLevelImmediateEntries(conversationKeyToDrain);
+          }
+          return;
+        }
+        if (seenMessageKey) {
+          pruneAppMentionRetryKeys(Date.now());
+          if (last.opts.source === "app_mention") {
+            // If app_mention wins the race and dispatches first, drop the later message dispatch.
+            appMentionDispatchedKeys.set(seenMessageKey, Date.now() + APP_MENTION_RETRY_TTL_MS);
+          } else if (
+            last.opts.source === "message" &&
+            appMentionDispatchedKeys.has(seenMessageKey)
+          ) {
+            appMentionDispatchedKeys.delete(seenMessageKey);
+            appMentionRetryKeys.delete(seenMessageKey);
+            const conversationKeyToDrain = releaseTopLevelPendingKey(last);
+            if (conversationKeyToDrain) {
+              await drainTopLevelImmediateEntries(conversationKeyToDrain);
+            }
+            return;
+          }
+          appMentionRetryKeys.delete(seenMessageKey);
+        }
+        if (entries.length > 1) {
+          const ids = entries.map((entry) => entry.message.ts).filter(Boolean) as string[];
+          if (ids.length > 0) {
+            prepared.ctxPayload.MessageSids = ids;
+            prepared.ctxPayload.MessageSidFirst = ids[0];
+            prepared.ctxPayload.MessageSidLast = ids[ids.length - 1];
+          }
+        }
+        await dispatchPreparedSlackMessage(prepared);
+        const conversationKeyToDrain = releaseTopLevelPendingKey(last);
+        if (conversationKeyToDrain) {
+          await drainTopLevelImmediateEntries(conversationKeyToDrain);
+        }
+      },
+      onError: (err, entries) => {
+        ctx.runtime.error?.(`slack inbound debounce flush failed: ${String(err)}`);
+        if ((err as { code?: string }).code !== "INBOUND_DEBOUNCE_MAX_RETRIES_EXCEEDED") {
+          return;
+        }
+        const last = entries.at(-1);
+        if (!last) {
+          return;
+        }
+        const conversationKeyToDrain = releaseTopLevelPendingKey(last);
+        if (conversationKeyToDrain) {
+          void drainTopLevelImmediateEntries(conversationKeyToDrain);
+        }
+      },
+    });
+  debouncer = createdDebouncer;
   const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
-  const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
   const appMentionRetryKeys = new Map<string, number>();
   const appMentionDispatchedKeys = new Map<string, number>();
 
@@ -248,8 +324,14 @@ export function createSlackMessageHandler(params: {
       const pendingKeys = pendingTopLevelDebounceKeys.get(conversationKey);
       if (pendingKeys && pendingKeys.size > 0) {
         const keysToFlush = Array.from(pendingKeys);
+        let waitingOnPendingKeys = false;
         for (const pendingKey of keysToFlush) {
-          await debouncer.flushKey(pendingKey);
+          waitingOnPendingKeys ||= !(await debouncer.flushKey(pendingKey));
+        }
+        if (waitingOnPendingKeys) {
+          // Keep immediate top-level followers behind older buffered keys until those keys resolve.
+          queueTopLevelImmediateEntry(conversationKey, { message: resolvedMessage, opts });
+          return;
         }
       }
     }

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -59,6 +59,17 @@ function shouldDebounceSlackMessage(message: SlackMessageEvent, cfg: SlackMonito
   });
 }
 
+function shouldFlushDirectSlackMessage(
+  message: SlackMessageEvent,
+  cfg: SlackMonitorContext["cfg"],
+): boolean {
+  return shouldFlushDirectTextInbound({
+    text: stripSlackMentionsForCommandDetection(message.text ?? ""),
+    cfg,
+    requiresDirectFlush: Boolean(message.files && message.files.length > 0),
+  });
+}
+
 function buildSeenMessageKey(channelId: string | undefined, ts: string | undefined): string | null {
   if (!channelId || !ts) {
     return null;
@@ -168,11 +179,7 @@ export function createSlackMessageHandler(params: {
       buildKey: (entry) => buildSlackDebounceKey(entry.message, ctx.accountId),
       shouldDebounce: (entry) => shouldDebounceSlackMessage(entry.message, ctx.cfg),
       shouldFlushDirectWhenPending: (entry) =>
-        shouldFlushDirectTextInbound({
-          text: stripSlackMentionsForCommandDetection(entry.message.text ?? ""),
-          cfg: ctx.cfg,
-          requiresDirectFlush: Boolean(entry.message.files && entry.message.files.length > 0),
-        }),
+        shouldFlushDirectSlackMessage(entry.message, ctx.cfg),
       onFlush: async (entries) => {
         const last = entries.at(-1);
         if (!last) {
@@ -320,6 +327,7 @@ export function createSlackMessageHandler(params: {
     const debounceKey = buildSlackDebounceKey(resolvedMessage, ctx.accountId);
     const conversationKey = buildTopLevelSlackConversationKey(resolvedMessage, ctx.accountId);
     const canDebounce = debounceMs > 0 && shouldDebounceSlackMessage(resolvedMessage, ctx.cfg);
+    const shouldFlushDirect = shouldFlushDirectSlackMessage(resolvedMessage, ctx.cfg);
     if (!canDebounce && conversationKey) {
       const pendingKeys = pendingTopLevelDebounceKeys.get(conversationKey);
       if (pendingKeys && pendingKeys.size > 0) {
@@ -329,6 +337,10 @@ export function createSlackMessageHandler(params: {
           waitingOnPendingKeys ||= !(await debouncer.flushKey(pendingKey));
         }
         if (waitingOnPendingKeys) {
+          if (shouldFlushDirect) {
+            await debouncer.enqueue({ message: resolvedMessage, opts });
+            return;
+          }
           // Keep immediate top-level followers behind older buffered keys until those keys resolve.
           queueTopLevelImmediateEntry(conversationKey, { message: resolvedMessage, opts });
           return;

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -1,5 +1,6 @@
 import {
   createChannelInboundDebouncer,
+  shouldFlushDirectTextInbound,
   shouldDebounceTextInbound,
 } from "../../channels/inbound-debounce-policy.js";
 import type { ResolvedSlackAccount } from "../accounts.js";
@@ -102,6 +103,11 @@ export function createSlackMessageHandler(params: {
     channel: "slack",
     buildKey: (entry) => buildSlackDebounceKey(entry.message, ctx.accountId),
     shouldDebounce: (entry) => shouldDebounceSlackMessage(entry.message, ctx.cfg),
+    shouldFlushDirectWhenPending: (entry) =>
+      shouldFlushDirectTextInbound({
+        text: stripSlackMentionsForCommandDetection(entry.message.text ?? ""),
+        cfg: ctx.cfg,
+      }),
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -107,6 +107,7 @@ export function createSlackMessageHandler(params: {
       shouldFlushDirectTextInbound({
         text: stripSlackMentionsForCommandDetection(entry.message.text ?? ""),
         cfg: ctx.cfg,
+        requiresDirectFlush: Boolean(entry.message.files && entry.message.files.length > 0),
       }),
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,6 +1,7 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
@@ -238,6 +239,10 @@ export const registerTelegramHandlers = ({
         return false;
       }
       return entry.allMedia.length === 0;
+    },
+    shouldFlushDirectWhenPending: (entry) => {
+      const text = entry.msg.text ?? entry.msg.caption ?? "";
+      return hasControlCommand(text, cfg, { botUsername: entry.botUsername });
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -191,6 +191,7 @@ export async function monitorWebChannel(
       }
       return !hasControlCommand(msg.body, cfg);
     };
+    const shouldFlushDirectWhenPending = (msg: WebInboundMsg) => hasControlCommand(msg.body, cfg);
 
     const listener = await (listenerFactory ?? monitorWebInbox)({
       verbose,
@@ -200,6 +201,7 @@ export async function monitorWebChannel(
       sendReadReceipts: account.sendReadReceipts,
       debounceMs: inboundDebounceMs,
       shouldDebounce,
+      shouldFlushDirectWhenPending,
       onMessage: async (msg: WebInboundMsg) => {
         handledMessages += 1;
         lastMessageAt = Date.now();

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -191,7 +191,15 @@ export async function monitorWebChannel(
       }
       return !hasControlCommand(msg.body, cfg);
     };
-    const shouldFlushDirectWhenPending = (msg: WebInboundMsg) => hasControlCommand(msg.body, cfg);
+    const shouldFlushDirectWhenPending = (msg: WebInboundMsg) =>
+      Boolean(
+        msg.mediaPath ||
+        msg.mediaType ||
+        msg.location ||
+        msg.replyToId ||
+        msg.replyToBody ||
+        hasControlCommand(msg.body, cfg),
+      );
 
     const listener = await (listenerFactory ?? monitorWebInbox)({
       verbose,

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -34,6 +34,8 @@ export async function monitorWebInbox(options: {
   debounceMs?: number;
   /** Optional debounce gating predicate. */
   shouldDebounce?: (msg: WebInboundMessage) => boolean;
+  /** Optional priority predicate for items that should bypass unresolved debounce buffers. */
+  shouldFlushDirectWhenPending?: (msg: WebInboundMessage) => boolean;
 }) {
   const inboundLogger = getChildLogger({ module: "web-inbound" });
   const inboundConsoleLog = createSubsystemLogger("gateway/channels/whatsapp").child("inbound");
@@ -81,6 +83,7 @@ export async function monitorWebInbox(options: {
       return `${msg.accountId}:${conversationKey}:${senderKey}`;
     },
     shouldDebounce: options.shouldDebounce,
+    shouldFlushDirectWhenPending: options.shouldFlushDirectWhenPending,
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {


### PR DESCRIPTION
## Summary

- Problem: `createInboundDebouncer` dropped buffered inbound messages when `onFlush` failed (for example, `timeout acquiring session store lock`).
- Why it matters: under normal lock contention, users could lose inbound messages permanently with only a log line.
- What changed: failed flush batches are now re-queued and retried; successful behavior is preserved.
- What did NOT change (scope boundary): this PR does not change session lock timeout policy, stale-lock reclaim policy, or provider streaming timeout behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17421
- Related #3092
- Related #13436
- Related #14838
- Related #17435
- Related #38297
- Related #13928

## User-visible / Behavior Changes

Inbound messages buffered by debounce are no longer dropped after transient flush failures; they are retried on the next flush window.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node/Bun local dev
- Model/provider: N/A
- Integration/channel (if any): inbound debounce pipeline
- Relevant config (redacted): N/A

### Steps

1. Create an inbound debouncer with `debounceMs > 0`.
2. Make first `onFlush` call throw `timeout acquiring session store lock`.
3. Enqueue a second item for the same key.

### Expected

- The first buffered item is not lost.
- A subsequent successful flush delivers both items in order.

### Actual

- Added regression test verifies delivery is `[["1","2"]]` after transient failure.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `src/auto-reply/inbound.test.ts` new regression: fails before, passes after.
  - Existing debounce behavior tests remain green.
- Edge cases checked:
  - Buffered-item ordering is preserved when re-queuing failed batch.
- What you did **not** verify:
  - Full end-to-end channel replay under live multi-channel contention.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit.
- Files/config to restore:
  - `src/auto-reply/inbound-debounce.ts`
  - `src/auto-reply/inbound.test.ts`
- Known bad symptoms reviewers should watch for:
  - Repeated flush retries for permanently failing `onFlush` handlers.

## Risks and Mitigations

- Risk: retry behavior can re-attempt indefinitely if flush keeps failing.
  - Mitigation: preserves data and current operator visibility (`onError` still fires each failure); this is safer than silent drop.

## Related PR context (for maintainers)

Thanks to prior contributors who explored adjacent fixes. For this narrow scope:

- #14838 improved lock acquisition/backoff and user-facing errors, but did not prevent debounce-buffer drop semantics.
- #17435 targeted the same symptom but is closed and currently has no active diff to review.
- #38297, #13928 address broader lock architecture/diagnostics and remain separate from this focused debounce-loss fix.
