### PR TITLE
feat: add auth-tunnel skill for secure web authentication

### DIFF
--- a/skills/auth-tunnel/SKILL.md
+++ b/skills/auth-tunnel/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: auth-tunnel
+description: |
+  Secure web authentication for headless servers. Opens a login page via reverse proxy + Tailscale Funnel so the user can log in on their phone/laptop. Captures session cookies/tokens after login. Use when the user needs to authenticate with a web service (JeFIT, Amazon, etc.) and you need the resulting session tokens.
+---
+
+# Auth Tunnel Skill
+
+Authenticate with web services on a headless server by proxying the login page through Tailscale Funnel. The user logs in on their phone with full native HTML (keyboard, responsive layout) — credentials go directly to the target service over HTTPS, never through chat.
+
+## Prerequisites
+
+- **Node.js 18+**
+- **Tailscale** with Funnel enabled
+- Operator set for non-root usage: `sudo tailscale set --operator=$USER`
+
+## Files
+
+- `auth-proxy.cjs` — Reverse proxy server with cookie capture
+- `auth-tunnel.sh` — Legacy VNC-based approach (fallback only)
+- `extract-cookies.cjs` — CDP cookie extraction (used by VNC approach)
+
+## Workflow
+
+### 1. Start the proxy
+
+```bash
+nohup node <skill-dir>/auth-proxy.cjs "<login-url>" \
+  --port 7890 \
+  --extract-cookies "<domain>" \
+  --output /tmp/<service>-cookies.json > /tmp/auth-proxy.log 2>&1 &
+disown
+```
+
+### 2. Start Tailscale Funnel
+
+```bash
+tailscale funnel --https=8443 --bg http://localhost:7890
+```
+
+### 3. Get the funnel URL
+
+```bash
+HOSTNAME=$(tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//')
+echo "https://${HOSTNAME}:8443/"
+```
+
+### 4. Send the URL to the user
+
+Send the URL via chat. The user opens it, sees the native login page, and logs in.
+
+### 5. After login — extract cookies
+
+Check status:
+```bash
+curl -s http://127.0.0.1:7890/__auth_proxy__/cookies | jq 'length'
+```
+
+Save cookies (also shuts down proxy):
+```bash
+curl -s http://127.0.0.1:7890/__auth_proxy__/done
+```
+
+Or the user can visit `/__auth_proxy__/status` in their browser and click "Done".
+
+### 6. Tear down funnel
+
+```bash
+tailscale funnel --https=8443 off
+```
+
+### 7. Use the cookies
+
+Read the output file to get tokens/cookies for configuring plugins:
+```bash
+cat /tmp/<service>-cookies.json | jq '.[] | select(.name=="<token-name>") | .value'
+```
+
+## Proxy Endpoints
+
+| Path | Description |
+|------|-------------|
+| `/` | Proxied target page (native HTML) |
+| `/__auth_proxy__/status` | Cookie count + "Done" button (mobile-friendly) |
+| `/__auth_proxy__/cookies` | Raw JSON cookie dump |
+| `/__auth_proxy__/done` | Save cookies to file and shut down |
+
+## Common Services
+
+### JeFIT
+```bash
+node auth-proxy.cjs "https://www.jefit.com/login" --extract-cookies "jefit.com" --output /tmp/jefit-cookies.json
+# After login, extract: jefitAccessToken, jefitRefreshToken
+```
+
+### Amazon
+```bash
+node auth-proxy.cjs "https://www.amazon.co.uk/ap/signin" --extract-cookies "amazon.co.uk" --output /tmp/amazon-cookies.json
+```
+
+## Security
+
+- Credentials are typed directly into the target service's login form, served as native HTML through the proxy.
+- The proxy runs on the user's own server — same trust model as a local browser.
+- Tailscale Funnel provides HTTPS with valid certificates.
+- Always tear down the funnel after use (`tailscale funnel --https=8443 off`).
+- Cookie output files contain sensitive tokens — handle accordingly.
+
+## Fallback: VNC Approach
+
+If the reverse proxy doesn't work for a particular site (heavy JS SPA, anti-bot detection, etc.), use the VNC approach:
+
+```bash
+bash <skill-dir>/auth-tunnel.sh "<login-url>" --extract-cookies "<domain>" --output /tmp/cookies.json
+```
+
+Requires: Xvfb, chromium-browser, x11vnc, noVNC, websockify, jq. Poor mobile UX — use only as fallback.

--- a/skills/auth-tunnel/auth-proxy.cjs
+++ b/skills/auth-tunnel/auth-proxy.cjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+/**
+ * auth-proxy — Reverse proxy for web auth with cookie capture.
+ *
+ * Proxies a target login page through a local HTTP server.
+ * User sees native HTML (mobile-friendly, real keyboard, copy-paste).
+ * Captures Set-Cookie headers from the target after login.
+ *
+ * Usage: node auth-proxy.cjs <target-url> [--port 7890] [--extract-cookies domain1,domain2] [--output cookies.json]
+ */
+
+const http = require("http");
+const https = require("https");
+const { URL } = require("url");
+const fs = require("fs");
+const path = require("path");
+
+// --- Parse args ---
+const args = process.argv.slice(2);
+let targetUrl = null;
+let port = 7890;
+let extractDomains = [];
+let outputFile = "cookies.json";
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--port") { port = parseInt(args[++i]); }
+  else if (args[i] === "--extract-cookies") { extractDomains = args[++i].split(",").map(d => d.trim()); }
+  else if (args[i] === "--output") { outputFile = args[++i]; }
+  else if (args[i] === "-h" || args[i] === "--help") {
+    console.log("Usage: auth-proxy.cjs <target-url> [--port 7890] [--extract-cookies d1,d2] [--output cookies.json]");
+    process.exit(0);
+  }
+  else if (!args[i].startsWith("-")) { targetUrl = args[i]; }
+}
+
+if (!targetUrl) {
+  console.error("Error: target URL required");
+  process.exit(1);
+}
+
+const target = new URL(targetUrl);
+const targetOrigin = target.origin;
+const isTargetHttps = target.protocol === "https:";
+const httpModule = isTargetHttps ? https : http;
+
+// Collected cookies from all responses
+const capturedCookies = new Map(); // name -> full cookie object
+
+function parseCookieHeader(setCookieHeader, requestHost) {
+  // Parse a Set-Cookie header string into a structured object
+  const parts = setCookieHeader.split(";").map(p => p.trim());
+  const [nameValue, ...attrs] = parts;
+  const eqIdx = nameValue.indexOf("=");
+  if (eqIdx === -1) return null;
+
+  const cookie = {
+    name: nameValue.substring(0, eqIdx),
+    value: nameValue.substring(eqIdx + 1),
+    domain: requestHost,
+    path: "/",
+    raw: setCookieHeader,
+  };
+
+  for (const attr of attrs) {
+    const [key, ...valParts] = attr.split("=");
+    const k = key.toLowerCase().trim();
+    const v = valParts.join("=").trim();
+    if (k === "domain") cookie.domain = v;
+    else if (k === "path") cookie.path = v;
+    else if (k === "expires") cookie.expires = v;
+    else if (k === "max-age") cookie.maxAge = parseInt(v);
+    else if (k === "httponly") cookie.httpOnly = true;
+    else if (k === "secure") cookie.secure = true;
+    else if (k === "samesite") cookie.sameSite = v;
+  }
+
+  return cookie;
+}
+
+// Build cookie jar string from captured cookies for forwarding
+function getCookieJar() {
+  return Array.from(capturedCookies.values())
+    .map(c => `${c.name}=${c.value}`)
+    .join("; ");
+}
+
+function rewriteHeaders(headers, proxyHost) {
+  const result = { ...headers };
+
+  // Remove hop-by-hop headers
+  delete result["host"];
+  delete result["connection"];
+  delete result["keep-alive"];
+  delete result["transfer-encoding"];
+  delete result["upgrade"];
+
+  // Set correct host for target
+  result["host"] = target.host;
+
+  // Forward cookies from our jar
+  const jar = getCookieJar();
+  if (jar) {
+    result["cookie"] = jar;
+  }
+
+  // Remove referer/origin that would expose the proxy
+  if (result["referer"]) {
+    result["referer"] = result["referer"].replace(new RegExp(`https?://[^/]+`, "g"), targetOrigin);
+  }
+  if (result["origin"]) {
+    result["origin"] = targetOrigin;
+  }
+
+  return result;
+}
+
+function rewriteLocationHeader(location, proxyHost) {
+  if (!location) return location;
+  try {
+    const locUrl = new URL(location, targetOrigin);
+    if (locUrl.origin === targetOrigin) {
+      return `http://${proxyHost}${locUrl.pathname}${locUrl.search}${locUrl.hash}`;
+    }
+  } catch {}
+  return location;
+}
+
+function rewriteBody(body, contentType, proxyHost) {
+  if (!contentType) return body;
+  const ct = contentType.toLowerCase();
+  if (!ct.includes("text/html") && !ct.includes("text/css") && !ct.includes("javascript")) {
+    return body;
+  }
+
+  let text = body.toString("utf-8");
+
+  // Rewrite absolute URLs to target → proxy
+  const escapedOrigin = targetOrigin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  text = text.replace(new RegExp(escapedOrigin, "g"), `http://${proxyHost}`);
+
+  // Also handle protocol-relative URLs
+  const protoRelative = targetOrigin.replace(/^https?:/, "");
+  text = text.replace(new RegExp(protoRelative.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), "g"), `//${proxyHost}`);
+
+  return Buffer.from(text, "utf-8");
+}
+
+// Status page
+function statusPage(proxyHost) {
+  const cookieCount = capturedCookies.size;
+  const cookieList = Array.from(capturedCookies.values())
+    .map(c => `  • ${c.name} (${c.domain})`)
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Auth Proxy Status</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 40px auto; padding: 0 20px; }
+  .btn { display: inline-block; padding: 12px 24px; background: #2563eb; color: white; text-decoration: none; border-radius: 8px; font-size: 16px; margin: 8px 4px; }
+  .btn.done { background: #16a34a; }
+  pre { background: #f3f4f6; padding: 12px; border-radius: 8px; overflow-x: auto; font-size: 13px; }
+  .cookie-count { font-size: 48px; font-weight: bold; color: ${cookieCount > 0 ? '#16a34a' : '#9ca3af'}; }
+</style>
+</head><body>
+<h1>🔐 Auth Proxy</h1>
+<p>Target: <strong>${targetOrigin}</strong></p>
+<p class="cookie-count">${cookieCount} cookies captured</p>
+${cookieList ? `<pre>${cookieList}</pre>` : '<p>No cookies yet. Log in first!</p>'}
+<a class="btn" href="/">→ Go to login page</a>
+${cookieCount > 0 ? '<a class="btn done" href="/__auth_proxy__/done">✅ Done — save cookies</a>' : ''}
+</body></html>`;
+}
+
+const server = http.createServer((req, res) => {
+  const proxyHost = req.headers.host || `localhost:${port}`;
+
+  // Status/control endpoints
+  if (req.url === "/__auth_proxy__/status") {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(statusPage(proxyHost));
+    return;
+  }
+
+  if (req.url === "/__auth_proxy__/cookies") {
+    const cookies = Array.from(capturedCookies.values());
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(cookies, null, 2));
+    return;
+  }
+
+  if (req.url === "/__auth_proxy__/done") {
+    const cookies = Array.from(capturedCookies.values());
+    if (outputFile) {
+      fs.writeFileSync(outputFile, JSON.stringify(cookies, null, 2) + "\n");
+      console.log(`\n✅ Saved ${cookies.length} cookies → ${outputFile}`);
+    }
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(`<!DOCTYPE html><html><head>
+      <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+      <style>body{font-family:-apple-system,system-ui,sans-serif;max-width:600px;margin:40px auto;padding:0 20px;text-align:center;}</style>
+      </head><body>
+      <h1>✅ Done!</h1>
+      <p>${cookies.length} cookies saved.</p>
+      <p>You can close this tab now.</p>
+      </body></html>`);
+
+    // Signal to parent process
+    console.log("__AUTH_PROXY_DONE__");
+    setTimeout(() => process.exit(0), 1000);
+    return;
+  }
+
+  // Proxy the request
+  const targetPath = req.url || "/";
+  const headers = rewriteHeaders(req.headers, proxyHost);
+
+  // Remove accept-encoding to get uncompressed response (easier to rewrite)
+  delete headers["accept-encoding"];
+
+  const proxyReq = httpModule.request(
+    {
+      hostname: target.hostname,
+      port: target.port || (isTargetHttps ? 443 : 80),
+      path: targetPath,
+      method: req.method,
+      headers: headers,
+      rejectUnauthorized: true,
+    },
+    (proxyRes) => {
+      // Capture Set-Cookie headers
+      const setCookies = proxyRes.headers["set-cookie"] || [];
+      for (const sc of setCookies) {
+        const parsed = parseCookieHeader(sc, target.hostname);
+        if (parsed) {
+          capturedCookies.set(parsed.name, parsed);
+          if (extractDomains.length === 0 || extractDomains.some(d => parsed.domain.includes(d))) {
+            console.log(`  🍪 ${parsed.name}=${parsed.value.substring(0, 20)}...`);
+          }
+        }
+      }
+
+      // Collect response body for rewriting
+      const chunks = [];
+      proxyRes.on("data", (chunk) => chunks.push(chunk));
+      proxyRes.on("end", () => {
+        let body = Buffer.concat(chunks);
+        const contentType = proxyRes.headers["content-type"] || "";
+
+        // Rewrite body (URLs)
+        body = rewriteBody(body, contentType, proxyHost);
+
+        // Rewrite response headers
+        const resHeaders = { ...proxyRes.headers };
+
+        // Rewrite Location headers for redirects
+        if (resHeaders["location"]) {
+          resHeaders["location"] = rewriteLocationHeader(resHeaders["location"], proxyHost);
+        }
+
+        // Rewrite Set-Cookie domains to work with proxy
+        if (resHeaders["set-cookie"]) {
+          resHeaders["set-cookie"] = resHeaders["set-cookie"].map(sc => {
+            // Remove Domain attribute so cookie applies to proxy host
+            return sc
+              .replace(/;\s*[Dd]omain=[^;]*/g, "")
+              .replace(/;\s*[Ss]ecure/g, "")
+              .replace(/;\s*[Ss]ame[Ss]ite=[^;]*/g, "; SameSite=Lax");
+          });
+        }
+
+        // Remove CSP that might block our proxy
+        delete resHeaders["content-security-policy"];
+        delete resHeaders["content-security-policy-report-only"];
+        delete resHeaders["x-frame-options"];
+
+        // Fix content-length since we might have rewritten the body
+        resHeaders["content-length"] = Buffer.byteLength(body);
+
+        // Remove transfer-encoding since we're sending the full body
+        delete resHeaders["transfer-encoding"];
+
+        res.writeHead(proxyRes.statusCode, resHeaders);
+        res.end(body);
+      });
+    }
+  );
+
+  proxyReq.on("error", (err) => {
+    console.error(`  ❌ Proxy error: ${err.message}`);
+    res.writeHead(502, { "Content-Type": "text/plain" });
+    res.end(`Proxy error: ${err.message}`);
+  });
+
+  // Forward request body
+  req.pipe(proxyReq);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`\n🔐 Auth Proxy running on http://127.0.0.1:${port}`);
+  console.log(`   Proxying → ${targetOrigin}`);
+  console.log(`   Status:  http://127.0.0.1:${port}/__auth_proxy__/status`);
+  console.log(`\n   After login, visit /__auth_proxy__/status to check cookies`);
+  console.log(`   Then hit /__auth_proxy__/done to save and exit\n`);
+});
+
+process.on("SIGINT", () => {
+  console.log("\n🧹 Shutting down...");
+  server.close();
+  process.exit(0);
+});

--- a/skills/auth-tunnel/auth-tunnel.sh
+++ b/skills/auth-tunnel/auth-tunnel.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# auth-tunnel — Secure browser-based auth via Tailscale Funnel
+#
+# Opens a headless Chromium on the server, exposes it via noVNC + Tailscale Funnel.
+# User logs in directly (credentials never leave HTTPS to the target service).
+# After login, cookies are extracted via Chrome DevTools Protocol (CDP).
+#
+# Usage: auth-tunnel.sh <url> [--port 8443] [--extract-cookies domain1,domain2]
+#
+# Dependencies: Xvfb, chromium-browser, x11vnc, websockify, noVNC, tailscale, curl, jq
+
+set -euo pipefail
+
+# --- Defaults ---
+URL=""
+FUNNEL_PORT=8443
+NOVNC_PORT=6080
+VNC_PORT=5900
+CDP_PORT=9222
+DISPLAY_NUM=99
+EXTRACT_DOMAINS=""
+COOKIE_OUTPUT="cookies.json"
+RESOLUTION="1280x800x24"
+CLEANUP_PIDS=()
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port) FUNNEL_PORT="$2"; shift 2 ;;
+    --extract-cookies) EXTRACT_DOMAINS="$2"; shift 2 ;;
+    --output) COOKIE_OUTPUT="$2"; shift 2 ;;
+    --resolution) RESOLUTION="$2"; shift 2 ;;
+    --vnc-port) VNC_PORT="$2"; shift 2 ;;
+    --novnc-port) NOVNC_PORT="$2"; shift 2 ;;
+    --cdp-port) CDP_PORT="$2"; shift 2 ;;
+    --display) DISPLAY_NUM="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: auth-tunnel.sh <url> [options]"
+      echo ""
+      echo "Options:"
+      echo "  --port PORT            Tailscale funnel port (default: 8443)"
+      echo "  --extract-cookies d1,d2  Comma-separated domains to extract cookies from"
+      echo "  --output FILE          Cookie output file (default: cookies.json)"
+      echo "  --resolution WxHxD     Screen resolution (default: 1280x800x24)"
+      echo "  --vnc-port PORT        VNC port (default: 5900)"
+      echo "  --novnc-port PORT      noVNC websockify port (default: 6080)"
+      echo "  --cdp-port PORT        Chrome DevTools Protocol port (default: 9222)"
+      echo "  --display NUM          X display number (default: 99)"
+      exit 0
+      ;;
+    -*) echo "Unknown option: $1" >&2; exit 1 ;;
+    *) URL="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$URL" ]]; then
+  echo "Error: URL is required" >&2
+  echo "Usage: auth-tunnel.sh <url> [--extract-cookies domain1,domain2]" >&2
+  exit 1
+fi
+
+# --- Cleanup on exit ---
+cleanup() {
+  echo ""
+  echo "🧹 Cleaning up..."
+  
+  # Kill all tracked processes
+  for pid in "${CLEANUP_PIDS[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  
+  # Stop tailscale funnel
+  tailscale funnel --https="$FUNNEL_PORT" off 2>/dev/null || true
+  
+  # Remove temporary chrome profile
+  if [[ -n "${CHROME_PROFILE:-}" && -d "$CHROME_PROFILE" ]]; then
+    rm -rf "$CHROME_PROFILE"
+  fi
+  
+  echo "✅ Cleaned up"
+}
+trap cleanup EXIT INT TERM
+
+# --- Check dependencies ---
+for cmd in Xvfb chromium-browser x11vnc websockify tailscale curl jq; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: $cmd not found" >&2
+    exit 1
+  fi
+done
+
+# --- Start Xvfb ---
+echo "🖥️  Starting virtual display :${DISPLAY_NUM}..."
+Xvfb ":${DISPLAY_NUM}" -screen 0 "$RESOLUTION" -ac &
+CLEANUP_PIDS+=($!)
+sleep 1
+
+export DISPLAY=":${DISPLAY_NUM}"
+
+# --- Start Chromium with CDP ---
+CHROME_PROFILE=$(mktemp -d /tmp/auth-tunnel-chrome.XXXXXX)
+echo "🌐 Starting Chromium → $URL"
+chromium-browser \
+  --no-sandbox \
+  --disable-gpu \
+  --disable-dev-shm-usage \
+  --user-data-dir="$CHROME_PROFILE" \
+  --remote-debugging-port="$CDP_PORT" \
+  --remote-debugging-address=127.0.0.1 \
+  --window-size=1280,800 \
+  --start-maximized \
+  "$URL" &
+CLEANUP_PIDS+=($!)
+sleep 2
+
+# --- Start x11vnc ---
+echo "📡 Starting VNC server on port $VNC_PORT..."
+x11vnc -display ":${DISPLAY_NUM}" -rfbport "$VNC_PORT" -nopw -forever -shared -quiet &
+CLEANUP_PIDS+=($!)
+sleep 1
+
+# --- Start noVNC via websockify ---
+echo "🌍 Starting noVNC on port $NOVNC_PORT..."
+websockify --web=/usr/share/novnc "$NOVNC_PORT" "localhost:$VNC_PORT" &
+CLEANUP_PIDS+=($!)
+sleep 1
+
+# --- Start Tailscale Funnel ---
+echo "🔗 Starting Tailscale Funnel on port $FUNNEL_PORT..."
+tailscale funnel --https="$FUNNEL_PORT" --bg "http://localhost:$NOVNC_PORT" 2>/dev/null
+
+# Get the funnel URL
+HOSTNAME=$(tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//')
+FUNNEL_URL="https://${HOSTNAME}:${FUNNEL_PORT}/vnc_lite.html?autoconnect=true&resize=remote"
+
+echo ""
+echo "════════════════════════════════════════════════"
+echo "🔐 Auth Tunnel Ready!"
+echo ""
+echo "   $FUNNEL_URL"
+echo ""
+echo "   Open this link, log in to the service."
+echo "   Your credentials go directly to $URL"
+echo "   (never through this server or any chat)."
+echo ""
+echo "   Press ENTER when you're done logging in."
+echo "════════════════════════════════════════════════"
+echo ""
+
+# --- Wait for user ---
+read -r -p "⏳ Waiting... Press ENTER after login is complete: "
+
+# --- Extract cookies via CDP ---
+if [[ -n "$EXTRACT_DOMAINS" ]]; then
+  echo ""
+  echo "🍪 Extracting cookies..."
+  
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  
+  NODE_PATH="${NODE_PATH:-$HOME/openclaw/node_modules}" \
+    node "$SCRIPT_DIR/extract-cookies.cjs" "$CDP_PORT" "$EXTRACT_DOMAINS" "$COOKIE_OUTPUT"
+else
+  echo "ℹ️  No --extract-cookies specified, skipping cookie extraction"
+fi
+
+echo ""
+echo "🏁 Done! Shutting down tunnel..."

--- a/skills/auth-tunnel/extract-cookies.cjs
+++ b/skills/auth-tunnel/extract-cookies.cjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Extract cookies from a running Chrome instance via CDP.
+ *
+ * Usage: node extract-cookies.cjs <cdp-port> <domains> [output-file]
+ *   domains: comma-separated list (e.g., "amazon.com,jefit.com")
+ *   output-file: defaults to stdout
+ */
+
+const http = require("http");
+const { WebSocket } = require("ws");
+const fs = require("fs");
+
+const [cdpPort, domainsArg, outputFile] = process.argv.slice(2);
+
+if (!cdpPort || !domainsArg) {
+  console.error("Usage: extract-cookies.cjs <cdp-port> <domains> [output-file]");
+  process.exit(1);
+}
+
+const domains = domainsArg.split(",").map((d) => d.trim().toLowerCase());
+
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    http
+      .get(url, { family: 4 }, (res) => {
+        let data = "";
+        res.on("data", (d) => (data += d));
+        res.on("end", () => resolve(JSON.parse(data)));
+      })
+      .on("error", reject);
+  });
+}
+
+async function getCookies() {
+  const targets = await httpGet(`http://localhost:${cdpPort}/json`);
+  const wsUrl = targets[0] && targets[0].webSocketDebuggerUrl;
+  if (!wsUrl) {
+    throw new Error("No debugger target found");
+  }
+
+  // Force IPv4 to match Chrome's --remote-debugging-address=127.0.0.1
+  const wsUrlIpv4 = wsUrl.replace("localhost", "127.0.0.1");
+  const ws = new WebSocket(wsUrlIpv4);
+  await new Promise((r) => ws.on("open", r));
+
+  ws.send(JSON.stringify({ id: 1, method: "Network.getAllCookies" }));
+
+  const result = await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("CDP timeout")), 5000);
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(raw);
+      if (msg.id === 1) {
+        clearTimeout(timeout);
+        resolve(msg.result);
+      }
+    });
+  });
+
+  ws.close();
+
+  const filtered = result.cookies.filter((c) =>
+    domains.some((d) => c.domain.toLowerCase().includes(d))
+  );
+
+  return filtered;
+}
+
+getCookies()
+  .then((cookies) => {
+    const json = JSON.stringify(cookies, null, 2);
+    if (outputFile) {
+      fs.writeFileSync(outputFile, json + "\n");
+      console.error(`✅ Extracted ${cookies.length} cookies → ${outputFile}`);
+    } else {
+      console.log(json);
+    }
+  })
+  .catch((err) => {
+    console.error(`❌ Cookie extraction failed: ${err.message}`);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Adds a new `auth-tunnel` skill that enables secure web authentication on headless servers via reverse proxy + Tailscale Funnel.

### Problem

Authenticating with web services (JeFIT, Amazon, etc.) on a headless server currently requires SSH port forwarding, VNC, and manual cookie copying — painful UX.

### Solution

A reverse proxy (`auth-proxy.cjs`) serves the target login page as **native HTML** through a Tailscale Funnel URL. The user:

1. Opens a link on their phone/laptop
2. Sees the actual responsive login page (keyboard works, copy-paste works)
3. Logs in normally — credentials go directly to the target service over HTTPS
4. Session cookies are captured automatically by the proxy

### Files

- `skills/auth-tunnel/SKILL.md` — Skill documentation
- `skills/auth-tunnel/auth-proxy.cjs` — Reverse proxy with cookie capture (recommended)
- `skills/auth-tunnel/auth-tunnel.sh` — Legacy VNC-based approach (fallback)
- `skills/auth-tunnel/extract-cookies.cjs` — CDP cookie extraction (used by VNC fallback)

### Security

- Credentials never flow through chat — typed directly into the service's login form
- Proxy runs on the user's own server (same trust model as a local browser)
- Tailscale Funnel provides HTTPS with valid certificates
- Tunnel is temporary — tear down after use

### Requirements

- Node.js 18+
- Tailscale with Funnel enabled

### Testing

Tested with JeFIT login on Ubuntu 24.04 — successfully captured JWT access/refresh tokens via mobile phone login.