### PR TITLE
fix(windows): avoid queued gateway restarts after schtasks /End

### DIFF
--- a/src/daemon/schtasks.restart.test.ts
+++ b/src/daemon/schtasks.restart.test.ts
@@ -118,6 +118,97 @@ describe("restartScheduledTask", () => {
     expect(taskQueryCount).toBe(2);
   });
 
+  it("keeps waiting when status is Running but the task has not written a numeric result code yet", async () => {
+    const calls: string[][] = [];
+    let taskQueryCount = 0;
+
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      calls.push(argv);
+      if (argv.length === 1 && argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      if (argv[0] === "/Query" && argv.includes("/TN")) {
+        taskQueryCount += 1;
+        if (taskQueryCount === 1) {
+          return {
+            code: 0,
+            stdout: renderTaskQuery({ status: "Running", lastRunResult: "N/A" }),
+            stderr: "",
+          };
+        }
+        return {
+          code: 0,
+          stdout: renderTaskQuery({ status: "Ready", lastRunResult: "0x0" }),
+          stderr: "",
+        };
+      }
+      if (argv[0] === "/Run") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      throw new Error(`Unexpected schtasks call: ${argv.join(" ")}`);
+    });
+
+    const restart = restartScheduledTask({
+      env: { USERNAME: "tester" },
+      stdout: new PassThrough(),
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(restart).resolves.toBeUndefined();
+    expect(taskQueryCount).toBe(2);
+    expect(calls).toEqual([
+      ["/Query"],
+      ["/End", "/TN", "OpenClaw Gateway"],
+      ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+      ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+      ["/Run", "/TN", "OpenClaw Gateway"],
+    ]);
+  });
+
+  it("re-checks once more before timing out when the task stops in the final delay window", async () => {
+    const terminalPolls = 40;
+    let taskQueryCount = 0;
+
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      if (argv.length === 1 && argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      if (argv[0] === "/Query" && argv.includes("/TN")) {
+        taskQueryCount += 1;
+        return taskQueryCount <= terminalPolls
+          ? {
+              code: 0,
+              stdout: renderTaskQuery({ status: "Running", lastRunResult: "0x41301" }),
+              stderr: "",
+            }
+          : {
+              code: 0,
+              stdout: renderTaskQuery({ status: "Ready", lastRunResult: "0x0" }),
+              stderr: "",
+            };
+      }
+      if (argv[0] === "/Run") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      throw new Error(`Unexpected schtasks call: ${argv.join(" ")}`);
+    });
+
+    const restart = restartScheduledTask({
+      env: { USERNAME: "tester" },
+      stdout: new PassThrough(),
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(restart).resolves.toBeUndefined();
+    expect(taskQueryCount).toBe(terminalPolls + 1);
+  });
+
   it("still starts the task immediately when /End reports it was not running", async () => {
     const calls: string[][] = [];
 

--- a/src/daemon/schtasks.restart.test.ts
+++ b/src/daemon/schtasks.restart.test.ts
@@ -1,0 +1,151 @@
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execSchtasksMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./schtasks-exec.js", () => ({
+  execSchtasks: (...args: unknown[]) => execSchtasksMock(...args),
+}));
+
+import { restartScheduledTask } from "./schtasks.js";
+
+function renderTaskQuery(params: { status: string; lastRunResult: string }): string {
+  return [
+    "TaskName: \\OpenClaw Gateway",
+    `Status: ${params.status}`,
+    "Last Run Time: 3/11/2026 9:41:00 AM",
+    `Last Run Result: ${params.lastRunResult}`,
+  ].join("\r\n");
+}
+
+beforeEach(() => {
+  execSchtasksMock.mockReset();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+describe("restartScheduledTask", () => {
+  it("waits for the previous task instance to stop before issuing /Run", async () => {
+    const calls: string[][] = [];
+    let taskQueryCount = 0;
+
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      calls.push(argv);
+      if (argv.length === 1 && argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      if (argv[0] === "/Query" && argv.includes("/TN")) {
+        taskQueryCount += 1;
+        if (taskQueryCount === 1) {
+          return {
+            code: 0,
+            stdout: renderTaskQuery({ status: "Running", lastRunResult: "0x41301" }),
+            stderr: "",
+          };
+        }
+        return {
+          code: 0,
+          stdout: renderTaskQuery({ status: "Ready", lastRunResult: "0x0" }),
+          stderr: "",
+        };
+      }
+      if (argv[0] === "/Run") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      throw new Error(`Unexpected schtasks call: ${argv.join(" ")}`);
+    });
+
+    const restart = restartScheduledTask({
+      env: { USERNAME: "tester" },
+      stdout: new PassThrough(),
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(restart).resolves.toBeUndefined();
+    expect(calls).toEqual([
+      ["/Query"],
+      ["/End", "/TN", "OpenClaw Gateway"],
+      ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+      ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+      ["/Run", "/TN", "OpenClaw Gateway"],
+    ]);
+  });
+
+  it("treats a queued task as still active before re-running it", async () => {
+    let taskQueryCount = 0;
+
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      if (argv.length === 1 && argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      if (argv[0] === "/Query" && argv.includes("/TN")) {
+        taskQueryCount += 1;
+        return taskQueryCount === 1
+          ? {
+              code: 0,
+              stdout: renderTaskQuery({ status: "Queued", lastRunResult: "0x41325" }),
+              stderr: "",
+            }
+          : {
+              code: 0,
+              stdout: renderTaskQuery({ status: "Ready", lastRunResult: "0x0" }),
+              stderr: "",
+            };
+      }
+      if (argv[0] === "/Run") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      throw new Error(`Unexpected schtasks call: ${argv.join(" ")}`);
+    });
+
+    const restart = restartScheduledTask({
+      env: { USERNAME: "tester" },
+      stdout: new PassThrough(),
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(restart).resolves.toBeUndefined();
+    expect(taskQueryCount).toBe(2);
+  });
+
+  it("still starts the task immediately when /End reports it was not running", async () => {
+    const calls: string[][] = [];
+
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      calls.push(argv);
+      if (argv.length === 1 && argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 1, stdout: "", stderr: "ERROR: The task is not running." };
+      }
+      if (argv[0] === "/Run") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      throw new Error(`Unexpected schtasks call: ${argv.join(" ")}`);
+    });
+
+    await expect(
+      restartScheduledTask({
+        env: { USERNAME: "tester" },
+        stdout: new PassThrough(),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(calls).toEqual([
+      ["/Query"],
+      ["/End", "/TN", "OpenClaw Gateway"],
+      ["/Run", "/TN", "OpenClaw Gateway"],
+    ]);
+  });
+});

--- a/src/daemon/schtasks.restart.test.ts
+++ b/src/daemon/schtasks.restart.test.ts
@@ -241,6 +241,42 @@ describe("restartScheduledTask", () => {
     expect(taskQueryCount).toBe(41);
   });
 
+  it("throws when schtasks query fails while waiting for the task to stop", async () => {
+    const calls: string[][] = [];
+
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      calls.push(argv);
+      if (argv.length === 1 && argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      if (argv[0] === "/Query" && argv.includes("/TN")) {
+        return {
+          code: 1,
+          stdout: "",
+          stderr: "ERROR: Access is denied.",
+        };
+      }
+      throw new Error(`Unexpected schtasks call: ${argv.join(" ")}`);
+    });
+
+    const restart = restartScheduledTask({
+      env: { USERNAME: "tester" },
+      stdout: new PassThrough(),
+    });
+    const rejection = expect(restart).rejects.toThrow(/schtasks query failed while waiting/i);
+
+    await vi.runAllTimersAsync();
+    await rejection;
+    expect(calls).toEqual([
+      ["/Query"],
+      ["/End", "/TN", "OpenClaw Gateway"],
+      ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+    ]);
+  });
+
   it("still starts the task immediately when /End reports it was not running", async () => {
     const calls: string[][] = [];
 

--- a/src/daemon/schtasks.restart.test.ts
+++ b/src/daemon/schtasks.restart.test.ts
@@ -209,6 +209,38 @@ describe("restartScheduledTask", () => {
     expect(taskQueryCount).toBe(terminalPolls + 1);
   });
 
+  it("throws when the task does not stop within the maximum wait time", async () => {
+    let taskQueryCount = 0;
+
+    execSchtasksMock.mockImplementation(async (argv: string[]) => {
+      if (argv.length === 1 && argv[0] === "/Query") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (argv[0] === "/End") {
+        return { code: 0, stdout: "SUCCESS", stderr: "" };
+      }
+      if (argv[0] === "/Query" && argv.includes("/TN")) {
+        taskQueryCount += 1;
+        return {
+          code: 0,
+          stdout: renderTaskQuery({ status: "Running", lastRunResult: "0x41301" }),
+          stderr: "",
+        };
+      }
+      throw new Error(`Unexpected schtasks call: ${argv.join(" ")}`);
+    });
+
+    const restart = restartScheduledTask({
+      env: { USERNAME: "tester" },
+      stdout: new PassThrough(),
+    });
+    const rejection = expect(restart).rejects.toThrow(/did not stop within/i);
+
+    await vi.runAllTimersAsync();
+    await rejection;
+    expect(taskQueryCount).toBe(41);
+  });
+
   it("still starts the task immediately when /End reports it was not running", async () => {
     const calls: string[][] = [];
 

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -44,6 +44,15 @@ describe("scheduled task runtime derivation", () => {
     ).toEqual({ status: "running" });
   });
 
+  it("treats Queued + 0x41325 as running", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Queued",
+        lastRunResult: "0x41325",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
   it("treats Running without numeric result as unknown", () => {
     expect(
       deriveScheduledTaskRuntimeStatus({

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -160,7 +160,7 @@ const RUNNING_RESULT_CODES = new Set(["0x41301"]);
 const QUEUED_RESULT_CODES = new Set(["0x41325"]);
 const UNKNOWN_STATUS_DETAIL =
   "Task status is locale-dependent and no numeric Last Run Result was available.";
-const TASK_ACTIVE_STATUSES = new Set(["queued"]);
+const TASK_ACTIVE_STATUSES = new Set(["queued", "running"]);
 const TASK_STOP_WAIT_ATTEMPTS = 40;
 const TASK_STOP_WAIT_DELAY_MS = 250;
 
@@ -343,6 +343,11 @@ async function waitForScheduledTaskStop(taskName: string): Promise<void> {
       return;
     }
     await sleep(TASK_STOP_WAIT_DELAY_MS);
+  }
+
+  const { parsed: finalInfo } = await queryScheduledTaskInfo(taskName);
+  if (!finalInfo || !isScheduledTaskActive(finalInfo)) {
+    return;
   }
 
   const waitSeconds = Math.ceil((TASK_STOP_WAIT_ATTEMPTS * TASK_STOP_WAIT_DELAY_MS) / 1000);

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -17,6 +17,7 @@ import type {
   GatewayServiceManageArgs,
   GatewayServiceRenderArgs,
 } from "./service-types.js";
+import { sleep } from "../utils.js";
 
 function resolveTaskName(env: GatewayServiceEnv): string {
   const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
@@ -156,8 +157,29 @@ function normalizeTaskResultCode(value?: string): string | null {
 }
 
 const RUNNING_RESULT_CODES = new Set(["0x41301"]);
+const QUEUED_RESULT_CODES = new Set(["0x41325"]);
 const UNKNOWN_STATUS_DETAIL =
   "Task status is locale-dependent and no numeric Last Run Result was available.";
+const TASK_ACTIVE_STATUSES = new Set(["queued"]);
+const TASK_STOP_WAIT_ATTEMPTS = 40;
+const TASK_STOP_WAIT_DELAY_MS = 250;
+
+function normalizeTaskStatus(value?: string): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || null;
+}
+
+function isScheduledTaskActive(parsed: ScheduledTaskInfo): boolean {
+  const normalizedResult = normalizeTaskResultCode(parsed.lastRunResult);
+  if (normalizedResult != null) {
+    if (RUNNING_RESULT_CODES.has(normalizedResult) || QUEUED_RESULT_CODES.has(normalizedResult)) {
+      return true;
+    }
+  }
+
+  const normalizedStatus = normalizeTaskStatus(parsed.status);
+  return normalizedStatus != null && TASK_ACTIVE_STATUSES.has(normalizedStatus);
+}
 
 export function deriveScheduledTaskRuntimeStatus(parsed: ScheduledTaskInfo): {
   status: GatewayServiceRuntime["status"];
@@ -165,7 +187,7 @@ export function deriveScheduledTaskRuntimeStatus(parsed: ScheduledTaskInfo): {
 } {
   const normalizedResult = normalizeTaskResultCode(parsed.lastRunResult);
   if (normalizedResult != null) {
-    if (RUNNING_RESULT_CODES.has(normalizedResult)) {
+    if (RUNNING_RESULT_CODES.has(normalizedResult) || QUEUED_RESULT_CODES.has(normalizedResult)) {
       return { status: "running" };
     }
     return {
@@ -303,6 +325,32 @@ function isTaskNotRunning(res: { stdout: string; stderr: string; code: number })
   return detail.includes("not running");
 }
 
+async function queryScheduledTaskInfo(taskName: string): Promise<{
+  res: { stdout: string; stderr: string; code: number };
+  parsed: ScheduledTaskInfo | null;
+}> {
+  const res = await execSchtasks(["/Query", "/TN", taskName, "/V", "/FO", "LIST"]);
+  return {
+    res,
+    parsed: res.code === 0 ? parseSchtasksQuery(res.stdout || "") : null,
+  };
+}
+
+async function waitForScheduledTaskStop(taskName: string): Promise<void> {
+  for (let attempt = 0; attempt < TASK_STOP_WAIT_ATTEMPTS; attempt += 1) {
+    const { parsed: info } = await queryScheduledTaskInfo(taskName);
+    if (!info || !isScheduledTaskActive(info)) {
+      return;
+    }
+    await sleep(TASK_STOP_WAIT_DELAY_MS);
+  }
+
+  const waitSeconds = Math.ceil((TASK_STOP_WAIT_ATTEMPTS * TASK_STOP_WAIT_DELAY_MS) / 1000);
+  throw new Error(
+    `Scheduled Task "${taskName}" did not stop within ${waitSeconds}s after /End; refusing to queue another instance.`,
+  );
+}
+
 export async function stopScheduledTask({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   await assertSchtasksAvailable();
   const taskName = resolveTaskName(env ?? (process.env as GatewayServiceEnv));
@@ -319,7 +367,11 @@ export async function restartScheduledTask({
 }: GatewayServiceControlArgs): Promise<void> {
   await assertSchtasksAvailable();
   const taskName = resolveTaskName(env ?? (process.env as GatewayServiceEnv));
-  await execSchtasks(["/End", "/TN", taskName]);
+  const end = await execSchtasks(["/End", "/TN", taskName]);
+  if (end.code === 0) {
+    // Task Scheduler queues a second launch if /Run races with a still-stopping instance.
+    await waitForScheduledTaskStop(taskName);
+  }
   const res = await execSchtasks(["/Run", "/TN", taskName]);
   if (res.code !== 0) {
     throw new Error(`schtasks run failed: ${res.stderr || res.stdout}`.trim());
@@ -346,8 +398,8 @@ export async function readScheduledTaskRuntime(
     };
   }
   const taskName = resolveTaskName(env);
-  const res = await execSchtasks(["/Query", "/TN", taskName, "/V", "/FO", "LIST"]);
-  if (res.code !== 0) {
+  const { res, parsed } = await queryScheduledTaskInfo(taskName);
+  if (!parsed) {
     const detail = (res.stderr || res.stdout).trim();
     const missing = detail.toLowerCase().includes("cannot find the file");
     return {
@@ -356,7 +408,6 @@ export async function readScheduledTaskRuntime(
       missingUnit: missing,
     };
   }
-  const parsed = parseSchtasksQuery(res.stdout || "");
   const derived = deriveScheduledTaskRuntimeStatus(parsed);
   return {
     status: derived.status,

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -328,26 +328,44 @@ function isTaskNotRunning(res: { stdout: string; stderr: string; code: number })
 async function queryScheduledTaskInfo(taskName: string): Promise<{
   res: { stdout: string; stderr: string; code: number };
   parsed: ScheduledTaskInfo | null;
+  missing: boolean;
 }> {
   const res = await execSchtasks(["/Query", "/TN", taskName, "/V", "/FO", "LIST"]);
+  const detail = (res.stderr || res.stdout).trim().toLowerCase();
   return {
     res,
     parsed: res.code === 0 ? parseSchtasksQuery(res.stdout || "") : null,
+    missing: res.code !== 0 && detail.includes("cannot find the file"),
   };
 }
 
 async function waitForScheduledTaskStop(taskName: string): Promise<void> {
   for (let attempt = 0; attempt < TASK_STOP_WAIT_ATTEMPTS; attempt += 1) {
-    const { parsed: info } = await queryScheduledTaskInfo(taskName);
-    if (!info || !isScheduledTaskActive(info)) {
+    const { res, parsed: info, missing } = await queryScheduledTaskInfo(taskName);
+    if (missing || (info && !isScheduledTaskActive(info))) {
       return;
+    }
+    if (!info) {
+      throw new Error(
+        `schtasks query failed while waiting for "${taskName}" to stop: ${(
+          res.stderr || res.stdout || "unknown error"
+        ).trim()}`.trim(),
+      );
     }
     await sleep(TASK_STOP_WAIT_DELAY_MS);
   }
 
-  const { parsed: finalInfo } = await queryScheduledTaskInfo(taskName);
-  if (!finalInfo || !isScheduledTaskActive(finalInfo)) {
+  const { res: finalRes, parsed: finalInfo, missing: finalMissing } =
+    await queryScheduledTaskInfo(taskName);
+  if (finalMissing || (finalInfo && !isScheduledTaskActive(finalInfo))) {
     return;
+  }
+  if (!finalInfo) {
+    throw new Error(
+      `schtasks query failed while waiting for "${taskName}" to stop: ${(
+        finalRes.stderr || finalRes.stdout || "unknown error"
+      ).trim()}`.trim(),
+    );
   }
 
   const waitSeconds = Math.ceil((TASK_STOP_WAIT_ATTEMPTS * TASK_STOP_WAIT_DELAY_MS) / 1000);
@@ -403,10 +421,9 @@ export async function readScheduledTaskRuntime(
     };
   }
   const taskName = resolveTaskName(env);
-  const { res, parsed } = await queryScheduledTaskInfo(taskName);
+  const { res, parsed, missing } = await queryScheduledTaskInfo(taskName);
   if (!parsed) {
     const detail = (res.stderr || res.stdout).trim();
-    const missing = detail.toLowerCase().includes("cannot find the file");
     return {
       status: missing ? "stopped" : "unknown",
       detail: detail || undefined,


### PR DESCRIPTION
## Summary

Fix Windows gateway restarts getting stuck in Task Scheduler `Queue` after `openclaw gateway restart`.

The root cause was that the Scheduled Task restart path called `schtasks /Run` immediately after `schtasks /End`, which can race with the previous task instance still shutting down. When that happens, Task Scheduler queues the new run instead of starting it right away.

This change:
- waits for the existing Scheduled Task instance to fully stop after `/End` before issuing `/Run`
- treats `0x41325` (`Queued`) as an active task state during runtime detection
- adds regression coverage for `Running -> Ready -> /Run` and `Queued -> Ready -> /Run` restart flows

## Issue

- fixes [#43134](https://github.com/openclaw/openclaw/issues/43134)

## Testing

```bash
pnpm exec vitest run src/daemon/schtasks.restart.test.ts src/daemon/schtasks.test.ts src/infra/windows-task-restart.test.ts src/infra/process-respawn.test.ts
pnpm exec tsc --noEmit
