### PR TITLE
Agents: expose context usage in runtime line

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -882,6 +882,7 @@ export async function runEmbeddedPiAgent(
             disableTools: params.disableTools,
             provider,
             modelId,
+            contextPercent: params.contextPercent,
             model: effectiveModel,
             authProfileId: lastProfileId,
             authProfileIdSource: lockedProfileId ? "user" : "auto",

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -984,6 +984,7 @@ export async function runEmbeddedAttempt(
         node: process.version,
         model: `${params.provider}/${params.modelId}`,
         defaultModel: defaultModelLabel,
+        contextPercent: params.contextPercent,
         shell: detectRuntimeShell(),
         channel: runtimeChannel,
         capabilities: runtimeCapabilities,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -76,6 +76,7 @@ export type RunEmbeddedPiAgentParams = {
   disableTools?: boolean;
   provider?: string;
   model?: string;
+  contextPercent?: number;
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
   thinkLevel?: ThinkLevel;

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -17,6 +17,7 @@ export type RuntimeInfoInput = {
   node: string;
   model: string;
   defaultModel?: string;
+  contextPercent?: number;
   shell?: string;
   channel?: string;
   capabilities?: string[];

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -622,6 +622,7 @@ describe("buildAgentSystemPrompt", () => {
         node: "v20",
         model: "anthropic/claude",
         defaultModel: "anthropic/claude-opus-4-5",
+        contextPercent: 45,
       },
       "telegram",
       ["inlineButtons"],
@@ -635,6 +636,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(line).toContain("node=v20");
     expect(line).toContain("model=anthropic/claude");
     expect(line).toContain("default_model=anthropic/claude-opus-4-5");
+    expect(line).toContain("context=45%");
     expect(line).toContain("channel=telegram");
     expect(line).toContain("capabilities=inlineButtons");
     expect(line).toContain("thinking=low");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -697,6 +697,7 @@ export function buildRuntimeLine(
     node?: string;
     model?: string;
     defaultModel?: string;
+    contextPercent?: number;
     shell?: string;
     repoRoot?: string;
   },
@@ -716,6 +717,7 @@ export function buildRuntimeLine(
     runtimeInfo?.node ? `node=${runtimeInfo.node}` : "",
     runtimeInfo?.model ? `model=${runtimeInfo.model}` : "",
     runtimeInfo?.defaultModel ? `default_model=${runtimeInfo.defaultModel}` : "",
+    typeof runtimeInfo?.contextPercent === "number" ? `context=${runtimeInfo.contextPercent}%` : "",
     runtimeInfo?.shell ? `shell=${runtimeInfo.shell}` : "",
     runtimeChannel ? `channel=${runtimeChannel}` : "",
     runtimeChannel

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -57,6 +57,25 @@ export type RuntimeFallbackAttempt = {
   code?: string;
 };
 
+function resolveRuntimeContextPercent(entry: SessionEntry | undefined): number | undefined {
+  if (!entry || entry.totalTokensFresh === false) {
+    return undefined;
+  }
+  const totalTokens = entry.totalTokens;
+  const contextTokens = entry.contextTokens;
+  if (
+    typeof totalTokens !== "number" ||
+    !Number.isFinite(totalTokens) ||
+    totalTokens < 0 ||
+    typeof contextTokens !== "number" ||
+    !Number.isFinite(contextTokens) ||
+    contextTokens <= 0
+  ) {
+    return undefined;
+  }
+  return Math.max(0, Math.min(999, Math.round((totalTokens / contextTokens) * 100)));
+}
+
 export type AgentRunLoopResult =
   | {
       kind: "success";
@@ -318,6 +337,7 @@ export async function runAgentTurnWithFallback(params: {
             model,
             runId,
             authProfile,
+            contextPercent: resolveRuntimeContextPercent(params.getActiveSessionEntry()),
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
           });
           return (async () => {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -174,6 +174,7 @@ export function buildEmbeddedRunBaseParams(params: {
   model: string;
   runId: string;
   authProfile: ReturnType<typeof resolveProviderScopedAuthProfile>;
+  contextPercent?: number;
   allowTransientCooldownProbe?: boolean;
 }) {
   return {
@@ -188,6 +189,7 @@ export function buildEmbeddedRunBaseParams(params: {
     enforceFinalTag: resolveEnforceFinalTag(params.run, params.provider),
     provider: params.provider,
     model: params.model,
+    contextPercent: params.contextPercent,
     ...params.authProfile,
     thinkLevel: params.run.thinkLevel,
     verboseLevel: params.run.verboseLevel,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -513,6 +513,60 @@ describe("runReplyAgent auto-compaction token update", () => {
     expect(stored[sessionKey].totalTokens).toBe(55_000);
   });
 
+  it("passes fresh context usage percentage into embedded runtime params", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-context-percent-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 45_000,
+      totalTokensFresh: true,
+      contextTokens: 100_000,
+      compactionCount: 0,
+    };
+
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+    });
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-5",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as { contextPercent?: number };
+    expect(call.contextPercent).toBe(45);
+  });
+
   it("does not enqueue legacy post-compaction audit warnings", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-no-audit-warning-"));
     const workspaceDir = path.join(tmp, "workspace");


### PR DESCRIPTION
## Summary
- add `context=X%` to the Runtime line when the session has a fresh `totalTokens/contextTokens` snapshot
- thread the context percentage from the reply runner into embedded run system prompt generation without changing existing token accounting
- cover both runtime line rendering and reply-runner param propagation with tests

## Testing
- pnpm test src/agents/system-prompt.test.ts
- pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
- pnpm exec oxfmt --check src/agents/system-prompt-params.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts src/agents/pi-embedded-runner/run/params.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/attempt.ts src/auto-reply/reply/agent-runner-utils.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
- pnpm build
