### PR TITLE
fix(agents): suppress missing tool warning for known core tools

### DIFF
--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -9,6 +9,8 @@ import {
   isOwnerOnlyToolName,
   normalizeToolName,
   resolveToolProfilePolicy,
+  stripPluginOnlyAllowlist,
+  type PluginToolGroups,
   TOOL_GROUPS,
 } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -223,5 +225,31 @@ describe("resolveSandboxToolPolicyForAgent", () => {
     const resolved = resolveSandboxToolPolicyForAgent(cfg, undefined);
     expect(resolved.allow).toEqual(["read"]);
     expect(resolved.deny).toEqual(["image"]);
+  });
+});
+
+describe("stripPluginOnlyAllowlist", () => {
+  const emptyPlugins: PluginToolGroups = {
+    all: [],
+    byPlugin: new Map(),
+  };
+
+  it("adds unknown tools to unknownAllowlist and sets strippedAllowlist=true if no core tools present", () => {
+    const policy = { allow: ["random_tool"] };
+    const result = stripPluginOnlyAllowlist(policy, emptyPlugins, new Set(["read"]));
+    expect(result.unknownAllowlist).toEqual(["random_tool"]);
+    expect(result.strippedAllowlist).toBe(true);
+  });
+
+  it("handles cases where a known core tool is requested but omitted from active coreTools", () => {
+    // "apply_patch" is a known core tool but is not in the active set here
+    const policy = { allow: ["apply_patch"] };
+    const result = stripPluginOnlyAllowlist(policy, emptyPlugins, new Set(["read", "write"]));
+
+    // The known core tool should NOT be flagged as unknown
+    expect(result.unknownAllowlist).toEqual([]);
+
+    // The known core tool should count as a core entry, so the allowlist shouldn't be stripped
+    expect(result.strippedAllowlist).toBe(false);
   });
 });

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -1,3 +1,4 @@
+import { isKnownCoreToolId } from "./tool-catalog.js";
 import {
   expandToolGroups,
   normalizeToolList,
@@ -6,6 +7,7 @@ import {
   TOOL_GROUPS,
 } from "./tool-policy-shared.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
 export {
   expandToolGroups,
   normalizeToolList,
@@ -13,7 +15,6 @@ export {
   resolveToolProfilePolicy,
   TOOL_GROUPS,
 } from "./tool-policy-shared.js";
-import { isKnownCoreToolId } from "./tool-catalog.js";
 export type { ToolProfileId } from "./tool-policy-shared.js";
 
 // Keep tool-policy browser-safe: do not import tools/common at runtime.
@@ -179,10 +180,12 @@ export function stripPluginOnlyAllowlist(
       entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry);
     const expanded = expandToolGroups([entry]);
     const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
-    if (isCoreEntry) {
+    const isKnownCoreEntry = expanded.some((tool) => isKnownCoreToolId(tool));
+
+    if (isCoreEntry || isKnownCoreEntry) {
       hasCoreEntry = true;
     }
-    const isKnownCoreEntry = expanded.some((tool) => isKnownCoreToolId(tool));
+
     if (!isCoreEntry && !isPluginEntry && !isKnownCoreEntry) {
       unknownAllowlist.push(entry);
     }

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -13,6 +13,7 @@ export {
   resolveToolProfilePolicy,
   TOOL_GROUPS,
 } from "./tool-policy-shared.js";
+import { isKnownCoreToolId } from "./tool-catalog.js";
 export type { ToolProfileId } from "./tool-policy-shared.js";
 
 // Keep tool-policy browser-safe: do not import tools/common at runtime.
@@ -181,7 +182,8 @@ export function stripPluginOnlyAllowlist(
     if (isCoreEntry) {
       hasCoreEntry = true;
     }
-    if (!isCoreEntry && !isPluginEntry) {
+    const isKnownCoreEntry = expanded.some((tool) => isKnownCoreToolId(tool));
+    if (!isCoreEntry && !isPluginEntry && !isKnownCoreEntry) {
       unknownAllowlist.push(entry);
     }
   }


### PR DESCRIPTION
When a tools profile (like `coding`) requests a core tool (like `apply_patch` or `image`) but the active model/agent context naturally omits it because it lacks support, OpenClaw warns the user about unknown entries in the allowlist. This PR updates  to recognize omitted known core tools as expected behavior and quietly suppresses the false warning.