### PR TITLE
fix(agents): preserve prompt and images on failure-mode-aware fallback retry

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -8,6 +8,7 @@ import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { FailoverError } from "./failover-error.js";
 import { isAnthropicBillingError } from "./live-auth-keys.js";
 import { runWithImageModelFallback, runWithModelFallback } from "./model-fallback.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
@@ -303,7 +304,7 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("gpt-4.1-mini");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5"],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -341,7 +342,7 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("openrouter/deepseek-chat");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-haiku-3-5"],
-      ["openrouter", "openrouter/deepseek-chat"],
+      ["openrouter", "openrouter/deepseek-chat", { previousFailureReason: "rate_limit" }],
     ]);
   });
 
@@ -372,7 +373,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["openai", "gpt-4.1-mini"],
-      ["anthropic", "claude-haiku-3-5"],
+      ["anthropic", "claude-haiku-3-5", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -443,7 +444,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4"],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -675,7 +676,7 @@ describe("runWithModelFallback", () => {
 
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5"],
-      ["anthropic", "claude-haiku-3-5"],
+      ["anthropic", "claude-haiku-3-5", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -758,7 +759,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-sonnet-4"],
-      ["openai", "gpt-4o"],
+      ["openai", "gpt-4o", { previousFailureReason: "rate_limit" }],
     ]);
   });
 
@@ -1025,7 +1026,9 @@ describe("runWithModelFallback", () => {
       expect(result.result).toBe("fallback success");
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-20250514");
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5"); // Fallback tried
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5", {
+        previousFailureReason: "rate_limit",
+      }); // Fallback tried
     });
 
     it("allows fallbacks with model version differences within same provider", async () => {
@@ -1054,7 +1057,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
 
     it("still skips fallbacks when using different provider than config", async () => {
@@ -1085,7 +1090,9 @@ describe("runWithModelFallback", () => {
       expect(result.result).toBe("config primary worked");
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini"); // Original request
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6"); // Config primary as final fallback
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6", {
+        previousFailureReason: "auth",
+      }); // Config primary as final fallback
     });
 
     it("uses fallbacks when session model exactly matches config primary", async () => {
@@ -1114,7 +1121,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("fallback worked");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
   });
 
@@ -1316,7 +1325,9 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
       }); // Rate limit allows attempt
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile"); // Cross-provider works
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      }); // Cross-provider works
     });
 
     it("limits cooldown probes to one per provider before moving to cross-provider fallback", async () => {
@@ -1356,7 +1367,9 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
       });
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
 
     it("does not consume transient probe slot when first same-provider probe fails with model_not_found", async () => {
@@ -1396,7 +1409,85 @@ describe("runWithModelFallback", () => {
       });
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5", {
         allowTransientCooldownProbe: true,
+        previousFailureReason: "model_not_found",
       });
+    });
+  });
+
+  describe("previousFailureReason forwarding", () => {
+    it("does not pass previousFailureReason on the first attempt", async () => {
+      const cfg = makeCfg();
+      const run = vi.fn().mockResolvedValueOnce("ok");
+
+      await runWithModelFallback({ cfg, provider: "anthropic", model: "claude-opus-4-5", run });
+
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(run.mock.calls[0]?.[2]).toBeUndefined();
+    });
+
+    it("forwards rate_limit reason after a 429 failure", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("rate limited", { reason: "rate_limit", status: 429 }),
+        )
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousFailureReason: "rate_limit" }),
+      );
+    });
+
+    it("forwards format reason after a 400 failure", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new FailoverError("bad request", { reason: "format", status: 400 }))
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousFailureReason: "format" }),
+      );
+    });
+
+    it("forwards timeout reason after a timeout failure", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new FailoverError("timed out", { reason: "timeout", status: 408 }))
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousFailureReason: "timeout" }),
+      );
     });
   });
 });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -36,6 +36,7 @@ const log = createSubsystemLogger("model-fallback");
 
 export type ModelFallbackRunOptions = {
   allowTransientCooldownProbe?: boolean;
+  previousFailureReason?: FailoverReason;
 };
 
 type ModelFallbackRunFn<T> = (
@@ -521,6 +522,7 @@ export async function runWithModelFallback<T>(params: {
     : null;
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
+  let previousFailureReason: FailoverReason | undefined;
   const cooldownProbeUsedProviders = new Set<string>();
 
   const hasFallbackCandidates = candidates.length > 1;
@@ -646,11 +648,21 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
+    const effectiveOptions: ModelFallbackRunOptions | undefined = (() => {
+      if (!previousFailureReason && !runOptions) {
+        return undefined;
+      }
+      const opts: ModelFallbackRunOptions = { ...runOptions };
+      if (previousFailureReason) {
+        opts.previousFailureReason = previousFailureReason;
+      }
+      return opts;
+    })();
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,
       attempts,
-      options: runOptions,
+      options: effectiveOptions,
     });
     if ("success" in attemptRun) {
       if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {
@@ -715,11 +727,12 @@ export async function runWithModelFallback<T>(params: {
 
       lastError = isKnownFailover ? normalized : err;
       const described = describeFailoverError(normalized);
+      previousFailureReason = described.reason ?? "unknown";
       attempts.push({
         provider: candidate.provider,
         model: candidate.model,
         error: described.message,
-        reason: described.reason ?? "unknown",
+        reason: previousFailureReason,
         status: described.status,
         code: described.code,
       });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -648,16 +648,10 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
-    const effectiveOptions: ModelFallbackRunOptions | undefined = (() => {
-      if (!previousFailureReason && !runOptions) {
-        return undefined;
-      }
-      const opts: ModelFallbackRunOptions = { ...runOptions };
-      if (previousFailureReason) {
-        opts.previousFailureReason = previousFailureReason;
-      }
-      return opts;
-    })();
+    const effectiveOptions: ModelFallbackRunOptions | undefined =
+      previousFailureReason || runOptions
+        ? { ...runOptions, ...(previousFailureReason && { previousFailureReason }) }
+        : undefined;
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -16,7 +16,7 @@ import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { agentCommand, agentCommandFromIngress } from "./agent.js";
+import { _testInternals, agentCommand, agentCommandFromIngress } from "./agent.js";
 import * as agentDeliveryModule from "./agent/delivery.js";
 
 vi.mock("../agents/auth-profiles.js", async (importOriginal) => {
@@ -983,5 +983,85 @@ describe("agentCommand", () => {
 
       expect(runtime.log).toHaveBeenCalledWith("ok");
     });
+  });
+});
+
+describe("resolveFallbackRetryPrompt", () => {
+  const { resolveFallbackRetryPrompt } = _testInternals;
+
+  it("returns original body when not a fallback retry", () => {
+    expect(resolveFallbackRetryPrompt({ body: "hello", isFallbackRetry: false })).toBe("hello");
+  });
+
+  it("preserves original body on fallback retry regardless of failure reason", () => {
+    const reasons = ["rate_limit", "timeout", "format", "auth", "unknown", undefined] as const;
+    for (const reason of reasons) {
+      expect(
+        resolveFallbackRetryPrompt({
+          body: "original prompt",
+          isFallbackRetry: true,
+          previousFailureReason: reason,
+        }),
+      ).toBe("original prompt");
+    }
+  });
+});
+
+describe("resolveRetryImages", () => {
+  const { resolveRetryImages } = _testInternals;
+  const fakeImages = [{ type: "image" as const, data: "abc", mimeType: "image/png" }];
+
+  it("preserves images when not a fallback retry", () => {
+    expect(resolveRetryImages({ images: fakeImages, isFallbackRetry: false })).toBe(fakeImages);
+  });
+
+  it("strips images on format failure reason", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "format",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves images on rate_limit failure reason", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "rate_limit",
+      }),
+    ).toBe(fakeImages);
+  });
+
+  it("preserves images on timeout failure reason", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "timeout",
+      }),
+    ).toBe(fakeImages);
+  });
+
+  it("preserves images on auth failure reason", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "auth",
+      }),
+    ).toBe(fakeImages);
+  });
+
+  it("preserves images when previousFailureReason is undefined", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: undefined,
+      }),
+    ).toBe(fakeImages);
   });
 });

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -594,6 +594,62 @@ describe("agentCommand", () => {
     });
   });
 
+  it("forwards original prompt body on fallback retry", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:subagent:prompt-test": {
+          sessionId: "session-prompt",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-5",
+        },
+      });
+
+      mockConfig(home, store, {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["openai/gpt-5.2"],
+        },
+        models: {
+          "anthropic/claude-opus-4-5": {},
+          "openai/gpt-4.1-mini": {},
+          "openai/gpt-5.2": {},
+        },
+      });
+
+      vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+        { id: "claude-opus-4-5", name: "Opus", provider: "anthropic" },
+        { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
+        { id: "gpt-5.2", name: "GPT-5.2", provider: "openai" },
+      ]);
+      vi.mocked(runEmbeddedPiAgent)
+        .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+        .mockResolvedValueOnce({
+          payloads: [{ text: "ok" }],
+          meta: {
+            durationMs: 5,
+            agentMeta: { sessionId: "session-prompt", provider: "openai", model: "gpt-5.2" },
+          },
+        });
+
+      const originalMessage = "Summarize the quarterly report";
+      await agentCommand(
+        {
+          message: originalMessage,
+          sessionKey: "agent:main:subagent:prompt-test",
+        },
+        runtime,
+      );
+
+      const calls = vi.mocked(runEmbeddedPiAgent).mock.calls;
+      expect(calls).toHaveLength(2);
+      // Both attempts must receive the original prompt, not a "Continue where you left off" string
+      expect(calls[0]?.[0]?.prompt).toBe(originalMessage);
+      expect(calls[1]?.[0]?.prompt).toBe(originalMessage);
+    });
+  });
+
   it("keeps stored session model override when models allowlist is empty", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -986,82 +986,31 @@ describe("agentCommand", () => {
   });
 });
 
-describe("resolveFallbackRetryPrompt", () => {
-  const { resolveFallbackRetryPrompt } = _testInternals;
-
-  it("returns original body when not a fallback retry", () => {
-    expect(resolveFallbackRetryPrompt({ body: "hello", isFallbackRetry: false })).toBe("hello");
-  });
-
-  it("preserves original body on fallback retry regardless of failure reason", () => {
-    const reasons = ["rate_limit", "timeout", "format", "auth", "unknown", undefined] as const;
-    for (const reason of reasons) {
-      expect(
-        resolveFallbackRetryPrompt({
-          body: "original prompt",
-          isFallbackRetry: true,
-          previousFailureReason: reason,
-        }),
-      ).toBe("original prompt");
-    }
-  });
-});
-
 describe("resolveRetryImages", () => {
   const { resolveRetryImages } = _testInternals;
   const fakeImages = [{ type: "image" as const, data: "abc", mimeType: "image/png" }];
 
   it("preserves images when not a fallback retry", () => {
-    expect(resolveRetryImages({ images: fakeImages, isFallbackRetry: false })).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, false)).toBe(fakeImages);
   });
 
   it("strips images on format failure reason", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: "format",
-      }),
-    ).toBeUndefined();
+    expect(resolveRetryImages(fakeImages, true, "format")).toBeUndefined();
   });
 
   it("preserves images on rate_limit failure reason", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: "rate_limit",
-      }),
-    ).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, true, "rate_limit")).toBe(fakeImages);
   });
 
   it("preserves images on timeout failure reason", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: "timeout",
-      }),
-    ).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, true, "timeout")).toBe(fakeImages);
   });
 
   it("preserves images on auth failure reason", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: "auth",
-      }),
-    ).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, true, "auth")).toBe(fakeImages);
   });
 
   it("preserves images when previousFailureReason is undefined", () => {
-    expect(
-      resolveRetryImages({
-        images: fakeImages,
-        isFallbackRetry: true,
-        previousFailureReason: undefined,
-      }),
-    ).toBe(fakeImages);
+    expect(resolveRetryImages(fakeImages, true, undefined)).toBe(fakeImages);
   });
 });

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -36,6 +36,7 @@ import {
   resolveDefaultModelForAgent,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
+import type { FailoverReason } from "../agents/pi-embedded-helpers.js";
 import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
@@ -139,11 +140,32 @@ async function persistSessionEntry(params: PersistSessionEntryParams): Promise<v
   params.sessionStore[params.sessionKey] = persisted;
 }
 
-function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boolean }): string {
+function resolveFallbackRetryPrompt(params: {
+  body: string;
+  isFallbackRetry: boolean;
+  previousFailureReason?: FailoverReason;
+}): string {
+  // Fallback retries only fire on thrown errors (not partial streaming results),
+  // so the original prompt is always safe to re-send. The orphaned-user-message
+  // repair in attempt.ts handles any residual duplicate user turns.
+  return params.body;
+}
+
+function resolveRetryImages(params: {
+  images: AgentCommandOpts["images"];
+  isFallbackRetry: boolean;
+  previousFailureReason?: FailoverReason;
+}): AgentCommandOpts["images"] {
   if (!params.isFallbackRetry) {
-    return params.body;
+    return params.images;
   }
-  return "Continue where you left off. The previous model attempt failed or timed out.";
+  // Format errors may be caused by image payloads the fallback model
+  // doesn't support — strip as a safety measure.
+  if (params.previousFailureReason === "format") {
+    return undefined;
+  }
+  // All other reasons: model never processed or rejected the images.
+  return params.images;
 }
 
 function prependInternalEventContext(
@@ -344,10 +366,12 @@ function runAgentAttempt(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
+  previousFailureReason?: FailoverReason;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
+    previousFailureReason: params.previousFailureReason,
   });
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,
@@ -374,7 +398,11 @@ function runAgentAttempt(params: {
         cliSessionId: nextCliSessionId,
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
-        images: params.isFallbackRetry ? undefined : params.opts.images,
+        images: resolveRetryImages({
+          images: params.opts.images,
+          isFallbackRetry: params.isFallbackRetry,
+          previousFailureReason: params.previousFailureReason,
+        }),
         streamParams: params.opts.streamParams,
       });
     return runCliWithSession(cliSessionId).catch(async (err) => {
@@ -478,7 +506,11 @@ function runAgentAttempt(params: {
     config: params.cfg,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
-    images: params.isFallbackRetry ? undefined : params.opts.images,
+    images: resolveRetryImages({
+      images: params.opts.images,
+      isFallbackRetry: params.isFallbackRetry,
+      previousFailureReason: params.previousFailureReason,
+    }),
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,
@@ -1135,6 +1167,7 @@ async function agentCommandInternal(
             sessionStore,
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            previousFailureReason: runOptions?.previousFailureReason,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (
@@ -1254,3 +1287,6 @@ export async function agentCommandFromIngress(
     deps,
   );
 }
+
+/** @internal – exposed for unit tests only */
+export const _testInternals = { resolveFallbackRetryPrompt, resolveRetryImages } as const;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -140,32 +140,17 @@ async function persistSessionEntry(params: PersistSessionEntryParams): Promise<v
   params.sessionStore[params.sessionKey] = persisted;
 }
 
-function resolveFallbackRetryPrompt(params: {
-  body: string;
-  isFallbackRetry: boolean;
-  previousFailureReason?: FailoverReason;
-}): string {
-  // Fallback retries only fire on thrown errors (not partial streaming results),
-  // so the original prompt is always safe to re-send. The orphaned-user-message
-  // repair in attempt.ts handles any residual duplicate user turns.
-  return params.body;
-}
-
-function resolveRetryImages(params: {
-  images: AgentCommandOpts["images"];
-  isFallbackRetry: boolean;
-  previousFailureReason?: FailoverReason;
-}): AgentCommandOpts["images"] {
-  if (!params.isFallbackRetry) {
-    return params.images;
-  }
+function resolveRetryImages(
+  images: AgentCommandOpts["images"],
+  isFallbackRetry: boolean,
+  previousFailureReason?: FailoverReason,
+): AgentCommandOpts["images"] {
   // Format errors may be caused by image payloads the fallback model
   // doesn't support — strip as a safety measure.
-  if (params.previousFailureReason === "format") {
+  if (isFallbackRetry && previousFailureReason === "format") {
     return undefined;
   }
-  // All other reasons: model never processed or rejected the images.
-  return params.images;
+  return images;
 }
 
 function prependInternalEventContext(
@@ -368,11 +353,10 @@ function runAgentAttempt(params: {
   allowTransientCooldownProbe?: boolean;
   previousFailureReason?: FailoverReason;
 }) {
-  const effectivePrompt = resolveFallbackRetryPrompt({
-    body: params.body,
-    isFallbackRetry: params.isFallbackRetry,
-    previousFailureReason: params.previousFailureReason,
-  });
+  // Fallback retries only fire on thrown errors (not partial streaming results),
+  // so the original prompt is always safe to re-send. The orphaned-user-message
+  // repair in attempt.ts handles any residual duplicate user turns.
+  const effectivePrompt = params.body;
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,
   );
@@ -398,11 +382,11 @@ function runAgentAttempt(params: {
         cliSessionId: nextCliSessionId,
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
-        images: resolveRetryImages({
-          images: params.opts.images,
-          isFallbackRetry: params.isFallbackRetry,
-          previousFailureReason: params.previousFailureReason,
-        }),
+        images: resolveRetryImages(
+          params.opts.images,
+          params.isFallbackRetry,
+          params.previousFailureReason,
+        ),
         streamParams: params.opts.streamParams,
       });
     return runCliWithSession(cliSessionId).catch(async (err) => {
@@ -506,11 +490,11 @@ function runAgentAttempt(params: {
     config: params.cfg,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
-    images: resolveRetryImages({
-      images: params.opts.images,
-      isFallbackRetry: params.isFallbackRetry,
-      previousFailureReason: params.previousFailureReason,
-    }),
+    images: resolveRetryImages(
+      params.opts.images,
+      params.isFallbackRetry,
+      params.previousFailureReason,
+    ),
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,
@@ -1139,6 +1123,8 @@ async function agentCommandInternal(
         agentDir,
         fallbacksOverride: effectiveFallbacksOverride,
         run: (providerOverride, modelOverride, runOptions) => {
+          // TODO: isFallbackRetry is derivable from `runOptions?.previousFailureReason !== undefined`;
+          // consider removing it in a future cleanup pass.
           const isFallbackRetry = fallbackAttemptIndex > 0;
           fallbackAttemptIndex += 1;
           return runAgentAttempt({
@@ -1289,4 +1275,4 @@ export async function agentCommandFromIngress(
 }
 
 /** @internal – exposed for unit tests only */
-export const _testInternals = { resolveFallbackRetryPrompt, resolveRetryImages } as const;
+export const _testInternals = { resolveRetryImages } as const;


### PR DESCRIPTION
## Summary

When a model fallback retry fires (rate limit, timeout, auth failure, format error), the retry callback previously:
1. **Replaced the user's prompt** with a hardcoded "Continue where you left off..." string — always wrong for thrown-error retries, and destructive for subagent spawns where the prompt *is* the task
2. **Unconditionally stripped images** — even when the failure had nothing to do with image support (e.g. rate limiting)

This PR fixes both behaviors and plumbs the failure reason so the retry callback can make informed decisions.

## Behavioral changes

### 1. Preserve original prompt on fallback retry

**Before:** `resolveFallbackRetryPrompt` replaced the user's message body with `"Continue where you left off. The previous model attempt failed or timed out."` on every fallback retry.

**After:** The original `body` is forwarded verbatim. Fallback retries only fire on thrown errors (not partial streaming results), so the original prompt is always safe to re-send. The orphaned-user-message repair in `attempt.ts` handles any residual duplicate user turns in session history.

**Why:** The continuation prompt was actively harmful — subagents lost their task text, and main agents got a content-free prompt that degraded response quality on the fallback model.

### 2. Failure-mode-aware image handling

**Before:** Images were stripped on every fallback retry (`images: params.isFallbackRetry ? undefined : params.opts.images`).

**After:** Images are only stripped when `previousFailureReason === "format"` — indicating the model can't handle the image modality. Rate limit, timeout, and auth failures preserve images for the fallback model.

**Why:** Unconditional stripping threw away valid image context on transient failures. Format-only stripping is the correct policy: if a model can't handle images, it should signal that through a format error, not a rate limit.

### 3. `previousFailureReason` plumbing

`ModelFallbackRunOptions` now includes an optional `previousFailureReason: FailoverReason` field, populated from the error classification of the previous attempt. This lets the `run` callback make failure-mode-aware decisions (currently used for image handling, available for future use).

### 4. Helper cleanup

- Deleted `resolveFallbackRetryPrompt` (was a no-op wrapper after the behavioral fix)
- Simplified `resolveRetryImages` to a 2-line function
- Replaced an IIFE with a direct conditional

## Supersedes

- #36273 — narrow subagent-only guard for prompt preservation (now replaced by this broader fix)
- #43303 — same code, but framed as "refactoring only" which reviewers correctly flagged as inaccurate

## Related open PRs (same fallback area)

- #40053 — preserve selected session model during fallback
- #32407 — sanitize thinking signatures on cross-provider model fallback
- #34569 — add fallbackModel to retry compaction on quota/rate-limit errors
- #19252 — continue model fallback on failover text payloads

## Issues addressed

**Directly fixes:**
- Subagent task text dropped on model failover (subagent receives "Continue where you left off" instead of its task)

**Partially addresses:**
- #26764 — Telegram duplicate user turns on model fallback (removes one source of orphaned messages — the injected continuation prompt — but root cause is inbound message re-queuing, a separate code path)
- #29290 — images poison session when model doesn't support vision (format-only stripping is smarter than unconditional, but root cause of images persisted in transcript is untouched)

**Related (not fixed here):**
- #31101 — Telegram partial message spam on fallback (streaming/delivery)
- #31664 — agent stalls mid-stream on rate limit (attempt.ts state machine)
- #40742 — tool-calling unreliable across provider failover (tool compatibility)
- #29014 — smarter overloaded error handling (`previousFailureReason` is a building block)

## CLI session concern (from #43303 review)

Codex review flagged that forwarding `params.body` on CLI retries could append a duplicate user turn to a resumed CLI session. This is pre-existing — the old continuation prompt also appended a user turn, just a misleading one. The orphaned-user-message repair in `attempt.ts` handles this for the embedded runner flow. Full CLI session dedup is tracked in the related issues above.

## Test plan

- [x] Existing `resolveRetryImages` tests cover all failure-reason branches (format strips, others preserve)
- [x] `previousFailureReason` forwarding tested in `model-fallback.ts` unit tests (undefined on first attempt, set on retry)
- [x] `pnpm test` passes
- [x] `pnpm check` passes
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)