### PR TITLE
fix(agents): sanitize tool call ids for OpenAI-compatible responses routes

### DIFF
--- a/src/agents/transcript-policy.policy.test.ts
+++ b/src/agents/transcript-policy.policy.test.ts
@@ -21,4 +21,14 @@ describe("resolveTranscriptPolicy e2e smoke", () => {
     expect(policy.sanitizeToolCallIds).toBe(true);
     expect(policy.toolCallIdMode).toBe("strict9");
   });
+
+  it("enables strict tool-call sanitization for OpenAI-compatible responses routes", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "vllm",
+      modelId: "gpt-5.2",
+      modelApi: "openai-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
 });

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -54,6 +54,26 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict");
   });
 
+  it("keeps tool-call id preservation for native OpenAI responses APIs", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-5.2",
+      modelApi: "openai-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(false);
+    expect(policy.toolCallIdMode).toBeUndefined();
+  });
+
+  it("enables strict tool call id sanitization for OpenAI-compatible responses APIs", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "vllm",
+      modelId: "gpt-5.2",
+      modelApi: "openai-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
   it("enables user-turn merge for strict OpenAI-compatible providers", () => {
     const policy = resolveTranscriptPolicy({
       provider: "moonshot",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -78,7 +78,11 @@ export function resolveTranscriptPolicy(params: {
       provider,
       modelId,
     });
-  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  const isOpenAiResponsesApi =
+    params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" ||
+    (isOpenAiResponsesApi && !isOpenAi && supportsOpenAiCompatTurnValidation(provider));
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").


### PR DESCRIPTION
## Summary
- apply strict tool-call id sanitization to **OpenAI-compatible** `openai-responses` / `openai-codex-responses` routes
- keep native OpenAI responses behavior unchanged (no tool id rewriting) so existing `call_id|fc_id` preservation still works
- add transcript-policy tests that cover both native OpenAI and OpenAI-compatible responses routes

## Reproducible issue linkage
Fixes #43305.

This addresses the reported `input[n].id` length rejection after tool-call turns/session startup on OpenAI-compatible responses backends by forcing compatible-safe id rewriting before outbound payload generation.

## Validation
- Attempted:
  - `pnpm exec vitest run --config vitest.unit.config.ts src/agents/transcript-policy.test.ts src/agents/transcript-policy.policy.test.ts src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts`
- Result:
  - Not runnable in this environment (`vitest` not found; local test dependencies are unavailable in the cron worker checkout).
