### PR TITLE
test(config): cover requiresOpenAiAnthropicToolPayload compat key

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -315,6 +315,7 @@ describe("model compat config schema", () => {
                   requiresAssistantAfterToolResult: false,
                   requiresThinkingAsText: false,
                   requiresMistralToolIds: false,
+                  requiresOpenAiAnthropicToolPayload: true,
                 },
               },
             ],


### PR DESCRIPTION
## Summary
- adds `requiresOpenAiAnthropicToolPayload` to the existing model-compat schema acceptance fixture in `config-misc.test.ts`
- links the regression report where onboarding fails with `Unrecognized key: "requiresOpenAiAnthropicToolPayload"`
- keeps scope minimal (test-only) to guard schema coverage for this compat field

## Issue linkage
- Closes #43339

## Validation
- ?? Could not run local tests in this environment.
  - `pnpm install --frozen-lockfile` fails while preparing `@tloncorp/api` (missing optional `@rollup/rollup-win32-x64-msvc` during nested npm install).
  - Because dependencies could not be fully prepared, `vitest` is unavailable in this checkout.
