### PR TITLE
feat(session): add session.channelIsolation config option

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -253,6 +253,20 @@ Manual reply tags are supported:
 
 Note: `replyToMode="off"` disables **all** reply threading in Slack, including explicit `[[reply_to_*]]` tags. This differs from Telegram, where explicit tags are still honored in `"off"` mode. The difference reflects the platform threading models: Slack threads hide messages from the channel, while Telegram replies remain visible in the main chat flow.
 
+### Shared session across channels (`session.channelIsolation`)
+
+By default, each non-DM channel or group gets its own session key (`agent:<id>:<channel>:<peerKind>:<peerId>`). Set `session.channelIsolation: false` to make all non-DM channels share the agent's main session instead.
+
+```yaml
+session:
+  channelIsolation: false
+```
+
+When disabled:
+
+- Non-DM peers (channels, groups) all resolve to the agent's main session key (`agent:<id>:main`).
+- DM scoping (`session.dmScope`) is unaffected — DMs still follow their own isolation rules.
+
 ## Media, chunking, and delivery
 
 <AccordionGroup>

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -255,17 +255,21 @@ Note: `replyToMode="off"` disables **all** reply threading in Slack, including e
 
 ### Shared session across channels (`session.channelIsolation`)
 
-By default, each non-DM channel or group gets its own session key (`agent:<id>:<channel>:<peerKind>:<peerId>`). Set `session.channelIsolation: false` to make all non-DM channels share the agent's main session instead.
+By default, each non-DM channel or group gets its own session key (`agent:<id>:<channel>:<peerKind>:<peerId>`). Set `session.channelIsolation` to `false` to make all non-DM channels share the agent's main session instead.
 
-```yaml
-session:
-  channelIsolation: false
+```json5
+{ session: { channelIsolation: false } }
 ```
 
 When disabled:
 
 - Non-DM peers (channels, groups) all resolve to the agent's main session key (`agent:<id>:main`).
 - DM scoping (`session.dmScope`) is unaffected — DMs still follow their own isolation rules.
+- Combine with `threadIsolation: false` for a fully unified session across all threads and channels.
+
+> **Note:** This is a global setting, not Slack-specific — it applies to all channels (Slack, Telegram, Discord, WhatsApp).
+
+> **Warning:** When channels share a session, `/new` or idle reset in any channel resets the session for all channels. Context from one channel is visible in others — be mindful of information leakage across channels.
 
 ## Media, chunking, and delivery
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2018,6 +2018,13 @@ See [Groups](/channels/groups) and [Group messages](/channels/group-messages).
 
 Direct chats collapse to the main session by default. Groups/channels have their own session keys, and Telegram topics / Discord threads are separate sessions. See [Groups](/channels/groups) and [Group messages](/channels/group-messages).
 
+**Advanced: opt into shared sessions.** For single-identity agents where you want cross-thread or cross-channel memory, two opt-in flags can collapse session isolation:
+
+- `session.threadIsolation: false` — Slack thread replies reuse the parent session instead of forking (Slack-only). See [Shared session across threads](/channels/slack#shared-session-across-threads-sessionthreadisolation).
+- `session.channelIsolation: false` — all non-DM channels share the agent's main session (global, all providers). See [Shared session across channels](/channels/slack#shared-session-across-channels-sessionchannelisolation).
+
+Both are off by default. Enabling them creates cross-context leakage — recommended for single-user or trusted-team deployments only.
+
 ### How many workspaces and agents can I create
 
 No hard limits. Dozens (even hundreds) are fine, but watch for:

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1132,6 +1132,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Default inactivity window in hours for thread-bound sessions across providers/channels (0 disables idle auto-unfocus). Default: 24.",
   "session.threadBindings.maxAgeHours":
     "Optional hard max age in hours for thread-bound sessions across providers/channels (0 disables hard cap). Default: 0.",
+  "session.channelIsolation":
+    "When false, non-DM channels share the agent's main session instead of per-channel sessions. DM scoping is unaffected. Default: true.",
   "session.maintenance":
     "Automatic session-store maintenance controls for pruning age, entry caps, and file rotation behavior. Start in warn mode to observe impact, then enforce once thresholds are tuned.",
   "session.maintenance.mode":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1133,7 +1133,7 @@ export const FIELD_HELP: Record<string, string> = {
   "session.threadBindings.maxAgeHours":
     "Optional hard max age in hours for thread-bound sessions across providers/channels (0 disables hard cap). Default: 0.",
   "session.channelIsolation":
-    "When false, non-DM channels share the agent's main session instead of per-channel sessions. DM scoping is unaffected. Default: true.",
+    "When false, non-DM channels share the agent's main session instead of per-channel sessions. DM scoping is unaffected. Default: true. WARNING: context leaks across channels, /new resets all channels, and lastRoute may flip between channels. Recommended for single-user or trusted-team deployments only. Differs from session.scope (which controls sender grouping within a peer) — this controls whether peer contexts collapse to the main session.",
   "session.maintenance":
     "Automatic session-store maintenance controls for pruning age, entry caps, and file rotation behavior. Start in warn mode to observe impact, then enforce once thresholds are tuned.",
   "session.maintenance.mode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -542,6 +542,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "session.threadBindings.enabled": "Thread Binding Enabled",
   "session.threadBindings.idleHours": "Thread Binding Idle Timeout (hours)",
   "session.threadBindings.maxAgeHours": "Thread Binding Max Age (hours)",
+  "session.channelIsolation": "Channel Session Isolation",
   "session.maintenance": "Session Maintenance",
   "session.maintenance.mode": "Session Maintenance Mode",
   "session.maintenance.pruneAfter": "Session Prune After",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -131,6 +131,11 @@ export type SessionConfig = {
   };
   /** Shared defaults for thread-bound session routing across channels/providers. */
   threadBindings?: SessionThreadBindingsConfig;
+  /**
+   * When false, non-DM channels share the agent's main session instead of
+   * per-channel sessions. DM scoping is unaffected. Default: true.
+   */
+  channelIsolation?: boolean;
   /** Automatic session store maintenance (pruning, capping, file rotation). */
   maintenance?: SessionMaintenanceConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -69,6 +69,7 @@ export const SessionSchema = z
       })
       .strict()
       .optional(),
+    channelIsolation: z.boolean().optional(),
     maintenance: z
       .object({
         mode: z.enum(["enforce", "warn"]).optional(),

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -298,6 +298,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         agentId: route.agentId,
         channel: route.channel,
         peer: { kind: "channel", id: threadParentId },
+        channelIsolation: cfg.session?.channelIsolation,
       });
     }
   }

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -115,6 +115,7 @@ function buildBaseSessionKey(params: {
     peer: params.peer,
     dmScope: params.cfg.session?.dmScope ?? "main",
     identityLinks: params.cfg.session?.identityLinks,
+    channelIsolation: params.cfg.session?.channelIsolation,
   });
 }
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -96,6 +96,8 @@ export function buildAgentSessionKey(params: {
   /** DM session scope. */
   dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
   identityLinks?: Record<string, string[]>;
+  /** When false, non-DM peers share the agent's main session. */
+  channelIsolation?: boolean;
 }): string {
   const channel = normalizeToken(params.channel) || "unknown";
   const peer = params.peer;
@@ -108,6 +110,7 @@ export function buildAgentSessionKey(params: {
     peerId: peer ? normalizeId(peer.id) || "unknown" : null,
     dmScope: params.dmScope,
     identityLinks: params.identityLinks,
+    channelIsolation: params.channelIsolation,
   });
 }
 
@@ -626,6 +629,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const memberRoleIdSet = new Set(memberRoleIds);
   const dmScope = input.cfg.session?.dmScope ?? "main";
   const identityLinks = input.cfg.session?.identityLinks;
+  const channelIsolation = input.cfg.session?.channelIsolation;
   const shouldLogDebug = shouldLogVerbose();
   const parentPeer = input.parentPeer
     ? {
@@ -667,6 +671,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       peer,
       dmScope,
       identityLinks,
+      channelIsolation,
     }).toLowerCase();
     const mainSessionKey = buildAgentMainSessionKey({
       agentId: resolvedAgentId,

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -2,7 +2,9 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { shouldLogVerbose } from "../globals.js";
+import { shouldLogVerbose, warn } from "../globals.js";
+
+let _channelIsolationWarned = false;
 import { logDebug } from "../logger.js";
 import { listBindings } from "./bindings.js";
 import {
@@ -630,6 +632,13 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const dmScope = input.cfg.session?.dmScope ?? "main";
   const identityLinks = input.cfg.session?.identityLinks;
   const channelIsolation = input.cfg.session?.channelIsolation;
+  if (channelIsolation === false && !_channelIsolationWarned) {
+    _channelIsolationWarned = true;
+    warn(
+      "session.channelIsolation=false: all non-DM channels share the main session. " +
+        "Context leaks across channels, /new resets all channels. Recommended for single-user deployments only.",
+    );
+  }
   const shouldLogDebug = shouldLogVerbose();
   const parentPeer = input.parentPeer
     ? {

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -5,6 +5,7 @@ import {
   isCronSessionKey,
 } from "../sessions/session-key-utils.js";
 import {
+  buildAgentPeerSessionKey,
   classifySessionKeyShape,
   isValidAgentId,
   parseAgentSessionKey,
@@ -128,5 +129,62 @@ describe("isValidAgentId", () => {
     expect(isValidAgentId("Agent not found: xyz")).toBe(false);
     expect(isValidAgentId("../../../etc/passwd")).toBe(false);
     expect(isValidAgentId("a".repeat(65))).toBe(false);
+  });
+});
+
+describe("buildAgentPeerSessionKey channelIsolation", () => {
+  it("returns main session key when channelIsolation is false for non-DM peers", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "slack",
+      peerKind: "channel",
+      peerId: "C123",
+      channelIsolation: false,
+    });
+    expect(key).toBe("agent:main:main");
+  });
+
+  it("returns main session key for group peers when channelIsolation is false", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "slack",
+      peerKind: "group",
+      peerId: "G456",
+      channelIsolation: false,
+    });
+    expect(key).toBe("agent:main:main");
+  });
+
+  it("does not affect DM peers when channelIsolation is false", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "slack",
+      peerKind: "direct",
+      peerId: "U789",
+      dmScope: "per-peer",
+      channelIsolation: false,
+    });
+    // DMs should still use per-peer scoping, not main session
+    expect(key).toContain("direct");
+    expect(key).toContain("u789");
+  });
+
+  it("preserves per-channel behavior when channelIsolation is undefined", () => {
+    const withoutFlag = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "slack",
+      peerKind: "channel",
+      peerId: "C123",
+    });
+    const withUndefined = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "slack",
+      peerKind: "channel",
+      peerId: "C123",
+      channelIsolation: undefined,
+    });
+    expect(withoutFlag).toBe(withUndefined);
+    expect(withoutFlag).toContain("slack");
+    expect(withoutFlag).toContain("channel");
   });
 });

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -132,6 +132,34 @@ describe("isValidAgentId", () => {
   });
 });
 
+// ── tripwire: default config unchanged ────────────────────────────
+describe("buildAgentPeerSessionKey default behavior", () => {
+  it("default config: channel peer session key includes channel and peer details", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "slack",
+      peerKind: "channel",
+      peerId: "C123",
+    });
+    expect(key).toContain("slack");
+    expect(key).toContain("channel");
+    expect(key).toContain("c123");
+    expect(key).not.toBe("agent:main:main");
+  });
+
+  it("default config: group peer session key includes group details", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "slack",
+      peerKind: "group",
+      peerId: "G456",
+    });
+    expect(key).toContain("group");
+    expect(key).toContain("g456");
+    expect(key).not.toBe("agent:main:main");
+  });
+});
+
 describe("buildAgentPeerSessionKey channelIsolation", () => {
   it("returns main session key when channelIsolation is false for non-DM peers", () => {
     const key = buildAgentPeerSessionKey({

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -134,6 +134,8 @@ export function buildAgentPeerSessionKey(params: {
   identityLinks?: Record<string, string[]>;
   /** DM session scope. */
   dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+  /** When false, non-DM peers share the agent's main session. Default: true. */
+  channelIsolation?: boolean;
 }): string {
   const peerKind = params.peerKind ?? "direct";
   if (peerKind === "direct") {
@@ -163,6 +165,13 @@ export function buildAgentPeerSessionKey(params: {
     if (dmScope === "per-peer" && peerId) {
       return `agent:${normalizeAgentId(params.agentId)}:direct:${peerId}`;
     }
+    return buildAgentMainSessionKey({
+      agentId: params.agentId,
+      mainKey: params.mainKey,
+    });
+  }
+  // When channel isolation is disabled, non-DM peers share the agent's main session.
+  if (params.channelIsolation === false) {
     return buildAgentMainSessionKey({
       agentId: params.agentId,
       mainKey: params.mainKey,

--- a/src/telegram/conversation-route.ts
+++ b/src/telegram/conversation-route.ts
@@ -64,6 +64,7 @@ export function resolveTelegramConversationRoute(params: {
         peer: { kind: params.isGroup ? "group" : "direct", id: peerId },
         dmScope: params.cfg.session?.dmScope,
         identityLinks: params.cfg.session?.identityLinks,
+        channelIsolation: params.cfg.session?.channelIsolation,
       }).toLowerCase(),
       mainSessionKey: buildAgentMainSessionKey({
         agentId: topicAgentId,
@@ -76,6 +77,7 @@ export function resolveTelegramConversationRoute(params: {
           peer: { kind: params.isGroup ? "group" : "direct", id: peerId },
           dmScope: params.cfg.session?.dmScope,
           identityLinks: params.cfg.session?.identityLinks,
+          channelIsolation: params.cfg.session?.channelIsolation,
         }).toLowerCase(),
         mainSessionKey: buildAgentMainSessionKey({
           agentId: topicAgentId,

--- a/src/web/auto-reply/monitor/broadcast.ts
+++ b/src/web/auto-reply/monitor/broadcast.ts
@@ -28,6 +28,7 @@ function buildBroadcastRouteKeys(params: {
     },
     dmScope: params.cfg.session?.dmScope,
     identityLinks: params.cfg.session?.identityLinks,
+    channelIsolation: params.cfg.session?.channelIsolation,
   });
   const mainSessionKey = buildAgentMainSessionKey({
     agentId: params.agentId,


### PR DESCRIPTION
> **Merge order:** Land #43360 first (narrow, Slack-scoped). This PR is optional/advanced and ok to defer.

## Summary

Adds `session.channelIsolation` config option (default: `true`). When `false`, non-DM channels share the agent's main session instead of per-channel sessions. DM scoping (`session.dmScope`) is unaffected.

This is a **global** setting — applies to all channels (Slack, Telegram, Discord, WhatsApp). Recommended for single-user or trusted-team deployments only.

**See also**: [#43360](https://github.com/openclaw/openclaw/pull/43360) for the companion `session.threadIsolation` PR.

## How this relates to other session knobs

| Setting | What it controls |
|---|---|
| `session.scope` | How senders are grouped **within** a peer context (e.g. per-peer vs main) |
| `session.channelIsolation` | Whether peer contexts **collapse** to the agent's main session |
| `session.threadIsolation` | Whether threads **fork** into separate sessions or share their parent |

## Behavior matrix

| `channelIsolation` | `threadIsolation` | channel sessionKey | thread sessionKey |
|---|---|---|---|
| `true` (default) | `true` (default) | `agent:main:<ch>:channel:<id>` | `...:thread:<threadTs>` |
| `true` | `false` | `agent:main:<ch>:channel:<id>` | same as channel (no `:thread:`) |
| `false` | `true` | `agent:main:main` | `agent:main:main:thread:<threadTs>` |
| `false` | `false` | `agent:main:main` | `agent:main:main` (fully unified) |

DMs always follow `session.dmScope` regardless of `channelIsolation`.

## Dangerous side effects (documented in help text + docs)

- `/new` or idle reset in any channel resets the session for **all** channels
- Context from one channel is visible in others — information leakage risk
- `lastRoute` may flip between channels as the most recent message wins
- Recommended for single-user or trusted-team deployments only

## Implementation

Threads through `buildAgentPeerSessionKey` → `buildAgentSessionKey` → `resolveAgentRoute` → outbound session resolution. Early return to `buildAgentMainSessionKey` when `channelIsolation === false` and peer is non-DM.

All callsites forwarding `channelIsolation`:
- `resolveAgentRoute` (primary route resolver)
- `outbound-session.ts` (outbound `buildBaseSessionKey`)
- `telegram/conversation-route.ts` (topic route override)
- `web/auto-reply/monitor/broadcast.ts` (whatsapp broadcast route)
- `discord/monitor/message-handler.process.ts` (thread parent session)

## Changed files

- **Config**: `types.base.ts`, `zod-schema.session.ts`, `schema.help.ts`, `schema.labels.ts`
- **Routing**: `session-key.ts` (early return in `buildAgentPeerSessionKey`), `resolve-route.ts` (forward param)
- **Outbound**: `outbound-session.ts` (forward to `buildBaseSessionKey`)
- **Telegram**: `conversation-route.ts` (forward in topic override)
- **WhatsApp**: `broadcast.ts` (forward in broadcast route builder)
- **Discord**: `message-handler.process.ts` (forward in thread parent key)
- **Docs**: `docs/channels/slack.md`
- **Tests**: `session-key.test.ts` — 4 new tests

## Config

```json5
{
  "session": {
    "channelIsolation": false  // default: true
  }
}
```

## Test plan

- [x] Channel peer → main session key when `channelIsolation: false`
- [x] Group peer → main session key when `channelIsolation: false`
- [x] DM peer unaffected by `channelIsolation: false`
- [x] `undefined` preserves default per-channel behavior
- [x] All session-key tests pass (28 total)
- [x] Build succeeds
- [x] Dogfooded on production Slack + Discord + Telegram bot with `channelIsolation: false`

Closes #43286