### PR TITLE
UI: render safe markdown images inline

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -222,6 +222,18 @@ function renderMessageImages(images: ImageBlock[]) {
   `;
 }
 
+function handleMarkdownImageClick(event: Event) {
+  const target = event.target;
+  if (!(target instanceof HTMLImageElement)) {
+    return;
+  }
+  const rawUrl = target.dataset.openclawImageUrl;
+  if (!rawUrl) {
+    return;
+  }
+  openExternalUrlSafe(rawUrl, { allowDataImage: true });
+}
+
 function renderGroupedMessage(
   message: unknown,
   opts: { isStreaming: boolean; showReasoning: boolean },
@@ -279,7 +291,13 @@ function renderGroupedMessage(
       }
       ${
         markdown
-          ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
+          ? html`<div
+              class="chat-text"
+              dir="${detectTextDirection(markdown)}"
+              @click=${handleMarkdownImageClick}
+            >
+              ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
+            </div>`
           : nothing
       }
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -30,10 +30,12 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("console.log(1)");
   });
 
-  it("flattens remote markdown images into alt text", () => {
+  it("renders safe remote markdown images inline", () => {
     const html = toSanitizedMarkdownHtml("![Alt text](https://example.com/image.png)");
-    expect(html).not.toContain("<img");
-    expect(html).toContain("Alt text");
+    expect(html).toContain("<img");
+    expect(html).toContain('src="https://example.com/image.png"');
+    expect(html).toContain('data-openclaw-image-url="https://example.com/image.png"');
+    expect(html).toContain('alt="Alt text"');
   });
 
   it("preserves base64 data URI images (#15437)", () => {
@@ -51,8 +53,8 @@ describe("toSanitizedMarkdownHtml", () => {
 
   it("uses a plain fallback label for unlabeled markdown images", () => {
     const html = toSanitizedMarkdownHtml("![](https://example.com/image.png)");
-    expect(html).not.toContain("<img");
-    expect(html).toContain("image");
+    expect(html).toContain("<img");
+    expect(html).toContain('alt="image"');
   });
 
   it("renders GFM markdown tables (#20410)", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -1,6 +1,7 @@
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 import { truncateText } from "./format.ts";
+import { resolveSafeExternalUrl } from "./open-external-url.ts";
 
 const allowedTags = [
   "a",
@@ -31,7 +32,17 @@ const allowedTags = [
   "img",
 ];
 
-const allowedAttrs = ["class", "href", "rel", "target", "title", "start", "src", "alt"];
+const allowedAttrs = [
+  "class",
+  "href",
+  "rel",
+  "target",
+  "title",
+  "start",
+  "src",
+  "alt",
+  "data-openclaw-image-url",
+];
 const sanitizeOptions = {
   ALLOWED_TAGS: allowedTags,
   ALLOWED_ATTR: allowedAttrs,
@@ -43,7 +54,7 @@ const MARKDOWN_CHAR_LIMIT = 140_000;
 const MARKDOWN_PARSE_LIMIT = 40_000;
 const MARKDOWN_CACHE_LIMIT = 200;
 const MARKDOWN_CACHE_MAX_CHARS = 50_000;
-const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
+const FALLBACK_MARKDOWN_BASE_HREF = "https://control-ui.invalid/";
 const markdownCache = new Map<string, string>();
 
 function getCachedMarkdown(key: string): string | null {
@@ -141,10 +152,15 @@ htmlEscapeRenderer.html = ({ text }: { text: string }) => escapeHtml(text);
 htmlEscapeRenderer.image = (token: { href?: string | null; text?: string | null }) => {
   const label = normalizeMarkdownImageLabel(token.text);
   const href = token.href?.trim() ?? "";
-  if (!INLINE_DATA_IMAGE_RE.test(href)) {
+  const safeUrl = resolveSafeExternalUrl(
+    href,
+    typeof window !== "undefined" ? window.location.href : FALLBACK_MARKDOWN_BASE_HREF,
+    { allowDataImage: true },
+  );
+  if (!safeUrl) {
     return escapeHtml(label);
   }
-  return `<img src="${escapeHtml(href)}" alt="${escapeHtml(label)}">`;
+  return `<img class="chat-message-image" src="${escapeHtml(safeUrl)}" alt="${escapeHtml(label)}" data-openclaw-image-url="${escapeHtml(safeUrl)}">`;
 };
 
 function normalizeMarkdownImageLabel(text?: string | null): string {

--- a/ui/src/ui/views/chat-image-open.browser.test.ts
+++ b/ui/src/ui/views/chat-image-open.browser.test.ts
@@ -15,6 +15,14 @@ function renderAssistantImage(url: string) {
   };
 }
 
+function renderAssistantMarkdownImage(url: string) {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: `![Inline image](${url})` }],
+    timestamp: Date.now(),
+  };
+}
+
 describe("chat image open safety", () => {
   it("opens safe image URLs in a hardened new tab", async () => {
     const app = mountApp("/chat");
@@ -66,5 +74,27 @@ describe("chat image open safety", () => {
     image?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders and opens safe markdown image URLs", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    app.chatMessages = [renderAssistantMarkdownImage("https://example.com/inline.png")];
+    await app.updateComplete;
+
+    const image = app.querySelector<HTMLImageElement>(".chat-text .chat-message-image");
+    expect(image).not.toBeNull();
+    expect(image?.getAttribute("src")).toBe("https://example.com/inline.png");
+
+    image?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://example.com/inline.png",
+      "_blank",
+      "noopener,noreferrer",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- render safe markdown image URLs inline in the Control UI instead of flattening every non-data image into alt text
- reuse the existing safe-external-url policy so javascript URLs stay blocked and SVG data URLs stay disallowed
- add browser coverage for inline markdown image rendering and click-open behavior

## Testing
- pnpm exec vitest run --config vitest.config.ts src/ui/markdown.test.ts src/ui/views/chat-image-open.browser.test.ts
- pnpm exec oxfmt --check ui/src/ui/markdown.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/markdown.test.ts ui/src/ui/views/chat-image-open.browser.test.ts
- pnpm exec oxlint ui/src/ui/markdown.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/markdown.test.ts ui/src/ui/views/chat-image-open.browser.test.ts

Fixes #6617
