### PR TITLE
feat(msteams): fetch thread history via Graph API for channel replies

### DIFF
--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -207,7 +207,17 @@ describe("stripHtmlTags", () => {
   });
 
   it("handles nested tags", () => {
-    expect(stripHtmlTags("<div><p><span>nested</span></p></div>")).toBe("nested");
+    expect(stripHtmlTags("<div><span>nested</span></div>")).toBe("nested");
+  });
+
+  it("preserves word boundaries across block elements", () => {
+    expect(stripHtmlTags("<div>First</div><div>Second</div>")).toBe("First Second");
+    expect(stripHtmlTags("<p>Line one</p><p>Line two</p>")).toBe("Line one Line two");
+  });
+
+  it("handles br tags as separators", () => {
+    expect(stripHtmlTags("hello<br>world")).toBe("hello world");
+    expect(stripHtmlTags("hello<br/>world")).toBe("hello world");
   });
 
   it("handles typical Teams message with mention and formatting", () => {

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -34,6 +34,7 @@ import {
   listTeamsByName,
   normalizeQuery,
   resolveGraphToken,
+  stripHtmlTags,
 } from "./graph.js";
 
 const originalFetch = globalThis.fetch;
@@ -161,5 +162,59 @@ describe("msteams graph helpers", () => {
       "/groups?$filter=resourceProvisioningOptions%2FAny(x%3Ax%20eq%20'Team')%20and%20startsWith(displayName%2C'Bob''s%20Team')&$select=id,displayName",
     );
     expect(calls[1]).toContain("/teams/team%2Fops/channels?$select=id,displayName");
+  });
+});
+
+describe("stripHtmlTags", () => {
+  it("removes basic HTML tags", () => {
+    expect(stripHtmlTags("<p>Hello <b>world</b></p>")).toBe("Hello world");
+  });
+
+  it("preserves @mention display names from <at> tags", () => {
+    expect(stripHtmlTags('<at id="123">John Doe</at> check this')).toBe("John Doe check this");
+  });
+
+  it("handles multiple @mentions", () => {
+    expect(stripHtmlTags('<at id="1">Alice</at> and <at id="2">Bob</at> please review')).toBe(
+      "Alice and Bob please review",
+    );
+  });
+
+  it("decodes common HTML entities", () => {
+    expect(stripHtmlTags("a &amp; b &lt; c &gt; d &quot;e&quot; f&apos;s")).toBe(
+      'a & b < c > d "e" f\'s',
+    );
+  });
+
+  it("decodes &#39; numeric entity for apostrophe", () => {
+    expect(stripHtmlTags("it&#39;s fine")).toBe("it's fine");
+  });
+
+  it("replaces &nbsp; with space", () => {
+    expect(stripHtmlTags("hello&nbsp;&nbsp;world")).toBe("hello world");
+  });
+
+  it("collapses whitespace and trims", () => {
+    expect(stripHtmlTags("  hello   world  ")).toBe("hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(stripHtmlTags("")).toBe("");
+  });
+
+  it("handles plain text without HTML", () => {
+    expect(stripHtmlTags("just plain text")).toBe("just plain text");
+  });
+
+  it("handles nested tags", () => {
+    expect(stripHtmlTags("<div><p><span>nested</span></p></div>")).toBe("nested");
+  });
+
+  it("handles typical Teams message with mention and formatting", () => {
+    expect(
+      stripHtmlTags(
+        '<div><div><at id="0">OpenClaw Bot</at>&nbsp;what&#39;s the &quot;status&quot;?</div></div>',
+      ),
+    ).toBe('OpenClaw Bot what\'s the "status"?');
   });
 });

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -225,6 +225,8 @@ export async function fetchThreadReplies(params: {
 export function stripHtmlTags(html: string): string {
   return html
     .replace(/<at[^>]*>(.*?)<\/at>/gi, "$1")
+    .replace(/<\/(?:div|p|br|li|tr)>/gi, " ")
+    .replace(/<br\s*\/?>/gi, " ")
     .replace(/<[^>]+>/g, "")
     .replace(/&nbsp;/g, " ")
     .replace(/&amp;/g, "&")

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -76,41 +76,67 @@ export async function listTeamsByName(token: string, query: string): Promise<Gra
   return res.value ?? [];
 }
 
-// Cache: conversation-style team ID → Azure AD group ID
-const teamIdToGroupIdCache = new Map<string, string>();
+// Cache: conversation-style team ID → Azure AD group ID (TTL-based to avoid stale entries).
+const TEAM_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const teamIdToGroupIdCache = new Map<string, { groupId: string; expiresAt: number }>();
 
 /**
  * Resolve the Azure AD group ID from a Teams conversation-style team ID (19:xxx@thread.tacv2).
  * Graph API endpoints need the group GUID, not the conversation ID.
+ * Paginates through all groups and caches results with a TTL.
  */
 export async function resolveTeamGroupId(
   token: string,
   conversationTeamId: string,
 ): Promise<string | null> {
   const cached = teamIdToGroupIdCache.get(conversationTeamId);
-  if (cached) return cached;
+  if (cached && cached.expiresAt > Date.now()) return cached.groupId;
 
-  // List all teams and match by internalId
+  // Paginate through all teams and match by internalId
   const filter = `resourceProvisioningOptions/Any(x:x eq 'Team')`;
-  const path = `/groups?$filter=${encodeURIComponent(filter)}&$select=id,displayName`;
-  const groups = await fetchGraphJson<GraphResponse<GraphGroup>>({ token, path });
-  for (const group of groups.value ?? []) {
-    if (!group.id) continue;
-    try {
-      const teamPath = `/teams/${encodeURIComponent(group.id)}?$select=id,internalId`;
-      const teamInfo = await fetchGraphJson<{ id?: string; internalId?: string }>({
-        token,
-        path: teamPath,
+  let nextPath: string | null =
+    `/groups?$filter=${encodeURIComponent(filter)}&$select=id,displayName&$top=100`;
+
+  type GroupPage = GraphResponse<GraphGroup> & { "@odata.nextLink"?: string };
+
+  while (nextPath) {
+    const pagePath = nextPath;
+    const page: GroupPage = await fetchGraphJson<GroupPage>({ token, path: pagePath });
+    const groups: GraphGroup[] = page.value ?? [];
+
+    // Resolve internalId for each group in parallel (batched)
+    const results = await Promise.all(
+      groups
+        .filter((g: GraphGroup) => g.id)
+        .map(async (group: GraphGroup) => {
+          try {
+            const teamPath = `/teams/${encodeURIComponent(group.id!)}?$select=id,internalId`;
+            return await fetchGraphJson<{ id?: string; internalId?: string }>({
+              token,
+              path: teamPath,
+            });
+          } catch {
+            return null; // Skip teams we can't access
+          }
+        }),
+    );
+
+    for (const teamInfo of results) {
+      if (!teamInfo?.internalId || !teamInfo.id) continue;
+      const groupId = groups.find((g: GraphGroup) => g.id === teamInfo.id)?.id;
+      if (!groupId) continue;
+      teamIdToGroupIdCache.set(teamInfo.internalId, {
+        groupId,
+        expiresAt: Date.now() + TEAM_CACHE_TTL_MS,
       });
-      if (teamInfo.internalId) {
-        teamIdToGroupIdCache.set(teamInfo.internalId, group.id);
-        if (teamInfo.internalId === conversationTeamId) {
-          return group.id;
-        }
+      if (teamInfo.internalId === conversationTeamId) {
+        return groupId;
       }
-    } catch {
-      // Skip teams we can't access
     }
+
+    // Follow pagination link — strip the Graph root since fetchGraphJson prepends it
+    const rawNext = page["@odata.nextLink"];
+    nextPath = rawNext ? rawNext.replace(/^https:\/\/graph\.microsoft\.com\/v1\.0/, "") : null;
   }
   return null;
 }
@@ -169,7 +195,10 @@ export async function fetchThreadReplies(params: {
 }
 
 /**
- * Strip HTML tags from Teams message body content.
+ * Strip HTML tags from Teams message body content for thread context display.
+ * Unlike `stripMSTeamsMentionTags` (in inbound.ts) which removes @mention text entirely
+ * for bot command parsing, this preserves mention display names so thread context
+ * retains who was mentioned.
  */
 export function stripHtmlTags(html: string): string {
   return html
@@ -180,6 +209,8 @@ export function stripHtmlTags(html: string): string {
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -76,8 +76,101 @@ export async function listTeamsByName(token: string, query: string): Promise<Gra
   return res.value ?? [];
 }
 
+// Cache: conversation-style team ID → Azure AD group ID
+const teamIdToGroupIdCache = new Map<string, string>();
+
+/**
+ * Resolve the Azure AD group ID from a Teams conversation-style team ID (19:xxx@thread.tacv2).
+ * Graph API endpoints need the group GUID, not the conversation ID.
+ */
+export async function resolveTeamGroupId(token: string, conversationTeamId: string): Promise<string | null> {
+  const cached = teamIdToGroupIdCache.get(conversationTeamId);
+  if (cached) return cached;
+
+  // List all teams and match by internalId
+  const filter = `resourceProvisioningOptions/Any(x:x eq 'Team')`;
+  const path = `/groups?$filter=${encodeURIComponent(filter)}&$select=id,displayName`;
+  const groups = await fetchGraphJson<GraphResponse<GraphGroup>>({ token, path });
+  for (const group of groups.value ?? []) {
+    if (!group.id) continue;
+    try {
+      const teamPath = `/teams/${encodeURIComponent(group.id)}?$select=id,internalId`;
+      const teamInfo = await fetchGraphJson<{ id?: string; internalId?: string }>({ token, path: teamPath });
+      if (teamInfo.internalId) {
+        teamIdToGroupIdCache.set(teamInfo.internalId, group.id);
+        if (teamInfo.internalId === conversationTeamId) {
+          return group.id;
+        }
+      }
+    } catch {
+      // Skip teams we can't access
+    }
+  }
+  return null;
+}
+
 export async function listChannelsForTeam(token: string, teamId: string): Promise<GraphChannel[]> {
   const path = `/teams/${encodeURIComponent(teamId)}/channels?$select=id,displayName`;
   const res = await fetchGraphJson<GraphResponse<GraphChannel>>({ token, path });
   return res.value ?? [];
+}
+
+export type GraphThreadMessage = {
+  id?: string;
+  from?: { user?: { displayName?: string; id?: string } };
+  body?: { content?: string; contentType?: string };
+  createdDateTime?: string;
+};
+
+/**
+ * Fetch the parent message of a channel thread.
+ */
+export async function fetchChannelMessage(params: {
+  token: string;
+  teamId: string;
+  channelId: string;
+  messageId: string;
+}): Promise<GraphThreadMessage | null> {
+  const path = `/teams/${encodeURIComponent(params.teamId)}/channels/${encodeURIComponent(params.channelId)}/messages/${encodeURIComponent(params.messageId)}`;
+  try {
+    return await fetchGraphJson<GraphThreadMessage>({ token: params.token, path });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch replies in a channel thread (up to `top` messages, default 50).
+ */
+export async function fetchThreadReplies(params: {
+  token: string;
+  teamId: string;
+  channelId: string;
+  messageId: string;
+  top?: number;
+}): Promise<GraphThreadMessage[]> {
+  const limit = params.top ?? 50;
+  const path = `/teams/${encodeURIComponent(params.teamId)}/channels/${encodeURIComponent(params.channelId)}/messages/${encodeURIComponent(params.messageId)}/replies?$top=${limit}&$orderby=createdDateTime asc`;
+  try {
+    const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({ token: params.token, path });
+    return res.value ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Strip HTML tags from Teams message body content.
+ */
+export function stripHtmlTags(html: string): string {
+  return html
+    .replace(/<at[^>]*>.*?<\/at>/gi, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
 }

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -90,7 +90,10 @@ export async function resolveTeamGroupId(
   conversationTeamId: string,
 ): Promise<string | null> {
   const cached = teamIdToGroupIdCache.get(conversationTeamId);
-  if (cached && cached.expiresAt > Date.now()) return cached.groupId;
+  if (cached && cached.expiresAt > Date.now()) {
+    // Negative cache: null groupId means lookup already failed recently
+    return cached.groupId || null;
+  }
 
   // Paginate through all teams and match by internalId
   const filter = `resourceProvisioningOptions/Any(x:x eq 'Team')`;
@@ -138,6 +141,11 @@ export async function resolveTeamGroupId(
     const rawNext = page["@odata.nextLink"];
     nextPath = rawNext ? rawNext.replace(/^https:\/\/graph\.microsoft\.com\/v1\.0/, "") : null;
   }
+  // Cache the miss to avoid re-scanning on every message
+  teamIdToGroupIdCache.set(conversationTeamId, {
+    groupId: "",
+    expiresAt: Date.now() + TEAM_CACHE_TTL_MS,
+  });
   return null;
 }
 

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -83,7 +83,10 @@ const teamIdToGroupIdCache = new Map<string, string>();
  * Resolve the Azure AD group ID from a Teams conversation-style team ID (19:xxx@thread.tacv2).
  * Graph API endpoints need the group GUID, not the conversation ID.
  */
-export async function resolveTeamGroupId(token: string, conversationTeamId: string): Promise<string | null> {
+export async function resolveTeamGroupId(
+  token: string,
+  conversationTeamId: string,
+): Promise<string | null> {
   const cached = teamIdToGroupIdCache.get(conversationTeamId);
   if (cached) return cached;
 
@@ -95,7 +98,10 @@ export async function resolveTeamGroupId(token: string, conversationTeamId: stri
     if (!group.id) continue;
     try {
       const teamPath = `/teams/${encodeURIComponent(group.id)}?$select=id,internalId`;
-      const teamInfo = await fetchGraphJson<{ id?: string; internalId?: string }>({ token, path: teamPath });
+      const teamInfo = await fetchGraphJson<{ id?: string; internalId?: string }>({
+        token,
+        path: teamPath,
+      });
       if (teamInfo.internalId) {
         teamIdToGroupIdCache.set(teamInfo.internalId, group.id);
         if (teamInfo.internalId === conversationTeamId) {
@@ -150,9 +156,12 @@ export async function fetchThreadReplies(params: {
   top?: number;
 }): Promise<GraphThreadMessage[]> {
   const limit = params.top ?? 50;
-  const path = `/teams/${encodeURIComponent(params.teamId)}/channels/${encodeURIComponent(params.channelId)}/messages/${encodeURIComponent(params.messageId)}/replies?$top=${limit}&$orderby=createdDateTime asc`;
+  const path = `/teams/${encodeURIComponent(params.teamId)}/channels/${encodeURIComponent(params.channelId)}/messages/${encodeURIComponent(params.messageId)}/replies?$top=${limit}&$orderby=${encodeURIComponent("createdDateTime asc")}`;
   try {
-    const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({ token: params.token, path });
+    const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({
+      token: params.token,
+      path,
+    });
     return res.value ?? [];
   } catch {
     return [];
@@ -164,7 +173,7 @@ export async function fetchThreadReplies(params: {
  */
 export function stripHtmlTags(html: string): string {
   return html
-    .replace(/<at[^>]*>.*?<\/at>/gi, "")
+    .replace(/<at[^>]*>(.*?)<\/at>/gi, "$1")
     .replace(/<[^>]+>/g, "")
     .replace(/&nbsp;/g, " ")
     .replace(/&amp;/g, "&")

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -180,7 +180,8 @@ export async function fetchChannelMessage(params: {
 }
 
 /**
- * Fetch replies in a channel thread (up to `top` messages, default 50).
+ * Fetch all replies in a channel thread, paginating through results.
+ * Uses `top` as page size (default 50) and follows `@odata.nextLink`.
  */
 export async function fetchThreadReplies(params: {
   token: string;
@@ -189,17 +190,30 @@ export async function fetchThreadReplies(params: {
   messageId: string;
   top?: number;
 }): Promise<GraphThreadMessage[]> {
-  const limit = params.top ?? 50;
-  const path = `/teams/${encodeURIComponent(params.teamId)}/channels/${encodeURIComponent(params.channelId)}/messages/${encodeURIComponent(params.messageId)}/replies?$top=${limit}&$orderby=${encodeURIComponent("createdDateTime asc")}`;
+  const pageSize = params.top ?? 50;
+  const basePath = `/teams/${encodeURIComponent(params.teamId)}/channels/${encodeURIComponent(params.channelId)}/messages/${encodeURIComponent(params.messageId)}/replies`;
+  type ReplyPage = GraphResponse<GraphThreadMessage> & { "@odata.nextLink"?: string };
+
+  const allReplies: GraphThreadMessage[] = [];
+  let nextPath: string | null =
+    `${basePath}?$top=${pageSize}&$orderby=${encodeURIComponent("createdDateTime asc")}`;
+
   try {
-    const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({
-      token: params.token,
-      path,
-    });
-    return res.value ?? [];
+    while (nextPath) {
+      const pagePath = nextPath;
+      const page: ReplyPage = await fetchGraphJson<ReplyPage>({
+        token: params.token,
+        path: pagePath,
+      });
+      allReplies.push(...(page.value ?? []));
+
+      const rawNext = page["@odata.nextLink"];
+      nextPath = rawNext ? rawNext.replace(/^https:\/\/graph\.microsoft\.com\/v1\.0/, "") : null;
+    }
   } catch {
-    return [];
+    // Return whatever we collected so far
   }
+  return allReplies;
 }
 
 /**

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -531,8 +531,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         // Exclude the current message from replies to avoid duplication.
         // Compare by both id and createdDateTime since Bot Framework activity.id
         // and Graph API reply.id may use different formats.
-        const currentTimestamp =
-          activity.timestamp instanceof Date ? activity.timestamp.toISOString() : undefined;
+        const currentTimestamp = timestamp?.toISOString();
         for (const reply of replies) {
           if (reply.id === currentActivityId) continue;
           if (currentTimestamp && reply.createdDateTime === currentTimestamp) continue;

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -535,6 +535,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         for (const reply of replies) {
           if (reply.id === currentActivityId) continue;
           if (currentTimestamp && reply.createdDateTime === currentTimestamp) continue;
+          // Skip replies newer than the triggering activity to avoid injecting future context
+          if (currentTimestamp && reply.createdDateTime && reply.createdDateTime > currentTimestamp)
+            continue;
           const sender = reply.from?.user?.displayName ?? "Unknown";
           const content = reply.body?.content ? stripHtmlTags(reply.body.content) : "";
           if (content) {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -499,19 +499,21 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         if (!graphTeamId) {
           throw new Error("Could not resolve team group ID");
         }
-        const parentMsg = await fetchChannelMessage({
-          token: graphToken,
-          teamId: graphTeamId,
-          channelId: conversationId,
-          messageId: conversationMessageId,
-        });
-        const replies = await fetchThreadReplies({
-          token: graphToken,
-          teamId: graphTeamId,
-          channelId: conversationId,
-          messageId: conversationMessageId,
-          top: 50,
-        });
+        const [parentMsg, replies] = await Promise.all([
+          fetchChannelMessage({
+            token: graphToken,
+            teamId: graphTeamId,
+            channelId: conversationId,
+            messageId: conversationMessageId,
+          }),
+          fetchThreadReplies({
+            token: graphToken,
+            teamId: graphTeamId,
+            channelId: conversationId,
+            messageId: conversationMessageId,
+            top: 50,
+          }),
+        ]);
         const threadMessages: string[] = [];
         if (parentMsg?.body?.content) {
           const sender = parentMsg.from?.user?.displayName ?? "Unknown";
@@ -520,10 +522,15 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
             threadMessages.push(`${sender}: ${content}`);
           }
         }
-        // Exclude the current message (last reply) to avoid duplication.
+        // Exclude the current message to avoid duplication.
+        // Compare by both id and createdDateTime since Bot Framework activity.id
+        // and Graph API reply.id may use different formats.
         const currentActivityId = activity.id;
+        const currentTimestamp =
+          activity.timestamp instanceof Date ? activity.timestamp.toISOString() : undefined;
         for (const reply of replies) {
           if (reply.id === currentActivityId) continue;
+          if (currentTimestamp && reply.createdDateTime === currentTimestamp) continue;
           const sender = reply.from?.user?.displayName ?? "Unknown";
           const content = reply.body?.content ? stripHtmlTags(reply.body.content) : "";
           if (content) {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -29,6 +29,13 @@ import {
 import type { StoredConversationReference } from "../conversation-store.js";
 import { formatUnknownError } from "../errors.js";
 import {
+  resolveGraphToken,
+  fetchChannelMessage,
+  fetchThreadReplies,
+  stripHtmlTags,
+  resolveTeamGroupId,
+} from "../graph.js";
+import {
   extractMSTeamsConversationMessageId,
   extractMSTeamsQuoteInfo,
   normalizeMSTeamsConversationId,
@@ -46,7 +53,6 @@ import {
 import { extractMSTeamsPollVote } from "../polls.js";
 import { createMSTeamsReplyDispatcher } from "../reply-dispatcher.js";
 import { getMSTeamsRuntime } from "../runtime.js";
-import { resolveGraphToken, fetchChannelMessage, fetchThreadReplies, stripHtmlTags, resolveTeamGroupId } from "../graph.js";
 import type { MSTeamsTurnContext } from "../sdk-types.js";
 import { recordMSTeamsSentMessage, wasMSTeamsMessageSent } from "../sent-message-cache.js";
 import { resolveMSTeamsInboundMedia } from "./inbound-media.js";
@@ -487,7 +493,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         const teamObj = channelData?.team as Record<string, unknown> | undefined;
         let graphTeamId = (teamObj?.aadGroupId as string) ?? "";
         if (!graphTeamId) {
-          graphTeamId = await resolveTeamGroupId(graphToken, teamId) ?? "";
+          graphTeamId = (await resolveTeamGroupId(graphToken, teamId)) ?? "";
           log.debug?.("resolved team group ID", { graphTeamId: graphTeamId || "FAILED" });
         }
         if (!graphTeamId) {
@@ -525,7 +531,10 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
           }
         }
         if (threadMessages.length > 0) {
-          threadContextBody = "\n\n--- Thread context (earlier messages) ---\n" + threadMessages.join("\n") + "\n--- End thread context ---\n\n";
+          threadContextBody =
+            "\n\n--- Thread context (earlier messages) ---\n" +
+            threadMessages.join("\n") +
+            "\n--- End thread context ---\n\n";
         }
         log.debug?.("fetched thread context", {
           parentMessageId: conversationMessageId,

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -101,6 +101,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     attachments: MSTeamsAttachmentLike[];
     wasMentioned: boolean;
     implicitMention: boolean;
+    debounceBatched?: boolean;
   };
 
   const handleTeamsMessageNow = async (params: MSTeamsDebounceEntry) => {
@@ -483,8 +484,10 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     const mediaPayload = buildMSTeamsMediaPayload(mediaList);
 
     // Fetch thread context from Graph API for channel thread replies.
+    // Skip when debounce-batched: the batched text already includes recent messages,
+    // and we only have the last activity.id so earlier debounced replies would be duplicated.
     let threadContextBody = "";
-    if (isChannel && conversationMessageId && teamId) {
+    if (isChannel && conversationMessageId && teamId && !params.debounceBatched) {
       try {
         const graphToken = await resolveGraphToken(cfg);
         // channelData.team.id is a conversation ID (19:xxx@thread.tacv2), NOT the Azure AD group ID.
@@ -779,6 +782,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         attachments: [],
         wasMentioned,
         implicitMention,
+        debounceBatched: true,
       });
     },
     onError: (err) => {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -46,6 +46,7 @@ import {
 import { extractMSTeamsPollVote } from "../polls.js";
 import { createMSTeamsReplyDispatcher } from "../reply-dispatcher.js";
 import { getMSTeamsRuntime } from "../runtime.js";
+import { resolveGraphToken, fetchChannelMessage, fetchThreadReplies, stripHtmlTags, resolveTeamGroupId } from "../graph.js";
 import type { MSTeamsTurnContext } from "../sdk-types.js";
 import { recordMSTeamsSentMessage, wasMSTeamsMessageSent } from "../sent-message-cache.js";
 import { resolveMSTeamsInboundMedia } from "./inbound-media.js";
@@ -474,6 +475,70 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     });
 
     const mediaPayload = buildMSTeamsMediaPayload(mediaList);
+
+    // Fetch thread context from Graph API for channel thread replies.
+    let threadContextBody = "";
+    if (isChannel && conversationMessageId && teamId) {
+      try {
+        const graphToken = await resolveGraphToken(cfg);
+        // channelData.team.id is a conversation ID (19:xxx@thread.tacv2), NOT the Azure AD group ID.
+        // Graph API needs the group GUID. Resolve it via internalId matching.
+        const channelData = activity.channelData as Record<string, unknown> | undefined;
+        const teamObj = channelData?.team as Record<string, unknown> | undefined;
+        let graphTeamId = (teamObj?.aadGroupId as string) ?? "";
+        if (!graphTeamId) {
+          graphTeamId = await resolveTeamGroupId(graphToken, teamId) ?? "";
+          log.debug?.("resolved team group ID", { graphTeamId: graphTeamId || "FAILED" });
+        }
+        if (!graphTeamId) {
+          throw new Error("Could not resolve team group ID");
+        }
+        const parentMsg = await fetchChannelMessage({
+          token: graphToken,
+          teamId: graphTeamId,
+          channelId: conversationId,
+          messageId: conversationMessageId,
+        });
+        const replies = await fetchThreadReplies({
+          token: graphToken,
+          teamId: graphTeamId,
+          channelId: conversationId,
+          messageId: conversationMessageId,
+          top: 50,
+        });
+        const threadMessages: string[] = [];
+        if (parentMsg?.body?.content) {
+          const sender = parentMsg.from?.user?.displayName ?? "Unknown";
+          const content = stripHtmlTags(parentMsg.body.content);
+          if (content) {
+            threadMessages.push(`${sender}: ${content}`);
+          }
+        }
+        // Exclude the current message (last reply) to avoid duplication.
+        const currentActivityId = activity.id;
+        for (const reply of replies) {
+          if (reply.id === currentActivityId) continue;
+          const sender = reply.from?.user?.displayName ?? "Unknown";
+          const content = reply.body?.content ? stripHtmlTags(reply.body.content) : "";
+          if (content) {
+            threadMessages.push(`${sender}: ${content}`);
+          }
+        }
+        if (threadMessages.length > 0) {
+          threadContextBody = "\n\n--- Thread context (earlier messages) ---\n" + threadMessages.join("\n") + "\n--- End thread context ---\n\n";
+        }
+        log.debug?.("fetched thread context", {
+          parentMessageId: conversationMessageId,
+          threadMessagesCount: threadMessages.length,
+          hasContext: threadContextBody.length > 0,
+        });
+      } catch (err) {
+        log.debug?.("failed to fetch thread context (Graph API)", {
+          error: formatUnknownError(err),
+        });
+      }
+    }
+
     const envelopeFrom = isDirectMessage ? senderName : conversationType;
     const { storePath, envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
       cfg,
@@ -488,7 +553,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       envelope: envelopeOptions,
       body: rawBody,
     });
-    let combinedBody = body;
+    let combinedBody = threadContextBody ? threadContextBody + body : body;
     const isRoomish = !isDirectMessage;
     const historyKey = isRoomish ? conversationId : undefined;
     if (isRoomish && historyKey) {
@@ -518,9 +583,10 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         : undefined;
     const commandBody = text.trim();
 
+    const bodyForAgent = threadContextBody ? threadContextBody + rawBody : rawBody;
     const ctxPayload = core.channel.reply.finalizeInboundContext({
       Body: combinedBody,
-      BodyForAgent: rawBody,
+      BodyForAgent: bodyForAgent,
       InboundHistory: inboundHistory,
       RawBody: rawBody,
       CommandBody: commandBody,

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -515,17 +515,19 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
           }),
         ]);
         const threadMessages: string[] = [];
-        if (parentMsg?.body?.content) {
+        // Skip the parent message if the current activity IS the thread root to avoid duplication.
+        const currentActivityId = activity.id;
+        const isThreadRoot = parentMsg?.id === currentActivityId;
+        if (parentMsg?.body?.content && !isThreadRoot) {
           const sender = parentMsg.from?.user?.displayName ?? "Unknown";
           const content = stripHtmlTags(parentMsg.body.content);
           if (content) {
             threadMessages.push(`${sender}: ${content}`);
           }
         }
-        // Exclude the current message to avoid duplication.
+        // Exclude the current message from replies to avoid duplication.
         // Compare by both id and createdDateTime since Bot Framework activity.id
         // and Graph API reply.id may use different formats.
-        const currentActivityId = activity.id;
         const currentTimestamp =
           activity.timestamp instanceof Date ? activity.timestamp.toISOString() : undefined;
         for (const reply of replies) {


### PR DESCRIPTION

Summary

• Problem: When a bot receives a reply in a Teams channel thread, it has no context about the parent message or earlier replies — it only sees the new message in isolation.
• Why it matters: Channel threads require full context to generate useful responses. Without thread history, the bot can't understand what's being discussed.
• What changed: Added Graph API calls to fetch parent message + thread replies, and inject them into BodyForAgent so the model sees the full conversation. Added resolveTeamGroupId() to map Teams conversation IDs to Azure AD group GUIDs (required by Graph API).
• What did NOT change: No changes to how the bot sends messages, handles DMs/group chats, or processes non-thread channel messages. No changes to the compiled dist/ bundle.

Change Type (select all)

• [ ] Bug fix
• [x] Feature
• [ ] Refactor
• [ ] Docs
• [ ] Security hardening
• [ ] Chore/infra

Scope (select all touched areas)

• [ ] Gateway / orchestration
• [ ] Skills / tool execution
• [ ] Auth / tokens
• [ ] Memory / storage
• [x] Integrations
• [ ] API / contracts
• [ ] UI / DX
• [ ] CI/CD / infra

Linked Issue/PR

• Closes #
• Related #

User-visible / Behavior Changes

• When the bot is mentioned or triggered in a Teams channel thread reply, it now receives the parent message and all prior replies as context (prepended to the prompt as "Thread context (earlier messages)").
• No config changes required. Feature activates automatically when ChannelMessage.Read.All Graph API permission is granted.
• If the permission is missing or Graph API fails, behavior is unchanged (graceful degradation).

Security Impact (required)

• New permissions/capabilities? Yes — requires ChannelMessage.Read.All (Application) with admin consent
• Secrets/tokens handling changed? No — reuses existing appId/appPassword for Graph token acquisition
• New/changed network calls? Yes — new Graph API calls to read channel messages and thread replies
• Command/tool execution surface changed? No
• Data access scope changed? Yes — bot can now read channel message history (previously could only see messages sent directly to it)
• Risk + mitigation: The bot reads only the specific thread it's replying in (parent + replies), not arbitrary channel messages. Graph token is acquired per-request with client_credentials grant. All Graph calls are wrapped in try/catch — failures are logged and silently skipped.

Repro + Verification

Environment

• OS: Linux 6.12.63+deb13-amd64
• Runtime/container: Node v22.22.0, OpenClaw gateway (jiti runtime for plugin .ts)
• Model/provider: Anthropic Claude Sonnet 4.5
• Integration/channel: Microsoft Teams (channel threads)
• Relevant config: msteams.appId, msteams.appPassword, msteams.tenantId (standard bot config)

Steps

1. Grant ChannelMessage.Read.All application permission + admin consent in Entra ID
2. Post a message in a Teams channel (creates a thread root)
3. Reply in that thread mentioning the bot

Expected

• Bot response includes awareness of the parent message content and prior replies

Actual

• Confirmed: Graph API returns parent message + replies, injected into BodyForAgent, model references thread context in its response

Evidence

• [x] Trace/log snippets
  • 2026-03-11T12:52:55.776+01:00 fetched thread context (after BodyForAgent fix)
  • Debug logs confirmed: parentMsg body populated, replies count > 0, threadContextBody length > 0
• [x] Manual verification: Bot correctly summarized a thread it had never seen before 

Human Verification (required)

• Verified scenarios: Thread reply in Teams channel — bot received thread context and responded with awareness of parent message content
• Edge cases checked: Missing Graph permission (graceful fallback), team ID resolution from conversation-style ID to group GUID, HTML stripping from message bodies, empty threads (no replies)
• What you did not verify: Behavior with >50 replies (pagination), threads in private channels, threads in shared channels across tenants

Compatibility / Migration

• Backward compatible? Yes
• Config/env changes? No (uses existing bot credentials for Graph API)
• Migration needed? No (but ChannelMessage.Read.All permission + admin consent required for feature to activate)
• If yes, exact upgrade steps: N/A

Failure Recovery (if this breaks)

• How to disable/revert: Revert changes to graph.ts and message-handler.ts, restart gateway
• Files/config to restore: extensions/msteams/src/graph.ts, extensions/msteams/src/monitor-handler/message-handler.ts
• Known bad symptoms: Slow message processing (Graph API timeout), errors in logs mentioning fetchChannelMessage or resolveTeamGroupId. Feature is fully wrapped in try/catch so failures should not break message delivery.

Risks and Mitigations

• Risk: Graph API rate limiting when bot is active in many threads simultaneously
  • Mitigation: Team group ID is cached in-memory after first resolution. Consider adding message-level caching if rate limits are hit.
• Risk: First message in a new team incurs ~2s latency for team list scan
  • Mitigation: One-time cost per team, cached afterward. Could be pre-warmed at startup if needed.

Review Conversations

• [] I replied to or resolved every bot review conversation I addressed in this PR.
• [] I left unresolved only the conversations that still need reviewer or maintainer judgment.