### PR TITLE
fix(message-tool): use runtime-resolved config for SecretRef credentials

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -14,6 +14,7 @@ import {
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
+import { getRuntimeConfigSnapshot } from "../../config/io.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../gateway/protocol/client-info.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
@@ -704,7 +705,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         }
       }
 
-      const cfg = options?.config ?? loadConfig();
+      const cfg = options?.config ?? getRuntimeConfigSnapshot() ?? loadConfig();
       const action = readStringParam(params, "action", {
         required: true,
       }) as ChannelMessageActionName;


### PR DESCRIPTION
## Problem

The message tool fails to send proactive messages when channel credentials (e.g. Telegram botToken) are stored as SecretRefs (#42848).

Normal inbound message flow works because the gateway resolves SecretRefs at boot and passes the resolved config through the auto-reply chain. But the message tool loads raw config via `loadConfig()`, which contains unresolved SecretRef objects.

## Root Cause

In `message-tool.ts`:
```ts
const cfg = options?.config ?? loadConfig(); // raw config with unresolved SecretRefs
```

This raw config flows through `runMessageAction` -> channel plugin -> `resolveTelegramToken` -> `normalizeResolvedSecretInputString` which throws on unresolved SecretRef objects.

## Fix

```ts
const cfg = options?.config ?? getRuntimeConfigSnapshot() ?? loadConfig();
```

Prefer the runtime-resolved config snapshot (which has SecretRefs evaluated) and only fall back to raw `loadConfig()` when no runtime snapshot is available.

Closes #42848