### PR TITLE
models auth login: add --profile-id support

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -836,11 +836,12 @@ Options:
 - `--set-image`
 - `--json`
 
-### `models auth add|setup-token|paste-token`
+### `models auth add|login|setup-token|paste-token`
 
 Options:
 
 - `add`: interactive auth helper
+- `login`: `--provider <id>`, `--method <id>`, `--profile-id <id>`, `--set-default`
 - `setup-token`: `--provider <name>` (default `anthropic`), `--yes`
 - `paste-token`: `--provider <name>`, `--profile-id <id>`, `--expires-in <duration>`
 

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -66,6 +66,7 @@ openclaw models fallbacks list
 ```bash
 openclaw models auth add
 openclaw models auth login --provider <id>
+openclaw models auth login --provider <id> --profile-id <provider:profile>
 openclaw models auth setup-token
 openclaw models auth paste-token
 ```
@@ -75,5 +76,6 @@ openclaw models auth paste-token
 
 Notes:
 
+- `login --profile-id <id>` writes the auth result to a specific profile id. You can pass either `<provider>:<name>` or a bare `<name>` (which is expanded to `<provider>:<name>`).
 - `setup-token` prompts for a setup-token value (generate it with `claude setup-token` on any machine).
 - `paste-token` accepts a token string generated elsewhere or from automation.

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -21,6 +21,8 @@ flows. Run them via:
 
 ```bash
 openclaw models auth login --provider <id>
+# Optional: force credentials into a specific profile id
+openclaw models auth login --provider <id> --profile-id <provider:profile>
 ```
 
 ## The token sink (why it exists)
@@ -130,6 +132,7 @@ Pick which profile is used:
 
 - globally via config ordering (`auth.order`)
 - per-session via `/model ...@<profileId>`
+- at login time via `openclaw models auth login --provider <id> --profile-id <id>`
 
 Example (session override):
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -46,6 +46,9 @@ openclaw onboard --auth-choice openai-codex
 
 # Or run OAuth directly
 openclaw models auth login --provider openai-codex
+
+# Or target a specific auth profile id
+openclaw models auth login --provider openai-codex --profile-id openai-codex:work
 ```
 
 ### Config snippet (Codex subscription)

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const githubCopilotLoginCommand = vi.fn();
+const modelsAuthLoginCommand = vi.fn().mockResolvedValue(undefined);
 const modelsStatusCommand = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("../commands/models.js", async () => {
@@ -10,6 +11,7 @@ vi.mock("../commands/models.js", async () => {
   return {
     ...actual,
     githubCopilotLoginCommand,
+    modelsAuthLoginCommand,
     modelsStatusCommand,
   };
 });
@@ -17,6 +19,7 @@ vi.mock("../commands/models.js", async () => {
 describe("models cli", () => {
   beforeEach(() => {
     githubCopilotLoginCommand.mockClear();
+    modelsAuthLoginCommand.mockClear();
     modelsStatusCommand.mockClear();
   });
 
@@ -73,6 +76,27 @@ describe("models cli", () => {
 
     expect(modelsStatusCommand).toHaveBeenCalledWith(
       expect.objectContaining({ agent: "poe" }),
+      expect.any(Object),
+    );
+  });
+
+  it("passes --profile-id to models auth login", async () => {
+    const { Command } = await import("commander");
+    const { registerModelsCli } = await import("./models-cli.js");
+
+    const program = new Command();
+    registerModelsCli(program);
+
+    await program.parseAsync(
+      ["models", "auth", "login", "--provider", "openai-codex", "--profile-id", "openai-codex:two"],
+      { from: "user" },
+    );
+
+    expect(modelsAuthLoginCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai-codex",
+        profileId: "openai-codex:two",
+      }),
       expect.any(Object),
     );
   });

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -308,6 +308,7 @@ export function registerModelsCli(program: Command) {
     .description("Run a provider plugin auth flow (OAuth/API key)")
     .option("--provider <id>", "Provider id registered by a plugin")
     .option("--method <id>", "Provider auth method id")
+    .option("--profile-id <id>", "Auth profile id override (e.g. openai-codex:work or work)")
     .option("--set-default", "Apply the provider's default model recommendation", false)
     .action(async (opts) => {
       await runModelsCommand(async () => {
@@ -315,6 +316,7 @@ export function registerModelsCli(program: Command) {
           {
             provider: opts.provider as string | undefined,
             method: opts.method as string | undefined,
+            profileId: opts.profileId as string | undefined,
             setDefault: Boolean(opts.setDefault),
           },
           defaultRuntime,

--- a/src/commands/models/auth.login-profile.test.ts
+++ b/src/commands/models/auth.login-profile.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAuthLoginProfileId, remapAuthLoginProfiles } from "./auth.js";
+
+describe("normalizeAuthLoginProfileId", () => {
+  it("returns undefined when no profile id is provided", () => {
+    expect(normalizeAuthLoginProfileId(undefined, "openai-codex")).toBeUndefined();
+    expect(normalizeAuthLoginProfileId("   ", "openai-codex")).toBeUndefined();
+  });
+
+  it("prefixes bare profile names with provider id", () => {
+    expect(normalizeAuthLoginProfileId("two", "openai-codex")).toBe("openai-codex:two");
+  });
+
+  it("normalizes prefixed profile ids for matching provider", () => {
+    expect(normalizeAuthLoginProfileId("OpenAI-Codex:two", "openai-codex")).toBe(
+      "openai-codex:two",
+    );
+  });
+
+  it("rejects profile ids for other providers", () => {
+    expect(() => normalizeAuthLoginProfileId("anthropic:work", "openai-codex")).toThrow(
+      'Auth profile "anthropic:work" is for anthropic, not openai-codex.',
+    );
+  });
+
+  it("rejects malformed prefixed ids", () => {
+    expect(() => normalizeAuthLoginProfileId("openai-codex:", "openai-codex")).toThrow(
+      'Invalid --profile-id "openai-codex:".',
+    );
+  });
+});
+
+describe("remapAuthLoginProfiles", () => {
+  const oauthCredential = {
+    type: "oauth" as const,
+    provider: "openai-codex",
+    access: "a",
+    refresh: "r",
+    expires: Date.now() + 60_000,
+  };
+
+  it("keeps original profiles when no override is provided", () => {
+    const profiles = [{ profileId: "openai-codex:default", credential: oauthCredential }];
+    expect(
+      remapAuthLoginProfiles({
+        profiles,
+        profileId: undefined,
+        providerId: "openai-codex",
+      }),
+    ).toEqual(profiles);
+  });
+
+  it("remaps a single returned profile to requested profile id", () => {
+    expect(
+      remapAuthLoginProfiles({
+        profiles: [{ profileId: "openai-codex:default", credential: oauthCredential }],
+        profileId: "openai-codex:two",
+        providerId: "openai-codex",
+      }),
+    ).toEqual([{ profileId: "openai-codex:two", credential: oauthCredential }]);
+  });
+
+  it("rejects remap when provider returns multiple profiles", () => {
+    expect(() =>
+      remapAuthLoginProfiles({
+        profiles: [
+          { profileId: "openai-codex:default", credential: oauthCredential },
+          { profileId: "openai-codex:other", credential: oauthCredential },
+        ],
+        profileId: "openai-codex:two",
+        providerId: "openai-codex",
+      }),
+    ).toThrow("--profile-id requires exactly one returned profile");
+  });
+
+  it("rejects remap when returned credential provider mismatches selection", () => {
+    expect(() =>
+      remapAuthLoginProfiles({
+        profiles: [
+          {
+            profileId: "anthropic:default",
+            credential: { ...oauthCredential, provider: "anthropic" },
+          },
+        ],
+        profileId: "openai-codex:two",
+        providerId: "openai-codex",
+      }),
+    ).toThrow('Auth flow returned provider "anthropic" but selected provider is "openai-codex".');
+  });
+});

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -236,8 +236,69 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
 type LoginOptions = {
   provider?: string;
   method?: string;
+  profileId?: string;
   setDefault?: boolean;
 };
+
+export function normalizeAuthLoginProfileId(
+  rawProfileId: string | undefined,
+  providerId: string,
+): string | undefined {
+  const trimmed = rawProfileId?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const providerKey = normalizeProviderId(providerId);
+  const colonIdx = trimmed.indexOf(":");
+  if (colonIdx < 0) {
+    return `${providerKey}:${trimmed}`;
+  }
+
+  const rawPrefix = trimmed.slice(0, colonIdx).trim();
+  const suffix = trimmed.slice(colonIdx + 1).trim();
+  if (!rawPrefix || !suffix) {
+    throw new Error(`Invalid --profile-id "${trimmed}". Expected "<provider>:<name>" or "<name>".`);
+  }
+
+  const normalizedPrefix = normalizeProviderId(rawPrefix);
+  if (normalizedPrefix !== providerKey) {
+    throw new Error(
+      `Auth profile "${trimmed}" is for ${normalizedPrefix}, not ${providerKey}. Use a ${providerKey}:<name> profile id.`,
+    );
+  }
+
+  return `${providerKey}:${suffix}`;
+}
+
+export function remapAuthLoginProfiles(params: {
+  profiles: Array<{ profileId: string; credential: AuthProfileCredential }>;
+  profileId?: string;
+  providerId: string;
+}): Array<{ profileId: string; credential: AuthProfileCredential }> {
+  const { profiles, profileId, providerId } = params;
+  if (!profileId) {
+    return profiles;
+  }
+  if (profiles.length === 0) {
+    throw new Error("Auth flow did not return any profiles to map.");
+  }
+  if (profiles.length > 1) {
+    throw new Error(
+      `Auth flow returned ${profiles.length} profiles. --profile-id requires exactly one returned profile.`,
+    );
+  }
+
+  const only = profiles[0];
+  const credentialProvider = normalizeProviderId(only.credential.provider);
+  const providerKey = normalizeProviderId(providerId);
+  if (credentialProvider !== providerKey) {
+    throw new Error(
+      `Auth flow returned provider "${credentialProvider}" but selected provider is "${providerKey}".`,
+    );
+  }
+
+  return [{ ...only, profileId }];
+}
 
 function resolveProviderMatch(
   providers: ProviderPlugin[],
@@ -386,11 +447,14 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
     throw new Error("Unknown auth method. Use --method <id> to select one.");
   }
 
+  const requestedProfileId = normalizeAuthLoginProfileId(opts.profileId, selectedProvider.id);
+
   const isRemote = isRemoteEnvironment();
   const result: ProviderAuthResult = await chosenMethod.run({
     config,
     agentDir,
     workspaceDir,
+    profileId: requestedProfileId,
     prompter,
     runtime,
     isRemote,
@@ -401,8 +465,13 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
       createVpsAwareHandlers: (params) => createVpsAwareOAuthHandlers(params),
     },
   });
+  const resolvedProfiles = remapAuthLoginProfiles({
+    profiles: result.profiles,
+    profileId: requestedProfileId,
+    providerId: selectedProvider.id,
+  });
 
-  for (const profile of result.profiles) {
+  for (const profile of resolvedProfiles) {
     upsertAuthProfile({
       profileId: profile.profileId,
       credential: profile.credential,
@@ -415,7 +484,7 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
     if (result.configPatch) {
       next = mergeConfigPatch(next, result.configPatch);
     }
-    for (const profile of result.profiles) {
+    for (const profile of resolvedProfiles) {
       next = applyAuthProfileConfig(next, {
         profileId: profile.profileId,
         provider: profile.credential.provider,
@@ -429,7 +498,7 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
   });
 
   logConfigUpdated(runtime);
-  for (const profile of result.profiles) {
+  for (const profile of resolvedProfiles) {
     runtime.log(
       `Auth profile: ${profile.profileId} (${profile.credential.provider}/${credentialMode(profile.credential)})`,
     );

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -94,6 +94,8 @@ export type ProviderAuthContext = {
   config: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
+  /** Optional explicit auth profile id target supplied by CLI. */
+  profileId?: string;
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
   isRemote: boolean;


### PR DESCRIPTION
## Summary
- add `--profile-id <id>` to `openclaw models auth login`
- normalize bare ids to `<provider>:<name>` and validate provider-prefixed ids match `--provider`
- thread optional `profileId` through provider auth context
- remap single-profile auth results to the requested profile id before persisting
- document the new login option in CLI/OAuth/OpenAI docs

## Why
`models auth login` was provider-only, which made profile-specific reauthentication impossible for multi-profile single-agent setups (e.g. `openai-codex:two`, `:six`, `:ten`).

## Tests
- `pnpm vitest src/cli/models-cli.test.ts src/commands/models/auth.login-profile.test.ts`

## Notes
- If a provider auth flow returns multiple profiles, `--profile-id` now errors to avoid ambiguous remapping.
