### PR TITLE
Agents: teach natural-language model switching

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -97,6 +97,14 @@ function getSessionStatusTool(agentSessionKey = "main") {
 }
 
 describe("session_status tool", () => {
+  it("documents natural-language model switching in the tool description", () => {
+    const tool = getSessionStatusTool();
+
+    expect(tool.description).toContain("switch models in natural language");
+    expect(tool.description).toContain("use local for this");
+    expect(tool.description).toContain("model=<alias or provider/model>");
+  });
+
   it("returns a status card for the current session", async () => {
     resetSessionStore({
       main: {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -428,6 +428,7 @@ describe("buildAgentSystemPrompt", () => {
   it("includes model alias guidance when aliases are provided", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      toolNames: ["session_status"],
       modelAliasLines: [
         "- Opus: anthropic/claude-opus-4-5",
         "- Sonnet: anthropic/claude-sonnet-4-5",
@@ -436,7 +437,21 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("## Model Aliases");
     expect(prompt).toContain("Prefer aliases when specifying model overrides");
+    expect(prompt).toContain(
+      "If the user asks to switch to a local, cheaper, or different model, call session_status with model=<alias or provider/model>; use model=default to reset.",
+    );
     expect(prompt).toContain("- Opus: anthropic/claude-opus-4-5");
+  });
+
+  it("documents natural-language model switching in the session_status tool summary", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["session_status"],
+    });
+
+    expect(prompt).toContain(
+      "- session_status: Show a /status-equivalent status card (usage + time + Reasoning/Verbose/Elevated); use for model-use questions (📊 session_status) and when the user asks to switch this session to another model; set model=<alias or provider/model> for per-session overrides",
+    );
   });
 
   it("adds ClaudeBot self-update guidance when gateway tool is available", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -267,7 +267,7 @@ export function buildAgentSystemPrompt(params: {
       : "Spawn an isolated sub-agent session",
     subagents: "List, steer, or kill sub-agent runs for this requester session",
     session_status:
-      "Show a /status-equivalent status card (usage + time + Reasoning/Verbose/Elevated); use for model-use questions (📊 session_status); optional per-session model override",
+      "Show a /status-equivalent status card (usage + time + Reasoning/Verbose/Elevated); use for model-use questions (📊 session_status) and when the user asks to switch this session to another model; set model=<alias or provider/model> for per-session overrides",
     image: "Analyze an image with the configured image model",
   };
 
@@ -443,7 +443,7 @@ export function buildAgentSystemPrompt(params: {
           "- sessions_history: fetch session history",
           "- sessions_send: send to another session",
           "- subagents: list/steer/kill sub-agent runs",
-          '- session_status: show usage/time/model state and answer "what model are we using?"',
+          '- session_status: show usage/time/model state, answer "what model are we using?", and switch this session to another model when the user asks',
         ].join("\n"),
     "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
     `For long waits, avoid rapid poll loops: use ${execToolName} with enough yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
@@ -499,6 +499,9 @@ export function buildAgentSystemPrompt(params: {
       : "",
     params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal
       ? "Prefer aliases when specifying model overrides; full provider/model is also accepted."
+      : "",
+    params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal
+      ? "If the user asks to switch to a local, cheaper, or different model, call session_status with model=<alias or provider/model>; use model=default to reset."
       : "",
     params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal
       ? params.modelAliasLines.join("\n")

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -180,7 +180,7 @@ export function createSessionStatusTool(opts?: {
     label: "Session Status",
     name: "session_status",
     description:
-      "Show a /status-equivalent session status card (usage + time + cost when available). Use for model-use questions (📊 session_status). Optional: set per-session model override (model=default resets overrides).",
+      'Show a /status-equivalent session status card (usage + time + cost when available). Use for model-use questions (📊 session_status) and when the user asks to switch models in natural language (for example "use local for this"). Set model=<alias or provider/model>; model=default resets overrides.',
     parameters: SessionStatusToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- teach `session_status` that it is the tool to use when the user asks to switch models in natural language
- add explicit system-prompt guidance for requests like "use local for this" or "switch to the cheap model"
- cover the prompt/tool wording with regression tests

## Testing
- pnpm test src/agents/openclaw-tools.session-status.test.ts
- pnpm test src/agents/system-prompt.test.ts
- pnpm exec oxfmt --check src/agents/tools/session-status-tool.ts src/agents/system-prompt.ts src/agents/openclaw-tools.session-status.test.ts src/agents/system-prompt.test.ts

Closes #6717
