### PR TITLE
fix(ssrf): thread connectOptions through fetch pipeline for Telegram IPv4 fallback

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -224,4 +224,51 @@ describe("fetchWithSsrFGuard hardening", () => {
       expectEnvProxy: true,
     });
   });
+
+  it("forwards connectOptions to pinned dispatcher (regression: 45b74fb56c)", async () => {
+    // Regression test: Telegram media downloads go through fetchWithSsrFGuard which
+    // creates a pinned dispatcher. The telegram fetch wrapper's IPv4 fallback is
+    // skipped when callerProvidedDispatcher is true (always the case for SSRF guard).
+    // Callers must be able to pass connectOptions (e.g. autoSelectFamily: false) to
+    // prevent IPv6 timeouts in dual-stack environments with broken IPv6 routes.
+    const lookupFn = createPublicLookup();
+    let capturedDispatcher: unknown = null;
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedDispatcher = (init as RequestInit & { dispatcher?: unknown }).dispatcher;
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.telegram.org/file/botTOKEN/documents/file_42.pdf",
+      fetchImpl,
+      lookupFn,
+      connectOptions: { autoSelectFamily: false },
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(capturedDispatcher).toBeDefined();
+    expect(capturedDispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
+    await result.release();
+  });
+
+  it("does not set connect options on pinned dispatcher when connectOptions is omitted", async () => {
+    const lookupFn = createPublicLookup();
+    let capturedDispatcher: unknown = null;
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedDispatcher = (init as RequestInit & { dispatcher?: unknown }).dispatcher;
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://example.com/file.pdf",
+      fetchImpl,
+      lookupFn,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // Dispatcher is present (pinned) but without connect options override
+    expect(capturedDispatcher).toBeDefined();
+    expect(capturedDispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
+    await result.release();
+  });
 });

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -38,6 +38,13 @@ export type GuardedFetchOptions = {
    */
   dangerouslyAllowEnvProxyWithoutPinnedDns?: boolean;
   auditContext?: string;
+  /**
+   * Connect-level options forwarded to the pinned SSRF dispatcher.
+   * Use `{ autoSelectFamily: false }` to disable Happy Eyeballs when the
+   * target is known to have broken IPv6 routes (e.g. Telegram media downloads
+   * in dual-stack containers).
+   */
+  connectOptions?: { autoSelectFamily?: boolean; autoSelectFamilyAttemptTimeout?: number };
 };
 
 export type GuardedFetchResult = {
@@ -196,7 +203,7 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       if (canUseTrustedEnvProxy) {
         dispatcher = new EnvHttpProxyAgent();
       } else if (params.pinDns !== false) {
-        dispatcher = createPinnedDispatcher(pinned);
+        dispatcher = createPinnedDispatcher(pinned, params.connectOptions);
       }
 
       const init: RequestInit & { dispatcher?: Dispatcher } = {

--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { agentCtor } = vi.hoisted(() => ({
   agentCtor: vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
@@ -12,26 +12,81 @@ vi.mock("undici", () => ({
 
 import { createPinnedDispatcher, type PinnedHostname } from "./ssrf.js";
 
+function makePinned(hostname = "api.telegram.org"): PinnedHostname {
+  return {
+    hostname,
+    addresses: ["149.154.167.220"],
+    lookup: vi.fn() as unknown as PinnedHostname["lookup"],
+  };
+}
+
+function lastAgentConnect(): Record<string, unknown> | undefined {
+  const lastCall = agentCtor.mock.calls.at(-1)?.[0] as
+    | { connect?: Record<string, unknown> }
+    | undefined;
+  return lastCall?.connect;
+}
+
 describe("createPinnedDispatcher", () => {
-  it("uses pinned lookup without overriding global family policy", () => {
-    const lookup = vi.fn() as unknown as PinnedHostname["lookup"];
-    const pinned: PinnedHostname = {
-      hostname: "api.telegram.org",
-      addresses: ["149.154.167.220"],
-      lookup,
-    };
+  beforeEach(() => {
+    agentCtor.mockClear();
+  });
+
+  it("uses pinned lookup without overriding global family policy by default", () => {
+    const pinned = makePinned();
 
     const dispatcher = createPinnedDispatcher(pinned);
 
     expect(dispatcher).toBeDefined();
     expect(agentCtor).toHaveBeenCalledWith({
       connect: {
-        lookup,
+        lookup: pinned.lookup,
       },
     });
-    const firstCallArg = agentCtor.mock.calls[0]?.[0] as
-      | { connect?: Record<string, unknown> }
-      | undefined;
-    expect(firstCallArg?.connect?.autoSelectFamily).toBeUndefined();
+    expect(lastAgentConnect()?.autoSelectFamily).toBeUndefined();
+  });
+
+  it("forwards autoSelectFamily when connectOptions provided", () => {
+    const pinned = makePinned();
+
+    createPinnedDispatcher(pinned, { autoSelectFamily: false });
+
+    expect(lastAgentConnect()?.autoSelectFamily).toBe(false);
+  });
+
+  it("forwards autoSelectFamily: true when explicitly requested", () => {
+    const pinned = makePinned();
+
+    createPinnedDispatcher(pinned, { autoSelectFamily: true });
+
+    expect(lastAgentConnect()?.autoSelectFamily).toBe(true);
+  });
+
+  it("forwards autoSelectFamilyAttemptTimeout via connectOptions", () => {
+    const pinned = makePinned();
+
+    createPinnedDispatcher(pinned, {
+      autoSelectFamily: true,
+      autoSelectFamilyAttemptTimeout: 500,
+    });
+
+    expect(lastAgentConnect()?.autoSelectFamily).toBe(true);
+    expect(lastAgentConnect()?.autoSelectFamilyAttemptTimeout).toBe(500);
+  });
+
+  it("does not set autoSelectFamilyAttemptTimeout when not provided", () => {
+    const pinned = makePinned();
+
+    createPinnedDispatcher(pinned, { autoSelectFamily: false });
+
+    expect(lastAgentConnect()?.autoSelectFamilyAttemptTimeout).toBeUndefined();
+  });
+
+  it("uses pinned lookup function for DNS resolution", () => {
+    const pinned = makePinned();
+
+    createPinnedDispatcher(pinned);
+
+    expect(lastAgentConnect()?.lookup).toBe(pinned.lookup);
   });
 });

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -329,10 +329,19 @@ export async function resolvePinnedHostname(
   return await resolvePinnedHostnameWithPolicy(hostname, { lookupFn });
 }
 
-export function createPinnedDispatcher(pinned: PinnedHostname): Dispatcher {
+export function createPinnedDispatcher(
+  pinned: PinnedHostname,
+  connectOptions?: { autoSelectFamily?: boolean; autoSelectFamilyAttemptTimeout?: number },
+): Dispatcher {
   return new Agent({
     connect: {
       lookup: pinned.lookup,
+      ...(connectOptions?.autoSelectFamily !== undefined
+        ? { autoSelectFamily: connectOptions.autoSelectFamily }
+        : {}),
+      ...(connectOptions?.autoSelectFamilyAttemptTimeout !== undefined
+        ? { autoSelectFamilyAttemptTimeout: connectOptions.autoSelectFamilyAttemptTimeout }
+        : {}),
     },
   });
 }

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -35,6 +35,8 @@ type FetchMediaOptions = {
   readIdleTimeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
+  /** Connect-level options forwarded to the SSRF pinned dispatcher. */
+  connectOptions?: { autoSelectFamily?: boolean; autoSelectFamilyAttemptTimeout?: number };
 };
 
 function stripQuotes(value: string): string {
@@ -92,6 +94,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     readIdleTimeoutMs,
     ssrfPolicy,
     lookupFn,
+    connectOptions,
   } = options;
 
   let res: Response;
@@ -106,6 +109,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
         maxRedirects,
         policy: ssrfPolicy,
         lookupFn,
+        connectOptions,
       }),
     );
     res = result.response;

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -177,6 +177,31 @@ describe("resolveMedia getFile retry", () => {
     );
   });
 
+  it("passes connectOptions with autoSelectFamily: false to fetchRemoteMedia (regression: 45b74fb56c)", async () => {
+    // Regression test: the SSRF pinned dispatcher must receive autoSelectFamily: false
+    // for Telegram media downloads. Without this, dual-stack containers with broken
+    // IPv6 routes hit ETIMEDOUT because the telegram fetch wrapper's IPv4 fallback is
+    // skipped when callerProvidedDispatcher is true (always the case for SSRF guard).
+    const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_42.pdf" });
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf-data"),
+      contentType: "application/pdf",
+      fileName: "file_42.pdf",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_42---uuid.pdf",
+      contentType: "application/pdf",
+    });
+
+    await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectOptions: { autoSelectFamily: false },
+      }),
+    );
+  });
+
   it.each(["voice", "photo", "video"] as const)(
     "returns null for %s when getFile exhausts retries so message is not dropped",
     async (mediaField) => {

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -126,6 +126,11 @@ async function downloadAndSaveTelegramFile(params: {
     maxBytes: params.maxBytes,
     readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
     ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
+    // Disable Happy Eyeballs on the SSRF pinned dispatcher. The telegram fetch
+    // wrapper's own IPv4 fallback (stickyIpv4Dispatcher) is skipped when the
+    // SSRF guard provides a caller dispatcher. Without this, dual-stack
+    // containers with broken IPv6 routes hit ETIMEDOUT before IPv4 connects.
+    connectOptions: { autoSelectFamily: false },
   });
   const originalName = params.telegramFileName ?? fetched.fileName ?? params.filePath;
   return saveMediaBuffer(


### PR DESCRIPTION
## Summary

Threads `connectOptions` through the SSRF fetch pipeline so the Telegram media download path can disable Happy Eyeballs on its pinned dispatcher — fixing media download failures (ETIMEDOUT) in dual-stack environments with broken IPv6 routes.

## Problem

Commit `45b74fb56c` ("move network fallback to resolver-scoped dispatchers") introduced a regression where the telegram fetch wrapper's sticky IPv4 fallback is skipped for all SSRF-guarded fetches. `fetchWithSsrFGuard` always injects a pinned dispatcher (`callerProvidedDispatcher = true`), so the fallback never applies to media downloads.

The pinned dispatcher inherits undici's default `autoSelectFamily: true`, which enables Happy Eyeballs with a 250ms attempt timeout. In containers with broken IPv6, this kills the IPv4 connection before it completes (~1s for Telegram API).

PR #27370 (merged Feb 26) attempted to fix by removing hardcoded `autoSelectFamily: true` — but the undici default is also `true`, making that change a no-op.

## Approach

Rather than changing the global default in `createPinnedDispatcher` (which would affect all SSRF callers and could break IPv4-broken environments that rely on Happy Eyeballs), this threads `connectOptions` through the pipeline so only the Telegram media download path opts out:

1. **`ssrf.ts`**: `createPinnedDispatcher()` accepts optional `connectOptions` (`autoSelectFamily`, `autoSelectFamilyAttemptTimeout`)
2. **`fetch-guard.ts`**: `GuardedFetchOptions` gains a `connectOptions` field, forwarded to `createPinnedDispatcher`
3. **`media/fetch.ts`**: `FetchMediaOptions` gains `connectOptions`, forwarded to `fetchWithSsrFGuard`
4. **`delivery.resolve-media.ts`**: Telegram media download passes `connectOptions: { autoSelectFamily: false }`

This scopes the fix to exactly where the regression occurs while preserving Happy Eyeballs for all other SSRF-guarded callers.

## Test Plan

- `ssrf.dispatcher.test.ts`: 6 tests — default behavior unchanged, explicit `connectOptions` forwarding, timeout passthrough
- `fetch-guard.ssrf.test.ts`: 2 new tests — `connectOptions` forwarded to pinned dispatcher, omitted when not provided
- `delivery.resolve-media-retry.test.ts`: 1 new test — Telegram media path passes `{ autoSelectFamily: false }`
- All 20 existing `telegram/fetch.test.ts` tests pass unmodified

Fixes #43464
Related: #26998, #20027, #41671