### PR TITLE
fix(node): honor gateway exec ask/security on system.run forwarding

### DIFF
--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -363,6 +363,24 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     expectAllowOnceForwardingResult(result);
   });
 
+  test("injects gateway-resolved exec policy for non-approval system.run calls", () => {
+    const result = sanitizeSystemRunParamsForForwarding({
+      rawParams: {
+        command: ["echo", "SAFE"],
+        rawCommand: "echo SAFE",
+      },
+      nodeId: "node-1",
+      client,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("unreachable");
+    }
+    const params = result.params as Record<string, unknown>;
+    expect(["deny", "allowlist", "full"]).toContain(params.security);
+    expect(["off", "on-miss", "always"]).toContain(params.ask);
+  });
+
   test("consumes allow-once approvals and blocks same runId replay", async () => {
     const approvalManager = new ExecApprovalManager();
     const runId = "approval-replay-1";

--- a/src/gateway/node-invoke-system-run-approval.ts
+++ b/src/gateway/node-invoke-system-run-approval.ts
@@ -1,3 +1,6 @@
+import { resolveAgentConfig } from "../agents/agent-scope.js";
+import { loadConfig } from "../config/config.js";
+import { normalizeExecAsk, normalizeExecSecurity } from "../infra/exec-approvals.js";
 import { resolveSystemRunApprovalRuntimeContext } from "../infra/system-run-approval-context.js";
 import { resolveSystemRunCommandRequest } from "../infra/system-run-command.js";
 import type { ExecApprovalRecord } from "./exec-approval-manager.js";
@@ -20,6 +23,8 @@ type SystemRunParamsLike = {
   needsScreenRecording?: unknown;
   agentId?: unknown;
   sessionKey?: unknown;
+  security?: unknown;
+  ask?: unknown;
   approved?: unknown;
   approvalDecision?: unknown;
   runId?: unknown;
@@ -88,6 +93,30 @@ function pickSystemRunParams(raw: Record<string, unknown>): Record<string, unkno
   return next;
 }
 
+function applyGatewayExecPolicy(next: Record<string, unknown>): void {
+  const agentId = normalizeString(next.agentId);
+  const cfg = loadConfig();
+  const agentExec = agentId ? resolveAgentConfig(cfg, agentId)?.tools?.exec : undefined;
+  const security =
+    normalizeExecSecurity(
+      typeof agentExec?.security === "string"
+        ? agentExec.security
+        : typeof cfg.tools?.exec?.security === "string"
+          ? cfg.tools.exec.security
+          : undefined,
+    ) ?? "deny";
+  const ask =
+    normalizeExecAsk(
+      typeof agentExec?.ask === "string"
+        ? agentExec.ask
+        : typeof cfg.tools?.exec?.ask === "string"
+          ? cfg.tools.exec.ask
+          : undefined,
+    ) ?? "on-miss";
+  next.security = security;
+  next.ask = ask;
+}
+
 /**
  * Gate `system.run` approval flags (`approved`, `approvalDecision`) behind a real
  * `exec.approval.*` record. This prevents users with only `operator.write` from
@@ -115,6 +144,7 @@ export function sanitizeSystemRunParamsForForwarding(opts: {
   // Always strip control fields from user input. If the override is allowed,
   // we re-add trusted fields based on the gateway approval record.
   const next: Record<string, unknown> = pickSystemRunParams(obj);
+  applyGatewayExecPolicy(next);
 
   if (!wantsApprovalOverride) {
     const cmdTextResolution = resolveSystemRunCommandRequest({
@@ -265,6 +295,9 @@ export function sanitizeSystemRunParamsForForwarding(opts: {
   if (!approvalMatch.ok) {
     return toSystemRunApprovalMismatchError({ runId, match: approvalMatch });
   }
+
+  // Re-apply policy in case runtime context rewrote agentId/session-bound fields.
+  applyGatewayExecPolicy(next);
 
   // Normal path: enforce the decision recorded by the gateway.
   if (snapshot.decision === "allow-once") {

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -318,6 +318,8 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     cwd?: string;
     security?: "full" | "allowlist";
     ask?: "off" | "on-miss" | "always";
+    forwardedSecurity?: "deny" | "full" | "allowlist";
+    forwardedAsk?: "off" | "on-miss" | "always";
     approved?: boolean;
     runCommand?: HandleSystemRunInvokeOptions["runCommand"];
     runViaMacAppExecHost?: HandleSystemRunInvokeOptions["runViaMacAppExecHost"];
@@ -373,14 +375,26 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         cwd: params.cwd,
         approved: params.approved ?? false,
         sessionKey: "agent:main:main",
+        security: params.forwardedSecurity,
+        ask: params.forwardedAsk,
       },
       skillBins: {
         current: params.skillBinsCurrent ?? (async () => []),
       },
       execHostEnforced: false,
       execHostFallbackAllowed: true,
-      resolveExecSecurity: () => params.security ?? "full",
-      resolveExecAsk: () => params.ask ?? "off",
+      resolveExecSecurity: (value) => {
+        if (value === "deny" || value === "allowlist" || value === "full") {
+          return value;
+        }
+        return params.security ?? "full";
+      },
+      resolveExecAsk: (value) => {
+        if (value === "off" || value === "on-miss" || value === "always") {
+          return value;
+        }
+        return params.ask ?? "off";
+      },
       isCmdExeInvocation: () => false,
       sanitizeEnv: () => undefined,
       runCommand,
@@ -407,6 +421,24 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     });
 
     expect(runViaMacAppExecHost).not.toHaveBeenCalled();
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    expectInvokeOk(sendInvokeResult, { payloadContains: "local-ok" });
+  });
+
+  it("honors forwarded security/ask policy over node-host defaults", async () => {
+    const { runCommand, sendNodeEvent, sendInvokeResult } = await runSystemInvoke({
+      preferMacAppExecHost: false,
+      security: "allowlist",
+      ask: "on-miss",
+      forwardedSecurity: "full",
+      forwardedAsk: "off",
+    });
+
+    expect(sendNodeEvent).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "exec.denied",
+      expect.objectContaining({ reason: "approval-required" }),
+    );
     expect(runCommand).toHaveBeenCalledTimes(1);
     expectInvokeOk(sendInvokeResult, { payloadContains: "local-ok" });
   });

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -78,6 +78,8 @@ type SystemRunParsePhase = {
   cwd: string | undefined;
   timeoutMs: number | undefined;
   needsScreenRecording: boolean;
+  security: string | undefined;
+  ask: string | undefined;
   approved: boolean;
   suppressNotifyOnExit: boolean;
 };
@@ -241,6 +243,8 @@ async function parseSystemRunPhase(
     cwd: opts.params.cwd?.trim() || undefined,
     timeoutMs: opts.params.timeoutMs ?? undefined,
     needsScreenRecording: opts.params.needsScreenRecording === true,
+    security: typeof opts.params.security === "string" ? opts.params.security : undefined,
+    ask: typeof opts.params.ask === "string" ? opts.params.ask : undefined,
     approved: opts.params.approved === true,
     suppressNotifyOnExit,
   };
@@ -255,9 +259,9 @@ async function evaluateSystemRunPolicyPhase(
     ? resolveAgentConfig(cfg, parsed.agentId)?.tools?.exec
     : undefined;
   const configuredSecurity = opts.resolveExecSecurity(
-    agentExec?.security ?? cfg.tools?.exec?.security,
+    parsed.security ?? agentExec?.security ?? cfg.tools?.exec?.security,
   );
-  const configuredAsk = opts.resolveExecAsk(agentExec?.ask ?? cfg.tools?.exec?.ask);
+  const configuredAsk = opts.resolveExecAsk(parsed.ask ?? agentExec?.ask ?? cfg.tools?.exec?.ask);
   const approvals = resolveExecApprovals(parsed.agentId, {
     security: configuredSecurity,
     ask: configuredAsk,

--- a/src/node-host/invoke-types.ts
+++ b/src/node-host/invoke-types.ts
@@ -10,6 +10,8 @@ export type SystemRunParams = {
   needsScreenRecording?: boolean | null;
   agentId?: string | null;
   sessionKey?: string | null;
+  security?: string | null;
+  ask?: string | null;
   approved?: boolean | null;
   approvalDecision?: string | null;
   runId?: string | null;


### PR DESCRIPTION
## Summary
- force gateway `node.invoke(system.run)` forwarding to attach the gateway-resolved exec policy (`security` + `ask`) instead of letting node-host fall back to its own local defaults
- teach node-host `system.run` handling to honor forwarded policy fields before local config fallback
- add regression tests for gateway policy injection and node-host precedence behavior

## Why
`tools.exec.security=full` + `tools.exec.ask=off` configured on the gateway did not reliably suppress approval prompts when execution was routed through node-host `system.run`.

Root cause: node-host evaluated policy from its own local config defaults because forwarded `system.run` params did not carry gateway policy.

## Validation
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/node-invoke-system-run-approval.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts src/node-host/invoke-system-run.test.ts`

Closes #43279.
