### PR TITLE
Agents: add session_status compact action

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+const compactEmbeddedPiSessionDirectMock = vi.fn();
 const loadSessionStoreMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
 
@@ -76,10 +77,16 @@ vi.mock("../infra/provider-usage.js", () => ({
   formatUsageSummaryLine: () => null,
 }));
 
+vi.mock("../agents/pi-embedded-runner/compact.runtime.js", () => ({
+  compactEmbeddedPiSessionDirect: (...args: unknown[]) =>
+    compactEmbeddedPiSessionDirectMock(...args),
+}));
+
 import "./test-helpers/fast-core-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 
 function resetSessionStore(store: Record<string, unknown>) {
+  compactEmbeddedPiSessionDirectMock.mockReset();
   loadSessionStoreMock.mockClear();
   updateSessionStoreMock.mockClear();
   loadSessionStoreMock.mockReturnValue(store);
@@ -97,6 +104,51 @@ function getSessionStatusTool(agentSessionKey = "main") {
 }
 
 describe("session_status tool", () => {
+  it("can self-compact the current session via action=compact", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+        totalTokens: 12_345,
+        totalTokensFresh: true,
+        contextTokens: 64_000,
+      },
+    });
+    compactEmbeddedPiSessionDirectMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "done",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 12_345,
+        tokensAfter: 4_096,
+      },
+    });
+
+    const tool = getSessionStatusTool();
+    const result = await tool.execute("call-compact", { action: "compact" });
+    const details = result.details as { ok?: boolean; compacted?: boolean; statusText?: string };
+
+    expect(compactEmbeddedPiSessionDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "s1",
+        sessionKey: "main",
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        trigger: "manual",
+      }),
+    );
+    expect(details.ok).toBe(true);
+    expect(details.compacted).toBe(true);
+    expect(details.statusText).toContain("Compacted (12345 -> 4096)");
+    const [, savedStore] = updateSessionStoreMock.mock.calls.at(-1) as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(savedStore.main?.compactionCount).toBe(1);
+    expect(savedStore.main?.totalTokens).toBe(4096);
+  });
+
   it("returns a status card for the current session", async () => {
     resetSessionStore({
       main: {

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -16,6 +16,12 @@ describe("tool mutation helpers", () => {
         model: "openai/gpt-4o",
       }),
     ).toBe(true);
+    expect(
+      isMutatingToolCall("session_status", {
+        sessionKey: "agent:main:main",
+        action: "compact",
+      }),
+    ).toBe(true);
   });
 
   it("builds stable fingerprints for mutating calls and omits read-only calls", () => {

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -117,7 +117,10 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
         typeof record?.message === "string"
       );
     case "session_status":
-      return typeof record?.model === "string" && record.model.trim().length > 0;
+      return (
+        (typeof record?.model === "string" && record.model.trim().length > 0) ||
+        action === "compact"
+      );
     default: {
       if (normalized === "cron" || normalized === "gateway" || normalized === "canvas") {
         return action == null || !READ_ONLY_ACTIONS.has(action);

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -1,11 +1,15 @@
 import { Type } from "@sinclair/typebox";
 import { normalizeGroupActivation } from "../../auto-reply/group-activation.js";
 import { getFollowupQueueDepth, resolveQueueSettings } from "../../auto-reply/reply/queue.js";
-import { buildStatusMessage } from "../../auto-reply/status.js";
+import { incrementCompactionCount } from "../../auto-reply/reply/session-updates.js";
+import { buildStatusMessage, formatContextUsageShort } from "../../auto-reply/status.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import {
   loadSessionStore,
+  resolveFreshSessionTotalTokens,
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
   resolveStorePath,
   type SessionEntry,
   updateSessionStore,
@@ -22,7 +26,7 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
-import { resolveAgentDir } from "../agent-scope.js";
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agent-scope.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { resolveModelAuthLabel } from "../model-auth-label.js";
 import { loadModelCatalog } from "../model-catalog.js";
@@ -33,6 +37,7 @@ import {
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
 } from "../model-selection.js";
+import { compactEmbeddedPiSessionDirect } from "../pi-embedded-runner/compact.runtime.js";
 import type { AnyAgentTool } from "./common.js";
 import { readStringParam } from "./common.js";
 import {
@@ -43,6 +48,8 @@ import {
 } from "./sessions-helpers.js";
 
 const SessionStatusToolSchema = Type.Object({
+  action: Type.Optional(Type.String()),
+  instructions: Type.Optional(Type.String()),
   sessionKey: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
 });
@@ -180,7 +187,7 @@ export function createSessionStatusTool(opts?: {
     label: "Session Status",
     name: "session_status",
     description:
-      "Show a /status-equivalent session status card (usage + time + cost when available). Use for model-use questions (📊 session_status). Optional: set per-session model override (model=default resets overrides).",
+      "Show a /status-equivalent session status card (usage + time + cost when available). Use for model-use questions (📊 session_status). Optional: set per-session model override (model=default resets overrides), or run self-compaction with action=compact.",
     parameters: SessionStatusToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -259,7 +266,14 @@ export function createSessionStatusTool(opts?: {
       }
 
       const configured = resolveDefaultModelForAgent({ cfg, agentId });
+      const actionRaw = readStringParam(params, "action")?.trim().toLowerCase();
+      if (actionRaw && actionRaw !== "compact") {
+        throw new Error(`Unsupported action "${actionRaw}".`);
+      }
       const modelRaw = readStringParam(params, "model");
+      if (actionRaw === "compact" && typeof modelRaw === "string" && modelRaw.trim().length > 0) {
+        throw new Error('session_status(action="compact") cannot be combined with model=');
+      }
       let changedModel = false;
       if (typeof modelRaw === "string") {
         const selection = await resolveModelOverride({
@@ -292,6 +306,80 @@ export function createSessionStatusTool(opts?: {
           resolved.entry = nextEntry;
           changedModel = true;
         }
+      }
+
+      if (actionRaw === "compact") {
+        if (!resolved.entry.sessionId) {
+          throw new Error("Compaction unavailable (missing session id).");
+        }
+        const providerForRun = resolved.entry.providerOverride?.trim() || configured.provider;
+        const modelForRun = resolved.entry.modelOverride?.trim() || configured.model;
+        const result = await compactEmbeddedPiSessionDirect({
+          sessionId: resolved.entry.sessionId,
+          sessionKey: resolved.key,
+          messageChannel: resolved.entry.channel ?? resolved.entry.lastChannel,
+          agentAccountId: resolved.entry.accountId,
+          authProfileId: resolved.entry.authProfileOverride,
+          groupId: resolved.entry.groupId,
+          groupChannel: resolved.entry.groupChannel,
+          groupSpace: resolved.entry.space,
+          spawnedBy: resolved.entry.spawnedBy,
+          senderIsOwner: false,
+          sessionFile: resolveSessionFilePath(
+            resolved.entry.sessionId,
+            resolved.entry,
+            resolveSessionFilePathOptions({ agentId, storePath }),
+          ),
+          workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+          agentDir: resolveAgentDir(cfg, agentId),
+          config: cfg,
+          skillsSnapshot: resolved.entry.skillsSnapshot,
+          provider: providerForRun,
+          model: modelForRun,
+          customInstructions: readStringParam(params, "instructions"),
+          trigger: "manual",
+        });
+
+        if (result.ok && result.compacted) {
+          await incrementCompactionCount({
+            sessionEntry: resolved.entry,
+            sessionStore: store,
+            sessionKey: resolved.key,
+            storePath,
+            tokensAfter: result.result?.tokensAfter,
+          });
+          resolved.entry = store[resolved.key] ?? resolved.entry;
+        }
+
+        const compactLabel = result.ok
+          ? result.compacted
+            ? result.result?.tokensBefore != null && result.result?.tokensAfter != null
+              ? `Compacted (${result.result.tokensBefore} -> ${result.result.tokensAfter})`
+              : result.result?.tokensBefore
+                ? `Compacted (${result.result.tokensBefore} before)`
+                : "Compacted"
+            : "Compaction skipped"
+          : "Compaction failed";
+        const totalTokens =
+          result.result?.tokensAfter ?? resolveFreshSessionTotalTokens(resolved.entry);
+        const contextSummary = formatContextUsageShort(
+          typeof totalTokens === "number" && totalTokens > 0 ? totalTokens : null,
+          resolved.entry.contextTokens ?? null,
+        );
+        const reason = result.reason?.trim();
+        const statusText = reason
+          ? `${compactLabel}: ${reason} • ${contextSummary}`
+          : `${compactLabel} • ${contextSummary}`;
+        return {
+          content: [{ type: "text", text: statusText }],
+          details: {
+            ok: result.ok,
+            compacted: result.compacted,
+            reason: result.reason,
+            sessionKey: resolved.key,
+            statusText,
+          },
+        };
       }
 
       const agentDir = resolveAgentDir(cfg, agentId);


### PR DESCRIPTION
## Summary
- add `session_status(action="compact")` so agents can trigger self-compaction inside the current run without relying on `/compact`
- route that path through direct compaction to avoid lane deadlocks, and persist compaction counters/token snapshots after a successful run
- mark the new action as mutating and cover it with focused tests

## Testing
- pnpm test src/agents/openclaw-tools.session-status.test.ts
- pnpm test src/agents/tool-mutation.test.ts
- pnpm exec oxfmt --check src/agents/tools/session-status-tool.ts src/agents/tool-mutation.ts src/agents/tool-mutation.test.ts src/agents/openclaw-tools.session-status.test.ts

Closes #6757
