### PR TITLE
UI: add Control UI agent switcher for chat sessions

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -336,6 +336,11 @@
   max-width: 300px;
 }
 
+.chat-controls__agent {
+  min-width: 120px;
+  max-width: 220px;
+}
+
 .chat-controls__thinking {
   display: flex;
   align-items: center;
@@ -426,6 +431,14 @@
   text-overflow: ellipsis;
 }
 
+.chat-controls__agent select {
+  padding: 6px 10px;
+  font-size: 13px;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .chat-controls__thinking {
   display: flex;
   align-items: center;
@@ -477,5 +490,9 @@
 
   .chat-controls__session {
     min-width: 120px;
+  }
+
+  .chat-controls__agent {
+    min-width: 110px;
   }
 }

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   isCronSessionKey,
   parseSessionKey,
+  resolveAgentMainSessionKey,
+  resolveSessionAgentId,
   resolveSessionDisplayName,
 } from "./app-render.helpers.ts";
 import type { SessionsListResult } from "./types.ts";
@@ -282,5 +284,39 @@ describe("isCronSessionKey", () => {
     expect(isCronSessionKey("main")).toBe(false);
     expect(isCronSessionKey("discord:group:eng")).toBe(false);
     expect(isCronSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
+  });
+});
+
+describe("resolveSessionAgentId", () => {
+  it("returns agent from scoped keys", () => {
+    expect(resolveSessionAgentId("agent:ops:main", "main")).toBe("ops");
+  });
+
+  it("falls back to default agent for legacy keys", () => {
+    expect(resolveSessionAgentId("main", "docs-agent")).toBe("docs-agent");
+  });
+});
+
+describe("resolveAgentMainSessionKey", () => {
+  it("keeps provided main session key for default agent", () => {
+    expect(
+      resolveAgentMainSessionKey({
+        agentId: "main",
+        defaultAgentId: "main",
+        mainSessionKey: "main",
+        mainKey: "main",
+      }),
+    ).toBe("main");
+  });
+
+  it("builds scoped main key for non-default agents", () => {
+    expect(
+      resolveAgentMainSessionKey({
+        agentId: "docs-agent",
+        defaultAgentId: "main",
+        mainSessionKey: "main",
+        mainKey: "work",
+      }),
+    ).toBe("agent:docs-agent:work");
   });
 });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,5 +1,9 @@
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import {
+  buildAgentMainSessionKey,
+  parseAgentSessionKey,
+} from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
@@ -124,6 +128,15 @@ function renderCronFilterIcon(hiddenCount: number) {
 
 export function renderChatControls(state: AppViewState) {
   const mainSessionKey = resolveMainSessionKey(state.hello, state.sessionsResult);
+  const defaultAgentId = resolveDefaultAgentId(state, mainSessionKey);
+  const selectedAgentId = resolveSessionAgentId(state.sessionKey, defaultAgentId);
+  const selectedAgentMainSessionKey = resolveAgentMainSessionKey({
+    agentId: selectedAgentId,
+    defaultAgentId,
+    mainSessionKey,
+    mainKey: state.agentsList?.mainKey,
+  });
+  const agentOptions = resolveAgentOptions(state, selectedAgentId, defaultAgentId);
   const hideCron = state.sessionsHideCron ?? true;
   const hiddenCronCount = hideCron
     ? countHiddenCronSessions(state.sessionKey, state.sessionsResult)
@@ -131,9 +144,37 @@ export function renderChatControls(state: AppViewState) {
   const sessionOptions = resolveSessionOptions(
     state.sessionKey,
     state.sessionsResult,
-    mainSessionKey,
+    selectedAgentMainSessionKey,
     hideCron,
+    {
+      selectedAgentId,
+      defaultAgentId,
+    },
   );
+  const applySessionSwitch = (next: string) => {
+    if (!next || state.sessionKey === next) {
+      return;
+    }
+    state.sessionKey = next;
+    state.chatMessage = "";
+    state.chatStream = null;
+    (state as unknown as OpenClawApp).chatStreamStartedAt = null;
+    state.chatRunId = null;
+    (state as unknown as OpenClawApp).resetToolStream();
+    (state as unknown as OpenClawApp).resetChatScroll();
+    state.applySettings({
+      ...state.settings,
+      sessionKey: next,
+      lastActiveSessionKey: next,
+    });
+    void state.loadAssistantIdentity();
+    syncUrlWithSessionKey(
+      state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
+      next,
+      true,
+    );
+    void loadChatHistory(state as unknown as ChatState);
+  };
   const disableThinkingToggle = state.onboarding;
   const disableFocusToggle = state.onboarding;
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
@@ -174,31 +215,48 @@ export function renderChatControls(state: AppViewState) {
   `;
   return html`
     <div class="chat-controls">
+      <label class="field chat-controls__agent">
+        <select
+          .value=${selectedAgentId}
+          ?disabled=${!state.connected}
+          aria-label=${t("nav.agent")}
+          title=${t("nav.agent")}
+          @change=${(e: Event) => {
+            const nextAgentId = normalizeAgentId((e.target as HTMLSelectElement).value);
+            if (!nextAgentId || nextAgentId === selectedAgentId) {
+              return;
+            }
+            const nextMainSessionKey = resolveAgentMainSessionKey({
+              agentId: nextAgentId,
+              defaultAgentId,
+              mainSessionKey,
+              mainKey: state.agentsList?.mainKey,
+            });
+            const nextSessionOptions = resolveSessionOptions(
+              state.sessionKey,
+              state.sessionsResult,
+              nextMainSessionKey,
+              hideCron,
+              { selectedAgentId: nextAgentId, defaultAgentId },
+            );
+            const nextSessionKey = nextSessionOptions[0]?.key ?? nextMainSessionKey;
+            applySessionSwitch(nextSessionKey);
+          }}
+        >
+          ${repeat(
+            agentOptions,
+            (agentId) => agentId,
+            (agentId) => html`<option value=${agentId}>${agentId}</option>`,
+          )}
+        </select>
+      </label>
       <label class="field chat-controls__session">
         <select
           .value=${state.sessionKey}
           ?disabled=${!state.connected}
           @change=${(e: Event) => {
             const next = (e.target as HTMLSelectElement).value;
-            state.sessionKey = next;
-            state.chatMessage = "";
-            state.chatStream = null;
-            (state as unknown as OpenClawApp).chatStreamStartedAt = null;
-            state.chatRunId = null;
-            (state as unknown as OpenClawApp).resetToolStream();
-            (state as unknown as OpenClawApp).resetChatScroll();
-            state.applySettings({
-              ...state.settings,
-              sessionKey: next,
-              lastActiveSessionKey: next,
-            });
-            void state.loadAssistantIdentity();
-            syncUrlWithSessionKey(
-              state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
-              next,
-              true,
-            );
-            void loadChatHistory(state as unknown as ChatState);
+            applySessionSwitch(next);
           }}
         >
           ${repeat(
@@ -308,6 +366,76 @@ function resolveMainSessionKey(
     return "main";
   }
   return null;
+}
+
+function normalizeAgentId(value: string | null | undefined): string {
+  const normalized = (value ?? "").trim().toLowerCase();
+  return normalized || "main";
+}
+
+function resolveDefaultAgentId(state: AppViewState, mainSessionKey?: string | null): string {
+  const configured = state.agentsList?.defaultId?.trim();
+  if (configured) {
+    return normalizeAgentId(configured);
+  }
+  const parsedMain = parseAgentSessionKey(mainSessionKey ?? "");
+  if (parsedMain?.agentId) {
+    return normalizeAgentId(parsedMain.agentId);
+  }
+  const parsedCurrent = parseAgentSessionKey(state.sessionKey);
+  if (parsedCurrent?.agentId) {
+    return normalizeAgentId(parsedCurrent.agentId);
+  }
+  return "main";
+}
+
+function resolveAgentOptions(
+  state: AppViewState,
+  selectedAgentId: string,
+  defaultAgentId: string,
+): string[] {
+  const seen = new Set<string>();
+  const options: string[] = [];
+  for (const entry of state.agentsList?.agents ?? []) {
+    const id = normalizeAgentId(entry.id);
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    options.push(id);
+  }
+  for (const fallback of [selectedAgentId, defaultAgentId]) {
+    const id = normalizeAgentId(fallback);
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    options.push(id);
+  }
+  return options.length > 0 ? options : ["main"];
+}
+
+export function resolveSessionAgentId(sessionKey: string, defaultAgentId: string): string {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId);
+  }
+  return normalizeAgentId(defaultAgentId);
+}
+
+export function resolveAgentMainSessionKey(params: {
+  agentId: string;
+  defaultAgentId: string;
+  mainSessionKey?: string | null;
+  mainKey?: string | null;
+}): string {
+  const agentId = normalizeAgentId(params.agentId);
+  const defaultAgentId = normalizeAgentId(params.defaultAgentId);
+  const mainSessionKey = (params.mainSessionKey ?? "").trim();
+  if (mainSessionKey && agentId === defaultAgentId) {
+    return mainSessionKey;
+  }
+  return buildAgentMainSessionKey({ agentId, mainKey: params.mainKey ?? undefined });
 }
 
 /* ── Channel display labels ────────────────────────────── */
@@ -436,15 +564,25 @@ function resolveSessionOptions(
   sessions: SessionsListResult | null,
   mainSessionKey?: string | null,
   hideCron = false,
+  agentFilter?: { selectedAgentId: string; defaultAgentId: string },
 ) {
   const seen = new Set<string>();
   const options: Array<{ key: string; displayName?: string }> = [];
+  const shouldIncludeSession = (key: string) => {
+    if (!agentFilter) {
+      return true;
+    }
+    return (
+      resolveSessionAgentId(key, agentFilter.defaultAgentId) ===
+      normalizeAgentId(agentFilter.selectedAgentId)
+    );
+  };
 
   const resolvedMain = mainSessionKey && sessions?.sessions?.find((s) => s.key === mainSessionKey);
   const resolvedCurrent = sessions?.sessions?.find((s) => s.key === sessionKey);
 
   // Add main session key first
-  if (mainSessionKey) {
+  if (mainSessionKey && shouldIncludeSession(mainSessionKey)) {
     seen.add(mainSessionKey);
     options.push({
       key: mainSessionKey,
@@ -454,7 +592,7 @@ function resolveSessionOptions(
 
   // Add current session key next — always include it even if it's a cron session,
   // so the active session is never silently dropped from the select.
-  if (!seen.has(sessionKey)) {
+  if (!seen.has(sessionKey) && shouldIncludeSession(sessionKey)) {
     seen.add(sessionKey);
     options.push({
       key: sessionKey,
@@ -465,7 +603,11 @@ function resolveSessionOptions(
   // Add sessions from the result, optionally filtering out cron sessions.
   if (sessions?.sessions) {
     for (const s of sessions.sessions) {
-      if (!seen.has(s.key) && !(hideCron && isCronSessionKey(s.key))) {
+      if (
+        !seen.has(s.key) &&
+        !(hideCron && isCronSessionKey(s.key)) &&
+        shouldIncludeSession(s.key)
+      ) {
         seen.add(s.key);
         options.push({
           key: s.key,


### PR DESCRIPTION
## Summary

- Problem: Control UI chat controls only exposed a session selector, which made switching configured agents hard and often left users in the default `main` agent flow.
- Why it matters: Multi-agent setups (for example code/docs/test agents) need quick in-UI switching without leaving the dashboard.
- What changed: Added an agent dropdown in chat controls, scoped the session dropdown to the selected agent, and switched session context when agent selection changes.
- What did NOT change (scope boundary): No gateway RPC contract changes, no session storage schema changes, and no non-chat tab behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32495
- Related #

## User-visible / Behavior Changes

- Chat controls now include an `Agent` selector listing configured agents.
- Session dropdown now shows sessions for the selected agent instead of mixed-agent session keys.
- Switching agent updates chat to that agent’s main session context (`agent:<id>:<mainKey>`), keeping chat context separated per agent.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): Control UI (web)
- Relevant config (redacted): multi-agent gateway config

### Steps

1. Open Control UI chat view.
2. Use the new agent dropdown to switch between configured agents.
3. Observe session dropdown updates to that agent’s sessions and chat context switches.

### Expected

- Agent list is selectable in chat controls.
- Session options are scoped per selected agent.
- Chat session key changes to the selected agent scope.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands and outcomes:

- `pnpm --dir ui test src/ui/app-render.helpers.node.test.ts` (passed, 40 tests)
- `pnpm --dir ui build` (passed)

## Human Verification (required)

- Verified scenarios: agent switch in chat controls, agent-scoped session options, default main-session resolution per agent.
- Edge cases checked: legacy non-agent session keys map to default agent; default-agent main session key remains unchanged when provided by snapshot.
- What you did **not** verify: full browser screenshot/manual UX QA across all mobile breakpoints.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `a63cff2b5`.
- Files/config to restore: `ui/src/ui/app-render.helpers.ts`, `ui/src/styles/chat/layout.css`.
- Known bad symptoms reviewers should watch for: session dropdown empty or wrong session scope when switching agents.

## Risks and Mitigations

- Risk: legacy sessions might be filtered unexpectedly if default agent inference is wrong.
  - Mitigation: fallback logic uses configured default agent, then snapshot/current session fallback, then `main`; helper tests cover this path.
