### PR TITLE
feat(slack): add session.threadIsolation config option

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -253,6 +253,24 @@ Manual reply tags are supported:
 
 Note: `replyToMode="off"` disables **all** reply threading in Slack, including explicit `[[reply_to_*]]` tags. This differs from Telegram, where explicit tags are still honored in `"off"` mode. The difference reflects the platform threading models: Slack threads hide messages from the channel, while Telegram replies remain visible in the main chat flow.
 
+### Shared session across threads (`session.threadIsolation`)
+
+By default, each Slack thread forks its own session (`:thread:<threadTs>` suffix). Set `session.threadIsolation: false` to make all threads share the parent session instead. This is useful for single-identity agents where you want cross-thread memory without duplicating context.
+
+```yaml
+session:
+  threadIsolation: false
+```
+
+When disabled:
+
+- Thread replies reuse the parent session key (no `:thread:` suffix).
+- Thread history and starter context are still injected per-thread using `threadTs` as the history bucket key, so concurrent threads don't collide.
+- `ThreadStarterBody` and `IsFirstThreadTurn` are always set for thread replies regardless of existing session state, since the shared session's timestamp reflects activity from any thread.
+- Thread history is always fetched for the same reason.
+
+This setting only affects Slack today. Other channels are unaffected.
+
 ## Media, chunking, and delivery
 
 <AccordionGroup>

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -266,8 +266,8 @@ When disabled:
 
 - Thread replies reuse the parent session key (no `:thread:` suffix).
 - Thread history and starter context are still injected per-thread using `threadTs` as the history bucket key, so concurrent threads don't collide.
-- `ThreadStarterBody` and `IsFirstThreadTurn` are always set for thread replies regardless of existing session state, since the shared session's timestamp reflects activity from any thread.
-- Thread history is always fetched for the same reason.
+- `ThreadStarterBody` and `IsFirstThreadTurn` are set on the first encounter of each thread (tracked per-session via `seenThreadIds`). Subsequent turns to the same thread skip these to avoid redundant Slack API calls.
+- Thread history is fetched once per thread for the same reason.
 
 This setting only affects Slack today. Other channels are unaffected.
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -255,19 +255,19 @@ Note: `replyToMode="off"` disables **all** reply threading in Slack, including e
 
 ### Shared session across threads (`session.threadIsolation`)
 
-By default, each Slack thread forks its own session (`:thread:<threadTs>` suffix). Set `session.threadIsolation: false` to make all threads share the parent session instead. This is useful for single-identity agents where you want cross-thread memory without duplicating context.
+By default, each Slack thread forks its own session (`:thread:<threadTs>` suffix). Set `session.threadIsolation` to `false` to make all threads share the parent session instead. This is useful for single-identity agents where you want cross-thread memory without duplicating context.
 
-```yaml
-session:
-  threadIsolation: false
+```json5
+{ session: { threadIsolation: false } }
 ```
 
 When disabled:
 
 - Thread replies reuse the parent session key (no `:thread:` suffix).
-- Thread history and starter context are still injected per-thread using `threadTs` as the history bucket key, so concurrent threads don't collide.
-- `ThreadStarterBody` and `IsFirstThreadTurn` are set on the first encounter of each thread (tracked per-session via `seenThreadIds`). Subsequent turns to the same thread skip these to avoid redundant Slack API calls.
+- Thread history and starter context are still injected per-thread using a composite `channel:threadTs` history key, so concurrent threads across channels don't collide.
+- `ThreadStarterBody` and `IsFirstThreadTurn` are set on the first encounter of each thread (tracked per-session via `seenThreadIds`, capped at 500 entries). Subsequent turns to the same thread skip these to avoid redundant Slack API calls.
 - Thread history is fetched once per thread for the same reason.
+- Session reset type follows the parent session (group/direct), not the thread reset type.
 
 This setting only affects Slack today. Other channels are unaffected.
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1132,6 +1132,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Default inactivity window in hours for thread-bound sessions across providers/channels (0 disables idle auto-unfocus). Default: 24.",
   "session.threadBindings.maxAgeHours":
     "Optional hard max age in hours for thread-bound sessions across providers/channels (0 disables hard cap). Default: 0.",
+  "session.threadIsolation":
+    "When false, thread replies reuse the parent session instead of forking into per-thread sessions. Only affects Slack. Thread history and starter context are still injected per-thread. Default: true.",
   "session.maintenance":
     "Automatic session-store maintenance controls for pruning age, entry caps, and file rotation behavior. Start in warn mode to observe impact, then enforce once thresholds are tuned.",
   "session.maintenance.mode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -542,6 +542,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "session.threadBindings.enabled": "Thread Binding Enabled",
   "session.threadBindings.idleHours": "Thread Binding Idle Timeout (hours)",
   "session.threadBindings.maxAgeHours": "Thread Binding Max Age (hours)",
+  "session.threadIsolation": "Thread Session Isolation",
   "session.maintenance": "Session Maintenance",
   "session.maintenance.mode": "Session Maintenance Mode",
   "session.maintenance.pruneAfter": "Session Prune After",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -131,6 +131,11 @@ export type SessionConfig = {
   };
   /** Shared defaults for thread-bound session routing across channels/providers. */
   threadBindings?: SessionThreadBindingsConfig;
+  /**
+   * When false, thread replies reuse the parent session instead of forking
+   * into per-thread sessions. Only affects Slack today. Default: true.
+   */
+  threadIsolation?: boolean;
   /** Automatic session store maintenance (pruning, capping, file rotation). */
   maintenance?: SessionMaintenanceConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -69,6 +69,7 @@ export const SessionSchema = z
       })
       .strict()
       .optional(),
+    threadIsolation: z.boolean().optional(),
     maintenance: z
       .object({
         mode: z.enum(["enforce", "warn"]).optional(),

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -219,6 +219,7 @@ async function resolveSlackSession(
   const threadKeys = resolveThreadSessionKeys({
     baseSessionKey,
     threadId,
+    useSuffix: params.cfg.session?.threadIsolation ?? true,
   });
   return {
     sessionKey: threadKeys.sessionKey,

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -5,9 +5,11 @@ import {
   isCronSessionKey,
 } from "../sessions/session-key-utils.js";
 import {
+  buildAgentPeerSessionKey,
   classifySessionKeyShape,
   isValidAgentId,
   parseAgentSessionKey,
+  resolveThreadSessionKeys,
   toAgentStoreSessionKey,
 } from "./session-key.js";
 
@@ -128,5 +130,62 @@ describe("isValidAgentId", () => {
     expect(isValidAgentId("Agent not found: xyz")).toBe(false);
     expect(isValidAgentId("../../../etc/passwd")).toBe(false);
     expect(isValidAgentId("a".repeat(65))).toBe(false);
+  });
+});
+
+describe("resolveThreadSessionKeys", () => {
+  const base = "agent:main:main";
+
+  it("appends thread suffix by default", () => {
+    const result = resolveThreadSessionKeys({ baseSessionKey: base, threadId: "12345" });
+    expect(result.sessionKey).toBe(`${base}:thread:12345`);
+  });
+
+  it("respects useSuffix: false to disable thread forking", () => {
+    const result = resolveThreadSessionKeys({
+      baseSessionKey: base,
+      threadId: "12345",
+      useSuffix: false,
+    });
+    expect(result.sessionKey).toBe(base);
+  });
+
+  it("respects useSuffix: true (explicit)", () => {
+    const result = resolveThreadSessionKeys({
+      baseSessionKey: base,
+      threadId: "12345",
+      useSuffix: true,
+    });
+    expect(result.sessionKey).toBe(`${base}:thread:12345`);
+  });
+
+  it("returns base key when no threadId", () => {
+    const result = resolveThreadSessionKeys({ baseSessionKey: base });
+    expect(result.sessionKey).toBe(base);
+  });
+
+  it("preserves parentSessionKey", () => {
+    const result = resolveThreadSessionKeys({
+      baseSessionKey: base,
+      threadId: "12345",
+      parentSessionKey: "agent:main:main",
+      useSuffix: false,
+    });
+    expect(result.sessionKey).toBe(base);
+    expect(result.parentSessionKey).toBe("agent:main:main");
+  });
+});
+
+describe("buildAgentPeerSessionKey", () => {
+  it("returns channel-specific key by default for non-direct peers", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "slack",
+      peerKind: "channel",
+      peerId: "C123",
+    });
+    expect(key).toContain("slack");
+    expect(key).toContain("channel");
+    expect(key).toContain("c123");
   });
 });

--- a/src/slack/monitor/context.test.ts
+++ b/src/slack/monitor/context.test.ts
@@ -34,6 +34,7 @@ function createTestContext() {
     replyToMode: "off",
     threadHistoryScope: "thread",
     threadInheritParent: false,
+    threadIsolation: true,
     slashCommand: {
       enabled: true,
       name: "openclaw",

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -50,6 +50,7 @@ export type SlackMonitorContext = {
   replyToMode: "off" | "first" | "all";
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
+  threadIsolation: boolean;
   slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
   textLimit: number;
   ackReactionScope: string;
@@ -114,6 +115,7 @@ export function createSlackMonitorContext(params: {
   replyToMode: SlackMonitorContext["replyToMode"];
   threadHistoryScope: SlackMonitorContext["threadHistoryScope"];
   threadInheritParent: SlackMonitorContext["threadInheritParent"];
+  threadIsolation: SlackMonitorContext["threadIsolation"];
   slashCommand: SlackMonitorContext["slashCommand"];
   textLimit: number;
   ackReactionScope: string;
@@ -413,6 +415,7 @@ export function createSlackMonitorContext(params: {
     replyToMode: params.replyToMode,
     threadHistoryScope: params.threadHistoryScope,
     threadInheritParent: params.threadInheritParent,
+    threadIsolation: params.threadIsolation,
     slashCommand: params.slashCommand,
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -51,6 +51,8 @@ export type SlackMonitorContext = {
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
   threadIsolation: boolean;
+  /** Tracks which threadTs values have been seen this session, to avoid redundant first-turn work. */
+  seenThreadIds: Set<string>;
   slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
   textLimit: number;
   ackReactionScope: string;
@@ -416,6 +418,7 @@ export function createSlackMonitorContext(params: {
     threadHistoryScope: params.threadHistoryScope,
     threadInheritParent: params.threadInheritParent,
     threadIsolation: params.threadIsolation,
+    seenThreadIds: new Set(),
     slashCommand: params.slashCommand,
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,

--- a/src/slack/monitor/message-handler/prepare-thread-context.ts
+++ b/src/slack/monitor/message-handler/prepare-thread-context.ts
@@ -76,7 +76,11 @@ export async function resolveSlackThreadContextData(params: {
     sessionKey: params.sessionKey,
   });
 
-  if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
+  // When thread isolation is disabled, the shared session's "previous timestamp"
+  // reflects activity from any thread — not just this one. Always fetch thread
+  // history in that case so each thread gets its conversation context.
+  const shouldFetchHistory = !threadSessionPreviousTimestamp || !params.ctx.threadIsolation;
+  if (threadInitialHistoryLimit > 0 && shouldFetchHistory) {
     const threadHistory = await resolveSlackThreadHistory({
       channelId: params.message.channel,
       threadTs: params.threadTs,

--- a/src/slack/monitor/message-handler/prepare-thread-context.ts
+++ b/src/slack/monitor/message-handler/prepare-thread-context.ts
@@ -76,10 +76,14 @@ export async function resolveSlackThreadContextData(params: {
     sessionKey: params.sessionKey,
   });
 
-  // When thread isolation is disabled, the shared session's "previous timestamp"
-  // reflects activity from any thread — not just this one. Always fetch thread
-  // history in that case so each thread gets its conversation context.
-  const shouldFetchHistory = !threadSessionPreviousTimestamp || !params.ctx.threadIsolation;
+  // When thread isolation is disabled, use seenThreadIds to fetch history only on
+  // the first encounter of each thread (the shared session's timestamp is unreliable
+  // since it reflects activity from any thread, not just this one).
+  const shouldFetchHistory = !params.ctx.threadIsolation
+    ? params.threadTs
+      ? !params.ctx.seenThreadIds.has(params.threadTs)
+      : true
+    : !threadSessionPreviousTimestamp;
   if (threadInitialHistoryLimit > 0 && shouldFetchHistory) {
     const threadHistory = await resolveSlackThreadHistory({
       channelId: params.message.channel,

--- a/src/slack/monitor/message-handler/prepare-thread-context.ts
+++ b/src/slack/monitor/message-handler/prepare-thread-context.ts
@@ -81,7 +81,7 @@ export async function resolveSlackThreadContextData(params: {
   // since it reflects activity from any thread, not just this one).
   const shouldFetchHistory = !params.ctx.threadIsolation
     ? params.threadTs
-      ? !params.ctx.seenThreadIds.has(params.threadTs)
+      ? !params.ctx.seenThreadIds.has(`${params.message.channel}:${params.threadTs}`)
       : true
     : !threadSessionPreviousTimestamp;
   if (threadInitialHistoryLimit > 0 && shouldFetchHistory) {

--- a/src/slack/monitor/message-handler/prepare.test-helpers.ts
+++ b/src/slack/monitor/message-handler/prepare.test-helpers.ts
@@ -38,6 +38,7 @@ export function createInboundSlackTestContext(params: {
     replyToMode: params.replyToMode ?? "off",
     threadHistoryScope: "thread",
     threadInheritParent: false,
+    threadIsolation: true,
     slashCommand: {
       enabled: false,
       name: "openclaw",

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -503,6 +503,150 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(replies).toHaveBeenCalledTimes(1);
   });
 
+  // ── threadIsolation: false ─────────────────────────────────────────
+  // When session.threadIsolation is false, threads reuse the parent session
+  // key but still get per-thread history/starter context via threadTs.
+
+  function createThreadIsolationOffCtx(params: { cfg: OpenClawConfig; replies: unknown }) {
+    const ctx = createInboundSlackCtx({
+      cfg: params.cfg,
+      appClient: { conversations: { replies: params.replies } } as App["client"],
+      defaultRequireMention: false,
+      replyToMode: "all",
+    });
+    // Disable thread isolation so threads share the parent session
+    ctx.threadIsolation = false;
+    return ctx;
+  }
+
+  it("does not append :thread: suffix when threadIsolation is false", async () => {
+    const { storePath } = makeTmpStorePath();
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [{ text: "starter", user: "U2", ts: "100.000" }],
+    });
+    const ctx = createThreadIsolationOffCtx({
+      cfg: {
+        session: { store: storePath },
+        channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+      } as OpenClawConfig,
+      replies,
+    });
+    ctx.resolveUserName = async () => ({ name: "Alice" });
+    ctx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareThreadMessage(ctx, {
+      text: "reply in thread",
+      ts: "101.000",
+    });
+
+    expect(prepared).toBeTruthy();
+    // Session key should NOT contain :thread: when isolation is off
+    expect(prepared!.ctxPayload.SessionKey).not.toContain(":thread:");
+  });
+
+  it("uses unique historyKey per threadTs when threadIsolation is false", async () => {
+    const { storePath } = makeTmpStorePath();
+    const repliesA = vi.fn().mockResolvedValueOnce({
+      messages: [{ text: "starter A", user: "U2", ts: "100.000" }],
+    });
+    const repliesB = vi.fn().mockResolvedValueOnce({
+      messages: [{ text: "starter B", user: "U2", ts: "200.000" }],
+    });
+
+    const cfg = {
+      session: { store: storePath },
+      channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+    } as OpenClawConfig;
+
+    const ctxA = createThreadIsolationOffCtx({ cfg, replies: repliesA });
+    ctxA.resolveUserName = async () => ({ name: "Alice" });
+    ctxA.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const ctxB = createThreadIsolationOffCtx({ cfg, replies: repliesB });
+    ctxB.resolveUserName = async () => ({ name: "Alice" });
+    ctxB.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const preparedA = await prepareThreadMessage(ctxA, {
+      text: "reply A",
+      ts: "101.000",
+      thread_ts: "100.000",
+    });
+    const preparedB = await prepareThreadMessage(ctxB, {
+      text: "reply B",
+      ts: "201.000",
+      thread_ts: "200.000",
+    });
+
+    expect(preparedA).toBeTruthy();
+    expect(preparedB).toBeTruthy();
+    // Both share the same session key (no :thread: suffix)
+    expect(preparedA!.ctxPayload.SessionKey).toBe(preparedB!.ctxPayload.SessionKey);
+    // But historyKeys must differ so they don't share history buckets
+    expect(preparedA!.historyKey).not.toBe(preparedB!.historyKey);
+  });
+
+  it("still injects thread starter and history when session exists and threadIsolation is false", async () => {
+    const { storePath } = makeTmpStorePath();
+    const cfg = {
+      session: { store: storePath },
+      channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+    } as OpenClawConfig;
+    // Pre-create a session entry to simulate an existing session
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: "default",
+      teamId: "T1",
+      peer: { kind: "channel", id: "C123" },
+    });
+    // With threadIsolation off, the session key is the base key (no :thread: suffix)
+    const sessionKey = resolveThreadSessionKeys({
+      baseSessionKey: route.sessionKey,
+      threadId: "300.000",
+      useSuffix: false,
+    }).sessionKey;
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ [sessionKey]: { updatedAt: Date.now() } }, null, 2),
+    );
+
+    const replies = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messages: [{ text: "parent message", user: "U2", ts: "300.000" }],
+      })
+      .mockResolvedValueOnce({
+        messages: [
+          { text: "parent message", user: "U2", ts: "300.000" },
+          { text: "old reply", user: "U1", ts: "300.500" },
+          { text: "new reply", user: "U1", ts: "301.000" },
+        ],
+        response_metadata: { next_cursor: "" },
+      });
+
+    const ctx = createThreadIsolationOffCtx({ cfg, replies });
+    ctx.resolveUserName = async (id: string) => ({
+      name: id === "U1" ? "Alice" : "Bob",
+    });
+    ctx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareThreadMessage(ctx, {
+      text: "new reply",
+      ts: "301.000",
+      thread_ts: "300.000",
+    });
+
+    expect(prepared).toBeTruthy();
+    // Thread starter should always be injected when isolation is off,
+    // even though the session already exists
+    expect(prepared!.ctxPayload.ThreadStarterBody).toContain("parent message");
+    // IsFirstThreadTurn should be set since the thread hasn't had its own
+    // previous activity marker
+    expect(prepared!.ctxPayload.IsFirstThreadTurn).toBe(true);
+    // Thread history should be fetched even with existing session
+    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("old reply");
+  });
+
   it("includes thread_ts and parent_user_id metadata in thread replies", async () => {
     const message = createSlackMessage({
       text: "this is a reply",
@@ -614,6 +758,7 @@ describe("prepareSlackMessage sender prefix", () => {
       replyToMode: "off",
       threadHistoryScope: "channel",
       threadInheritParent: false,
+      threadIsolation: true,
       slashCommand: params.slashCommand,
       textLimit: 2000,
       ackReactionScope: "off",

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -647,6 +647,62 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("old reply");
   });
 
+  it("skips first-turn injection on subsequent turns to the same thread when threadIsolation is false", async () => {
+    const { storePath } = makeTmpStorePath();
+    const cfg = {
+      session: { store: storePath },
+      channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+    } as OpenClawConfig;
+
+    const replies = vi
+      .fn()
+      // First turn: starter lookup + history fetch
+      .mockResolvedValueOnce({
+        messages: [{ text: "starter msg", user: "U2", ts: "400.000" }],
+      })
+      .mockResolvedValueOnce({
+        messages: [
+          { text: "starter msg", user: "U2", ts: "400.000" },
+          { text: "first reply", user: "U1", ts: "401.000" },
+        ],
+        response_metadata: { next_cursor: "" },
+      })
+      // Second turn: starter lookup only (history should be skipped)
+      .mockResolvedValueOnce({
+        messages: [{ text: "starter msg", user: "U2", ts: "400.000" }],
+      });
+
+    // Use the same ctx instance so seenThreadIds persists between calls
+    const ctx = createThreadIsolationOffCtx({ cfg, replies });
+    ctx.resolveUserName = async (id: string) => ({
+      name: id === "U1" ? "Alice" : "Bob",
+    });
+    ctx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    // First turn to thread 400.000
+    const first = await prepareThreadMessage(ctx, {
+      text: "first reply",
+      ts: "401.000",
+      thread_ts: "400.000",
+    });
+    expect(first).toBeTruthy();
+    expect(first!.ctxPayload.IsFirstThreadTurn).toBe(true);
+    expect(first!.ctxPayload.ThreadStarterBody).toContain("starter msg");
+
+    // Second turn to the SAME thread — should NOT be first turn
+    const second = await prepareThreadMessage(ctx, {
+      text: "second reply",
+      ts: "402.000",
+      thread_ts: "400.000",
+    });
+    expect(second).toBeTruthy();
+    expect(second!.ctxPayload.IsFirstThreadTurn).toBeUndefined();
+    expect(second!.ctxPayload.ThreadStarterBody).toBeUndefined();
+    // replies called 2 times total:
+    // turn 1: starter lookup + history fetch; turn 2: starter cached, history skipped
+    expect(replies).toHaveBeenCalledTimes(2);
+  });
+
   it("includes thread_ts and parent_user_id metadata in thread replies", async () => {
     const message = createSlackMessage({
       text: "this is a reply",

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -503,6 +503,33 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(replies).toHaveBeenCalledTimes(1);
   });
 
+  // ── tripwire: default config unchanged ────────────────────────────
+  it("default config: thread reply session key contains :thread: suffix", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [{ text: "starter", user: "U2", ts: "900.000" }],
+    });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        session: { store: makeTmpStorePath().storePath },
+        channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+      } as OpenClawConfig,
+      appClient: { conversations: { replies } } as App["client"],
+      defaultRequireMention: false,
+      replyToMode: "all",
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareThreadMessage(slackCtx, {
+      text: "thread reply",
+      ts: "901.000",
+      thread_ts: "900.000",
+    });
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.SessionKey).toContain(":thread:");
+  });
+
   // ── threadIsolation: false ─────────────────────────────────────────
   // When session.threadIsolation is false, threads reuse the parent session
   // key but still get per-thread history/starter context via threadTs.

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -610,6 +610,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(preparedA!.ctxPayload.SessionKey).toBe(preparedB!.ctxPayload.SessionKey);
     // But historyKeys must differ so they don't share history buckets
     expect(preparedA!.historyKey).not.toBe(preparedB!.historyKey);
+    // historyKey must be channel-prefixed to prevent cross-channel collisions
+    expect(preparedA!.historyKey).toBe("C123:100.000");
+    expect(preparedB!.historyKey).toBe("C123:200.000");
   });
 
   it("still injects thread starter and history when session exists and threadIsolation is false", async () => {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -296,10 +296,15 @@ function resolveSlackRoutingContext(params: {
     baseSessionKey: route.sessionKey,
     threadId: canonicalThreadId,
     parentSessionKey: canonicalThreadId && ctx.threadInheritParent ? route.sessionKey : undefined,
+    useSuffix: ctx.threadIsolation,
   });
   const sessionKey = threadKeys.sessionKey;
+  // When thread isolation is disabled, key history off threadTs so threads
+  // don't share the same history bucket on the now-shared session key.
   const historyKey =
-    isThreadReply && ctx.threadHistoryScope === "thread" ? sessionKey : message.channel;
+    isThreadReply && ctx.threadHistoryScope === "thread"
+      ? (ctx.threadIsolation ? sessionKey : threadTs ?? sessionKey)
+      : message.channel;
 
   return {
     route,
@@ -705,11 +710,16 @@ export async function prepareSlackMessage(params: {
     // Preserve thread context for routed tool notifications.
     MessageThreadId: threadContext.messageThreadId,
     ParentSessionKey: threadKeys.parentSessionKey,
-    // Only include thread starter body for NEW sessions (existing sessions already have it in their transcript)
-    ThreadStarterBody: !threadSessionPreviousTimestamp ? threadStarterBody : undefined,
+    // Include thread starter body for new sessions, or always when thread isolation
+    // is disabled (shared session means the "previous timestamp" check is unreliable
+    // since it reflects activity from any thread, not just this one).
+    ThreadStarterBody:
+      !ctx.threadIsolation || !threadSessionPreviousTimestamp ? threadStarterBody : undefined,
     ThreadHistoryBody: threadHistoryBody,
     IsFirstThreadTurn:
-      isThreadReply && threadTs && !threadSessionPreviousTimestamp ? true : undefined,
+      isThreadReply && threadTs && (!ctx.threadIsolation || !threadSessionPreviousTimestamp)
+        ? true
+        : undefined,
     ThreadLabel: threadLabel,
     Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
     WasMentioned: isRoomish ? effectiveWasMentioned : undefined,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -761,9 +761,10 @@ export async function prepareSlackMessage(params: {
   // shouldn't be marked since they weren't processed as thread context.
   // Channel-prefixed to prevent collisions when channelIsolation is also off.
   if (isThreadReply && threadTs && !ctx.threadIsolation) {
-    // Cap at 500 entries to prevent unbounded growth in long-running sessions.
+    // Evict oldest entry at 500 to prevent unbounded growth in long-running sessions.
+    // Set preserves insertion order, so values().next() yields the oldest entry.
     if (ctx.seenThreadIds.size >= 500) {
-      ctx.seenThreadIds.clear();
+      ctx.seenThreadIds.delete(ctx.seenThreadIds.values().next().value!);
     }
     ctx.seenThreadIds.add(`${message.channel}:${threadTs}`);
   }

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -299,13 +299,16 @@ function resolveSlackRoutingContext(params: {
     useSuffix: ctx.threadIsolation,
   });
   const sessionKey = threadKeys.sessionKey;
-  // When thread isolation is disabled, key history off threadTs so threads
+  // When thread isolation is disabled, key history off channel:threadTs so threads
   // don't share the same history bucket on the now-shared session key.
+  // The channel prefix prevents collisions when channelIsolation is also off.
   const historyKey =
     isThreadReply && ctx.threadHistoryScope === "thread"
       ? ctx.threadIsolation
         ? sessionKey
-        : (threadTs ?? sessionKey)
+        : threadTs
+          ? `${message.channel}:${threadTs}`
+          : sessionKey
       : message.channel;
 
   return {
@@ -714,9 +717,10 @@ export async function prepareSlackMessage(params: {
     ParentSessionKey: threadKeys.parentSessionKey,
     // Include thread starter body on the first encounter of each thread.
     // When isolation is off, use seenThreadIds (shared session timestamp is unreliable).
+    // Channel-prefixed key prevents collisions when channelIsolation is also off.
     // When isolation is on, use threadSessionPreviousTimestamp as before.
     ThreadStarterBody: !ctx.threadIsolation
-      ? threadTs && !ctx.seenThreadIds.has(threadTs)
+      ? threadTs && !ctx.seenThreadIds.has(`${message.channel}:${threadTs}`)
         ? threadStarterBody
         : undefined
       : !threadSessionPreviousTimestamp
@@ -726,7 +730,9 @@ export async function prepareSlackMessage(params: {
     IsFirstThreadTurn:
       isThreadReply &&
       threadTs &&
-      (!ctx.threadIsolation ? !ctx.seenThreadIds.has(threadTs) : !threadSessionPreviousTimestamp)
+      (!ctx.threadIsolation
+        ? !ctx.seenThreadIds.has(`${message.channel}:${threadTs}`)
+        : !threadSessionPreviousTimestamp)
         ? true
         : undefined,
     ThreadLabel: threadLabel,
@@ -749,10 +755,17 @@ export async function prepareSlackMessage(params: {
     NativeChannelId: message.channel,
   }) satisfies FinalizedMsgContext;
 
-  // Mark this threadTs as seen so subsequent turns skip first-turn work
+  // Mark this thread as seen so subsequent turns skip first-turn work
   // (thread starter injection, history fetch, IsFirstThreadTurn flag).
-  if (threadTs && !ctx.threadIsolation) {
-    ctx.seenThreadIds.add(threadTs);
+  // Only for actual thread replies — parent messages with thread_ts === ts
+  // shouldn't be marked since they weren't processed as thread context.
+  // Channel-prefixed to prevent collisions when channelIsolation is also off.
+  if (isThreadReply && threadTs && !ctx.threadIsolation) {
+    // Cap at 500 entries to prevent unbounded growth in long-running sessions.
+    if (ctx.seenThreadIds.size >= 500) {
+      ctx.seenThreadIds.clear();
+    }
+    ctx.seenThreadIds.add(`${message.channel}:${threadTs}`);
   }
 
   const pinnedMainDmOwner = isDirectMessage

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -303,7 +303,9 @@ function resolveSlackRoutingContext(params: {
   // don't share the same history bucket on the now-shared session key.
   const historyKey =
     isThreadReply && ctx.threadHistoryScope === "thread"
-      ? (ctx.threadIsolation ? sessionKey : threadTs ?? sessionKey)
+      ? ctx.threadIsolation
+        ? sessionKey
+        : (threadTs ?? sessionKey)
       : message.channel;
 
   return {
@@ -710,14 +712,21 @@ export async function prepareSlackMessage(params: {
     // Preserve thread context for routed tool notifications.
     MessageThreadId: threadContext.messageThreadId,
     ParentSessionKey: threadKeys.parentSessionKey,
-    // Include thread starter body for new sessions, or always when thread isolation
-    // is disabled (shared session means the "previous timestamp" check is unreliable
-    // since it reflects activity from any thread, not just this one).
-    ThreadStarterBody:
-      !ctx.threadIsolation || !threadSessionPreviousTimestamp ? threadStarterBody : undefined,
+    // Include thread starter body on the first encounter of each thread.
+    // When isolation is off, use seenThreadIds (shared session timestamp is unreliable).
+    // When isolation is on, use threadSessionPreviousTimestamp as before.
+    ThreadStarterBody: !ctx.threadIsolation
+      ? threadTs && !ctx.seenThreadIds.has(threadTs)
+        ? threadStarterBody
+        : undefined
+      : !threadSessionPreviousTimestamp
+        ? threadStarterBody
+        : undefined,
     ThreadHistoryBody: threadHistoryBody,
     IsFirstThreadTurn:
-      isThreadReply && threadTs && (!ctx.threadIsolation || !threadSessionPreviousTimestamp)
+      isThreadReply &&
+      threadTs &&
+      (!ctx.threadIsolation ? !ctx.seenThreadIds.has(threadTs) : !threadSessionPreviousTimestamp)
         ? true
         : undefined,
     ThreadLabel: threadLabel,
@@ -739,6 +748,13 @@ export async function prepareSlackMessage(params: {
     OriginatingTo: slackTo,
     NativeChannelId: message.channel,
   }) satisfies FinalizedMsgContext;
+
+  // Mark this threadTs as seen so subsequent turns skip first-turn work
+  // (thread starter injection, history fetch, IsFirstThreadTurn flag).
+  if (threadTs && !ctx.threadIsolation) {
+    ctx.seenThreadIds.add(threadTs);
+  }
+
   const pinnedMainDmOwner = isDirectMessage
     ? resolvePinnedMainDmOwnerFromAllowlist({
         dmScope: cfg.session?.dmScope,

--- a/src/slack/monitor/monitor.test.ts
+++ b/src/slack/monitor/monitor.test.ts
@@ -119,6 +119,7 @@ const baseParams = () => ({
   mediaMaxBytes: 1,
   threadHistoryScope: "thread" as const,
   threadInheritParent: false,
+  threadIsolation: true,
   removeAckAfterReply: false,
 });
 

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -178,6 +178,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const replyToMode = slackCfg.replyToMode ?? "off";
   const threadHistoryScope = slackCfg.thread?.historyScope ?? "thread";
   const threadInheritParent = slackCfg.thread?.inheritParent ?? false;
+  const threadIsolation = cfg.session?.threadIsolation !== false;
   const slashCommand = resolveSlackSlashCommandConfig(opts.slashCommand ?? slackCfg.slashCommand);
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
@@ -277,6 +278,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     replyToMode,
     threadHistoryScope,
     threadInheritParent,
+    threadIsolation,
     slashCommand,
     textLimit,
     ackReactionScope,

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -179,6 +179,12 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const threadHistoryScope = slackCfg.thread?.historyScope ?? "thread";
   const threadInheritParent = slackCfg.thread?.inheritParent ?? false;
   const threadIsolation = cfg.session?.threadIsolation !== false;
+  if (!threadIsolation) {
+    warn(
+      "session.threadIsolation=false: Slack threads share the parent session. " +
+        "Thread context is still injected per-thread, but conversation history may leak across threads.",
+    );
+  }
   const slashCommand = resolveSlackSlashCommandConfig(opts.slashCommand ?? slackCfg.slashCommand);
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";


### PR DESCRIPTION
> **Merge order:** This PR first (#43360), then optionally #43459. #43459 is advanced/optional and ok to defer.

## Summary

Adds `session.threadIsolation: false` — an opt-in config flag that lets Slack thread replies reuse the parent session instead of forking into per-thread sessions. This enables cross-thread memory for single-identity agents.

Scoped to Slack only — the global `resolveThreadSessionKeys` default is unchanged (`useSuffix ?? true`). Slack passes `useSuffix: false` via its own monitor context.

Defaults to `true`, preserving current behavior.

**See also**: [#43459](https://github.com/openclaw/openclaw/pull/43459) for the companion `session.channelIsolation` PR.

## Behavior matrix

| `threadIsolation` | sessionKey | historyKey | thread starter/history |
|---|---|---|---|
| `true` (default) | `agent:main:slack:...:thread:<threadTs>` | same as sessionKey | gated by session `previousTimestamp` |
| `false` | `agent:main:slack:...` (no `:thread:` suffix) | `<channel>:<threadTs>` | gated by `seenThreadIds` (channel-prefixed, capped at 500) |

## Review feedback addressed

- **`seenThreadIds: Set<string>`** on `SlackMonitorContext` — tracks `channel:threadTs` keys per-session, so `IsFirstThreadTurn`/`ThreadStarterBody` and `conversations.replies` only fire on the first encounter of each thread (not every turn)
- **`isThreadReply` guard** — only actual thread replies mark threads as seen (parent messages with `thread_ts === ts` are excluded)
- **LRU-style eviction** — oldest entry evicted at 500 cap instead of clearing the whole set
- **Channel-prefixed keys** — `historyKey` and `seenThreadIds` use `channel:threadTs` composite keys to prevent cross-channel collisions when `channelIsolation` is also off
- **Outbound thread key alignment** — `resolveSlackSession` now passes `useSuffix: cfg.session?.threadIsolation ?? true` so outbound messages use the same session key as inbound
- **Reset type follows parent** — when isolation is off, the session key has no `:thread:` suffix, so `resolveSessionResetType` returns the parent's reset type (group/direct) — no thread-specific reset can wipe a shared session

## Edge cases handled

| Issue | Fix |
|-------|-----|
| Thread history bucket collision | `historyKey` uses `channel:threadTs` instead of `sessionKey` when isolation is off |
| Thread starter not injected on existing sessions | `ThreadStarterBody` + `IsFirstThreadTurn` use `seenThreadIds` to fire only on first encounter per thread |
| Thread history never fetched for existing sessions | Thread history fetch uses `seenThreadIds` — fetched once per thread |
| Redundant `conversations.replies` calls | `seenThreadIds` prevents re-fetching history on subsequent turns |
| Outbound thread key mismatch | Outbound `resolveThreadSessionKeys` now honors `threadIsolation` config |
| Parent message poisoning seenThreadIds | `isThreadReply` guard prevents parent posts from being marked as seen |
| Unbounded seenThreadIds growth | Evicts oldest entry at 500 cap (Set insertion order) |

## Changed files

- **Config**: `types.base.ts`, `zod-schema.session.ts`, `schema.help.ts`, `schema.labels.ts` — add `threadIsolation` option
- **Slack context**: `context.ts`, `provider.ts` — read and propagate `threadIsolation` flag + `seenThreadIds` Set
- **Slack prepare**: `prepare.ts` — pass `useSuffix`, fix `historyKey`, `seenThreadIds`-gated `ThreadStarterBody`/`IsFirstThreadTurn`
- **Slack thread context**: `prepare-thread-context.ts` — `seenThreadIds`-gated thread history fetch
- **Outbound**: `outbound-session.ts` — pass `useSuffix` from config to `resolveThreadSessionKeys`
- **Docs**: `docs/channels/slack.md` — updated "Shared session across threads" section
- **Tests**: `prepare.test.ts` — 4 tests for threadIsolation behavior incl. second-turn skipping + historyKey prefix assertion; `session-key.test.ts` — `resolveThreadSessionKeys` useSuffix tests

## Config

```json5
{
  "session": {
    "threadIsolation": false  // default: true
  }
}
```

## Test plan

- [x] Existing tests pass with `threadIsolation: true` (default)
- [x] `resolveThreadSessionKeys` returns base key when `useSuffix: false`
- [x] No `:thread:` suffix on session key when `threadIsolation: false`
- [x] historyKey uses `channel:threadTs` format when threads share session key
- [x] Thread starter + history injected on first encounter, skipped on second turn
- [x] Outbound thread keys honor `threadIsolation` config
- [x] `prepare.test.ts` — 25/25 pass
- [x] `session-key.test.ts` — 28/28 pass
- [x] Dogfooded on production Slack + Discord bot

Closes #43286