### PR TITLE
fix(discord): route REST sends through proxy-aware fetch

### DIFF
--- a/src/discord/client.proxy.test.ts
+++ b/src/discord/client.proxy.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const { makeProxyFetch, proxyFetch } = vi.hoisted(() => {
+  const proxyFetch = vi.fn();
+  return {
+    makeProxyFetch: vi.fn(() => proxyFetch as typeof fetch),
+    proxyFetch,
+  };
+});
+
+vi.mock("../infra/net/proxy-fetch.js", () => ({
+  makeProxyFetch,
+}));
+
+import { createDiscordRestClient } from "./client.js";
+
+describe("createDiscordRestClient proxy support", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("routes outbound Discord REST sends through the configured proxy fetch", async () => {
+    const globalFetch = vi.fn();
+    globalFetch.mockResolvedValue(
+      new Response(JSON.stringify({ id: "global-fetch-should-not-run" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", globalFetch);
+    proxyFetch.mockResolvedValue(
+      new Response(JSON.stringify({ id: "message-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({}, cfg);
+    const result = await rest.post("/channels/123/messages", {
+      body: { content: "hello" },
+    });
+
+    expect(makeProxyFetch).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(proxyFetch).toHaveBeenCalledWith(
+      "https://discord.com/api/channels/123/messages",
+      expect.objectContaining({
+        method: "POST",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    const init = proxyFetch.mock.calls[0]?.[1] as RequestInit;
+    expect((init.headers as Headers).get("Authorization")).toBe("Bot test-token");
+    expect(init.body).toBe(JSON.stringify({ content: "hello" }));
+    expect(globalFetch).not.toHaveBeenCalled();
+    expect(result).toEqual({ id: "message-1" });
+  });
+});

--- a/src/discord/client.proxy.test.ts
+++ b/src/discord/client.proxy.test.ts
@@ -68,4 +68,52 @@ describe("createDiscordRestClient proxy support", () => {
     expect(globalFetch).not.toHaveBeenCalled();
     expect(result).toEqual({ id: "message-1" });
   });
+
+  it("strips nested upload files from payload_json and preserves existing attachments", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    proxyFetch.mockResolvedValue(
+      new Response(JSON.stringify({ id: "message-2" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({}, cfg);
+    await rest.patch("/channels/123/messages/456", {
+      body: {
+        attachments: [{ id: "keep-1", filename: "keep.png" }],
+        data: {
+          content: "updated",
+          files: [{ data: "hello", name: "new.png", description: "new upload" }],
+        },
+      },
+    });
+
+    const init = proxyFetch.mock.calls[0]?.[1] as RequestInit;
+    const formData = init.body as FormData;
+    const payloadJsonPart = formData.get("payload_json");
+    expect(typeof payloadJsonPart).toBe("string");
+    const payloadJson = JSON.parse(payloadJsonPart as string) as {
+      attachments: Array<{ id: string | number; filename: string; description?: string }>;
+      data?: Record<string, unknown>;
+      files?: unknown;
+    };
+
+    expect(payloadJson.files).toBeUndefined();
+    expect(payloadJson.data?.files).toBeUndefined();
+    expect(payloadJson.attachments).toEqual([
+      { id: "keep-1", filename: "keep.png" },
+      { id: 0, filename: "new.png", description: "new upload" },
+    ]);
+    expect(formData.get("files[0]")).toBeInstanceOf(File);
+  });
 });

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -1,7 +1,9 @@
-import { RequestClient } from "@buape/carbon";
+import { DiscordError, RateLimitError, RequestClient, type QueuedRequest } from "@buape/carbon";
 import { loadConfig } from "../config/config.js";
+import { makeProxyFetch } from "../infra/net/proxy-fetch.js";
 import { createDiscordRetryRunner, type RetryRunner } from "../infra/retry-policy.js";
 import type { RetryConfig } from "../infra/retry.js";
+import { logWarn } from "../logger.js";
 import { normalizeAccountId } from "../routing/session-key.js";
 import {
   mergeDiscordAccountConfig,
@@ -29,8 +31,261 @@ function resolveToken(params: { accountId: string; fallbackToken?: string }) {
   return fallback;
 }
 
-function resolveRest(token: string, rest?: RequestClient) {
-  return rest ?? new RequestClient(token);
+type ProxyAwareRequestClient = {
+  options: RequestClient["options"];
+  executeRequest: (request: QueuedRequest) => Promise<unknown>;
+  scheduleRateLimit(routeKey: string, path: string, error: RateLimitError): void;
+  updateBucketFromHeaders(routeKey: string, path: string, response: Response): void;
+  waitForBucket(routeKey: string): Promise<void>;
+};
+
+type RequestClientAbortState = {
+  abortController?: AbortController | null;
+};
+
+type DiscordUploadFile = {
+  data: Blob | Buffer | ArrayBuffer | ArrayBufferView | string;
+  name: string;
+  description?: string;
+};
+
+type DiscordMultipartBody = Record<string, unknown> & {
+  attachments?: Array<{ id: number; filename: string; description?: string }>;
+  files?: DiscordUploadFile[];
+  data?: Record<string, unknown> & { files?: DiscordUploadFile[] };
+};
+
+function toBlobPart(value: DiscordUploadFile["data"]): BlobPart {
+  if (typeof value === "string" || value instanceof Blob || value instanceof ArrayBuffer) {
+    return value;
+  }
+  if (ArrayBuffer.isView(value)) {
+    const bytes = new Uint8Array(value.byteLength);
+    bytes.set(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+    return bytes;
+  }
+  return String(value);
+}
+
+function buildDiscordQueryString(query?: QueuedRequest["query"]) {
+  if (!query) {
+    return "";
+  }
+  return `?${Object.entries(query)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join("&")}`;
+}
+
+async function executeRequestWithFetch(
+  client: ProxyAwareRequestClient,
+  abortState: RequestClientAbortState,
+  token: string,
+  request: QueuedRequest,
+  fetcher: typeof fetch,
+): Promise<unknown> {
+  const { method, path, data, query, routeKey } = request;
+  await client.waitForBucket(routeKey);
+
+  const url = `${client.options.baseUrl}${path}${buildDiscordQueryString(query)}`;
+  const headers =
+    token === "webhook"
+      ? new Headers()
+      : new Headers({
+          Authorization: `${client.options.tokenHeader} ${token}`,
+        });
+
+  if (data?.headers) {
+    for (const [key, value] of Object.entries(data.headers)) {
+      headers.set(key, value);
+    }
+  }
+
+  const timeoutMs =
+    typeof client.options.timeout === "number" && client.options.timeout > 0
+      ? client.options.timeout
+      : undefined;
+  let body: BodyInit | undefined;
+
+  if (
+    data?.body &&
+    typeof data.body === "object" &&
+    ("files" in data.body ||
+      ("data" in data.body &&
+        data.body.data &&
+        typeof data.body.data === "object" &&
+        "files" in data.body.data))
+  ) {
+    const payload = data.body as DiscordMultipartBody;
+    data.body = { ...payload, attachments: [] } satisfies DiscordMultipartBody;
+    const multipartBody = data.body as DiscordMultipartBody;
+    const formData = new FormData();
+    const files = (() => {
+      if (Array.isArray(payload.files)) {
+        return payload.files;
+      }
+      if (payload.data && typeof payload.data === "object" && Array.isArray(payload.data.files)) {
+        return payload.data.files;
+      }
+      return [] as DiscordUploadFile[];
+    })();
+
+    for (const [index, file] of files.entries()) {
+      let { data: fileData } = file;
+      if (!(fileData instanceof Blob)) {
+        fileData = new Blob([toBlobPart(fileData)]);
+      }
+      formData.append(`files[${index}]`, fileData, file.name);
+      multipartBody.attachments?.push({
+        id: index,
+        filename: file.name,
+        description: file.description,
+      });
+    }
+
+    if (multipartBody != null) {
+      const cleanedBody = {
+        ...multipartBody,
+        files: undefined,
+      };
+      formData.append("payload_json", JSON.stringify(cleanedBody));
+    }
+    body = formData;
+  } else if (data?.body != null) {
+    headers.set("Content-Type", "application/json");
+    body = data.rawBody ? (data.body as BodyInit) : JSON.stringify(data.body);
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  if (timeoutMs !== undefined) {
+    timeoutId = setTimeout(() => {
+      abortState.abortController?.abort();
+    }, timeoutMs);
+  }
+
+  let response: Response;
+  abortState.abortController = new AbortController();
+  try {
+    response = await fetcher(url, {
+      method,
+      headers,
+      body,
+      signal: abortState.abortController.signal,
+    });
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    abortState.abortController = null;
+  }
+
+  let rawBody = "";
+  let parsedBody: unknown;
+  try {
+    rawBody = await response.text();
+  } catch {
+    rawBody = "";
+  }
+
+  if (rawBody.length > 0) {
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch {
+      parsedBody = undefined;
+    }
+  }
+
+  if (response.status === 429) {
+    const rateLimitBody =
+      parsedBody &&
+      typeof parsedBody === "object" &&
+      "retry_after" in parsedBody &&
+      "message" in parsedBody
+        ? parsedBody
+        : {
+            message:
+              typeof parsedBody === "string"
+                ? parsedBody
+                : rawBody || "You are being rate limited.",
+            retry_after: (() => {
+              const retryAfterHeader = response.headers.get("Retry-After");
+              if (retryAfterHeader && !Number.isNaN(Number(retryAfterHeader))) {
+                return Number(retryAfterHeader);
+              }
+              return 1;
+            })(),
+            global: response.headers.get("X-RateLimit-Scope") === "global",
+          };
+    const rateLimitError = new RateLimitError(
+      response,
+      rateLimitBody as {
+        message: string;
+        retry_after: number;
+        global: boolean;
+      },
+    );
+    client.scheduleRateLimit(routeKey, path, rateLimitError);
+    throw rateLimitError;
+  }
+
+  client.updateBucketFromHeaders(routeKey, path, response);
+
+  if (response.status >= 400 && response.status < 600) {
+    const discordErrorBody =
+      parsedBody && typeof parsedBody === "object"
+        ? parsedBody
+        : {
+            message: rawBody || "Discord API error",
+            code: 0,
+          };
+    throw new DiscordError(
+      response,
+      discordErrorBody as {
+        message: string;
+        code: number;
+      },
+    );
+  }
+
+  if (parsedBody !== undefined) {
+    return parsedBody;
+  }
+  if (rawBody.length > 0) {
+    return rawBody;
+  }
+  return null;
+}
+
+function attachDiscordRestFetch(
+  client: RequestClient,
+  token: string,
+  fetcher: typeof fetch,
+): RequestClient {
+  const proxyAwareClient = client as unknown as ProxyAwareRequestClient;
+  const abortState = client as unknown as RequestClientAbortState;
+  proxyAwareClient.executeRequest = (request) =>
+    executeRequestWithFetch(proxyAwareClient, abortState, token, request, fetcher);
+  return client;
+}
+
+function resolveRest(token: string, proxyUrl: string | undefined, rest?: RequestClient) {
+  if (rest) {
+    return rest;
+  }
+
+  const client = new RequestClient(token);
+  const proxy = proxyUrl?.trim();
+  if (!proxy) {
+    return client;
+  }
+
+  try {
+    return attachDiscordRestFetch(client, token, makeProxyFetch(proxy));
+  } catch (err) {
+    logWarn(
+      `discord: invalid rest proxy: ${err instanceof Error ? err.message : String(err)}. Falling back to direct REST fetch.`,
+    );
+    return client;
+  }
 }
 
 function resolveAccountWithoutToken(params: {
@@ -66,7 +321,7 @@ export function createDiscordRestClient(
       accountId: account.accountId,
       fallbackToken: account.token,
     });
-  const rest = resolveRest(token, opts.rest);
+  const rest = resolveRest(token, account.config.proxy, opts.rest);
   return { token, rest, account };
 }
 

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -43,6 +43,12 @@ type RequestClientAbortState = {
   abortController?: AbortController | null;
 };
 
+type DiscordAttachment = Record<string, unknown> & {
+  id: number | string;
+  filename?: string;
+  description?: string;
+};
+
 type DiscordUploadFile = {
   data: Blob | Buffer | ArrayBuffer | ArrayBufferView | string;
   name: string;
@@ -50,7 +56,7 @@ type DiscordUploadFile = {
 };
 
 type DiscordMultipartBody = Record<string, unknown> & {
-  attachments?: Array<{ id: number; filename: string; description?: string }>;
+  attachments?: DiscordAttachment[];
   files?: DiscordUploadFile[];
   data?: Record<string, unknown> & { files?: DiscordUploadFile[] };
 };
@@ -74,6 +80,73 @@ function buildDiscordQueryString(query?: QueuedRequest["query"]) {
   return `?${Object.entries(query)
     .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
     .join("&")}`;
+}
+
+function getDiscordUploadFiles(payload: DiscordMultipartBody): DiscordUploadFile[] {
+  if (Array.isArray(payload.files)) {
+    return payload.files;
+  }
+  if (payload.data && typeof payload.data === "object" && Array.isArray(payload.data.files)) {
+    return payload.data.files;
+  }
+  return [];
+}
+
+function buildDiscordMultipartBody(payload: DiscordMultipartBody): FormData {
+  const formData = new FormData();
+  const files = getDiscordUploadFiles(payload);
+  const attachments = Array.isArray(payload.attachments) ? [...payload.attachments] : [];
+
+  for (const [index, file] of files.entries()) {
+    let { data: fileData } = file;
+    if (!(fileData instanceof Blob)) {
+      fileData = new Blob([toBlobPart(fileData)]);
+    }
+    formData.append(`files[${index}]`, fileData, file.name);
+    attachments.push({
+      id: index,
+      filename: file.name,
+      description: file.description,
+    });
+  }
+
+  const cleanedBody: DiscordMultipartBody = {
+    ...payload,
+    attachments,
+    files: undefined,
+    data:
+      payload.data && typeof payload.data === "object"
+        ? {
+            ...payload.data,
+            files: undefined,
+          }
+        : payload.data,
+  };
+  formData.append("payload_json", JSON.stringify(cleanedBody));
+  return formData;
+}
+
+function resolveProxyAwareClient(client: RequestClient): {
+  abortState: RequestClientAbortState;
+  client: ProxyAwareRequestClient;
+} | null {
+  const surface = client as RequestClientAbortState &
+    Partial<ProxyAwareRequestClient> & {
+      options?: RequestClient["options"];
+    };
+  if (
+    !surface.options ||
+    typeof surface.executeRequest !== "function" ||
+    typeof surface.scheduleRateLimit !== "function" ||
+    typeof surface.updateBucketFromHeaders !== "function" ||
+    typeof surface.waitForBucket !== "function"
+  ) {
+    return null;
+  }
+  return {
+    abortState: surface,
+    client: surface as ProxyAwareRequestClient,
+  };
 }
 
 async function executeRequestWithFetch(
@@ -116,40 +189,7 @@ async function executeRequestWithFetch(
         "files" in data.body.data))
   ) {
     const payload = data.body as DiscordMultipartBody;
-    data.body = { ...payload, attachments: [] } satisfies DiscordMultipartBody;
-    const multipartBody = data.body as DiscordMultipartBody;
-    const formData = new FormData();
-    const files = (() => {
-      if (Array.isArray(payload.files)) {
-        return payload.files;
-      }
-      if (payload.data && typeof payload.data === "object" && Array.isArray(payload.data.files)) {
-        return payload.data.files;
-      }
-      return [] as DiscordUploadFile[];
-    })();
-
-    for (const [index, file] of files.entries()) {
-      let { data: fileData } = file;
-      if (!(fileData instanceof Blob)) {
-        fileData = new Blob([toBlobPart(fileData)]);
-      }
-      formData.append(`files[${index}]`, fileData, file.name);
-      multipartBody.attachments?.push({
-        id: index,
-        filename: file.name,
-        description: file.description,
-      });
-    }
-
-    if (multipartBody != null) {
-      const cleanedBody = {
-        ...multipartBody,
-        files: undefined,
-      };
-      formData.append("payload_json", JSON.stringify(cleanedBody));
-    }
-    body = formData;
+    body = buildDiscordMultipartBody(payload);
   } else if (data?.body != null) {
     headers.set("Content-Type", "application/json");
     body = data.rawBody ? (data.body as BodyInit) : JSON.stringify(data.body);
@@ -260,10 +300,13 @@ function attachDiscordRestFetch(
   token: string,
   fetcher: typeof fetch,
 ): RequestClient {
-  const proxyAwareClient = client as unknown as ProxyAwareRequestClient;
-  const abortState = client as unknown as RequestClientAbortState;
-  proxyAwareClient.executeRequest = (request) =>
-    executeRequestWithFetch(proxyAwareClient, abortState, token, request, fetcher);
+  const surface = resolveProxyAwareClient(client);
+  if (!surface) {
+    logWarn("discord: RequestClient runtime surface changed; falling back to direct REST fetch.");
+    return client;
+  }
+  surface.client.executeRequest = (request) =>
+    executeRequestWithFetch(surface.client, surface.abortState, token, request, fetcher);
   return client;
 }
 

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -130,7 +130,7 @@ function resolveProxyAwareClient(client: RequestClient): {
   abortState: RequestClientAbortState;
   client: ProxyAwareRequestClient;
 } | null {
-  const surface = client as RequestClientAbortState &
+  const surface = client as unknown as RequestClientAbortState &
     Partial<ProxyAwareRequestClient> & {
       options?: RequestClient["options"];
     };

--- a/src/discord/monitor/provider.rest-proxy.test.ts
+++ b/src/discord/monitor/provider.rest-proxy.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveDiscordRestFetch } from "./rest-fetch.js";
 
-const { undiciFetchMock, proxyAgentSpy } = vi.hoisted(() => ({
-  undiciFetchMock: vi.fn(),
+const { globalFetchMock, proxyAgentSpy } = vi.hoisted(() => ({
+  globalFetchMock: vi.fn(),
   proxyAgentSpy: vi.fn(),
 }));
 
@@ -19,26 +19,36 @@ vi.mock("undici", () => {
   }
   return {
     ProxyAgent,
-    fetch: undiciFetchMock,
   };
 });
 
 describe("resolveDiscordRestFetch", () => {
-  it("uses undici proxy fetch when a proxy URL is configured", async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", globalFetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses global fetch with dispatcher when a proxy URL is configured", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
       exit: vi.fn(),
     } as const;
-    undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
-    proxyAgentSpy.mockClear();
+    globalFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
     const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
 
     await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
 
+    const request = globalFetchMock.mock.calls[0]?.[0] as Request;
     expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
-    expect(undiciFetchMock).toHaveBeenCalledWith(
-      "https://discord.com/api/v10/oauth2/applications/@me",
+    expect(request).toBeInstanceOf(Request);
+    expect(request.url).toBe("https://discord.com/api/v10/oauth2/applications/@me");
+    expect(globalFetchMock).toHaveBeenCalledWith(
+      request,
       expect.objectContaining({
         dispatcher: expect.objectContaining({ proxyUrl: "http://proxy.test:8080" }),
       }),

--- a/src/discord/monitor/rest-fetch.ts
+++ b/src/discord/monitor/rest-fetch.ts
@@ -1,7 +1,11 @@
-import { ProxyAgent, fetch as undiciFetch } from "undici";
+import { ProxyAgent } from "undici";
 import { danger } from "../../globals.js";
 import { wrapFetchWithAbortSignal } from "../../infra/fetch.js";
 import type { RuntimeEnv } from "../../runtime.js";
+
+function buildDiscordProxyRequest(input: RequestInfo | URL, init?: RequestInit): Request {
+  return new Request(input, init);
+}
 
 export function resolveDiscordRestFetch(
   proxyUrl: string | undefined,
@@ -14,10 +18,9 @@ export function resolveDiscordRestFetch(
   try {
     const agent = new ProxyAgent(proxy);
     const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
-      undiciFetch(input as string | URL, {
-        ...(init as Record<string, unknown>),
+      fetch(buildDiscordProxyRequest(input, init), {
         dispatcher: agent,
-      }) as unknown as Promise<Response>) as typeof fetch;
+      } as RequestInit & { dispatcher: ProxyAgent })) as typeof fetch;
     runtime.log?.("discord: rest proxy enabled");
     return wrapFetchWithAbortSignal(fetcher);
   } catch (err) {

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { ProxyAgent, EnvHttpProxyAgent, undiciFetch, proxyAgentSpy, envAgentSpy, getLastAgent } =
+const { ProxyAgent, EnvHttpProxyAgent, globalFetch, proxyAgentSpy, envAgentSpy, getLastAgent } =
   vi.hoisted(() => {
-    const undiciFetch = vi.fn();
+    const globalFetch = vi.fn();
     const proxyAgentSpy = vi.fn();
     const envAgentSpy = vi.fn();
     class ProxyAgent {
@@ -25,7 +25,7 @@ const { ProxyAgent, EnvHttpProxyAgent, undiciFetch, proxyAgentSpy, envAgentSpy, 
     return {
       ProxyAgent,
       EnvHttpProxyAgent,
-      undiciFetch,
+      globalFetch,
       proxyAgentSpy,
       envAgentSpy,
       getLastAgent: () => ProxyAgent.lastCreated,
@@ -35,33 +35,60 @@ const { ProxyAgent, EnvHttpProxyAgent, undiciFetch, proxyAgentSpy, envAgentSpy, 
 vi.mock("undici", () => ({
   ProxyAgent,
   EnvHttpProxyAgent,
-  fetch: undiciFetch,
 }));
 
 import { makeProxyFetch, resolveProxyFetchFromEnv } from "./proxy-fetch.js";
 
 describe("makeProxyFetch", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", globalFetch);
+  });
+  afterEach(() => vi.unstubAllGlobals());
 
-  it("uses undici fetch with ProxyAgent dispatcher", async () => {
+  it("uses global fetch with ProxyAgent dispatcher", async () => {
     const proxyUrl = "http://proxy.test:8080";
-    undiciFetch.mockResolvedValue({ ok: true });
+    globalFetch.mockResolvedValue({ ok: true });
 
     const proxyFetch = makeProxyFetch(proxyUrl);
     expect(proxyAgentSpy).not.toHaveBeenCalled();
     await proxyFetch("https://api.example.com/v1/audio");
 
+    const request = globalFetch.mock.calls[0]?.[0] as Request;
     expect(proxyAgentSpy).toHaveBeenCalledWith(proxyUrl);
-    expect(undiciFetch).toHaveBeenCalledWith(
-      "https://api.example.com/v1/audio",
+    expect(request).toBeInstanceOf(Request);
+    expect(request.url).toBe("https://api.example.com/v1/audio");
+    expect(globalFetch).toHaveBeenCalledWith(
+      request,
       expect.objectContaining({ dispatcher: getLastAgent() }),
     );
+  });
+
+  it("materializes multipart content-type before proxy dispatch", async () => {
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+    const form = new FormData();
+    form.append("file", new Blob(["hello"]), "smoke.txt");
+    globalFetch.mockResolvedValue({ ok: true });
+
+    await proxyFetch("https://api.example.com/upload", {
+      method: "POST",
+      body: form,
+    });
+
+    const request = globalFetch.mock.calls[0]?.[0] as Request;
+    expect(request.headers.get("content-type")).toContain("multipart/form-data");
   });
 });
 
 describe("resolveProxyFetchFromEnv", () => {
-  beforeEach(() => vi.clearAllMocks());
-  afterEach(() => vi.unstubAllEnvs());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", globalFetch);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
 
   it("returns undefined when no proxy env vars are set", () => {
     vi.stubEnv("HTTPS_PROXY", "");
@@ -79,17 +106,19 @@ describe("resolveProxyFetchFromEnv", () => {
     vi.stubEnv("https_proxy", "");
     vi.stubEnv("http_proxy", "");
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
-    undiciFetch.mockResolvedValue({ ok: true });
+    globalFetch.mockResolvedValue({ ok: true });
 
     const fetchFn = resolveProxyFetchFromEnv();
     expect(fetchFn).toBeDefined();
     expect(envAgentSpy).toHaveBeenCalled();
 
     await fetchFn!("https://api.example.com");
-    expect(undiciFetch).toHaveBeenCalledWith(
-      "https://api.example.com",
+    const request = globalFetch.mock.calls[0]?.[0] as Request;
+    expect(globalFetch).toHaveBeenCalledWith(
+      request,
       expect.objectContaining({ dispatcher: EnvHttpProxyAgent.lastCreated }),
     );
+    expect(request.url).toBe("https://api.example.com/");
   });
 
   it("returns proxy fetch when HTTP_PROXY is set", () => {

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -1,5 +1,9 @@
-import { EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
+import { EnvHttpProxyAgent, ProxyAgent } from "undici";
 import { logWarn } from "../../logger.js";
+
+function buildProxiedRequest(input: RequestInfo | URL, init?: RequestInit): Request {
+  return new Request(input, init);
+}
 
 export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
 type ProxyFetchWithMetadata = typeof fetch & {
@@ -18,13 +22,10 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
     }
     return agent;
   };
-  // undici's fetch is runtime-compatible with global fetch but the types diverge
-  // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
   const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
-    undiciFetch(input as string | URL, {
-      ...(init as Record<string, unknown>),
+    fetch(buildProxiedRequest(input, init), {
       dispatcher: resolveAgent(),
-    }) as unknown as Promise<Response>) as ProxyFetchWithMetadata;
+    } as RequestInit & { dispatcher: ProxyAgent })) as ProxyFetchWithMetadata;
   Object.defineProperty(proxyFetch, PROXY_FETCH_PROXY_URL, {
     value: proxyUrl,
     enumerable: false,
@@ -62,10 +63,9 @@ export function resolveProxyFetchFromEnv(): typeof fetch | undefined {
   try {
     const agent = new EnvHttpProxyAgent();
     return ((input: RequestInfo | URL, init?: RequestInit) =>
-      undiciFetch(input as string | URL, {
-        ...(init as Record<string, unknown>),
+      fetch(buildProxiedRequest(input, init), {
         dispatcher: agent,
-      }) as unknown as Promise<Response>) as typeof fetch;
+      } as RequestInit & { dispatcher: EnvHttpProxyAgent })) as typeof fetch;
   } catch (err) {
     logWarn(
       `Proxy env var set but agent creation failed — falling back to direct fetch: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary
- route Discord REST sends through a proxy-aware fetch path when a channel or account proxy is configured
- preserve multipart request bodies by materializing a real `Request` before passing the dispatcher
- add focused tests for the Discord client, REST fetch wiring, and proxy fetch helper

## Why
When Discord sends used a proxy in the monitor path but not in the outbound REST client path, attachment uploads could fail with `fetch failed` on networks that require a proxy or during TLS instability.

## Testing
- `pnpm exec vitest run src/discord/client.proxy.test.ts src/infra/net/proxy-fetch.test.ts src/discord/monitor/provider.rest-proxy.test.ts`
