### PR TITLE
fix(exec): honor ask=off from user config in approval context

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/exec-approvals.js")>();
+  return {
+    ...actual,
+    resolveExecApprovals: vi.fn(),
+  };
+});
+
+import { resolveExecApprovals } from "../infra/exec-approvals.js";
+import { resolveExecHostApprovalContext } from "./bash-tools.exec-host-shared.js";
+
+const resolveExecApprovalsMock = vi.mocked(resolveExecApprovals);
+
+function stubApprovals(overrides: {
+  security?: "deny" | "allowlist" | "full";
+  ask?: "off" | "on-miss" | "always";
+  askFallback?: "deny" | "allowlist" | "full";
+}) {
+  resolveExecApprovalsMock.mockReturnValue({
+    path: "/tmp/exec-approvals.json",
+    socketPath: "/tmp/exec-approvals.sock",
+    token: "",
+    defaults: {
+      security: "allowlist",
+      ask: "on-miss",
+      askFallback: "deny",
+      autoAllowSkills: false,
+    },
+    agent: {
+      security: overrides.security ?? "allowlist",
+      ask: overrides.ask ?? "on-miss",
+      askFallback: overrides.askFallback ?? "deny",
+      autoAllowSkills: false,
+    },
+    allowlist: [],
+    file: { agents: {} },
+  });
+}
+
+describe("resolveExecHostApprovalContext", () => {
+  it("returns ask=off when params.ask is off and agent.ask is on-miss", () => {
+    stubApprovals({ ask: "on-miss" });
+
+    const result = resolveExecHostApprovalContext({
+      security: "allowlist",
+      ask: "off",
+      host: "node",
+    });
+
+    expect(result.hostAsk).toBe("off");
+  });
+
+  it("returns ask=off when agent.ask is off and params.ask is on-miss", () => {
+    stubApprovals({ ask: "off" });
+
+    const result = resolveExecHostApprovalContext({
+      security: "allowlist",
+      ask: "on-miss",
+      host: "node",
+    });
+
+    expect(result.hostAsk).toBe("off");
+  });
+
+  it("returns ask=off when both params.ask and agent.ask are off", () => {
+    stubApprovals({ ask: "off" });
+
+    const result = resolveExecHostApprovalContext({
+      security: "allowlist",
+      ask: "off",
+      host: "node",
+    });
+
+    expect(result.hostAsk).toBe("off");
+  });
+
+  it("returns the stricter ask when neither side is off", () => {
+    stubApprovals({ ask: "always" });
+
+    const result = resolveExecHostApprovalContext({
+      security: "allowlist",
+      ask: "on-miss",
+      host: "gateway",
+    });
+
+    expect(result.hostAsk).toBe("always");
+  });
+
+  it("throws when resolved security is deny", () => {
+    stubApprovals({ security: "deny" });
+
+    expect(() =>
+      resolveExecHostApprovalContext({
+        security: "full",
+        ask: "on-miss",
+        host: "node",
+      }),
+    ).toThrow("exec denied");
+  });
+});

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -35,7 +35,7 @@ function stubApprovals(overrides: {
       autoAllowSkills: false,
     },
     allowlist: [],
-    file: { agents: {} },
+    file: { version: 1, agents: {} },
   });
 }
 

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -133,9 +133,13 @@ export function resolveExecHostApprovalContext(params: {
     ask: params.ask,
   });
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  // An explicit ask=off policy in exec-approvals.json must be able to suppress
-  // prompts even when tool/runtime defaults are stricter (for example on-miss).
-  const hostAsk = approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask);
+  // An explicit ask=off — whether from the user config (params.ask) or from
+  // exec-approvals.json (approvals.agent.ask) — must suppress prompts even when
+  // the other source defaults to a stricter level (e.g. on-miss).
+  const hostAsk =
+    params.ask === "off" || approvals.agent.ask === "off"
+      ? "off"
+      : maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error(`exec denied: host=${params.host} security=deny`);


### PR DESCRIPTION
Fix #43279

## Problem

When users set `tools.exec.ask=off` in their config, the exec approval prompt should be suppressed. However, `resolveExecHostApprovalContext` only checked `approvals.agent.ask` (from `exec-approvals.json`) for the `off` value, ignoring `params.ask` (from user config).

When `exec-approvals.json` had an explicit `ask` value like `on-miss` at the agent or wildcard level, `maxAsk('off', 'on-miss')` returned `'on-miss'`, causing the approval prompt to appear despite the user's explicit opt-out.

## Root Cause

In `resolveExecHostApprovalContext` (`bash-tools.exec-host-shared.ts`):

```ts
// Before (bug): only checks exec-approvals.json side
const hostAsk = approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask);
```

`params.ask` carries the user's config value (`off`), but it was only fed into `maxAsk` — which picks the stricter option — never checked for the short-circuit.

## Fix

```ts
// After: either source's ask=off is authoritative
const hostAsk =
  params.ask === "off" || approvals.agent.ask === "off"
    ? "off"
    : maxAsk(params.ask, approvals.agent.ask);
```

## Validation

Added `bash-tools.exec-host-shared.test.ts` with 5 test cases:
- `params.ask=off` + `agent.ask=on-miss` → `off` ✅ (regression case)
- `agent.ask=off` + `params.ask=on-miss` → `off` ✅ (existing behavior)
- Both `off` → `off` ✅
- Neither `off` → picks stricter ✅
- `security=deny` → throws ✅