### PR TITLE
fix(cli-runner): validate session ID format in pickSessionId

### DIFF
--- a/src/agents/cli-runner/helpers.test.ts
+++ b/src/agents/cli-runner/helpers.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { CliBackendConfig } from "../../config/types.js";
+import { parseCliJson, parseCliJsonl } from "./helpers.js";
+
+const DEFAULT_BACKEND = {} as CliBackendConfig;
+
+describe("parseCliJson", () => {
+  it("accepts a valid UUID session_id", () => {
+    const raw = JSON.stringify({
+      session_id: "550e8400-e29b-41d4-a716-446655440000",
+      result: "hello",
+    });
+    const out = parseCliJson(raw, DEFAULT_BACKEND);
+    expect(out?.sessionId).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("rejects error sentinel 'rate-limited' as session_id", () => {
+    const raw = JSON.stringify({
+      session_id: "rate-limited",
+      result: "hello",
+    });
+    const out = parseCliJson(raw, DEFAULT_BACKEND);
+    expect(out?.sessionId).toBeUndefined();
+  });
+
+  it("rejects short error sentinels like 'error' and 'none'", () => {
+    for (const sentinel of ["error", "none", "null", "false"]) {
+      const raw = JSON.stringify({ session_id: sentinel, result: "hi" });
+      const out = parseCliJson(raw, DEFAULT_BACKEND);
+      expect(out?.sessionId).toBeUndefined();
+    }
+  });
+
+  it("rejects sentinels with no digits like 'rate-limited'", () => {
+    const raw = JSON.stringify({
+      session_id: "rate-limited",
+      result: "hello",
+    });
+    const out = parseCliJson(raw, DEFAULT_BACKEND);
+    expect(out?.sessionId).toBeUndefined();
+  });
+
+  it("accepts OpenAI-style thread IDs via sessionIdFields", () => {
+    const backend = {
+      sessionIdFields: ["thread_id"],
+    } as CliBackendConfig;
+    const raw = JSON.stringify({
+      thread_id: "thread_01abc2def345",
+      result: "hello",
+    });
+    const out = parseCliJson(raw, backend);
+    expect(out?.sessionId).toBe("thread_01abc2def345");
+  });
+
+  it("still parses text when session_id is rejected", () => {
+    const raw = JSON.stringify({
+      session_id: "rate-limited",
+      result: "the response text",
+    });
+    const out = parseCliJson(raw, DEFAULT_BACKEND);
+    expect(out?.text).toBe("the response text");
+    expect(out?.sessionId).toBeUndefined();
+  });
+});
+
+describe("parseCliJsonl", () => {
+  it("rejects error sentinel in thread_id fallback", () => {
+    const raw = JSON.stringify({
+      thread_id: "rate-limited",
+      item: { type: "message", text: "hello" },
+    });
+    const out = parseCliJsonl(raw, DEFAULT_BACKEND);
+    expect(out?.sessionId).toBeUndefined();
+  });
+
+  it("accepts valid thread_id in fallback path", () => {
+    const raw = JSON.stringify({
+      thread_id: "thread_01abc2def345",
+      item: { type: "message", text: "hello" },
+    });
+    const out = parseCliJsonl(raw, DEFAULT_BACKEND);
+    expect(out?.sessionId).toBe("thread_01abc2def345");
+  });
+});

--- a/src/agents/cli-runner/helpers.test.ts
+++ b/src/agents/cli-runner/helpers.test.ts
@@ -31,13 +31,12 @@ describe("parseCliJson", () => {
     }
   });
 
-  it("rejects sentinels with no digits like 'rate-limited'", () => {
-    const raw = JSON.stringify({
-      session_id: "rate-limited",
-      result: "hello",
-    });
-    const out = parseCliJson(raw, DEFAULT_BACKEND);
-    expect(out?.sessionId).toBeUndefined();
+  it("rejects long sentinels with no digits", () => {
+    for (const sentinel of ["blocked-now", "forbidden-access", "unavailable"]) {
+      const raw = JSON.stringify({ session_id: sentinel, result: "hi" });
+      const out = parseCliJson(raw, DEFAULT_BACKEND);
+      expect(out?.sessionId).toBeUndefined();
+    }
   });
 
   it("accepts OpenAI-style thread IDs via sessionIdFields", () => {

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -162,6 +162,11 @@ function collectText(value: unknown): string {
  * Real session IDs (UUIDs, thread IDs, etc.) are structured identifiers that
  * contain at least one digit and are at least 8 characters long. Error
  * sentinels like "rate-limited", "error", or "none" fail this check.
+ *
+ * Note: this heuristic is intentionally simple. Error sentinels that happen to
+ * contain a digit (e.g. "rate-limited-2", "error-404") would still pass.
+ * If a backend is known to emit such values, a stricter pattern (e.g. UUID
+ * or prefix validation) should be added via sessionIdFields config.
  */
 function looksLikeSessionId(value: string): boolean {
   return value.length >= 8 && /\d/.test(value);

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -158,6 +158,15 @@ function collectText(value: unknown): string {
   return "";
 }
 
+/**
+ * Real session IDs (UUIDs, thread IDs, etc.) are structured identifiers that
+ * contain at least one digit and are at least 8 characters long. Error
+ * sentinels like "rate-limited", "error", or "none" fail this check.
+ */
+function looksLikeSessionId(value: string): boolean {
+  return value.length >= 8 && /\d/.test(value);
+}
+
 function pickSessionId(
   parsed: Record<string, unknown>,
   backend: CliBackendConfig,
@@ -171,7 +180,10 @@ function pickSessionId(
   for (const field of fields) {
     const value = parsed[field];
     if (typeof value === "string" && value.trim()) {
-      return value.trim();
+      const trimmed = value.trim();
+      if (looksLikeSessionId(trimmed)) {
+        return trimmed;
+      }
     }
   }
   return undefined;
@@ -226,7 +238,10 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
       sessionId = pickSessionId(parsed, backend);
     }
     if (!sessionId && typeof parsed.thread_id === "string") {
-      sessionId = parsed.thread_id.trim();
+      const tid = parsed.thread_id.trim();
+      if (looksLikeSessionId(tid)) {
+        sessionId = tid;
+      }
     }
     if (isRecord(parsed.usage)) {
       usage = toUsage(parsed.usage) ?? usage;


### PR DESCRIPTION
Fixes #43288

## Summary

`pickSessionId()` accepts any non-empty string as a session ID without validation. When a CLI backend returns an error sentinel like `"session_id": "rate-limited"`, this value gets persisted and later passed to `--resume "rate-limited"`, crashing the agent.

## Changes

- Added `looksLikeSessionId()` helper that requires values to be at least 8 characters and contain at least one digit - real session IDs (UUIDs, thread IDs) always meet this, while error sentinels like "rate-limited", "error", "none" do not
- Applied the validation in `pickSessionId()` and in the `thread_id` fallback path in `parseCliJsonl()`
- Added test coverage for both valid and invalid session ID values

## Test plan

- `pnpm test -- src/agents/cli-runner/helpers.test.ts` - 8 tests pass
- `pnpm check` - passes

This contribution was developed with AI assistance (Claude Code).