### PR TITLE
Web: enable WhatsApp link previews

### DIFF
--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -71,7 +71,10 @@ describe("web session", () => {
     await createWaSocket(true, false);
     const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
     expect(makeWASocket).toHaveBeenCalledWith(
-      expect.objectContaining({ printQRInTerminal: false }),
+      expect.objectContaining({
+        printQRInTerminal: false,
+        generateHighQualityLinkPreview: true,
+      }),
     );
     const passed = makeWASocket.mock.calls[0][0];
     const passedLogger = (passed as { logger?: { level?: string; trace?: unknown } }).logger;

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -116,6 +116,7 @@ export async function createWaSocket(
     browser: ["openclaw", "cli", VERSION],
     syncFullHistory: false,
     markOnlineOnConnect: false,
+    generateHighQualityLinkPreview: true,
   });
 
   sock.ev.on("creds.update", () => enqueueSaveCreds(authDir, saveCreds, sessionLogger));


### PR DESCRIPTION
## Summary
- enable Baileys high-quality link previews for WhatsApp sessions
- keep the change localized to socket initialization so outbound URL messages can render previews without extra user config
- cover the new socket option in the existing session test

## Testing
- pnpm test src/web/session.test.ts
- pnpm exec oxfmt --check src/web/session.ts src/web/session.test.ts

Closes #6722
