### PR TITLE
Reply: add /models test-fallback

### DIFF
--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -1,4 +1,13 @@
-import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  resolveAgentDir,
+  resolveAgentModelFallbacksOverride,
+  resolveSessionAgentId,
+} from "../../agents/agent-scope.js";
+import { describeFailoverError } from "../../agents/failover-error.js";
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import {
@@ -8,7 +17,9 @@ import {
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
+import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   buildModelsKeyboard,
@@ -23,6 +34,14 @@ import type { CommandHandler } from "./commands-types.js";
 
 const PAGE_SIZE_DEFAULT = 20;
 const PAGE_SIZE_MAX = 100;
+const FALLBACK_TEST_PROMPT = "Reply with OK. Do not use tools.";
+const FALLBACK_TEST_TIMEOUT_MS = 8_000;
+const FALLBACK_TEST_MAX_TOKENS = 8;
+
+type ResolvedModelRef = {
+  provider: string;
+  model: string;
+};
 
 export type ModelsProviderData = {
   byProvider: Map<string, Set<string>>;
@@ -216,6 +235,166 @@ export function formatModelsAvailableHeader(params: {
   return `Models (${providerLabel}) — ${params.total} available`;
 }
 
+function parseModelsFallbackTestArgs(raw: string): {
+  enabled: boolean;
+  all: boolean;
+  invalidToken?: string;
+} {
+  const trimmed = raw.trim();
+  if (!trimmed.toLowerCase().startsWith("test-fallback")) {
+    return { enabled: false, all: false };
+  }
+
+  const rest = trimmed.slice("test-fallback".length).trim();
+  if (!rest) {
+    return { enabled: true, all: false };
+  }
+
+  let all = false;
+  for (const token of rest.split(/\s+/g).filter(Boolean)) {
+    const lower = token.toLowerCase();
+    if (lower === "all" || lower === "--all") {
+      all = true;
+      continue;
+    }
+    return { enabled: true, all, invalidToken: token };
+  }
+
+  return { enabled: true, all };
+}
+
+function resolveFallbackTestModels(params: { cfg: OpenClawConfig; agentId?: string }): {
+  primary: ResolvedModelRef;
+  fallbacks: ResolvedModelRef[];
+} {
+  const primary = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: primary.provider,
+  });
+  const defaultsFallbacks = resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
+  const scopedFallbacks = params.agentId
+    ? resolveAgentModelFallbacksOverride(params.cfg, params.agentId)
+    : undefined;
+  const rawFallbacks = scopedFallbacks ?? defaultsFallbacks;
+  const fallbacks: ResolvedModelRef[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of rawFallbacks) {
+    const resolved = resolveModelRefFromString({
+      raw,
+      defaultProvider: primary.provider,
+      aliasIndex,
+    });
+    if (!resolved) {
+      continue;
+    }
+    const key = `${resolved.ref.provider}/${resolved.ref.model}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    fallbacks.push(resolved.ref);
+  }
+
+  return { primary, fallbacks };
+}
+
+function createFallbackProbeConfig(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  target: string;
+}): OpenClawConfig {
+  const defaults = {
+    ...params.cfg.agents?.defaults,
+    model: {
+      primary: params.target,
+      fallbacks: [],
+    },
+  };
+
+  const list = Array.isArray(params.cfg.agents?.list)
+    ? params.cfg.agents.list.map((entry) => {
+        const entryId = typeof entry?.id === "string" ? entry.id.trim().toLowerCase() : "";
+        const targetId = params.agentId?.trim().toLowerCase() ?? "";
+        if (!targetId || entryId !== targetId) {
+          return entry;
+        }
+        return {
+          ...entry,
+          model: {
+            primary: params.target,
+            fallbacks: [],
+          },
+        };
+      })
+    : params.cfg.agents?.list;
+
+  return {
+    ...params.cfg,
+    agents: {
+      ...params.cfg.agents,
+      defaults,
+      ...(list ? { list } : undefined),
+    },
+  };
+}
+
+function formatFallbackProbeFailure(err: unknown): string {
+  const described = describeFailoverError(err);
+  const reason = described.reason ? described.reason.replaceAll("_", " ") : "error";
+  const detail = described.message.split("\n")[0]?.trim();
+  return detail ? `${reason}: ${detail}` : reason;
+}
+
+async function probeFallbackModel(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  agentDir?: string;
+  workspaceDir: string;
+  target: ResolvedModelRef;
+}): Promise<{ target: string; ok: boolean; detail?: string }> {
+  const targetLabel = `${params.target.provider}/${params.target.model}`;
+  const probeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-model-fallback-"));
+  const sessionId = `models-test-fallback-${crypto.randomUUID()}`;
+  const sessionFile = path.join(probeDir, `${sessionId}.jsonl`);
+
+  try {
+    await runEmbeddedPiAgent({
+      sessionId,
+      sessionKey: `probe:${sessionId}`,
+      agentId: params.agentId,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      sessionFile,
+      config: createFallbackProbeConfig({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        target: targetLabel,
+      }),
+      prompt: FALLBACK_TEST_PROMPT,
+      provider: params.target.provider,
+      model: params.target.model,
+      disableTools: true,
+      timeoutMs: FALLBACK_TEST_TIMEOUT_MS,
+      runId: `models-test-fallback-${crypto.randomUUID()}`,
+      lane: `models-test-fallback:${params.target.provider}:${params.target.model}`,
+      thinkLevel: "off",
+      reasoningLevel: "off",
+      verboseLevel: "off",
+      streamParams: { maxTokens: FALLBACK_TEST_MAX_TOKENS },
+    });
+    return { target: targetLabel, ok: true };
+  } catch (err) {
+    return { target: targetLabel, ok: false, detail: formatFallbackProbeFailure(err) };
+  } finally {
+    await fs.rm(probeDir, { recursive: true, force: true });
+  }
+}
+
 export async function resolveModelsCommandReply(params: {
   cfg: OpenClawConfig;
   commandBodyNormalized: string;
@@ -224,6 +403,7 @@ export async function resolveModelsCommandReply(params: {
   agentId?: string;
   agentDir?: string;
   sessionEntry?: SessionEntry;
+  workspaceDir?: string;
 }): Promise<ReplyPayload | null> {
   const body = params.commandBodyNormalized.trim();
   if (!body.startsWith("/models")) {
@@ -231,6 +411,60 @@ export async function resolveModelsCommandReply(params: {
   }
 
   const argText = body.replace(/^\/models\b/i, "").trim();
+  const fallbackTest = parseModelsFallbackTestArgs(argText);
+  if (fallbackTest.enabled) {
+    if (fallbackTest.invalidToken) {
+      return {
+        text: [
+          `Unknown /models test-fallback argument: ${fallbackTest.invalidToken}`,
+          "",
+          "Use: /models test-fallback",
+          "All: /models test-fallback all",
+        ].join("\n"),
+      };
+    }
+
+    const { primary, fallbacks } = resolveFallbackTestModels({
+      cfg: params.cfg,
+      agentId: params.agentId,
+    });
+    const primaryLabel = `${primary.provider}/${primary.model}`;
+    if (fallbacks.length === 0) {
+      return {
+        text: [
+          `No fallback models configured for ${primaryLabel}.`,
+          "",
+          "Set fallbacks in config, then retry:",
+          "Use: /models test-fallback",
+        ].join("\n"),
+      };
+    }
+
+    const targets = fallbackTest.all ? fallbacks : fallbacks.slice(0, 1);
+    const workspaceDir = params.workspaceDir ?? process.cwd();
+    const results = [];
+    for (const target of targets) {
+      results.push(
+        await probeFallbackModel({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          agentDir: params.agentDir,
+          workspaceDir,
+          target,
+        }),
+      );
+    }
+
+    const lines = [`Fallback test (primary skipped: ${primaryLabel})`];
+    for (const result of results) {
+      lines.push(`- ${result.target}: ${result.ok ? "OK" : (result.detail ?? "error")}`);
+    }
+    if (!fallbackTest.all && fallbacks.length > 1) {
+      lines.push("", "More: /models test-fallback all");
+    }
+    return { text: lines.join("\n") };
+  }
+
   const { provider, page, pageSize, all } = parseModelsArgs(argText);
 
   const { byProvider, providers } = await buildModelsProviderData(params.cfg, params.agentId);
@@ -391,6 +625,7 @@ export const handleModelsCommand: CommandHandler = async (params, allowTextComma
     agentId: modelsAgentId,
     agentDir: modelsAgentDir,
     sessionEntry: params.sessionEntry,
+    workspaceDir: params.workspaceDir,
   });
   if (!reply) {
     return null;

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { abortEmbeddedPiRun, compactEmbeddedPiSession } from "../../agents/pi-embedded.js";
+import {
+  abortEmbeddedPiRun,
+  compactEmbeddedPiSession,
+  runEmbeddedPiAgent,
+} from "../../agents/pi-embedded.js";
 import {
   addSubagentRunForTests,
   listSubagentRunsForRequester,
@@ -1124,6 +1128,10 @@ describe("/models command", () => {
     agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
   } as unknown as OpenClawConfig;
 
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+  });
+
   it.each(["discord", "whatsapp"])("lists providers on %s (text)", async (surface) => {
     const params = buildPolicyParams("/models", cfg, { Provider: surface, Surface: surface });
     const result = await handleCommands(params);
@@ -1259,6 +1267,152 @@ describe("/models command", () => {
     });
 
     expect(result.reply?.text).toContain("localai");
+  });
+
+  it("tests the first configured fallback by default", async () => {
+    vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+      payloads: [{ text: "OK" }],
+      meta: {},
+    } as never);
+
+    const fallbackCfg = {
+      commands: { text: true },
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-5",
+            fallbacks: ["openai/gpt-4.1", "google/gemini-2.0-flash"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await handleCommands(
+      buildPolicyParams("/models test-fallback", fallbackCfg, {
+        Provider: "discord",
+        Surface: "discord",
+      }),
+    );
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain(
+      "Fallback test (primary skipped: anthropic/claude-opus-4-5)",
+    );
+    expect(result.reply?.text).toContain("- openai/gpt-4.1: OK");
+    expect(result.reply?.text).toContain("More: /models test-fallback all");
+    expect(result.reply?.text).not.toContain("google/gemini-2.0-flash");
+    expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4.1",
+        disableTools: true,
+        config: expect.objectContaining({
+          agents: expect.objectContaining({
+            defaults: expect.objectContaining({
+              model: {
+                primary: "openai/gpt-4.1",
+                fallbacks: [],
+              },
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("tests every fallback when /models test-fallback all is used", async () => {
+    vi.mocked(runEmbeddedPiAgent)
+      .mockResolvedValueOnce({
+        payloads: [{ text: "OK" }],
+        meta: {},
+      } as never)
+      .mockRejectedValueOnce(new Error("provider unavailable"));
+
+    const fallbackCfg = {
+      commands: { text: true },
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-5",
+            fallbacks: ["openai/gpt-4.1", "google/gemini-2.0-flash"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await handleCommands(
+      buildPolicyParams("/models test-fallback all", fallbackCfg, {
+        Provider: "discord",
+        Surface: "discord",
+      }),
+    );
+
+    expect(result.reply?.text).toContain("- openai/gpt-4.1: OK");
+    expect(result.reply?.text).toContain("- google/gemini-2.0-flash:");
+    expect(result.reply?.text).toContain("provider unavailable");
+    expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses agent-specific fallback overrides for /models test-fallback", async () => {
+    vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+      payloads: [{ text: "OK" }],
+      meta: {},
+    } as never);
+
+    const scopedCfg = {
+      commands: { text: true },
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-5",
+            fallbacks: ["openai/gpt-4.1"],
+          },
+        },
+        list: [
+          {
+            id: "support",
+            model: {
+              primary: "localai/ultra-chat",
+              fallbacks: ["google/gemini-2.0-flash"],
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const params = buildPolicyParams("/models test-fallback", scopedCfg, {
+      Provider: "discord",
+      Surface: "discord",
+    });
+    const result = await handleCommands({
+      ...params,
+      agentId: "support",
+      sessionKey: "agent:support:main",
+    });
+
+    expect(result.reply?.text).toContain("Fallback test (primary skipped: localai/ultra-chat)");
+    expect(result.reply?.text).toContain("- google/gemini-2.0-flash: OK");
+    expect(result.reply?.text).not.toContain("openai/gpt-4.1");
+    expect(vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        provider: "google",
+        model: "gemini-2.0-flash",
+        config: expect.objectContaining({
+          agents: expect.objectContaining({
+            list: expect.arrayContaining([
+              expect.objectContaining({
+                id: "support",
+                model: {
+                  primary: "google/gemini-2.0-flash",
+                  fallbacks: [],
+                },
+              }),
+            ]),
+          }),
+        }),
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add `/models test-fallback` to proactively verify configured fallback models without waiting for a real primary failure
- default to probing the first fallback and support `/models test-fallback all` for the whole chain
- respect agent-scoped fallback overrides and report per-model success or failure inline

## Testing
- pnpm test src/auto-reply/reply/commands.test.ts
- pnpm build
