### PR TITLE
Fix tool dispatch for malformed or missing tool call names

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -304,6 +304,29 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(finalToolCall.name).toBe("exec");
   });
 
+  it("maps colon-delimited provider-prefixed tool names to allowed canonical tools", async () => {
+    const partialToolCall = { type: "toolCall", name: " functions:read " };
+    const messageToolCall = { type: "toolCall", name: " tools:write " };
+    const finalToolCall = { type: "toolCall", name: " provider:exec " };
+    const event = {
+      type: "toolcall_delta",
+      partial: { role: "assistant", content: [partialToolCall] },
+      message: { role: "assistant", content: [messageToolCall] },
+    };
+    const { baseFn } = createEventStream({ event, finalToolCall });
+
+    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write", "exec"]));
+
+    for await (const _item of stream) {
+      // drain
+    }
+    await stream.result();
+
+    expect(partialToolCall.name).toBe("read");
+    expect(messageToolCall.name).toBe("write");
+    expect(finalToolCall.name).toBe("exec");
+  });
+
   it("normalizes toolUse and functionCall names before dispatch", async () => {
     const partialToolCall = { type: "toolUse", name: " functions.read " };
     const messageToolCall = { type: "functionCall", name: " functions.exec " };
@@ -370,6 +393,58 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(partialToolCall.name).toBe("   ");
     expect(finalToolCall.name).toBe("\t  ");
     expect(baseFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("infers blank tool call names from call ids when possible", async () => {
+    const partialToolCall = { type: "toolCall", id: "functions.read:0", name: "  " };
+    const finalToolCall = { type: "toolCall", id: "functionsexec0", name: " " };
+    const event = {
+      type: "toolcall_delta",
+      partial: { role: "assistant", content: [partialToolCall] },
+    };
+    const { baseFn } = createEventStream({ event, finalToolCall });
+
+    const stream = await invokeWrappedStream(baseFn, new Set(["read", "exec"]));
+
+    for await (const _item of stream) {
+      // drain
+    }
+    await stream.result();
+
+    expect(partialToolCall.name).toBe("read");
+    expect(finalToolCall.name).toBe("exec");
+  });
+
+  it("fills missing tool call names from call ids when possible", async () => {
+    const partialToolCall: { type: string; id: string; name?: string } = {
+      type: "toolCall",
+      id: "functions.write:2",
+    };
+    const finalToolCall: { type: string; id: string; name?: string } = {
+      type: "toolCall",
+      id: "functions.read:3",
+    };
+    const event = {
+      type: "toolcall_delta",
+      partial: { role: "assistant", content: [partialToolCall] },
+    };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [event],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write"]));
+
+    for await (const _item of stream) {
+      // drain
+    }
+    await stream.result();
+
+    expect(partialToolCall.name).toBe("write");
+    expect(finalToolCall.name).toBe("read");
   });
 
   it("assigns fallback ids to missing/blank tool call ids in streamed and final messages", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -242,38 +242,21 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
     });
 }
 
-function normalizeToolCallNameForDispatch(rawName: string, allowedToolNames?: Set<string>): string {
-  const trimmed = rawName.trim();
-  if (!trimmed) {
-    // Keep whitespace-only placeholders unchanged so they do not collapse to
-    // empty names (which can later surface as toolName="" loops).
-    return rawName;
-  }
+function resolveAllowedToolNameCandidate(
+  candidates: Set<string>,
+  allowedToolNames?: Set<string>,
+): string | undefined {
   if (!allowedToolNames || allowedToolNames.size === 0) {
-    return trimmed;
+    return undefined;
   }
 
-  const candidateNames = new Set<string>([trimmed, normalizeToolName(trimmed)]);
-  const normalizedDelimiter = trimmed.replace(/\//g, ".");
-  const segments = normalizedDelimiter
-    .split(".")
-    .map((segment) => segment.trim())
-    .filter(Boolean);
-  if (segments.length > 1) {
-    for (let index = 1; index < segments.length; index += 1) {
-      const suffix = segments.slice(index).join(".");
-      candidateNames.add(suffix);
-      candidateNames.add(normalizeToolName(suffix));
-    }
-  }
-
-  for (const candidate of candidateNames) {
+  for (const candidate of candidates) {
     if (allowedToolNames.has(candidate)) {
       return candidate;
     }
   }
 
-  for (const candidate of candidateNames) {
+  for (const candidate of candidates) {
     const folded = candidate.toLowerCase();
     let caseInsensitiveMatch: string | null = null;
     for (const name of allowedToolNames) {
@@ -287,6 +270,105 @@ function normalizeToolCallNameForDispatch(rawName: string, allowedToolNames?: Se
     }
     if (caseInsensitiveMatch) {
       return caseInsensitiveMatch;
+    }
+  }
+
+  return undefined;
+}
+
+function collectToolNameCandidates(raw: string): Set<string> {
+  const candidates = new Set<string>([raw, normalizeToolName(raw)]);
+  const normalizedDelimiter = raw.replace(/[/:]/g, ".");
+  const segments = normalizedDelimiter
+    .split(".")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  if (segments.length > 1) {
+    for (let index = 1; index < segments.length; index += 1) {
+      const suffix = segments.slice(index).join(".");
+      candidates.add(suffix);
+      candidates.add(normalizeToolName(suffix));
+    }
+  }
+  return candidates;
+}
+
+function inferToolNameFromToolCallId(
+  rawToolCallId: string,
+  allowedToolNames?: Set<string>,
+): string | undefined {
+  if (!allowedToolNames || allowedToolNames.size === 0) {
+    return undefined;
+  }
+  const trimmedId = rawToolCallId.trim();
+  if (!trimmedId) {
+    return undefined;
+  }
+
+  const idCandidates = collectToolNameCandidates(trimmedId);
+  const trimmedNumericSuffix = trimmedId.replace(/[:._-]?\d+$/u, "");
+  if (trimmedNumericSuffix && trimmedNumericSuffix !== trimmedId) {
+    for (const candidate of collectToolNameCandidates(trimmedNumericSuffix)) {
+      idCandidates.add(candidate);
+    }
+  }
+
+  const directMatch = resolveAllowedToolNameCandidate(idCandidates, allowedToolNames);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const compactId = trimmedId.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const compactNoIndex = compactId.replace(/\d+$/u, "");
+  const allowedByLengthDesc = Array.from(allowedToolNames).toSorted(
+    (left, right) => right.length - left.length,
+  );
+  for (const allowedName of allowedByLengthDesc) {
+    const normalizedAllowed = allowedName.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (!normalizedAllowed) {
+      continue;
+    }
+    if (compactNoIndex.endsWith(normalizedAllowed)) {
+      return allowedName;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeToolCallNameForDispatch(
+  rawName: string,
+  allowedToolNames?: Set<string>,
+  toolCallId?: string,
+): string {
+  const trimmed = rawName.trim();
+  if (!trimmed) {
+    const inferred =
+      typeof toolCallId === "string"
+        ? inferToolNameFromToolCallId(toolCallId, allowedToolNames)
+        : undefined;
+    if (inferred) {
+      return inferred;
+    }
+    // Keep whitespace-only placeholders unchanged so they do not collapse to
+    // empty names (which can later surface as toolName="" loops).
+    return rawName;
+  }
+  if (!allowedToolNames || allowedToolNames.size === 0) {
+    return trimmed;
+  }
+
+  const directMatch = resolveAllowedToolNameCandidate(
+    collectToolNameCandidates(trimmed),
+    allowedToolNames,
+  );
+  if (directMatch) {
+    return directMatch;
+  }
+  if (typeof toolCallId === "string") {
+    const inferred = inferToolNameFromToolCallId(toolCallId, allowedToolNames);
+    if (inferred) {
+      return inferred;
     }
   }
 
@@ -366,11 +448,26 @@ function trimWhitespaceFromToolCallNamesInMessage(
     if (!block || typeof block !== "object") {
       continue;
     }
-    const typedBlock = block as { type?: unknown; name?: unknown };
-    if (!isToolCallBlockType(typedBlock.type) || typeof typedBlock.name !== "string") {
+    const typedBlock = block as { type?: unknown; name?: unknown; id?: unknown };
+    if (!isToolCallBlockType(typedBlock.type)) {
       continue;
     }
-    const normalized = normalizeToolCallNameForDispatch(typedBlock.name, allowedToolNames);
+    const toolCallId = typeof typedBlock.id === "string" ? typedBlock.id : undefined;
+    if (typeof typedBlock.name !== "string") {
+      const inferred =
+        typeof toolCallId === "string"
+          ? inferToolNameFromToolCallId(toolCallId, allowedToolNames)
+          : undefined;
+      if (inferred) {
+        typedBlock.name = inferred;
+      }
+      continue;
+    }
+    const normalized = normalizeToolCallNameForDispatch(
+      typedBlock.name,
+      allowedToolNames,
+      toolCallId,
+    );
     if (normalized !== typedBlock.name) {
       typedBlock.name = normalized;
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Some OpenAI-compatible/Kimi responses emit malformed tool names (`functions:read`) or blank/missing names while still carrying usable `toolCallId` values, which causes dispatch misses and repeated `Tool not found` failures.
- Why it matters: Users can have `tools.profile: "full"` correctly configured but still lose practical access to tools because calls fail at dispatch-time.
- What changed: Extended live tool-call name normalization to (1) treat `:` as a provider-prefix delimiter and (2) recover blank/missing tool names from `toolCallId` when an allowed canonical tool can be inferred.
- What did NOT change (scope boundary): No config policy/profile behavior was changed; this patch only hardens tool-call name resolution in the runner.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43283
- Related #41462

## User-visible / Behavior Changes

- Tool calls with malformed names like `functions:read` are now mapped to canonical tools (for example `read`) when allowed.
- Tool calls with blank/missing `name` can now be recovered from `toolCallId` patterns like `functions.read:0` and `functionsexec0`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev machine)
- Runtime/container: Node 22 + pnpm + Vitest
- Model/provider: runner normalization path for OpenAI-compatible tool-call payloads
- Integration/channel (if any): N/A (unit test coverage)
- Relevant config (redacted): N/A

### Steps

1. Add regression cases for colon-delimited tool names and blank/missing names with informative `toolCallId` values.
2. Run focused runner tests.
3. Run formatting check.

### Expected

- Malformed provider-prefixed names are normalized to canonical allowed tool names.
- Blank/missing names can be inferred from `toolCallId` where possible.

### Actual

- Verified with passing focused tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm vitest run src/agents/pi-embedded-runner/run/attempt.test.ts`
  - Outcome: pass (`1 passed`, `45 passed` tests)
- `pnpm format:check`
  - Outcome: pass (`All matched files use the correct format.`)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Colon-delimited provider prefixes now normalize (`functions:read` -> `read`).
  - Blank name + informative call id is recovered (`functions.read:0` -> `read`).
  - Missing name + informative call id is recovered.
- Edge cases checked:
  - Existing whitespace-trim and slash/dot prefix normalization tests still pass.
- What you did **not** verify:
  - Live remote Kimi/Ollama-cloud end-to-end run against an external gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts` and tests.
- Known bad symptoms reviewers should watch for: incorrect tool-name inference from unusual tool-call ids.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-aggressive inference could map an unexpected malformed id to the wrong allowed tool.
  - Mitigation: Inference runs only against the currently allowed tool set and prefers direct canonical matches before fallback suffix matching; added focused regression tests for known problematic patterns.
