### PR TITLE
Fix opencode-go env API key resolution

### DIFF
--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -4,6 +4,7 @@ export const PROVIDER_ENV_API_KEY_CANDIDATES: Record<string, string[]> = {
   chutes: ["CHUTES_OAUTH_TOKEN", "CHUTES_API_KEY"],
   zai: ["ZAI_API_KEY", "Z_AI_API_KEY"],
   opencode: ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"],
+  "opencode-go": ["OPENCODE_API_KEY"],
   "qwen-portal": ["QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"],
   volcengine: ["VOLCANO_ENGINE_API_KEY"],
   "volcengine-plan": ["VOLCANO_ENGINE_API_KEY"],

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -356,6 +356,20 @@ describe("getApiKeyForModel", () => {
     });
   });
 
+  it("resolveEnvApiKey('opencode-go') returns OPENCODE_API_KEY when set", async () => {
+    await withEnvAsync(
+      {
+        OPENCODE_API_KEY: "opencode-go-test-key",
+        OPENCODE_ZEN_API_KEY: undefined,
+      },
+      async () => {
+        const resolved = resolveEnvApiKey("opencode-go");
+        expect(resolved?.apiKey).toBe("opencode-go-test-key");
+        expect(resolved?.source).toContain("OPENCODE_API_KEY");
+      },
+    );
+  });
+
   it("resolveEnvApiKey('huggingface') returns HUGGINGFACE_HUB_TOKEN when set", async () => {
     await withEnvAsync(
       {


### PR DESCRIPTION
## Summary
- add `opencode-go` to `PROVIDER_ENV_API_KEY_CANDIDATES` so env API key resolution includes this provider
- map `opencode-go` to `OPENCODE_API_KEY` (same key family used by opencode)
- add a regression test for `resolveEnvApiKey("opencode-go")`

## Validation
- `pnpm test src/agents/model-auth.profiles.test.ts`
  - Result: passed (`1` file, `19` tests)

Closes #43247
