### PR TITLE
fix: make isMemoryPath and isEvergreenMemoryPath case-insensitive for directory prefix

### DIFF
--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildFileEntry,
   chunkMarkdown,
+  isMemoryPath,
   listMemoryFiles,
   normalizeExtraMemoryPaths,
   remapChunkLines,
@@ -33,6 +34,28 @@ describe("normalizeExtraMemoryPaths", () => {
       "",
     ]);
     expect(result).toEqual([path.resolve(workspaceDir, "notes"), absPath]);
+  });
+});
+
+describe("isMemoryPath", () => {
+  it("recognizes root memory files", () => {
+    expect(isMemoryPath("MEMORY.md")).toBe(true);
+    expect(isMemoryPath("memory.md")).toBe(true);
+    expect(isMemoryPath("./MEMORY.md")).toBe(true);
+  });
+
+  it("recognizes memory subdirectory paths case-insensitively", () => {
+    expect(isMemoryPath("memory/notes.md")).toBe(true);
+    expect(isMemoryPath("MEMORY/notes.md")).toBe(true);
+    expect(isMemoryPath("Memory/daily.md")).toBe(true);
+    expect(isMemoryPath("./memory/nested/file.md")).toBe(true);
+    expect(isMemoryPath("./MEMORY/nested/file.md")).toBe(true);
+  });
+
+  it("rejects non-memory paths", () => {
+    expect(isMemoryPath("")).toBe(false);
+    expect(isMemoryPath("src/index.ts")).toBe(false);
+    expect(isMemoryPath("notes/memory.md")).toBe(false);
   });
 });
 

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -53,7 +53,7 @@ export function isMemoryPath(relPath: string): boolean {
   if (normalized === "MEMORY.md" || normalized === "memory.md") {
     return true;
   }
-  return normalized.startsWith("memory/");
+  return normalized.toLowerCase().startsWith("memory/");
 }
 
 async function walkDir(dir: string, files: string[]) {

--- a/src/memory/temporal-decay.test.ts
+++ b/src/memory/temporal-decay.test.ts
@@ -74,6 +74,38 @@ describe("temporal decay", () => {
     expect(decayed[1]?.score).toBeCloseTo(0.75);
   });
 
+  it("treats case-variant evergreen topic paths as evergreen", async () => {
+    // MEMORY/notes.md should be treated as evergreen (no decay) even with
+    // uppercase directory name.
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [
+        { path: "MEMORY/notes.md", score: 0.9, source: "memory" },
+        { path: "Memory/topics.md", score: 0.8, source: "memory" },
+      ],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    // Evergreen files should not decay — scores should remain unchanged.
+    expect(decayed[0]?.score).toBeCloseTo(0.9);
+    expect(decayed[1]?.score).toBeCloseTo(0.8);
+  });
+
+  it("decays dated files under case-variant memory directories", async () => {
+    // MEMORY/2025-01-01.md is a dated file and should decay, even though the
+    // directory name is uppercase.
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [
+        { path: "MEMORY/2025-01-01.md", score: 0.95, source: "memory" },
+      ],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    // Dated file is ~406 days old at NOW_MS — score should be heavily decayed.
+    expect(decayed[0]?.score).toBeLessThan(0.01);
+  });
+
   it("applies decay in hybrid merging before ranking", async () => {
     const merged = await mergeHybridResults({
       vectorWeight: 1,

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -73,7 +73,7 @@ function isEvergreenMemoryPath(filePath: string): boolean {
   if (normalized === "MEMORY.md" || normalized === "memory.md") {
     return true;
   }
-  if (!normalized.startsWith("memory/")) {
+  if (!normalized.toLowerCase().startsWith("memory/")) {
     return false;
   }
   return !DATED_MEMORY_PATH_RE.test(normalized);

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -73,10 +73,11 @@ function isEvergreenMemoryPath(filePath: string): boolean {
   if (normalized === "MEMORY.md" || normalized === "memory.md") {
     return true;
   }
-  if (!normalized.toLowerCase().startsWith("memory/")) {
+  const lowered = normalized.toLowerCase();
+  if (!lowered.startsWith("memory/")) {
     return false;
   }
-  return !DATED_MEMORY_PATH_RE.test(normalized);
+  return !DATED_MEMORY_PATH_RE.test(lowered);
 }
 
 async function extractTimestamp(params: {


### PR DESCRIPTION
## Problem

`isMemoryPath` in `src/memory/internal.ts` and `isEvergreenMemoryPath` in `src/memory/temporal-decay.ts` accept both `MEMORY.md` and `memory.md` as root memory files, but only check the lowercase `memory/` prefix for subdirectory paths.

On case-insensitive filesystems (macOS HFS+/APFS default), the memory directory can legitimately be named `MEMORY/`, `Memory/`, or any other case variant. Files under these directories would not be recognized as memory paths, causing them to:
1. Be excluded from memory indexing in `manager.ts`
2. Not receive temporal decay exemption (evergreen files would erroneously decay)

## Fix

- `isMemoryPath`: compare the lowercased normalized path against `memory/` prefix
- `isEvergreenMemoryPath`: same case-insensitive prefix check

## Tests

Added new `isMemoryPath` test suite covering:
- Root memory files (`MEMORY.md`, `memory.md`)
- Case-insensitive subdirectory matching (`MEMORY/notes.md`, `Memory/daily.md`)
- Non-memory path rejection
