### PR TITLE
Gateway: avoid false webchat event gaps on dropped broadcasts

### DIFF
--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -209,6 +209,48 @@ describe("gateway broadcaster", () => {
     expect(approvalsSocket.send).toHaveBeenCalledTimes(1);
     expect(pairingSocket.send).toHaveBeenCalledTimes(1);
   });
+
+  it("does not assign seq numbers to dropIfSlow broadcasts", () => {
+    const fastSocket: TestSocket = {
+      bufferedAmount: 0,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+
+    const clients = new Set<GatewayWsClient>([
+      {
+        socket: fastSocket as unknown as GatewayWsClient["socket"],
+        connect: { role: "operator", scopes: ["operator.admin"] } as GatewayWsClient["connect"],
+        connId: "c-fast",
+      },
+    ]);
+
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("agent", { state: "first" });
+    broadcast("presence", { presence: [] }, { dropIfSlow: true });
+    broadcast("agent", { state: "second" });
+
+    const first = JSON.parse(String(vi.mocked(fastSocket.send).mock.calls[0]?.[0])) as {
+      seq?: number;
+      event?: string;
+    };
+    const second = JSON.parse(String(vi.mocked(fastSocket.send).mock.calls[1]?.[0])) as {
+      seq?: number;
+      event?: string;
+    };
+    const third = JSON.parse(String(vi.mocked(fastSocket.send).mock.calls[2]?.[0])) as {
+      seq?: number;
+      event?: string;
+    };
+
+    expect(first.event).toBe("agent");
+    expect(first.seq).toBe(1);
+    expect(second.event).toBe("presence");
+    expect(second.seq).toBeUndefined();
+    expect(third.event).toBe("agent");
+    expect(third.seq).toBe(2);
+  });
 });
 
 describe("chat run registry", () => {

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -67,7 +67,9 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       return;
     }
     const isTargeted = Boolean(targetConnIds);
-    const eventSeq = isTargeted ? undefined : ++seq;
+    // dropIfSlow events are intentionally lossy, so they must not advance the
+    // global sequence or clients will report false "event gap" errors.
+    const eventSeq = isTargeted || opts?.dropIfSlow ? undefined : ++seq;
     const frame = JSON.stringify({
       type: "event",
       event,

--- a/src/gateway/server.health.test.ts
+++ b/src/gateway/server.health.test.ts
@@ -124,7 +124,7 @@ describe("gateway server health/presence", () => {
   });
 
   test(
-    "presence events carry seq + stateVersion",
+    "presence events carry stateVersion without consuming the reliable seq stream",
     { timeout: PRESENCE_EVENT_TIMEOUT_MS },
     async () => {
       const { ws } = await harness.openClient();
@@ -143,7 +143,7 @@ describe("gateway server health/presence", () => {
       );
 
       const evt = await presenceEventP;
-      expect(typeof evt.seq).toBe("number");
+      expect(evt.seq).toBeUndefined();
       expect(evt.stateVersion?.presence).toBeGreaterThan(0);
       const evtPayload = evt.payload as { presence?: unknown } | undefined;
       expect(Array.isArray(evtPayload?.presence)).toBe(true);
@@ -213,7 +213,7 @@ describe("gateway server health/presence", () => {
       for (const evt of events) {
         const evtPayload = evt.payload as { presence?: unknown[] } | undefined;
         expect(evtPayload?.presence?.length).toBeGreaterThan(0);
-        expect(typeof evt.seq).toBe("number");
+        expect(evt.seq).toBeUndefined();
       }
       for (const { ws } of clients) {
         ws.close();


### PR DESCRIPTION
## Summary
- stop assigning global event `seq` numbers to `dropIfSlow` broadcasts because those events are intentionally lossy
- add broadcaster coverage to ensure lossy events stay unsequenced while reliable events still advance the seq stream
- update gateway health tests to assert presence snapshots rely on `stateVersion` instead of triggering false gap detection

## Testing
- pnpm test src/gateway/gateway-misc.test.ts
- pnpm test src/gateway/server.health.test.ts
- pnpm exec oxfmt --check src/gateway/server-broadcast.ts src/gateway/gateway-misc.test.ts src/gateway/server.health.test.ts
