### PR TITLE
fix(gateway): harden launchd restart paths

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -67,6 +67,14 @@ export async function runGatewayLoop(params: {
           ? `spawned pid ${respawn.pid ?? "unknown"}`
           : "supervisor restart";
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
+      // On supervised restarts (launchd/systemd), add a brief delay before
+      // exiting to prevent the supervisor from interpreting rapid successive
+      // SIGUSR1 restarts as a crash loop. macOS launchd in particular will
+      // silently unload the service after rapid exits, even with KeepAlive.
+      // See: https://github.com/openclaw/openclaw/issues/14161
+      if (respawn.mode === "supervised") {
+        await new Promise((r) => setTimeout(r, 1500));
+      }
       exitProcess(0);
       return;
     }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -15,6 +15,11 @@ import {
 
 const state = vi.hoisted(() => ({
   launchctlCalls: [] as string[][],
+  spawnCalls: [] as Array<{
+    file: string;
+    args: string[];
+    options: Record<string, unknown>;
+  }>,
   listOutput: "",
   printOutput: "",
   bootstrapError: "",
@@ -51,6 +56,15 @@ vi.mock("./exec-file.js", () => ({
   }),
 }));
 
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn((file: string, args: string[], options: Record<string, unknown>) => {
+    state.spawnCalls.push({ file, args, options });
+    return {
+      unref: vi.fn(),
+    };
+  }),
+}));
+
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
   const wrapped = {
@@ -79,6 +93,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 
 beforeEach(() => {
   state.launchctlCalls.length = 0;
+  state.spawnCalls.length = 0;
   state.listOutput = "";
   state.printOutput = "";
   state.bootstrapError = "";
@@ -241,67 +256,37 @@ describe("launchd install", () => {
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>`);
   });
 
-  it("restarts LaunchAgent with bootout-bootstrap-kickstart order", async () => {
+  it("restarts LaunchAgent via detached script with launchctl restart sequence", async () => {
     const env = createDefaultLaunchdEnv();
     await restartLaunchAgent({
       env,
       stdout: new PassThrough(),
     });
 
-    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-    const label = "ai.openclaw.gateway";
-    const plistPath = resolveLaunchAgentPlistPath(env);
-    const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
+    expect(state.spawnCalls).toHaveLength(1);
+    expect(state.spawnCalls[0]?.file).toBe("/bin/sh");
+    const scriptPath = String(state.spawnCalls[0]?.args[0] ?? "");
+    const script = state.files.get(scriptPath) ?? "";
+    expect(script).toContain("launchctl enable");
+    expect(script).toContain("launchctl bootout");
+    expect(script).toContain("launchctl bootstrap");
+    expect(script).toContain("launchctl kickstart -k");
+    expect(script.indexOf("launchctl bootout")).toBeLessThan(script.indexOf("launchctl bootstrap"));
+    expect(script.indexOf("launchctl bootstrap")).toBeLessThan(
+      script.indexOf("launchctl kickstart -k"),
     );
-    const bootstrapIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
-    );
-    const kickstartIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
-    );
-
-    expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-    expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeLessThan(bootstrapIndex);
-    expect(bootstrapIndex).toBeLessThan(kickstartIndex);
   });
 
-  it("waits for previous launchd pid to exit before bootstrapping", async () => {
+  it("includes previous pid polling in the detached restart script when launchd reports a pid", async () => {
     const env = createDefaultLaunchdEnv();
     state.printOutput = ["state = running", "pid = 4242"].join("\n");
-    const killSpy = vi.spyOn(process, "kill");
-    killSpy
-      .mockImplementationOnce(() => true)
-      .mockImplementationOnce(() => {
-        const err = new Error("no such process") as NodeJS.ErrnoException;
-        err.code = "ESRCH";
-        throw err;
-      });
-
-    vi.useFakeTimers();
-    try {
-      const restartPromise = restartLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-      });
-      await vi.advanceTimersByTimeAsync(250);
-      await restartPromise;
-      expect(killSpy).toHaveBeenCalledWith(4242, 0);
-      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-      const label = "ai.openclaw.gateway";
-      const bootoutIndex = state.launchctlCalls.findIndex(
-        (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
-      );
-      const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
-      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-      expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-      expect(bootoutIndex).toBeLessThan(bootstrapIndex);
-    } finally {
-      vi.useRealTimers();
-      killSpy.mockRestore();
-    }
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+    const scriptPath = String(state.spawnCalls[0]?.args[0] ?? "");
+    const script = state.files.get(scriptPath) ?? "";
+    expect(script).toContain("kill -0 4242");
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,4 +1,6 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import {
@@ -334,30 +336,60 @@ function isUnsupportedGuiDomain(detail: string): boolean {
 
 const RESTART_PID_WAIT_TIMEOUT_MS = 10_000;
 const RESTART_PID_WAIT_INTERVAL_MS = 200;
-
-async function sleepMs(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
-async function waitForPidExit(pid: number): Promise<void> {
-  if (!Number.isFinite(pid) || pid <= 1) {
-    return;
-  }
-  const deadline = Date.now() + RESTART_PID_WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      process.kill(pid, 0);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ESRCH" || code === "EPERM") {
-        return;
-      }
-      return;
-    }
-    await sleepMs(RESTART_PID_WAIT_INTERVAL_MS);
-  }
+function buildDetachedLaunchAgentRestartScript(params: {
+  domain: string;
+  label: string;
+  plistPath: string;
+  previousPid?: number;
+}): string {
+  const target = `${params.domain}/${params.label}`;
+  const previousPidBlock =
+    typeof params.previousPid === "number" && params.previousPid > 1
+      ? `
+i=0
+while [ "$i" -lt ${Math.ceil(RESTART_PID_WAIT_TIMEOUT_MS / RESTART_PID_WAIT_INTERVAL_MS)} ]; do
+  kill -0 ${params.previousPid} 2>/dev/null || break
+  i=$((i + 1))
+  sleep ${RESTART_PID_WAIT_INTERVAL_MS / 1000}
+done
+`
+      : "";
+  return `#!/bin/sh
+sleep 1
+launchctl enable ${shellQuote(target)} >/dev/null 2>&1 || true
+launchctl bootout ${shellQuote(target)} >/dev/null 2>&1 || true${previousPidBlock}
+launchctl bootstrap ${shellQuote(params.domain)} ${shellQuote(params.plistPath)} >/dev/null 2>&1 || exit 1
+launchctl kickstart -k ${shellQuote(target)} >/dev/null 2>&1 || exit 1
+rm -f "$0"
+`;
+}
+
+async function scheduleDetachedLaunchAgentRestart(params: {
+  env: GatewayServiceEnv;
+  label: string;
+  plistPath: string;
+  previousPid?: number;
+}): Promise<void> {
+  const domain = resolveGuiDomain();
+  const tmpDir = path.join(os.tmpdir(), "openclaw");
+  await fs.mkdir(tmpDir, { recursive: true });
+  const scriptPath = path.join(tmpDir, `openclaw-launchd-restart-${Date.now()}-${process.pid}.sh`);
+  const script = buildDetachedLaunchAgentRestartScript({
+    domain,
+    label: params.label,
+    plistPath: params.plistPath,
+    previousPid: params.previousPid,
+  });
+  await fs.writeFile(scriptPath, script, { encoding: "utf8", mode: 0o755 });
+  spawn("/bin/sh", [scriptPath], {
+    detached: true,
+    stdio: "ignore",
+    env: params.env,
+  }).unref();
 }
 
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
@@ -457,36 +489,12 @@ export async function restartLaunchAgent({
     runtime.code === 0
       ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
       : undefined;
-
-  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
-  if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
-    throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
-  }
-  if (typeof previousPid === "number") {
-    await waitForPidExit(previousPid);
-  }
-
-  const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
-  if (boot.code !== 0) {
-    const detail = (boot.stderr || boot.stdout).trim();
-    if (isUnsupportedGuiDomain(detail)) {
-      throw new Error(
-        [
-          `launchctl bootstrap failed: ${detail}`,
-          `LaunchAgent restart requires a logged-in macOS GUI session for this user (${domain}).`,
-          "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
-          "Fix: sign in to the macOS desktop as the target user and rerun `openclaw gateway restart`.",
-          "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
-        ].join("\n"),
-      );
-    }
-    throw new Error(`launchctl bootstrap failed: ${detail}`);
-  }
-
-  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
-  if (start.code !== 0) {
-    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
-  }
+  await scheduleDetachedLaunchAgentRestart({
+    env: serviceEnv,
+    label,
+    plistPath,
+    previousPid,
+  });
   try {
     stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
   } catch (err: unknown) {

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -46,16 +46,17 @@ function clearSupervisorHints() {
   }
 }
 
-function expectLaunchdKickstartSupervised(params?: { launchJobLabel?: string }) {
+function expectLaunchdSupervised(params?: { launchJobLabel?: string }) {
   setPlatform("darwin");
   if (params?.launchJobLabel) {
     process.env.LAUNCH_JOB_LABEL = params.launchJobLabel;
   }
   process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-  triggerOpenClawRestartMock.mockReturnValue({ ok: true, method: "launchctl" });
   const result = restartGatewayProcessWithFreshPid();
   expect(result.mode).toBe("supervised");
-  expect(triggerOpenClawRestartMock).toHaveBeenCalledOnce();
+  // launchd: rely on KeepAlive to restart; do NOT call triggerOpenClawRestart
+  // (kickstart -k races with graceful exit and causes crash-loop throttling)
+  expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
   expect(spawnMock).not.toHaveBeenCalled();
 }
 
@@ -67,35 +68,19 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("returns supervised when launchd hints are present on macOS", () => {
+  it("returns supervised when launchd hints are present on macOS (no kickstart)", () => {
     clearSupervisorHints();
     setPlatform("darwin");
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
-    triggerOpenClawRestartMock.mockReturnValue({ ok: true, method: "launchctl" });
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
-    expect(triggerOpenClawRestartMock).toHaveBeenCalledOnce();
+    // launchd: rely on KeepAlive, do NOT call triggerOpenClawRestart
+    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("runs launchd kickstart helper on macOS when launchd label is set", () => {
-    expectLaunchdKickstartSupervised({ launchJobLabel: "ai.openclaw.gateway" });
-  });
-
-  it("returns failed when launchd kickstart helper fails", () => {
-    setPlatform("darwin");
-    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    triggerOpenClawRestartMock.mockReturnValue({
-      ok: false,
-      method: "launchctl",
-      detail: "spawn failed",
-    });
-
-    const result = restartGatewayProcessWithFreshPid();
-
-    expect(result.mode).toBe("failed");
-    expect(result.detail).toContain("spawn failed");
+  it("returns supervised on macOS when launchd label is set (no kickstart)", () => {
+    expectLaunchdSupervised({ launchJobLabel: "ai.openclaw.gateway" });
   });
 
   it("does not schedule kickstart on non-darwin platforms", () => {
@@ -133,7 +118,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when OPENCLAW_LAUNCHD_LABEL is set (stock launchd plist)", () => {
     clearSupervisorHints();
-    expectLaunchdKickstartSupervised();
+    expectLaunchdSupervised();
   });
 
   it("returns supervised when OPENCLAW_SYSTEMD_UNIT is set", () => {

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -30,7 +30,17 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
   }
   const supervisor = detectRespawnSupervisor(process.env);
   if (supervisor) {
-    if (supervisor === "launchd" || supervisor === "schtasks") {
+    // On macOS launchd, do NOT call `launchctl kickstart -k` here.
+    // The run-loop has already closed the server and released the lock;
+    // calling kickstart -k sends SIGKILL to this process, which races
+    // with the graceful exit and can leave the port in TIME_WAIT.
+    // Instead, let the caller exit cleanly and rely on KeepAlive to
+    // relaunch the process. This avoids launchd's crash-loop throttling
+    // (which silently unloads the service after rapid successive exits).
+    //
+    // For schtasks (Windows), triggerOpenClawRestart is still needed
+    // because schtasks does not have a KeepAlive equivalent.
+    if (supervisor === "schtasks") {
       const restart = triggerOpenClawRestart();
       if (!restart.ok) {
         return {


### PR DESCRIPTION
## Summary
- avoid calling `launchctl kickstart -k` from the supervised gateway respawn path on macOS and let launchd `KeepAlive` restart the process instead
- add a short supervised-exit delay so rapid SIGUSR1 restarts do not get treated as a launchd crash loop
- make `openclaw gateway restart` use a detached helper script on macOS so `bootout -> bootstrap -> kickstart` can complete even when the current service process is being torn down
- update launchd/unit tests to cover the detached restart flow

## Problem
We were seeing two related launchd restart failures on macOS:

1. Gateway-initiated restarts could exit too quickly under launchd and trigger crash-loop throttling.
2. `openclaw gateway restart` could unload the LaunchAgent but fail to bring it back because the restart sequence was executed inline from the process tree being restarted.

In practice this left the gateway stopped with launchd reporting the service as missing or not loaded after a restart attempt.

## Root Cause
There were two different restart paths with different failure modes:

- The gateway run loop treated launchd like other supervisors and could end up in a rapid restart/unload pattern.
- The daemon-side LaunchAgent restart path ran `bootout -> bootstrap -> kickstart` inline. When `bootout` tore down the active service tree, the later bootstrap/kickstart steps were not guaranteed to finish.

## Fix
- For the gateway respawn path, keep launchd in supervised mode and rely on `KeepAlive` instead of issuing a launchd kickstart from inside the service.
- Add a brief delay before exiting a supervised restart so launchd does not classify fast successive exits as a crash loop.
- For the CLI LaunchAgent restart path, write and spawn a detached shell helper that performs the full restart sequence outside the process tree being restarted.
- Preserve previous-pid polling in the detached helper so restart still waits for the old process to get out of the way.

## Testing
- `pnpm test src/daemon/launchd.test.ts src/infra/process-respawn.test.ts`
- validated locally by reinstalling the LaunchAgent and running a real `openclaw gateway restart`; the LaunchAgent stayed loaded and the gateway came back with a fresh PID