### PR TITLE
fix: validate edge tts output file is non-empty before reporting success

### DIFF
--- a/src/tts/edge-tts-validation.test.ts
+++ b/src/tts/edge-tts-validation.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 let mockTtsPromise = vi.fn<(text: string, filePath: string) => Promise<void>>();
 
@@ -25,10 +25,14 @@ const baseEdgeConfig = {
 };
 
 describe("edgeTTS – empty audio validation", () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
 
   it("throws when the output file is 0 bytes", async () => {
-
-    const tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
+    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
     const outputPath = path.join(tempDir, "voice.mp3");
 
     mockTtsPromise = vi.fn(async (_text: string, filePath: string) => {
@@ -43,16 +47,14 @@ describe("edgeTTS – empty audio validation", () => {
         timeoutMs: 10000,
       }),
     ).rejects.toThrow("Edge TTS produced empty audio file");
-
   });
 
   it("succeeds when the output file has content", async () => {
-
-    const tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
+    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
     const outputPath = path.join(tempDir, "voice.mp3");
 
     mockTtsPromise = vi.fn(async (_text: string, filePath: string) => {
-      writeFileSync(filePath, Buffer.from([0xff,0xfb,0x90,0x00]));
+      writeFileSync(filePath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     });
 
     await expect(
@@ -63,7 +65,5 @@ describe("edgeTTS – empty audio validation", () => {
         timeoutMs: 10000,
       }),
     ).resolves.toBeUndefined();
-
   });
-
 });

--- a/src/tts/edge-tts-validation.test.ts
+++ b/src/tts/edge-tts-validation.test.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+let mockTtsPromise = vi.fn<(text: string, filePath: string) => Promise<void>>();
+
+vi.mock("node-edge-tts", () => ({
+  EdgeTTS: class {
+    ttsPromise(text: string, filePath: string) {
+      return mockTtsPromise(text, filePath);
+    }
+  },
+}));
+
+const { edgeTTS } = await import("./tts-core.js");
+
+const baseEdgeConfig = {
+  enabled: true,
+  voice: "en-US-MichelleNeural",
+  lang: "en-US",
+  outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+  outputFormatConfigured: false,
+  saveSubtitles: false,
+};
+
+describe("edgeTTS – empty audio validation", () => {
+
+  it("throws when the output file is 0 bytes", async () => {
+
+    const tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
+    const outputPath = path.join(tempDir, "voice.mp3");
+
+    mockTtsPromise = vi.fn(async (_text: string, filePath: string) => {
+      writeFileSync(filePath, "");
+    });
+
+    await expect(
+      edgeTTS({
+        text: "Hello",
+        outputPath,
+        config: baseEdgeConfig,
+        timeoutMs: 10000,
+      }),
+    ).rejects.toThrow("Edge TTS produced empty audio file");
+
+  });
+
+  it("succeeds when the output file has content", async () => {
+
+    const tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
+    const outputPath = path.join(tempDir, "voice.mp3");
+
+    mockTtsPromise = vi.fn(async (_text: string, filePath: string) => {
+      writeFileSync(filePath, Buffer.from([0xff,0xfb,0x90,0x00]));
+    });
+
+    await expect(
+      edgeTTS({
+        text: "Hello",
+        outputPath,
+        config: baseEdgeConfig,
+        timeoutMs: 10000,
+      }),
+    ).resolves.toBeUndefined();
+
+  });
+
+});

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,4 +1,4 @@
-import { rmSync } from "node:fs";
+import { rmSync, statSync } from "node:fs";
 import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
 import { EdgeTTS } from "node-edge-tts";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
@@ -696,4 +696,10 @@ export async function edgeTTS(params: {
     timeout: config.timeoutMs ?? timeoutMs,
   });
   await tts.ttsPromise(text, outputPath);
+  
+  const { size } = statSync(outputPath);
+
+if (size === 0) {
+  throw new Error("Edge TTS produced empty audio file");
+  }
 }

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -696,10 +696,10 @@ export async function edgeTTS(params: {
     timeout: config.timeoutMs ?? timeoutMs,
   });
   await tts.ttsPromise(text, outputPath);
-  
+
   const { size } = statSync(outputPath);
 
-if (size === 0) {
-  throw new Error("Edge TTS produced empty audio file");
+  if (size === 0) {
+    throw new Error("Edge TTS produced empty audio file");
   }
 }


### PR DESCRIPTION
## Summary

## Summary

- Problem: Edge TTS sometimes resolves successfully but produces a 0-byte MP3 file.
- Why it matters: The system treats this as a valid TTS result and sends empty audio messages (e.g. Telegram voice messages with no sound).
- What changed: Added a statSync file size validation after ttsPromise() resolves. If the file is 0 bytes, an error is thrown so the provider fallback can try another TTS provider.
- What did NOT change (scope boundary): No changes to TTS provider logic, configuration, or external integrations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43229
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

Verified that edgeTTS throws an error when the generated file is empty.
Added unit tests for both empty-file and valid-file cases.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation:
