### PR TITLE
docs: add troubleshooting note for upstream 403 blocked responses

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -155,9 +155,9 @@ Use this when an upstream LLM provider returns:
 Do not assume this is always an OpenClaw configuration issue. This can also come from an upstream security layer such as Cloudflare, WAF/Bot Management, or reverse-proxy filtering.
 
 ```bash
-openclaw logs --follow
 openclaw status
 openclaw gateway status
+openclaw logs --follow
 ```
 
 Look for:
@@ -174,9 +174,15 @@ Fix approach:
 3. If filtering is confirmed, prefer a narrowly scoped allow/skip/exception rule for the required API path.
 4. Avoid disabling protection for the entire site.
 
-Important:
+<Warning>
+A successful minimal `curl` does not guarantee that real SDK-style requests will pass.
+</Warning>
 
-> A successful minimal `curl` does not guarantee that real SDK-style requests will pass.
+Related:
+
+- [OpenAI-compatible endpoints](/gateway/configuration-reference#openai-compatible-endpoints)
+- [Provider configuration](/providers)
+- [Logs](/reference/logs)
 
 ## No replies
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -147,6 +147,37 @@ Related:
 - [Local models](/gateway/local-models)
 - [OpenAI-compatible endpoints](/gateway/configuration-reference#openai-compatible-endpoints)
 
+## Upstream 403 your request was blocked
+
+Use this when an upstream LLM provider returns:
+`403 Your request was blocked.`
+
+Do not assume this is always an OpenClaw configuration issue. This can also come from an upstream security layer such as Cloudflare, WAF/Bot Management, or reverse-proxy filtering.
+
+```bash
+openclaw logs --follow
+openclaw status
+openclaw gateway status
+```
+
+Look for:
+
+- Multiple models under the same provider failing in the same way.
+- HTML or generic security text instead of a normal API error.
+- Provider-side security events showing blocked requests.
+- Cases where a minimal `curl` succeeds but real SDK-style requests still fail.
+
+Fix approach:
+
+1. Check the provider-side security layer first if the provider is behind Cloudflare or another WAF/CDN.
+2. Confirm whether the upstream response looks like a block page rather than an application error.
+3. If filtering is confirmed, prefer a narrowly scoped allow/skip/exception rule for the required API path.
+4. Avoid disabling protection for the entire site.
+
+Important:
+
+> A successful minimal `curl` does not guarantee that real SDK-style requests will pass.
+
 ## No replies
 
 If channels are up but nothing answers, check routing and policy before reconnecting anything.


### PR DESCRIPTION
## Summary

- Problem: Users can hit upstream `403 Your request was blocked.` responses and misdiagnose them as OpenClaw configuration issues.
- Why it matters: This can lead to wasted debugging time on model/provider config when the real cause is upstream security filtering.
- What changed: Added a short troubleshooting note to `docs/gateway/troubleshooting.md` covering provider-side security layers, block-page signals, and the limits of minimal `curl` checks.
- What did NOT change (scope boundary): No runtime behavior, provider logic, network handling, or error parsing was changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Added a troubleshooting note for upstream `403 Your request was blocked.` errors in gateway docs.
- Clarified that this may be caused by provider-side security layers such as Cloudflare, WAF/Bot Management, or reverse-proxy filtering.
- Clarified that a successful minimal `curl` does not rule out SDK-style request blocking.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

None.

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 LTS
- Runtime/container: local git checkout
- Model/provider: custom OpenAI-compatible provider behind upstream protection
- Integration/channel (if any): N/A
- Relevant config (redacted): custom `models.providers` entry using an OpenAI-compatible upstream

### Steps

1. Configure an OpenAI-compatible upstream provider that is protected by Cloudflare or another security layer.
2. Trigger requests through OpenClaw.
3. Observe an upstream `403 Your request was blocked.` response.
4. Read the new troubleshooting note in `docs/gateway/troubleshooting.md`.

### Expected

- Docs provide a short, accurate troubleshooting path.
- Readers are guided to check provider-side security filtering before over-focusing on OpenClaw config.

### Actual

- The new docs note covers the main failure pattern and mitigation guidance.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reviewed the new section in `docs/gateway/troubleshooting.md` for placement and clarity.
  - Confirmed the guidance matches the observed upstream-blocking failure pattern.
- Edge cases checked:
  - Wording is generic and not tied to a single provider or API path.
  - Guidance does not recommend site-wide protection disablement.
- What you did **not** verify:
  - No automated docs build was run as part of this change.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

None.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the docs commit.
- Files/config to restore: `docs/gateway/troubleshooting.md`
- Known bad symptoms reviewers should watch for: Wording duplication, poor placement, or troubleshooting guidance that is too provider-specific.

## Risks and Mitigations

- Risk: The note may be seen as too specific to one upstream security setup.
  - Mitigation: Kept wording generic and framed it as a common provider-side blocking pattern.
- Risk: The note may overlap with other troubleshooting docs.
  - Mitigation: Added it as a short targeted subsection in the deep gateway troubleshooting page instead of creating a separate long-form doc.
