### PR TITLE
browser: extend /start timeout budget

### DIFF
--- a/src/browser/client.test.ts
+++ b/src/browser/client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CHROME_LAUNCH_READY_WINDOW_MS } from "./cdp-timeouts.js";
 import {
   browserAct,
   browserArmDialog,
@@ -8,7 +9,15 @@ import {
   browserPdfSave,
   browserScreenshotAction,
 } from "./client-actions.js";
-import { browserOpenTab, browserSnapshot, browserStatus, browserTabs } from "./client.js";
+import {
+  BROWSER_START_TIMEOUT_MS,
+  browserOpenTab,
+  browserSnapshot,
+  browserStart,
+  browserStatus,
+  browserTabs,
+} from "./client.js";
+import { CDP_READY_AFTER_LAUNCH_WINDOW_MS } from "./server-context.constants.js";
 
 describe("browser client", () => {
   function stubSnapshotFetch(calls: string[]) {
@@ -31,6 +40,7 @@ describe("browser client", () => {
   }
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -50,6 +60,45 @@ describe("browser client", () => {
   it("adds useful timeout messaging for abort-like failures", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("aborted")));
     await expect(browserStatus("http://127.0.0.1:18791")).rejects.toThrow(/timed out/i);
+  });
+
+  it("keeps browser start timeout ahead of the synchronous server launch budget (#3941)", async () => {
+    expect(BROWSER_START_TIMEOUT_MS).toBeGreaterThan(
+      CHROME_LAUNCH_READY_WINDOW_MS + CDP_READY_AFTER_LAUNCH_WINDOW_MS,
+    );
+
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            if (!signal) {
+              return;
+            }
+            if (signal.aborted) {
+              reject(signal.reason ?? new Error("aborted"));
+              return;
+            }
+            signal.addEventListener("abort", () => reject(signal.reason ?? new Error("aborted")), {
+              once: true,
+            });
+          }),
+      ),
+    );
+
+    let settled = false;
+    const promise = browserStart("http://127.0.0.1:18791").finally(() => {
+      settled = true;
+    });
+    const rejected = expect(promise).rejects.toThrow(new RegExp(`${BROWSER_START_TIMEOUT_MS}ms`));
+
+    await vi.advanceTimersByTimeAsync(BROWSER_START_TIMEOUT_MS - 1);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await rejected;
   });
 
   it("surfaces non-2xx responses with body text", async () => {

--- a/src/browser/client.ts
+++ b/src/browser/client.ts
@@ -1,4 +1,6 @@
+import { CHROME_LAUNCH_READY_WINDOW_MS } from "./cdp-timeouts.js";
 import { fetchBrowserJson } from "./client-fetch.js";
+import { CDP_READY_AFTER_LAUNCH_WINDOW_MS } from "./server-context.constants.js";
 
 export type BrowserStatus = {
   enabled: boolean;
@@ -100,6 +102,12 @@ function withBaseUrl(baseUrl: string | undefined, path: string): string {
   return `${trimmed.replace(/\/$/, "")}${path}`;
 }
 
+// /start waits synchronously for managed Chrome launch + post-launch CDP readiness.
+// Keep the client timeout ahead of that combined server-side window so the request
+// does not abort first on slower Linux hosts.
+export const BROWSER_START_TIMEOUT_MS =
+  CHROME_LAUNCH_READY_WINDOW_MS + CDP_READY_AFTER_LAUNCH_WINDOW_MS + 7000;
+
 export async function browserStatus(
   baseUrl?: string,
   opts?: { profile?: string },
@@ -124,7 +132,7 @@ export async function browserStart(baseUrl?: string, opts?: { profile?: string }
   const q = buildProfileQuery(opts?.profile);
   await fetchBrowserJson(withBaseUrl(baseUrl, `/start${q}`), {
     method: "POST",
-    timeoutMs: 15000,
+    timeoutMs: BROWSER_START_TIMEOUT_MS,
   });
 }
 


### PR DESCRIPTION
## Summary
- keep browser /start client timeout ahead of the synchronous server launch budget
- derive the timeout from the managed Chrome launch and post-launch CDP readiness windows
- cover the timeout budget with a browser client regression test

## Testing
- pnpm test src/browser/client.test.ts
- pnpm build

Closes #3941
