### PR TITLE
fix(ui): render subagent announces as tool output

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -11,7 +11,11 @@ import {
   extractThinkingCached,
   formatReasoningMarkdown,
 } from "./message-extract.ts";
-import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer.ts";
+import {
+  isSubagentAnnounceToolMessage,
+  isToolResultMessage,
+  normalizeRoleForGrouping,
+} from "./message-normalizer.ts";
 import { extractToolCards, renderToolCardSidebar } from "./tool-cards.ts";
 
 type ImageBlock = {
@@ -122,7 +126,9 @@ export function renderMessageGroup(
       ? (userLabel ?? "You")
       : normalizedRole === "assistant"
         ? assistantName
-        : normalizedRole;
+        : normalizedRole === "tool"
+          ? "Tool Output"
+          : normalizedRole;
   const roleClass =
     normalizedRole === "user" ? "user" : normalizedRole === "assistant" ? "assistant" : "other";
   const timestamp = new Date(group.timestamp).toLocaleTimeString([], {
@@ -235,6 +241,7 @@ function renderGroupedMessage(
     role.toLowerCase() === "tool_result" ||
     typeof m.toolCallId === "string" ||
     typeof m.tool_call_id === "string";
+  const isSubagentToolMessage = isSubagentAnnounceToolMessage(message);
 
   const toolCards = extractToolCards(message);
   const hasToolCards = toolCards.length > 0;
@@ -258,7 +265,11 @@ function renderGroupedMessage(
     .filter(Boolean)
     .join(" ");
 
-  if (!markdown && hasToolCards && isToolResult) {
+  if (
+    hasToolCards &&
+    (isToolResult || isSubagentToolMessage) &&
+    (!markdown || isSubagentToolMessage)
+  ) {
     return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
   }
 

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  isSubagentAnnounceToolMessage,
   normalizeMessage,
   normalizeRoleForGrouping,
   isToolResultMessage,
@@ -121,6 +122,20 @@ describe("message-normalizer", () => {
 
       expect(result.senderLabel).toBe("Iris");
     });
+
+    it("normalizes subagent announce injections as tool messages", () => {
+      const result = normalizeMessage({
+        role: "user",
+        content: "Subagent findings",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceTool: "subagent_announce",
+        },
+      });
+
+      expect(result.role).toBe("tool");
+      expect(result.content).toEqual([{ type: "text", text: "Subagent findings" }]);
+    });
   });
 
   describe("normalizeRoleForGrouping", () => {
@@ -185,6 +200,32 @@ describe("message-normalizer", () => {
     it("returns false for non-string role", () => {
       expect(isToolResultMessage({ role: 123 })).toBe(false);
       expect(isToolResultMessage({ role: null })).toBe(false);
+    });
+  });
+
+  describe("isSubagentAnnounceToolMessage", () => {
+    it("detects inter-session subagent announce payloads", () => {
+      expect(
+        isSubagentAnnounceToolMessage({
+          role: "user",
+          inputProvenance: {
+            kind: "inter_session",
+            sourceTool: "subagent_announce",
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it("ignores unrelated provenance payloads", () => {
+      expect(
+        isSubagentAnnounceToolMessage({
+          role: "user",
+          inputProvenance: {
+            kind: "inter_session",
+            sourceTool: "sessions_send",
+          },
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -5,6 +5,18 @@
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 
+export function isSubagentAnnounceToolMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const provenance = (message as { inputProvenance?: unknown }).inputProvenance;
+  if (!provenance || typeof provenance !== "object") {
+    return false;
+  }
+  const record = provenance as { kind?: unknown; sourceTool?: unknown };
+  return record.kind === "inter_session" && record.sourceTool === "subagent_announce";
+}
+
 /**
  * Normalize a raw message object into a consistent structure.
  */
@@ -30,6 +42,8 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
 
   if (hasToolId || hasToolContent || hasToolName) {
     role = "toolResult";
+  } else if (isSubagentAnnounceToolMessage(message)) {
+    role = "tool";
   }
 
   // Extract content

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { extractToolCards } from "./tool-cards.ts";
+
+describe("extractToolCards", () => {
+  it("synthesizes a tool result card for subagent announce injections", () => {
+    const cards = extractToolCards({
+      role: "user",
+      content: "Final subagent findings",
+      inputProvenance: {
+        kind: "inter_session",
+        sourceTool: "subagent_announce",
+      },
+    });
+
+    expect(cards).toEqual([
+      {
+        kind: "result",
+        name: "subagents",
+        text: "Final subagent findings",
+      },
+    ]);
+  });
+});

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -4,7 +4,7 @@ import { formatToolDetail, resolveToolDisplay } from "../tool-display.ts";
 import type { ToolCard } from "../types/chat-types.ts";
 import { TOOL_INLINE_THRESHOLD } from "./constants.ts";
 import { extractTextCached } from "./message-extract.ts";
-import { isToolResultMessage } from "./message-normalizer.ts";
+import { isSubagentAnnounceToolMessage, isToolResultMessage } from "./message-normalizer.ts";
 import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
 
 export function extractToolCards(message: unknown): ToolCard[] {
@@ -43,6 +43,11 @@ export function extractToolCards(message: unknown): ToolCard[] {
       "tool";
     const text = extractTextCached(message) ?? undefined;
     cards.push({ kind: "result", name, text });
+  }
+
+  if (isSubagentAnnounceToolMessage(message) && !cards.some((card) => card.kind === "result")) {
+    const text = extractTextCached(message) ?? undefined;
+    cards.push({ kind: "result", name: "subagents", text });
   }
 
   return cards;


### PR DESCRIPTION
## Summary
- detect `subagent_announce` inter-session injections in the web UI and group them as tool output instead of user chat
- synthesize a tool result card for those messages so the chat renders a collapsible tool-style block instead of a user bubble
- label tool groups as `Tool Output` in the chat footer for clearer provenance

## Testing
- `pnpm exec vitest run --config vitest.config.ts src/ui/chat/message-normalizer.test.ts src/ui/chat/tool-cards.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/chat/message-normalizer.ts ui/src/ui/chat/tool-cards.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/message-normalizer.test.ts ui/src/ui/chat/tool-cards.test.ts`

Closes #6662
