### PR TITLE
Reply: preserve reminder coverage across compaction

### DIFF
--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
@@ -60,6 +60,35 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.getCompactionCount()).toBe(0);
   });
 
+  it("preserves successful cron adds across compaction retries", async () => {
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-compaction-cron-add",
+    });
+
+    emit({
+      type: "tool_execution_start",
+      toolName: "cron",
+      toolCallId: "tool-cron-1",
+      args: { action: "add", job: { name: "reminder" } },
+    });
+    await Promise.resolve();
+
+    emit({
+      type: "tool_execution_end",
+      toolName: "cron",
+      toolCallId: "tool-cron-1",
+      isError: false,
+      result: { details: { status: "ok" } },
+    });
+    await Promise.resolve();
+
+    expect(subscription.getSuccessfulCronAdds()).toBe(1);
+
+    emit({ type: "auto_compaction_end", willRetry: true, result: { summary: "s" } });
+
+    expect(subscription.getSuccessfulCronAdds()).toBe(1);
+  });
+
   it("emits compaction events on the agent event bus", async () => {
     const { emit } = createSubscribedSessionHarness({
       runId: "run-compaction",

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -597,7 +597,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentMediaUrls.length = 0;
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
-    state.successfulCronAdds = 0;
+    // Keep successful cron adds across compaction retries so reply guards
+    // still know a reminder tool already succeeded in this turn.
     state.pendingMessagingMediaUrls.clear();
     state.deterministicApprovalPromptSent = false;
     resetAssistantMessageState(0);

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -28,6 +28,7 @@ export function hasUnbackedReminderCommitment(text: string): boolean {
 export async function hasSessionRelatedCronJobs(params: {
   cronStorePath?: string;
   sessionKey?: string;
+  agentId?: string;
 }): Promise<boolean> {
   try {
     const storePath = resolveCronStorePath(params.cronStorePath);
@@ -35,10 +36,17 @@ export async function hasSessionRelatedCronJobs(params: {
     if (store.jobs.length === 0) {
       return false;
     }
-    if (params.sessionKey) {
-      return store.jobs.some((job) => job.enabled && job.sessionKey === params.sessionKey);
-    }
-    return false;
+    return store.jobs.some((job) => {
+      if (!job.enabled) {
+        return false;
+      }
+      if (params.sessionKey && job.sessionKey === params.sessionKey) {
+        return true;
+      }
+      // Isolated reminder jobs intentionally omit sessionKey, so fall back to
+      // same-agent coverage before appending a contradictory disclaimer.
+      return !job.sessionKey && Boolean(params.agentId) && job.agentId === params.agentId;
+    });
   } catch {
     // If we cannot read the cron store, do not suppress the note.
     return false;

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1108,7 +1108,7 @@ describe("runReplyAgent messaging tool suppression", () => {
 });
 
 describe("runReplyAgent reminder commitment guard", () => {
-  function createRun(params?: { sessionKey?: string; omitSessionKey?: boolean }) {
+  function createRun(params?: { sessionKey?: string; omitSessionKey?: boolean; agentId?: string }) {
     const typing = createMockTypingController();
     const sessionCtx = {
       Provider: "telegram",
@@ -1130,6 +1130,7 @@ describe("runReplyAgent reminder commitment guard", () => {
         workspaceDir: "/tmp",
         config: {},
         skillsSnapshot: {},
+        ...(params?.agentId ? { agentId: params.agentId } : {}),
         provider: "anthropic",
         model: "claude",
         thinkLevel: "low",
@@ -1217,6 +1218,34 @@ describe("runReplyAgent reminder commitment guard", () => {
     const result = await createRun();
     expect(result).toMatchObject({
       text: "I'll ping you when it's done.",
+    });
+  });
+
+  it("suppresses guard note when same agent already has an isolated cron job", async () => {
+    loadCronStoreMock.mockResolvedValueOnce({
+      version: 1,
+      jobs: [
+        {
+          id: "isolated-job",
+          name: "thursday-ping",
+          enabled: true,
+          agentId: "main",
+          sessionKey: undefined,
+          createdAtMs: Date.now() - 60_000,
+          updatedAtMs: Date.now() - 60_000,
+        },
+      ],
+    });
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "I'll ping you Thursday morning." }],
+      meta: {},
+      successfulCronAdds: 0,
+    });
+
+    const result = await createRun({ sessionKey: "main", agentId: "main" });
+    expect(result).toMatchObject({
+      text: "I'll ping you Thursday morning.",
     });
   });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -515,6 +515,9 @@ export async function runReplyAgent(params: {
     }
 
     const successfulCronAdds = runResult.successfulCronAdds ?? 0;
+    const reminderAgentId =
+      followupRun.run.agentId ??
+      (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined);
     const hasReminderCommitment = replyPayloads.some(
       (payload) =>
         !payload.isError &&
@@ -528,6 +531,7 @@ export async function runReplyAgent(params: {
         ? await hasSessionRelatedCronJobs({
             cronStorePath: cfg.cron?.store,
             sessionKey,
+            agentId: reminderAgentId,
           })
         : false;
     const guardedReplyPayloads =


### PR DESCRIPTION
## Summary
- preserve `successfulCronAdds` across compaction retries so reminder coverage from this turn survives retry cleanup
- treat enabled isolated cron jobs for the same agent as reminder coverage when the guard checks existing jobs
- add regressions for both the isolated-job lookup and the compaction retry counter

## Testing
- pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
- pnpm test src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
- pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts
- pnpm exec oxfmt --check src/auto-reply/reply/agent-runner-reminder-guard.ts src/auto-reply/reply/agent-runner.ts src/agents/pi-embedded-subscribe.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts

Fixes #43292
