### PR TITLE
fix(agents): sanitize raw assistant errors from Codex

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -80,6 +80,20 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toBe("LLM error server_error: Something exploded");
   });
+  it("unwraps Codex-prefixed raw API payloads", () => {
+    const msg = makeAssistantError(
+      'Codex error: {"type":"error","error":{"message":"Something exploded","type":"server_error"}}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe("LLM error server_error: Something exploded");
+  });
+  it("hides provider boilerplate for Codex server errors", () => {
+    const msg = makeAssistantError(
+      'Codex error: {"type":"error","error":{"type":"server_error","message":"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID req_123 in your message."}}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service returned a server error. Please try again in a moment.",
+    );
+  });
   it("returns a friendly billing message for credit balance errors", () => {
     const msg = makeAssistantError("Your credit balance is too low to access the Anthropic API.");
     const result = formatAssistantErrorText(msg);

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -82,6 +82,22 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("sanitizes Codex-prefixed raw API error payloads", () => {
+    const raw =
+      'Codex error: {"type":"error","error":{"message":"Something exploded","type":"server_error"}}';
+    expect(sanitizeUserFacingText(raw, { errorContext: true })).toBe(
+      "LLM error server_error: Something exploded",
+    );
+  });
+
+  it("hides provider boilerplate for Codex server errors", () => {
+    const raw =
+      'Codex error: {"type":"error","error":{"type":"server_error","message":"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID req_123 in your message."}}';
+    expect(sanitizeUserFacingText(raw, { errorContext: true })).toBe(
+      "The AI service returned a server error. Please try again in a moment.",
+    );
+  });
+
   it("returns a friendly message for rate limit errors in Error: prefixed payloads", () => {
     expect(sanitizeUserFacingText("Error: 429 Rate limit exceeded", { errorContext: true })).toBe(
       "⚠️ API rate limit reached. Please try again later.",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -42,6 +42,8 @@ export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
+const SERVER_ERROR_USER_MESSAGE =
+  "The AI service returned a server error. Please try again in a moment.";
 
 function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
   if (isRateLimitErrorMessage(raw)) {
@@ -51,6 +53,19 @@ function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
     return OVERLOADED_ERROR_USER_MESSAGE;
   }
   return undefined;
+}
+
+function shouldHideServerErrorDetails(info: ApiErrorInfo): boolean {
+  if ((info.type ?? "").toLowerCase() !== "server_error") {
+    return false;
+  }
+  const message = info.message ?? "";
+  return (
+    /an error occurred while processing your request/i.test(message) ||
+    /contact us through our help center/i.test(message) ||
+    /help\.openai\.com/i.test(message) ||
+    /\brequest id\b/i.test(message)
+  );
 }
 
 function isReasoningConstraintErrorMessage(raw: string): boolean {
@@ -214,10 +229,10 @@ export function extractObservedOverflowTokenCount(errorMessage?: string): number
 
 // Allow provider-wrapped API payloads such as "Ollama API error 400: {...}".
 const ERROR_PAYLOAD_PREFIX_RE =
-  /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error)(?:\s+\d{3})?[:\s-]+/i;
+  /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error|codex(?:\s+cli)?\s*error)(?:\s+\d{3})?[:\s-]+/i;
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
 const ERROR_PREFIX_RE =
-  /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
+  /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex(?:\s+cli)?\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
   /^(?:context overflow:|request_too_large\b|request size exceeds\b|request exceeds the maximum size\b|context length exceeded\b|maximum context length\b|prompt is too long\b|exceeds model context window\b)/i;
 const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
@@ -549,6 +564,13 @@ function parseApiErrorPayload(raw: string): ErrorPayload | null {
   if (ERROR_PAYLOAD_PREFIX_RE.test(trimmed)) {
     candidates.push(trimmed.replace(ERROR_PAYLOAD_PREFIX_RE, "").trim());
   }
+  const firstBraceIndex = trimmed.indexOf("{");
+  if (firstBraceIndex > 0) {
+    const prefix = trimmed.slice(0, firstBraceIndex);
+    if (/\b(?:error|failed)\b/i.test(prefix)) {
+      candidates.push(trimmed.slice(firstBraceIndex).trim());
+    }
+  }
   for (const candidate of candidates) {
     if (!candidate.startsWith("{") || !candidate.endsWith("}")) {
       continue;
@@ -664,6 +686,9 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
 
   const info = parseApiErrorInfo(trimmed);
   if (info?.message) {
+    if (shouldHideServerErrorDetails(info)) {
+      return SERVER_ERROR_USER_MESSAGE;
+    }
     const prefix = info.httpCode ? `HTTP ${info.httpCode}` : "LLM error";
     const type = info.type ? ` ${info.type}` : "";
     const requestId = info.requestId ? ` (request_id: ${info.requestId})` : "";

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -149,6 +149,66 @@ describe("handleAgentEnd", () => {
     });
   });
 
+  it("sanitizes Codex-prefixed raw payloads before emitting lifecycle errors", () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage:
+          'Codex error: {"type":"error","error":{"message":"Something exploded","type":"server_error"}}',
+        content: [{ type: "text", text: "" }],
+      },
+      { onAgentEvent },
+    );
+
+    handleAgentEnd(ctx);
+
+    const warn = vi.mocked(ctx.log.warn);
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({
+      event: "embedded_run_agent_end",
+      error: "LLM error server_error: Something exploded",
+      providerErrorType: "server_error",
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        error: "LLM error server_error: Something exploded",
+      },
+    });
+  });
+
+  it("hides provider boilerplate before emitting lifecycle errors", () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage:
+          'Codex error: {"type":"error","error":{"type":"server_error","message":"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID req_123 in your message."}}',
+        content: [{ type: "text", text: "" }],
+      },
+      { onAgentEvent },
+    );
+
+    handleAgentEnd(ctx);
+
+    const warn = vi.mocked(ctx.log.warn);
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({
+      event: "embedded_run_agent_end",
+      error: "The AI service returned a server error. Please try again in a moment.",
+      providerErrorType: "server_error",
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        error: "The AI service returned a server error. Please try again in a moment.",
+      },
+    });
+  });
+
   it("keeps non-error run-end logging on debug only", () => {
     const ctx = createContext(undefined);
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -5,11 +5,7 @@ import {
   buildTextObservationFields,
   sanitizeForConsole,
 } from "./pi-embedded-error-observation.js";
-import {
-  classifyFailoverReason,
-  formatAssistantErrorText,
-  sanitizeUserFacingText,
-} from "./pi-embedded-helpers.js";
+import { classifyFailoverReason, formatAssistantErrorText } from "./pi-embedded-helpers.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { isAssistantMessage } from "./pi-embedded-utils.js";
 
@@ -47,10 +43,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     });
     const rawError = lastAssistant.errorMessage?.trim();
     const failoverReason = classifyFailoverReason(rawError ?? "");
-    const sanitizedFallback = sanitizeUserFacingText(rawError ?? "", {
-      errorContext: true,
-    }).trim();
-    const errorText = (friendlyError || sanitizedFallback || "LLM request failed.").trim();
+    const errorText = (friendlyError || "LLM request failed.").trim();
     const observedError = buildApiErrorObservationFields(rawError);
     const safeErrorText =
       buildTextObservationFields(errorText).textPreview ?? "LLM request failed.";

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -5,7 +5,11 @@ import {
   buildTextObservationFields,
   sanitizeForConsole,
 } from "./pi-embedded-error-observation.js";
-import { classifyFailoverReason, formatAssistantErrorText } from "./pi-embedded-helpers.js";
+import {
+  classifyFailoverReason,
+  formatAssistantErrorText,
+  sanitizeUserFacingText,
+} from "./pi-embedded-helpers.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { isAssistantMessage } from "./pi-embedded-utils.js";
 
@@ -43,7 +47,10 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     });
     const rawError = lastAssistant.errorMessage?.trim();
     const failoverReason = classifyFailoverReason(rawError ?? "");
-    const errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
+    const sanitizedFallback = sanitizeUserFacingText(rawError ?? "", {
+      errorContext: true,
+    }).trim();
+    const errorText = (friendlyError || sanitizedFallback || "LLM request failed.").trim();
     const observedError = buildApiErrorObservationFields(rawError);
     const safeErrorText =
       buildTextObservationFields(errorText).textPreview ?? "LLM request failed.";


### PR DESCRIPTION
## Summary
- sanitize raw Codex/provider payloads before surfacing assistant errors to users
- fall back to stable, user-facing text when the provider returns boilerplate or JSON-like error blobs
- add focused tests for helper sanitization and subscribe lifecycle behavior

## Why
Without sanitization, raw provider error payloads can leak through to the embedded assistant UI as noisy `Codex error: {...}` strings. This makes failures harder to understand and exposes implementation details that are not useful to end users.

## Testing
- `pnpm exec vitest run src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts`
