### PR TITLE
Voice-call: time out hanging ngrok commands

### DIFF
--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -1,0 +1,98 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+import { isNgrokAvailable, startNgrokTunnel } from "./tunnel.js";
+
+function createFakeChild() {
+  const child = new EventEmitter() as EventEmitter & ChildProcess;
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  let killed = false;
+  const kill = vi.fn<(signal?: NodeJS.Signals) => boolean>(() => {
+    killed = true;
+    return true;
+  });
+
+  Object.defineProperty(child, "stdout", {
+    value: stdout,
+    configurable: true,
+  });
+  Object.defineProperty(child, "stderr", {
+    value: stderr,
+    configurable: true,
+  });
+  Object.defineProperty(child, "stdin", {
+    value: null,
+    configurable: true,
+  });
+  Object.defineProperty(child, "kill", {
+    value: kill,
+    configurable: true,
+  });
+  Object.defineProperty(child, "killed", {
+    get: () => killed,
+    configurable: true,
+  });
+
+  return { child, stdout, stderr, kill };
+}
+
+describe("voice-call tunnel ngrok timeouts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns false when ngrok version probe hangs", async () => {
+    vi.useFakeTimers();
+    const fake = createFakeChild();
+    spawnMock.mockReturnValue(fake.child);
+
+    const availabilityPromise = isNgrokAvailable();
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(availabilityPromise).resolves.toBe(false);
+    expect(spawnMock).toHaveBeenCalledWith("ngrok", ["version"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect(fake.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("times out ngrok auth-token setup before tunnel startup", async () => {
+    vi.useFakeTimers();
+    const fake = createFakeChild();
+    spawnMock.mockReturnValue(fake.child);
+
+    const tunnelPromise = expect(
+      startNgrokTunnel({
+        port: 3334,
+        path: "/voice/webhook",
+        authToken: "token-123",
+      }),
+    ).rejects.toThrow("ngrok command timed out after 30000ms");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await tunnelPromise;
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenCalledWith("ngrok", ["config", "add-authtoken", "token-123"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect(fake.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+});

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -1,6 +1,9 @@
 import { spawn } from "node:child_process";
 import { getTailscaleDnsName } from "./webhook/tailscale.js";
 
+const NGROK_COMMAND_TIMEOUT_MS = 30_000;
+const NGROK_AVAILABILITY_TIMEOUT_MS = 5_000;
+
 /**
  * Tunnel configuration for exposing the webhook server.
  */
@@ -169,6 +172,25 @@ async function runNgrokCommand(args: string[]): Promise<string> {
 
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    const timeout = setTimeout(() => {
+      proc.kill("SIGKILL");
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(new Error(`ngrok command timed out after ${NGROK_COMMAND_TIMEOUT_MS}ms`));
+    }, NGROK_COMMAND_TIMEOUT_MS);
+    timeout.unref?.();
+
+    const finishReject = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    };
 
     proc.stdout.on("data", (data) => {
       stdout += data.toString();
@@ -178,6 +200,11 @@ async function runNgrokCommand(args: string[]): Promise<string> {
     });
 
     proc.on("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
       if (code === 0) {
         resolve(stdout);
       } else {
@@ -185,7 +212,9 @@ async function runNgrokCommand(args: string[]): Promise<string> {
       }
     });
 
-    proc.on("error", reject);
+    proc.on("error", (error) => {
+      finishReject(error instanceof Error ? error : new Error(String(error)));
+    });
   });
 }
 
@@ -197,12 +226,32 @@ export async function isNgrokAvailable(): Promise<boolean> {
     const proc = spawn("ngrok", ["version"], {
       stdio: ["ignore", "pipe", "pipe"],
     });
+    let settled = false;
+    const timeout = setTimeout(() => {
+      proc.kill("SIGKILL");
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(false);
+    }, NGROK_AVAILABILITY_TIMEOUT_MS);
+    timeout.unref?.();
 
     proc.on("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
       resolve(code === 0);
     });
 
     proc.on("error", () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
       resolve(false);
     });
   });


### PR DESCRIPTION
## Summary

- Problem: the voice-call extension spawned `ngrok` for auth-token setup and availability probing with no timeout, so a hung CLI process could block startup forever.
- Why it matters: a broken `ngrok` binary or network path could leave the voice-call feature permanently stuck instead of failing closed.
- What changed: added hard timeouts to `runNgrokCommand()` and `isNgrokAvailable()`, killing the child process and failing/returning `false` when `ngrok` does not respond.
- What did NOT change (scope boundary): this does not change the existing tunnel startup timeout or add new user-facing config knobs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #6627
- Related #43421

## User-visible / Behavior Changes

- Hanging `ngrok` version checks now resolve to `false` instead of blocking indefinitely.
- Hanging `ngrok config add-authtoken` calls now fail after 30 seconds instead of blocking tunnel startup forever.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): voice-call extension / ngrok tunnel helper
- Relevant config (redacted): test-only fake child processes

### Steps

1. Mock `spawn("ngrok", ...)` with a child process that never exits.
2. Call `isNgrokAvailable()` and `startNgrokTunnel({ authToken })`.
3. Advance fake timers past the timeout and verify the process is killed and the promise resolves/rejects as expected.

### Expected

- Hung ngrok subprocesses are killed and do not block the caller forever.

### Actual

- Verified locally with targeted timeout tests and a full build.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: hung `ngrok version` returns `false`; hung `ngrok config add-authtoken` rejects with a timeout and never reaches tunnel startup.
- Edge cases checked: timeout path sends `SIGKILL`, and settled guards prevent double resolution/rejection after a timeout.
- What you did **not** verify: real ngrok network failures against a live ngrok binary.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit after landing.
- Files/config to restore: `extensions/voice-call/src/tunnel.ts`
- Known bad symptoms reviewers should watch for: false timeout failures when ngrok starts normally but the timeout is too aggressive.

## Risks and Mitigations

- Risk: an unusually slow host could hit the new timeout before ngrok responds.
  - Mitigation: the new guards only cover commands that previously had no bound at all, and startup already used a 30s timeout in the same file.
