### PR TITLE
Session: add system event suppression switch

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -86,6 +86,9 @@ export async function drainFormattedSystemEvents(params: {
 
   const systemLines: string[] = [];
   const queued = drainSystemEventEntries(params.sessionKey);
+  if (params.cfg.session?.systemEvents?.enabled === false) {
+    return undefined;
+  }
   systemLines.push(
     ...queued
       .map((event) => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -11,7 +11,11 @@ import {
   __testing as sessionBindingTesting,
   registerSessionBindingAdapter,
 } from "../../infra/outbound/session-binding-service.js";
-import { enqueueSystemEvent, resetSystemEventsForTest } from "../../infra/system-events.js";
+import {
+  enqueueSystemEvent,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "../../infra/system-events.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
 import { drainFormattedSystemEvents } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
@@ -1582,6 +1586,27 @@ describe("drainFormattedSystemEvents", () => {
       resetSystemEventsForTest();
       vi.useRealTimers();
     }
+  });
+
+  it("drops queued system events when session.systemEvents.enabled=false", async () => {
+    enqueueSystemEvent("exec started: brew install", { sessionKey: "agent:main:main" });
+
+    const result = await drainFormattedSystemEvents({
+      cfg: {
+        session: {
+          systemEvents: {
+            enabled: false,
+          },
+        },
+      } as OpenClawConfig,
+      sessionKey: "agent:main:main",
+      isMainSession: false,
+      isNewSession: false,
+    });
+
+    expect(result).toBeUndefined();
+    expect(peekSystemEvents("agent:main:main")).toEqual([]);
+    resetSystemEventsForTest();
   });
 });
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1120,6 +1120,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Matches a normalized session-key prefix after internal key normalization steps in policy consumers. Use this for general prefix controls, and prefer rawKeyPrefix when exact full-key matching is required.",
   "session.sendPolicy.rules[].match.rawKeyPrefix":
     "Matches the raw, unnormalized session-key prefix for exact full-key policy targeting. Use this when normalized keyPrefix is too broad and you need agent-prefixed or transport-specific precision.",
+  "session.systemEvents":
+    "Controls whether queued system events are injected into the next user-visible turn. Disable this when exec/tool lifecycle notices add too much conversational noise.",
+  "session.systemEvents.enabled":
+    "When true (default), queued system events are prepended as trusted System: lines on the next turn. Set false to silently drop queued system events instead of injecting them into the conversation.",
   "session.agentToAgent":
     "Groups controls for inter-agent session exchanges, including loop prevention limits on reply chaining. Keep defaults unless you run advanced agent-to-agent automation with strict turn caps.",
   "session.agentToAgent.maxPingPongTurns":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -183,6 +183,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.agentToAgent": "Agent-to-Agent Tool Access",
   "tools.agentToAgent.enabled": "Enable Agent-to-Agent Tool",
   "tools.agentToAgent.allow": "Agent-to-Agent Target Allowlist",
+  "session.systemEvents": "Session System Events",
+  "session.systemEvents.enabled": "Inject Session System Events",
   "tools.elevated": "Elevated Tool Access",
   "tools.elevated.enabled": "Enable Elevated Tool Access",
   "tools.elevated.allowFrom": "Elevated Tool Allow Rules",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -125,6 +125,11 @@ export type SessionConfig = {
   parentForkMaxTokens?: number;
   mainKey?: string;
   sendPolicy?: SessionSendPolicyConfig;
+  /** Controls whether queued system events are injected into the next turn. */
+  systemEvents?: {
+    /** Default: true. Set false to drop queued system events instead of prepending them. */
+    enabled?: boolean;
+  };
   agentToAgent?: {
     /** Max ping-pong turns between requester/target (0–5). Default: 5. */
     maxPingPongTurns?: number;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -55,6 +55,12 @@ export const SessionSchema = z
     parentForkMaxTokens: z.number().int().nonnegative().optional(),
     mainKey: z.string().optional(),
     sendPolicy: SessionSendPolicySchema.optional(),
+    systemEvents: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     agentToAgent: z
       .object({
         maxPingPongTurns: z.number().int().min(0).max(5).optional(),


### PR DESCRIPTION
## Summary
- add `session.systemEvents.enabled` so operators can suppress queued system-event lines from being injected into the next turn
- drop queued events when that flag is disabled, so exec/system-event backlog does not leak back in later
- document and label the new config field, and cover the suppression path in session tests

## Testing
- pnpm test src/auto-reply/reply/session.test.ts
- pnpm test src/config/schema.help.quality.test.ts
- pnpm exec oxfmt --check src/config/types.base.ts src/config/zod-schema.session.ts src/config/schema.help.ts src/config/schema.labels.ts src/auto-reply/reply/session-updates.ts src/auto-reply/reply/session.test.ts

Closes #7532.
