### PR TITLE
fix(daemon): use kickstart-first launchd restart path

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -18,6 +18,7 @@ const state = vi.hoisted(() => ({
   listOutput: "",
   printOutput: "",
   bootstrapError: "",
+  kickstartErrors: [] as string[],
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
@@ -48,6 +49,10 @@ vi.mock("./exec-file.js", () => ({
     }
     if (call[0] === "bootstrap" && state.bootstrapError) {
       return { stdout: "", stderr: state.bootstrapError, code: 1 };
+    }
+    if (call[0] === "kickstart" && state.kickstartErrors.length > 0) {
+      const detail = state.kickstartErrors.shift() ?? "";
+      return { stdout: "", stderr: detail, code: 1 };
     }
     return { stdout: "", stderr: "", code: 0 };
   }),
@@ -109,6 +114,7 @@ beforeEach(() => {
   state.listOutput = "";
   state.printOutput = "";
   state.bootstrapError = "";
+  state.kickstartErrors.length = 0;
   state.dirs.clear();
   state.dirModes.clear();
   state.files.clear();
@@ -304,7 +310,7 @@ describe("launchd install", () => {
     expect(state.fileModes.get(plistPath)).toBe(0o644);
   });
 
-  it("restarts LaunchAgent with bootout-enable-bootstrap-kickstart order", async () => {
+  it("restarts LaunchAgent with kickstart only when service is already loaded", async () => {
     const env = createDefaultLaunchdEnv();
     await restartLaunchAgent({
       env,
@@ -313,31 +319,18 @@ describe("launchd install", () => {
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
-    const plistPath = resolveLaunchAgentPlistPath(env);
     const serviceId = `${domain}/${label}`;
-    const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === serviceId,
-    );
-    const enableIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "enable" && c[1] === serviceId,
-    );
-    const bootstrapIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
-    );
     const kickstartIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
 
-    expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-    expect(enableIndex).toBeGreaterThanOrEqual(0);
-    expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
     expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeLessThan(enableIndex);
-    expect(enableIndex).toBeLessThan(bootstrapIndex);
-    expect(bootstrapIndex).toBeLessThan(kickstartIndex);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout")).toBe(false);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootstrap")).toBe(false);
+    expect(state.launchctlCalls.some((c) => c[0] === "enable")).toBe(false);
   });
 
-  it("waits for previous launchd pid to exit before bootstrapping", async () => {
+  it("waits for previous launchd pid to exit after kickstart", async () => {
     const env = createDefaultLaunchdEnv();
     state.printOutput = ["state = running", "pid = 4242"].join("\n");
     const killSpy = vi.spyOn(process, "kill");
@@ -360,17 +353,48 @@ describe("launchd install", () => {
       expect(killSpy).toHaveBeenCalledWith(4242, 0);
       const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
       const label = "ai.openclaw.gateway";
-      const bootoutIndex = state.launchctlCalls.findIndex(
-        (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
+      const kickstartIndex = state.launchctlCalls.findIndex(
+        (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
       );
-      const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
-      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-      expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-      expect(bootoutIndex).toBeLessThan(bootstrapIndex);
+      expect(kickstartIndex).toBeGreaterThanOrEqual(0);
     } finally {
       vi.useRealTimers();
       killSpy.mockRestore();
     }
+  });
+
+  it("falls back to enable+bootstrap when kickstart reports service is not loaded", async () => {
+    const env = createDefaultLaunchdEnv();
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const serviceId = `${domain}/${label}`;
+    state.kickstartErrors.push("Could not find service");
+
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    const firstKickstartIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
+    );
+    const enableIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "enable" && c[1] === serviceId,
+    );
+    const bootstrapIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
+    );
+    const kickstartIndexes = state.launchctlCalls
+      .map((c, idx) => (c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId ? idx : -1))
+      .filter((idx) => idx >= 0);
+    const secondKickstartIndex = kickstartIndexes[kickstartIndexes.length - 1] ?? -1;
+
+    expect(firstKickstartIndex).toBeGreaterThanOrEqual(0);
+    expect(enableIndex).toBeGreaterThan(firstKickstartIndex);
+    expect(bootstrapIndex).toBeGreaterThan(enableIndex);
+    expect(secondKickstartIndex).toBeGreaterThan(bootstrapIndex);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout")).toBe(false);
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -483,37 +483,38 @@ export async function restartLaunchAgent({
       ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
       : undefined;
 
-  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
-  if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
-    throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
+  let start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
+  if (start.code !== 0) {
+    if (!isLaunchctlNotLoaded(start)) {
+      throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
+    }
+
+    // If the service isn't currently loaded, re-register it and retry kickstart.
+    await execLaunchctl(["enable", `${domain}/${label}`]);
+    const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
+    if (boot.code !== 0) {
+      const detail = (boot.stderr || boot.stdout).trim();
+      if (isUnsupportedGuiDomain(detail)) {
+        throw new Error(
+          [
+            `launchctl bootstrap failed: ${detail}`,
+            `LaunchAgent restart requires a logged-in macOS GUI session for this user (${domain}).`,
+            "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
+            "Fix: sign in to the macOS desktop as the target user and rerun `openclaw gateway restart`.",
+            "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
+          ].join("\n"),
+        );
+      }
+      throw new Error(`launchctl bootstrap failed: ${detail}`);
+    }
+
+    start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
+    if (start.code !== 0) {
+      throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
+    }
   }
   if (typeof previousPid === "number") {
     await waitForPidExit(previousPid);
-  }
-
-  // launchd can persist "disabled" state after bootout; clear it before bootstrap
-  // (matches the same guard in installLaunchAgent).
-  await execLaunchctl(["enable", `${domain}/${label}`]);
-  const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
-  if (boot.code !== 0) {
-    const detail = (boot.stderr || boot.stdout).trim();
-    if (isUnsupportedGuiDomain(detail)) {
-      throw new Error(
-        [
-          `launchctl bootstrap failed: ${detail}`,
-          `LaunchAgent restart requires a logged-in macOS GUI session for this user (${domain}).`,
-          "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
-          "Fix: sign in to the macOS desktop as the target user and rerun `openclaw gateway restart`.",
-          "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
-        ].join("\n"),
-      );
-    }
-    throw new Error(`launchctl bootstrap failed: ${detail}`);
-  }
-
-  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
-  if (start.code !== 0) {
-    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
   }
   try {
     stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw gateway restart` used `launchctl bootout` first on macOS, which unloads the LaunchAgent and can leave the gateway down when restart is triggered from inside the running gateway process.
- Why it matters: users can lose all channel connectivity until manual reinstall/rebootstrap.
- What changed: switch restart to a kickstart-first path (`launchctl kickstart -k`) that keeps the service registered, with fallback handling retained for robustness; updated launchd tests to cover successful restart, kickstart failures, and fallback behavior.
- What did NOT change (scope boundary): no changes to non-launchd restart paths or non-macOS service managers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43311
- Related #

## User-visible / Behavior Changes

On macOS LaunchAgent installs, `openclaw gateway restart` now uses a kickstart-first restart path that avoids unloading the service definition, reducing cases where restart leaves the gateway down.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 10 (test runner)
- Runtime/container: Node.js + Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm vitest run src/daemon/launchd.test.ts`.
2. Verify restart-path tests pass, including kickstart and fallback branches.

### Expected

- Launchd restart keeps service registration and executes restart flow without requiring manual re-install.

### Actual

- Updated tests pass and cover the kickstart-first logic plus fallback behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: launchd restart unit-test suite passes with kickstart-first path and fallback cases.
- Edge cases checked: kickstart command failure handling and restart fallback branch behavior.
- What you did **not** verify: end-to-end restart on a live macOS LaunchAgent host in this run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore prior restart behavior.
- Files/config to restore: `src/daemon/launchd.ts`, `src/daemon/launchd.test.ts`.
- Known bad symptoms reviewers should watch for: launchd restart errors on macOS if kickstart invocation semantics change.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: macOS launchctl variants might differ in `kickstart -k` behavior.
  - Mitigation: fallback path remains tested; launchd tests now explicitly cover kickstart and fallback flows.

AI-assisted: yes (prepared with coding assistant support; manually reviewed and validated).