### PR TITLE
fix(google-gemini-cli-auth): align loadCodeAssist metadata with Gemini CLI

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -239,17 +239,6 @@ describe("loginGeminiCliOAuth", () => {
     "GOOGLE_CLOUD_PROJECT_ID",
   ] as const;
 
-  function getExpectedPlatform(): "WINDOWS" | "MACOS" | "PLATFORM_UNSPECIFIED" {
-    if (process.platform === "win32") {
-      return "WINDOWS";
-    }
-    if (process.platform === "darwin") {
-      return "MACOS";
-    }
-    // Matches updated resolvePlatform() which uses PLATFORM_UNSPECIFIED for Linux
-    return "PLATFORM_UNSPECIFIED";
-  }
-
   function getRequestUrl(input: string | URL | Request): string {
     return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
   }
@@ -373,16 +362,16 @@ describe("loginGeminiCliOAuth", () => {
     const clientMetadata = getHeaderValue(firstHeaders, "Client-Metadata");
     expect(clientMetadata).toBeDefined();
     expect(JSON.parse(clientMetadata as string)).toEqual({
-      ideType: "ANTIGRAVITY",
-      platform: getExpectedPlatform(),
+      ideType: "IDE_UNSPECIFIED",
+      platform: "PLATFORM_UNSPECIFIED",
       pluginType: "GEMINI",
     });
 
     const body = JSON.parse(String(loadRequests[0]?.init?.body));
     expect(body).toEqual({
       metadata: {
-        ideType: "ANTIGRAVITY",
-        platform: getExpectedPlatform(),
+        ideType: "IDE_UNSPECIFIED",
+        platform: "PLATFORM_UNSPECIFIED",
         pluginType: "GEMINI",
       },
     });

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -224,18 +224,6 @@ function generatePkce(): { verifier: string; challenge: string } {
   return { verifier, challenge };
 }
 
-function resolvePlatform(): "WINDOWS" | "MACOS" | "PLATFORM_UNSPECIFIED" {
-  if (process.platform === "win32") {
-    return "WINDOWS";
-  }
-  if (process.platform === "darwin") {
-    return "MACOS";
-  }
-  // Google's loadCodeAssist API rejects "LINUX" as an invalid Platform enum value.
-  // Use "PLATFORM_UNSPECIFIED" for Linux and other platforms to match the pi-ai runtime.
-  return "PLATFORM_UNSPECIFIED";
-}
-
 async function fetchWithTimeout(
   url: string,
   init: RequestInit,
@@ -466,7 +454,6 @@ async function getUserEmail(accessToken: string): Promise<string | undefined> {
 
 async function discoverProject(accessToken: string): Promise<string> {
   const envProject = process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
-  const platform = resolvePlatform();
   const metadata = {
     ideType: "IDE_UNSPECIFIED",
     platform: "PLATFORM_UNSPECIFIED",

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -468,8 +468,8 @@ async function discoverProject(accessToken: string): Promise<string> {
   const envProject = process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
   const platform = resolvePlatform();
   const metadata = {
-    ideType: "ANTIGRAVITY",
-    platform,
+    ideType: "IDE_UNSPECIFIED",
+    platform: "PLATFORM_UNSPECIFIED",
     pluginType: "GEMINI",
   };
   const headers = {


### PR DESCRIPTION
## Summary

- Fix `loadCodeAssist failed: 400 Bad Request` during Gemini CLI OAuth by aligning `discoverProject` metadata with Gemini CLI's own values
- Change `ideType` from `"ANTIGRAVITY"` to `"IDE_UNSPECIFIED"` and `platform` from the resolved platform string to `"PLATFORM_UNSPECIFIED"`

## Root Cause

`discoverProject()` in `extensions/google-gemini-cli-auth/oauth.ts` sends metadata to Google's Code Assist API (`cloudcode-pa.googleapis.com/v1internal:loadCodeAssist`). The values `ideType: "ANTIGRAVITY"` and a resolved platform string (e.g. `"MACOS"`) are not in the server-side allowlist, causing a `400 Bad Request`.

Gemini CLI itself (`@google/gemini-cli-core/dist/src/code_assist/setup.js`) uses:
```js
ideType: "IDE_UNSPECIFIED",
platform: "PLATFORM_UNSPECIFIED",
pluginType: "GEMINI",
```
These values are accepted by the API.

## Test plan

- [x] Verified Gemini CLI v0.33.0 uses `IDE_UNSPECIFIED` / `PLATFORM_UNSPECIFIED` in its own `loadCodeAssist` call
- [x] Confirmed OAuth flow completes successfully after the fix (browser auth → token exchange → loadCodeAssist → profile created)
- [ ] Run `openclaw models auth login --provider google-gemini-cli` and verify auth succeeds

Fixes #41224

🤖 Generated with [Claude Code](https://claude.com/claude-code)