### PR TITLE
fix(agents): rephrase session reset prompt to avoid Azure content filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/session reset: preserve `lastAccountId` and `lastThreadId` across gateway session resets so replies keep routing back to the same account and thread after `/reset`. (#44773) Thanks @Lanfei.
 - Agents/memory bootstrap: load only one root memory file, preferring `MEMORY.md` and using `memory.md` as a fallback, so case-insensitive Docker mounts no longer inject duplicate memory context. (#26054) Thanks @Lanfei.
 - Agents/OpenAI-compatible compat overrides: respect explicit user `models[].compat` opt-ins for non-native `openai-completions` endpoints so usage-in-streaming capability overrides no longer get forced off when the endpoint actually supports them. (#44432) Thanks @cheapestinference.
+- Agents/Azure OpenAI startup prompts: rephrase the built-in `/new`, `/reset`, and post-compaction startup instruction so Azure OpenAI deployments no longer hit HTTP 400 false positives from the content filter. (#43403) Thanks @xingsy97.
 
 ## 2026.3.12
 

--- a/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
@@ -363,7 +363,7 @@ export async function runGreetingPromptForBareNewOrReset(params: {
   expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
   const prompt = runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0]?.prompt ?? "";
   expect(prompt).toContain("A new session was started via /new or /reset");
-  expect(prompt).toContain("Execute your Session Startup sequence now");
+  expect(prompt).toContain("Run your Session Startup sequence");
 }
 
 export function installTriggerHandlingE2eTestHooks() {

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -332,7 +332,7 @@ Read WORKFLOW.md on startup.
       fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
       const result = await readPostCompactionContext(tmpDir);
       expect(result).not.toBeNull();
-      expect(result).toContain("Execute your Session Startup sequence now");
+      expect(result).toContain("Run your Session Startup sequence");
     });
 
     it("falls back to legacy sections when defaults are explicitly configured", async () => {
@@ -368,7 +368,7 @@ Read WORKFLOW.md on startup.
       expect(result).not.toBeNull();
       expect(result).toContain("Do startup things");
       expect(result).toContain("Be safe");
-      expect(result).toContain("Execute your Session Startup sequence now");
+      expect(result).toContain("Run your Session Startup sequence");
     });
 
     it("custom section names are matched case-insensitively", async () => {

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -136,7 +136,7 @@ export async function readPostCompactionContext(
     // would be misleading for deployments that use different section names.
     const prose = isDefaultSections
       ? "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
-        "Execute your Session Startup sequence now — read the required files before responding to the user."
+        "Run your Session Startup sequence — read the required files before responding to the user."
       : `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
         `Re-read the sections injected below (${displayNames.join(", ")}) and follow your configured startup procedure before responding to the user.`;
 

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -5,7 +5,7 @@ import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
 describe("buildBareSessionResetPrompt", () => {
   it("includes the core session startup instruction", () => {
     const prompt = buildBareSessionResetPrompt();
-    expect(prompt).toContain("Execute your Session Startup sequence now");
+    expect(prompt).toContain("Run your Session Startup sequence");
     expect(prompt).toContain("read the required files before responding to the user");
   });
 

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -2,7 +2,7 @@ import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
 
 const BARE_SESSION_RESET_PROMPT_BASE =
-  "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+  "A new session was started via /new or /reset. Run your Session Startup sequence - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
 
 /**
  * Build the bare session reset prompt, appending the current date/time so agents

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -582,7 +582,7 @@ describe("gateway agent handler", () => {
     expect(mocks.performGatewaySessionReset).toHaveBeenCalledTimes(1);
     const call = readLastAgentCommandCall();
     // Message is now dynamically built with current date — check key substrings
-    expect(call?.message).toContain("Execute your Session Startup sequence now");
+    expect(call?.message).toContain("Run your Session Startup sequence");
     expect(call?.message).toContain("Current time:");
     expect(call?.message).not.toBe(BARE_SESSION_RESET_PROMPT);
     expect(call?.sessionId).toBe("reset-session-id");

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -287,7 +287,7 @@ describe("gateway server agent", () => {
     await vi.waitFor(() => expect(calls.length).toBeGreaterThan(callsBefore));
     const call = (calls.at(-1)?.[0] ?? {}) as Record<string, unknown>;
     expect(call.message).toBeTypeOf("string");
-    expect(call.message).toContain("Execute your Session Startup sequence now");
+    expect(call.message).toContain("Run your Session Startup sequence");
     expect(call.message).toContain("Current time:");
     expect(typeof call.sessionId).toBe("string");
     expect(call.sessionId).not.toBe("sess-main-before-reset");


### PR DESCRIPTION
## Problem

Azure OpenAI content filter flags the phrase `Execute your Session Startup sequence now` as potentially harmful, causing `/new` and `/reset` to return HTTP 400 for all Azure-hosted deployments.

## Root Cause

The word "Execute" combined with the imperative "now" triggers Azure's content safety filter. This affects two prompt strings:
- `session-reset-prompt.ts` — the bare session reset prompt sent on `/new` and `/reset`
- `post-compaction-context.ts` — the post-compaction reinit instruction

## Fix

Replace `Execute your Session Startup sequence now` with `Run your Session Startup sequence`. Semantics identical, avoids the false-positive.

## Validation

All 28 affected tests updated and passing.

Closes #42769