### PR TITLE
refactor(agents): simplify fallback retry helpers

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -8,6 +8,7 @@ import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { FailoverError } from "./failover-error.js";
 import { isAnthropicBillingError } from "./live-auth-keys.js";
 import { runWithImageModelFallback, runWithModelFallback } from "./model-fallback.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
@@ -303,7 +304,7 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("gpt-4.1-mini");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5"],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -341,7 +342,7 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("openrouter/deepseek-chat");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-haiku-3-5"],
-      ["openrouter", "openrouter/deepseek-chat"],
+      ["openrouter", "openrouter/deepseek-chat", { previousFailureReason: "rate_limit" }],
     ]);
   });
 
@@ -372,7 +373,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["openai", "gpt-4.1-mini"],
-      ["anthropic", "claude-haiku-3-5"],
+      ["anthropic", "claude-haiku-3-5", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -443,7 +444,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4"],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -675,7 +676,7 @@ describe("runWithModelFallback", () => {
 
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5"],
-      ["anthropic", "claude-haiku-3-5"],
+      ["anthropic", "claude-haiku-3-5", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -758,7 +759,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-sonnet-4"],
-      ["openai", "gpt-4o"],
+      ["openai", "gpt-4o", { previousFailureReason: "rate_limit" }],
     ]);
   });
 
@@ -1025,7 +1026,9 @@ describe("runWithModelFallback", () => {
       expect(result.result).toBe("fallback success");
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-20250514");
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5"); // Fallback tried
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5", {
+        previousFailureReason: "rate_limit",
+      }); // Fallback tried
     });
 
     it("allows fallbacks with model version differences within same provider", async () => {
@@ -1054,7 +1057,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
 
     it("still skips fallbacks when using different provider than config", async () => {
@@ -1085,7 +1090,9 @@ describe("runWithModelFallback", () => {
       expect(result.result).toBe("config primary worked");
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini"); // Original request
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6"); // Config primary as final fallback
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6", {
+        previousFailureReason: "auth",
+      }); // Config primary as final fallback
     });
 
     it("uses fallbacks when session model exactly matches config primary", async () => {
@@ -1114,7 +1121,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("fallback worked");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
   });
 
@@ -1316,7 +1325,9 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
       }); // Rate limit allows attempt
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile"); // Cross-provider works
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      }); // Cross-provider works
     });
 
     it("limits cooldown probes to one per provider before moving to cross-provider fallback", async () => {
@@ -1356,7 +1367,9 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
       });
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
 
     it("does not consume transient probe slot when first same-provider probe fails with model_not_found", async () => {
@@ -1396,7 +1409,85 @@ describe("runWithModelFallback", () => {
       });
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5", {
         allowTransientCooldownProbe: true,
+        previousFailureReason: "model_not_found",
       });
+    });
+  });
+
+  describe("previousFailureReason forwarding", () => {
+    it("does not pass previousFailureReason on the first attempt", async () => {
+      const cfg = makeCfg();
+      const run = vi.fn().mockResolvedValueOnce("ok");
+
+      await runWithModelFallback({ cfg, provider: "anthropic", model: "claude-opus-4-5", run });
+
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(run.mock.calls[0]?.[2]).toBeUndefined();
+    });
+
+    it("forwards rate_limit reason after a 429 failure", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("rate limited", { reason: "rate_limit", status: 429 }),
+        )
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousFailureReason: "rate_limit" }),
+      );
+    });
+
+    it("forwards format reason after a 400 failure", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new FailoverError("bad request", { reason: "format", status: 400 }))
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousFailureReason: "format" }),
+      );
+    });
+
+    it("forwards timeout reason after a timeout failure", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new FailoverError("timed out", { reason: "timeout", status: 408 }))
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousFailureReason: "timeout" }),
+      );
     });
   });
 });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -36,6 +36,7 @@ const log = createSubsystemLogger("model-fallback");
 
 export type ModelFallbackRunOptions = {
   allowTransientCooldownProbe?: boolean;
+  previousFailureReason?: FailoverReason;
 };
 
 type ModelFallbackRunFn<T> = (
@@ -521,6 +522,7 @@ export async function runWithModelFallback<T>(params: {
     : null;
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
+  let previousFailureReason: FailoverReason | undefined;
   const cooldownProbeUsedProviders = new Set<string>();
 
   const hasFallbackCandidates = candidates.length > 1;
@@ -646,11 +648,21 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
+    const effectiveOptions: ModelFallbackRunOptions | undefined = (() => {
+      if (!previousFailureReason && !runOptions) {
+        return undefined;
+      }
+      const opts: ModelFallbackRunOptions = { ...runOptions };
+      if (previousFailureReason) {
+        opts.previousFailureReason = previousFailureReason;
+      }
+      return opts;
+    })();
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,
       attempts,
-      options: runOptions,
+      options: effectiveOptions,
     });
     if ("success" in attemptRun) {
       if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {
@@ -715,11 +727,12 @@ export async function runWithModelFallback<T>(params: {
 
       lastError = isKnownFailover ? normalized : err;
       const described = describeFailoverError(normalized);
+      previousFailureReason = described.reason ?? "unknown";
       attempts.push({
         provider: candidate.provider,
         model: candidate.model,
         error: described.message,
-        reason: described.reason ?? "unknown",
+        reason: previousFailureReason,
         status: described.status,
         code: described.code,
       });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -648,16 +648,10 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
-    const effectiveOptions: ModelFallbackRunOptions | undefined = (() => {
-      if (!previousFailureReason && !runOptions) {
-        return undefined;
-      }
-      const opts: ModelFallbackRunOptions = { ...runOptions };
-      if (previousFailureReason) {
-        opts.previousFailureReason = previousFailureReason;
-      }
-      return opts;
-    })();
+    const effectiveOptions: ModelFallbackRunOptions | undefined =
+      previousFailureReason || runOptions
+        ? { ...runOptions, ...(previousFailureReason && { previousFailureReason }) }
+        : undefined;
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -16,7 +16,7 @@ import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { agentCommand, agentCommandFromIngress } from "./agent.js";
+import { _testInternals, agentCommand, agentCommandFromIngress } from "./agent.js";
 import * as agentDeliveryModule from "./agent/delivery.js";
 
 vi.mock("../agents/auth-profiles.js", async (importOriginal) => {
@@ -983,5 +983,85 @@ describe("agentCommand", () => {
 
       expect(runtime.log).toHaveBeenCalledWith("ok");
     });
+  });
+});
+
+describe("resolveFallbackRetryPrompt", () => {
+  const { resolveFallbackRetryPrompt } = _testInternals;
+
+  it("returns original body when not a fallback retry", () => {
+    expect(resolveFallbackRetryPrompt({ body: "hello", isFallbackRetry: false })).toBe("hello");
+  });
+
+  it("preserves original body on fallback retry regardless of failure reason", () => {
+    const reasons = ["rate_limit", "timeout", "format", "auth", "unknown", undefined] as const;
+    for (const reason of reasons) {
+      expect(
+        resolveFallbackRetryPrompt({
+          body: "original prompt",
+          isFallbackRetry: true,
+          previousFailureReason: reason,
+        }),
+      ).toBe("original prompt");
+    }
+  });
+});
+
+describe("resolveRetryImages", () => {
+  const { resolveRetryImages } = _testInternals;
+  const fakeImages = [{ type: "image" as const, data: "abc", mimeType: "image/png" }];
+
+  it("preserves images when not a fallback retry", () => {
+    expect(resolveRetryImages({ images: fakeImages, isFallbackRetry: false })).toBe(fakeImages);
+  });
+
+  it("strips images on format failure reason", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "format",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves images on rate_limit failure reason", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "rate_limit",
+      }),
+    ).toBe(fakeImages);
+  });
+
+  it("preserves images on timeout failure reason", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "timeout",
+      }),
+    ).toBe(fakeImages);
+  });
+
+  it("preserves images on auth failure reason", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "auth",
+      }),
+    ).toBe(fakeImages);
+  });
+
+  it("preserves images when previousFailureReason is undefined", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: undefined,
+      }),
+    ).toBe(fakeImages);
   });
 });

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -986,82 +986,31 @@ describe("agentCommand", () => {
   });
 });
 
-describe("resolveFallbackRetryPrompt", () => {
-  const { resolveFallbackRetryPrompt } = _testInternals;
-
-  it("returns original body when not a fallback retry", () => {
-    expect(resolveFallbackRetryPrompt({ body: "hello", isFallbackRetry: false })).toBe("hello");
-  });
-
-  it("preserves original body on fallback retry regardless of failure reason", () => {
-    const reasons = ["rate_limit", "timeout", "format", "auth", "unknown", undefined] as const;
-    for (const reason of reasons) {
-      expect(
-        resolveFallbackRetryPrompt({
-          body: "original prompt",
-          isFallbackRetry: true,
-          previousFailureReason: reason,
-        }),
-      ).toBe("original prompt");
-    }
-  });
-});
-
 describe("resolveRetryImages", () => {
   const { resolveRetryImages } = _testInternals;
   const fakeImages = [{ type: "image" as const, data: "abc", mimeType: "image/png" }];
 
   it("preserves images when not a fallback retry", () => {
-    expect(resolveRetryImages({ images: fakeImages, isFallbackRetry: false })).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, false)).toBe(fakeImages);
   });
 
   it("strips images on format failure reason", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: "format",
-      }),
-    ).toBeUndefined();
+    expect(resolveRetryImages(fakeImages, true, "format")).toBeUndefined();
   });
 
   it("preserves images on rate_limit failure reason", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: "rate_limit",
-      }),
-    ).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, true, "rate_limit")).toBe(fakeImages);
   });
 
   it("preserves images on timeout failure reason", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: "timeout",
-      }),
-    ).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, true, "timeout")).toBe(fakeImages);
   });
 
   it("preserves images on auth failure reason", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: "auth",
-      }),
-    ).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, true, "auth")).toBe(fakeImages);
   });
 
   it("preserves images when previousFailureReason is undefined", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: undefined,
-      }),
-    ).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, true, undefined)).toBe(fakeImages);
   });
 });

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -36,6 +36,7 @@ import {
   resolveDefaultModelForAgent,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
+import type { FailoverReason } from "../agents/pi-embedded-helpers.js";
 import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
@@ -139,11 +140,32 @@ async function persistSessionEntry(params: PersistSessionEntryParams): Promise<v
   params.sessionStore[params.sessionKey] = persisted;
 }
 
-function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boolean }): string {
+function resolveFallbackRetryPrompt(params: {
+  body: string;
+  isFallbackRetry: boolean;
+  previousFailureReason?: FailoverReason;
+}): string {
+  // Fallback retries only fire on thrown errors (not partial streaming results),
+  // so the original prompt is always safe to re-send. The orphaned-user-message
+  // repair in attempt.ts handles any residual duplicate user turns.
+  return params.body;
+}
+
+function resolveRetryImages(params: {
+  images: AgentCommandOpts["images"];
+  isFallbackRetry: boolean;
+  previousFailureReason?: FailoverReason;
+}): AgentCommandOpts["images"] {
   if (!params.isFallbackRetry) {
-    return params.body;
+    return params.images;
   }
-  return "Continue where you left off. The previous model attempt failed or timed out.";
+  // Format errors may be caused by image payloads the fallback model
+  // doesn't support — strip as a safety measure.
+  if (params.previousFailureReason === "format") {
+    return undefined;
+  }
+  // All other reasons: model never processed or rejected the images.
+  return params.images;
 }
 
 function prependInternalEventContext(
@@ -344,10 +366,12 @@ function runAgentAttempt(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
+  previousFailureReason?: FailoverReason;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
+    previousFailureReason: params.previousFailureReason,
   });
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,
@@ -374,7 +398,11 @@ function runAgentAttempt(params: {
         cliSessionId: nextCliSessionId,
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
-        images: params.isFallbackRetry ? undefined : params.opts.images,
+        images: resolveRetryImages({
+          images: params.opts.images,
+          isFallbackRetry: params.isFallbackRetry,
+          previousFailureReason: params.previousFailureReason,
+        }),
         streamParams: params.opts.streamParams,
       });
     return runCliWithSession(cliSessionId).catch(async (err) => {
@@ -478,7 +506,11 @@ function runAgentAttempt(params: {
     config: params.cfg,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
-    images: params.isFallbackRetry ? undefined : params.opts.images,
+    images: resolveRetryImages({
+      images: params.opts.images,
+      isFallbackRetry: params.isFallbackRetry,
+      previousFailureReason: params.previousFailureReason,
+    }),
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,
@@ -1135,6 +1167,7 @@ async function agentCommandInternal(
             sessionStore,
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            previousFailureReason: runOptions?.previousFailureReason,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (
@@ -1254,3 +1287,6 @@ export async function agentCommandFromIngress(
     deps,
   );
 }
+
+/** @internal – exposed for unit tests only */
+export const _testInternals = { resolveFallbackRetryPrompt, resolveRetryImages } as const;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -140,32 +140,17 @@ async function persistSessionEntry(params: PersistSessionEntryParams): Promise<v
   params.sessionStore[params.sessionKey] = persisted;
 }
 
-function resolveFallbackRetryPrompt(params: {
-  body: string;
-  isFallbackRetry: boolean;
-  previousFailureReason?: FailoverReason;
-}): string {
-  // Fallback retries only fire on thrown errors (not partial streaming results),
-  // so the original prompt is always safe to re-send. The orphaned-user-message
-  // repair in attempt.ts handles any residual duplicate user turns.
-  return params.body;
-}
-
-function resolveRetryImages(params: {
-  images: AgentCommandOpts["images"];
-  isFallbackRetry: boolean;
-  previousFailureReason?: FailoverReason;
-}): AgentCommandOpts["images"] {
-  if (!params.isFallbackRetry) {
-    return params.images;
-  }
+function resolveRetryImages(
+  images: AgentCommandOpts["images"],
+  isFallbackRetry: boolean,
+  previousFailureReason?: FailoverReason,
+): AgentCommandOpts["images"] {
   // Format errors may be caused by image payloads the fallback model
   // doesn't support — strip as a safety measure.
-  if (params.previousFailureReason === "format") {
+  if (isFallbackRetry && previousFailureReason === "format") {
     return undefined;
   }
-  // All other reasons: model never processed or rejected the images.
-  return params.images;
+  return images;
 }
 
 function prependInternalEventContext(
@@ -368,11 +353,10 @@ function runAgentAttempt(params: {
   allowTransientCooldownProbe?: boolean;
   previousFailureReason?: FailoverReason;
 }) {
-  const effectivePrompt = resolveFallbackRetryPrompt({
-    body: params.body,
-    isFallbackRetry: params.isFallbackRetry,
-    previousFailureReason: params.previousFailureReason,
-  });
+  // Fallback retries only fire on thrown errors (not partial streaming results),
+  // so the original prompt is always safe to re-send. The orphaned-user-message
+  // repair in attempt.ts handles any residual duplicate user turns.
+  const effectivePrompt = params.body;
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,
   );
@@ -398,11 +382,11 @@ function runAgentAttempt(params: {
         cliSessionId: nextCliSessionId,
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
-        images: resolveRetryImages({
-          images: params.opts.images,
-          isFallbackRetry: params.isFallbackRetry,
-          previousFailureReason: params.previousFailureReason,
-        }),
+        images: resolveRetryImages(
+          params.opts.images,
+          params.isFallbackRetry,
+          params.previousFailureReason,
+        ),
         streamParams: params.opts.streamParams,
       });
     return runCliWithSession(cliSessionId).catch(async (err) => {
@@ -506,11 +490,11 @@ function runAgentAttempt(params: {
     config: params.cfg,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
-    images: resolveRetryImages({
-      images: params.opts.images,
-      isFallbackRetry: params.isFallbackRetry,
-      previousFailureReason: params.previousFailureReason,
-    }),
+    images: resolveRetryImages(
+      params.opts.images,
+      params.isFallbackRetry,
+      params.previousFailureReason,
+    ),
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,
@@ -1139,6 +1123,8 @@ async function agentCommandInternal(
         agentDir,
         fallbacksOverride: effectiveFallbacksOverride,
         run: (providerOverride, modelOverride, runOptions) => {
+          // TODO: isFallbackRetry is derivable from `runOptions?.previousFailureReason !== undefined`;
+          // consider removing it in a future cleanup pass.
           const isFallbackRetry = fallbackAttemptIndex > 0;
           fallbackAttemptIndex += 1;
           return runAgentAttempt({
@@ -1289,4 +1275,4 @@ export async function agentCommandFromIngress(
 }
 
 /** @internal – exposed for unit tests only */
-export const _testInternals = { resolveFallbackRetryPrompt, resolveRetryImages } as const;
+export const _testInternals = { resolveRetryImages } as const;


### PR DESCRIPTION
## Summary

- Delete no-op `resolveFallbackRetryPrompt` and inline `body` directly at the call site
- Simplify `resolveRetryImages` to positional args with a single `isFallbackRetry && reason === "format"` guard
- Replace the `effectiveOptions` IIFE in `model-fallback.ts` with a conditional spread one-liner
- Trim `_testInternals` export to `resolveRetryImages` only; remove the dead tests for the deleted function
- Add TODO noting `isFallbackRetry` is derivable from `previousFailureReason` presence

Net -71 lines, no behavioral changes.

## Related

- Built on #36273 (preserve prompt and images on failure-mode-aware fallback retry)
- Cleans up the `previousFailureReason` plumbing added in that PR

## Test plan

- [x] `pnpm test -- --run src/commands/agent.test.ts src/agents/model-fallback.test.ts` passes (same 2 pre-existing failures unrelated to this change)
- [x] `pnpm build` type-checks cleanly for touched files
- [x] `pnpm check` lint/format clean for touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)