### PR TITLE
Discord: support Unicode handle mention rewrite

### DIFF
--- a/extensions/discord/src/mentions.test.ts
+++ b/extensions/discord/src/mentions.test.ts
@@ -44,6 +44,82 @@ describe("rewriteDiscordKnownMentions", () => {
     expect(rewritten).toBe("ping <@123456789> and <@123456789>");
   });
 
+  it("rewrites unicode handles in multilingual text", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "2233445566",
+      handles: ["张三"],
+    });
+    const rewritten = rewriteDiscordKnownMentions("你好@张三，收到请回复。", {
+      accountId: "default",
+    });
+    expect(rewritten).toBe("你好<@2233445566>，收到请回复。");
+  });
+
+  it("does not rewrite email addresses", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const rewritten = rewriteDiscordKnownMentions("email a@alice.com and ping @alice", {
+      accountId: "default",
+    });
+    expect(rewritten).toBe("email a@alice.com and ping <@123456789>");
+  });
+
+  it("does not rewrite unicode local-part email addresses", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "777777777",
+      handles: ["alice.com"],
+    });
+    const rewritten = rewriteDiscordKnownMentions("邮件 用户@alice.com", {
+      accountId: "default",
+    });
+    expect(rewritten).toBe("邮件 用户@alice.com");
+  });
+
+  it("does not rewrite handles in URL paths", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const rewritten = rewriteDiscordKnownMentions("profile https://x.com/@alice and ping @alice", {
+      accountId: "default",
+    });
+    expect(rewritten).toBe("profile https://x.com/@alice and ping <@123456789>");
+  });
+
+  it("does not rewrite CJK inline mentions inside URL tokens", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "2233445566",
+      handles: ["张三"],
+    });
+    const rewritten = rewriteDiscordKnownMentions(
+      "url https://x.com/你好@张三 and ping 你好@张三",
+      { accountId: "default" },
+    );
+    expect(rewritten).toBe("url https://x.com/你好@张三 and ping 你好<@2233445566>");
+  });
+
+  it("does not rewrite CJK inline mentions inside wrapped URL tokens", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "2233445566",
+      handles: ["张三"],
+    });
+    const rewritten = rewriteDiscordKnownMentions(
+      "urls <https://x.com/你好@张三> and (https://x.com/你好@张三) then ping 你好@张三",
+      { accountId: "default" },
+    );
+    expect(rewritten).toBe(
+      "urls <https://x.com/你好@张三> and (https://x.com/你好@张三) then ping 你好<@2233445566>",
+    );
+  });
+
   it("preserves unknown mentions and reserved mentions", () => {
     rememberDiscordDirectoryUser({
       accountId: "default",
@@ -54,6 +130,18 @@ describe("rewriteDiscordKnownMentions", () => {
       accountId: "default",
     });
     expect(rewritten).toBe("hello @unknown @everyone @here");
+  });
+
+  it("does not rewrite already-formatted Discord mentions", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice", "123456789"],
+    });
+    const rewritten = rewriteDiscordKnownMentions("already <@123456789> and ping @alice", {
+      accountId: "default",
+    });
+    expect(rewritten).toBe("already <@123456789> and ping <@123456789>");
   });
 
   it("does not rewrite mentions inside markdown code spans", () => {

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -6,7 +6,13 @@ import {
 import { resolveDiscordDirectoryUserId } from "./directory-cache.js";
 
 const MARKDOWN_CODE_SEGMENT_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
-const MENTION_CANDIDATE_PATTERN = /(^|[\s([{"'.,;:!?])@([a-z0-9_.-]{2,32}(?:#[0-9]{4})?)/gi;
+const MENTION_CANDIDATE_PATTERN =
+  /(^|[\s([{"'.,;:!?，。！？、：；（）《》「」『』【】])@([\p{L}\p{N}_.-]{2,32}(?:#[0-9]{4})?)/gu;
+const CJK_ADJACENT_MENTION_CANDIDATE_PATTERN =
+  /(?<=[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}])@([\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{N}_.-]{2,32}(?:#[0-9]{4})?)/gu;
+const URL_SCHEME_TOKEN_PATTERN = /^[a-z][a-z0-9+.-]*:\/\/\S+$/i;
+const URL_TOKEN_LEADING_WRAPPERS_PATTERN = /^[<([{（【《「『]+/u;
+const URL_TOKEN_TRAILING_PUNCTUATION_PATTERN = /[)\]}>.,;:!?，。！？、：；）】》」』]+$/u;
 const DISCORD_RESERVED_MENTIONS = new Set(["everyone", "here"]);
 
 function normalizeSnowflake(value: string | number | bigint): string | null {
@@ -47,7 +53,7 @@ function rewritePlainTextMentions(text: string, accountId?: string | null): stri
   if (!text.includes("@")) {
     return text;
   }
-  return text.replace(MENTION_CANDIDATE_PATTERN, (match, prefix, rawHandle) => {
+  const rewriteCandidate = (match: string, rawHandle: string): string => {
     const handle = normalizeOptionalString(rawHandle) ?? "";
     if (!handle) {
       return match;
@@ -63,8 +69,43 @@ function rewritePlainTextMentions(text: string, accountId?: string | null): stri
     if (!userId) {
       return match;
     }
-    return `${String(prefix ?? "")}${formatMention({ userId })}`;
-  });
+    return formatMention({ userId });
+  };
+  const withDelimitedMentions = text.replace(
+    MENTION_CANDIDATE_PATTERN,
+    (match, prefix, rawHandle) => {
+      const rewritten = rewriteCandidate(match, String(rawHandle ?? ""));
+      if (rewritten === match) {
+        return match;
+      }
+      return `${String(prefix ?? "")}${rewritten}`;
+    },
+  );
+  return withDelimitedMentions.replace(
+    CJK_ADJACENT_MENTION_CANDIDATE_PATTERN,
+    (match, rawHandle, offset, sourceText) => {
+      if (isLikelyUrlTokenContext(sourceText, offset)) {
+        return match;
+      }
+      return rewriteCandidate(match, String(rawHandle ?? ""));
+    },
+  );
+}
+
+function isLikelyUrlTokenContext(text: string, atIndex: number): boolean {
+  let tokenStart = atIndex;
+  while (tokenStart > 0 && !/\s/u.test(text[tokenStart - 1] ?? "")) {
+    tokenStart -= 1;
+  }
+  let tokenEnd = atIndex;
+  while (tokenEnd < text.length && !/\s/u.test(text[tokenEnd] ?? "")) {
+    tokenEnd += 1;
+  }
+  const token = text
+    .slice(tokenStart, tokenEnd)
+    .replace(URL_TOKEN_LEADING_WRAPPERS_PATTERN, "")
+    .replace(URL_TOKEN_TRAILING_PUNCTUATION_PATTERN, "");
+  return URL_SCHEME_TOKEN_PATTERN.test(token);
 }
 
 export function rewriteDiscordKnownMentions(

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -42,8 +42,9 @@
           "order": 85
         },
         "install": {
-          "npmSpec": "openclaw-plugin-yuanbao",
-          "defaultChoice": "npm"
+          "npmSpec": "openclaw-plugin-yuanbao@2.11.0",
+          "defaultChoice": "npm",
+          "expectedIntegrity": "sha512-lYmBrU71ox3v7dzRqaltvzTXPcMjjgYrNqpBj5HIBkXgEFkXRRG8wplXg9Fub41/FjsSPn3WAbYpdTc+k+jsHg=="
         }
       }
     }

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -45,6 +45,6 @@ describeChannelCatalogEntryContract({
 
 describeChannelCatalogEntryContract({
   channelId: "openclaw-plugin-yuanbao",
-  npmSpec: "openclaw-plugin-yuanbao",
+  npmSpec: "openclaw-plugin-yuanbao@2.11.0",
   alias: "yb",
 });

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -94,8 +94,10 @@ describe("buildOfficialChannelCatalog", () => {
               label: "Yuanbao",
             }),
             install: {
-              npmSpec: "openclaw-plugin-yuanbao",
+              npmSpec: "openclaw-plugin-yuanbao@2.11.0",
               defaultChoice: "npm",
+              expectedIntegrity:
+                "sha512-lYmBrU71ox3v7dzRqaltvzTXPcMjjgYrNqpBj5HIBkXgEFkXRRG8wplXg9Fub41/FjsSPn3WAbYpdTc+k+jsHg==",
             },
           }),
         }),


### PR DESCRIPTION
## Summary
- expand Discord outbound mention candidate parsing from ASCII-only to Unicode letters/numbers
- keep `@everyone` and `@here` passthrough behavior unchanged
- avoid rewriting email local-parts while still allowing mentions in CJK text like `你好@张三`
- add regression tests for Unicode handles and email-address safety

## Testing
- `pnpm vitest src/discord/mentions.test.ts src/discord/send.sends-basic-channel-messages.test.ts`
