### PR TITLE
Handle stack-supervised gateway status

### DIFF
--- a/src/commands/status.service-summary.test.ts
+++ b/src/commands/status.service-summary.test.ts
@@ -49,6 +49,37 @@ describe("readServiceStatusSummary", () => {
     expect(summary.loadedText).toBe("running (externally managed)");
   });
 
+  it("treats stack-supervised services as OpenClaw-managed when the supervisor plist is detected", async () => {
+    const summary = await readServiceStatusSummary(
+      createService({
+        label: "LaunchAgent",
+        loadedText: "loaded",
+        notLoadedText: "not loaded",
+        isLoaded: vi.fn(async () => true),
+        readCommand: vi.fn(async () => ({
+          programArguments: ["/Users/test/clawd/scripts/stack_supervisor.sh"],
+          sourcePath: "/Users/test/Library/LaunchAgents/ai.openclaw.stack.plist",
+        })),
+        readRuntime: vi.fn(async () => ({
+          status: "running",
+          pid: 39395,
+          detail: "via ai.openclaw.stack",
+        })),
+      }),
+      "Daemon",
+    );
+
+    expect(summary.installed).toBe(true);
+    expect(summary.managedByOpenClaw).toBe(true);
+    expect(summary.externallyManaged).toBe(false);
+    expect(summary.loadedText).toBe("loaded");
+    expect(summary.runtime).toMatchObject({
+      status: "running",
+      pid: 39395,
+      detail: "via ai.openclaw.stack",
+    });
+  });
+
   it("keeps missing services as not installed when nothing is running", async () => {
     const summary = await readServiceStatusSummary(createService({}), "Daemon");
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -7,7 +7,10 @@ import {
 import {
   installLaunchAgent,
   isLaunchAgentListed,
+  isLaunchAgentLoaded,
   parseLaunchctlPrint,
+  readLaunchAgentProgramArguments,
+  readLaunchAgentRuntime,
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
@@ -17,6 +20,7 @@ const state = vi.hoisted(() => ({
   launchctlCalls: [] as string[][],
   listOutput: "",
   printOutput: "",
+  printOutputs: new Map<string, { stdout: string; stderr?: string; code?: number }>(),
   bootstrapError: "",
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
@@ -44,6 +48,15 @@ vi.mock("./exec-file.js", () => ({
       return { stdout: state.listOutput, stderr: "", code: 0 };
     }
     if (call[0] === "print") {
+      const key = call[1] ?? "";
+      const override = state.printOutputs.get(key);
+      if (override) {
+        return {
+          stdout: override.stdout,
+          stderr: override.stderr ?? "",
+          code: override.code ?? 0,
+        };
+      }
       return { stdout: state.printOutput, stderr: "", code: 0 };
     }
     if (call[0] === "bootstrap" && state.bootstrapError) {
@@ -91,6 +104,13 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       }
       throw new Error(`ENOENT: no such file or directory, chmod '${key}'`);
     }),
+    readFile: vi.fn(async (p: string) => {
+      const key = String(p);
+      if (state.files.has(key)) {
+        return state.files.get(key) ?? "";
+      }
+      throw new Error(`ENOENT: no such file or directory, readFile '${key}'`);
+    }),
     unlink: vi.fn(async (p: string) => {
       state.files.delete(String(p));
     }),
@@ -108,6 +128,7 @@ beforeEach(() => {
   state.launchctlCalls.length = 0;
   state.listOutput = "";
   state.printOutput = "";
+  state.printOutputs.clear();
   state.bootstrapError = "";
   state.dirs.clear();
   state.dirModes.clear();
@@ -181,6 +202,71 @@ describe("launchctl list detection", () => {
       env: { HOME: "/Users/test", OPENCLAW_PROFILE: "default" },
     });
     expect(listed).toBe(false);
+  });
+});
+
+describe("launchd gateway supervisor fallback", () => {
+  const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+
+  it("treats the supervisor launch agent as loaded when configured", async () => {
+    const env = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+      OPENCLAW_GATEWAY_SUPERVISOR_LABEL: "ai.openclaw.stack",
+    };
+    state.printOutputs.set(`${domain}/ai.openclaw.gateway`, {
+      stdout: "",
+      stderr:
+        'Bad request.\nCould not find service "ai.openclaw.gateway" in domain for user gui: 501',
+      code: 113,
+    });
+    state.printOutputs.set(`${domain}/ai.openclaw.stack`, {
+      stdout: ["state = running", "pid = 39395"].join("\n"),
+    });
+
+    const loaded = await isLaunchAgentLoaded({ env });
+    const runtime = await readLaunchAgentRuntime(env);
+
+    expect(loaded).toBe(true);
+    expect(runtime.status).toBe("running");
+    expect(runtime.pid).toBe(39395);
+    expect(runtime.detail).toBe("via ai.openclaw.stack");
+    expect(runtime.missingUnit).toBeUndefined();
+  });
+
+  it("reads program arguments from the supervisor plist when the gateway plist is absent", async () => {
+    const env = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+      OPENCLAW_GATEWAY_SUPERVISOR_LABEL: "ai.openclaw.stack",
+    };
+    const supervisorPlist = "/Users/test/Library/LaunchAgents/ai.openclaw.stack.plist";
+    state.files.set(
+      supervisorPlist,
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<plist version="1.0"><dict>',
+        "<key>ProgramArguments</key>",
+        "<array>",
+        "<string>/Users/test/clawd/scripts/stack_supervisor.sh</string>",
+        "</array>",
+        "<key>WorkingDirectory</key>",
+        "<string>/Users/test/clawd</string>",
+        "<key>EnvironmentVariables</key>",
+        "<dict>",
+        "<key>PATH</key>",
+        "<string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>",
+        "</dict>",
+        "</dict></plist>",
+      ].join("\n"),
+    );
+
+    const command = await readLaunchAgentProgramArguments(env);
+
+    expect(command?.programArguments).toEqual(["/Users/test/clawd/scripts/stack_supervisor.sh"]);
+    expect(command?.workingDirectory).toBe("/Users/test/clawd");
+    expect(command?.environment?.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+    expect(command?.sourcePath).toBe(supervisorPlist);
   });
 });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -44,6 +44,33 @@ function resolveLaunchAgentPlistPathForLabel(
   return path.posix.join(home, "Library", "LaunchAgents", `${label}.plist`);
 }
 
+function resolveGatewaySupervisorLaunchAgentLabel(
+  env: Record<string, string | undefined>,
+): string | null {
+  const raw = env.OPENCLAW_GATEWAY_SUPERVISOR_LABEL?.trim();
+  if (!raw) {
+    return null;
+  }
+  const canonical = resolveLaunchAgentLabel({ env });
+  return raw === canonical ? null : raw;
+}
+
+async function execLaunchctlPrintForLabel(
+  env: Record<string, string | undefined>,
+  label: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const domain = resolveGuiDomain();
+  return await execLaunchctl(["print", `${domain}/${label}`]);
+}
+
+async function readLaunchAgentProgramArgumentsForLabel(
+  env: GatewayServiceEnv,
+  label: string,
+): Promise<GatewayServiceCommandConfig | null> {
+  const plistPath = resolveLaunchAgentPlistPathForLabel(env, label);
+  return readLaunchAgentProgramArgumentsFromFile(plistPath);
+}
+
 export function resolveLaunchAgentPlistPath(env: GatewayServiceEnv): string {
   const label = resolveLaunchAgentLabel({ env });
   return resolveLaunchAgentPlistPathForLabel(env, label);
@@ -67,8 +94,25 @@ export function resolveGatewayLogPaths(env: GatewayServiceEnv): {
 export async function readLaunchAgentProgramArguments(
   env: GatewayServiceEnv,
 ): Promise<GatewayServiceCommandConfig | null> {
-  const plistPath = resolveLaunchAgentPlistPath(env);
-  return readLaunchAgentProgramArgumentsFromFile(plistPath);
+  const direct = await readLaunchAgentProgramArgumentsForLabel(
+    env,
+    resolveLaunchAgentLabel({ env }),
+  );
+  if (direct) {
+    return direct;
+  }
+  const supervisorLabel = resolveGatewaySupervisorLaunchAgentLabel(env);
+  if (!supervisorLabel) {
+    return null;
+  }
+  const fallback = await readLaunchAgentProgramArgumentsForLabel(env, supervisorLabel);
+  if (!fallback) {
+    return null;
+  }
+  return {
+    ...fallback,
+    sourcePath: fallback.sourcePath ?? resolveLaunchAgentPlistPathForLabel(env, supervisorLabel),
+  };
 }
 
 export function buildLaunchAgentPlist({
@@ -165,10 +209,18 @@ export function parseLaunchctlPrint(output: string): LaunchctlPrintInfo {
 }
 
 export async function isLaunchAgentLoaded(args: GatewayServiceEnvArgs): Promise<boolean> {
-  const domain = resolveGuiDomain();
-  const label = resolveLaunchAgentLabel({ env: args.env });
-  const res = await execLaunchctl(["print", `${domain}/${label}`]);
-  return res.code === 0;
+  const env = args.env;
+  const label = resolveLaunchAgentLabel({ env });
+  const res = await execLaunchctlPrintForLabel(env, label);
+  if (res.code === 0) {
+    return true;
+  }
+  const supervisorLabel = resolveGatewaySupervisorLaunchAgentLabel(env);
+  if (!supervisorLabel) {
+    return false;
+  }
+  const supervisorRes = await execLaunchctlPrintForLabel(env, supervisorLabel);
+  return supervisorRes.code === 0;
 }
 
 export async function isLaunchAgentListed(args: GatewayServiceEnvArgs): Promise<boolean> {
@@ -193,18 +245,35 @@ export async function launchAgentPlistExists(env: GatewayServiceEnv): Promise<bo
 export async function readLaunchAgentRuntime(
   env: Record<string, string | undefined>,
 ): Promise<GatewayServiceRuntime> {
-  const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["print", `${domain}/${label}`]);
-  if (res.code !== 0) {
+  let activeLabel = label;
+  let activeRes = await execLaunchctlPrintForLabel(env, label);
+  let viaSupervisor = false;
+
+  if (activeRes.code !== 0) {
+    const supervisorLabel = resolveGatewaySupervisorLaunchAgentLabel(env);
+    if (supervisorLabel) {
+      const supervisorRes = await execLaunchctlPrintForLabel(env, supervisorLabel);
+      if (supervisorRes.code === 0) {
+        activeLabel = supervisorLabel;
+        activeRes = supervisorRes;
+        viaSupervisor = true;
+      }
+    }
+  }
+
+  if (activeRes.code !== 0) {
     return {
       status: "unknown",
-      detail: (res.stderr || res.stdout).trim() || undefined,
+      detail: (activeRes.stderr || activeRes.stdout).trim() || undefined,
       missingUnit: true,
     };
   }
-  const parsed = parseLaunchctlPrint(res.stdout || res.stderr || "");
-  const plistExists = await launchAgentPlistExists(env);
+  const parsed = parseLaunchctlPrint(activeRes.stdout || activeRes.stderr || "");
+  const plistExists = await fs
+    .access(resolveLaunchAgentPlistPathForLabel(env, activeLabel))
+    .then(() => true)
+    .catch(() => false);
   const state = parsed.state?.toLowerCase();
   const status = state === "running" || parsed.pid ? "running" : state ? "stopped" : "unknown";
   return {
@@ -214,6 +283,7 @@ export async function readLaunchAgentRuntime(
     lastExitStatus: parsed.lastExitStatus,
     lastExitReason: parsed.lastExitReason,
     cachedLabel: !plistExists,
+    ...(viaSupervisor ? { detail: `via ${activeLabel}` } : {}),
   };
 }
 

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -150,6 +150,29 @@ describe("auditGatewayServiceConfig", () => {
       audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayTokenMismatch),
     ).toBe(false);
   });
+
+  it("skips the gateway subcommand audit for configured supervisor launch agents", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: {
+        HOME: "/tmp",
+        OPENCLAW_GATEWAY_SUPERVISOR_LABEL: "ai.openclaw.stack",
+      },
+      platform: "darwin",
+      command: {
+        programArguments: ["/Users/test/clawd/scripts/stack_supervisor.sh"],
+        sourcePath: "/Users/test/Library/LaunchAgents/ai.openclaw.stack.plist",
+        environment: {
+          PATH: buildMinimalServicePath({
+            platform: "darwin",
+            env: { HOME: "/tmp" },
+          }),
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayCommandMissing),
+    ).toBe(false);
+  });
 });
 
 describe("checkTokenDrift", () => {

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -192,6 +192,20 @@ async function auditLaunchdPlist(
   }
 }
 
+function isGatewaySupervisorCommand(
+  env: Record<string, string | undefined>,
+  command: GatewayServiceCommand,
+): boolean {
+  const supervisorLabel = env.OPENCLAW_GATEWAY_SUPERVISOR_LABEL?.trim();
+  if (!supervisorLabel || !command) {
+    return false;
+  }
+  if (command.sourcePath?.endsWith(`/${supervisorLabel}.plist`)) {
+    return true;
+  }
+  return command.programArguments.some((arg) => arg.includes("stack_supervisor.sh"));
+}
+
 function auditGatewayCommand(programArguments: string[] | undefined, issues: ServiceConfigIssue[]) {
   if (!programArguments || programArguments.length === 0) {
     return;
@@ -408,7 +422,9 @@ export async function auditGatewayServiceConfig(params: {
   const issues: ServiceConfigIssue[] = [];
   const platform = params.platform ?? process.platform;
 
-  auditGatewayCommand(params.command?.programArguments, issues);
+  if (!isGatewaySupervisorCommand(params.env, params.command)) {
+    auditGatewayCommand(params.command?.programArguments, issues);
+  }
   auditGatewayToken(params.command, issues, params.expectedGatewayToken);
   auditGatewayServicePath(params.command, issues, params.env, platform);
   await auditGatewayRuntime(params.env, params.command, issues, platform);


### PR DESCRIPTION
## Summary
- fix macOS gateway status/audit handling when the gateway is launched through the stack supervisor LaunchAgent instead of a direct `ai.openclaw.gateway` plist
- fall back to `OPENCLAW_GATEWAY_SUPERVISOR_LABEL` when reading launchd load state, runtime details, and program arguments
- add regression tests for the supervisor-managed status path and audit behavior

## Problem
On stack-supervised macOS installs, the gateway can be running under the supervisor LaunchAgent (`ai.openclaw.stack`) rather than a direct gateway LaunchAgent. In that setup, status/audit code could treat the gateway as missing or externally managed because it only looked for the canonical gateway label/plist and expected a direct `gateway` subcommand in the service definition.

## What changed
- add a launchd fallback path that checks the configured supervisor label when the direct gateway LaunchAgent is not present
- allow program-argument inspection to read from the supervisor plist when the gateway plist is absent
- report runtime details as `via <supervisor label>` when the supervisor agent is the active unit
- skip the aggressive `gatewayCommandMissing` audit when the inspected command is the configured stack supervisor LaunchAgent

## Regression coverage
- launchd tests for supervisor-label loaded/runtime fallback
- launchd tests for reading program arguments from the supervisor plist
- service-summary coverage that treats stack-supervised services as OpenClaw-managed
- service-audit coverage that avoids false positives for the supervisor command path
