### PR TITLE
fix(web-search): unblock freshness and date filters for Brave llm-context

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -141,8 +141,8 @@ For a gateway install, put these in `~/.openclaw/.env` (or your service environm
 ```
 
 `llm-context` returns extracted page chunks for grounding instead of standard Brave snippets.
-In this mode, `country` and `language` / `search_lang` still work, but `ui_lang`,
-`freshness`, `date_after`, and `date_before` are rejected.
+In this mode, `country`, `language` / `search_lang`, `freshness`, `date_after`, and
+`date_before` all work. Only `ui_lang` is not supported.
 
 **Perplexity Search:**
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1626,9 +1626,13 @@ async function runWebSearch(params: {
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
             : "";
+  // When dateAfter is set without dateBefore, the API uses today as end date;
+  // include today in the cache key so UTC day rollover invalidates stale entries.
+  const llmContextDateEnd =
+    params.dateBefore || (params.dateAfter ? new Date().toISOString().slice(0, 10) : "default");
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
-      ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}`
+      ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${llmContextDateEnd}`
       : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1529,6 +1529,8 @@ async function runBraveLlmContextSearch(params: {
   country?: string;
   search_lang?: string;
   freshness?: string;
+  dateAfter?: string;
+  dateBefore?: string;
 }): Promise<{
   results: Array<{
     url: string;
@@ -1548,6 +1550,15 @@ async function runBraveLlmContextSearch(params: {
   }
   if (params.freshness) {
     url.searchParams.set("freshness", params.freshness);
+  } else if (params.dateAfter && params.dateBefore) {
+    url.searchParams.set("freshness", `${params.dateAfter}to${params.dateBefore}`);
+  } else if (params.dateAfter) {
+    url.searchParams.set(
+      "freshness",
+      `${params.dateAfter}to${new Date().toISOString().slice(0, 10)}`,
+    );
+  } else if (params.dateBefore) {
+    url.searchParams.set("freshness", `1970-01-01to${params.dateBefore}`);
   }
 
   return withTrustedWebSearchEndpoint(
@@ -1617,7 +1628,7 @@ async function runWebSearch(params: {
             : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
-      ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
+      ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}`
       : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
@@ -1781,6 +1792,8 @@ async function runWebSearch(params: {
       country: params.country,
       search_lang: params.search_lang,
       freshness: params.freshness,
+      dateAfter: params.dateAfter,
+      dateBefore: params.dateBefore,
     });
 
     const mapped = llmResults.map((entry) => ({
@@ -2038,14 +2051,6 @@ export function createWebSearchTool(options?: {
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
-      if (rawFreshness && provider === "brave" && braveMode === "llm-context") {
-        return jsonResult({
-          error: "unsupported_freshness",
-          message:
-            "freshness filtering is not supported by Brave llm-context mode. Remove freshness or use Brave web mode.",
-          docs: "https://docs.openclaw.ai/tools/web",
-        });
-      }
       const freshness = rawFreshness ? normalizeFreshness(rawFreshness, provider) : undefined;
       if (rawFreshness && !freshness) {
         return jsonResult({
@@ -2075,14 +2080,6 @@ export function createWebSearchTool(options?: {
             provider === "perplexity"
               ? "date_after/date_before are only supported by the native Perplexity Search API path. Remove Perplexity baseUrl/model overrides or use a direct PERPLEXITY_API_KEY to enable them."
               : `date_after/date_before filtering is not supported by the ${provider} provider. Only Brave and Perplexity support date filtering.`,
-          docs: "https://docs.openclaw.ai/tools/web",
-        });
-      }
-      if ((rawDateAfter || rawDateBefore) && provider === "brave" && braveMode === "llm-context") {
-        return jsonResult({
-          error: "unsupported_date_filter",
-          message:
-            "date_after/date_before filtering is not supported by Brave llm-context mode. Use Brave web mode for date filters.",
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -905,12 +905,12 @@ describe("web_search external content wrapping", () => {
     expect(details.sources?.[0]?.hostname).toBe("example.com");
   });
 
-  it("rejects freshness in Brave llm-context mode", async () => {
+  it("passes freshness to Brave llm-context endpoint", async () => {
     vi.stubEnv("BRAVE_API_KEY", "test-key");
     const mockFetch = installBraveLlmContextFetch({
-      title: "unused",
-      url: "https://example.com",
-      snippets: ["unused"],
+      title: "Context title",
+      url: "https://example.com/ctx",
+      snippets: ["snippet"],
     });
 
     const tool = createWebSearchTool({
@@ -928,31 +928,48 @@ describe("web_search external content wrapping", () => {
       },
       sandboxed: true,
     });
-    const result = await tool?.execute?.("call-1", { query: "test", freshness: "week" });
+    await tool?.execute?.("call-1", { query: "test", freshness: "week" });
 
-    expect(result?.details).toMatchObject({ error: "unsupported_freshness" });
-    expect(mockFetch).not.toHaveBeenCalled();
+    const requestUrl = new URL(mockFetch.mock.calls[0]?.[0] as string);
+    expect(requestUrl.pathname).toBe("/res/v1/llm/context");
+    expect(requestUrl.searchParams.get("freshness")).toBe("pw");
   });
 
-  it.each([
-    [
-      "rejects date_after/date_before in Brave llm-context mode",
-      {
-        query: "test",
-        date_after: "2025-01-01",
-        date_before: "2025-01-31",
+  it("passes date_after/date_before as freshness range to Brave llm-context endpoint", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "test-key");
+    const mockFetch = installBraveLlmContextFetch({
+      title: "Context title",
+      url: "https://example.com/ctx",
+      snippets: ["snippet"],
+    });
+
+    const tool = createWebSearchTool({
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+              brave: {
+                mode: "llm-context",
+              },
+            },
+          },
+        },
       },
-      "unsupported_date_filter",
-    ],
-    [
-      "rejects ui_lang in Brave llm-context mode",
-      {
-        query: "test",
-        ui_lang: "de-DE",
-      },
-      "unsupported_ui_lang",
-    ],
-  ])("%s", async (_name, input, expectedError) => {
+      sandboxed: true,
+    });
+    await tool?.execute?.("call-1", {
+      query: "test",
+      date_after: "2025-01-01",
+      date_before: "2025-01-31",
+    });
+
+    const requestUrl = new URL(mockFetch.mock.calls[0]?.[0] as string);
+    expect(requestUrl.pathname).toBe("/res/v1/llm/context");
+    expect(requestUrl.searchParams.get("freshness")).toBe("2025-01-01to2025-01-31");
+  });
+
+  it("rejects ui_lang in Brave llm-context mode", async () => {
     vi.stubEnv("BRAVE_API_KEY", "test-key");
     const mockFetch = installBraveLlmContextFetch({
       title: "unused",
@@ -975,9 +992,9 @@ describe("web_search external content wrapping", () => {
       },
       sandboxed: true,
     });
-    const result = await tool?.execute?.("call-1", input);
+    const result = await tool?.execute?.("call-1", { query: "test", ui_lang: "de-DE" });
 
-    expect(result?.details).toMatchObject({ error: expectedError });
+    expect(result?.details).toMatchObject({ error: "unsupported_ui_lang" });
     expect(mockFetch).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- **Problem:** Brave's LLM Context API (`/res/v1/llm/context`) supports the `freshness` query parameter (including `pd`/`pw`/`pm`/`py` shorthands and `YYYY-MM-DDtoYYYY-MM-DD` date ranges), but OpenClaw's `web_search` tool incorrectly rejected `freshness`, `date_after`, and `date_before` with misleading `unsupported_freshness` / `unsupported_date_filter` errors when using Brave `llm-context` mode.
- **Why it matters:** Users configuring Brave in `llm-context` mode (recommended for RAG/agentic use) lost access to time-scoped queries, forcing a workaround of switching to standard `web` mode — which returns snippets instead of extracted page content.
- **What changed:**
  - Removed two validation guards in `createWebSearchTool` that blocked freshness and date filters for `llm-context` mode (`src/agents/tools/web-search.ts`)
  - Added `dateAfter`/`dateBefore` parameters to `runBraveLlmContextSearch` and wired `date_after`/`date_before` → Brave `freshness` range conversion (matching the existing web-search logic)
  - Fixed the llm-context cache key to include `dateAfter`/`dateBefore` so different date filters produce separate cache entries
  - Updated `docs/tools/web.md` to stop telling users these filters are rejected
  - Updated tests: converted rejection tests into acceptance tests that verify the freshness and date range parameters reach the Brave endpoint correctly
- **What did NOT change (scope boundary):**
  - `ui_lang` remains correctly rejected for llm-context mode (Brave doesn't support it on that endpoint)
  - No changes to other providers (Perplexity, Tavily, etc.)
  - No schema changes — no new parameters added to the tool; existing `freshness`/`date_after`/`date_before` parameters are simply unblocked
  - No config changes

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `freshness`, `date_after`, and `date_before` parameters now work with Brave `llm-context` mode instead of returning errors
- `date_after`/`date_before` are converted to Brave's `freshness` range format (`YYYY-MM-DDtoYYYY-MM-DD`) on the llm-context endpoint
- Cache entries for llm-context queries with different date filters are now correctly separated

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No new endpoints — `freshness` and date range parameters are appended as query params on the existing Brave llm-context API call that was already in use.
- Command/tool execution surface changed? No — existing parameters are unblocked, no new parameters added.
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+
- Model/provider: Brave Search API (llm-context mode)
- Integration/channel (if any): N/A
- Relevant config (redacted): `tools.web.search.provider=brave`, `tools.web.search.brave.mode=llm-context`, Brave API key configured

### Steps

1. Configure Brave in llm-context mode
2. Call `web_search` with `freshness: "week"` → before: `unsupported_freshness` error; after: results returned with `freshness=pw` query param
3. Call `web_search` with `date_after: "2025-01-01"`, `date_before: "2025-01-31"` → before: `unsupported_date_filter` error; after: results returned with `freshness=2025-01-01to2025-01-31` query param

### Expected

- Freshness and date range filters pass through to the Brave llm-context endpoint and return time-scoped results

### Actual

- Matches expected after fix

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Tests updated: rejection tests (`rejects freshness in Brave llm-context mode`, `rejects date_after/date_before in Brave llm-context mode`) converted to acceptance tests that assert the correct query parameters reach the Brave endpoint.

## Human Verification (required)

- Verified scenarios: build pass, web-search tests pass, format clean
- Edge cases checked: `ui_lang` still correctly rejected for llm-context mode (test retained), cache key includes date params, `date_after`-only and `date_before`-only produce correct range bounds
- What you did **not** verify: live API call with date-range freshness on llm-context endpoint

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes — removes errors that previously blocked valid usage; no breaking changes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the commit; guards are re-added, date params removed from llm-context path
- Files/config to restore: none
- Known bad symptoms reviewers should watch for: Brave llm-context API returning errors for freshness/date params (would indicate Brave API behavior change)

## Risks and Mitigations

- Risk: Brave llm-context API could silently ignore `freshness` instead of filtering by it, giving users false confidence in time scoping.
  - Mitigation: Brave documents `freshness` support on the llm-context endpoint; verified parameter reaches the API. Behavior is consistent with the web-search endpoint.
