### PR TITLE
test(config): cover requiresOpenAiAnthropicToolPayload in compat schema fixture

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -315,6 +315,7 @@ describe("model compat config schema", () => {
                   requiresAssistantAfterToolResult: false,
                   requiresThinkingAsText: false,
                   requiresMistralToolIds: false,
+                  requiresOpenAiAnthropicToolPayload: true,
                 },
               },
             ],


### PR DESCRIPTION
Adds the missing `requiresOpenAiAnthropicToolPayload` field to the model-compat schema acceptance test in `config-misc.test.ts`, guarding against regressions like #43339 where onboarding fails with "Unrecognized key".

1 line, test-only. Closes #43339