### PR TITLE
CLI: validate backend session ids

### DIFF
--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -65,6 +65,7 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     const resolved = resolveCliBackendConfig("claude-cli");
 
     expect(resolved).not.toBeNull();
+    expect(resolved?.config.sessionIdFormat).toBe("uuid");
     expect(resolved?.config.args).toContain("--permission-mode");
     expect(resolved?.config.args).toContain("bypassPermissions");
     expect(resolved?.config.args).not.toContain("--dangerously-skip-permissions");
@@ -90,6 +91,7 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
 
     expect(resolved).not.toBeNull();
     expect(resolved?.config.command).toBe("/usr/local/bin/claude");
+    expect(resolved?.config.sessionIdFormat).toBe("uuid");
     expect(resolved?.config.args).toContain("--permission-mode");
     expect(resolved?.config.args).toContain("bypassPermissions");
     expect(resolved?.config.resumeArgs).toContain("--permission-mode");
@@ -164,5 +166,25 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     ]);
     expect(resolved?.config.args).not.toContain("bypassPermissions");
     expect(resolved?.config.resumeArgs).not.toContain("bypassPermissions");
+  });
+
+  it("allows overriding claude session id parsing back to any string", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              sessionIdFormat: "any",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveCliBackendConfig("claude-cli", cfg);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.config.sessionIdFormat).toBe("any");
   });
 });

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -56,6 +56,7 @@ const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
   sessionArg: "--session-id",
   sessionMode: "always",
   sessionIdFields: ["session_id", "sessionId", "conversation_id", "conversationId"],
+  sessionIdFormat: "uuid",
   systemPromptArg: "--append-system-prompt",
   systemPromptMode: "append",
   systemPromptWhen: "first",
@@ -139,6 +140,7 @@ function mergeBackendConfig(base: CliBackendConfig, override?: CliBackendConfig)
     modelAliases: { ...base.modelAliases, ...override.modelAliases },
     clearEnv: Array.from(new Set([...(base.clearEnv ?? []), ...(override.clearEnv ?? [])])),
     sessionIdFields: override.sessionIdFields ?? base.sessionIdFields,
+    sessionIdFormat: override.sessionIdFormat ?? base.sessionIdFormat,
     sessionArgs: override.sessionArgs ?? base.sessionArgs,
     resumeArgs: override.resumeArgs ?? base.resumeArgs,
     reliability: {

--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -3,8 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveCliBackendConfig } from "./cli-backends.js";
 import { runCliAgent } from "./cli-runner.js";
-import { resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
+import { parseCliJson, parseCliJsonl, resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
 
 const supervisorSpawnMock = vi.fn();
 const enqueueSystemEventMock = vi.fn();
@@ -55,6 +56,48 @@ function createManagedRun(exit: MockRunExit, pid = 1234) {
     cancel: vi.fn(),
   };
 }
+
+describe("CLI session id parsing", () => {
+  it("ignores non-UUID session ids for claude-cli outputs", () => {
+    const backend = resolveCliBackendConfig("claude-cli")?.config;
+
+    expect(backend).toBeTruthy();
+    expect(
+      parseCliJson('{"session_id":"rate-limited","message":{"text":"hello"}}', backend!),
+    ).toMatchObject({
+      text: "hello",
+      sessionId: undefined,
+    });
+  });
+
+  it("keeps valid UUID session ids for claude-cli outputs", () => {
+    const backend = resolveCliBackendConfig("claude-cli")?.config;
+    const sessionId = "550e8400-e29b-41d4-a716-446655440000";
+
+    expect(backend).toBeTruthy();
+    expect(
+      parseCliJson(`{"session_id":"${sessionId}","message":{"text":"hello"}}`, backend!),
+    ).toMatchObject({
+      text: "hello",
+      sessionId,
+    });
+  });
+
+  it("keeps non-UUID thread ids for codex-cli jsonl outputs", () => {
+    const backend = resolveCliBackendConfig("codex-cli")?.config;
+
+    expect(backend).toBeTruthy();
+    expect(
+      parseCliJsonl(
+        '{"thread_id":"thread_123"}\n{"item":{"type":"message","text":"hello"}}',
+        backend!,
+      ),
+    ).toMatchObject({
+      text: "hello",
+      sessionId: "thread_123",
+    });
+  });
+});
 
 describe("runCliAgent with process supervisor", () => {
   beforeEach(() => {

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -38,6 +38,8 @@ export type CliOutput = {
   usage?: CliUsage;
 };
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function buildSystemPrompt(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
@@ -171,7 +173,11 @@ function pickSessionId(
   for (const field of fields) {
     const value = parsed[field];
     if (typeof value === "string" && value.trim()) {
-      return value.trim();
+      const trimmed = value.trim();
+      if (backend.sessionIdFormat === "uuid" && !UUID_RE.test(trimmed)) {
+        continue;
+      }
+      return trimmed;
     }
   }
   return undefined;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -75,6 +75,8 @@ export type CliBackendConfig = {
   sessionMode?: "always" | "existing" | "none";
   /** JSON fields to read session id from (in order). */
   sessionIdFields?: string[];
+  /** Format expected for parsed session ids. */
+  sessionIdFormat?: "any" | "uuid";
   /** Flag used to pass system prompt. */
   systemPromptArg?: string;
   /** System prompt behavior (append vs replace). */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -466,6 +466,7 @@ export const CliBackendSchema = z
       .union([z.literal("always"), z.literal("existing"), z.literal("none")])
       .optional(),
     sessionIdFields: z.array(z.string()).optional(),
+    sessionIdFormat: z.union([z.literal("any"), z.literal("uuid")]).optional(),
     systemPromptArg: z.string().optional(),
     systemPromptMode: z.union([z.literal("append"), z.literal("replace")]).optional(),
     systemPromptWhen: z


### PR DESCRIPTION
## Summary
- add `sessionIdFormat` to CLI backend configs so backends can constrain parsed session ids
- default `claude-cli` to UUID-only session ids so sentinel values like `rate-limited` are ignored
- add regression tests for Claude UUID filtering and Codex thread id preservation

## Testing
- pnpm test src/agents/cli-backends.test.ts
- pnpm test src/agents/cli-runner.test.ts
- pnpm test src/config/io.write-config.test.ts
- pnpm exec oxfmt --check src/config/types.agent-defaults.ts src/config/zod-schema.core.ts src/agents/cli-backends.ts src/agents/cli-runner/helpers.ts src/agents/cli-backends.test.ts src/agents/cli-runner.test.ts

Closes #43288
