### PR TITLE
Doctor: fix legacy gateway cleanup hints

### DIFF
--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -406,4 +406,86 @@ describe("maybeScanExtraGatewayServices", () => {
       "Legacy gateway services removed. Installing OpenClaw gateway next.",
     );
   });
+
+  it("does not show generic cleanup hints after successful legacy removal", async () => {
+    mocks.findExtraGatewayServices.mockResolvedValue([
+      {
+        platform: "linux",
+        label: "moltbot-gateway.service",
+        detail: "unit: /home/test/.config/systemd/user/moltbot-gateway.service",
+        scope: "user",
+        legacy: true,
+      },
+    ]);
+    mocks.uninstallLegacySystemdUnits.mockResolvedValue([
+      {
+        name: "moltbot-gateway",
+        unitPath: "/home/test/.config/systemd/user/moltbot-gateway.service",
+        enabled: true,
+        exists: true,
+      },
+    ]);
+    mocks.renderGatewayServiceCleanupHints.mockReturnValue([
+      "systemctl --user disable --now openclaw-gateway.service",
+    ]);
+
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const prompter = {
+      confirm: vi.fn(),
+      confirmRepair: vi.fn(),
+      confirmAggressive: vi.fn(),
+      confirmSkipInNonInteractive: vi.fn().mockResolvedValue(true),
+      select: vi.fn(),
+      shouldRepair: false,
+      shouldForce: false,
+    };
+
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, prompter);
+
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("openclaw-gateway.service"),
+      "Cleanup hints",
+    );
+  });
+
+  it("shows legacy-specific cleanup hints when cleanup cannot complete", async () => {
+    mocks.findExtraGatewayServices.mockResolvedValue([
+      {
+        platform: "linux",
+        label: "moltbot-gateway.service",
+        detail: "unit: /home/test/.config/systemd/user/moltbot-gateway.service",
+        scope: "system",
+        legacy: true,
+      },
+    ]);
+    mocks.renderGatewayServiceCleanupHints.mockReturnValue([
+      "systemctl --user disable --now openclaw-gateway.service",
+    ]);
+
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const prompter = {
+      confirm: vi.fn(),
+      confirmRepair: vi.fn(),
+      confirmAggressive: vi.fn(),
+      confirmSkipInNonInteractive: vi.fn().mockResolvedValue(true),
+      select: vi.fn(),
+      shouldRepair: false,
+      shouldForce: false,
+    };
+
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, prompter);
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("moltbot-gateway.service (system)"),
+      "Legacy gateway cleanup incomplete",
+    );
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("systemctl --user disable --now moltbot-gateway.service"),
+      "Cleanup hints",
+    );
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("openclaw-gateway.service"),
+      "Cleanup hints",
+    );
+  });
 });

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -66,6 +66,34 @@ function extractDetailPath(detail: string, prefix: string): string | null {
   return value.length > 0 ? value : null;
 }
 
+function renderLegacyGatewayServiceCleanupHints(services: ExtraGatewayService[]): string[] {
+  const hints = new Set<string>();
+  for (const svc of services) {
+    if (svc.platform === "darwin") {
+      const plistPath = extractDetailPath(svc.detail, "plist:");
+      if (plistPath) {
+        hints.add(`launchctl bootout gui/$UID/${svc.label}`);
+        hints.add(`rm ${plistPath}`);
+      }
+      continue;
+    }
+
+    if (svc.platform === "linux") {
+      const unitPath = extractDetailPath(svc.detail, "unit:");
+      hints.add(`systemctl --user disable --now ${svc.label}`);
+      if (unitPath) {
+        hints.add(`rm ${unitPath}`);
+      }
+      continue;
+    }
+
+    if (svc.platform === "win32") {
+      hints.add(`schtasks /Delete /TN "${svc.label}" /F`);
+    }
+  }
+  return [...hints];
+}
+
 async function cleanupLegacyLaunchdService(params: {
   label: string;
   plistPath: string;
@@ -391,6 +419,7 @@ export async function maybeScanExtraGatewayServices(
   );
 
   const legacyServices = extraServices.filter((svc) => svc.legacy === true);
+  let legacyCleanupHints: string[] = [];
   if (legacyServices.length > 0) {
     const shouldRemove = await prompter.confirmSkipInNonInteractive({
       message: "Remove legacy gateway services (clawdbot/moltbot) now?",
@@ -417,15 +446,24 @@ export async function maybeScanExtraGatewayServices(
         note(removed.map((line) => `- ${line}`).join("\n"), "Legacy gateway removed");
       }
       if (failed.length > 0) {
-        note(failed.map((line) => `- ${line}`).join("\n"), "Legacy gateway cleanup skipped");
+        note(failed.map((line) => `- ${line}`).join("\n"), "Legacy gateway cleanup incomplete");
+        const failedServices = legacyServices.filter((svc) =>
+          failed.some((line) => line.startsWith(svc.label)),
+        );
+        legacyCleanupHints = renderLegacyGatewayServiceCleanupHints(
+          failedServices.length > 0 ? failedServices : legacyServices,
+        );
       }
       if (removed.length > 0) {
         runtime.log("Legacy gateway services removed. Installing OpenClaw gateway next.");
       }
+    } else {
+      legacyCleanupHints = renderLegacyGatewayServiceCleanupHints(legacyServices);
     }
   }
 
-  const cleanupHints = renderGatewayServiceCleanupHints();
+  const cleanupHints =
+    legacyServices.length > 0 ? legacyCleanupHints : renderGatewayServiceCleanupHints();
   if (cleanupHints.length > 0) {
     note(cleanupHints.map((hint) => `- ${hint}`).join("\n"), "Cleanup hints");
   }


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` mixed up legacy-service cleanup output by showing generic `openclaw-gateway.service` hints even after a successful clawdbot/moltbot cleanup, and used "skipped" for partial failures.
- Why it matters: the operator sees contradictory repair output and gets the wrong manual cleanup commands.
- What changed: legacy cleanup now suppresses generic hints after a successful removal, emits service-specific manual cleanup hints when cleanup is declined or incomplete, and renames the partial-failure note to `Legacy gateway cleanup incomplete`.
- What did NOT change (scope boundary): this does not change how extra non-legacy gateway-like services are detected or repaired.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #6720
- Related #43423

## User-visible / Behavior Changes

- `openclaw doctor` no longer prints generic `openclaw-gateway.service` cleanup commands after a successful clawdbot/moltbot removal.
- If legacy cleanup cannot complete, the hint block now references the actual legacy service names and paths.
- Partial failures now read `Legacy gateway cleanup incomplete` instead of `skipped`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): `openclaw doctor`
- Relevant config (redacted): mocked extra gateway service entries only

### Steps

1. Simulate a legacy `moltbot-gateway.service` being discovered by `openclaw doctor`.
2. Run the successful removal path and verify no generic `openclaw-gateway.service` hints are shown.
3. Run a partial-failure path and verify the note title and manual cleanup hints reference the legacy service.

### Expected

- Cleanup output matches the actual legacy service state and commands.

### Actual

- Verified locally with focused doctor-gateway-services tests and a full build.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: successful legacy removal suppresses generic hints; incomplete legacy cleanup shows `moltbot-gateway.service` manual commands.
- Edge cases checked: declined cleanup and partial failure both route through the same legacy-specific hint renderer.
- What you did **not** verify: live systemd/launchd cleanup on a real host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the commit after landing.
- Files/config to restore: `src/commands/doctor-gateway-services.ts`
- Known bad symptoms reviewers should watch for: missing cleanup hints when legacy services still remain.

## Risks and Mitigations

- Risk: a malformed legacy service `detail` string could omit the file-removal hint.
  - Mitigation: service labels are still surfaced, and the disable/bootout command is emitted even when the file path cannot be extracted.
