### PR TITLE
feat: add native anthropic-vertex provider for Claude on Google Vertex AI

### DIFF
--- a/src/agents/anthropic-vertex-auth.test.ts
+++ b/src/agents/anthropic-vertex-auth.test.ts
@@ -1,8 +1,10 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  buildSignedJwt,
   buildVertexBaseUrl,
   hasGcpAdcCredentials,
   readAdcCredentials,
@@ -11,6 +13,13 @@ import {
   resolveVertexProjectId,
   resolveVertexRegion,
 } from "./anthropic-vertex-auth.js";
+
+// Generate a throwaway RSA key pair for testing JWT signing.
+const { publicKey: testPublicKey, privateKey: testPrivateKey } = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
 
 describe("resolveAdcPath", () => {
   it("returns GOOGLE_APPLICATION_CREDENTIALS when set", () => {
@@ -35,7 +44,9 @@ describe("resolveAdcPath", () => {
 });
 
 describe("readAdcCredentials", () => {
-  it("parses valid credentials", () => {
+  // ── authorized_user ──────────────────────────────────────────────────
+
+  it("parses valid authorized_user credentials", () => {
     const creds = {
       client_id: "test-id",
       client_secret: "test-secret",
@@ -46,15 +57,18 @@ describe("readAdcCredentials", () => {
     fs.writeFileSync(tmpFile, JSON.stringify(creds));
     try {
       const result = readAdcCredentials(tmpFile);
-      expect(result.client_id).toBe("test-id");
-      expect(result.client_secret).toBe("test-secret");
-      expect(result.refresh_token).toBe("test-refresh");
+      expect(result.type).toBe("authorized_user");
+      if (result.type === "authorized_user") {
+        expect(result.client_id).toBe("test-id");
+        expect(result.client_secret).toBe("test-secret");
+        expect(result.refresh_token).toBe("test-refresh");
+      }
     } finally {
       fs.unlinkSync(tmpFile);
     }
   });
 
-  it("throws when refresh_token is missing", () => {
+  it("throws when refresh_token is missing for authorized_user", () => {
     const creds = { client_id: "id", client_secret: "secret", type: "authorized_user" };
     const tmpFile = path.join(os.tmpdir(), `test-adc-no-rt-${Date.now()}.json`);
     fs.writeFileSync(tmpFile, JSON.stringify(creds));
@@ -65,7 +79,7 @@ describe("readAdcCredentials", () => {
     }
   });
 
-  it("throws when client_id is missing", () => {
+  it("throws when client_id is missing for authorized_user", () => {
     const creds = { client_secret: "secret", refresh_token: "rt", type: "authorized_user" };
     const tmpFile = path.join(os.tmpdir(), `test-adc-no-cid-${Date.now()}.json`);
     fs.writeFileSync(tmpFile, JSON.stringify(creds));
@@ -76,8 +90,175 @@ describe("readAdcCredentials", () => {
     }
   });
 
+  it("defaults to authorized_user when type is absent", () => {
+    const creds = { client_id: "id", client_secret: "secret", refresh_token: "rt" };
+    const tmpFile = path.join(os.tmpdir(), `test-adc-notype-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(creds));
+    try {
+      const result = readAdcCredentials(tmpFile);
+      expect(result.type).toBe("authorized_user");
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  // ── service_account ──────────────────────────────────────────────────
+
+  it("parses valid service_account credentials", () => {
+    const creds = {
+      type: "service_account",
+      client_email: "test@project.iam.gserviceaccount.com",
+      private_key: testPrivateKey,
+      token_uri: "https://oauth2.googleapis.com/token",
+    };
+    const tmpFile = path.join(os.tmpdir(), `test-sa-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(creds));
+    try {
+      const result = readAdcCredentials(tmpFile);
+      expect(result.type).toBe("service_account");
+      if (result.type === "service_account") {
+        expect(result.client_email).toBe("test@project.iam.gserviceaccount.com");
+        expect(result.private_key).toBe(testPrivateKey);
+        expect(result.token_uri).toBe("https://oauth2.googleapis.com/token");
+      }
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it("defaults token_uri when missing from service_account", () => {
+    const creds = {
+      type: "service_account",
+      client_email: "sa@proj.iam.gserviceaccount.com",
+      private_key: testPrivateKey,
+    };
+    const tmpFile = path.join(os.tmpdir(), `test-sa-no-uri-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(creds));
+    try {
+      const result = readAdcCredentials(tmpFile);
+      expect(result.type).toBe("service_account");
+      if (result.type === "service_account") {
+        expect(result.token_uri).toBe("https://oauth2.googleapis.com/token");
+      }
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it("throws when client_email is missing for service_account", () => {
+    const creds = { type: "service_account", private_key: testPrivateKey };
+    const tmpFile = path.join(os.tmpdir(), `test-sa-no-email-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(creds));
+    try {
+      expect(() => readAdcCredentials(tmpFile)).toThrow("client_email");
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it("throws when private_key is missing for service_account", () => {
+    const creds = {
+      type: "service_account",
+      client_email: "sa@proj.iam.gserviceaccount.com",
+    };
+    const tmpFile = path.join(os.tmpdir(), `test-sa-no-key-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(creds));
+    try {
+      expect(() => readAdcCredentials(tmpFile)).toThrow("private_key");
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  // ── general ──────────────────────────────────────────────────────────
+
   it("throws on non-existent file", () => {
     expect(() => readAdcCredentials("/nonexistent/file.json")).toThrow();
+  });
+});
+
+describe("buildSignedJwt", () => {
+  const iat = 1700000000;
+  const exp = iat + 3600;
+  const tokenUri = "https://oauth2.googleapis.com/token";
+  const clientEmail = "test@project.iam.gserviceaccount.com";
+
+  it("produces a three-part base64url JWT", () => {
+    const jwt = buildSignedJwt({
+      clientEmail,
+      privateKey: testPrivateKey,
+      tokenUri,
+      iat,
+      exp,
+    });
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+    // All parts must be valid base64url (no +, /, or =)
+    for (const part of parts) {
+      expect(part).toMatch(/^[A-Za-z0-9_-]+$/);
+    }
+  });
+
+  it("encodes correct header", () => {
+    const jwt = buildSignedJwt({
+      clientEmail,
+      privateKey: testPrivateKey,
+      tokenUri,
+      iat,
+      exp,
+    });
+    const header = JSON.parse(Buffer.from(jwt.split(".")[0], "base64url").toString("utf8"));
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+  });
+
+  it("encodes correct payload", () => {
+    const jwt = buildSignedJwt({
+      clientEmail,
+      privateKey: testPrivateKey,
+      tokenUri,
+      iat,
+      exp,
+    });
+    const payload = JSON.parse(Buffer.from(jwt.split(".")[1], "base64url").toString("utf8"));
+    expect(payload).toEqual({
+      iss: clientEmail,
+      scope: "https://www.googleapis.com/auth/cloud-platform",
+      aud: tokenUri,
+      iat,
+      exp,
+    });
+  });
+
+  it("signature verifies with the corresponding public key", () => {
+    const jwt = buildSignedJwt({
+      clientEmail,
+      privateKey: testPrivateKey,
+      tokenUri,
+      iat,
+      exp,
+    });
+    const [headerB64, payloadB64, signatureB64] = jwt.split(".");
+    const signingInput = `${headerB64}.${payloadB64}`;
+    const signature = Buffer.from(signatureB64, "base64url");
+    const ok = crypto.verify(
+      "RSA-SHA256",
+      Buffer.from(signingInput, "utf8"),
+      testPublicKey,
+      signature,
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("different iat/exp produce different signatures", () => {
+    const jwt1 = buildSignedJwt({ clientEmail, privateKey: testPrivateKey, tokenUri, iat, exp });
+    const jwt2 = buildSignedJwt({
+      clientEmail,
+      privateKey: testPrivateKey,
+      tokenUri,
+      iat: iat + 100,
+      exp: exp + 100,
+    });
+    expect(jwt1).not.toBe(jwt2);
   });
 });
 

--- a/src/agents/anthropic-vertex-auth.test.ts
+++ b/src/agents/anthropic-vertex-auth.test.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildVertexBaseUrl,
+  hasGcpAdcCredentials,
+  readAdcCredentials,
+  resetVertexAuthCacheForTest,
+  resolveAdcPath,
+  resolveVertexProjectId,
+  resolveVertexRegion,
+} from "./anthropic-vertex-auth.js";
+
+describe("resolveAdcPath", () => {
+  it("returns GOOGLE_APPLICATION_CREDENTIALS when set", () => {
+    const env = { GOOGLE_APPLICATION_CREDENTIALS: "/custom/creds.json" };
+    expect(resolveAdcPath(env)).toBe("/custom/creds.json");
+  });
+
+  it("returns default gcloud path when env var not set", () => {
+    const expected = path.join(
+      os.homedir(),
+      ".config",
+      "gcloud",
+      "application_default_credentials.json",
+    );
+    expect(resolveAdcPath({})).toBe(expected);
+  });
+
+  it("trims whitespace from GOOGLE_APPLICATION_CREDENTIALS", () => {
+    const env = { GOOGLE_APPLICATION_CREDENTIALS: "  /trimmed/path.json  " };
+    expect(resolveAdcPath(env)).toBe("/trimmed/path.json");
+  });
+});
+
+describe("readAdcCredentials", () => {
+  it("parses valid credentials", () => {
+    const creds = {
+      client_id: "test-id",
+      client_secret: "test-secret",
+      refresh_token: "test-refresh",
+      type: "authorized_user",
+    };
+    const tmpFile = path.join(os.tmpdir(), `test-adc-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(creds));
+    try {
+      const result = readAdcCredentials(tmpFile);
+      expect(result.client_id).toBe("test-id");
+      expect(result.client_secret).toBe("test-secret");
+      expect(result.refresh_token).toBe("test-refresh");
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it("throws when refresh_token is missing", () => {
+    const creds = { client_id: "id", client_secret: "secret", type: "authorized_user" };
+    const tmpFile = path.join(os.tmpdir(), `test-adc-no-rt-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(creds));
+    try {
+      expect(() => readAdcCredentials(tmpFile)).toThrow("refresh_token");
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it("throws when client_id is missing", () => {
+    const creds = { client_secret: "secret", refresh_token: "rt", type: "authorized_user" };
+    const tmpFile = path.join(os.tmpdir(), `test-adc-no-cid-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(creds));
+    try {
+      expect(() => readAdcCredentials(tmpFile)).toThrow("client_id");
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it("throws on non-existent file", () => {
+    expect(() => readAdcCredentials("/nonexistent/file.json")).toThrow();
+  });
+});
+
+describe("hasGcpAdcCredentials", () => {
+  it("returns true when ADC file exists", () => {
+    const tmpFile = path.join(os.tmpdir(), `test-adc-exists-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, "{}");
+    try {
+      expect(hasGcpAdcCredentials({ GOOGLE_APPLICATION_CREDENTIALS: tmpFile })).toBe(true);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it("returns false when ADC file does not exist", () => {
+    expect(hasGcpAdcCredentials({ GOOGLE_APPLICATION_CREDENTIALS: "/no/such/file.json" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("resolveVertexProjectId", () => {
+  it("prefers ANTHROPIC_VERTEX_PROJECT_ID", () => {
+    const env = {
+      ANTHROPIC_VERTEX_PROJECT_ID: "vertex-project",
+      GOOGLE_CLOUD_PROJECT: "gcp-project",
+    };
+    expect(resolveVertexProjectId(env)).toBe("vertex-project");
+  });
+
+  it("falls back to GOOGLE_CLOUD_PROJECT", () => {
+    const env = { GOOGLE_CLOUD_PROJECT: "gcp-project" };
+    expect(resolveVertexProjectId(env)).toBe("gcp-project");
+  });
+
+  it("falls back to GCLOUD_PROJECT", () => {
+    const env = { GCLOUD_PROJECT: "gcloud-project" };
+    expect(resolveVertexProjectId(env)).toBe("gcloud-project");
+  });
+
+  it("returns undefined when no project env is set", () => {
+    expect(resolveVertexProjectId({})).toBeUndefined();
+  });
+
+  it("trims whitespace", () => {
+    expect(resolveVertexProjectId({ GOOGLE_CLOUD_PROJECT: "  proj  " })).toBe("proj");
+  });
+
+  it("returns undefined for whitespace-only values", () => {
+    expect(resolveVertexProjectId({ GOOGLE_CLOUD_PROJECT: "   " })).toBeUndefined();
+  });
+});
+
+describe("resolveVertexRegion", () => {
+  it("prefers CLOUD_ML_REGION", () => {
+    const env = { CLOUD_ML_REGION: "europe-west1", GOOGLE_CLOUD_LOCATION: "us-central1" };
+    expect(resolveVertexRegion(env)).toBe("europe-west1");
+  });
+
+  it("falls back to GOOGLE_CLOUD_LOCATION", () => {
+    const env = { GOOGLE_CLOUD_LOCATION: "us-central1" };
+    expect(resolveVertexRegion(env)).toBe("us-central1");
+  });
+
+  it("defaults to us-east5", () => {
+    expect(resolveVertexRegion({})).toBe("us-east5");
+  });
+});
+
+describe("buildVertexBaseUrl", () => {
+  it("constructs correct Vertex AI endpoint URL with trailing #", () => {
+    const url = buildVertexBaseUrl({
+      project: "my-project",
+      region: "us-east5",
+      model: "claude-sonnet-4-6@20250514",
+    });
+    expect(url).toBe(
+      "https://us-east5-aiplatform.googleapis.com/v1/projects/my-project/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-6@20250514:streamRawPredict#",
+    );
+  });
+
+  it("trailing # absorbs appended /v1/messages in URL fragment", () => {
+    const baseUrl = buildVertexBaseUrl({
+      project: "proj",
+      region: "us-east5",
+      model: "claude-opus-4-6@20250514",
+    });
+    // Simulate what the Anthropic SDK does: baseUrl + "/v1/messages"
+    const sdkUrl = new URL(baseUrl + "/v1/messages");
+    // Fragment should contain /v1/messages, actual request URL should not
+    expect(sdkUrl.hash).toBe("#/v1/messages");
+    expect(sdkUrl.pathname).toBe(
+      "/v1/projects/proj/locations/us-east5/publishers/anthropic/models/claude-opus-4-6@20250514:streamRawPredict",
+    );
+  });
+
+  it("works with different regions", () => {
+    const url = buildVertexBaseUrl({
+      project: "test",
+      region: "europe-west4",
+      model: "claude-haiku-4-5@20251001",
+    });
+    expect(url).toContain("europe-west4-aiplatform.googleapis.com");
+    expect(url).toContain("locations/europe-west4");
+  });
+});
+
+describe("resetVertexAuthCacheForTest", () => {
+  afterEach(() => {
+    resetVertexAuthCacheForTest();
+  });
+
+  it("resets without error", () => {
+    expect(() => resetVertexAuthCacheForTest()).not.toThrow();
+  });
+});

--- a/src/agents/anthropic-vertex-auth.ts
+++ b/src/agents/anthropic-vertex-auth.ts
@@ -1,0 +1,167 @@
+/**
+ * GCP Application Default Credentials (ADC) authentication for Vertex AI.
+ *
+ * Builds on the approach from @sallyom's original anthropic-vertex provider
+ * (PR #23985, issues #6937 and #17277), simplified to use zero external
+ * dependencies — raw OAuth2 refresh_token flow via native fetch instead of
+ * `@anthropic-ai/vertex-sdk`.
+ *
+ * @see https://github.com/openclaw/openclaw/pull/23985
+ * @see https://github.com/openclaw/openclaw/issues/6937
+ * @see https://github.com/openclaw/openclaw/issues/17277
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("anthropic-vertex-auth");
+
+const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+// Refresh 60 seconds before expiry to avoid edge cases.
+const TOKEN_REFRESH_MARGIN_MS = 60_000;
+
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0;
+let inflightRefresh: Promise<string> | null = null;
+
+export type GcpAdcCredentials = {
+  client_id: string;
+  client_secret: string;
+  refresh_token: string;
+  type: string;
+};
+
+/**
+ * Resolve the path to GCP Application Default Credentials.
+ */
+export function resolveAdcPath(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.GOOGLE_APPLICATION_CREDENTIALS?.trim()) {
+    return env.GOOGLE_APPLICATION_CREDENTIALS.trim();
+  }
+  return path.join(os.homedir(), ".config", "gcloud", "application_default_credentials.json");
+}
+
+/**
+ * Read and parse ADC credentials from disk.
+ */
+export function readAdcCredentials(adcPath: string): GcpAdcCredentials {
+  const raw = fs.readFileSync(adcPath, "utf8");
+  const creds = JSON.parse(raw) as Partial<GcpAdcCredentials>;
+  if (!creds.refresh_token) {
+    throw new Error(
+      `GCP ADC credentials at ${adcPath} must contain a refresh_token (run: gcloud auth application-default login)`,
+    );
+  }
+  if (!creds.client_id || !creds.client_secret) {
+    throw new Error(`GCP ADC credentials at ${adcPath} missing client_id or client_secret`);
+  }
+  return creds as GcpAdcCredentials;
+}
+
+/**
+ * Check whether GCP ADC credentials are available.
+ */
+export function hasGcpAdcCredentials(env: NodeJS.ProcessEnv = process.env): boolean {
+  try {
+    const adcPath = resolveAdcPath(env);
+    fs.accessSync(adcPath, fs.constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Refresh the OAuth2 access token using GCP ADC refresh_token flow.
+ * Returns a valid access token (cached if not expired).
+ */
+export async function getVertexAccessToken(env: NodeJS.ProcessEnv = process.env): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && now < tokenExpiresAt - TOKEN_REFRESH_MARGIN_MS) {
+    return cachedToken;
+  }
+  // Deduplicate concurrent refresh requests.
+  if (inflightRefresh) {
+    return inflightRefresh;
+  }
+  inflightRefresh = refreshAccessToken(env);
+  try {
+    return await inflightRefresh;
+  } finally {
+    inflightRefresh = null;
+  }
+}
+
+async function refreshAccessToken(env: NodeJS.ProcessEnv): Promise<string> {
+  const adcPath = resolveAdcPath(env);
+  const creds = readAdcCredentials(adcPath);
+
+  const body = new URLSearchParams({
+    client_id: creds.client_id,
+    client_secret: creds.client_secret,
+    refresh_token: creds.refresh_token,
+    grant_type: "refresh_token",
+  });
+
+  const res = await fetch(TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "unknown");
+    throw new Error(`GCP token refresh failed (${res.status}): ${errText}`);
+  }
+
+  const data = (await res.json()) as { access_token: string; expires_in: number };
+  cachedToken = data.access_token;
+  tokenExpiresAt = Date.now() + data.expires_in * 1000;
+  log.debug(`GCP access token refreshed, expires in ${data.expires_in}s`);
+  return cachedToken;
+}
+
+/**
+ * Resolve the GCP project ID from environment or ADC credentials.
+ */
+export function resolveVertexProjectId(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return (
+    env.ANTHROPIC_VERTEX_PROJECT_ID?.trim() ||
+    env.GOOGLE_CLOUD_PROJECT?.trim() ||
+    env.GCLOUD_PROJECT?.trim() ||
+    undefined
+  );
+}
+
+/**
+ * Resolve the Vertex AI region from environment.
+ */
+export function resolveVertexRegion(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CLOUD_ML_REGION?.trim() || env.GOOGLE_CLOUD_LOCATION?.trim() || "us-east5";
+}
+
+/**
+ * Build the Vertex AI streamRawPredict URL for a given model.
+ * A trailing `#` is appended so that when the Anthropic SDK appends
+ * `/v1/messages`, the extra path is absorbed into the URL fragment
+ * and stripped by `fetch()` per the WHATWG Fetch spec.
+ */
+export function buildVertexBaseUrl(params: {
+  project: string;
+  region: string;
+  model: string;
+}): string {
+  return (
+    `https://${params.region}-aiplatform.googleapis.com/v1/projects/${params.project}` +
+    `/locations/${params.region}/publishers/anthropic/models/${params.model}:streamRawPredict#`
+  );
+}
+
+/** Reset cached token (for testing). */
+export function resetVertexAuthCacheForTest(): void {
+  cachedToken = null;
+  tokenExpiresAt = 0;
+  inflightRefresh = null;
+}

--- a/src/agents/anthropic-vertex-auth.ts
+++ b/src/agents/anthropic-vertex-auth.ts
@@ -1,15 +1,19 @@
 /**
  * GCP Application Default Credentials (ADC) authentication for Vertex AI.
  *
+ * Supports two credential types:
+ * - **authorized_user**: OAuth2 refresh_token flow (from `gcloud auth application-default login`)
+ * - **service_account**: JWT-signed token exchange (from service account key JSON)
+ *
  * Builds on the approach from @sallyom's original anthropic-vertex provider
  * (PR #23985, issues #6937 and #17277), simplified to use zero external
- * dependencies — raw OAuth2 refresh_token flow via native fetch instead of
- * `@anthropic-ai/vertex-sdk`.
+ * dependencies — raw OAuth2/JWT flows via native fetch + Node crypto.
  *
  * @see https://github.com/openclaw/openclaw/pull/23985
  * @see https://github.com/openclaw/openclaw/issues/6937
  * @see https://github.com/openclaw/openclaw/issues/17277
  */
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -17,7 +21,9 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("anthropic-vertex-auth");
 
-const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const DEFAULT_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+const JWT_LIFETIME_SECONDS = 3600;
 
 // Refresh 60 seconds before expiry to avoid edge cases.
 const TOKEN_REFRESH_MARGIN_MS = 60_000;
@@ -26,12 +32,21 @@ let cachedToken: string | null = null;
 let tokenExpiresAt = 0;
 let inflightRefresh: Promise<string> | null = null;
 
-export type GcpAdcCredentials = {
+export type GcpAuthorizedUserCredentials = {
+  type: "authorized_user";
   client_id: string;
   client_secret: string;
   refresh_token: string;
-  type: string;
 };
+
+export type GcpServiceAccountCredentials = {
+  type: "service_account";
+  client_email: string;
+  private_key: string;
+  token_uri: string;
+};
+
+export type GcpAdcCredentials = GcpAuthorizedUserCredentials | GcpServiceAccountCredentials;
 
 /**
  * Resolve the path to GCP Application Default Credentials.
@@ -45,19 +60,50 @@ export function resolveAdcPath(env: NodeJS.ProcessEnv = process.env): string {
 
 /**
  * Read and parse ADC credentials from disk.
+ * Supports both authorized_user (refresh_token) and service_account (JWT) types.
  */
 export function readAdcCredentials(adcPath: string): GcpAdcCredentials {
   const raw = fs.readFileSync(adcPath, "utf8");
-  const creds = JSON.parse(raw) as Partial<GcpAdcCredentials>;
-  if (!creds.refresh_token) {
+  const creds = JSON.parse(raw) as Record<string, unknown>;
+  const credType = typeof creds.type === "string" ? creds.type : "";
+
+  if (credType === "service_account") {
+    const clientEmail = typeof creds.client_email === "string" ? creds.client_email.trim() : "";
+    const privateKey = typeof creds.private_key === "string" ? creds.private_key : "";
+    const tokenUri =
+      typeof creds.token_uri === "string" ? creds.token_uri.trim() : DEFAULT_TOKEN_ENDPOINT;
+    if (!clientEmail) {
+      throw new Error(`GCP service account credentials at ${adcPath} missing client_email`);
+    }
+    if (!privateKey) {
+      throw new Error(`GCP service account credentials at ${adcPath} missing private_key`);
+    }
+    return {
+      type: "service_account",
+      client_email: clientEmail,
+      private_key: privateKey,
+      token_uri: tokenUri,
+    };
+  }
+
+  // Default: authorized_user
+  const refreshToken = typeof creds.refresh_token === "string" ? creds.refresh_token : "";
+  const clientId = typeof creds.client_id === "string" ? creds.client_id : "";
+  const clientSecret = typeof creds.client_secret === "string" ? creds.client_secret : "";
+  if (!refreshToken) {
     throw new Error(
       `GCP ADC credentials at ${adcPath} must contain a refresh_token (run: gcloud auth application-default login)`,
     );
   }
-  if (!creds.client_id || !creds.client_secret) {
+  if (!clientId || !clientSecret) {
     throw new Error(`GCP ADC credentials at ${adcPath} missing client_id or client_secret`);
   }
-  return creds as GcpAdcCredentials;
+  return {
+    type: "authorized_user",
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+  };
 }
 
 /**
@@ -74,7 +120,11 @@ export function hasGcpAdcCredentials(env: NodeJS.ProcessEnv = process.env): bool
 }
 
 /**
- * Refresh the OAuth2 access token using GCP ADC refresh_token flow.
+ * Refresh the OAuth2 access token using GCP ADC credentials.
+ * Detects credential type and uses the appropriate flow:
+ * - authorized_user: OAuth2 refresh_token exchange
+ * - service_account: JWT-signed assertion exchange
+ *
  * Returns a valid access token (cached if not expired).
  */
 export async function getVertexAccessToken(env: NodeJS.ProcessEnv = process.env): Promise<string> {
@@ -98,6 +148,13 @@ async function refreshAccessToken(env: NodeJS.ProcessEnv): Promise<string> {
   const adcPath = resolveAdcPath(env);
   const creds = readAdcCredentials(adcPath);
 
+  if (creds.type === "service_account") {
+    return refreshServiceAccountToken(creds);
+  }
+  return refreshAuthorizedUserToken(creds);
+}
+
+async function refreshAuthorizedUserToken(creds: GcpAuthorizedUserCredentials): Promise<string> {
   const body = new URLSearchParams({
     client_id: creds.client_id,
     client_secret: creds.client_secret,
@@ -105,7 +162,7 @@ async function refreshAccessToken(env: NodeJS.ProcessEnv): Promise<string> {
     grant_type: "refresh_token",
   });
 
-  const res = await fetch(TOKEN_ENDPOINT, {
+  const res = await fetch(DEFAULT_TOKEN_ENDPOINT, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: body.toString(),
@@ -119,8 +176,73 @@ async function refreshAccessToken(env: NodeJS.ProcessEnv): Promise<string> {
   const data = (await res.json()) as { access_token: string; expires_in: number };
   cachedToken = data.access_token;
   tokenExpiresAt = Date.now() + data.expires_in * 1000;
-  log.debug(`GCP access token refreshed, expires in ${data.expires_in}s`);
+  log.debug(`GCP access token refreshed (authorized_user), expires in ${data.expires_in}s`);
   return cachedToken;
+}
+
+async function refreshServiceAccountToken(creds: GcpServiceAccountCredentials): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const signedJwt = buildSignedJwt({
+    clientEmail: creds.client_email,
+    privateKey: creds.private_key,
+    tokenUri: creds.token_uri,
+    iat: now,
+    exp: now + JWT_LIFETIME_SECONDS,
+  });
+
+  const body = new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: signedJwt,
+  });
+
+  const res = await fetch(creds.token_uri, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "unknown");
+    throw new Error(`GCP service account token exchange failed (${res.status}): ${errText}`);
+  }
+
+  const data = (await res.json()) as { access_token: string; expires_in: number };
+  cachedToken = data.access_token;
+  tokenExpiresAt = Date.now() + data.expires_in * 1000;
+  log.debug(`GCP access token refreshed (service_account), expires in ${data.expires_in}s`);
+  return cachedToken;
+}
+
+// ── JWT construction (zero deps — uses Node crypto) ────────────────────────
+
+function base64UrlEncode(data: Buffer | string): string {
+  const buf = typeof data === "string" ? Buffer.from(data, "utf8") : data;
+  return buf.toString("base64url");
+}
+
+/** Build and sign a JWT for the service account OAuth2 assertion flow. */
+export function buildSignedJwt(params: {
+  clientEmail: string;
+  privateKey: string;
+  tokenUri: string;
+  iat: number;
+  exp: number;
+}): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64UrlEncode(
+    JSON.stringify({
+      iss: params.clientEmail,
+      scope: CLOUD_PLATFORM_SCOPE,
+      aud: params.tokenUri,
+      iat: params.iat,
+      exp: params.exp,
+    }),
+  );
+
+  const signingInput = `${header}.${payload}`;
+  const signature = crypto.sign("RSA-SHA256", Buffer.from(signingInput, "utf8"), params.privateKey);
+
+  return `${signingInput}.${base64UrlEncode(signature)}`;
 }
 
 /**

--- a/src/agents/anthropic-vertex-stream.test.ts
+++ b/src/agents/anthropic-vertex-stream.test.ts
@@ -3,18 +3,18 @@ import { createAnthropicVertexStreamFn } from "./anthropic-vertex-stream.js";
 
 // Mock the auth module to avoid real GCP token refresh
 vi.mock("./anthropic-vertex-auth.js", async (importOriginal) => {
-  const original = await importOriginal();
+  const mod: Record<string, unknown> = await importOriginal();
   return {
-    ...original,
+    ...mod,
     getVertexAccessToken: vi.fn().mockResolvedValue("test-gcp-access-token"),
   };
 });
 
 // Mock streamSimple to capture what's passed to it
 vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
-  const original = await importOriginal();
+  const mod: Record<string, unknown> = await importOriginal();
   return {
-    ...original,
+    ...mod,
     streamSimple: vi.fn((_model, _context, _options) => {
       // Return a minimal event stream mock
       return {

--- a/src/agents/anthropic-vertex-stream.test.ts
+++ b/src/agents/anthropic-vertex-stream.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAnthropicVertexStreamFn } from "./anthropic-vertex-stream.js";
+
+// Mock the auth module to avoid real GCP token refresh
+vi.mock("./anthropic-vertex-auth.js", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    getVertexAccessToken: vi.fn().mockResolvedValue("test-gcp-access-token"),
+  };
+});
+
+// Mock streamSimple to capture what's passed to it
+vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    streamSimple: vi.fn((_model, _context, _options) => {
+      // Return a minimal event stream mock
+      return {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => ({ done: true, value: undefined }),
+        }),
+        result: async () => ({}),
+      };
+    }),
+  };
+});
+
+describe("createAnthropicVertexStreamFn", () => {
+  it("creates a stream function", () => {
+    const streamFn = createAnthropicVertexStreamFn({
+      project: "my-project",
+      region: "us-east5",
+    });
+    expect(typeof streamFn).toBe("function");
+  });
+
+  it("passes correct Vertex baseUrl to streamSimple", async () => {
+    const { streamSimple } = await import("@mariozechner/pi-ai");
+    const streamFn = createAnthropicVertexStreamFn({
+      project: "test-proj",
+      region: "us-east5",
+    });
+
+    const mockModel = {
+      id: "claude-sonnet-4-6@20250514",
+      api: "anthropic-messages",
+      provider: "anthropic-vertex",
+      baseUrl: "https://original.example.com",
+    };
+    const mockContext = { messages: [], systemPrompt: "test" };
+
+    // The StreamFn returns a promise (async wrapper)
+    await streamFn(mockModel as never, mockContext as never, undefined);
+
+    expect(streamSimple).toHaveBeenCalledTimes(1);
+    const call = (streamSimple as ReturnType<typeof vi.fn>).mock.calls[0];
+    const passedModel = call[0];
+
+    // baseUrl should be the Vertex endpoint with trailing #
+    expect(passedModel.baseUrl).toBe(
+      "https://us-east5-aiplatform.googleapis.com/v1/projects/test-proj/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-6@20250514:streamRawPredict#",
+    );
+  });
+
+  it("injects Bearer auth header from GCP token", async () => {
+    const { streamSimple } = await import("@mariozechner/pi-ai");
+    (streamSimple as ReturnType<typeof vi.fn>).mockClear();
+
+    const streamFn = createAnthropicVertexStreamFn({
+      project: "proj",
+      region: "us-east5",
+    });
+
+    const mockModel = {
+      id: "claude-opus-4-6@20250514",
+      api: "anthropic-messages",
+      provider: "anthropic-vertex",
+    };
+
+    await streamFn(mockModel as never, { messages: [] } as never, undefined);
+
+    const call = (streamSimple as ReturnType<typeof vi.fn>).mock.calls[0];
+    const passedModel = call[0];
+    expect(passedModel.headers?.Authorization).toBe("Bearer test-gcp-access-token");
+  });
+
+  it("onPayload removes model field and adds anthropic_version", async () => {
+    const { streamSimple } = await import("@mariozechner/pi-ai");
+    (streamSimple as ReturnType<typeof vi.fn>).mockClear();
+
+    const streamFn = createAnthropicVertexStreamFn({
+      project: "proj",
+      region: "us-east5",
+    });
+
+    const mockModel = {
+      id: "claude-sonnet-4-6@20250514",
+      api: "anthropic-messages",
+      provider: "anthropic-vertex",
+    };
+
+    await streamFn(mockModel as never, { messages: [] } as never, undefined);
+
+    const call = (streamSimple as ReturnType<typeof vi.fn>).mock.calls[0];
+    const passedOptions = call[2];
+    expect(typeof passedOptions.onPayload).toBe("function");
+
+    // Simulate the payload that buildParams would produce
+    const payload = {
+      model: "claude-sonnet-4-6@20250514",
+      messages: [],
+      max_tokens: 4096,
+      stream: true,
+    };
+    passedOptions.onPayload(payload, mockModel);
+
+    // model should be removed
+    expect(payload).not.toHaveProperty("model");
+    // anthropic_version should be added
+    expect((payload as Record<string, unknown>).anthropic_version).toBe("vertex-2023-10-16");
+  });
+
+  it("chains with existing onPayload callback", async () => {
+    const { streamSimple } = await import("@mariozechner/pi-ai");
+    (streamSimple as ReturnType<typeof vi.fn>).mockClear();
+
+    const originalOnPayload = vi.fn();
+    const streamFn = createAnthropicVertexStreamFn({
+      project: "proj",
+      region: "us-east5",
+    });
+
+    const mockModel = {
+      id: "claude-sonnet-4-6@20250514",
+      api: "anthropic-messages",
+      provider: "anthropic-vertex",
+    };
+
+    await streamFn(
+      mockModel as never,
+      { messages: [] } as never,
+      {
+        onPayload: originalOnPayload,
+      } as never,
+    );
+
+    const call = (streamSimple as ReturnType<typeof vi.fn>).mock.calls[0];
+    const passedOptions = call[2];
+    const payload = { model: "claude-sonnet-4-6@20250514", messages: [] };
+    passedOptions.onPayload(payload, mockModel);
+
+    expect(originalOnPayload).toHaveBeenCalledOnce();
+  });
+
+  it("preserves existing model headers", async () => {
+    const { streamSimple } = await import("@mariozechner/pi-ai");
+    (streamSimple as ReturnType<typeof vi.fn>).mockClear();
+
+    const streamFn = createAnthropicVertexStreamFn({
+      project: "proj",
+      region: "us-east5",
+    });
+
+    const mockModel = {
+      id: "claude-sonnet-4-6@20250514",
+      api: "anthropic-messages",
+      provider: "anthropic-vertex",
+      headers: { "x-custom": "value" },
+    };
+
+    await streamFn(mockModel as never, { messages: [] } as never, undefined);
+
+    const call = (streamSimple as ReturnType<typeof vi.fn>).mock.calls[0];
+    const passedModel = call[0];
+    expect(passedModel.headers["x-custom"]).toBe("value");
+    expect(passedModel.headers.Authorization).toBe("Bearer test-gcp-access-token");
+  });
+});

--- a/src/agents/anthropic-vertex-stream.ts
+++ b/src/agents/anthropic-vertex-stream.ts
@@ -1,0 +1,119 @@
+/**
+ * Vertex AI StreamFn — routes Claude requests through Google Vertex AI
+ * while reusing the existing anthropic-messages pipeline end-to-end.
+ *
+ * Inspired by @sallyom's anthropic-vertex-stream.ts from PR #23985.
+ * This version avoids a parallel streaming implementation by intercepting
+ * at the HTTP layer (URL rewrite + auth swap via onPayload/headers),
+ * keeping the diff minimal and reusing all existing SSE, tool use,
+ * and thinking/reasoning support.
+ *
+ * @see https://github.com/openclaw/openclaw/pull/23985
+ * @see https://github.com/openclaw/openclaw/issues/6937
+ */
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  buildVertexBaseUrl,
+  getVertexAccessToken,
+  resolveVertexProjectId,
+  resolveVertexRegion,
+} from "./anthropic-vertex-auth.js";
+
+const log = createSubsystemLogger("anthropic-vertex-stream");
+
+const VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16";
+
+/**
+ * Create a StreamFn that routes requests through the existing
+ * `anthropic-messages` pipeline but redirects them to Google Vertex AI.
+ *
+ * How it works:
+ * 1. The model's `baseUrl` is set to the Vertex streamRawPredict endpoint
+ *    with a trailing `#`. The Anthropic SDK (used by pi-ai) appends
+ *    `/v1/messages` via string concatenation, but the `#` causes it to
+ *    land in the URL fragment, which `fetch()` strips per the WHATWG spec.
+ * 2. The `Authorization: Bearer <gcp_token>` header is injected via
+ *    `model.headers`, overriding the SDK's default `x-api-key`.
+ * 3. `onPayload` removes the `model` field from the body (Vertex encodes
+ *    it in the URL) and injects `anthropic_version`.
+ *
+ * This reuses 100% of pi-ai's Anthropic Messages streaming, parsing,
+ * tool use, and thinking support with zero new dependencies.
+ */
+export function createAnthropicVertexStreamFn(params: {
+  project: string;
+  region: string;
+  env?: NodeJS.ProcessEnv;
+}): StreamFn {
+  const { project, region } = params;
+  const env = params.env ?? process.env;
+
+  return (model, context, options) => {
+    const vertexBaseUrl = buildVertexBaseUrl({
+      project,
+      region,
+      model: model.id,
+    });
+
+    // Wrap in an async-start pattern: obtain the GCP token, then delegate.
+    const run = async () => {
+      const token = await getVertexAccessToken(env);
+
+      const vertexModel = {
+        ...model,
+        baseUrl: vertexBaseUrl,
+        headers: {
+          ...model.headers,
+          Authorization: `Bearer ${token}`,
+        },
+      } as typeof model;
+
+      const originalOnPayload = options?.onPayload;
+
+      return streamSimple(vertexModel, context, {
+        ...options,
+        onPayload: (payload, payloadModel) => {
+          if (payload && typeof payload === "object") {
+            const p = payload as Record<string, unknown>;
+            // Vertex: model is in the URL, not the body.
+            delete p.model;
+            // Vertex requires anthropic_version in the body.
+            p.anthropic_version = VERTEX_ANTHROPIC_VERSION;
+          }
+          return originalOnPayload?.(payload, payloadModel);
+        },
+      });
+    };
+
+    // streamSimple returns synchronously (an event stream object).
+    // We need to start async work but return the stream immediately.
+    // Use the same pattern as the ollama-stream: create the event stream,
+    // run async logic, and pipe results through.
+    //
+    // However, streamSimple itself returns an event stream. We need to
+    // proxy it. We'll return a Promise-like that resolves to the stream.
+    // pi-ai's agent loop handles both sync and async StreamFn returns.
+    return run() as unknown as ReturnType<StreamFn>;
+  };
+}
+
+/**
+ * Resolve Vertex configuration from environment and create the StreamFn.
+ * Returns null if required config (project ID) is not available.
+ */
+export function resolveAnthropicVertexStreamFn(
+  env: NodeJS.ProcessEnv = process.env,
+): StreamFn | null {
+  const project = resolveVertexProjectId(env);
+  if (!project) {
+    log.debug("anthropic-vertex: no project ID configured, skipping");
+    return null;
+  }
+
+  const region = resolveVertexRegion(env);
+  log.debug(`anthropic-vertex: project=${project} region=${region}`);
+
+  return createAnthropicVertexStreamFn({ project, region, env });
+}

--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -38,6 +38,7 @@ export const PROVIDER_ENV_API_KEY_CANDIDATES: Record<string, string[]> = {
   sglang: ["SGLANG_API_KEY"],
   vllm: ["VLLM_API_KEY"],
   kilocode: ["KILOCODE_API_KEY"],
+  "anthropic-vertex": ["ANTHROPIC_VERTEX_PROJECT_ID", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT"],
 };
 
 export function listKnownProviderEnvApiKeyNames(): string[] {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -113,7 +113,13 @@ function resolveProviderAuthOverride(
 ): ModelProviderAuthMode | undefined {
   const entry = resolveProviderConfig(cfg, provider);
   const auth = entry?.auth;
-  if (auth === "api-key" || auth === "aws-sdk" || auth === "oauth" || auth === "token") {
+  if (
+    auth === "api-key" ||
+    auth === "aws-sdk" ||
+    auth === "gcp-adc" ||
+    auth === "oauth" ||
+    auth === "token"
+  ) {
     return auth;
   }
   return undefined;
@@ -171,6 +177,28 @@ export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): s
   return undefined;
 }
 
+function resolveGcpAdcAuthInfo(): ResolvedProviderAuth {
+  const applied = new Set(getShellEnvAppliedKeys());
+  const projectVar = process.env.ANTHROPIC_VERTEX_PROJECT_ID?.trim()
+    ? "ANTHROPIC_VERTEX_PROJECT_ID"
+    : process.env.GOOGLE_CLOUD_PROJECT?.trim()
+      ? "GOOGLE_CLOUD_PROJECT"
+      : process.env.GCLOUD_PROJECT?.trim()
+        ? "GCLOUD_PROJECT"
+        : undefined;
+  return {
+    apiKey: projectVar ?? "GCP_ADC",
+    mode: "gcp-adc",
+    source: projectVar
+      ? resolveEnvSourceLabel({
+          applied,
+          envVars: [projectVar],
+          label: projectVar,
+        })
+      : "gcp-adc default chain",
+  };
+}
+
 function resolveAwsSdkAuthInfo(): { mode: "aws-sdk"; source: string } {
   const applied = new Set(getShellEnvAppliedKeys());
   if (process.env[AWS_BEARER_ENV]?.trim()) {
@@ -210,7 +238,7 @@ export type ResolvedProviderAuth = {
   apiKey?: string;
   profileId?: string;
   source: string;
-  mode: "api-key" | "oauth" | "token" | "aws-sdk";
+  mode: "api-key" | "oauth" | "token" | "aws-sdk" | "gcp-adc";
 };
 
 export async function resolveApiKeyForProvider(params: {
@@ -246,6 +274,9 @@ export async function resolveApiKeyForProvider(params: {
   const authOverride = resolveProviderAuthOverride(cfg, provider);
   if (authOverride === "aws-sdk") {
     return resolveAwsSdkAuthInfo();
+  }
+  if (authOverride === "gcp-adc") {
+    return resolveGcpAdcAuthInfo();
   }
 
   const order = resolveAuthProfileOrder({
@@ -299,6 +330,9 @@ export async function resolveApiKeyForProvider(params: {
   if (authOverride === undefined && normalized === "amazon-bedrock") {
     return resolveAwsSdkAuthInfo();
   }
+  if (authOverride === undefined && normalized === "anthropic-vertex") {
+    return resolveGcpAdcAuthInfo();
+  }
 
   if (provider === "openai") {
     const hasCodex = listProfilesForProvider(store, "openai-codex").length > 0;
@@ -321,7 +355,14 @@ export async function resolveApiKeyForProvider(params: {
 }
 
 export type EnvApiKeyResult = { apiKey: string; source: string };
-export type ModelAuthMode = "api-key" | "oauth" | "token" | "mixed" | "aws-sdk" | "unknown";
+export type ModelAuthMode =
+  | "api-key"
+  | "oauth"
+  | "token"
+  | "mixed"
+  | "aws-sdk"
+  | "gcp-adc"
+  | "unknown";
 
 export function resolveEnvApiKey(
   provider: string,
@@ -372,6 +413,9 @@ export function resolveModelAuthMode(
   if (authOverride === "aws-sdk") {
     return "aws-sdk";
   }
+  if (authOverride === "gcp-adc") {
+    return "gcp-adc";
+  }
 
   const authStore = store ?? ensureAuthProfileStore();
   const profiles = listProfilesForProvider(authStore, resolved);
@@ -400,6 +444,9 @@ export function resolveModelAuthMode(
 
   if (authOverride === undefined && normalizeProviderId(resolved) === "amazon-bedrock") {
     return "aws-sdk";
+  }
+  if (authOverride === undefined && normalizeProviderId(resolved) === "anthropic-vertex") {
+    return "gcp-adc";
   }
 
   const envKey = resolveEnvApiKey(resolved);

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -187,6 +187,9 @@ function resolveOpenAICodexForwardCompatModel(
   } as Model<Api>);
 }
 
+// Providers that serve Anthropic Claude models and share the same model ID scheme.
+const ANTHROPIC_FAMILY_PROVIDERS = new Set(["anthropic", "anthropic-vertex"]);
+
 function resolveAnthropic46ForwardCompatModel(params: {
   provider: string;
   modelId: string;
@@ -199,7 +202,7 @@ function resolveAnthropic46ForwardCompatModel(params: {
 }): Model<Api> | undefined {
   const { provider, modelId, modelRegistry, dashModelId, dotModelId } = params;
   const normalizedProvider = normalizeProviderId(provider);
-  if (normalizedProvider !== "anthropic") {
+  if (!ANTHROPIC_FAMILY_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
 
@@ -223,12 +226,39 @@ function resolveAnthropic46ForwardCompatModel(params: {
   }
   templateIds.push(...params.fallbackTemplateIds);
 
-  return cloneFirstTemplateModel({
+  // Search for templates under the actual provider first, then fall back
+  // to the base "anthropic" provider (cloud providers like anthropic-vertex
+  // register models under their own provider key, but templates may only
+  // exist under "anthropic" in the built-in registry).
+  const direct = cloneFirstTemplateModel({
     normalizedProvider,
     trimmedModelId,
     templateIds,
     modelRegistry,
   });
+  if (direct) {
+    return direct;
+  }
+
+  // Cross-provider template lookup: find the template under "anthropic" but
+  // rebrand the cloned model to the actual provider so auth, streaming, and
+  // URL routing use the correct provider-specific paths.
+  if (normalizedProvider !== "anthropic") {
+    const crossProvider = cloneFirstTemplateModel({
+      normalizedProvider: "anthropic",
+      trimmedModelId,
+      templateIds,
+      modelRegistry,
+    });
+    if (crossProvider) {
+      return normalizeModelCompat({
+        ...crossProvider,
+        provider: normalizedProvider,
+      } as Model<Api>);
+    }
+  }
+
+  return undefined;
 }
 
 function resolveAnthropicOpus46ForwardCompatModel(

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -87,6 +87,9 @@ export function normalizeProviderId(provider: string): string {
   if (normalized === "bedrock" || normalized === "aws-bedrock") {
     return "amazon-bedrock";
   }
+  if (normalized === "vertex-anthropic" || normalized === "google-vertex-anthropic") {
+    return "anthropic-vertex";
+  }
   // Backward compatibility for older provider naming.
   if (normalized === "bytedance" || normalized === "doubao") {
     return "volcengine";

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -61,6 +61,11 @@ import {
   resolvePluginDiscoveryProviders,
 } from "../plugins/provider-discovery.js";
 import {
+  hasGcpAdcCredentials,
+  resolveVertexProjectId,
+  resolveVertexRegion,
+} from "./anthropic-vertex-auth.js";
+import {
   MINIMAX_OAUTH_MARKER,
   QWEN_OAUTH_MARKER,
   isNonSecretApiKeyMarker,
@@ -527,11 +532,26 @@ export function normalizeProviders(params: {
     const hasConfiguredApiKey = Boolean(normalizedApiKey || normalizedProvider.apiKey);
     if (hasModels && !hasConfiguredApiKey) {
       const authMode =
-        normalizedProvider.auth ?? (normalizedKey === "amazon-bedrock" ? "aws-sdk" : undefined);
+        normalizedProvider.auth ??
+        (normalizedKey === "amazon-bedrock"
+          ? "aws-sdk"
+          : normalizedKey === "anthropic-vertex"
+            ? "gcp-adc"
+            : undefined);
       if (authMode === "aws-sdk") {
         const apiKey = resolveAwsSdkApiKeyVarName(env);
         mutated = true;
         normalizedProvider = { ...normalizedProvider, apiKey };
+      } else if (authMode === "gcp-adc") {
+        const projectVar = env.ANTHROPIC_VERTEX_PROJECT_ID?.trim()
+          ? "ANTHROPIC_VERTEX_PROJECT_ID"
+          : env.GOOGLE_CLOUD_PROJECT?.trim()
+            ? "GOOGLE_CLOUD_PROJECT"
+            : env.GCLOUD_PROJECT?.trim()
+              ? "GCLOUD_PROJECT"
+              : "GCP_ADC";
+        mutated = true;
+        normalizedProvider = { ...normalizedProvider, apiKey: projectVar };
       } else {
         const fromEnv = resolveEnvApiKeyVarName(normalizedKey, env);
         const apiKey = fromEnv ?? profileApiKey?.apiKey;
@@ -905,6 +925,13 @@ export async function resolveImplicitProviders(
       : implicitBedrock;
   }
 
+  if (!providers["anthropic-vertex"]) {
+    const implicitVertex = resolveImplicitAnthropicVertexProvider({ env });
+    if (implicitVertex) {
+      providers["anthropic-vertex"] = implicitVertex;
+    }
+  }
+
   return providers;
 }
 
@@ -963,6 +990,67 @@ export async function resolveImplicitCopilotProvider(params: {
   return {
     baseUrl,
     models: [],
+  } satisfies ProviderConfig;
+}
+
+/**
+ * Auto-discover anthropic-vertex when GCP project + ADC credentials are present.
+ * Follows the same implicit-provider pattern as Bedrock (resolveImplicitBedrockProvider).
+ * See: https://github.com/openclaw/openclaw/issues/6937
+ */
+export function resolveImplicitAnthropicVertexProvider(params: {
+  env?: NodeJS.ProcessEnv;
+}): ProviderConfig | null {
+  const env = params.env ?? process.env;
+  const project = resolveVertexProjectId(env);
+  if (!project) {
+    return null;
+  }
+  if (!hasGcpAdcCredentials(env)) {
+    return null;
+  }
+
+  const region = resolveVertexRegion(env);
+  const projectVar = env.ANTHROPIC_VERTEX_PROJECT_ID?.trim()
+    ? "ANTHROPIC_VERTEX_PROJECT_ID"
+    : env.GOOGLE_CLOUD_PROJECT?.trim()
+      ? "GOOGLE_CLOUD_PROJECT"
+      : "GCLOUD_PROJECT";
+
+  return {
+    baseUrl: `https://${region}-aiplatform.googleapis.com`,
+    api: "anthropic-messages",
+    auth: "gcp-adc",
+    apiKey: projectVar,
+    models: [
+      {
+        id: "claude-opus-4-6@20250514",
+        name: "Claude Opus 4.6 (Vertex AI)",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 32000,
+      },
+      {
+        id: "claude-sonnet-4-6@20250514",
+        name: "Claude Sonnet 4.6 (Vertex AI)",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 16000,
+      },
+      {
+        id: "claude-haiku-4-5@20251001",
+        name: "Claude Haiku 4.5 (Vertex AI)",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      },
+    ],
   } satisfies ProviderConfig;
 }
 

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -376,3 +376,7 @@ export function isAnthropicBedrockModel(modelId: string): boolean {
   const normalized = modelId.toLowerCase();
   return normalized.includes("anthropic.claude") || normalized.includes("anthropic/claude");
 }
+
+export function isAnthropicVertexProvider(provider: string): boolean {
+  return provider === "anthropic-vertex";
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -34,6 +34,7 @@ import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
+import { resolveAnthropicVertexStreamFn } from "../../anthropic-vertex-stream.js";
 import {
   analyzeBootstrapBudget,
   buildBootstrapPromptWarning,
@@ -1889,6 +1890,14 @@ export async function runEmbeddedAttempt(
         });
         activeSession.agent.streamFn = ollamaStreamFn;
         ensureCustomApiRegistered(params.model.api, ollamaStreamFn);
+      } else if (normalizeProviderId(params.provider) === "anthropic-vertex") {
+        const vertexStreamFn = resolveAnthropicVertexStreamFn();
+        if (vertexStreamFn) {
+          activeSession.agent.streamFn = vertexStreamFn;
+        } else {
+          log.warn(`anthropic-vertex: missing project/region config; using default stream`);
+          activeSession.agent.streamFn = streamSimple;
+        }
       } else if (params.model.api === "openai-responses" && params.provider === "openai") {
         const wsApiKey = await params.authStorage.getApiKey(params.provider);
         if (wsApiKey) {

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -33,6 +33,9 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
   "amazon-bedrock": {
     providerFamily: "anthropic",
   },
+  "anthropic-vertex": {
+    providerFamily: "anthropic",
+  },
   // kimi-coding natively supports Anthropic tool framing (input_schema);
   // converting to OpenAI format causes XML text fallback instead of tool_use blocks.
   "kimi-coding": {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -150,6 +150,7 @@ export function resolveThinkingDefaultForModel(params: {
   const isAnthropicFamilyModel =
     normalizedProvider === "anthropic" ||
     normalizedProvider === "amazon-bedrock" ||
+    normalizedProvider === "anthropic-vertex" ||
     modelLower.includes("anthropic/") ||
     modelLower.includes(".anthropic.");
   if (isAnthropicFamilyModel && CLAUDE_46_MODEL_RE.test(modelLower)) {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -712,7 +712,7 @@ export const FIELD_HELP: Record<string, string> = {
   "models.providers.*.apiKey":
     "Provider credential used for API-key based authentication when the provider requires direct key auth. Use secret/env substitution and avoid storing real keys in committed config files.",
   "models.providers.*.auth":
-    'Selects provider auth style: "api-key" for API key auth, "token" for bearer token auth, "oauth" for OAuth credentials, and "aws-sdk" for AWS credential resolution. Match this to your provider requirements.',
+    'Selects provider auth style: "api-key" for API key auth, "token" for bearer token auth, "oauth" for OAuth credentials, "aws-sdk" for AWS credential resolution, and "gcp-adc" for Google Cloud Application Default Credentials. Match this to your provider requirements.',
   "models.providers.*.api":
     "Provider API adapter selection controlling request/response compatibility handling for model calls. Use the adapter that matches your upstream provider protocol to avoid feature mismatch.",
   "models.providers.*.injectNumCtxForOpenAICompat":

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -29,7 +29,7 @@ export type ModelCompatConfig = {
   requiresOpenAiAnthropicToolPayload?: boolean;
 };
 
-export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";
+export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "gcp-adc" | "oauth" | "token";
 
 export type ModelDefinitionConfig = {
   id: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -229,7 +229,13 @@ export const ModelProviderSchema = z
     baseUrl: z.string().min(1),
     apiKey: SecretInputSchema.optional().register(sensitive),
     auth: z
-      .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token")])
+      .union([
+        z.literal("api-key"),
+        z.literal("aws-sdk"),
+        z.literal("gcp-adc"),
+        z.literal("oauth"),
+        z.literal("token"),
+      ])
       .optional(),
     api: ModelApiSchema.optional(),
     injectNumCtxForOpenAICompat: z.boolean().optional(),


### PR DESCRIPTION
Adds `anthropic-vertex` as a first-class provider that routes Claude requests through Google Vertex AI using GCP Application Default Credentials (ADC).

### Motivation

This has been requested multiple times (#6937, #17277) and was partially addressed in #23985 by @sallyom. This implementation takes a different approach: zero new dependencies, reusing 100% of the existing `anthropic-messages` pipeline.

### How it works

1. **Auto-discovery:** When `GOOGLE_CLOUD_PROJECT` (or `ANTHROPIC_VERTEX_PROJECT_ID`) is set and GCP ADC credentials exist, the provider registers implicitly with Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5 models
2. **Auth:** OAuth2 token refresh from `~/.config/gcloud/application_default_credentials.json` with 60s pre-expiry caching — zero external dependencies
3. **Request flow:** `streamSimple` → pi-ai's `streamAnthropic` → Anthropic SDK → `fetch(vertexUrl#/v1/messages)` → Vertex AI
4. **Body transform:** `onPayload` removes `model` field, adds `anthropic_version: "vertex-2023-10-16"`

The key insight: the Anthropic SDK constructs URLs via `baseURL + path`. By appending a URL fragment (`#`) to the Vertex `streamRawPredict` endpoint, the `/v1/messages` path the SDK appends gets absorbed into the fragment — which `fetch()` strips per the WHATWG Fetch spec.

### Files

**New (4):**
| File | LOC | Purpose |
|------|-----|---------|
| `anthropic-vertex-auth.ts` | 155 | GCP ADC OAuth2 token refresh with caching |
| `anthropic-vertex-stream.ts` | 106 | StreamFn wrapper — redirects to Vertex endpoint |
| `anthropic-vertex-auth.test.ts` | 196 | 22 tests covering auth, ADC, URL construction |
| `anthropic-vertex-stream.test.ts` | 180 | 6 tests covering StreamFn delegation + payload transform |

**Modified (11):** model-auth, model-auth-env-vars, model-selection, provider-capabilities, models-config.providers, attempt.ts, anthropic-stream-wrappers, model-forward-compat, types.models, zod-schema.core, schema.help

### Env vars

- `ANTHROPIC_VERTEX_PROJECT_ID` or `GOOGLE_CLOUD_PROJECT` — GCP project ID
- `CLOUD_ML_REGION` or `GOOGLE_CLOUD_LOCATION` — region (defaults to `us-east5`)

### Note on pi-mono

This is a pragmatic implementation that works entirely within OpenClaw today. When pi-mono gains native Vertex support (being explored separately by @sallyom), this can be removed in favor of just config and provider registration — no long-term code burden.

### AI-assisted

Built with Claude Code (AI-assisted), fully tested. `pnpm build && pnpm check && pnpm test` all pass (898 test files, 7348 tests).

Closes #6937

Co-authored-by: Sally O'Malley <somalley@redhat.com>