### PR TITLE
Nodes tool: honor full/off policy for node system.run

### DIFF
--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -132,6 +132,17 @@ describe("createNodesTool screen_record duration guardrails", () => {
     });
     expect(prepareCall?.params).not.toHaveProperty("rawCommand");
   });
+});
+
+describe("createNodesTool run approvals", () => {
+  beforeEach(() => {
+    gatewayMocks.callGatewayTool.mockReset();
+    gatewayMocks.readGatewayCallOptions.mockReset();
+    gatewayMocks.readGatewayCallOptions.mockReturnValue({});
+    nodeUtilsMocks.resolveNodeId.mockClear();
+    screenMocks.parseScreenRecordPayload.mockClear();
+    screenMocks.writeScreenRecordToFile.mockClear();
+  });
 
   it("auto-resolves allow-once for run when tools.exec is full/off", async () => {
     nodeUtilsMocks.listNodes.mockResolvedValue([
@@ -201,5 +212,70 @@ describe("createNodesTool screen_record duration guardrails", () => {
       (call) => call[0] === "exec.approval.request",
     )?.[2];
     expect(approvalRequestCall?.twoPhase).toBe(true);
+  });
+
+  it("does not swallow system.run errors after full/off auto-approval", async () => {
+    nodeUtilsMocks.listNodes.mockResolvedValue([
+      {
+        nodeId: "node-1",
+        commands: ["system.run"],
+      },
+    ]);
+    gatewayMocks.callGatewayTool.mockImplementation(async (method, _opts, payload) => {
+      if (method === "node.invoke" && payload?.command === "system.run.prepare") {
+        return {
+          payload: {
+            cmdText: "echo hi",
+            plan: {
+              argv: ["echo", "hi"],
+              cwd: null,
+              rawCommand: "echo hi",
+              agentId: null,
+              sessionKey: null,
+            },
+          },
+        };
+      }
+      if (method === "exec.approval.request") {
+        return {
+          status: "accepted",
+          id: payload?.id,
+        };
+      }
+      if (method === "exec.approval.resolve") {
+        return { ok: true };
+      }
+      if (method === "node.invoke" && payload?.command === "system.run") {
+        if (payload?.params?.approved !== true) {
+          throw new Error("unexpected legacy fallback");
+        }
+        throw new Error("transport failure");
+      }
+      throw new Error(`unexpected call: ${method}`);
+    });
+    const tool = createNodesTool({
+      config: {
+        tools: {
+          exec: {
+            security: "full",
+            ask: "off",
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    await expect(
+      tool.execute("call-3", {
+        action: "run",
+        node: "macbook",
+        command: ["echo", "hi"],
+      }),
+    ).rejects.toThrow("transport failure");
+
+    const runCalls = gatewayMocks.callGatewayTool.mock.calls.filter(
+      (call) => call[0] === "node.invoke" && call[2]?.command === "system.run",
+    );
+    expect(runCalls).toHaveLength(1);
+    expect(runCalls[0]?.[2]?.params?.approved).toBe(true);
   });
 });

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 
 const gatewayMocks = vi.hoisted(() => ({
   callGatewayTool: vi.fn(),
@@ -130,5 +131,75 @@ describe("createNodesTool screen_record duration guardrails", () => {
       agentId: "main",
     });
     expect(prepareCall?.params).not.toHaveProperty("rawCommand");
+  });
+
+  it("auto-resolves allow-once for run when tools.exec is full/off", async () => {
+    nodeUtilsMocks.listNodes.mockResolvedValue([
+      {
+        nodeId: "node-1",
+        commands: ["system.run"],
+      },
+    ]);
+    gatewayMocks.callGatewayTool.mockImplementation(async (method, _opts, payload) => {
+      if (method === "node.invoke" && payload?.command === "system.run.prepare") {
+        return {
+          payload: {
+            cmdText: "echo hi",
+            plan: {
+              argv: ["echo", "hi"],
+              cwd: null,
+              rawCommand: "echo hi",
+              agentId: null,
+              sessionKey: null,
+            },
+          },
+        };
+      }
+      if (method === "exec.approval.request") {
+        return {
+          status: "accepted",
+          id: payload?.id,
+        };
+      }
+      if (method === "exec.approval.resolve") {
+        return { ok: true };
+      }
+      if (method === "node.invoke" && payload?.command === "system.run") {
+        if (payload?.params?.approved !== true) {
+          throw new Error("SYSTEM_RUN_DENIED: approval required");
+        }
+        return { payload: { ok: true } };
+      }
+      throw new Error(`unexpected call: ${method}`);
+    });
+    const tool = createNodesTool({
+      config: {
+        tools: {
+          exec: {
+            security: "full",
+            ask: "off",
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const result = await tool.execute("call-2", {
+      action: "run",
+      node: "macbook",
+      command: ["echo", "hi"],
+    });
+
+    expect(result.details).toEqual({ ok: true });
+    const firstRunCall = gatewayMocks.callGatewayTool.mock.calls.find(
+      (call) => call[0] === "node.invoke" && call[2]?.command === "system.run",
+    )?.[2];
+    expect(firstRunCall).toBeTruthy();
+    expect(firstRunCall?.params?.approved).toBe(true);
+    expect(firstRunCall?.params?.approvalDecision).toBe("allow-once");
+    expect(firstRunCall?.params?.runId).toBeTruthy();
+    const approvalRequestCall = gatewayMocks.callGatewayTool.mock.calls.find(
+      (call) => call[0] === "exec.approval.request",
+    )?.[2];
+    expect(approvalRequestCall?.twoPhase).toBe(true);
   });
 });

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -172,6 +172,18 @@ describe("createNodesTool run approvals", () => {
           id: payload?.id,
         };
       }
+      if (method === "exec.approvals.node.get") {
+        return {
+          file: {
+            version: 1,
+            defaults: {
+              security: "full",
+              ask: "off",
+            },
+            agents: {},
+          },
+        };
+      }
       if (method === "exec.approval.resolve") {
         return { ok: true };
       }
@@ -214,6 +226,83 @@ describe("createNodesTool run approvals", () => {
     expect(approvalRequestCall?.twoPhase).toBe(true);
   });
 
+  it("does not auto-resolve when node approvals override ask to always", async () => {
+    nodeUtilsMocks.listNodes.mockResolvedValue([
+      {
+        nodeId: "node-1",
+        commands: ["system.run"],
+      },
+    ]);
+    gatewayMocks.callGatewayTool.mockImplementation(async (method, _opts, payload) => {
+      if (method === "node.invoke" && payload?.command === "system.run.prepare") {
+        return {
+          payload: {
+            cmdText: "echo hi",
+            plan: {
+              argv: ["echo", "hi"],
+              cwd: null,
+              rawCommand: "echo hi",
+              agentId: null,
+              sessionKey: null,
+            },
+          },
+        };
+      }
+      if (method === "exec.approvals.node.get") {
+        return {
+          file: {
+            version: 1,
+            defaults: {
+              security: "full",
+              ask: "always",
+            },
+            agents: {},
+          },
+        };
+      }
+      if (method === "node.invoke" && payload?.command === "system.run") {
+        if (payload?.params?.approved !== true) {
+          throw new Error("SYSTEM_RUN_DENIED: approval required");
+        }
+        return { payload: { ok: true } };
+      }
+      if (method === "exec.approval.request") {
+        return { decision: "allow-once" };
+      }
+      throw new Error(`unexpected call: ${method}`);
+    });
+    const tool = createNodesTool({
+      config: {
+        tools: {
+          exec: {
+            security: "full",
+            ask: "off",
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const result = await tool.execute("call-2b", {
+      action: "run",
+      node: "macbook",
+      command: ["echo", "hi"],
+    });
+
+    expect(result.details).toEqual({ ok: true });
+    const requestCalls = gatewayMocks.callGatewayTool.mock.calls
+      .filter((call) => call[0] === "exec.approval.request")
+      .map((call) => call[2]);
+    expect(requestCalls).toHaveLength(1);
+    expect(requestCalls[0]?.twoPhase).toBeUndefined();
+
+    const runCalls = gatewayMocks.callGatewayTool.mock.calls
+      .filter((call) => call[0] === "node.invoke" && call[2]?.command === "system.run")
+      .map((call) => call[2]);
+    expect(runCalls).toHaveLength(2);
+    expect(runCalls[0]?.params?.approved).not.toBe(true);
+    expect(runCalls[1]?.params?.approved).toBe(true);
+  });
+
   it("does not swallow system.run errors after full/off auto-approval", async () => {
     nodeUtilsMocks.listNodes.mockResolvedValue([
       {
@@ -240,6 +329,18 @@ describe("createNodesTool run approvals", () => {
         return {
           status: "accepted",
           id: payload?.id,
+        };
+      }
+      if (method === "exec.approvals.node.get") {
+        return {
+          file: {
+            version: 1,
+            defaults: {
+              security: "full",
+              ask: "off",
+            },
+            agents: {},
+          },
         };
       }
       if (method === "exec.approval.resolve") {

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -716,8 +716,9 @@ export function createNodesTool(options?: {
               agentId,
             });
             if (shouldAutoApproveNodeRun(execPolicy)) {
+              const approvalId = crypto.randomUUID();
+              let approvalPreResolved = false;
               try {
-                const approvalId = crypto.randomUUID();
                 await callGatewayTool(
                   "exec.approval.request",
                   { ...gatewayOpts, timeoutMs: APPROVAL_TIMEOUT_MS + 5_000 },
@@ -745,13 +746,17 @@ export function createNodesTool(options?: {
                   id: approvalId,
                   decision: "allow-once",
                 });
+                approvalPreResolved = true;
+              } catch {
+                // Fall back to the standard approval workflow if pre-resolve fails.
+              }
+
+              if (approvalPreResolved) {
                 const raw = await invokeWithApproval({
                   approvalId,
                   approvalDecision: "allow-once",
                 });
                 return jsonResult(raw?.payload ?? {});
-              } catch {
-                // Fall back to the standard approval workflow if pre-resolve fails.
               }
             }
 

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -20,7 +20,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { parsePreparedSystemRunPayload } from "../../infra/system-run-approval-context.js";
 import { imageMimeFromFormat } from "../../media/mime.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
-import { resolveSessionAgentId } from "../agent-scope.js";
+import { resolveAgentConfig, resolveSessionAgentId } from "../agent-scope.js";
 import { resolveImageSanitizationLimits } from "../image-sanitization.js";
 import { optionalStringEnum, stringEnum } from "../schema/typebox.js";
 import { sanitizeToolResultImages } from "../tool-images.js";
@@ -100,6 +100,25 @@ function extractPairingRequestId(message: string): string | null {
   }
   const value = (match[1] ?? "").trim();
   return value.length > 0 ? value : null;
+}
+
+function resolveExecPolicyForNodeRun(params: { config?: OpenClawConfig; agentId?: string }): {
+  security?: string;
+  ask?: string;
+} {
+  const globalExec = params.config?.tools?.exec;
+  const agentExec =
+    params.config && params.agentId
+      ? resolveAgentConfig(params.config, params.agentId)?.tools?.exec
+      : undefined;
+  return {
+    security: agentExec?.security ?? globalExec?.security,
+    ask: agentExec?.ask ?? globalExec?.ask,
+  };
+}
+
+function shouldAutoApproveNodeRun(policy: { security?: string; ask?: string }): boolean {
+  return policy.security === "full" && policy.ask === "off";
 }
 
 // Flattened schema: runtime validates per-action requirements.
@@ -672,6 +691,69 @@ export function createNodesTool(options?: {
               agentId: prepared.plan.agentId ?? agentId,
               sessionKey: prepared.plan.sessionKey ?? sessionKey,
             };
+            const APPROVAL_TIMEOUT_MS = 120_000;
+
+            const invokeWithApproval = async (params: {
+              approvalId: string;
+              approvalDecision: "allow-once" | "allow-always";
+            }) => {
+              return await callGatewayTool<{ payload?: unknown }>("node.invoke", gatewayOpts, {
+                nodeId,
+                command: "system.run",
+                params: {
+                  ...runParams,
+                  runId: params.approvalId,
+                  approved: true,
+                  approvalDecision: params.approvalDecision,
+                },
+                timeoutMs: invokeTimeoutMs,
+                idempotencyKey: crypto.randomUUID(),
+              });
+            };
+
+            const execPolicy = resolveExecPolicyForNodeRun({
+              config: options?.config,
+              agentId,
+            });
+            if (shouldAutoApproveNodeRun(execPolicy)) {
+              try {
+                const approvalId = crypto.randomUUID();
+                await callGatewayTool(
+                  "exec.approval.request",
+                  { ...gatewayOpts, timeoutMs: APPROVAL_TIMEOUT_MS + 5_000 },
+                  {
+                    id: approvalId,
+                    command: prepared.cmdText,
+                    commandArgv: prepared.plan.argv,
+                    systemRunPlan: prepared.plan,
+                    cwd: prepared.plan.cwd ?? cwd,
+                    nodeId,
+                    host: "node",
+                    security: "full",
+                    ask: "off",
+                    agentId: prepared.plan.agentId ?? agentId,
+                    sessionKey: prepared.plan.sessionKey ?? sessionKey,
+                    turnSourceChannel,
+                    turnSourceTo,
+                    turnSourceAccountId,
+                    turnSourceThreadId,
+                    timeoutMs: APPROVAL_TIMEOUT_MS,
+                    twoPhase: true,
+                  },
+                );
+                await callGatewayTool("exec.approval.resolve", gatewayOpts, {
+                  id: approvalId,
+                  decision: "allow-once",
+                });
+                const raw = await invokeWithApproval({
+                  approvalId,
+                  approvalDecision: "allow-once",
+                });
+                return jsonResult(raw?.payload ?? {});
+              } catch {
+                // Fall back to the standard approval workflow if pre-resolve fails.
+              }
+            }
 
             // First attempt without approval flags.
             try {
@@ -692,7 +774,6 @@ export function createNodesTool(options?: {
 
             // Node requires approval – create a pending approval request on
             // the gateway and wait for the user to approve/deny via the UI.
-            const APPROVAL_TIMEOUT_MS = 120_000;
             const approvalId = crypto.randomUUID();
             const approvalResult = await callGatewayTool(
               "exec.approval.request",
@@ -732,17 +813,9 @@ export function createNodesTool(options?: {
             }
 
             // Retry with the approval decision.
-            const raw = await callGatewayTool<{ payload?: unknown }>("node.invoke", gatewayOpts, {
-              nodeId,
-              command: "system.run",
-              params: {
-                ...runParams,
-                runId: approvalId,
-                approved: true,
-                approvalDecision,
-              },
-              timeoutMs: invokeTimeoutMs,
-              idempotencyKey: crypto.randomUUID(),
+            const raw = await invokeWithApproval({
+              approvalId,
+              approvalDecision,
             });
             return jsonResult(raw?.payload ?? {});
           }

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -17,6 +17,16 @@ import {
 } from "../../cli/nodes-screen.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import {
+  maxAsk,
+  minSecurity,
+  normalizeExecAsk,
+  normalizeExecSecurity,
+  resolveExecApprovalsFromFile,
+  type ExecApprovalsFile,
+  type ExecAsk,
+  type ExecSecurity,
+} from "../../infra/exec-approvals.js";
 import { parsePreparedSystemRunPayload } from "../../infra/system-run-approval-context.js";
 import { imageMimeFromFormat } from "../../media/mime.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
@@ -103,22 +113,76 @@ function extractPairingRequestId(message: string): string | null {
 }
 
 function resolveExecPolicyForNodeRun(params: { config?: OpenClawConfig; agentId?: string }): {
-  security?: string;
-  ask?: string;
+  security?: ExecSecurity;
+  ask?: ExecAsk;
 } {
   const globalExec = params.config?.tools?.exec;
   const agentExec =
     params.config && params.agentId
       ? resolveAgentConfig(params.config, params.agentId)?.tools?.exec
       : undefined;
+  const security = normalizeExecSecurity(agentExec?.security ?? globalExec?.security) ?? undefined;
+  const ask = normalizeExecAsk(agentExec?.ask ?? globalExec?.ask) ?? undefined;
   return {
-    security: agentExec?.security ?? globalExec?.security,
-    ask: agentExec?.ask ?? globalExec?.ask,
+    security,
+    ask,
   };
 }
 
-function shouldAutoApproveNodeRun(policy: { security?: string; ask?: string }): boolean {
+function shouldAutoApproveNodeRun(policy: { security?: ExecSecurity; ask?: ExecAsk }): boolean {
   return policy.security === "full" && policy.ask === "off";
+}
+
+async function resolveNodeRunEffectiveExecPolicy(params: {
+  gatewayOpts: GatewayCallOptions;
+  nodeId: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+}): Promise<{
+  security?: ExecSecurity;
+  ask?: ExecAsk;
+}> {
+  const configuredPolicy = resolveExecPolicyForNodeRun({
+    config: params.config,
+    agentId: params.agentId,
+  });
+  try {
+    const approvalsSnapshot = await callGatewayTool<{ file?: unknown }>(
+      "exec.approvals.node.get",
+      params.gatewayOpts,
+      {
+        nodeId: params.nodeId,
+      },
+    );
+    const approvalsFile =
+      approvalsSnapshot && typeof approvalsSnapshot === "object"
+        ? approvalsSnapshot.file
+        : undefined;
+    if (!approvalsFile || typeof approvalsFile !== "object") {
+      return configuredPolicy;
+    }
+    const approvals = resolveExecApprovalsFromFile({
+      file: approvalsFile as ExecApprovalsFile,
+      agentId: params.agentId,
+      overrides: {
+        security: configuredPolicy.security,
+        ask: configuredPolicy.ask,
+      },
+    });
+    const effectiveSecurity = configuredPolicy.security
+      ? minSecurity(configuredPolicy.security, approvals.agent.security)
+      : approvals.agent.security;
+    const effectiveAsk = configuredPolicy.ask
+      ? maxAsk(configuredPolicy.ask, approvals.agent.ask)
+      : approvals.agent.ask;
+    return {
+      security: effectiveSecurity,
+      ask: effectiveAsk,
+    };
+  } catch {
+    // Keep the original fallback behavior when node approvals are temporarily unavailable.
+    return configuredPolicy;
+  }
 }
 
 // Flattened schema: runtime validates per-action requirements.
@@ -711,7 +775,9 @@ export function createNodesTool(options?: {
               });
             };
 
-            const execPolicy = resolveExecPolicyForNodeRun({
+            const execPolicy = await resolveNodeRunEffectiveExecPolicy({
+              gatewayOpts,
+              nodeId,
               config: options?.config,
               agentId,
             });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `nodes` tool `action=run` always did an unapproved first `system.run` invoke, which triggers `approval-required` and approval UI even when `tools.exec.security=full` and `tools.exec.ask=off`.
- Why it matters: control-ui/webchat users in explicit full/off mode still hit approval interruptions and misleading denied/finished event sequences.
- What changed: when effective exec policy resolves to `security=full` + `ask=off`, `nodes.run` now pre-registers and auto-resolves an internal allow-once approval before the first `system.run` invoke, then executes with bound approval flags.
- What did NOT change (scope boundary): non-full/off paths keep the existing behavior (first unapproved attempt, then interactive approval fallback on `SYSTEM_RUN_DENIED: approval required`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43279
- Related #

## User-visible / Behavior Changes

- With `tools.exec.security=full` and `tools.exec.ask=off`, `nodes` tool `action=run` no longer starts with an unapproved `system.run` call that emits `approval-required`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: full/off mode now pre-resolves an allow-once approval internally for `nodes.run`.
  - Mitigation: only enabled when effective exec policy is explicitly full/off; other policies keep existing approval flow.

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (unit test)
- Integration/channel (if any): nodes tool path
- Relevant config (redacted): `tools.exec.security=full`, `tools.exec.ask=off`

### Steps

1. Configure `tools.exec.security=full` and `tools.exec.ask=off`.
2. Invoke `nodes` tool `action=run` against a node-backed `system.run` path.
3. Observe that the call now pre-resolves allow-once and invokes with approval flags on first run.

### Expected

- No initial unapproved `system.run` call.
- No `approval-required` gate before command execution in full/off mode.

### Actual

- Behavior matches expected in test coverage.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test for `nodes.run` full/off path.
  - Confirmed it sends `exec.approval.request` with `twoPhase: true`, auto-resolves `allow-once`, and first `system.run` invoke carries `approved=true` + `approvalDecision=allow-once`.
- Edge cases checked:
  - Existing non-full/off fallback path remains in place.
- What you did **not** verify:
  - Live webchat/control-ui manual end-to-end against a real paired Windows node.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `f56e5de05`.
- Files/config to restore:
  - `src/agents/tools/nodes-tool.ts`
  - `src/agents/tools/nodes-tool.test.ts`
- Known bad symptoms reviewers should watch for:
  - `nodes.run` unexpectedly entering manual approval flow in full/off mode.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - If exec approval clients are unavailable, auto pre-resolve can fail and fallback path may still require interactive approval.
  - Mitigation:
    - Code keeps existing fallback behavior unchanged when pre-resolve fails.
