### PR TITLE
fix: restore web tools to coding profile

### DIFF
--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { resolveCoreToolProfilePolicy } from "./tool-catalog.js";
+
+describe("tool-catalog", () => {
+  it("includes web_search and web_fetch in the coding profile policy", () => {
+    const policy = resolveCoreToolProfilePolicy("coding");
+    expect(policy?.allow).toContain("web_search");
+    expect(policy?.allow).toContain("web_fetch");
+  });
+});

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -4,7 +4,8 @@ import { resolveCoreToolProfilePolicy } from "./tool-catalog.js";
 describe("tool-catalog", () => {
   it("includes web_search and web_fetch in the coding profile policy", () => {
     const policy = resolveCoreToolProfilePolicy("coding");
-    expect(policy?.allow).toContain("web_search");
-    expect(policy?.allow).toContain("web_fetch");
+    expect(policy).toBeDefined();
+    expect(policy!.allow).toContain("web_search");
+    expect(policy!.allow).toContain("web_fetch");
   });
 });

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -86,7 +86,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "web_search",
     description: "Search the web",
     sectionId: "web",
-    profiles: [],
+    profiles: ["coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -94,7 +94,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "web_fetch",
     description: "Fetch web content",
     sectionId: "web",
-    profiles: [],
+    profiles: ["coding"],
     includeInOpenClawGroup: true,
   },
   {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `tools.profile = "coding"` did not include `web_search` or `web_fetch`, so those tools were filtered out before the model saw them.
- Why it matters: normal coding-profile agent runs could truthfully report that web search was unavailable even when web search was enabled and configured.
- What changed: restored `web_search` and `web_fetch` to the `coding` profile in the tool catalog and added a regression test covering the profile policy.
- What did NOT change (scope boundary): no web-search execution logic, provider behavior, config schema, or tool runtime contracts changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`coding` profile agent runs now expose `web_search` and `web_fetch` again when those tools are otherwise enabled/configured.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - Restores intended tool availability for the existing `coding` profile only; regression test covers the profile policy mapping.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node / Vitest
- Model/provider: N/A for automated verification
- Integration/channel (if any): N/A
- Relevant config (redacted): `tools.profile = "coding"`

### Steps

1. Run an agent session with `tools.profile = "coding"`.
2. Inspect the tool list available to the model.
3. Observe whether `web_search` and `web_fetch` are present.

### Expected

- `web_search` and `web_fetch` are included for the `coding` profile.

### Actual

- Before the fix, both tools were omitted because the tool catalog marked them with `profiles: []`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: traced the missing `web_search` symptom back to `src/agents/tool-catalog.ts`, confirmed the `coding` profile policy omitted both web tools, then reran focused Vitest coverage after the fix.
- Edge cases checked: verified existing web-tool default tests still pass alongside the new profile-policy regression.
- What you did **not** verify: did not rerun a live channel session after rebuild as part of this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f5d628318a`.
- Files/config to restore: `src/agents/tool-catalog.ts`
- Known bad symptoms reviewers should watch for: `coding` profile unexpectedly exposing or hiding the web tools.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: `coding` profile now includes two more tools than current `main`.
  - Mitigation: this restores intended behavior and is covered by a focused profile-policy regression test.
