### PR TITLE
Feat/telegram tool summary

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -542,6 +542,16 @@ export const dispatchTelegramMessage = async ({
             toolSummaryLines.length = 0;
           }
           if (info.kind === "tool") {
+            if (
+              shouldSuppressLocalTelegramExecApprovalPrompt({
+                cfg,
+                accountId: route.accountId,
+                payload,
+              })
+            ) {
+              queuedFinal = true;
+              return;
+            }
             const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
             if (hasMedia) {
               toolSummaryMessageId = undefined;
@@ -555,10 +565,15 @@ export const dispatchTelegramMessage = async ({
             }
             toolSummaryLines.push(line);
             const aggregated = toolSummaryLines.join("\n");
+            const maxToolSummaryChars = Math.min(textLimit, 4096);
+            const safeAggregated =
+              aggregated.length > maxToolSummaryChars
+                ? `${aggregated.slice(0, maxToolSummaryChars - 20)}\n…`
+                : aggregated;
             if (toolSummaryMessageId === undefined) {
               const result = await deliverReplies({
                 ...deliveryBaseOptions,
-                replies: [{ ...payload, text: aggregated }],
+                replies: [{ ...payload, text: safeAggregated }],
                 onVoiceRecording: sendRecordVoice,
               });
               if (result.delivered) {
@@ -570,10 +585,12 @@ export const dispatchTelegramMessage = async ({
                   // to avoid re-sending the same lines in the next delivery.
                   toolSummaryLines.length = 0;
                 }
+              } else {
+                toolSummaryLines.length = 0;
               }
             }
             try {
-              await editMessageTelegram(chatId, toolSummaryMessageId, aggregated, {
+              await editMessageTelegram(chatId, toolSummaryMessageId, safeAggregated, {
                 api: bot.api,
                 cfg,
                 accountId: route.accountId,
@@ -584,14 +601,18 @@ export const dispatchTelegramMessage = async ({
               toolSummaryMessageId = undefined;
               const res = await deliverReplies({
                 ...deliveryBaseOptions,
-                replies: [{ ...payload, text: aggregated }],
+                replies: [{ ...payload, text: safeAggregated }],
                 onVoiceRecording: sendRecordVoice,
               });
               if (res.delivered) {
                 deliveryState.markDelivered();
                 if (res.firstMessageId != null) {
                   toolSummaryMessageId = res.firstMessageId;
+                } else {
+                  toolSummaryLines.length = 0;
                 }
+              } else {
+                toolSummaryLines.length = 0;
               }
             }
             return;

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -566,9 +566,10 @@ export const dispatchTelegramMessage = async ({
             toolSummaryLines.push(line);
             const aggregated = toolSummaryLines.join("\n");
             const maxToolSummaryChars = Math.min(textLimit, 4096);
+            const sliceEnd = Math.max(0, maxToolSummaryChars - 20);
             const safeAggregated =
               aggregated.length > maxToolSummaryChars
-                ? `${aggregated.slice(0, maxToolSummaryChars - 20)}\n…`
+                ? `${aggregated.slice(0, sliceEnd)}\n…`
                 : aggregated;
             if (toolSummaryMessageId === undefined) {
               const result = await deliverReplies({

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -588,6 +588,7 @@ export const dispatchTelegramMessage = async ({
               } else {
                 toolSummaryLines.length = 0;
               }
+              return;
             }
             try {
               await editMessageTelegram(chatId, toolSummaryMessageId, safeAggregated, {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -509,6 +509,8 @@ export const dispatchTelegramMessage = async ({
   });
 
   let queuedFinal = false;
+  let toolSummaryMessageId: number | undefined;
+  const toolSummaryLines: string[] = [];
 
   if (statusReactionController) {
     void statusReactionController.setThinking();
@@ -535,6 +537,62 @@ export const dispatchTelegramMessage = async ({
         ...prefixOptions,
         typingCallbacks,
         deliver: async (payload, info) => {
+          if (info.kind === "block" || info.kind === "final") {
+            toolSummaryMessageId = undefined;
+            toolSummaryLines.length = 0;
+          }
+          if (info.kind === "tool") {
+            const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+            if (hasMedia) {
+              toolSummaryMessageId = undefined;
+              toolSummaryLines.length = 0;
+              await sendPayload(payload);
+              return;
+            }
+            const line = typeof payload.text === "string" ? payload.text.trim() : "";
+            if (!line) {
+              return;
+            }
+            toolSummaryLines.push(line);
+            const aggregated = toolSummaryLines.join("\n");
+            if (toolSummaryMessageId === undefined) {
+              const result = await deliverReplies({
+                ...deliveryBaseOptions,
+                replies: [{ ...payload, text: aggregated }],
+                onVoiceRecording: sendRecordVoice,
+              });
+              if (result.delivered) {
+                deliveryState.markDelivered();
+                if (result.firstMessageId != null) {
+                  toolSummaryMessageId = result.firstMessageId;
+                }
+              }
+              return;
+            }
+            try {
+              await editMessageTelegram(chatId, toolSummaryMessageId, aggregated, {
+                api: bot.api,
+                cfg,
+                accountId: route.accountId,
+                linkPreview: telegramCfg.linkPreview,
+              });
+            } catch (err) {
+              logVerbose(`telegram: tool summary edit failed, sending new message: ${String(err)}`);
+              toolSummaryMessageId = undefined;
+              const res = await deliverReplies({
+                ...deliveryBaseOptions,
+                replies: [{ ...payload, text: aggregated }],
+                onVoiceRecording: sendRecordVoice,
+              });
+              if (res.delivered) {
+                deliveryState.markDelivered();
+                if (res.firstMessageId != null) {
+                  toolSummaryMessageId = res.firstMessageId;
+                }
+              }
+            }
+            return;
+          }
           if (info.kind === "final") {
             // Assistant callbacks are fire-and-forget; ensure queued boundary
             // rotations/partials are applied before final delivery mapping.

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -565,9 +565,12 @@ export const dispatchTelegramMessage = async ({
                 deliveryState.markDelivered();
                 if (result.firstMessageId != null) {
                   toolSummaryMessageId = result.firstMessageId;
+                } else {
+                  // Cannot track the message to edit later; reset accumulation
+                  // to avoid re-sending the same lines in the next delivery.
+                  toolSummaryLines.length = 0;
                 }
               }
-              return;
             }
             try {
               await editMessageTelegram(chatId, toolSummaryMessageId, aggregated, {

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -578,7 +578,7 @@ export async function deliverReplies(params: {
   linkPreview?: boolean;
   /** Optional quote text for Telegram reply_parameters. */
   replyQuoteText?: string;
-}): Promise<{ delivered: boolean }> {
+}): Promise<{ delivered: boolean; firstMessageId?: number }> {
   const progress: DeliveryProgress = {
     hasReplied: false,
     hasDelivered: false,
@@ -592,6 +592,7 @@ export async function deliverReplies(params: {
     chunkMode: params.chunkMode ?? "length",
     tableMode: params.tableMode,
   });
+  let firstMessageId: number | undefined;
   for (const originalReply of params.replies) {
     let reply = originalReply;
     const mediaList = reply?.mediaUrls?.length
@@ -688,6 +689,9 @@ export async function deliverReplies(params: {
         firstDeliveredMessageId,
       });
 
+      if (firstMessageId == null && firstDeliveredMessageId != null) {
+        firstMessageId = firstDeliveredMessageId;
+      }
       emitMessageSentHooks({
         hookRunner,
         enabled: hasMessageSentHooks,
@@ -717,5 +721,8 @@ export async function deliverReplies(params: {
     }
   }
 
-  return { delivered: progress.hasDelivered };
+  return {
+    delivered: progress.hasDelivered,
+    firstMessageId,
+  };
 }


### PR DESCRIPTION

Aqui está o template preenchido para o PR do tool summary no Telegram:

---

## Summary

- **Problema:** Com `verboseDefault: "on"`, cada execução de ferramenta (Write, Exec, etc.) gerava uma mensagem separada no Telegram, poluindo o chat.
- **Por que importa:** Em tarefas com várias tools, o usuário recebia muitas bolhas em vez de um resumo único.
- **O que mudou:** Tool summaries sem mídia passam a ser agregados em uma única mensagem que é editada conforme novas tools rodam; `deliverReplies` passa a retornar `firstMessageId` para permitir edição.
- **O que NÃO mudou:** Comportamento com mídia, exec-approval, block/final e outros canais permanecem iguais.

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Telegram)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Com verbose ligado, tool summaries (Write, Exec, etc.) aparecem em **uma única mensagem** que é editada conforme novas tools rodam, em vez de uma mensagem por tool.
- Se o edit falhar (ex.: mensagem apagada), é enviada uma nova mensagem com o texto agregado.
- Se `textLimit` for &lt; 20, o slice é limitado para evitar índice negativo.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node
- Model/provider: N/A
- Integration/channel: Telegram (DM ou grupo)
- Relevant config: `agents.defaults.verboseDefault: "on"` e `channels.telegram.streaming: "partial"`

### Steps

1. Configurar `verboseDefault: "on"` no agent.
2. Enviar uma mensagem que dispare várias tools (ex.: ler arquivo, rodar script, instalar dependência).
3. Observar o chat no Telegram.

### Expected

- Uma única mensagem com as linhas de tool (Write, Exec, etc.) sendo editada conforme novas tools rodam.

### Actual

- Comportamento esperado confirmado.

## Evidence

- [x] Testes passando: `src/telegram/bot-message-dispatch.test.ts` (66 tests)
- [x] Teste "keeps streamed preview visible when final text regresses after a tool warning" passando

## Human Verification

- **Cenários verificados:** Tool summaries agregados, edit in-place, fallback quando edit falha, exec-approval antes do branch de tool, reset quando `firstMessageId` não vem, clamp do slice quando `textLimit` &lt; 20.
- **Edge cases:** Payload com mídia segue fluxo normal; tool warning + final regressivo mantém preview.
- **Não verificado:** Sessões muito longas com dezenas de tools (possível truncamento em 4096 chars).

## Review Conversations

- [x] Respostas dadas às sugestões do Greptile (reset de `toolSummaryLines`).
- [x] Respostas dadas às sugestões do Codex P1 (exec-approval antes do branch de tool).
- [x] Respostas dadas às sugestões do Codex P2 (chunk/clamp do slice).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery

- **Desabilitar:** `verboseDefault: "off"` ou `/verbose off` na sessão.
- **Reverter:** Restaurar `bot-message-dispatch.ts` e `delivery.replies.ts` para a versão anterior.
- **Sintomas a observar:** Mensagens duplicadas ou edit falhando em cenários específicos.

## Risks and Mitigations

- **Risco:** Edit falhar em cenários raros (mensagem apagada, limite do Telegram).
  - **Mitigação:** Fallback para envio de nova mensagem; clamp do slice em `Math.max(0, maxToolSummaryChars - 20)`.

---