### PR TITLE
fix(models): enable tool call ID sanitization for non-OpenAI providers using Responses API

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -54,6 +54,37 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict");
   });
 
+  it("enables tool call ID sanitization for non-OpenAI providers using openai-responses API (#43305)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "custom-proxy",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("enables tool call ID sanitization for non-OpenAI providers using openai-codex-responses API (#43305)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "custom-codex-proxy",
+      modelId: "codex",
+      modelApi: "openai-codex-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("does NOT sanitize tool call IDs for first-party OpenAI using openai-responses API (#43305)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-5.2",
+      modelApi: "openai-responses",
+    });
+    // First-party OpenAI uses canonical IDs (call_123|fc_123) that must not be sanitized
+    expect(policy.sanitizeToolCallIds).toBe(false);
+    expect(policy.toolCallIdMode).toBeUndefined();
+  });
+
   it("enables user-turn merge for strict OpenAI-compatible providers", () => {
     const policy = resolveTranscriptPolicy({
       provider: "moonshot",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -79,6 +79,12 @@ export function resolveTranscriptPolicy(params: {
       modelId,
     });
   const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  // OpenAI Responses API has a 64-character limit on call_id.
+  // Only non-OpenAI providers using Responses API need sanitization.
+  // First-party OpenAI uses canonical IDs (call_123|fc_123) that must not be sanitized.
+  const requiresResponsesApiSanitization =
+    !isOpenAi &&
+    (params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses");
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
@@ -109,7 +115,9 @@ export function resolveTranscriptPolicy(params: {
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
     sanitizeToolCallIds:
-      (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
+      (!isOpenAi && sanitizeToolCallIds) ||
+      requiresOpenAiCompatibleToolIdSanitization ||
+      requiresResponsesApiSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
     preserveSignatures: isAnthropic && preservesAnthropicThinkingSignatures(provider),


### PR DESCRIPTION
## Summary

- The OpenAI Responses API has a 64-character limit on `call_id`
- Only **non-OpenAI providers** (custom proxies) using Responses API need sanitization
- First-party OpenAI uses canonical IDs (`call_123|fc_123`) that must **NOT** be sanitized

## Root Cause

When using `api: "openai-responses"` against an OpenAI-compatible proxy, tool call IDs could exceed 64 characters, causing HTTP 400 errors.

## Fix

Added `requiresResponsesApiSanitization` check that only enables sanitization for:
- Non-OpenAI providers
- Using `openai-responses` or `openai-codex-responses` API

This preserves canonical ID format for first-party OpenAI, avoiding regression in reasoning replay.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43305
- Supersedes #43315 (previous fix was incorrect)

## User-visible / Behavior Changes

Users using `openai-responses` API with custom providers will no longer encounter tool call ID length errors.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS/Linux/Windows
- Runtime: Node.js 22
- Model/provider: Custom provider using openai-responses API

### Steps
1. Configure a custom provider with `api: "openai-responses"`
2. Trigger a session with tool calls
3. Verify no HTTP 400 errors about ID length

## Evidence

- [x] Failing test/log before + passing after (test added)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: 
  - Non-OpenAI provider with openai-responses: sanitization enabled
  - First-party OpenAI with openai-responses: sanitization disabled (preserves canonical IDs)
- Edge cases checked: openai-codex-responses API
- What did **not** verify: Actual OpenAI Responses API endpoint (no access)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None. This is a targeted fix that only affects non-OpenAI providers using Responses API.

🤖 Generated by AI Contributor (kincoy)