### PR TITLE
fix: sanitize tool call IDs for openai-responses and codex-responses APIs

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -54,6 +54,26 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict");
   });
 
+  it("enables strict tool call id sanitization for openai-responses API", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "lanproxy",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("enables strict tool call id sanitization for openai-codex-responses API", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai-codex",
+      modelId: "codex-mini",
+      modelApi: "openai-codex-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
   it("enables user-turn merge for strict OpenAI-compatible providers", () => {
     const policy = resolveTranscriptPolicy({
       provider: "moonshot",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -78,7 +78,10 @@ export function resolveTranscriptPolicy(params: {
       provider,
       modelId,
     });
-  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" ||
+    params.modelApi === "openai-responses" ||
+    params.modelApi === "openai-codex-responses";
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").


### PR DESCRIPTION
When using `api: "openai-responses"` with a non-OpenAI provider (e.g. a custom proxy), tool call IDs from session history can exceed the 64-character limit enforced by the backend, resulting in:

```
400 Invalid 'input[3].id': string too long. Expected a string with maximum length 64, but got a string with length 408 instead.
```

`resolveTranscriptPolicy` only enabled tool call ID sanitization for `openai-completions` but missed `openai-responses` and `openai-codex-responses`. The existing `sanitizeToolCallIdsForCloudCodeAssist` already handles this correctly (caps IDs at 40 chars in strict mode), it just was not being triggered for the responses API paths.

**Changes:**
- `transcript-policy.ts`: extend `requiresOpenAiCompatibleToolIdSanitization` to cover `openai-responses` and `openai-codex-responses`
- `transcript-policy.test.ts`: add test coverage for both API variants

Switching to `openai-completions` works around the issue because that API mode already had sanitization enabled.

Fixes #43305