### PR TITLE
fix(media): classify audio-only MP4/M4A containers as audio/mp4

### DIFF
--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -10,6 +10,19 @@ import {
   normalizeMimeType,
 } from "./mime.js";
 
+// Build a minimal MPEG-4 ftyp box with the specified major brand.
+// Structure: [size:4][ftyp:4][major_brand:4][minor_version:4][compatible_brands:N]
+function makeMp4FtypBox(majorBrand: string): Buffer {
+  const size = 20; // minimum ftyp box with one compatible brand
+  const buf = Buffer.alloc(size);
+  buf.writeUInt32BE(size, 0); // box size
+  buf.write("ftyp", 4, 4, "ascii"); // box type
+  buf.write(majorBrand, 8, 4, "ascii"); // major brand
+  buf.writeUInt32BE(0, 12); // minor version
+  buf.write("isom", 16, 4, "ascii"); // compatible brand
+  return buf;
+}
+
 async function makeOoxmlZip(opts: { mainMime: string; partPath: string }): Promise<Buffer> {
   const zip = new JSZip();
   zip.file(
@@ -67,6 +80,22 @@ describe("mime detection", () => {
       filePath: "/tmp/a2ui.bundle.js",
     });
     expect(mime).toBe("text/javascript");
+  });
+
+  it.each([
+    // file-type already handles uppercase M4A correctly (returns audio/x-m4a)
+    { brand: "M4A ", expected: "audio/x-m4a", description: "M4A audio" },
+    // file-type misclassifies lowercase m4a as video/mp4; our fix corrects to audio/mp4
+    { brand: "m4a ", expected: "audio/mp4", description: "M4A audio (lowercase)" },
+    { brand: "M4B ", expected: "audio/mp4", description: "M4B audiobook" },
+    { brand: "F4A ", expected: "audio/mp4", description: "F4A Flash audio" },
+    { brand: "mp41", expected: "video/mp4", description: "MP4v1 video" },
+    { brand: "isom", expected: "video/mp4", description: "ISO Base Media" },
+    { brand: "avc1", expected: "video/mp4", description: "AVC video" },
+  ] as const)("classifies $description by ftyp major brand", async ({ brand, expected }) => {
+    const buf = makeMp4FtypBox(brand);
+    const mime = await detectMime({ buffer: buf });
+    expect(mime).toBe(expected);
   });
 });
 

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -88,7 +88,10 @@ describe("mime detection", () => {
     // file-type misclassifies lowercase m4a as video/mp4; our fix corrects to audio/mp4
     { brand: "m4a ", expected: "audio/mp4", description: "M4A audio (lowercase)" },
     { brand: "M4B ", expected: "audio/mp4", description: "M4B audiobook" },
+    { brand: "M4P ", expected: "audio/mp4", description: "M4P protected audio" },
+    { brand: "M4R ", expected: "audio/mp4", description: "M4R ringtone" },
     { brand: "F4A ", expected: "audio/mp4", description: "F4A Flash audio" },
+    { brand: "F4B ", expected: "audio/mp4", description: "F4B Flash audiobook" },
     { brand: "mp41", expected: "video/mp4", description: "MP4v1 video" },
     { brand: "isom", expected: "video/mp4", description: "ISO Base Media" },
     { brand: "avc1", expected: "video/mp4", description: "AVC video" },

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -2,6 +2,18 @@ import path from "node:path";
 import { fileTypeFromBuffer } from "file-type";
 import { type MediaKind, mediaKindFromMime } from "./constants.js";
 
+// Major brands for audio-only MPEG-4 containers.
+// file-type cannot distinguish audio-only MP4/M4A from video MP4,
+// so we check the ftyp major brand at bytes 8-11.
+const AUDIO_MP4_BRANDS = new Set([
+  "m4a ", // M4A (iTunes audio)
+  "m4b ", // M4B (audiobook)
+  "m4p ", // M4P (protected iTunes audio)
+  "m4r ", // M4R (iPhone ringtone)
+  "f4a ", // F4A (Flash audio)
+  "f4b ", // F4B (Flash audiobook)
+]);
+
 // Map common mimes to preferred file extensions.
 const EXT_BY_MIME: Record<string, string> = {
   "image/heic": ".heic",
@@ -67,6 +79,14 @@ async function sniffMime(buffer?: Buffer): Promise<string | undefined> {
   }
   try {
     const type = await fileTypeFromBuffer(buffer);
+    // file-type returns "video/mp4" for all MPEG-4 containers, including audio-only
+    // M4A files. Check the ftyp major brand to correct audio-only containers.
+    if (type?.mime === "video/mp4" && buffer.length >= 12) {
+      const majorBrand = buffer.toString("ascii", 8, 12).toLowerCase();
+      if (AUDIO_MP4_BRANDS.has(majorBrand)) {
+        return "audio/mp4";
+      }
+    }
     return type?.mime ?? undefined;
   } catch {
     return undefined;


### PR DESCRIPTION
## Summary

- The `file-type` library returns `video/mp4` for all MPEG-4 containers, including audio-only M4A/M4B files
- This causes the transcription pipeline to skip these files when filtering for audio capability
- Fix: Check the ftyp major brand at bytes 8-11 to distinguish audio-only containers

## Root Cause

When OpenClay processes audio files:
- MP3 files → detected as `audio/mpeg` → transcription triggers ✅
- OGG files → detected as `audio/ogg` → transcription triggers ✅
- Audio-only MP4/M4A → detected as `video/mp4` → transcription skipped ❌

The `file-type` library cannot distinguish audio-only MPEG-4 containers from video ones.

## Fix

Check the ftyp major brand at bytes 8-11 (as specified in ISO 14496-12):
- Audio brands: `m4a `, `m4b `, `m4p `, `m4r `, `f4a `, `f4b `
- Return `audio/mp4` instead of `video/mp4` for these brands

Reference implementation already exists in `src/line/download.ts`.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43313

## User-visible / Behavior Changes

Users can now transcribe audio-only MP4/M4A files across all channels (Telegram, Slack, Feishu, etc.).

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS/Linux/Windows
- Runtime: Node.js 22
- File types: M4A, M4B, MP4 audio

### Steps
1. Configure transcription with any provider
2. Send an audio-only M4A file
3. Verify transcription triggers (previously skipped)

## Evidence

- [x] Failing test/log before + passing after (test added)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: M4A, M4B, F4A audio brands detected correctly
- Edge cases checked: MP4v1, ISO Base Media, AVC video still return video/mp4
- What did **not** verify: Full transcription pipeline (unit test only)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None. This is a targeted fix that only affects MIME type detection for audio-only MP4 containers.

🤖 Generated by AI Contributor (kincoy)