### PR TITLE
feat(acp): add acp_send tool and sessions_cancel tool

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -6,6 +6,7 @@ import { resolveSessionAgentId } from "./agent-scope.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
+import { createAcpSendTool } from "./tools/acp-send-tool.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import { createBrowserTool } from "./tools/browser-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
@@ -17,6 +18,7 @@ import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
+import { createSessionsCancelTool } from "./tools/sessions-cancel-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
@@ -185,6 +187,12 @@ export function createOpenClawTools(
       sandboxed: options?.sandboxed,
       config: options?.config,
     }),
+    createAcpSendTool({
+      agentSessionKey: options?.agentSessionKey,
+      agentChannel: options?.agentChannel,
+      sandboxed: options?.sandboxed,
+    }),
+    createSessionsCancelTool(),
     createSessionsYieldTool({
       sessionId: options?.sessionId,
       onYield: options?.onYield,

--- a/src/agents/tool-display-overrides.json
+++ b/src/agents/tool-display-overrides.json
@@ -31,6 +31,16 @@
       "title": "Session Send",
       "detailKeys": ["label", "sessionKey", "agentId", "timeoutSeconds"]
     },
+    "acp_send": {
+      "emoji": "📨",
+      "title": "ACP Send",
+      "detailKeys": ["label", "sessionKey", "agentId"]
+    },
+    "sessions_cancel": {
+      "emoji": "⏹️",
+      "title": "Session Cancel",
+      "detailKeys": ["sessionKey", "reason"]
+    },
     "sessions_history": {
       "emoji": "🧾",
       "title": "Session History",

--- a/src/agents/tools/acp-send-tool.ts
+++ b/src/agents/tools/acp-send-tool.ts
@@ -1,0 +1,262 @@
+import crypto from "node:crypto";
+import { Type } from "@sinclair/typebox";
+import { callGateway } from "../../gateway/call.js";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
+import {
+  type GatewayMessageChannel,
+  INTERNAL_MESSAGE_CHANNEL,
+} from "../../utils/message-channel.js";
+import { AGENT_LANE_NESTED } from "../lanes.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+import {
+  createSessionVisibilityGuard,
+  createAgentToAgentPolicy,
+  resolveEffectiveSessionToolsVisibility,
+  resolveSessionReference,
+  resolveSessionToolContext,
+  resolveVisibleSessionReference,
+} from "./sessions-helpers.js";
+import { buildAgentToAgentMessageContext } from "./sessions-send-helpers.js";
+
+const AcpSendToolSchema = Type.Object({
+  sessionKey: Type.Optional(Type.String()),
+  label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
+  agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
+  message: Type.String(),
+});
+
+/**
+ * Fire-and-forget tool for sending messages to ACP sessions.
+ *
+ * Unlike `sessions_send`, this tool:
+ * - Does NOT trigger the framework A2A flow (ping-pong + announce).
+ * - Does NOT wait for a reply (always fire-and-forget).
+ * - Result delivery relies on the ACP callback mechanism.
+ *
+ * Reuses session resolution, permission checking, and visibility guards
+ * from the shared sessions-helpers.
+ */
+export function createAcpSendTool(opts?: {
+  agentSessionKey?: string;
+  agentChannel?: GatewayMessageChannel;
+  sandboxed?: boolean;
+}): AnyAgentTool {
+  return {
+    label: "ACP Send",
+    name: "acp_send",
+    description:
+      "Send a follow-up message to an ACP session (fire-and-forget). The ACP agent's reply will arrive as a callback. Use sessionKey from the original sessions_spawn result.",
+    parameters: AcpSendToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const message = readStringParam(params, "message", { required: true });
+      const { cfg, mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
+        resolveSessionToolContext(opts);
+
+      const a2aPolicy = createAgentToAgentPolicy(cfg);
+      const sessionVisibility = resolveEffectiveSessionToolsVisibility({
+        cfg,
+        sandboxed: opts?.sandboxed === true,
+      });
+
+      const sessionKeyParam = readStringParam(params, "sessionKey");
+      const labelParam = readStringParam(params, "label")?.trim() || undefined;
+      const labelAgentIdParam = readStringParam(params, "agentId")?.trim() || undefined;
+      if (sessionKeyParam && labelParam) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: "Provide either sessionKey or label (not both).",
+        });
+      }
+
+      let sessionKey = sessionKeyParam;
+      if (!sessionKey && labelParam) {
+        const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
+        const requestedAgentId = labelAgentIdParam
+          ? normalizeAgentId(labelAgentIdParam)
+          : undefined;
+
+        if (restrictToSpawned && requestedAgentId && requestedAgentId !== requesterAgentId) {
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "forbidden",
+            error: "Sandboxed acp_send label lookup is limited to this agent",
+          });
+        }
+
+        if (requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId) {
+          if (!a2aPolicy.enabled) {
+            return jsonResult({
+              runId: crypto.randomUUID(),
+              status: "forbidden",
+              error:
+                "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
+            });
+          }
+          if (!a2aPolicy.isAllowed(requesterAgentId, requestedAgentId)) {
+            return jsonResult({
+              runId: crypto.randomUUID(),
+              status: "forbidden",
+              error: "Agent-to-agent messaging denied by tools.agentToAgent.allow.",
+            });
+          }
+        }
+
+        const resolveParams: Record<string, unknown> = {
+          label: labelParam,
+          ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
+          ...(restrictToSpawned ? { spawnedBy: effectiveRequesterKey } : {}),
+        };
+        let resolvedKey = "";
+        try {
+          const resolved = await callGateway<{ key: string }>({
+            method: "sessions.resolve",
+            params: resolveParams,
+            timeoutMs: 10_000,
+          });
+          resolvedKey = typeof resolved?.key === "string" ? resolved.key.trim() : "";
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (restrictToSpawned) {
+            return jsonResult({
+              runId: crypto.randomUUID(),
+              status: "forbidden",
+              error: "Session not visible from this sandboxed agent session.",
+            });
+          }
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "error",
+            error: msg || `No session found with label: ${labelParam}`,
+          });
+        }
+
+        if (!resolvedKey) {
+          if (restrictToSpawned) {
+            return jsonResult({
+              runId: crypto.randomUUID(),
+              status: "forbidden",
+              error: "Session not visible from this sandboxed agent session.",
+            });
+          }
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "error",
+            error: `No session found with label: ${labelParam}`,
+          });
+        }
+        sessionKey = resolvedKey;
+      }
+
+      if (!sessionKey) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: "Either sessionKey or label is required",
+        });
+      }
+
+      const resolvedSession = await resolveSessionReference({
+        sessionKey,
+        alias,
+        mainKey,
+        requesterInternalKey: effectiveRequesterKey,
+        restrictToSpawned,
+      });
+      if (!resolvedSession.ok) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: resolvedSession.status,
+          error: resolvedSession.error,
+        });
+      }
+
+      const visibleSession = await resolveVisibleSessionReference({
+        resolvedSession,
+        requesterSessionKey: effectiveRequesterKey,
+        restrictToSpawned,
+        visibilitySessionKey: sessionKey,
+      });
+      if (!visibleSession.ok) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: visibleSession.status,
+          error: visibleSession.error,
+          sessionKey: visibleSession.displayKey,
+        });
+      }
+
+      const resolvedKey = visibleSession.key;
+      const displayKey = visibleSession.displayKey;
+
+      const visibilityGuard = await createSessionVisibilityGuard({
+        action: "send",
+        requesterSessionKey: effectiveRequesterKey,
+        visibility: sessionVisibility,
+        a2aPolicy,
+      });
+      const access = visibilityGuard.check(resolvedKey);
+      if (!access.allowed) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: access.status,
+          error: access.error,
+          sessionKey: displayKey,
+        });
+      }
+
+      const agentMessageContext = buildAgentToAgentMessageContext({
+        requesterSessionKey: opts?.agentSessionKey,
+        requesterChannel: opts?.agentChannel,
+        targetSessionKey: displayKey,
+      });
+
+      const idempotencyKey = crypto.randomUUID();
+      const sendParams = {
+        message,
+        sessionKey: resolvedKey,
+        idempotencyKey,
+        deliver: false,
+        channel: INTERNAL_MESSAGE_CHANNEL,
+        lane: AGENT_LANE_NESTED,
+        extraSystemPrompt: agentMessageContext,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: opts?.agentSessionKey,
+          sourceChannel: opts?.agentChannel,
+          sourceTool: "acp_send",
+        },
+      };
+      let runId: string = idempotencyKey;
+
+      try {
+        const response = await callGateway<{ runId: string }>({
+          method: "agent",
+          params: sendParams,
+          timeoutMs: 10_000,
+        });
+        if (typeof response?.runId === "string" && response.runId) {
+          runId = response.runId;
+        }
+      } catch (err) {
+        const messageText =
+          err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+        return jsonResult({
+          runId,
+          status: "error",
+          error: messageText,
+          sessionKey: displayKey,
+        });
+      }
+
+      return jsonResult({
+        runId,
+        status: "accepted",
+        sessionKey: displayKey,
+      });
+    },
+  };
+}

--- a/src/agents/tools/sessions-cancel-tool.ts
+++ b/src/agents/tools/sessions-cancel-tool.ts
@@ -1,0 +1,53 @@
+import { Type } from "@sinclair/typebox";
+import { callGateway } from "../../gateway/call.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+
+const SessionsCancelToolSchema = Type.Object({
+  sessionKey: Type.String(),
+  reason: Type.Optional(Type.String({ maxLength: 256 })),
+});
+
+/**
+ * Cancel an active ACP session turn.
+ *
+ * Interrupts the currently running turn for the given session key.
+ * If the session is idle (no active turn), the cancel is a no-op.
+ * Does not close the session — the ACP agent remains available for
+ * subsequent turns.
+ */
+export function createSessionsCancelTool(): AnyAgentTool {
+  return {
+    label: "Sessions Cancel",
+    name: "sessions_cancel",
+    description:
+      "Cancel the active turn of a spawned ACP session. This interrupts the current computation but keeps the session open for future messages. Use the sessionKey from sessions_spawn.",
+    parameters: SessionsCancelToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const sessionKey = readStringParam(params, "sessionKey", { required: true });
+      const reason = readStringParam(params, "reason") || "agent-requested";
+
+      try {
+        await callGateway<{ ok: boolean; key: string }>({
+          method: "sessions.cancel",
+          params: { key: sessionKey, reason },
+          timeoutMs: 15_000,
+        });
+      } catch (err) {
+        const messageText =
+          err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+        return jsonResult({
+          status: "error",
+          error: messageText,
+          sessionKey,
+        });
+      }
+
+      return jsonResult({
+        status: "cancelled",
+        sessionKey,
+      });
+    },
+  };
+}

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -105,6 +105,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "browser.request",
     "push.test",
     "node.pending.enqueue",
+    "sessions.cancel",
   ],
   [ADMIN_SCOPE]: [
     "channels.logout",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -186,6 +186,8 @@ import {
   type SecretsResolveResult,
   SecretsResolveParamsSchema,
   SecretsResolveResultSchema,
+  type SessionsCancelParams,
+  SessionsCancelParamsSchema,
   type SessionsCompactParams,
   SessionsCompactParamsSchema,
   type SessionsDeleteParams,
@@ -336,6 +338,9 @@ export const validateSessionsCompactParams = ajv.compile<SessionsCompactParams>(
 );
 export const validateSessionsUsageParams =
   ajv.compile<SessionsUsageParams>(SessionsUsageParamsSchema);
+export const validateSessionsCancelParams = ajv.compile<SessionsCancelParams>(
+  SessionsCancelParamsSchema,
+);
 export const validateConfigGetParams = ajv.compile<ConfigGetParams>(ConfigGetParamsSchema);
 export const validateConfigSetParams = ajv.compile<ConfigSetParams>(ConfigSetParamsSchema);
 export const validateConfigApplyParams = ajv.compile<ConfigApplyParams>(ConfigApplyParamsSchema);
@@ -495,6 +500,7 @@ export {
   SessionsPatchParamsSchema,
   SessionsResetParamsSchema,
   SessionsDeleteParamsSchema,
+  SessionsCancelParamsSchema,
   SessionsCompactParamsSchema,
   SessionsUsageParamsSchema,
   ConfigGetParamsSchema,
@@ -650,6 +656,7 @@ export type {
   SessionsPatchResult,
   SessionsResetParams,
   SessionsDeleteParams,
+  SessionsCancelParams,
   SessionsCompactParams,
   SessionsUsageParams,
   CronJob,

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -138,6 +138,7 @@ import {
   SecretsResolveResultSchema,
 } from "./secrets.js";
 import {
+  SessionsCancelParamsSchema,
   SessionsCompactParamsSchema,
   SessionsDeleteParamsSchema,
   SessionsListParamsSchema,
@@ -209,6 +210,7 @@ export const ProtocolSchemas = {
   SessionsDeleteParams: SessionsDeleteParamsSchema,
   SessionsCompactParams: SessionsCompactParamsSchema,
   SessionsUsageParams: SessionsUsageParamsSchema,
+  SessionsCancelParams: SessionsCancelParamsSchema,
   ConfigGetParams: ConfigGetParamsSchema,
   ConfigSetParams: ConfigSetParamsSchema,
   ConfigApplyParams: ConfigApplyParamsSchema,

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -116,6 +116,14 @@ export const SessionsCompactParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const SessionsCancelParamsSchema = Type.Object(
+  {
+    key: NonEmptyString,
+    reason: Type.Optional(Type.String({ maxLength: 256 })),
+  },
+  { additionalProperties: false },
+);
+
 export const SessionsUsageParamsSchema = Type.Object(
   {
     /** Specific session key to analyze; if omitted returns all sessions. */

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -46,6 +46,7 @@ export type SessionsResetParams = SchemaType<"SessionsResetParams">;
 export type SessionsDeleteParams = SchemaType<"SessionsDeleteParams">;
 export type SessionsCompactParams = SchemaType<"SessionsCompactParams">;
 export type SessionsUsageParams = SchemaType<"SessionsUsageParams">;
+export type SessionsCancelParams = SchemaType<"SessionsCancelParams">;
 export type ConfigGetParams = SchemaType<"ConfigGetParams">;
 export type ConfigSetParams = SchemaType<"ConfigSetParams">;
 export type ConfigApplyParams = SchemaType<"ConfigApplyParams">;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -12,6 +13,7 @@ import { GATEWAY_CLIENT_IDS } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
+  validateSessionsCancelParams,
   validateSessionsCompactParams,
   validateSessionsDeleteParams,
   validateSessionsListParams,
@@ -443,5 +445,26 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
+  },
+  "sessions.cancel": async ({ params, respond }) => {
+    if (!assertValidParams(params, validateSessionsCancelParams, "sessions.cancel", respond)) {
+      return;
+    }
+    const p = params;
+    const key = requireSessionKey(p.key, respond);
+    if (!key) {
+      return;
+    }
+    const reason = typeof p.reason === "string" ? p.reason : "agent-requested";
+    const cfg = loadConfig();
+    const acpManager = getAcpSessionManager();
+    try {
+      await acpManager.cancelSession({ cfg, sessionKey: key, reason });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      respond(false, undefined, errorShape(ErrorCodes.INTERNAL_ERROR, msg));
+      return;
+    }
+    respond(true, { ok: true, key }, undefined);
   },
 };


### PR DESCRIPTION
## Summary

Add two new agent tools for ACP session lifecycle management:

- **`acp_send`**: Fire-and-forget message delivery to ACP sessions. Unlike `sessions_send`, skips the A2A ping-pong/announce flow and relies on ACP callback for result delivery. Follows the same session resolution, visibility, and A2A policy checks as `sessions_send`.

- **`sessions_cancel`**: Cancel the active turn of an ACP session without closing it. Backed by a new `sessions.cancel` gateway RPC that delegates to `acpManager.cancelSession()`.

### Changes

| File | Change |
|------|--------|
| `src/agents/tools/acp-send-tool.ts` | New `acp_send` tool implementation |
| `src/agents/tools/sessions-cancel-tool.ts` | New `sessions_cancel` tool implementation |
| `src/agents/openclaw-tools.ts` | Register both new tools |
| `src/agents/tool-display-overrides.json` | Display config for streaming card history panel |
| `src/gateway/protocol/schema/sessions.ts` | `SessionsCancelParamsSchema` |
| `src/gateway/protocol/schema/protocol-schemas.ts` | Register schema |
| `src/gateway/protocol/schema/types.ts` | Derive type |
| `src/gateway/protocol/index.ts` | Validator + re-exports |
| `src/gateway/server-methods/sessions.ts` | `sessions.cancel` handler |
| `src/gateway/method-scopes.ts` | Register in `WRITE_SCOPE` |

### Design decisions

- `acp_send` uses the same inline resolution pattern as `sessions_send` rather than extracting shared logic, keeping the PR self-contained and additive-only.
- `sessions.cancel` is placed in `WRITE_SCOPE` (not `ADMIN_SCOPE`) since agents need to call it during normal operation.
- The cancel is a no-op if no active turn exists — it does not error, matching the existing `acpManager.cancelSession()` semantics.