### PR TITLE
fix(sessions): thread agentChannel through sessions_send instead of hardcoding INTERNAL_MESSAGE_CHANNEL

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -222,7 +222,7 @@ export function createSessionsSendTool(opts?: {
         sessionKey: resolvedKey,
         idempotencyKey,
         deliver: false,
-        channel: INTERNAL_MESSAGE_CHANNEL,
+        channel: opts?.agentChannel ?? INTERNAL_MESSAGE_CHANNEL,
         lane: AGENT_LANE_NESTED,
         extraSystemPrompt: agentMessageContext,
         inputProvenance: {

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -55,7 +55,9 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
 
     expect(resolved.config.allowFrom).toBeUndefined();
   });
+});
 
+describe("resolveDiscordMaxLinesPerMessage", () => {
   it("falls back to merged root discord maxLinesPerMessage when runtime config omits it", () => {
     const resolved = resolveDiscordMaxLinesPerMessage({
       cfg: {

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -55,6 +55,63 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
 
     expect(resolved.config.allowFrom).toBeUndefined();
   });
+
+  it("falls back to merged root discord maxLinesPerMessage when runtime config omits it", () => {
+    const resolved = resolveDiscordMaxLinesPerMessage({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+            accounts: {
+              default: { token: "token-default" },
+            },
+          },
+        },
+      },
+      discordConfig: {},
+      accountId: "default",
+    });
+
+    expect(resolved).toBe(120);
+  });
+
+  it("prefers explicit runtime discord maxLinesPerMessage over merged config", () => {
+    const resolved = resolveDiscordMaxLinesPerMessage({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+            accounts: {
+              default: { token: "token-default", maxLinesPerMessage: 80 },
+            },
+          },
+        },
+      },
+      discordConfig: { maxLinesPerMessage: 55 },
+      accountId: "default",
+    });
+
+    expect(resolved).toBe(55);
+  });
+
+  it("uses per-account discord maxLinesPerMessage over the root value when runtime config omits it", () => {
+    const resolved = resolveDiscordMaxLinesPerMessage({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+            accounts: {
+              work: { token: "token-work", maxLinesPerMessage: 80 },
+            },
+          },
+        },
+      },
+      discordConfig: {},
+      accountId: "work",
+    });
+
+    expect(resolved).toBe(80);
+  });
 });
 
 describe("resolveDiscordMaxLinesPerMessage", () => {


### PR DESCRIPTION
## Problem

`sessions_send` hardcodes `channel: INTERNAL_MESSAGE_CHANNEL` ("webchat") when injecting messages into target sessions. For main sessions with an active external channel route (Discord, Telegram, etc.), this causes `resolveLastChannelRaw` to flip `lastChannel` to `"webchat"` for that turn — silently routing the agent's reply to the control UI instead of the user's channel.

The flip happens because `resolveLastChannelRaw` has an early-return for main sessions when `originatingChannel === INTERNAL_MESSAGE_CHANNEL`, which short-circuits the fallback to `persistedLastChannel`. This means the previously established Discord/Telegram/etc. route is overridden for the duration of that turn.

Closes #43318

## Fix

Pass `opts?.agentChannel` through instead of hardcoding:

```typescript
// before
channel: INTERNAL_MESSAGE_CHANNEL,

// after
channel: opts?.agentChannel ?? INTERNAL_MESSAGE_CHANNEL,
```

Falls back to `INTERNAL_MESSAGE_CHANNEL` for internal spawns where no `agentChannel` is set, preserving existing behaviour for those cases.

## Impact

- Any multi-agent setup using `sessions_send` where the receiving agent has an active external channel route is affected
- The routing flip occurs on every `sessions_send` call to a main session; user-visible consequence is intermittent depending on whether the next external-channel message resets the route before the agent replies
- Fix is a one-line change with no behaviour change for non-external-channel sessions