### PR TITLE
Clarify Telegram attachment delivery guidance in agent prompts

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -254,6 +254,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 - DM messages can carry `message_thread_id`; OpenClaw routes them with thread-aware session keys and preserves thread ID for replies.
 - Long polling uses grammY runner with per-chat/per-thread sequencing. Overall runner sink concurrency uses `agents.defaults.maxConcurrent`.
 - Telegram Bot API has no read-receipt support (`sendReadReceipts` does not apply).
+- Agent-generated attachments should use OpenClaw delivery primitives: `MEDIA:<path-or-url>` in the reply, or the `message` tool `media` / `filePath` / `buffer` fields for proactive sends. Do not script raw `sendDocument` / `sendPhoto` Bot API calls from the agent for normal delivery.
 
 ## Feature reference
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -254,7 +254,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 - DM messages can carry `message_thread_id`; OpenClaw routes them with thread-aware session keys and preserves thread ID for replies.
 - Long polling uses grammY runner with per-chat/per-thread sequencing. Overall runner sink concurrency uses `agents.defaults.maxConcurrent`.
 - Telegram Bot API has no read-receipt support (`sendReadReceipts` does not apply).
-- Agent-generated attachments should use OpenClaw delivery primitives: `MEDIA:<path-or-url>` in the reply, or the `message` tool `media` / `filePath` / `buffer` fields for proactive sends. Do not script raw `sendDocument` / `sendPhoto` Bot API calls from the agent for normal delivery.
+- Agent-generated attachments should use OpenClaw delivery primitives: `MEDIA:<path-or-url>` in the reply, or the `message` tool `media` / `path` / `filePath` fields for proactive sends. If you need a base64 `buffer` / `filename` payload, use `action=sendAttachment`. Do not script raw `sendDocument` / `sendPhoto` Bot API calls from the agent for normal delivery.
 
 ## Feature reference
 

--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -4,6 +4,7 @@ import { listKnownProviderEnvApiKeyNames } from "./model-auth-env-vars.js";
 export const MINIMAX_OAUTH_MARKER = "minimax-oauth";
 export const QWEN_OAUTH_MARKER = "qwen-oauth";
 export const OLLAMA_LOCAL_AUTH_MARKER = "ollama-local";
+export const CUSTOM_NO_AUTH_MARKER = "custom-no-auth";
 export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
 export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
 
@@ -71,6 +72,7 @@ export function isNonSecretApiKeyMarker(
     trimmed === MINIMAX_OAUTH_MARKER ||
     trimmed === QWEN_OAUTH_MARKER ||
     trimmed === OLLAMA_LOCAL_AUTH_MARKER ||
+    trimmed === CUSTOM_NO_AUTH_MARKER ||
     trimmed === NON_ENV_SECRETREF_MARKER ||
     isAwsSdkAuthMarker(trimmed);
   if (isKnownMarker) {

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AuthProfileStore } from "./auth-profiles.js";
-import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
+import { CUSTOM_NO_AUTH_MARKER, NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import {
   hasUsableCustomProviderApiKey,
   requireApiKey,
@@ -126,6 +126,27 @@ describe("requireApiKey", () => {
 });
 
 describe("resolveUsableCustomProviderApiKey", () => {
+  it("returns the custom no-auth marker for onboarding-generated custom providers", () => {
+    const resolved = resolveUsableCustomProviderApiKey({
+      cfg: {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://example.com/v1",
+              apiKey: CUSTOM_NO_AUTH_MARKER,
+              models: [],
+            },
+          },
+        },
+      },
+      provider: "custom",
+    });
+    expect(resolved).toEqual({
+      apiKey: CUSTOM_NO_AUTH_MARKER,
+      source: "models.json (custom provider no-auth marker)",
+    });
+  });
+
   it("returns literal custom provider keys", () => {
     const resolved = resolveUsableCustomProviderApiKey({
       cfg: {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -19,6 +19,7 @@ import {
 } from "./auth-profiles.js";
 import { PROVIDER_ENV_API_KEY_CANDIDATES } from "./model-auth-env-vars.js";
 import {
+  CUSTOM_NO_AUTH_MARKER,
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
   OLLAMA_LOCAL_AUTH_MARKER,
@@ -77,6 +78,12 @@ export function resolveUsableCustomProviderApiKey(params: {
   const customKey = getCustomProviderApiKey(params.cfg, params.provider);
   if (!customKey) {
     return null;
+  }
+  if (customKey === CUSTOM_NO_AUTH_MARKER) {
+    return {
+      apiKey: CUSTOM_NO_AUTH_MARKER,
+      source: "models.json (custom provider no-auth marker)",
+    };
   }
   if (!isNonSecretApiKeyMarker(customKey)) {
     return { apiKey: customKey, source: "models.json" };

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -213,6 +213,24 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("do not forward raw internal metadata");
   });
 
+  it("guides attachment delivery without raw provider API calls", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["message"],
+    });
+
+    expect(prompt).toContain(
+      "Do not use exec/curl for normal outbound provider messaging; OpenClaw handles user-visible delivery internally.",
+    );
+    expect(prompt).toContain(
+      "Provider API calls via exec/curl are only for setup or diagnostics when the docs explicitly instruct them.",
+    );
+    expect(prompt).toContain("To attach media in the current reply, put `MEDIA:<path-or-url>` on its own line.");
+    expect(prompt).toContain(
+      "For `action=send` attachments, use `media` (URL/path) or `filePath`/`buffer` instead of calling provider APIs directly.",
+    );
+  });
+
   it("guides subagent workflows to avoid polling loops", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -225,7 +225,9 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       "Provider API calls via exec/curl are only for setup or diagnostics when the docs explicitly instruct them.",
     );
-    expect(prompt).toContain("To attach media in the current reply, put `MEDIA:<path-or-url>` on its own line.");
+    expect(prompt).toContain(
+      "To attach media in the current reply, put `MEDIA:<path-or-url>` on its own line.",
+    );
     expect(prompt).toContain(
       "For `action=send` attachments, use `media` (URL/path) or `filePath`/`buffer` instead of calling provider APIs directly.",
     );

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -229,7 +229,7 @@ describe("buildAgentSystemPrompt", () => {
       "To attach media in the current reply, put `MEDIA:<path-or-url>` on its own line.",
     );
     expect(prompt).toContain(
-      "For `action=send` attachments, use `media` (URL/path) or `filePath`/`buffer` instead of calling provider APIs directly.",
+      "For `action=send` attachments, use `media` (URL/path) or `path`/`filePath`; use `action=sendAttachment` when you need `buffer`/`filename` payloads.",
     );
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -134,13 +134,16 @@ function buildMessagingSection(params: {
     "- Cross-session messaging → use sessions_send(sessionKey, message)",
     "- Sub-agent orchestration → use subagents(action=list|steer|kill)",
     `- Runtime-generated completion events may ask for a user update. Rewrite those in your normal assistant voice and send the update (do not forward raw internal metadata or default to ${SILENT_REPLY_TOKEN}).`,
-    "- Never use exec/curl for provider messaging; OpenClaw handles all routing internally.",
+    "- Do not use exec/curl for normal outbound provider messaging; OpenClaw handles user-visible delivery internally.",
+    "- Provider API calls via exec/curl are only for setup or diagnostics when the docs explicitly instruct them.",
+    "- To attach media in the current reply, put `MEDIA:<path-or-url>` on its own line.",
     params.availableTools.has("message")
       ? [
           "",
           "### message tool",
           "- Use `message` for proactive sends + channel actions (polls, reactions, etc.).",
           "- For `action=send`, include `to` and `message`.",
+          "- For `action=send` attachments, use `media` (URL/path) or `filePath`/`buffer` instead of calling provider APIs directly.",
           `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
           `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
           params.inlineButtonsEnabled

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -143,7 +143,7 @@ function buildMessagingSection(params: {
           "### message tool",
           "- Use `message` for proactive sends + channel actions (polls, reactions, etc.).",
           "- For `action=send`, include `to` and `message`.",
-          "- For `action=send` attachments, use `media` (URL/path) or `filePath`/`buffer` instead of calling provider APIs directly.",
+          "- For `action=send` attachments, use `media` (URL/path) or `path`/`filePath`; use `action=sendAttachment` when you need `buffer`/`filename` payloads.",
           `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
           `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
           params.inlineButtonsEnabled

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -252,6 +252,33 @@ describe("message tool schema scoping", () => {
     expect(actionEnum).toContain("poll");
   });
 
+  it("documents buffer as a sendAttachment-only payload field", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "telegram",
+    });
+    const properties = getToolProperties(tool);
+    const mediaDescription = (
+      properties.media as {
+        description?: string;
+      }
+    )?.description;
+    const bufferDescription = (
+      properties.buffer as {
+        description?: string;
+      }
+    )?.description;
+
+    expect(mediaDescription).toContain("For action=send, use media/path/filePath.");
+    expect(mediaDescription).toContain("use action=sendAttachment with buffer");
+    expect(bufferDescription).toContain("sendAttachment");
+    expect(bufferDescription).toContain("action=send ignores this field");
+  });
+
   it("hides telegram poll extras when telegram polls are disabled in scoped mode", () => {
     const telegramPluginWithConfig = createChannelPlugin({
       id: "telegram",

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -178,13 +178,15 @@ function buildSendSchema(options: {
     ),
     media: Type.Optional(
       Type.String({
-        description: "Media URL or local path. data: URLs are not supported here, use buffer.",
+        description:
+          "Media URL or local path. For action=send, use media/path/filePath. If you need a base64 or data: payload, use action=sendAttachment with buffer.",
       }),
     ),
     filename: Type.Optional(Type.String()),
     buffer: Type.Optional(
       Type.String({
-        description: "Base64 payload for attachments (optionally a data: URL).",
+        description:
+          "Base64 payload for attachment-style actions such as sendAttachment (optionally a data: URL). action=send ignores this field.",
       }),
     ),
     contentType: Type.Optional(Type.String()),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -82,16 +82,25 @@ async function createEphemeralSessionFileClone(sessionFile: string): Promise<{
   cleanup: () => Promise<void>;
 }> {
   const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-session-"));
-  const clonedSessionFile = path.join(tempDir, path.basename(sessionFile) || "session.jsonl");
-  if (fs.existsSync(sessionFile)) {
-    await fsPromises.copyFile(sessionFile, clonedSessionFile);
-  }
-  return {
-    sessionFile: clonedSessionFile,
-    cleanup: async () => {
+  try {
+    const clonedSessionFile = path.join(tempDir, path.basename(sessionFile) || "session.jsonl");
+    if (fs.existsSync(sessionFile)) {
+      await fsPromises.copyFile(sessionFile, clonedSessionFile);
+    }
+    return {
+      sessionFile: clonedSessionFile,
+      cleanup: async () => {
+        await fsPromises.rm(tempDir, { recursive: true, force: true });
+      },
+    };
+  } catch (err) {
+    try {
       await fsPromises.rm(tempDir, { recursive: true, force: true });
-    },
-  };
+    } catch (cleanupErr) {
+      logVerbose(`heartbeat session clone setup cleanup failed: ${String(cleanupErr)}`);
+    }
+    throw err;
+  }
 }
 
 type EphemeralSessionFileClone = Awaited<ReturnType<typeof createEphemeralSessionFileClone>>;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,5 +1,8 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
@@ -73,6 +76,23 @@ export type AgentRunLoopResult =
       directlySentBlockKeys?: Set<string>;
     }
   | { kind: "final"; payload: ReplyPayload };
+
+async function createEphemeralSessionFileClone(sessionFile: string): Promise<{
+  sessionFile: string;
+  cleanup: () => Promise<void>;
+}> {
+  const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-session-"));
+  const clonedSessionFile = path.join(tempDir, path.basename(sessionFile) || "session.jsonl");
+  if (fs.existsSync(sessionFile)) {
+    await fsPromises.copyFile(sessionFile, clonedSessionFile);
+  }
+  return {
+    sessionFile: clonedSessionFile,
+    cleanup: async () => {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    },
+  };
+}
 
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
@@ -224,13 +244,17 @@ export async function runAgentTurnWithFallback(params: {
             });
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
             return (async () => {
+              const sessionClone = params.isHeartbeat
+                ? await createEphemeralSessionFileClone(params.followupRun.run.sessionFile)
+                : null;
+              const sessionFile = sessionClone?.sessionFile ?? params.followupRun.run.sessionFile;
               let lifecycleTerminalEmitted = false;
               try {
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
                   sessionKey: params.sessionKey,
                   agentId: params.followupRun.run.agentId,
-                  sessionFile: params.followupRun.run.sessionFile,
+                  sessionFile,
                   workspaceDir: params.followupRun.run.workspaceDir,
                   config: params.followupRun.run.config,
                   prompt: params.commandBody,
@@ -305,6 +329,7 @@ export async function runAgentTurnWithFallback(params: {
                     },
                   });
                 }
+                await sessionClone?.cleanup();
               }
             })();
           }
@@ -323,150 +348,159 @@ export async function runAgentTurnWithFallback(params: {
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
           });
           return (async () => {
-            const result = await runEmbeddedPiAgent({
-              ...embeddedContext,
-              trigger: params.isHeartbeat ? "heartbeat" : "user",
-              groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
-              groupChannel:
-                params.sessionCtx.GroupChannel?.trim() ?? params.sessionCtx.GroupSubject?.trim(),
-              groupSpace: params.sessionCtx.GroupSpace?.trim() ?? undefined,
-              ...senderContext,
-              ...runBaseParams,
-              prompt: params.commandBody,
-              extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-              toolResultFormat: (() => {
-                const channel = resolveMessageChannel(
-                  params.sessionCtx.Surface,
-                  params.sessionCtx.Provider,
-                );
-                if (!channel) {
-                  return "markdown";
-                }
-                return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
-              })(),
-              suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
-              bootstrapContextMode: params.opts?.bootstrapContextMode,
-              bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
-              images: params.opts?.images,
-              abortSignal: params.opts?.abortSignal,
-              blockReplyBreak: params.resolvedBlockStreamingBreak,
-              blockReplyChunking: params.blockReplyChunking,
-              onPartialReply: async (payload) => {
-                const textForTyping = await handlePartialForTyping(payload);
-                if (!params.opts?.onPartialReply || textForTyping === undefined) {
-                  return;
-                }
-                await params.opts.onPartialReply({
-                  text: textForTyping,
-                  mediaUrls: payload.mediaUrls,
-                });
-              },
-              onAssistantMessageStart: async () => {
-                await params.typingSignals.signalMessageStart();
-                await params.opts?.onAssistantMessageStart?.();
-              },
-              onReasoningStream:
-                params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
-                  ? async (payload) => {
-                      await params.typingSignals.signalReasoningDelta();
-                      await params.opts?.onReasoningStream?.({
-                        text: payload.text,
-                        mediaUrls: payload.mediaUrls,
-                      });
-                    }
-                  : undefined,
-              onReasoningEnd: params.opts?.onReasoningEnd,
-              onAgentEvent: async (evt) => {
-                // Signal run start only after the embedded agent emits real activity.
-                const hasLifecyclePhase =
-                  evt.stream === "lifecycle" && typeof evt.data.phase === "string";
-                if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
-                  notifyAgentRunStart();
-                }
-                // Trigger typing when tools start executing.
-                // Must await to ensure typing indicator starts before tool summaries are emitted.
-                if (evt.stream === "tool") {
-                  const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
-                  const name = typeof evt.data.name === "string" ? evt.data.name : undefined;
-                  if (phase === "start" || phase === "update") {
-                    await params.typingSignals.signalToolStart();
-                    await params.opts?.onToolStart?.({ name, phase });
+            const sessionClone = params.isHeartbeat
+              ? await createEphemeralSessionFileClone(params.followupRun.run.sessionFile)
+              : null;
+            const sessionFile = sessionClone?.sessionFile ?? params.followupRun.run.sessionFile;
+            try {
+              const result = await runEmbeddedPiAgent({
+                ...embeddedContext,
+                trigger: params.isHeartbeat ? "heartbeat" : "user",
+                groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
+                groupChannel:
+                  params.sessionCtx.GroupChannel?.trim() ?? params.sessionCtx.GroupSubject?.trim(),
+                groupSpace: params.sessionCtx.GroupSpace?.trim() ?? undefined,
+                ...senderContext,
+                ...runBaseParams,
+                sessionFile,
+                prompt: params.commandBody,
+                extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                toolResultFormat: (() => {
+                  const channel = resolveMessageChannel(
+                    params.sessionCtx.Surface,
+                    params.sessionCtx.Provider,
+                  );
+                  if (!channel) {
+                    return "markdown";
                   }
-                }
-                // Track auto-compaction completion
-                if (evt.stream === "compaction") {
-                  const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
-                  if (phase === "end") {
-                    autoCompactionCompleted = true;
+                  return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
+                })(),
+                suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
+                bootstrapContextMode: params.opts?.bootstrapContextMode,
+                bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
+                images: params.opts?.images,
+                abortSignal: params.opts?.abortSignal,
+                blockReplyBreak: params.resolvedBlockStreamingBreak,
+                blockReplyChunking: params.blockReplyChunking,
+                onPartialReply: async (payload) => {
+                  const textForTyping = await handlePartialForTyping(payload);
+                  if (!params.opts?.onPartialReply || textForTyping === undefined) {
+                    return;
                   }
-                }
-              },
-              // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
-              // even when regular block streaming is disabled. The handler sends directly
-              // via opts.onBlockReply when the pipeline isn't available.
-              onBlockReply: params.opts?.onBlockReply
-                ? createBlockReplyDeliveryHandler({
-                    onBlockReply: params.opts.onBlockReply,
-                    currentMessageId:
-                      params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
-                    normalizeStreamingText,
-                    applyReplyToMode: params.applyReplyToMode,
-                    normalizeMediaPaths: normalizeReplyMediaPaths,
-                    typingSignals: params.typingSignals,
-                    blockStreamingEnabled: params.blockStreamingEnabled,
-                    blockReplyPipeline,
-                    directlySentBlockKeys,
-                  })
-                : undefined,
-              onBlockReplyFlush:
-                params.blockStreamingEnabled && blockReplyPipeline
-                  ? async () => {
-                      await blockReplyPipeline.flush({ force: true });
-                    }
-                  : undefined,
-              shouldEmitToolResult: params.shouldEmitToolResult,
-              shouldEmitToolOutput: params.shouldEmitToolOutput,
-              bootstrapPromptWarningSignaturesSeen,
-              bootstrapPromptWarningSignature:
-                bootstrapPromptWarningSignaturesSeen[
-                  bootstrapPromptWarningSignaturesSeen.length - 1
-                ],
-              onToolResult: onToolResult
-                ? (() => {
-                    // Serialize tool result delivery to preserve message ordering.
-                    // Without this, concurrent tool callbacks race through typing signals
-                    // and message sends, causing out-of-order delivery to the user.
-                    // See: https://github.com/openclaw/openclaw/issues/11044
-                    let toolResultChain: Promise<void> = Promise.resolve();
-                    return (payload: ReplyPayload) => {
-                      toolResultChain = toolResultChain
-                        .then(async () => {
-                          const { text, skip } = normalizeStreamingText(payload);
-                          if (skip) {
-                            return;
-                          }
-                          await params.typingSignals.signalTextDelta(text);
-                          await onToolResult({
-                            ...payload,
-                            text,
-                          });
-                        })
-                        .catch((err) => {
-                          // Keep chain healthy after an error so later tool results still deliver.
-                          logVerbose(`tool result delivery failed: ${String(err)}`);
+                  await params.opts.onPartialReply({
+                    text: textForTyping,
+                    mediaUrls: payload.mediaUrls,
+                  });
+                },
+                onAssistantMessageStart: async () => {
+                  await params.typingSignals.signalMessageStart();
+                  await params.opts?.onAssistantMessageStart?.();
+                },
+                onReasoningStream:
+                  params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
+                    ? async (payload) => {
+                        await params.typingSignals.signalReasoningDelta();
+                        await params.opts?.onReasoningStream?.({
+                          text: payload.text,
+                          mediaUrls: payload.mediaUrls,
                         });
-                      const task = toolResultChain.finally(() => {
-                        params.pendingToolTasks.delete(task);
-                      });
-                      params.pendingToolTasks.add(task);
-                    };
-                  })()
-                : undefined,
-            });
-            bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-              result.meta?.systemPromptReport,
-            );
-            return result;
+                      }
+                    : undefined,
+                onReasoningEnd: params.opts?.onReasoningEnd,
+                onAgentEvent: async (evt) => {
+                  // Signal run start only after the embedded agent emits real activity.
+                  const hasLifecyclePhase =
+                    evt.stream === "lifecycle" && typeof evt.data.phase === "string";
+                  if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
+                    notifyAgentRunStart();
+                  }
+                  // Trigger typing when tools start executing.
+                  // Must await to ensure typing indicator starts before tool summaries are emitted.
+                  if (evt.stream === "tool") {
+                    const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                    const name = typeof evt.data.name === "string" ? evt.data.name : undefined;
+                    if (phase === "start" || phase === "update") {
+                      await params.typingSignals.signalToolStart();
+                      await params.opts?.onToolStart?.({ name, phase });
+                    }
+                  }
+                  // Track auto-compaction completion
+                  if (evt.stream === "compaction") {
+                    const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                    if (phase === "end") {
+                      autoCompactionCompleted = true;
+                    }
+                  }
+                },
+                // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
+                // even when regular block streaming is disabled. The handler sends directly
+                // via opts.onBlockReply when the pipeline isn't available.
+                onBlockReply: params.opts?.onBlockReply
+                  ? createBlockReplyDeliveryHandler({
+                      onBlockReply: params.opts.onBlockReply,
+                      currentMessageId:
+                        params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
+                      normalizeStreamingText,
+                      applyReplyToMode: params.applyReplyToMode,
+                      normalizeMediaPaths: normalizeReplyMediaPaths,
+                      typingSignals: params.typingSignals,
+                      blockStreamingEnabled: params.blockStreamingEnabled,
+                      blockReplyPipeline,
+                      directlySentBlockKeys,
+                    })
+                  : undefined,
+                onBlockReplyFlush:
+                  params.blockStreamingEnabled && blockReplyPipeline
+                    ? async () => {
+                        await blockReplyPipeline.flush({ force: true });
+                      }
+                    : undefined,
+                shouldEmitToolResult: params.shouldEmitToolResult,
+                shouldEmitToolOutput: params.shouldEmitToolOutput,
+                bootstrapPromptWarningSignaturesSeen,
+                bootstrapPromptWarningSignature:
+                  bootstrapPromptWarningSignaturesSeen[
+                    bootstrapPromptWarningSignaturesSeen.length - 1
+                  ],
+                onToolResult: onToolResult
+                  ? (() => {
+                      // Serialize tool result delivery to preserve message ordering.
+                      // Without this, concurrent tool callbacks race through typing signals
+                      // and message sends, causing out-of-order delivery to the user.
+                      // See: https://github.com/openclaw/openclaw/issues/11044
+                      let toolResultChain: Promise<void> = Promise.resolve();
+                      return (payload: ReplyPayload) => {
+                        toolResultChain = toolResultChain
+                          .then(async () => {
+                            const { text, skip } = normalizeStreamingText(payload);
+                            if (skip) {
+                              return;
+                            }
+                            await params.typingSignals.signalTextDelta(text);
+                            await onToolResult({
+                              ...payload,
+                              text,
+                            });
+                          })
+                          .catch((err) => {
+                            // Keep chain healthy after an error so later tool results still deliver.
+                            logVerbose(`tool result delivery failed: ${String(err)}`);
+                          });
+                        const task = toolResultChain.finally(() => {
+                          params.pendingToolTasks.delete(task);
+                        });
+                        params.pendingToolTasks.add(task);
+                      };
+                    })()
+                  : undefined,
+              });
+              bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+                result.meta?.systemPromptReport,
+              );
+              return result;
+            } finally {
+              await sessionClone?.cleanup();
+            }
           })();
         },
       });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -260,18 +260,15 @@ export async function runAgentTurnWithFallback(params: {
             });
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
             return (async () => {
-              let sessionClone: EphemeralSessionFileClone | null = null;
               let lifecycleTerminalEmitted = false;
               try {
-                sessionClone = params.isHeartbeat
-                  ? await createEphemeralSessionFileClone(params.followupRun.run.sessionFile)
-                  : null;
-                const sessionFile = sessionClone?.sessionFile ?? params.followupRun.run.sessionFile;
+                // CLI backends currently do not read or write session transcripts, so
+                // heartbeat transcript isolation only applies to the embedded path below.
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
                   sessionKey: params.sessionKey,
                   agentId: params.followupRun.run.agentId,
-                  sessionFile,
+                  sessionFile: params.followupRun.run.sessionFile,
                   workspaceDir: params.followupRun.run.workspaceDir,
                   config: params.followupRun.run.config,
                   prompt: params.commandBody,
@@ -346,10 +343,6 @@ export async function runAgentTurnWithFallback(params: {
                     },
                   });
                 }
-                await cleanupEphemeralSessionFileClone({
-                  sessionClone,
-                  label: "cli",
-                });
               }
             })();
           }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -94,6 +94,22 @@ async function createEphemeralSessionFileClone(sessionFile: string): Promise<{
   };
 }
 
+type EphemeralSessionFileClone = Awaited<ReturnType<typeof createEphemeralSessionFileClone>>;
+
+async function cleanupEphemeralSessionFileClone(params: {
+  sessionClone: EphemeralSessionFileClone | null;
+  label: "cli" | "embedded";
+}): Promise<void> {
+  if (!params.sessionClone) {
+    return;
+  }
+  try {
+    await params.sessionClone.cleanup();
+  } catch (err) {
+    logVerbose(`heartbeat session clone cleanup failed (${params.label}): ${String(err)}`);
+  }
+}
+
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -244,8 +260,7 @@ export async function runAgentTurnWithFallback(params: {
             });
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
             return (async () => {
-              let sessionClone: Awaited<ReturnType<typeof createEphemeralSessionFileClone>> | null =
-                null;
+              let sessionClone: EphemeralSessionFileClone | null = null;
               let lifecycleTerminalEmitted = false;
               try {
                 sessionClone = params.isHeartbeat
@@ -331,7 +346,10 @@ export async function runAgentTurnWithFallback(params: {
                     },
                   });
                 }
-                await sessionClone?.cleanup();
+                await cleanupEphemeralSessionFileClone({
+                  sessionClone,
+                  label: "cli",
+                });
               }
             })();
           }
@@ -501,7 +519,10 @@ export async function runAgentTurnWithFallback(params: {
               );
               return result;
             } finally {
-              await sessionClone?.cleanup();
+              await cleanupEphemeralSessionFileClone({
+                sessionClone,
+                label: "embedded",
+              });
             }
           })();
         },

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -84,8 +84,15 @@ async function createEphemeralSessionFileClone(sessionFile: string): Promise<{
   const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-session-"));
   try {
     const clonedSessionFile = path.join(tempDir, path.basename(sessionFile) || "session.jsonl");
-    if (fs.existsSync(sessionFile)) {
+    try {
       await fsPromises.copyFile(sessionFile, clonedSessionFile);
+    } catch (err) {
+      // Heartbeats can race with transcript rotation/reset. If the source
+      // session file disappears before the clone copy starts, continue with
+      // an empty clone instead of failing the run.
+      if ((err as NodeJS.ErrnoException | null)?.code !== "ENOENT") {
+        throw err;
+      }
     }
     return {
       sessionFile: clonedSessionFile,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -244,12 +244,14 @@ export async function runAgentTurnWithFallback(params: {
             });
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
             return (async () => {
-              const sessionClone = params.isHeartbeat
-                ? await createEphemeralSessionFileClone(params.followupRun.run.sessionFile)
-                : null;
-              const sessionFile = sessionClone?.sessionFile ?? params.followupRun.run.sessionFile;
+              let sessionClone: Awaited<ReturnType<typeof createEphemeralSessionFileClone>> | null =
+                null;
               let lifecycleTerminalEmitted = false;
               try {
+                sessionClone = params.isHeartbeat
+                  ? await createEphemeralSessionFileClone(params.followupRun.run.sessionFile)
+                  : null;
+                const sessionFile = sessionClone?.sessionFile ?? params.followupRun.run.sessionFile;
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
                   sessionKey: params.sessionKey,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -521,6 +521,39 @@ describe("runReplyAgent heartbeat transcript isolation", () => {
       }
     });
   });
+
+  it("cleans up the temp dir when embedded heartbeat clone copy fails during setup", async () => {
+    await withTempSessionFile("seed", async (sessionFile) => {
+      const realMkdtemp = fs.mkdtemp.bind(fs);
+      const createdDirs: string[] = [];
+      const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockImplementation(async (prefix) => {
+        const dir = await realMkdtemp(prefix);
+        createdDirs.push(dir);
+        return dir;
+      });
+      const copyFileSpy = vi.spyOn(fs, "copyFile").mockRejectedValueOnce(new Error("copy failed"));
+
+      try {
+        const { run } = createMinimalRun({
+          opts: { isHeartbeat: true },
+          runOverrides: { sessionFile },
+        });
+
+        const result = await run();
+        const payload = Array.isArray(result)
+          ? (result[0] as { text?: string } | undefined)
+          : (result as { text?: string } | undefined);
+
+        expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+        expect(payload?.text).toContain("copy failed");
+        expect(createdDirs).toHaveLength(1);
+        expect(await pathExists(createdDirs[0])).toBe(false);
+      } finally {
+        copyFileSpy.mockRestore();
+        mkdtempSpy.mockRestore();
+      }
+    });
+  });
 });
 
 describe("runReplyAgent typing (heartbeat)", () => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -26,6 +26,7 @@ type AgentRunParams = {
 };
 
 type EmbeddedRunParams = {
+  sessionFile?: string;
   prompt?: string;
   extraSystemPrompt?: string;
   memoryFlushWritePath?: string;
@@ -289,6 +290,39 @@ async function runReplyAgentWithBase(params: {
   });
 }
 
+const makeTranscriptMessageLine = (text: string) =>
+  `${JSON.stringify({
+    type: "message",
+    message: {
+      role: "user",
+      content: [{ type: "text", text }],
+    },
+  })}\n`;
+
+async function withTempSessionFile<T>(
+  seedText: string,
+  fn: (sessionFile: string, seeded: string) => Promise<T>,
+): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(tmpdir(), "openclaw-heartbeat-sessionfile-"));
+  const sessionFile = path.join(dir, "session.jsonl");
+  const seeded = makeTranscriptMessageLine(seedText);
+  await fs.writeFile(sessionFile, seeded, "utf-8");
+  try {
+    return await fn(sessionFile, seeded);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("runReplyAgent heartbeat followup guard", () => {
   it("drops heartbeat runs when another run is active", async () => {
     const { run, typing } = createMinimalRun({
@@ -338,6 +372,105 @@ describe("runReplyAgent heartbeat followup guard", () => {
     } finally {
       persistSpy.mockRestore();
     }
+  });
+});
+
+describe("runReplyAgent heartbeat transcript isolation", () => {
+  it("writes normal run transcript updates to the live session file", async () => {
+    await withTempSessionFile("seed", async (sessionFile) => {
+      const appendedText = "normal transcript write";
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedRunParams) => {
+        await fs.appendFile(
+          String(params.sessionFile),
+          makeTranscriptMessageLine(appendedText),
+          "utf-8",
+        );
+        return { payloads: [{ text: "ok" }], meta: {} };
+      });
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: false },
+        runOverrides: { sessionFile },
+      });
+
+      await run();
+
+      const liveRaw = await fs.readFile(sessionFile, "utf-8");
+      expect(liveRaw).toContain(appendedText);
+
+      const embeddedCall = state.runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0] as
+        | EmbeddedRunParams
+        | undefined;
+      expect(embeddedCall?.sessionFile).toBe(sessionFile);
+    });
+  });
+
+  it("routes heartbeat transcript writes into a temporary clone instead of the live session file", async () => {
+    await withTempSessionFile("seed", async (sessionFile, seeded) => {
+      const appendedText = "Read HEARTBEAT.md and process exec completion";
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedRunParams) => {
+        await fs.appendFile(
+          String(params.sessionFile),
+          makeTranscriptMessageLine(appendedText),
+          "utf-8",
+        );
+        return { payloads: [{ text: "ok" }], meta: {} };
+      });
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: true },
+        runOverrides: { sessionFile },
+      });
+
+      await run();
+
+      const liveRaw = await fs.readFile(sessionFile, "utf-8");
+      expect(liveRaw).toBe(seeded);
+      expect(liveRaw).not.toContain("HEARTBEAT.md");
+
+      const embeddedCall = state.runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0] as
+        | EmbeddedRunParams
+        | undefined;
+      expect(embeddedCall?.sessionFile).toBeDefined();
+      expect(embeddedCall?.sessionFile).not.toBe(sessionFile);
+      expect(await pathExists(String(embeddedCall?.sessionFile))).toBe(false);
+    });
+  });
+
+  it("isolates heartbeat transcript writes for CLI providers too", async () => {
+    await withTempSessionFile("seed", async (sessionFile, seeded) => {
+      const appendedText = "cli heartbeat transcript write";
+      state.runCliAgentMock.mockImplementationOnce(async (params: { sessionFile?: string }) => {
+        await fs.appendFile(
+          String(params.sessionFile),
+          makeTranscriptMessageLine(appendedText),
+          "utf-8",
+        );
+        return { payloads: [{ text: "ok" }], meta: {} };
+      });
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: true },
+        runOverrides: {
+          sessionFile,
+          provider: "claude-cli",
+          model: "sonnet",
+        },
+      });
+
+      await run();
+
+      const liveRaw = await fs.readFile(sessionFile, "utf-8");
+      expect(liveRaw).toBe(seeded);
+      expect(liveRaw).not.toContain(appendedText);
+
+      const cliCall = state.runCliAgentMock.mock.calls.at(-1)?.[0] as
+        | { sessionFile?: string }
+        | undefined;
+      expect(cliCall?.sessionFile).toBeDefined();
+      expect(cliCall?.sessionFile).not.toBe(sessionFile);
+      expect(await pathExists(String(cliCall?.sessionFile))).toBe(false);
+    });
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -472,6 +472,48 @@ describe("runReplyAgent heartbeat transcript isolation", () => {
       expect(await pathExists(String(cliCall?.sessionFile))).toBe(false);
     });
   });
+
+  it("emits a terminal lifecycle error when CLI heartbeat clone creation fails", async () => {
+    await withTempSessionFile("seed", async (sessionFile) => {
+      const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockRejectedValueOnce(new Error("mkdtemp failed"));
+      const phases: string[] = [];
+      const lifecycleErrors: string[] = [];
+      const off = onAgentEvent((evt) => {
+        const phase = typeof evt.data?.phase === "string" ? evt.data.phase : null;
+        if (evt.stream !== "lifecycle" || !phase) {
+          return;
+        }
+        phases.push(phase);
+        if (phase === "error" && typeof evt.data.error === "string") {
+          lifecycleErrors.push(evt.data.error);
+        }
+      });
+
+      try {
+        const { run } = createMinimalRun({
+          opts: { isHeartbeat: true },
+          runOverrides: {
+            sessionFile,
+            provider: "claude-cli",
+            model: "sonnet",
+          },
+        });
+
+        const result = await run();
+        const payload = Array.isArray(result)
+          ? (result[0] as { text?: string } | undefined)
+          : (result as { text?: string } | undefined);
+
+        expect(state.runCliAgentMock).not.toHaveBeenCalled();
+        expect(payload?.text).toContain("mkdtemp failed");
+        expect(phases).toEqual(["start", "error"]);
+        expect(lifecycleErrors).toContain("Error: mkdtemp failed");
+      } finally {
+        off();
+        mkdtempSpy.mockRestore();
+      }
+    });
+  });
 });
 
 describe("runReplyAgent typing (heartbeat)", () => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -473,6 +473,88 @@ describe("runReplyAgent heartbeat transcript isolation", () => {
     });
   });
 
+  it("does not fail a successful embedded heartbeat run when clone cleanup fails", async () => {
+    await withTempSessionFile("seed", async (sessionFile, seeded) => {
+      const realRm = fs.rm.bind(fs);
+      const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+        if (String(target).includes("openclaw-heartbeat-session-")) {
+          throw new Error("cleanup failed");
+        }
+        return await realRm(target, options);
+      });
+      const globals = await import("../../globals.js");
+      const logVerboseSpy = vi.spyOn(globals, "logVerbose").mockImplementation(() => {});
+      state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+        payloads: [{ text: "ok" }],
+        meta: {},
+      });
+
+      try {
+        const { run } = createMinimalRun({
+          opts: { isHeartbeat: true },
+          runOverrides: { sessionFile },
+        });
+
+        const result = await run();
+        const payload = Array.isArray(result)
+          ? (result[0] as { text?: string } | undefined)
+          : (result as { text?: string } | undefined);
+
+        expect(payload?.text).toBe("ok");
+        expect(await fs.readFile(sessionFile, "utf-8")).toBe(seeded);
+        expect(logVerboseSpy).toHaveBeenCalledWith(
+          expect.stringContaining("heartbeat session clone cleanup failed (embedded)"),
+        );
+      } finally {
+        logVerboseSpy.mockRestore();
+        rmSpy.mockRestore();
+      }
+    });
+  });
+
+  it("does not fail a successful CLI heartbeat run when clone cleanup fails", async () => {
+    await withTempSessionFile("seed", async (sessionFile, seeded) => {
+      const realRm = fs.rm.bind(fs);
+      const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+        if (String(target).includes("openclaw-heartbeat-session-")) {
+          throw new Error("cleanup failed");
+        }
+        return await realRm(target, options);
+      });
+      const globals = await import("../../globals.js");
+      const logVerboseSpy = vi.spyOn(globals, "logVerbose").mockImplementation(() => {});
+      state.runCliAgentMock.mockResolvedValueOnce({
+        payloads: [{ text: "ok" }],
+        meta: {},
+      });
+
+      try {
+        const { run } = createMinimalRun({
+          opts: { isHeartbeat: true },
+          runOverrides: {
+            sessionFile,
+            provider: "claude-cli",
+            model: "sonnet",
+          },
+        });
+
+        const result = await run();
+        const payload = Array.isArray(result)
+          ? (result[0] as { text?: string } | undefined)
+          : (result as { text?: string } | undefined);
+
+        expect(payload?.text).toBe("ok");
+        expect(await fs.readFile(sessionFile, "utf-8")).toBe(seeded);
+        expect(logVerboseSpy).toHaveBeenCalledWith(
+          expect.stringContaining("heartbeat session clone cleanup failed (cli)"),
+        );
+      } finally {
+        logVerboseSpy.mockRestore();
+        rmSpy.mockRestore();
+      }
+    });
+  });
+
   it("emits a terminal lifecycle error when CLI heartbeat clone creation fails", async () => {
     await withTempSessionFile("seed", async (sessionFile) => {
       const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockRejectedValueOnce(new Error("mkdtemp failed"));

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -437,39 +437,49 @@ describe("runReplyAgent heartbeat transcript isolation", () => {
     });
   });
 
-  it("isolates heartbeat transcript writes for CLI providers too", async () => {
+  it("does not create heartbeat transcript clones for CLI providers", async () => {
     await withTempSessionFile("seed", async (sessionFile, seeded) => {
-      const appendedText = "cli heartbeat transcript write";
-      state.runCliAgentMock.mockImplementationOnce(async (params: { sessionFile?: string }) => {
-        await fs.appendFile(
-          String(params.sessionFile),
-          makeTranscriptMessageLine(appendedText),
-          "utf-8",
-        );
-        return { payloads: [{ text: "ok" }], meta: {} };
+      const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockRejectedValueOnce(new Error("mkdtemp failed"));
+      const phases: string[] = [];
+      const off = onAgentEvent((evt) => {
+        const phase = typeof evt.data?.phase === "string" ? evt.data.phase : null;
+        if (evt.stream === "lifecycle" && phase) {
+          phases.push(phase);
+        }
+      });
+      state.runCliAgentMock.mockResolvedValueOnce({
+        payloads: [{ text: "ok" }],
+        meta: {},
       });
 
-      const { run } = createMinimalRun({
-        opts: { isHeartbeat: true },
-        runOverrides: {
-          sessionFile,
-          provider: "claude-cli",
-          model: "sonnet",
-        },
-      });
+      try {
+        const { run } = createMinimalRun({
+          opts: { isHeartbeat: true },
+          runOverrides: {
+            sessionFile,
+            provider: "claude-cli",
+            model: "sonnet",
+          },
+        });
 
-      await run();
+        const result = await run();
+        const payload = Array.isArray(result)
+          ? (result[0] as { text?: string } | undefined)
+          : (result as { text?: string } | undefined);
 
-      const liveRaw = await fs.readFile(sessionFile, "utf-8");
-      expect(liveRaw).toBe(seeded);
-      expect(liveRaw).not.toContain(appendedText);
+        expect(payload?.text).toBe("ok");
+        expect(await fs.readFile(sessionFile, "utf-8")).toBe(seeded);
+        expect(mkdtempSpy).not.toHaveBeenCalled();
+        expect(phases).toEqual(["start", "end"]);
 
-      const cliCall = state.runCliAgentMock.mock.calls.at(-1)?.[0] as
-        | { sessionFile?: string }
-        | undefined;
-      expect(cliCall?.sessionFile).toBeDefined();
-      expect(cliCall?.sessionFile).not.toBe(sessionFile);
-      expect(await pathExists(String(cliCall?.sessionFile))).toBe(false);
+        const cliCall = state.runCliAgentMock.mock.calls.at(-1)?.[0] as
+          | { sessionFile?: string }
+          | undefined;
+        expect(cliCall?.sessionFile).toBe(sessionFile);
+      } finally {
+        off();
+        mkdtempSpy.mockRestore();
+      }
     });
   });
 
@@ -508,91 +518,6 @@ describe("runReplyAgent heartbeat transcript isolation", () => {
       } finally {
         logVerboseSpy.mockRestore();
         rmSpy.mockRestore();
-      }
-    });
-  });
-
-  it("does not fail a successful CLI heartbeat run when clone cleanup fails", async () => {
-    await withTempSessionFile("seed", async (sessionFile, seeded) => {
-      const realRm = fs.rm.bind(fs);
-      const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
-        if (String(target).includes("openclaw-heartbeat-session-")) {
-          throw new Error("cleanup failed");
-        }
-        return await realRm(target, options);
-      });
-      const globals = await import("../../globals.js");
-      const logVerboseSpy = vi.spyOn(globals, "logVerbose").mockImplementation(() => {});
-      state.runCliAgentMock.mockResolvedValueOnce({
-        payloads: [{ text: "ok" }],
-        meta: {},
-      });
-
-      try {
-        const { run } = createMinimalRun({
-          opts: { isHeartbeat: true },
-          runOverrides: {
-            sessionFile,
-            provider: "claude-cli",
-            model: "sonnet",
-          },
-        });
-
-        const result = await run();
-        const payload = Array.isArray(result)
-          ? (result[0] as { text?: string } | undefined)
-          : (result as { text?: string } | undefined);
-
-        expect(payload?.text).toBe("ok");
-        expect(await fs.readFile(sessionFile, "utf-8")).toBe(seeded);
-        expect(logVerboseSpy).toHaveBeenCalledWith(
-          expect.stringContaining("heartbeat session clone cleanup failed (cli)"),
-        );
-      } finally {
-        logVerboseSpy.mockRestore();
-        rmSpy.mockRestore();
-      }
-    });
-  });
-
-  it("emits a terminal lifecycle error when CLI heartbeat clone creation fails", async () => {
-    await withTempSessionFile("seed", async (sessionFile) => {
-      const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockRejectedValueOnce(new Error("mkdtemp failed"));
-      const phases: string[] = [];
-      const lifecycleErrors: string[] = [];
-      const off = onAgentEvent((evt) => {
-        const phase = typeof evt.data?.phase === "string" ? evt.data.phase : null;
-        if (evt.stream !== "lifecycle" || !phase) {
-          return;
-        }
-        phases.push(phase);
-        if (phase === "error" && typeof evt.data.error === "string") {
-          lifecycleErrors.push(evt.data.error);
-        }
-      });
-
-      try {
-        const { run } = createMinimalRun({
-          opts: { isHeartbeat: true },
-          runOverrides: {
-            sessionFile,
-            provider: "claude-cli",
-            model: "sonnet",
-          },
-        });
-
-        const result = await run();
-        const payload = Array.isArray(result)
-          ? (result[0] as { text?: string } | undefined)
-          : (result as { text?: string } | undefined);
-
-        expect(state.runCliAgentMock).not.toHaveBeenCalled();
-        expect(payload?.text).toContain("mkdtemp failed");
-        expect(phases).toEqual(["start", "error"]);
-        expect(lifecycleErrors).toContain("Error: mkdtemp failed");
-      } finally {
-        off();
-        mkdtempSpy.mockRestore();
       }
     });
   });

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -437,6 +437,57 @@ describe("runReplyAgent heartbeat transcript isolation", () => {
     });
   });
 
+  it("treats a missing source transcript during clone copy as a non-fatal heartbeat race", async () => {
+    await withTempSessionFile("seed", async (sessionFile, seeded) => {
+      const realMkdtemp = fs.mkdtemp.bind(fs);
+      const createdDirs: string[] = [];
+      const appendedText = "heartbeat write after missing source transcript";
+      const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockImplementation(async (prefix) => {
+        const dir = await realMkdtemp(prefix);
+        createdDirs.push(dir);
+        return dir;
+      });
+      const copyErr = Object.assign(new Error("source transcript disappeared"), { code: "ENOENT" });
+      const copyFileSpy = vi.spyOn(fs, "copyFile").mockRejectedValueOnce(copyErr);
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedRunParams) => {
+        await fs.appendFile(
+          String(params.sessionFile),
+          makeTranscriptMessageLine(appendedText),
+          "utf-8",
+        );
+        return { payloads: [{ text: "ok" }], meta: {} };
+      });
+
+      try {
+        const { run } = createMinimalRun({
+          opts: { isHeartbeat: true },
+          runOverrides: { sessionFile },
+        });
+
+        const result = await run();
+        const payload = Array.isArray(result)
+          ? (result[0] as { text?: string } | undefined)
+          : (result as { text?: string } | undefined);
+
+        expect(payload?.text).toBe("ok");
+        const liveRaw = await fs.readFile(sessionFile, "utf-8");
+        expect(liveRaw).toBe(seeded);
+        expect(liveRaw).not.toContain(appendedText);
+
+        const embeddedCall = state.runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0] as
+          | EmbeddedRunParams
+          | undefined;
+        expect(embeddedCall?.sessionFile).toBeDefined();
+        expect(embeddedCall?.sessionFile).not.toBe(sessionFile);
+        expect(createdDirs).toHaveLength(1);
+        expect(await pathExists(createdDirs[0])).toBe(false);
+      } finally {
+        copyFileSpy.mockRestore();
+        mkdtempSpy.mockRestore();
+      }
+    });
+  });
+
   it("does not create heartbeat transcript clones for CLI providers", async () => {
     await withTempSessionFile("seed", async (sessionFile, seeded) => {
       const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockRejectedValueOnce(new Error("mkdtemp failed"));

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -512,13 +512,16 @@ describe("update-cli", () => {
           call[0][1] === "i" &&
           call[0][2] === "-g",
       );
-    const mergedPath = updateCall?.[1]?.env?.Path ?? updateCall?.[1]?.env?.PATH ?? "";
+    const updateOptions = updateCall?.[1];
+    const updateEnv =
+      typeof updateOptions === "object" && updateOptions ? updateOptions.env : undefined;
+    const mergedPath = updateEnv?.Path ?? updateEnv?.PATH ?? "";
     expect(mergedPath.split(path.delimiter).slice(0, 2)).toEqual([
       portableGitMingw,
       portableGitUsr,
     ]);
-    expect(updateCall?.[1]?.env?.NPM_CONFIG_SCRIPT_SHELL).toBe("cmd.exe");
-    expect(updateCall?.[1]?.env?.NODE_LLAMA_CPP_SKIP_DOWNLOAD).toBe("1");
+    expect(updateEnv?.NPM_CONFIG_SCRIPT_SHELL).toBe("cmd.exe");
+    expect(updateEnv?.NODE_LLAMA_CPP_SKIP_DOWNLOAD).toBe("1");
   });
 
   it("uses OPENCLAW_UPDATE_PACKAGE_SPEC for package updates", async () => {

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
 import { OLLAMA_DEFAULT_BASE_URL } from "../agents/ollama-models.js";
+import { CUSTOM_NO_AUTH_MARKER } from "../agents/model-auth-markers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import {
@@ -383,6 +384,20 @@ describe("promptCustomApiConfig", () => {
 });
 
 describe("applyCustomApiConfig", () => {
+  it("stores a no-auth marker when a custom provider does not require an API key", () => {
+    const result = applyCustomApiConfig({
+      config: {},
+      baseUrl: "http://127.0.0.1:8080/v1",
+      modelId: "Qwen/Qwen3.5-8B",
+      compatibility: "openai",
+      providerId: "custom-127-0-0-1-8080",
+    });
+
+    expect(result.config.models?.providers?.["custom-127-0-0-1-8080"]?.apiKey).toBe(
+      CUSTOM_NO_AUTH_MARKER,
+    );
+  });
+
   it.each([
     {
       name: "uses hard-min context window for newly added custom models",

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
-import { OLLAMA_DEFAULT_BASE_URL } from "../agents/ollama-models.js";
 import { CUSTOM_NO_AUTH_MARKER } from "../agents/model-auth-markers.js";
+import { OLLAMA_DEFAULT_BASE_URL } from "../agents/ollama-models.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -1,5 +1,6 @@
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { CUSTOM_NO_AUTH_MARKER } from "../agents/model-auth-markers.js";
 import { buildModelAliasIndex, modelKey } from "../agents/model-selection.js";
 import { OLLAMA_DEFAULT_BASE_URL } from "../agents/ollama-models.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -619,7 +620,8 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   const { apiKey: existingApiKey, ...existingProviderRest } = existingProvider ?? {};
   const normalizedApiKey =
     normalizeOptionalProviderApiKey(params.apiKey) ??
-    normalizeOptionalProviderApiKey(existingApiKey);
+    normalizeOptionalProviderApiKey(existingApiKey) ??
+    CUSTOM_NO_AUTH_MARKER;
 
   let config: OpenClawConfig = {
     ...params.config,

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { CUSTOM_NO_AUTH_MARKER } from "../agents/model-auth-markers.js";
+import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { validateConfigObject } from "../config/config.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -131,10 +133,13 @@ async function runOnboardingAndReadConfig(
 async function expectWrittenConfigValid(configPath: string): Promise<void> {
   const cfg = await readJsonFile<Record<string, unknown>>(configPath);
   const validated = validateConfigObject(cfg);
-  const details =
-    validated.issues?.map((issue) => `${issue.path || "<root>"}: ${issue.message}`).join("\n") ??
-    "";
-  expect(validated.ok, details).toBe(true);
+  if (!validated.ok) {
+    const details = validated.issues
+      .map((issue) => `${issue.path || "<root>"}: ${issue.message}`)
+      .join("\n");
+    throw new Error(details || "expected config to be valid");
+  }
+  expect(validated.ok).toBe(true);
 }
 
 const CUSTOM_LOCAL_BASE_URL = "https://models.custom.local/v1";
@@ -648,6 +653,37 @@ describe("onboard (non-interactive): provider auth", () => {
       expect(provider?.models?.some((model) => model.id === "foo-large")).toBe(true);
       expect(cfg.agents?.defaults?.model?.primary).toBe("custom-llm-example-com/foo-large");
     });
+  });
+
+  it("allows onboarding a custom provider without an API key and resolves runtime auth", async () => {
+    await withOnboardEnv(
+      "openclaw-onboard-custom-provider-no-auth-",
+      async ({ configPath, runtime }) => {
+        await runNonInteractiveOnboardingWithDefaults(runtime, {
+          authChoice: "custom-api-key",
+          customBaseUrl: "http://127.0.0.1:8080/v1",
+          customModelId: "Qwen/Qwen3.5-8B",
+          skipSkills: true,
+        });
+
+        const cfg = await readJsonFile<ProviderAuthConfigSnapshot>(configPath);
+        const provider = cfg.models?.providers?.["custom-127-0-0-1-8080"];
+
+        expect(provider?.baseUrl).toBe("http://127.0.0.1:8080/v1");
+        expect(provider?.api).toBe("openai-completions");
+        expect(provider?.apiKey).toBe(CUSTOM_NO_AUTH_MARKER);
+        expect(cfg.agents?.defaults?.model?.primary).toBe("custom-127-0-0-1-8080/Qwen/Qwen3.5-8B");
+        await expectWrittenConfigValid(configPath);
+
+        const resolved = await resolveApiKeyForProvider({
+          provider: "custom-127-0-0-1-8080",
+          cfg: cfg as never,
+          store: { version: 1, profiles: {} },
+        });
+        expect(resolved.apiKey).toBe(CUSTOM_NO_AUTH_MARKER);
+        expect(resolved.source).toContain("no-auth marker");
+      },
+    );
   });
 
   it("infers custom provider auth choice from custom flags", async () => {

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -131,9 +131,9 @@ async function runOnboardingAndReadConfig(
 async function expectWrittenConfigValid(configPath: string): Promise<void> {
   const cfg = await readJsonFile<Record<string, unknown>>(configPath);
   const validated = validateConfigObject(cfg);
-  const details = validated.ok
-    ? "expected config validation to succeed"
-    : validated.issues.map((issue) => `${issue.path || "<root>"}: ${issue.message}`).join("\n");
+  const details =
+    validated.issues?.map((issue) => `${issue.path || "<root>"}: ${issue.message}`).join("\n") ??
+    "";
   expect(validated.ok, details).toBe(true);
 }
 

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { validateConfigObject } from "../config/config.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { MINIMAX_API_BASE_URL, MINIMAX_CN_API_BASE_URL } from "./onboard-auth.js";
@@ -127,6 +128,15 @@ async function runOnboardingAndReadConfig(
   return readJsonFile<ProviderAuthConfigSnapshot>(env.configPath);
 }
 
+async function expectWrittenConfigValid(configPath: string): Promise<void> {
+  const cfg = await readJsonFile<Record<string, unknown>>(configPath);
+  const validated = validateConfigObject(cfg);
+  const details = validated.ok
+    ? "expected config validation to succeed"
+    : validated.issues.map((issue) => `${issue.path || "<root>"}: ${issue.message}`).join("\n");
+  expect(validated.ok, details).toBe(true);
+}
+
 const CUSTOM_LOCAL_BASE_URL = "https://models.custom.local/v1";
 const CUSTOM_LOCAL_MODEL_ID = "local-large";
 const CUSTOM_LOCAL_PROVIDER_ID = "custom-models-custom-local";
@@ -230,6 +240,28 @@ describe("onboard (non-interactive): provider auth", () => {
       expect(cfg.models?.providers?.zai?.baseUrl).toBe("https://api.z.ai/api/paas/v4");
       expect(cfg.agents?.defaults?.model?.primary).toBe("zai/glm-5");
       await expectApiKeyProfile({ profileId: "zai:default", provider: "zai", key: "zai-test-key" });
+    });
+  });
+
+  it("stores Kimi Coding API key and writes a schema-valid config", async () => {
+    await withOnboardEnv("openclaw-onboard-kimi-coding-", async (env) => {
+      const cfg = await runOnboardingAndReadConfig(env, {
+        authChoice: "kimi-code-api-key",
+        kimiCodeApiKey: "kimi-coding-test-key", // pragma: allowlist secret
+      });
+
+      expect(cfg.auth?.profiles?.["kimi-coding:default"]?.provider).toBe("kimi-coding");
+      expect(cfg.auth?.profiles?.["kimi-coding:default"]?.mode).toBe("api_key");
+      expect(cfg.models?.providers?.["kimi-coding"]?.baseUrl).toBe("https://api.kimi.com/coding/");
+      expect(cfg.models?.providers?.["kimi-coding"]?.api).toBe("anthropic-messages");
+      expect(cfg.models?.providers?.["kimi-coding"]?.models?.[0]?.id).toBe("k2p5");
+      expect(cfg.agents?.defaults?.model?.primary).toBe("kimi-coding/k2p5");
+      await expectApiKeyProfile({
+        profileId: "kimi-coding:default",
+        provider: "kimi-coding",
+        key: "kimi-coding-test-key",
+      });
+      await expectWrittenConfigValid(env.configPath);
     });
   });
 

--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -1,5 +1,5 @@
 import "./isolated-agent.mocks.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
 import {
   createCliDeps,
@@ -15,45 +15,36 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
     setupIsolatedAgentTurnMocks();
   });
 
-  it("routes forum-topic and plain telegram targets through the correct delivery path", async () => {
+  it.each([
+    {
+      label: "forum-topic targets",
+      text: "forum message",
+      to: "123:topic:42",
+      expected: { chatId: "123", text: "forum message", messageThreadId: 42 },
+    },
+    {
+      label: "plain telegram targets",
+      text: "plain message",
+      to: "123",
+      expected: { chatId: "123", text: "plain message" },
+    },
+  ])("routes $label through the direct telegram delivery path", async ({ text, to, expected }) => {
     await withTempCronHome(async (home) => {
       const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
       const deps = createCliDeps();
-      mockAgentPayloads([{ text: "forum message" }]);
+      mockAgentPayloads([{ text }]);
 
       const res = await runTelegramAnnounceTurn({
         home,
         storePath,
         deps,
-        delivery: { mode: "announce", channel: "telegram", to: "123:topic:42" },
+        delivery: { mode: "announce", channel: "telegram", to },
       });
 
       expect(res.status).toBe("ok");
       expect(res.delivered).toBe(true);
       expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
-      expectDirectTelegramDelivery(deps, {
-        chatId: "123",
-        text: "forum message",
-        messageThreadId: 42,
-      });
-
-      vi.clearAllMocks();
-      mockAgentPayloads([{ text: "plain message" }]);
-
-      const plainRes = await runTelegramAnnounceTurn({
-        home,
-        storePath,
-        deps,
-        delivery: { mode: "announce", channel: "telegram", to: "123" },
-      });
-
-      expect(plainRes.status).toBe("ok");
-      expect(plainRes.delivered).toBe(true);
-      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
-      expectDirectTelegramDelivery(deps, {
-        chatId: "123",
-        text: "plain message",
-      });
+      expectDirectTelegramDelivery(deps, expected);
     });
   });
 });

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -63,10 +63,14 @@ vi.mock("../../agents/skills/refresh.js", () => ({
   getSkillsSnapshotVersion: vi.fn().mockReturnValue(42),
 }));
 
-vi.mock("../../agents/workspace.js", () => ({
-  DEFAULT_IDENTITY_FILENAME: "IDENTITY.md",
-  ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
-}));
+vi.mock("../../agents/workspace.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/workspace.js")>();
+  return {
+    ...actual,
+    DEFAULT_IDENTITY_FILENAME: "IDENTITY.md",
+    ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
+  };
+});
 
 vi.mock("../../agents/model-catalog.js", () => ({
   loadModelCatalog: vi.fn().mockResolvedValue({ models: [] }),
@@ -172,12 +176,16 @@ vi.mock("../../logger.js", () => ({
   logWarn: (...args: unknown[]) => logWarnMock(...args),
 }));
 
-vi.mock("../../security/external-content.js", () => ({
-  buildSafeExternalPrompt: vi.fn().mockReturnValue("safe prompt"),
-  detectSuspiciousPatterns: vi.fn().mockReturnValue([]),
-  getHookType: vi.fn().mockReturnValue("unknown"),
-  isExternalHookSession: vi.fn().mockReturnValue(false),
-}));
+vi.mock("../../security/external-content.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../security/external-content.js")>();
+  return {
+    ...actual,
+    buildSafeExternalPrompt: vi.fn().mockReturnValue("safe prompt"),
+    detectSuspiciousPatterns: vi.fn().mockReturnValue([]),
+    getHookType: vi.fn().mockReturnValue("unknown"),
+    isExternalHookSession: vi.fn().mockReturnValue(false),
+  };
+});
 
 vi.mock("../delivery.js", () => ({
   resolveCronDeliveryPlan: resolveCronDeliveryPlanMock,

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -16,9 +16,13 @@ vi.mock("./message.js", () => ({
   sendPoll: mocks.sendPoll,
 }));
 
-vi.mock("../../media/local-roots.js", () => ({
-  getAgentScopedMediaLocalRoots: mocks.getAgentScopedMediaLocalRoots,
-}));
+vi.mock("../../media/local-roots.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../media/local-roots.js")>();
+  return {
+    ...actual,
+    getAgentScopedMediaLocalRoots: mocks.getAgentScopedMediaLocalRoots,
+  };
+});
 
 import { executePollAction, executeSendAction } from "./outbound-send-service.js";
 

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -91,7 +91,9 @@ describe("resolveGatewayConnection", () => {
     resolveGatewayPort.mockClear();
     pickPrimaryTailnetIPv4.mockClear();
     pickPrimaryLanIPv4.mockClear();
-    resolveGatewayPort.mockReturnValue(18789);
+    resolveGatewayPort.mockImplementation(
+      (cfg?: { gateway?: { port?: number } }) => cfg?.gateway?.port ?? 18789,
+    );
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
     pickPrimaryLanIPv4.mockReturnValue(undefined);
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
@@ -147,8 +149,7 @@ describe("resolveGatewayConnection", () => {
       setup: () => pickPrimaryLanIPv4.mockReturnValue("192.168.1.42"),
     },
   ])("uses loopback host when local bind is $label", async ({ bind, setup }) => {
-    loadConfig.mockReturnValue({ gateway: { mode: "local", bind } });
-    resolveGatewayPort.mockReturnValue(18800);
+    loadConfig.mockReturnValue({ gateway: { mode: "local", bind, port: 18800 } });
     setup();
 
     const result = await withEnvAsync({ OPENCLAW_GATEWAY_TOKEN: "env-token" }, async () => {


### PR DESCRIPTION
## Summary

Fixes #43256.

Some models were interpreting the existing system-prompt guidance too broadly:

> Never use exec/curl for provider messaging; OpenClaw handles all routing internally.

That wording could make the model conclude that Telegram file delivery was not available at all, and refuse to send attachments unless it called raw Bot API endpoints like `sendDocument`.

This PR clarifies the intended path:

- normal outbound delivery should not use raw provider API calls
- current-reply attachments should use `MEDIA:<path-or-url>`
- proactive attachment sends should use the `message` tool with `media`, `filePath`, or `buffer`

## Changes

- update the agent messaging section in the system prompt to distinguish:
  - normal outbound delivery
  - setup/diagnostic API calls
  - attachment delivery paths
- add a regression test covering the clarified prompt guidance
- document the same Telegram-specific guidance in the channel docs

## Why this fixes the issue

OpenClaw already supports Telegram media/file delivery through its own outbound pipeline.  
The problem was prompt guidance, not missing Telegram send capability.

After this change, the model is explicitly told how to send attachments without falling back to raw `sendDocument` / `sendPhoto` Bot API calls.

## Validation

Ran:

```bash
pnpm vitest run src/agents/system-prompt.test.ts
