### PR TITLE
fix(models): enable tool call ID sanitization for openai-responses API

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -54,6 +54,36 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict");
   });
 
+  it("enables strict tool call id sanitization for openai-responses API (#43305)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-5.2",
+      modelApi: "openai-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("enables strict tool call id sanitization for custom providers using openai-responses API (#43305)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "custom-proxy",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("enables strict tool call id sanitization for openai-codex-responses API (#43305)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai-codex",
+      modelId: "codex",
+      modelApi: "openai-codex-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
   it("enables user-turn merge for strict OpenAI-compatible providers", () => {
     const policy = resolveTranscriptPolicy({
       provider: "moonshot",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -78,7 +78,12 @@ export function resolveTranscriptPolicy(params: {
       provider,
       modelId,
     });
-  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  // OpenAI Responses API has a 64-character limit on call_id.
+  // OpenAI Completions API also requires alphanumeric-only tool call IDs for some providers.
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" ||
+    params.modelApi === "openai-responses" ||
+    params.modelApi === "openai-codex-responses";
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").


### PR DESCRIPTION
## Summary

- The OpenAI Responses API has a 64-character limit on `call_id`
- Previously, only `openai-completions` had tool call ID sanitization enabled
- This fix extends the sanitization to `openai-responses` API as well

## Root Cause

When using `api: "openai-responses"` against an OpenAI-compatible proxy, tool call IDs could exceed 64 characters, causing HTTP 400 errors:
```
Invalid 'input[n].id': string too long. Expected a string with maximum length 64, but got a string with length 408 instead.
```

## Fix

Added `openai-responses` to the condition that enables strict tool call ID sanitization in `src/agents/transcript-policy.ts`.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43305

## User-visible / Behavior Changes

Users using `openai-responses` API will no longer encounter tool call ID length errors.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS/Linux/Windows
- Runtime: Node.js 22
- Model/provider: Any using openai-responses API

### Steps
1. Configure a provider with `api: "openai-responses"`
2. Trigger a session with tool calls
3. Verify no HTTP 400 errors about ID length

## Evidence

- [x] Failing test/log before + passing after (test added)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: openai-responses API with tool calls
- Edge cases checked: Custom providers using openai-responses
- What did **not** verify: Actual OpenAI Responses API endpoint (no access)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None. This is a straightforward fix that extends existing sanitization logic to another API type.

🤖 Generated by AI Contributor (kincoy)