### PR TITLE
fix: include all dimensions in cosineSimilarity norm for different-length vectors

### DIFF
--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildFileEntry,
   chunkMarkdown,
+  cosineSimilarity,
   listMemoryFiles,
   normalizeExtraMemoryPaths,
   remapChunkLines,
@@ -228,5 +229,59 @@ describe("remapChunkLines", () => {
     for (const chunk of chunks) {
       expect(chunk.startLine).toBeLessThanOrEqual(chunk.endLine);
     }
+  });
+});
+
+describe("cosineSimilarity", () => {
+  it("returns 1 for identical vectors", () => {
+    expect(cosineSimilarity([1, 0], [1, 0])).toBeCloseTo(1);
+    expect(cosineSimilarity([0.5, 0.5], [0.5, 0.5])).toBeCloseTo(1);
+  });
+
+  it("returns 0 for orthogonal vectors", () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0);
+  });
+
+  it("returns 0 when either vector is empty", () => {
+    expect(cosineSimilarity([], [1, 2])).toBe(0);
+    expect(cosineSimilarity([1, 2], [])).toBe(0);
+  });
+
+  it("returns 0 when either vector is all zeros", () => {
+    expect(cosineSimilarity([0, 0], [1, 2])).toBe(0);
+    expect(cosineSimilarity([1, 2], [0, 0])).toBe(0);
+  });
+
+  it("handles vectors of different lengths correctly", () => {
+    // [1, 0, 0, 1] vs [1, 0] — shorter vector is zero-padded to [1, 0, 0, 0]
+    // dot = 1*1 + 0*0 = 1
+    // normA = sqrt(1 + 0 + 0 + 1) = sqrt(2)
+    // normB = sqrt(1 + 0) = 1
+    // similarity = 1 / sqrt(2) ≈ 0.7071
+    const result = cosineSimilarity([1, 0, 0, 1], [1, 0]);
+    expect(result).toBeCloseTo(1 / Math.sqrt(2));
+
+    // Reversed argument order should give the same result
+    const reversed = cosineSimilarity([1, 0], [1, 0, 0, 1]);
+    expect(reversed).toBeCloseTo(1 / Math.sqrt(2));
+  });
+
+  it("does not inflate similarity for different-length vectors", () => {
+    // Without the fix, the old code would compute:
+    // dot = 1*1 = 1, normA = sqrt(1) = 1, normB = sqrt(1) = 1
+    // result = 1.0 (incorrect — ignores extra dimensions)
+    //
+    // With the fix:
+    // dot = 1*1 = 1, normA = sqrt(1+1) = sqrt(2), normB = sqrt(1) = 1
+    // result = 1/sqrt(2) ≈ 0.7071
+    const result = cosineSimilarity([1, 1], [1]);
+    expect(result).toBeLessThan(1);
+    expect(result).toBeCloseTo(1 / Math.sqrt(2));
+  });
+
+  it("is symmetric", () => {
+    const a = [0.3, 0.7, 0.1];
+    const b = [0.5, 0.2];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(cosineSimilarity(b, a));
   });
 });

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -309,6 +309,18 @@ export function cosineSimilarity(a: number[], b: number[]): number {
     normA += av * av;
     normB += bv * bv;
   }
+  // Include remaining dimensions of the longer vector in its norm.
+  // When vectors differ in length, the shorter one is implicitly zero-padded;
+  // those zeros contribute nothing to the dot product but the extra dimensions
+  // of the longer vector still affect its magnitude.
+  for (let i = len; i < a.length; i += 1) {
+    const av = a[i] ?? 0;
+    normA += av * av;
+  }
+  for (let i = len; i < b.length; i += 1) {
+    const bv = b[i] ?? 0;
+    normB += bv * bv;
+  }
   if (normA === 0 || normB === 0) {
     return 0;
   }


### PR DESCRIPTION
## Problem

`cosineSimilarity()` in `src/memory/internal.ts` uses `Math.min(a.length, b.length)` for **both** the dot product and the norm computation. When vectors have different lengths, the extra dimensions in the longer vector are silently ignored in the norm calculation, producing inflated similarity scores.

### Example

```
cosineSimilarity([1, 1], [1])
// Old: dot=1, normA=√1=1, normB=√1=1 → result=1.0 (WRONG)
// New: dot=1, normA=√(1+1)=√2, normB=√1=1 → result=1/√2≈0.707 (CORRECT)
```

Mathematically, comparing vectors of different lengths is equivalent to zero-padding the shorter one. The dot product loop is correct (zeros contribute nothing), but each vector's full magnitude must include **all** its dimensions.

This matters when embedding providers return vectors of different dimensionality (e.g., after model version upgrades, or mixed providers in the same memory store).

## Fix

Add two additional loops after the shared-length computation to include the remaining dimensions of whichever vector is longer:

```typescript
for (let i = len; i < a.length; i += 1) {
  const av = a[i] ?? 0;
  normA += av * av;
}
for (let i = len; i < b.length; i += 1) {
  const bv = b[i] ?? 0;
  normB += bv * bv;
}
```

## Tests

Added comprehensive `cosineSimilarity` test suite:
- Identical vectors → 1.0
- Orthogonal vectors → 0.0
- Empty/zero vectors → 0
- **Different-length vectors → correct reduced similarity** (key regression test)
- Symmetry: `sim(a, b) === sim(b, a)`
