### PR TITLE
feat(plugins): add api.resetSession() on top of gateway reset service

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -151,6 +151,8 @@ type PluginTypedHookPolicy = {
   allowPromptInjection?: boolean;
 };
 
+const inFlightPluginResets = new Set<string>();
+
 const constrainLegacyPromptInjectionHook = (
   handler: PluginHookHandlerMap["before_agent_start"],
 ): PluginHookHandlerMap["before_agent_start"] => {
@@ -164,6 +166,23 @@ const constrainLegacyPromptInjectionHook = (
     return stripPromptMutationFieldsFromLegacyHookResult(result);
   };
 };
+
+function normalizeResetSessionError(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object") {
+    const message = "message" in error ? (error as { message?: unknown }).message : undefined;
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+  return "session reset failed";
+}
+
+export function clearInFlightPluginResetsForTesting(): void {
+  inFlightPluginResets.clear();
+}
 
 export function createEmptyPluginRegistry(): PluginRegistry {
   return {
@@ -602,6 +621,61 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerCommand: (command) => registerCommand(record, command),
       registerContextEngine: (id, factory) => registerContextEngine(id, factory),
       resolvePath: (input: string) => resolveUserPath(input),
+      resetSession: async (key, reason) => {
+        if (typeof key !== "string") {
+          return { ok: false, key: "", error: "key required" };
+        }
+        const trimmedKey = key.trim();
+        if (!trimmedKey) {
+          return { ok: false, key: "", error: "key required" };
+        }
+
+        const [{ resolveSessionStoreKey }, { performGatewaySessionReset }] = await Promise.all([
+          import("../gateway/session-utils.js"),
+          import("../gateway/session-reset-service.js"),
+        ]);
+        const canonicalKey = resolveSessionStoreKey({
+          cfg: params.config,
+          sessionKey: trimmedKey,
+        });
+
+        if (inFlightPluginResets.has(canonicalKey)) {
+          return {
+            ok: false,
+            key: canonicalKey,
+            error: `reset already in progress for ${canonicalKey}`,
+          };
+        }
+
+        inFlightPluginResets.add(canonicalKey);
+        try {
+          const result = await performGatewaySessionReset({
+            key: trimmedKey,
+            reason: reason === "reset" ? "reset" : "new",
+            commandSource: `plugin:${record.id}`,
+          });
+          if (!result.ok) {
+            return {
+              ok: false,
+              key: canonicalKey,
+              error: normalizeResetSessionError(result.error),
+            };
+          }
+          return {
+            ok: true,
+            key: result.key,
+            sessionId: result.entry.sessionId,
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            key: canonicalKey,
+            error: normalizeResetSessionError(error),
+          };
+        } finally {
+          inFlightPluginResets.delete(canonicalKey);
+        }
+      },
       on: (hookName, handler, opts) =>
         registerTypedHook(record, hookName, handler, opts, params.hookPolicy),
     };

--- a/src/plugins/reset-session.test.ts
+++ b/src/plugins/reset-session.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearInFlightPluginResetsForTesting,
+  createPluginRegistry,
+  type PluginRecord,
+} from "./registry.js";
+import type { PluginRuntime } from "./runtime/types.js";
+
+const mockPerformGatewaySessionReset = vi.fn();
+const mockResolveSessionStoreKey = vi.fn(({ sessionKey }: { sessionKey: string }) =>
+  sessionKey.toLowerCase(),
+);
+
+vi.mock("../gateway/session-reset-service.js", () => ({
+  performGatewaySessionReset: (...args: unknown[]) =>
+    mockPerformGatewaySessionReset(...(args as [never])),
+}));
+
+vi.mock("../gateway/session-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../gateway/session-utils.js")>()),
+  resolveSessionStoreKey: (...args: unknown[]) => mockResolveSessionStoreKey(...(args as [never])),
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makePluginRecord(id = "test-plugin"): PluginRecord {
+  return {
+    id,
+    name: id,
+    source: `/tmp/${id}/index.js`,
+    origin: "global",
+    enabled: true,
+    status: "loaded",
+    toolNames: [],
+    hookNames: [],
+    channelIds: [],
+    providerIds: [],
+    gatewayMethods: [],
+    cliCommands: [],
+    services: [],
+    commands: [],
+    httpRoutes: 0,
+    hookCount: 0,
+    configSchema: false,
+  };
+}
+
+function makeSuccessResult(key: string, sessionId = "session-123") {
+  return {
+    ok: true as const,
+    key,
+    entry: {
+      sessionId,
+      updatedAt: Date.now(),
+      systemSent: false,
+      abortedLastRun: false,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      totalTokensFresh: true,
+    },
+  };
+}
+
+const dummyLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+const dummyRuntime = {
+  version: "test",
+} as unknown as PluginRuntime;
+
+describe("api.resetSession", () => {
+  let resetSession: NonNullable<
+    ReturnType<ReturnType<typeof createPluginRegistry>["createApi"]>["resetSession"]
+  >;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPerformGatewaySessionReset.mockReset();
+    mockResolveSessionStoreKey.mockReset();
+    clearInFlightPluginResetsForTesting();
+    mockResolveSessionStoreKey.mockImplementation(({ sessionKey }: { sessionKey: string }) =>
+      sessionKey.toLowerCase(),
+    );
+    const registry = createPluginRegistry({
+      logger: dummyLogger,
+      runtime: dummyRuntime,
+    });
+    const api = registry.createApi(makePluginRecord(), {
+      config: { session: {} } as never,
+    });
+    resetSession = api.resetSession as NonNullable<typeof api.resetSession>;
+  });
+
+  it("returns an error for non-string keys", async () => {
+    const result = await (resetSession as (key: unknown) => ReturnType<typeof resetSession>)(123);
+    expect(result).toEqual({ ok: false, key: "", error: "key required" });
+    expect(mockPerformGatewaySessionReset).not.toHaveBeenCalled();
+  });
+
+  it("returns an error for empty keys", async () => {
+    await expect(resetSession("")).resolves.toEqual({ ok: false, key: "", error: "key required" });
+    await expect(resetSession("   ")).resolves.toEqual({
+      ok: false,
+      key: "",
+      error: "key required",
+    });
+    expect(mockPerformGatewaySessionReset).not.toHaveBeenCalled();
+  });
+
+  it('trims keys and defaults the reason to "new"', async () => {
+    mockPerformGatewaySessionReset.mockResolvedValue(
+      makeSuccessResult("agent:test:main", "session-new"),
+    );
+
+    await expect(resetSession("  Main  ")).resolves.toEqual({
+      ok: true,
+      key: "agent:test:main",
+      sessionId: "session-new",
+    });
+    expect(mockResolveSessionStoreKey).toHaveBeenCalledWith({
+      cfg: { session: {} },
+      sessionKey: "Main",
+    });
+    expect(mockPerformGatewaySessionReset).toHaveBeenCalledWith({
+      key: "Main",
+      reason: "new",
+      commandSource: "plugin:test-plugin",
+    });
+  });
+
+  it('forwards an explicit "reset" reason', async () => {
+    mockPerformGatewaySessionReset.mockResolvedValue(makeSuccessResult("agent:test:main"));
+
+    await resetSession("main", "reset");
+
+    expect(mockPerformGatewaySessionReset).toHaveBeenCalledWith({
+      key: "main",
+      reason: "reset",
+      commandSource: "plugin:test-plugin",
+    });
+  });
+
+  it("normalizes gateway failure results to plugin error strings", async () => {
+    mockPerformGatewaySessionReset.mockResolvedValue({
+      ok: false,
+      error: { message: "Session main is still active; try again in a moment." },
+    });
+
+    await expect(resetSession("main")).resolves.toEqual({
+      ok: false,
+      key: "main",
+      error: "Session main is still active; try again in a moment.",
+    });
+  });
+
+  it("normalizes thrown errors to plugin error strings", async () => {
+    mockPerformGatewaySessionReset.mockRejectedValue(new Error("kaboom"));
+
+    await expect(resetSession("main")).resolves.toEqual({
+      ok: false,
+      key: "main",
+      error: "kaboom",
+    });
+  });
+
+  it("applies the in-flight guard to canonicalized keys", async () => {
+    const first = deferred<ReturnType<typeof makeSuccessResult>>();
+    mockResolveSessionStoreKey.mockImplementation(() => "agent:test:main");
+    mockPerformGatewaySessionReset.mockImplementationOnce(() => first.promise);
+
+    const firstCall = resetSession("Main");
+    const secondCall = await resetSession("agent:test:main");
+
+    expect(secondCall).toEqual({
+      ok: false,
+      key: "agent:test:main",
+      error: "reset already in progress for agent:test:main",
+    });
+
+    first.resolve(makeSuccessResult("agent:test:main", "session-first"));
+    await expect(firstCall).resolves.toEqual({
+      ok: true,
+      key: "agent:test:main",
+      sessionId: "session-first",
+    });
+    expect(mockPerformGatewaySessionReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows concurrent resets for different canonical keys", async () => {
+    const alpha = deferred<ReturnType<typeof makeSuccessResult>>();
+    mockResolveSessionStoreKey.mockImplementation(
+      ({ sessionKey }: { sessionKey: string }) => `canon:${sessionKey.toLowerCase()}`,
+    );
+    mockPerformGatewaySessionReset
+      .mockImplementationOnce(() => alpha.promise)
+      .mockResolvedValueOnce(makeSuccessResult("canon:beta", "session-beta"));
+
+    const alphaCall = resetSession("alpha");
+    const betaCall = await resetSession("beta");
+
+    alpha.resolve(makeSuccessResult("canon:alpha", "session-alpha"));
+
+    await expect(alphaCall).resolves.toEqual({
+      ok: true,
+      key: "canon:alpha",
+      sessionId: "session-alpha",
+    });
+    expect(betaCall.ok).toBe(true);
+  });
+
+  it("releases the in-flight guard after a failed reset", async () => {
+    mockResolveSessionStoreKey.mockReturnValue("agent:test:main");
+    mockPerformGatewaySessionReset
+      .mockResolvedValueOnce({
+        ok: false,
+        error: { message: "temporary failure" },
+      })
+      .mockResolvedValueOnce(makeSuccessResult("agent:test:main", "session-second"));
+
+    await expect(resetSession("main")).resolves.toEqual({
+      ok: false,
+      key: "agent:test:main",
+      error: "temporary failure",
+    });
+    await expect(resetSession("main")).resolves.toEqual({
+      ok: true,
+      key: "agent:test:main",
+      sessionId: "session-second",
+    });
+    expect(mockPerformGatewaySessionReset).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -260,6 +260,18 @@ export type OpenClawPluginModule =
   | OpenClawPluginDefinition
   | ((api: OpenClawPluginApi) => void | Promise<void>);
 
+export type PluginResetSessionResult =
+  | {
+      ok: true;
+      key: string;
+      sessionId: string;
+    }
+  | {
+      ok: false;
+      key: string;
+      error: string;
+    };
+
 export type OpenClawPluginApi = {
   id: string;
   name: string;
@@ -297,6 +309,11 @@ export type OpenClawPluginApi = {
     factory: import("../context-engine/registry.js").ContextEngineFactory,
   ) => void;
   resolvePath: (input: string) => string;
+  /**
+   * Reset a session by key, creating a new session ID and archiving the old transcript.
+   * Equivalent to the `sessions.reset` gateway method / `/new` command.
+   */
+  resetSession?: (key: string, reason?: "new" | "reset") => Promise<PluginResetSessionResult>;
   /** Register a lifecycle hook handler */
   on: <K extends PluginHookName>(
     hookName: K,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -313,7 +313,7 @@ export type OpenClawPluginApi = {
    * Reset a session by key, creating a new session ID and archiving the old transcript.
    * Equivalent to the `sessions.reset` gateway method / `/new` command.
    */
-  resetSession?: (key: string, reason?: "new" | "reset") => Promise<PluginResetSessionResult>;
+  resetSession: (key: string, reason?: "new" | "reset") => Promise<PluginResetSessionResult>;
   /** Register a lifecycle hook handler */
   on: <K extends PluginHookName>(
     hookName: K,


### PR DESCRIPTION
## Summary

- Exposes the existing gateway session reset capability to plugins as `api.resetSession(key, reason?)`
- Reuses current `main` reset architecture via `performGatewaySessionReset(...)`
- Adds a canonical-key in-flight guard to prevent hook-driven reset recursion without reviving the old cooldown design
- Adds focused plugin API contract tests only

## Why this is a replacement PR

- Supersedes the old dirty/conflict-prone shape from `#36901`
- Keeps the scope to the three plugin files needed to unblock Engram compaction reset
- Avoids reviving `session-ops.ts` or touching gateway reset plumbing already absorbed by `main`

## Verification

- `pnpm exec vitest run src/plugins/reset-session.test.ts`
- `pnpm exec oxfmt --check src/plugins/reset-session.test.ts src/plugins/registry.ts src/plugins/types.ts`
- `pnpm exec oxlint --type-aware src/plugins/registry.ts src/plugins/types.ts src/plugins/reset-session.test.ts`

## Notes

- Full `pnpm check` is not fully proven in this environment because `format:check` also reports an unrelated existing issue in `src/cli/daemon-cli/lifecycle.test.ts` on the current branch baseline.
- Downstream dependency: `joshuaswarren/openclaw-engram#120`
