### PR TITLE
fix(cron): avoid false unscheduled reminder note for isolated cron jobs

### DIFF
--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts
@@ -25,6 +25,47 @@ describe("subscribeEmbeddedPiSession", () => {
     emitAssistantTextDeltaAndEnd({ emit, text });
     expectFencedChunks(onBlockReply.mock.calls, "```json");
   });
+  it("preserves successful cron.add count across compaction retries", async () => {
+    const listeners: SessionEventHandler[] = [];
+    const session = {
+      subscribe: (listener: SessionEventHandler) => {
+        listeners.push(listener);
+        return () => {};
+      },
+    } as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"];
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-cron-count",
+    });
+
+    for (const listener of listeners) {
+      listener({
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId: "cron-add-1",
+        args: { action: "add", job: { name: "reminder" } },
+      });
+      listener({
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId: "cron-add-1",
+        isError: false,
+        result: { details: { status: "ok" } },
+      });
+    }
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(subscription.getSuccessfulCronAdds()).toBe(1);
+
+    for (const listener of listeners) {
+      listener({ type: "auto_compaction_end", willRetry: true });
+    }
+
+    expect(subscription.getSuccessfulCronAdds()).toBe(1);
+  });
+
   it("waits for auto-compaction retry and clears buffered text", async () => {
     const listeners: SessionEventHandler[] = [];
     const session = {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -597,7 +597,6 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentMediaUrls.length = 0;
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
-    state.successfulCronAdds = 0;
     state.pendingMessagingMediaUrls.clear();
     state.deterministicApprovalPromptSent = false;
     resetAssistantMessageState(0);

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -28,6 +28,7 @@ export function hasUnbackedReminderCommitment(text: string): boolean {
 export async function hasSessionRelatedCronJobs(params: {
   cronStorePath?: string;
   sessionKey?: string;
+  agentId?: string;
 }): Promise<boolean> {
   try {
     const storePath = resolveCronStorePath(params.cronStorePath);
@@ -36,7 +37,19 @@ export async function hasSessionRelatedCronJobs(params: {
       return false;
     }
     if (params.sessionKey) {
-      return store.jobs.some((job) => job.enabled && job.sessionKey === params.sessionKey);
+      const normalizedAgentId = params.agentId?.trim().toLowerCase();
+      return store.jobs.some((job) => {
+        if (!job.enabled) {
+          return false;
+        }
+        if (job.sessionKey === params.sessionKey) {
+          return true;
+        }
+        if (!job.sessionKey && normalizedAgentId) {
+          return (job.agentId ?? "").trim().toLowerCase() === normalizedAgentId;
+        }
+        return false;
+      });
     }
     return false;
   } catch {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1220,6 +1220,34 @@ describe("runReplyAgent reminder commitment guard", () => {
     });
   });
 
+  it("suppresses guard note when isolated cron exists for the same agent", async () => {
+    loadCronStoreMock.mockResolvedValueOnce({
+      version: 1,
+      jobs: [
+        {
+          id: "isolated-job",
+          name: "reminder",
+          enabled: true,
+          sessionKey: undefined,
+          agentId: "main",
+          createdAtMs: Date.now() - 60_000,
+          updatedAtMs: Date.now() - 60_000,
+        },
+      ],
+    });
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "I'll ping you tomorrow at 9am." }],
+      meta: {},
+      successfulCronAdds: 0,
+    });
+
+    const result = await createRun();
+    expect(result).toMatchObject({
+      text: "I'll ping you tomorrow at 9am.",
+    });
+  });
+
   it("still appends guard note when cron jobs exist but not for the current session", async () => {
     loadCronStoreMock.mockResolvedValueOnce({
       version: 1,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -528,6 +528,7 @@ export async function runReplyAgent(params: {
         ? await hasSessionRelatedCronJobs({
             cronStorePath: cfg.cron?.store,
             sessionKey,
+            agentId: sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined,
           })
         : false;
     const guardedReplyPayloads =


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: the unscheduled-reminder guard could append a contradictory note even when a reminder cron was successfully created for an isolated session.
- Why it matters: users could see "I'll remind you..." immediately followed by "I did not schedule a reminder," which breaks trust in reminder delivery.
- What changed: `hasSessionRelatedCronJobs` now also considers enabled isolated jobs (`sessionKey` unset) that match the current agent ID, and `runReplyAgent` now passes the agent ID into that check.
- What changed: compaction retry reset no longer clears `successfulCronAdds`, so a same-turn successful `cron.add` survives compaction retries.
- What did NOT change (scope boundary): reminder commitment detection patterns and unrelated cron scheduling behavior were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43292
- Related #32228

## User-visible / Behavior Changes

Reminder commitments are no longer followed by a false "I did not schedule a reminder in this turn" note when coverage comes from an enabled isolated-session cron for the same agent, including compaction-retry paths.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: Node.js + pnpm
- Model/provider: N/A (unit tests)
- Integration/channel (if any): N/A
- Relevant config (redacted): default test config

### Steps

1. Run reply-guard tests covering reminder note behavior for session + isolated cron jobs.
2. Run compaction retry subscription test covering successful `cron.add` count persistence.
3. Confirm reminder note is suppressed when isolated cron exists for the same agent and compaction retry occurs.

### Expected

- No contradictory unscheduled-reminder note when reminder coverage exists via same-agent isolated cron.
- `successfulCronAdds` remains >0 across compaction retry boundaries.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts -t "isolated cron exists for the same agent"`
  - `pnpm exec vitest run src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts -t "preserves successful cron.add count across compaction retries"`
- Edge cases checked:
  - existing session-key-based cron suppression remains unchanged
  - missing session key path still appends guard note
- What you did **not** verify:
  - full repository test suite
  - end-to-end channel-level reminder flows

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: restore previous versions of reminder guard and embedded subscribe state-reset logic.
- Known bad symptoms reviewers should watch for: reminder guard note might be over-suppressed if isolated cron matching logic is incorrect.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: isolated-job matching by agent ID could suppress the note for an unrelated isolated job owned by the same agent.
  - Mitigation: matching is only consulted when a session key exists and only for enabled jobs; previous session-key exact matching still takes precedence.
