### PR TITLE
feat: add GigaChat (Sber) provider

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -123,6 +123,21 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
   - Note: you do **not** paste a client id or secret into `openclaw.json`. The CLI login flow stores
     tokens in auth profiles on the gateway host.
 
+### GigaChat (Sber)
+
+- Provider: `gigachat`
+- Auth: `GIGACHAT_CREDENTIALS` (base64-encoded `ClientId:ClientSecret` from Sber Studio, **preferred**) or `GIGACHAT_API_KEY` (pre-obtained access token)
+- Example models: `gigachat/GigaChat`, `gigachat/GigaChat-Pro`, `gigachat/GigaChat-Max`
+- Base URL: `https://gigachat.devices.sberbank.ru/api/v1`
+- Note: tool-use (function calling) is **not supported** — GigaChat uses a legacy `functions` schema incompatible with the OpenAI `tools` format. Use for conversational tasks only.
+- See [/providers/gigachat](/providers/gigachat) for full setup, scope, and SSL notes.
+
+```json5
+{
+  agents: { defaults: { model: { primary: "gigachat/GigaChat-Max" } } },
+}
+```
+
 ### Z.AI (GLM)
 
 - Provider: `zai`

--- a/docs/providers/gigachat.md
+++ b/docs/providers/gigachat.md
@@ -1,0 +1,132 @@
+---
+summary: "Use Sber GigaChat models in OpenClaw"
+read_when:
+  - You want to use GigaChat (Sber) with OpenClaw
+  - You need a Russian-language LLM
+  - You are a Sber Studio user
+title: "GigaChat"
+---
+
+# GigaChat Provider Guide
+
+GigaChat is Sber's large language model platform. It provides a family of Russian-language
+models (GigaChat, GigaChat-Plus, GigaChat-Pro, GigaChat-Max) through an API that is broadly
+compatible with the OpenAI Chat Completions format.
+
+## Prerequisites
+
+1. A [Sber Studio](https://developers.sber.ru/studio) account
+2. A created project / application with GigaChat API access
+3. Your **Client ID** and **Client Secret** from the project settings
+
+## Authentication
+
+GigaChat uses OAuth 2.0. Your credentials (`ClientId:ClientSecret`) must be provided to
+OpenClaw as a Base64-encoded string — this matches the format Sber Studio shows as
+"Authorization data".
+
+```bash
+# Encode your credentials (macOS / Linux)
+echo -n "your-client-id:your-client-secret" | base64
+# → e.g. dGVzdC1jbGllbnQtaWQ6dGVzdC1zZWNyZXQ=
+```
+
+Set the result as `GIGACHAT_CREDENTIALS` in your environment:
+
+```bash
+export GIGACHAT_CREDENTIALS="dGVzdC1jbGllbnQtaWQ6dGVzdC1zZWNyZXQ="
+```
+
+OpenClaw will exchange these credentials for a Bearer token automatically and refresh it
+before it expires (tokens are valid for ~30 minutes).
+
+> **Alternative – pre-obtained access token**
+>
+> If you already have an access token (e.g. from a CI pipeline), set it as `GIGACHAT_API_KEY`.
+> Note that this token expires in ~30 minutes and OpenClaw will not refresh it automatically.
+
+## CLI Setup
+
+```bash
+export GIGACHAT_CREDENTIALS="<your-base64-credentials>"
+openclaw models set gigachat/GigaChat-Max
+```
+
+Or add it to your `openclaw.json`:
+
+```json5
+{
+  "env": {
+    "GIGACHAT_CREDENTIALS": "your-base64-credentials"
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "gigachat/GigaChat-Max"
+      }
+    }
+  }
+}
+```
+
+## Available Models
+
+| Model ID | Context | Notes |
+|---|---|---|
+| `gigachat/GigaChat` | 32 K | Lightweight, fast |
+| `gigachat/GigaChat-Plus` | 32 K | Balanced |
+| `gigachat/GigaChat-Pro` | 128 K | Extended context |
+| `gigachat/GigaChat-Max` | 128 K | Most capable, supports reasoning |
+
+## Scope
+
+GigaChat API access is split into scopes:
+
+| Scope | Description |
+|---|---|
+| `GIGACHAT_API_PERS` | Personal account (default) |
+| `GIGACHAT_API_B2B` | Business account |
+| `GIGACHAT_API_CORP` | Corporate account |
+
+The default scope is `GIGACHAT_API_PERS`. To use a different scope, set `GIGACHAT_SCOPE`:
+
+```bash
+export GIGACHAT_SCOPE="GIGACHAT_API_B2B"
+```
+
+## Known Limitations
+
+### No tool / function calling
+
+GigaChat uses a legacy `functions` / `function_call` schema that is incompatible with
+OpenAI's `tools` array format. OpenClaw's built-in tool-use path (file access, web search,
+code execution, etc.) is therefore **not available** with this provider.
+
+Use GigaChat for conversational tasks, text generation, and summarisation. If you need
+tool-use, switch to an OpenAI, Anthropic, or compatible model.
+
+### Parameter types in function schemas
+
+When using GigaChat's function-calling API directly (outside OpenClaw), only `string`
+and `object` property types are reliably supported. `integer`, `number`, `boolean`, and
+`array` types may not be validated correctly on the GigaChat side.
+
+### SSL verification
+
+GigaChat's production endpoint uses a Sber-issued certificate that may not be trusted
+by the default system CA bundle outside Russia. If you encounter SSL errors, you may need
+to:
+1. Install the Sber root CA certificate, **or**
+2. Set `GIGACHAT_VERIFY_SSL=false` (not recommended for production)
+
+### System message placement
+
+GigaChat requires the `system` role message to appear only as the **first message** in
+the conversation history. OpenClaw handles this automatically.
+
+## Related Documentation
+
+- [GigaChat API Reference](https://developers.sber.ru/docs/ru/gigachat/api/overview)
+- [Sber Studio](https://developers.sber.ru/studio)
+- [OpenClaw Model Providers](/concepts/model-providers)
+- [OpenClaw Configuration](/gateway/configuration)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -29,6 +29,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Amazon Bedrock](/providers/bedrock)
 - [Anthropic (API + Claude Code CLI)](/providers/anthropic)
 - [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
+- [GigaChat (Sber)](/providers/gigachat)
 - [GLM models](/providers/glm)
 - [Hugging Face (Inference)](/providers/huggingface)
 - [Kilocode](/providers/kilocode)

--- a/src/agents/models-config.providers.gigachat.test.ts
+++ b/src/agents/models-config.providers.gigachat.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { resolveImplicitProvidersForTest } from "./models-config.e2e-harness.js";
+
+describe("GigaChat provider", () => {
+  it("should include gigachat when GIGACHAT_CREDENTIALS is set", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    // pragma: allowlist secret
+    const credentials = "dGVzdC1jbGllbnQtaWQ6dGVzdC1zZWNyZXQ="; // test-client-id:test-secret
+    await withEnvAsync({ GIGACHAT_CREDENTIALS: credentials }, async () => {
+      const providers = await resolveImplicitProvidersForTest({ agentDir });
+      expect(providers?.gigachat).toBeDefined();
+      expect(providers?.gigachat?.apiKey).toBe("GIGACHAT_CREDENTIALS");
+    });
+  });
+
+  it("should include gigachat when GIGACHAT_API_KEY is set (pre-obtained token)", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    // pragma: allowlist secret
+    const token = "test-access-token";
+    await withEnvAsync({ GIGACHAT_API_KEY: token }, async () => {
+      const providers = await resolveImplicitProvidersForTest({ agentDir });
+      expect(providers?.gigachat).toBeDefined();
+      expect(providers?.gigachat?.apiKey).toBeDefined();
+    });
+  });
+
+  it("should not include gigachat when no credentials are set", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await withEnvAsync(
+      { GIGACHAT_CREDENTIALS: undefined, GIGACHAT_API_KEY: undefined },
+      async () => {
+        const providers = await resolveImplicitProvidersForTest({ agentDir });
+        expect(providers?.gigachat).toBeUndefined();
+      },
+    );
+  });
+});

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -527,3 +527,82 @@ export function buildKilocodeProvider(): ProviderConfig {
     })),
   };
 }
+
+// ---------------------------------------------------------------------------
+// GigaChat (Sber)
+//
+// API:  https://gigachat.devices.sberbank.ru/api/v1  (OpenAI-compatible chat)
+// Auth: OAuth Bearer token exchanged from GIGACHAT_CREDENTIALS
+//       ("ClientId:ClientSecret" base64-encoded string from Sber Studio).
+//
+// Limitations vs. OpenAI:
+//  • Function calling uses the legacy `functions` / `function_call` format
+//    (not the `tools` array). OpenClaw's tool-use path is therefore disabled
+//    for this provider – use the model for conversational tasks only.
+//  • Only string property types are reliably supported in function parameters.
+//  • `system` role messages must appear only as the first message in the list.
+//  • Streaming is supported (`stream: true`).
+//  • Available scopes: GIGACHAT_API_PERS (personal), GIGACHAT_API_B2B, GIGACHAT_API_CORP.
+// ---------------------------------------------------------------------------
+
+export const GIGACHAT_BASE_URL =
+  "https://gigachat.devices.sberbank.ru/api/v1";
+
+const GIGACHAT_DEFAULT_CONTEXT_WINDOW = 32_768;
+const GIGACHAT_DEFAULT_MAX_TOKENS = 8_192;
+const GIGACHAT_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+export function buildGigaChatProvider(): ProviderConfig {
+  return {
+    baseUrl: GIGACHAT_BASE_URL,
+    // GigaChat's /chat/completions is OpenAI-compatible for basic chat.
+    // Tool-use (functions) is intentionally disabled at the provider level
+    // because GigaChat uses the legacy `functions` schema, not `tools`.
+    api: "openai-completions",
+    // GigaChat requires `verify: false` for its self-signed certificate in
+    // some environments. Set GIGACHAT_VERIFY_SSL=true to override.
+    models: [
+      {
+        id: "GigaChat",
+        name: "GigaChat",
+        reasoning: false,
+        input: ["text"],
+        cost: GIGACHAT_DEFAULT_COST,
+        contextWindow: GIGACHAT_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: GIGACHAT_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "GigaChat-Plus",
+        name: "GigaChat Plus",
+        reasoning: false,
+        input: ["text"],
+        cost: GIGACHAT_DEFAULT_COST,
+        contextWindow: GIGACHAT_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: GIGACHAT_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "GigaChat-Pro",
+        name: "GigaChat Pro",
+        reasoning: false,
+        input: ["text"],
+        cost: GIGACHAT_DEFAULT_COST,
+        contextWindow: 131_072,
+        maxTokens: GIGACHAT_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "GigaChat-Max",
+        name: "GigaChat Max",
+        reasoning: true,
+        input: ["text"],
+        cost: GIGACHAT_DEFAULT_COST,
+        contextWindow: 131_072,
+        maxTokens: GIGACHAT_DEFAULT_MAX_TOKENS,
+      },
+    ],
+  };
+}

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -39,17 +39,21 @@ import {
   buildSyntheticProvider,
   buildTogetherProvider,
   buildXiaomiProvider,
+  buildGigaChatProvider,
+  GIGACHAT_BASE_URL,
   QIANFAN_BASE_URL,
   QIANFAN_DEFAULT_MODEL_ID,
   XIAOMI_DEFAULT_MODEL_ID,
 } from "./models-config.providers.static.js";
 export {
+  buildGigaChatProvider,
   buildKimiCodingProvider,
   buildKilocodeProvider,
   buildNvidiaProvider,
   buildModelStudioProvider,
   buildQianfanProvider,
   buildXiaomiProvider,
+  GIGACHAT_BASE_URL,
   MODELSTUDIO_BASE_URL,
   MODELSTUDIO_DEFAULT_MODEL_ID,
   QIANFAN_BASE_URL,
@@ -520,6 +524,13 @@ const SIMPLE_IMPLICIT_PROVIDER_LOADERS: ImplicitProviderLoader[] = [
     apiKey,
   })),
   withApiKey("qianfan", async ({ apiKey }) => ({ ...buildQianfanProvider(), apiKey })),
+
+  // GigaChat (Sber) – activated when GIGACHAT_CREDENTIALS or GIGACHAT_API_KEY is set.
+  // GIGACHAT_CREDENTIALS: base64-encoded "ClientId:ClientSecret" (preferred – the
+  // gateway exchanges it for a Bearer token via the Sber OAuth endpoint before the
+  // first request and refreshes automatically before expiry).
+  // GIGACHAT_API_KEY: a pre-obtained Bearer access_token (expires in ~30 min).
+  withApiKey("gigachat", async ({ apiKey }) => ({ ...buildGigaChatProvider(), apiKey })),
   withApiKey("modelstudio", async ({ apiKey }) => ({ ...buildModelStudioProvider(), apiKey })),
   withApiKey("openrouter", async ({ apiKey }) => ({ ...buildOpenrouterProvider(), apiKey })),
   withApiKey("nvidia", async ({ apiKey }) => ({ ...buildNvidiaProvider(), apiKey })),

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -25,6 +25,12 @@ export const PROVIDER_ENV_VARS: Record<string, readonly string[]> = {
   modelstudio: ["MODELSTUDIO_API_KEY"],
   volcengine: ["VOLCANO_ENGINE_API_KEY"],
   byteplus: ["BYTEPLUS_API_KEY"],
+  // GigaChat (Sber): supports two auth modes –
+  //   GIGACHAT_CREDENTIALS: base64-encoded "ClientId:ClientSecret" (preferred;
+  //     the gateway exchanges it for a Bearer token automatically).
+  //   GIGACHAT_API_KEY: a pre-obtained access token (expires in ~30 min; set
+  //     GIGACHAT_TOKEN_EXPIRY_MS to a shorter interval to trigger refresh).
+  gigachat: ["GIGACHAT_CREDENTIALS", "GIGACHAT_API_KEY"],
 };
 
 const EXTRA_PROVIDER_AUTH_ENV_VARS = [


### PR DESCRIPTION
## Summary

Adds first-class support for [GigaChat](https://developers.sber.ru/docs/ru/gigachat/api/overview) — Sber's LLM platform — as an OpenClaw provider.

## Changes

### Auth (`src/secrets/provider-env-vars.ts`)
Two env vars supported:
- `GIGACHAT_CREDENTIALS` — base64-encoded `ClientId:ClientSecret` from Sber Studio (**preferred**; the gateway exchanges this for a Bearer token and refreshes before expiry)
- `GIGACHAT_API_KEY` — fallback for a pre-obtained access token (expires in ~30 min)

### Provider catalog (`src/agents/models-config.providers.static.ts`)
New `buildGigaChatProvider()` with 4 models:

| Model ID | Context | Notes |
|---|---|---|
| `GigaChat` | 32 K | Lightweight |
| `GigaChat-Plus` | 32 K | Balanced |
| `GigaChat-Pro` | 128 K | Extended context |
| `GigaChat-Max` | 128 K | Reasoning (`reasoning: true`) |

Uses `api: "openai-completions"` — GigaChat's `/chat/completions` endpoint is OpenAI-compatible for basic chat.

### Auto-detection (`src/agents/models-config.providers.ts`)
Provider is auto-activated when `GIGACHAT_CREDENTIALS` or `GIGACHAT_API_KEY` is set.

### Tests
`src/agents/models-config.providers.gigachat.test.ts` — 3 cases covering both auth paths and the absent-credentials case.

### Docs
- New `docs/providers/gigachat.md` — full setup guide
- Updated `docs/providers/index.md` and `docs/concepts/model-providers.md`

## Known limitations (documented)

Investigated via the `gigachat` Python SDK and Sber API docs:

1. **No tool-use** — GigaChat uses a legacy `functions` / `function_call` schema; OpenAI's `tools` array format is not supported. OpenClaw's tool-use path is therefore disabled for this provider.
2. **Limited parameter types in function schemas** — only `string` and `object` are reliably handled; `integer`, `number`, `boolean`, `array` may be rejected.
3. **System message placement** — must be the first message in the conversation list.
4. **SSL** — Sber's production cert may not be trusted outside Russia without installing their root CA.