### PR TITLE
Plugins: apply manifest config patches on install

### DIFF
--- a/src/cli/plugins-cli.test.ts
+++ b/src/cli/plugins-cli.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { applyPluginInstallConfigPatch } from "./plugins-cli.js";
+
+describe("applyPluginInstallConfigPatch", () => {
+  it("deep-merges manifest configPatch into the install config", () => {
+    const config = {
+      plugins: {
+        entries: {
+          demo: { enabled: true },
+        },
+      },
+      tools: {
+        alsoAllow: ["existing"],
+      },
+    } as OpenClawConfig;
+
+    const next = applyPluginInstallConfigPatch(config, {
+      providers: {
+        demo: {
+          apiKey: "test-key",
+        },
+      },
+      tools: {
+        alsoAllow: ["plugin-tool"],
+      },
+    });
+
+    expect(next.plugins?.entries?.demo?.enabled).toBe(true);
+    expect(next.providers).toEqual({
+      demo: {
+        apiKey: "test-key",
+      },
+    });
+    expect(next.tools?.alsoAllow).toEqual(["plugin-tool"]);
+  });
+});

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { Command } from "commander";
+import { mergeConfigPatch } from "../commands/provider-auth-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig, writeConfigFile } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -11,6 +12,7 @@ import { enablePluginInConfig } from "../plugins/enable.js";
 import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
 import { recordPluginInstall } from "../plugins/installs.js";
 import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
+import { loadPluginManifest } from "../plugins/manifest.js";
 import type { PluginRecord } from "../plugins/registry.js";
 import { applyExclusiveSlotSelection } from "../plugins/slots.js";
 import { resolvePluginSourceRoots, formatPluginSourceForTable } from "../plugins/source-display.js";
@@ -144,6 +146,16 @@ function createPluginInstallLogger(): { info: (msg: string) => void; warn: (msg:
   };
 }
 
+export function applyPluginInstallConfigPatch(
+  config: OpenClawConfig,
+  patch?: Partial<OpenClawConfig>,
+): OpenClawConfig {
+  if (!patch) {
+    return config;
+  }
+  return mergeConfigPatch(config, patch);
+}
+
 function logSlotWarnings(warnings: string[]) {
   if (warnings.length === 0) {
     return;
@@ -180,6 +192,11 @@ async function installBundledPluginSource(params: {
       },
     },
   };
+  const manifestResult = loadPluginManifest(params.bundledSource.localPath, false);
+  next = applyPluginInstallConfigPatch(
+    next,
+    manifestResult.ok ? manifestResult.manifest.configPatch : undefined,
+  );
   next = recordPluginInstall(next, {
     pluginId: params.bundledSource.pluginId,
     source: "path",
@@ -233,6 +250,7 @@ async function runPluginInstallCommand(params: {
         },
         probe.pluginId,
       ).config;
+      next = applyPluginInstallConfigPatch(next, probe.configPatch);
       next = recordPluginInstall(next, {
         pluginId: probe.pluginId,
         source: "path",
@@ -262,6 +280,7 @@ async function runPluginInstallCommand(params: {
     clearPluginManifestRegistryCache();
 
     let next = enablePluginInConfig(cfg, result.pluginId).config;
+    next = applyPluginInstallConfigPatch(next, result.configPatch);
     const source: "archive" | "path" = resolveArchiveKind(resolved) ? "archive" : "path";
     next = recordPluginInstall(next, {
       pluginId: result.pluginId,
@@ -341,6 +360,7 @@ async function runPluginInstallCommand(params: {
   clearPluginManifestRegistryCache();
 
   let next = enablePluginInConfig(cfg, result.pluginId).config;
+  next = applyPluginInstallConfigPatch(next, result.configPatch);
   const installRecord = resolvePinnedNpmInstallRecordForCli(
     raw,
     Boolean(opts.pin),

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -214,7 +214,10 @@ async function installFromDirWithWarnings(params: { pluginDir: string; extension
   return { result, warnings };
 }
 
-function setupManifestInstallFixture(params: { manifestId: string }) {
+function setupManifestInstallFixture(params: {
+  manifestId: string;
+  configPatch?: Record<string, unknown>;
+}) {
   const caseDir = makeTempDir();
   const stateDir = path.join(caseDir, "state");
   const pluginDir = path.join(caseDir, "plugin-src");
@@ -225,6 +228,7 @@ function setupManifestInstallFixture(params: { manifestId: string }) {
     JSON.stringify({
       id: params.manifestId,
       configSchema: { type: "object", properties: {} },
+      ...(params.configPatch ? { configPatch: params.configPatch } : {}),
     }),
     "utf-8",
   );
@@ -712,6 +716,36 @@ describe("installPluginFromDir", () => {
     });
 
     expectInstalledAsMemoryCognee(res, extensionsDir);
+  });
+
+  it("returns manifest configPatch so install flows can apply it", async () => {
+    const { pluginDir, extensionsDir } = setupManifestInstallFixture({
+      manifestId: "memory-cognee",
+      configPatch: {
+        providers: {
+          cognee: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    const res = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expectInstalledAsMemoryCognee(res, extensionsDir);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.configPatch).toEqual({
+      providers: {
+        cognee: {
+          enabled: true,
+        },
+      },
+    });
   });
 });
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
 import { fileExists, readJsonFile, resolveArchiveKind } from "../infra/archive.js";
 import { writeFileFromPathWithinRoot } from "../infra/fs-safe.js";
 import { resolveExistingInstallPath, withExtractedArchiveRoot } from "../infra/install-flow.js";
@@ -67,6 +68,7 @@ export type InstallPluginResult =
       manifestName?: string;
       version?: string;
       extensions: string[];
+      configPatch?: Partial<OpenClawConfig>;
       npmResolution?: NpmSpecResolution;
       integrityDrift?: NpmIntegrityDrift;
     }
@@ -245,6 +247,9 @@ async function installPluginFromPackageDir(
     ocManifestResult.ok && ocManifestResult.manifest.id
       ? unscopedPackageName(ocManifestResult.manifest.id)
       : undefined;
+  const manifestConfigPatch = ocManifestResult.ok
+    ? ocManifestResult.manifest.configPatch
+    : undefined;
 
   const pluginId = manifestPluginId ?? npmPluginId;
   const pluginIdError = validatePluginId(pluginId);
@@ -335,6 +340,7 @@ async function installPluginFromPackageDir(
       manifestName: pkgName || undefined,
       version: typeof manifest.version === "string" ? manifest.version : undefined,
       extensions,
+      configPatch: manifestConfigPatch,
     };
   }
 
@@ -373,6 +379,7 @@ async function installPluginFromPackageDir(
     manifestName: pkgName || undefined,
     version: typeof manifest.version === "string" ? manifest.version : undefined,
     extensions,
+    configPatch: manifestConfigPatch,
   };
 }
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
 import type { PluginConfigUiHint, PluginKind } from "./types.js";
@@ -19,6 +20,7 @@ export type PluginManifest = {
   description?: string;
   version?: string;
   uiHints?: Record<string, PluginConfigUiHint>;
+  configPatch?: Partial<OpenClawConfig>;
 };
 
 export type PluginManifestLoadResult =
@@ -99,6 +101,9 @@ export function loadPluginManifest(
   if (isRecord(raw.uiHints)) {
     uiHints = raw.uiHints as Record<string, PluginConfigUiHint>;
   }
+  const configPatch = isRecord(raw.configPatch)
+    ? (raw.configPatch as Partial<OpenClawConfig>)
+    : undefined;
 
   return {
     ok: true,
@@ -113,6 +118,7 @@ export function loadPluginManifest(
       description,
       version,
       uiHints,
+      configPatch,
     },
     manifestPath,
   };


### PR DESCRIPTION
## Summary

- Problem: plugin manifests could not declare install-time config changes, so users still had to manually edit `openclaw.json` after `openclaw plugins install`.
- Why it matters: plugins that need `tools.*`, provider, service, or hook config were still easy to misconfigure even after a successful install.
- What changed: `openclaw.plugin.json` now accepts `configPatch`, package installs return it, and `plugins install` deep-merges that patch into the saved config for local, linked, npm, and bundled-plugin install flows.
- What did NOT change (scope boundary): this does not add uninstall rollback or a user-facing diff printer for each patched key.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #6792
- Related #43394

## User-visible / Behavior Changes

- `openclaw plugins install` now applies manifest-declared `configPatch` automatically instead of requiring a separate manual config edit.
- This applies to linked local paths, copied local paths/archives, npm installs, and bundled-plugin installs.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): plugin install CLI
- Relevant config (redacted): local test fixtures only

### Steps

1. Create a plugin fixture with `openclaw.plugin.json` containing `configPatch`.
2. Install it through the existing plugin install helpers / CLI merge path.
3. Verify the install result carries the patch and the install config deep-merges it without dropping existing fields.

### Expected

- Plugin installs expose manifest `configPatch` and `plugins install` persists it into config.

### Actual

- Verified locally with targeted tests and a full build.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: manifest `configPatch` is parsed, propagated through `installPluginFromDir`, and merged by the CLI install path helper.
- Edge cases checked: existing nested config remains in place while patched keys overwrite only the targeted branch; bundled-plugin install path also reads the manifest patch.
- What you did **not** verify: uninstall/revert flows, or a user-visible config diff output.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit 79089e559 or manually remove the merged config keys and reinstall.
- Files/config to restore: the user's `openclaw.json` if an applied patch needs to be rolled back.
- Known bad symptoms reviewers should watch for: plugin install unexpectedly overwriting unrelated config branches.

## Risks and Mitigations

- Risk: manifest patches are applied silently and could surprise users if a plugin ships an aggressive patch.
  - Mitigation: scope is limited to explicit manifest keys, merge behavior is the existing `mergeConfigPatch` logic already used by provider auth, and config validation still runs on write.
