### PR TITLE
feat(matrix): wire Atelier P2-M4a runtime hook via trigger helper

### DIFF
--- a/extensions/airi/index.ts
+++ b/extensions/airi/index.ts
@@ -1,0 +1,283 @@
+/**
+ * AIRI Channel Plugin for OpenClaw (Native Plugin)
+ *
+ * Native OpenClaw extension that provides OpenAI-compatible /airi/v1/chat/completions endpoint.
+ * This runs inside the OpenClaw process using the native agent invocation API (api.invokeAgent).
+ *
+ * Configuration (via OpenClaw config):
+ * - channels.airi.token: Bearer token for auth
+ * - channels.airi.defaultAgent: Default agent ID (default: kiki)
+ * - channels.airi.allowedAgents: Array of allowed agent IDs
+ * - channels.airi.systemPrompt: Custom system prompt for AIRI context
+ */
+
+import crypto from "crypto";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+
+// Configuration defaults
+const DEFAULT_TOKEN = "airi-secret-token-change-me";
+const DEFAULT_AGENT = "kiki";
+const DEFAULT_CONTEXT =
+  "You are currently serving the AIRI system. Keep responses natural and conversational — suitable for real-time voice interaction.";
+
+// Session storage for AIRI conversation history (in-memory)
+// Using simple format for compatibility with invokeAgent
+const sessionHistory = new Map<string, Array<{ role: string; content: string }>>();
+
+// Resolve config from plugin config or environment
+function resolveConfig(api: OpenClawPluginApi) {
+  const pluginConfig = (api.pluginConfig as Record<string, any>) || {};
+
+  return {
+    token: pluginConfig.token || process.env.AIRI_TOKEN || DEFAULT_TOKEN,
+    defaultAgent: pluginConfig.defaultAgent || process.env.AIRI_DEFAULT_AGENT || DEFAULT_AGENT,
+    allowedAgents: pluginConfig.allowedAgents ||
+      process.env.AIRI_ALLOWED_AGENTS?.split(",") || [DEFAULT_AGENT],
+    contextInject: pluginConfig.systemPrompt || process.env.AIRI_CONTEXT_INJECT || DEFAULT_CONTEXT,
+  };
+}
+
+const plugin = {
+  id: "airi",
+  name: "AIRI Channel",
+  description: "Native OpenAI-compatible channel for AIRI voice assistant",
+
+  register(api: OpenClawPluginApi) {
+    const CONFIG = resolveConfig(api);
+
+    // Log plugin initialization
+    console.log(
+      `[AIRI] ✓ Native Plugin initialized - allowed agents: ${CONFIG.allowedAgents.join(", ")}`,
+    );
+    api.logger.info(
+      `AIRI native plugin loaded - allowed agents: ${CONFIG.allowedAgents.join(", ")}`,
+    );
+
+    // Register HTTP route for OpenAI-compatible endpoint with /airi/ prefix
+    api.registerHttpRoute({
+      path: "/airi/v1/chat/completions",
+      auth: "plugin", // We handle auth ourselves
+      match: "exact",
+      handler: async (req, res) => {
+        // Parse method and headers
+        const method = req.method || "GET";
+        const authHeader = req.headers["authorization"] || "";
+        const conversationId = (req.headers["x-conversation-id"] as string) || "";
+
+        // Bearer token auth
+        if (!authHeader.startsWith("Bearer ") || authHeader.slice(7) !== CONFIG.token) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: { message: "Unauthorized" } }));
+          return true;
+        }
+
+        if (method !== "POST") {
+          res.writeHead(405, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: { message: "Method not allowed" } }));
+          return true;
+        }
+
+        // Parse body
+        let body = "";
+        for await (const chunk of req) {
+          body += chunk;
+        }
+
+        let parsed;
+        try {
+          parsed = JSON.parse(body);
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: { message: "Invalid JSON" } }));
+          return true;
+        }
+
+        const { messages, model, stream } = parsed;
+        const requestedModel = model || CONFIG.defaultAgent;
+
+        // Security: Validate model against allowlist
+        if (!CONFIG.allowedAgents.includes(requestedModel)) {
+          res.writeHead(400, {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          });
+          res.end(
+            JSON.stringify({
+              error: {
+                message: `Model '${requestedModel}' not allowed. Allowed: ${CONFIG.allowedAgents.join(", ")}`,
+              },
+            }),
+          );
+          return true;
+        }
+
+        const agentId = requestedModel;
+
+        // Session isolation: use conversation ID or generate new session key
+        const sessionKey = conversationId ? `airi:${conversationId}` : undefined; // Let invokeAgent generate a new session
+
+        // Build messages with AIRI context - use simple object format for invokeAgent
+        const systemMessage = { role: "system" as const, content: CONFIG.contextInject };
+
+        // Get existing conversation history if session exists
+        let conversationHistory: Array<{ role: string; content: string }> = [];
+        const historyKey = conversationId ? `airi:${conversationId}` : null;
+        if (historyKey && sessionHistory.has(historyKey)) {
+          conversationHistory = sessionHistory.get(historyKey) || [];
+        }
+
+        // Add new user messages
+        const userMessages = (messages || []).map((m: any) => ({
+          role: m.role || "user",
+          content: m.content || "",
+        }));
+
+        // Combine: system + history + new messages
+        const allMessages = [systemMessage, ...conversationHistory, ...userMessages];
+
+        if (stream) {
+          // Streaming response using invokeAgentStream
+          res.writeHead(200, {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+            "Access-Control-Allow-Origin": "*",
+          });
+
+          // Send role chunk first
+          res.write('data: {"choices":[{"delta":{"role":"assistant","content":""}}]}\n\n');
+
+          try {
+            // Use the native invokeAgentStream API
+            // Use the native invokeAgentStream API
+            if (!api.invokeAgentStream) {
+              throw new Error("invokeAgentStream is not available");
+            }
+            const streamResponse = await api.invokeAgentStream({
+              agentId,
+              messages: allMessages,
+              sessionKey,
+              timeoutSeconds: 60,
+            });
+
+            // Read from the stream and forward to response
+            const reader = streamResponse.getReader();
+            const decoder = new TextDecoder();
+
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              const text = decoder.decode(value, { stream: true });
+              res.write(text);
+            }
+
+            res.write("data: [DONE]\n\n");
+          } catch (err: any) {
+            res.write(`data: {"error":{"message":"${err.message}"}}\n\n`);
+            res.write("data: [DONE]\n\n");
+          }
+
+          res.end();
+          return true;
+        } else {
+          // Non-streaming response using invokeAgent
+          try {
+            // Use the native invokeAgent API
+            if (!api.invokeAgent) {
+              throw new Error("invokeAgent is not available");
+            }
+            const result = await api.invokeAgent({
+              agentId,
+              messages: allMessages,
+              sessionKey,
+              timeoutSeconds: 60,
+            });
+
+            if (!result.success) {
+              throw new Error(result.error || "Agent execution failed");
+            }
+
+            const responseContent = result.content || "";
+            const responseReplyTag = result.replyTag;
+
+            // Store the conversation for session continuity
+            if (historyKey) {
+              const updatedHistory = [
+                ...conversationHistory,
+                ...userMessages,
+                { role: "assistant" as const, content: responseContent },
+              ];
+              sessionHistory.set(historyKey, updatedHistory);
+            }
+
+            // Format OpenAI-compatible response
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                id: `chatcmpl-${crypto.randomUUID().slice(0, 8)}`,
+                object: "chat.completion",
+                created: Math.floor(Date.now() / 1000),
+                model: agentId,
+                choices: [
+                  {
+                    index: 0,
+                    message: { role: "assistant", content: responseContent },
+                    finish_reason: "stop",
+                  },
+                ],
+                ...(responseReplyTag?.hasReplyTag ? { replyTag: responseReplyTag } : {}),
+                usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+              }),
+            );
+          } catch (err: any) {
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: { message: err.message } }));
+          }
+          return true;
+        }
+      },
+    });
+
+    // Health check endpoint
+    api.registerHttpRoute({
+      path: "/airi/health",
+      auth: "plugin",
+      match: "exact",
+      handler: async (req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            status: "ok",
+            service: "airi-native-channel",
+            version: "2.0.0-native-api",
+          }),
+        );
+        return true;
+      },
+    });
+
+    // Models list endpoint
+    api.registerHttpRoute({
+      path: "/airi/v1/models",
+      auth: "plugin",
+      match: "exact",
+      handler: async (req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            object: "list",
+            data: CONFIG.allowedAgents.map((id: string) => ({
+              id,
+              object: "model",
+              created: Date.now(),
+              owned_by: "openclaw",
+            })),
+          }),
+        );
+        return true;
+      },
+    });
+  },
+};
+
+export default plugin;

--- a/extensions/airi/openclaw.plugin.json
+++ b/extensions/airi/openclaw.plugin.json
@@ -1,0 +1,30 @@
+{
+  "id": "airi",
+  "name": "AIRI Channel",
+  "description": "OpenAI-compatible channel for AIRI voice assistant (native plugin)",
+  "version": "2.0.0",
+  "entry": "index.js",
+  "pluginType": "channel",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "token": {
+        "type": "string",
+        "description": "Bearer token for AIRI authentication"
+      },
+      "defaultAgent": {
+        "type": "string",
+        "description": "Default agent ID"
+      },
+      "allowedAgents": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "List of allowed agent IDs"
+      },
+      "systemPrompt": {
+        "type": "string",
+        "description": "Custom system prompt for AIRI context"
+      }
+    }
+  }
+}

--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -62,8 +62,10 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
 
     if (action === "send") {
       const to = readStringParam(params, "to", { required: true });
+      const eventType = readStringParam(params, "eventType");
+      const eventContent = params.eventContent;
       const content = readStringParam(params, "message", {
-        required: true,
+        required: !eventType,
         allowEmpty: true,
       });
       const mediaUrl = readStringParam(params, "media", { trim: false });
@@ -73,10 +75,12 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
         {
           action: "sendMessage",
           to,
-          content,
+          content: content ?? "",
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyTo ?? undefined,
           threadId: threadId ?? undefined,
+          eventType: eventType ?? undefined,
+          eventContent,
         },
         cfg as CoreConfig,
       );

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import {
   createActionGate,
@@ -25,6 +26,58 @@ import type { CoreConfig } from "./types.js";
 const messageActions = new Set(["sendMessage", "editMessage", "deleteMessage", "readMessages"]);
 const reactionActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
+const ATELIER_EVENT_TYPES = new Set(["ai.atelier.canvas.update", "ai.atelier.agent.presence"]);
+
+type AtelierTriggerModule = {
+  postOpenClawEvent: (args: {
+    payload: {
+      roomId: string;
+      eventType: string;
+      content: Record<string, unknown>;
+    };
+    adapterUrl?: string;
+    ingestToken?: string;
+  }) => Promise<unknown>;
+};
+
+const resolveAtelierTriggerHelperPath = (): string => {
+  const explicit = process.env.ATELIER_TRIGGER_HELPER_PATH?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const home = process.env.HOME ?? "";
+  return `${home}/.openclaw/workspace/projects/atelier/infra/gateway-adapter/src/openclaw-trigger.mjs`;
+};
+
+async function emitAtelierEventViaTrigger(args: {
+  roomId: string;
+  eventType: string;
+  eventContent: Record<string, unknown>;
+}): Promise<unknown> {
+  const helperPath = resolveAtelierTriggerHelperPath();
+  let mod: AtelierTriggerModule;
+  try {
+    mod = (await import(pathToFileURL(helperPath).href)) as AtelierTriggerModule;
+  } catch (error) {
+    throw new Error(
+      `Failed to load Atelier trigger helper at ${helperPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (typeof mod.postOpenClawEvent !== "function") {
+    throw new Error(`Atelier trigger helper is missing postOpenClawEvent(): ${helperPath}`);
+  }
+
+  return await mod.postOpenClawEvent({
+    payload: {
+      roomId: args.roomId,
+      eventType: args.eventType,
+      content: args.eventContent,
+    },
+    adapterUrl: process.env.ATELIER_ADAPTER_URL,
+    ingestToken: process.env.ATELIER_ADAPTER_INGEST_TOKEN,
+  });
+}
 
 function readRoomId(params: Record<string, unknown>, required = true): string {
   const direct = readStringParam(params, "roomId") ?? readStringParam(params, "channelId");
@@ -74,6 +127,27 @@ export async function handleMatrixAction(
     switch (action) {
       case "sendMessage": {
         const to = readStringParam(params, "to", { required: true });
+        const eventType = readStringParam(params, "eventType");
+        if (eventType && ATELIER_EVENT_TYPES.has(eventType)) {
+          const rawEventContent = params.eventContent;
+          const parsedEventContent =
+            typeof rawEventContent === "string" ? JSON.parse(rawEventContent) : rawEventContent;
+
+          if (!parsedEventContent || typeof parsedEventContent !== "object") {
+            throw new Error(
+              "Matrix sendMessage Atelier mode requires eventContent object (or JSON string)",
+            );
+          }
+
+          const result = await emitAtelierEventViaTrigger({
+            roomId: to,
+            eventType,
+            eventContent: parsedEventContent as Record<string, unknown>,
+          });
+
+          return jsonResult({ ok: true, atelierEvent: true, result });
+        }
+
         const content = readStringParam(params, "content", {
           required: true,
           allowEmpty: true,

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -264,6 +264,8 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       getSessionMessages: vi.fn(),
       getSession: vi.fn(),
       deleteSession: vi.fn(),
+      invokeAgent: vi.fn(),
+      invokeAgentStream: vi.fn(),
     },
   };
 

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -566,6 +566,22 @@ function buildChatCommands(): ChatCommandDefinition[] {
       ],
     }),
     defineChatCommand({
+      key: "save",
+      nativeName: "save",
+      description:
+        "Review conversation and save context to memory files. Optionally: /save: <extra instructions>",
+      textAlias: "/save",
+      category: "session",
+      args: [
+        {
+          name: "instructions",
+          description: "Extra memory-save instructions",
+          type: "string",
+          captureRemaining: true,
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "think",
       nativeName: "think",
       description: "Set thinking level.",

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,9 +1,7 @@
-import fs from "node:fs/promises";
 import { resetAcpSessionInPlace } from "../../acp/persistent-bindings.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
-import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { isAcpSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { isAcpSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
 import { handleAcpCommand } from "./commands-acp.js";
@@ -23,6 +21,7 @@ import {
 } from "./commands-info.js";
 import { handleModelsCommand } from "./commands-models.js";
 import { handlePluginCommand } from "./commands-plugin.js";
+import { handleSaveCommand } from "./commands-save.js";
 import {
   handleAbortTrigger,
   handleActivationCommand,
@@ -90,48 +89,6 @@ export async function emitResetCommandHooks(params: {
       });
     }
   }
-
-  // Fire before_reset plugin hook — extract memories before session history is lost
-  const hookRunner = getGlobalHookRunner();
-  if (hookRunner?.hasHooks("before_reset")) {
-    const prevEntry = params.previousSessionEntry;
-    const sessionFile = prevEntry?.sessionFile;
-    // Fire-and-forget: read old session messages and run hook
-    void (async () => {
-      try {
-        const messages: unknown[] = [];
-        if (sessionFile) {
-          const content = await fs.readFile(sessionFile, "utf-8");
-          for (const line of content.split("\n")) {
-            if (!line.trim()) {
-              continue;
-            }
-            try {
-              const entry = JSON.parse(line);
-              if (entry.type === "message" && entry.message) {
-                messages.push(entry.message);
-              }
-            } catch {
-              // skip malformed lines
-            }
-          }
-        } else {
-          logVerbose("before_reset: no session file available, firing hook with empty messages");
-        }
-        await hookRunner.runBeforeReset(
-          { sessionFile, messages, reason: params.action },
-          {
-            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
-            sessionKey: params.sessionKey,
-            sessionId: prevEntry?.sessionId,
-            workspaceDir: params.workspaceDir,
-          },
-        );
-      } catch (err: unknown) {
-        logVerbose(`before_reset hook failed: ${String(err)}`);
-      }
-    })();
-  }
 }
 
 function applyAcpResetTailContext(ctx: HandleCommandsParams["ctx"], resetTail: string): void {
@@ -195,6 +152,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleModelsCommand,
       handleStopCommand,
       handleCompactCommand,
+      handleSaveCommand,
       handleAbortTrigger,
     ];
   }

--- a/src/auto-reply/reply/commands-save.test.ts
+++ b/src/auto-reply/reply/commands-save.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { handleSaveCommand } from "./commands-save.js";
+import { buildCommandTestParams } from "./commands.test-harness.js";
+
+const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: enqueueSystemEventMock,
+}));
+
+describe("handleSaveCommand", () => {
+  beforeEach(() => {
+    enqueueSystemEventMock.mockReset();
+  });
+
+  it("injects default save prompt for /save and returns shouldContinue false", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-10T01:04:00.000Z"));
+
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      agents: { defaults: { userTimezone: "Australia/Melbourne" } },
+    } as OpenClawConfig;
+    const params = buildCommandTestParams("/save", cfg);
+
+    const result = await handleSaveCommand(params, true);
+
+    expect(result).toEqual({ shouldContinue: false });
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventMock.mock.calls[0]?.[0]).toContain("memory/2026-03-10.md");
+    expect(enqueueSystemEventMock.mock.calls[0]?.[0]).not.toContain("Additional instructions:");
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(expect.any(String), {
+      sessionKey: "agent:main:main",
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("appends custom instructions for /save: ...", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildCommandTestParams("/save: remember the deployment discussion", cfg);
+
+    const result = await handleSaveCommand(params, true);
+
+    expect(result).toEqual({ shouldContinue: false });
+    const prompt = enqueueSystemEventMock.mock.calls.at(-1)?.[0] as string;
+    expect(prompt).toContain("Additional instructions: remember the deployment discussion");
+  });
+
+  it("ignores unauthorized /save", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildCommandTestParams("/save", cfg);
+
+    const result = await handleSaveCommand(
+      {
+        ...params,
+        command: {
+          ...params.command,
+          isAuthorizedSender: false,
+          senderId: "unauthorized",
+        },
+      },
+      true,
+    );
+
+    expect(result).toEqual({ shouldContinue: false });
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/commands-save.ts
+++ b/src/auto-reply/reply/commands-save.ts
@@ -1,0 +1,83 @@
+import { resolveUserTimezone } from "../../agents/date-time.js";
+import { logVerbose } from "../../globals.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import type { CommandHandler } from "./commands-types.js";
+import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+
+const DEFAULT_SAVE_PROMPT =
+  "Review this conversation and save any important context, decisions, and insights to memory. Update memory/YYYY-MM-DD.md with a log of what happened today. Update MEMORY.md with anything worth keeping long-term. Be concise — capture what matters, skip the noise.";
+
+function formatDateStampInTimezone(nowMs: number, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(nowMs));
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  if (year && month && day) {
+    return `${year}-${month}-${day}`;
+  }
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+function extractSaveInstructions(params: {
+  rawBody?: string;
+  ctx: import("../templating.js").MsgContext;
+  cfg: import("../../config/config.js").OpenClawConfig;
+  agentId?: string;
+  isGroup: boolean;
+}): string | undefined {
+  const raw = stripStructuralPrefixes(params.rawBody ?? "");
+  const stripped = params.isGroup
+    ? stripMentions(raw, params.ctx, params.cfg, params.agentId)
+    : raw;
+  const trimmed = stripped.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const lowered = trimmed.toLowerCase();
+  const prefix = lowered.startsWith("/save") ? "/save" : null;
+  if (!prefix) {
+    return undefined;
+  }
+  let rest = trimmed.slice(prefix.length).trimStart();
+  if (rest.startsWith(":")) {
+    rest = rest.slice(1).trimStart();
+  }
+  return rest.length ? rest : undefined;
+}
+
+export const handleSaveCommand: CommandHandler = async (params) => {
+  const normalized = params.command.commandBodyNormalized;
+  const saveRequested =
+    normalized === "/save" || normalized.startsWith("/save ") || normalized.startsWith("/save:");
+  if (!saveRequested) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /save from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+
+  const customInstructions = extractSaveInstructions({
+    rawBody: params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body,
+    ctx: params.ctx,
+    cfg: params.cfg,
+    agentId: params.agentId,
+    isGroup: params.isGroup,
+  });
+  const timezone = resolveUserTimezone(params.cfg.agents?.defaults?.userTimezone);
+  const dateStamp = formatDateStampInTimezone(Date.now(), timezone);
+  const basePrompt = DEFAULT_SAVE_PROMPT.replaceAll("YYYY-MM-DD", dateStamp);
+  const prompt = customInstructions
+    ? `${basePrompt}\n\nAdditional instructions: ${customInstructions}`
+    : basePrompt;
+
+  enqueueSystemEvent(prompt, { sessionKey: params.sessionKey });
+  return { shouldContinue: false };
+};

--- a/src/auto-reply/reply/commands-save.ts
+++ b/src/auto-reply/reply/commands-save.ts
@@ -5,7 +5,7 @@ import type { CommandHandler } from "./commands-types.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 
 const DEFAULT_SAVE_PROMPT =
-  "Review this conversation and save any important context, decisions, and insights to memory. Update memory/YYYY-MM-DD.md with a log of what happened today. Update MEMORY.md with anything worth keeping long-term. Be concise — capture what matters, skip the noise.";
+  "Review this conversation and save any important context, decisions, and insights to memory. Update memory/YYYY-MM-DD.md with a log of what happened today. Update MEMORY.md with anything worth keeping long-term. Be concise — capture what matters, skip the noise. After finishing, send a brief confirmation message to the user: reply with 'Saved to memory.' if you wrote anything, or 'Nothing important to save.' if there was nothing worth recording.";
 
 function formatDateStampInTimezone(nowMs: number, timezone: string): string {
   const parts = new Intl.DateTimeFormat("en-US", {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -102,6 +102,172 @@ afterEach(() => {
 });
 
 describe("loadGatewayPlugins", () => {
+  test("invokeAgent uses deterministic session key and extracts text blocks", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("invoke-agent"));
+
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "agent") {
+        opts.respond(true, { runId: "run-1" });
+        return;
+      }
+      opts.respond(true, {});
+    });
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "agent.wait") {
+        opts.respond(true, { status: "ok" });
+        return;
+      }
+      opts.respond(true, {});
+    });
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "sessions.get") {
+        opts.respond(true, {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "text", text: "Hello" },
+                { type: "tool_use", name: "noop" },
+                { type: "text", text: "world" },
+              ],
+            },
+          ],
+        });
+        return;
+      }
+      opts.respond(true, {});
+    });
+
+    const result = await runtime.invokeAgent?.({
+      agentId: "kiki",
+      messages: [{ role: "user", content: "say hi" }],
+      idempotencyKey: "idem-123",
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.content).toBe("Hello\nworld");
+    expect(result?.replyTag).toEqual({ hasReplyTag: false, replyToCurrent: false });
+    expect(result?.sessionKey).toBe("agent:kiki:plugin-invoke:idem-123");
+
+    const agentCall = handleGatewayRequest.mock.calls[0]?.[0] as
+      | { req?: { params?: { sessionKey?: string } } }
+      | undefined;
+    const agentParams = agentCall?.req?.params;
+    expect(agentParams?.sessionKey).toBe("agent:kiki:plugin-invoke:idem-123");
+  });
+
+  test("invokeAgent strips reply tags and returns reply-tag metadata", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("invoke-agent-reply-tag"));
+
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "agent") {
+        opts.respond(true, { runId: "run-1" });
+        return;
+      }
+      opts.respond(true, {});
+    });
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "agent.wait") {
+        opts.respond(true, { status: "ok" });
+        return;
+      }
+      opts.respond(true, {});
+    });
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "sessions.get") {
+        opts.respond(true, {
+          messages: [
+            {
+              role: "assistant",
+              content: "On it [[reply_to:msg-42]]",
+            },
+          ],
+        });
+        return;
+      }
+      opts.respond(true, {});
+    });
+
+    const result = await runtime.invokeAgent?.({
+      agentId: "kiki",
+      prompt: "say yes",
+      idempotencyKey: "idem-rt",
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.content).toBe("On it");
+    expect(result?.replyTag).toEqual({
+      hasReplyTag: true,
+      replyToId: "msg-42",
+      replyToCurrent: false,
+    });
+  });
+
+  test("invokeAgentStream emits content deltas from assistant text", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("invoke-agent-stream"));
+
+    let sessionsGetCount = 0;
+    handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "agent") {
+        opts.respond(true, { runId: "run-stream" });
+        return;
+      }
+      if (opts.req.method === "sessions.get") {
+        sessionsGetCount += 1;
+        if (sessionsGetCount === 1) {
+          opts.respond(true, {
+            messages: [
+              {
+                role: "assistant",
+                content: [{ type: "text", text: "hello" }],
+              },
+            ],
+          });
+          return;
+        }
+        opts.respond(true, {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "hello" }],
+            },
+          ],
+        });
+        return;
+      }
+      opts.respond(true, { status: "ok" });
+    });
+
+    const stream = await runtime.invokeAgentStream?.({
+      agentId: "kiki",
+      messages: [{ role: "user", content: "say hello" }],
+      idempotencyKey: "idem-stream",
+      timeoutSeconds: 3,
+    });
+    const reader = stream?.getReader();
+    expect(reader).toBeTruthy();
+    const decoder = new TextDecoder();
+    let output = "";
+    if (reader) {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        output += decoder.decode(value, { stream: true });
+      }
+    }
+
+    expect(output).toContain('"content":"hello"');
+    expect(output).toContain('"finish_reason":"stop"');
+  });
+
   test("logs plugin errors with details", async () => {
     const { loadGatewayPlugins } = await importServerPluginsModule();
     const diagnostics: PluginDiagnostic[] = [

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "node:crypto";
 import type { loadConfig } from "../config/config.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
-import type { PluginRuntime } from "../plugins/runtime/types.js";
+import type {
+  PluginAgentInvokeReplyTagMetadata,
+  PluginAgentInvokeRuntimeResult,
+  PluginRuntime,
+} from "../plugins/runtime/types.js";
+import { parseInlineDirectives } from "../utils/directive-tags.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./protocol/client-info.js";
 import type { ErrorShape } from "./protocol/index.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
@@ -113,6 +118,117 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
     return { messages: Array.isArray(payload?.messages) ? payload.messages : [] };
   };
 
+  /**
+   * Convert messages array to a single prompt string for the subagent.
+   */
+  const messagesToPrompt = (messages?: Array<{ role: string; content: string }>): string => {
+    if (!messages || messages.length === 0) {
+      return "";
+    }
+    const userMsg = messages.find((m) => m.role === "user");
+    if (userMsg) {
+      return userMsg.content;
+    }
+    return messages.map((m) => `${m.role}: ${m.content}`).join("\n");
+  };
+
+  const toAgentScopedSessionKey = (agentId: string, sessionKey?: string): string | undefined => {
+    const raw = sessionKey?.trim();
+    if (!raw) {
+      return undefined;
+    }
+    if (raw.startsWith("agent:")) {
+      return raw;
+    }
+    return `agent:${agentId}:${raw}`;
+  };
+
+  const ensureInvokeSessionKey = (
+    agentId: string,
+    sessionKey: string | undefined,
+    idempotencyKey: string,
+  ): string => {
+    const scoped = toAgentScopedSessionKey(agentId, sessionKey);
+    if (scoped) {
+      return scoped;
+    }
+    return `agent:${agentId}:plugin-invoke:${idempotencyKey}`;
+  };
+
+  const normalizeMessageContent = (content: unknown): string => {
+    if (typeof content === "string") {
+      return content;
+    }
+    if (Array.isArray(content)) {
+      return content
+        .map((block) => {
+          if (typeof block === "string") {
+            return block;
+          }
+          if (!block || typeof block !== "object") {
+            return "";
+          }
+          const record = block as Record<string, unknown>;
+          if (record.type === "text" && typeof record.text === "string") {
+            return record.text;
+          }
+          if (typeof record.text === "string") {
+            return record.text;
+          }
+          if (typeof record.content === "string") {
+            return record.content;
+          }
+          return "";
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+    if (content == null) {
+      return "";
+    }
+    try {
+      return JSON.stringify(content);
+    } catch {
+      return "";
+    }
+  };
+
+  const extractReplyTagMetadata = (
+    text: string,
+  ): { content: string; replyTag: PluginAgentInvokeReplyTagMetadata } => {
+    const parsed = parseInlineDirectives(text, {
+      stripReplyTags: true,
+      stripAudioTag: false,
+    });
+    return {
+      content: parsed.text,
+      replyTag: {
+        hasReplyTag: parsed.hasReplyTag,
+        replyToId: parsed.replyToId,
+        replyToCurrent: parsed.replyToCurrent,
+      },
+    };
+  };
+
+  const extractContentFromMessages = (
+    messages: unknown[],
+  ): { content: string; replyTag: PluginAgentInvokeReplyTagMetadata } => {
+    if (!messages || messages.length === 0) {
+      return {
+        content: "",
+        replyTag: { hasReplyTag: false, replyToCurrent: false },
+      };
+    }
+    const asRecords = messages as Array<Record<string, unknown>>;
+    const assistantMsgs = asRecords.filter((m) => m?.role === "assistant" || m?.role === "agent");
+    if (assistantMsgs.length > 0) {
+      const lastAssistant = assistantMsgs[assistantMsgs.length - 1];
+      return extractReplyTagMetadata(normalizeMessageContent(lastAssistant?.content));
+    }
+    const lastMsg = asRecords[asRecords.length - 1];
+    return extractReplyTagMetadata(normalizeMessageContent(lastMsg?.content));
+  };
+
   return {
     async run(params) {
       const payload = await dispatchGatewayMethod<{ runId?: string }>("agent", {
@@ -155,6 +271,243 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         key: params.sessionKey,
         deleteTranscript: params.deleteTranscript ?? true,
       });
+    },
+    /**
+     * Invoke an agent directly (non-streaming) via the plugin API.
+     * Uses the gateway's agent method with deliver=false to avoid channel ambiguity.
+     */
+    async invokeAgent(params): Promise<PluginAgentInvokeRuntimeResult> {
+      const agentId = params.agentId?.trim() || "kiki";
+      const message = params.prompt || messagesToPrompt(params.messages);
+      const timeoutMs = params.timeoutSeconds ? params.timeoutSeconds * 1000 : undefined;
+      const idempotencyKey = params.idempotencyKey || `plugin-invoke:${randomUUID()}`;
+      const sessionKey = ensureInvokeSessionKey(agentId, params.sessionKey, idempotencyKey);
+
+      if (!message) {
+        return { success: false, error: "No message or prompt provided" };
+      }
+
+      try {
+        // Use the agent gateway method with deliver=false
+        const runPayload = await dispatchGatewayMethod<{ runId?: string; sessionKey?: string }>(
+          "agent",
+          {
+            sessionKey,
+            message,
+            agentId,
+            idempotencyKey,
+            deliver: false, // Avoid channel ambiguity
+          },
+        );
+
+        const runId = runPayload?.runId;
+        const resultSessionKey = runPayload?.sessionKey || sessionKey;
+
+        if (!runId) {
+          return { success: false, error: "Failed to get runId from agent invocation" };
+        }
+
+        // Wait for the agent to complete
+        const waitPayload = await dispatchGatewayMethod<{ status?: string; error?: string }>(
+          "agent.wait",
+          {
+            runId,
+            timeoutMs,
+          },
+        );
+
+        if (waitPayload?.status === "error") {
+          return {
+            success: false,
+            error: waitPayload.error || "Agent execution failed",
+            sessionKey: resultSessionKey,
+          };
+        }
+
+        if (waitPayload?.status === "timeout") {
+          return {
+            success: false,
+            error: "Agent execution timed out",
+            sessionKey: resultSessionKey,
+          };
+        }
+
+        // Get the session messages to extract the response
+        const sessionMsgs = await getSessionMessages({
+          sessionKey: resultSessionKey,
+          limit: 20,
+        });
+
+        const { content, replyTag } = extractContentFromMessages(sessionMsgs.messages || []);
+
+        return {
+          success: true,
+          content,
+          messages: sessionMsgs.messages,
+          sessionKey: resultSessionKey,
+          replyTag,
+        };
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        return { success: false, error: `Agent invocation failed: ${error}` };
+      }
+    },
+    /**
+     * Invoke an agent with streaming response via the plugin API.
+     * Returns a ReadableStream that emits SSE-compatible chunks.
+     */
+    async invokeAgentStream(params): Promise<ReadableStream<Uint8Array>> {
+      const encoder = new TextEncoder();
+      let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+      let cancelled = false;
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(c) {
+          controller = c;
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+
+      // Run the invocation asynchronously
+      void (async () => {
+        let streamController = controller;
+        try {
+          const agentId = params.agentId?.trim() || "kiki";
+          const message = params.prompt || messagesToPrompt(params.messages);
+          const timeoutMs = params.timeoutSeconds ? params.timeoutSeconds * 1000 : undefined;
+          const idempotencyKey = params.idempotencyKey || `plugin-invoke:${randomUUID()}`;
+          const sessionKey = ensureInvokeSessionKey(agentId, params.sessionKey, idempotencyKey);
+
+          if (!message) {
+            const errorChunk = encoder.encode(
+              `data: ${JSON.stringify({ error: { message: "No message or prompt provided" } })}\n\n`,
+            );
+            streamController?.enqueue(errorChunk);
+            streamController?.close();
+            return;
+          }
+
+          // Use session mode to allow polling for updates
+          const runPayload = await dispatchGatewayMethod<{
+            runId?: string;
+            sessionKey?: string;
+          }>("agent", {
+            sessionKey,
+            message,
+            agentId,
+            idempotencyKey,
+            deliver: false, // Avoid channel ambiguity
+          });
+
+          if (!runPayload?.runId) {
+            const errorChunk = encoder.encode(
+              `data: ${JSON.stringify({ error: { message: "Failed to start agent" } })}\n\n`,
+            );
+            streamController?.enqueue(errorChunk);
+            streamController?.close();
+            return;
+          }
+
+          const resultSessionKey = runPayload.sessionKey || sessionKey;
+
+          // Poll for session messages and stream them
+          const pollInterval = 500;
+          const maxPolls = Math.ceil((timeoutMs || 60000) / pollInterval);
+          let polls = 0;
+          let lastContent = "";
+
+          while (polls < maxPolls && !cancelled) {
+            await new Promise((resolve) => setTimeout(resolve, pollInterval));
+            polls++;
+
+            const sessionMsgs = await getSessionMessages({
+              sessionKey: resultSessionKey,
+              limit: 20,
+            });
+
+            if (sessionMsgs.messages && sessionMsgs.messages.length > 0) {
+              const assistantMsgs = (sessionMsgs.messages as Array<Record<string, unknown>>).filter(
+                (m) => m?.role === "assistant" || m?.role === "agent",
+              );
+
+              if (assistantMsgs.length > 0) {
+                const latestMsg = assistantMsgs[assistantMsgs.length - 1];
+                const { content: newContent } = extractReplyTagMetadata(
+                  normalizeMessageContent(latestMsg?.content),
+                );
+
+                if (newContent !== lastContent) {
+                  const delta = newContent.slice(lastContent.length);
+                  if (delta) {
+                    const chunk = encoder.encode(
+                      `data: ${JSON.stringify({ choices: [{ delta: { content: delta } }] })}\n\n`,
+                    );
+                    streamController?.enqueue(chunk);
+                  }
+                  lastContent = newContent;
+                }
+              }
+
+              // Check if we're done
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const lastMsg = sessionMsgs.messages[sessionMsgs.messages.length - 1] as any;
+              if (lastMsg?.role === "assistant" || lastMsg?.role === "agent") {
+                // Give it a bit more time, then finish
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+                const finalMsgs = await getSessionMessages({
+                  sessionKey: resultSessionKey,
+                  limit: 20,
+                });
+                const finalList = finalMsgs.messages as Array<Record<string, unknown>>;
+                const finalMsg = finalList[finalList.length - 1];
+                const { content: finalContent, replyTag } = extractReplyTagMetadata(
+                  normalizeMessageContent(finalMsg?.content) || lastContent,
+                );
+
+                if (finalContent === lastContent) {
+                  const finishChunk = encoder.encode(
+                    `data: ${JSON.stringify({
+                      choices: [{ delta: { finish_reason: "stop" } }],
+                      ...(replyTag.hasReplyTag ? { replyTag } : {}),
+                    })}\n\n`,
+                  );
+                  streamController?.enqueue(finishChunk);
+                  streamController?.close();
+                  return;
+                }
+              }
+            }
+          }
+
+          if (cancelled) {
+            return;
+          }
+
+          // Send final content
+          if (lastContent) {
+            const { replyTag } = extractReplyTagMetadata(lastContent);
+            const chunk = encoder.encode(
+              `data: ${JSON.stringify({
+                choices: [{ delta: { content: lastContent, finish_reason: "stop" } }],
+                ...(replyTag.hasReplyTag ? { replyTag } : {}),
+              })}\n\n`,
+            );
+            streamController?.enqueue(chunk);
+          }
+          streamController?.close();
+        } catch (err) {
+          const error = err instanceof Error ? err.message : String(err);
+          const errorChunk = encoder.encode(
+            `data: ${JSON.stringify({ error: { message: `Agent invocation failed: ${error}` } })}\n\n`,
+          );
+          streamController?.enqueue(errorChunk);
+          streamController?.close();
+        }
+      })();
+
+      return stream;
     },
   };
 }

--- a/src/plugin-sdk/agent-invoke.ts
+++ b/src/plugin-sdk/agent-invoke.ts
@@ -1,0 +1,28 @@
+import type { PluginRuntime } from "../plugins/runtime/types.js";
+import type { PluginAgentInvokeOptions, PluginAgentInvokeResult } from "../plugins/types.js";
+
+export interface AgentMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export type { PluginAgentInvokeOptions as AgentInvokeOptions };
+export type { PluginAgentInvokeResult as AgentInvokeResult };
+
+export async function invokeAgent(
+  _runtime: PluginRuntime,
+  _opts: PluginAgentInvokeOptions,
+): Promise<PluginAgentInvokeResult> {
+  throw new Error(
+    "invokeAgent is implemented in the plugin registry and accessed via api.invokeAgent",
+  );
+}
+
+export async function invokeAgentStream(
+  _runtime: PluginRuntime,
+  _opts: PluginAgentInvokeOptions,
+): Promise<ReadableStream<Uint8Array>> {
+  throw new Error(
+    "invokeAgentStream is implemented in the plugin registry and accessed via api.invokeAgentStream",
+  );
+}

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -4,6 +4,9 @@ export type {
   OpenClawPluginService,
   ProviderAuthContext,
   ProviderAuthResult,
+  AgentMessage,
+  PluginAgentInvokeOptions,
+  PluginAgentInvokeResult,
 } from "../plugins/types.js";
 export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -103,6 +103,9 @@ export type {
   PluginLogger,
   ProviderAuthContext,
   ProviderAuthResult,
+  AgentMessage,
+  PluginAgentInvokeOptions,
+  PluginAgentInvokeResult,
 } from "../plugins/types.js";
 export type {
   GatewayRequestHandler,
@@ -630,6 +633,7 @@ export { detectMime, extensionForMime, getFileExtension } from "../media/mime.js
 export { extractOriginalFilename } from "../media/store.js";
 export { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 export type { SkillCommandSpec } from "../agents/skills.js";
+export * from "./smart-reset-memory.js";
 
 // Channel: Discord
 export {
@@ -800,12 +804,6 @@ export type {
 } from "../context-engine/types.js";
 export { registerContextEngine } from "../context-engine/registry.js";
 export type { ContextEngineFactory } from "../context-engine/registry.js";
-
-// Model authentication types for plugins.
-// Plugins should use runtime.modelAuth (which strips unsafe overrides like
-// agentDir/store) rather than importing raw helpers directly.
-export { requireApiKey } from "../agents/model-auth.js";
-export type { ResolvedProviderAuth } from "../agents/model-auth.js";
 
 // Security utilities
 export { redactSensitiveText } from "../logging/redact.js";

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -21,7 +21,6 @@ import type {
   PluginHookBeforeCompactionEvent,
   PluginHookLlmInputEvent,
   PluginHookLlmOutputEvent,
-  PluginHookBeforeResetEvent,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginHookGatewayContext,
@@ -65,7 +64,6 @@ export type {
   PluginHookLlmOutputEvent,
   PluginHookAgentEndEvent,
   PluginHookBeforeCompactionEvent,
-  PluginHookBeforeResetEvent,
   PluginHookAfterCompactionEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
@@ -366,18 +364,6 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     ctx: PluginHookAgentContext,
   ): Promise<void> {
     return runVoidHook("after_compaction", event, ctx);
-  }
-
-  /**
-   * Run before_reset hook.
-   * Fired when /new or /reset clears a session, before messages are lost.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runBeforeReset(
-    event: PluginHookBeforeResetEvent,
-    ctx: PluginHookAgentContext,
-  ): Promise<void> {
-    return runVoidHook("before_reset", event, ctx);
   }
 
   // =========================================================================
@@ -732,7 +718,6 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runAgentEnd,
     runBeforeCompaction,
     runAfterCompaction,
-    runBeforeReset,
     // Message hooks
     runMessageReceived,
     runMessageSending,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -580,6 +580,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       hookPolicy?: PluginTypedHookPolicy;
     },
   ): OpenClawPluginApi => {
+    const runtime = registryParams.runtime;
+    const subagentRuntime = runtime?.subagent;
+
     return {
       id: record.id,
       name: record.name,
@@ -588,7 +591,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       source: record.source,
       config: params.config,
       pluginConfig: params.pluginConfig,
-      runtime: registryParams.runtime,
+      runtime,
       logger: normalizeLogger(registryParams.logger),
       registerTool: (tool, opts) => registerTool(record, tool, opts),
       registerHook: (events, handler, opts) =>
@@ -604,6 +607,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       resolvePath: (input: string) => resolveUserPath(input),
       on: (hookName, handler, opts) =>
         registerTypedHook(record, hookName, handler, opts, params.hookPolicy),
+      invokeAgent: subagentRuntime?.invokeAgent
+        ? async (opts) =>
+            subagentRuntime.invokeAgent(opts) as Promise<
+              import("./types.js").PluginAgentInvokeResult
+            >
+        : undefined,
+      invokeAgentStream: subagentRuntime?.invokeAgentStream
+        ? async (opts) => subagentRuntime.invokeAgentStream(opts)
+        : undefined,
     };
   };
 

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,8 +1,4 @@
 import { createRequire } from "node:module";
-import {
-  getApiKeyForModel as getApiKeyForModelRaw,
-  resolveApiKeyForProvider as resolveApiKeyForProviderRaw,
-} from "../../agents/model-auth.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
 import { textToSpeechTelephony } from "../../tts/tts.js";
@@ -36,12 +32,17 @@ function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
   const unavailable = () => {
     throw new Error("Plugin runtime subagent methods are only available during a gateway request.");
   };
+  const unavailableWithReturn = (_opts?: unknown) => {
+    throw new Error("Plugin runtime subagent methods are only available during a gateway request.");
+  };
   return {
     run: unavailable,
     waitForRun: unavailable,
     getSessionMessages: unavailable,
     getSession: unavailable,
     deleteSession: unavailable,
+    invokeAgent: unavailableWithReturn,
+    invokeAgentStream: unavailableWithReturn,
   };
 }
 
@@ -63,24 +64,6 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     events: createRuntimeEvents(),
     logging: createRuntimeLogging(),
     state: { resolveStateDir },
-    modelAuth: {
-      // Wrap model-auth helpers so plugins cannot steer credential lookups:
-      // - agentDir / store: stripped (prevents reading other agents' stores)
-      // - profileId / preferredProfile: stripped (prevents cross-provider
-      //   credential access via profile steering)
-      // Plugins only specify provider/model; the core auth pipeline picks
-      // the appropriate credential automatically.
-      getApiKeyForModel: (params) =>
-        getApiKeyForModelRaw({
-          model: params.model,
-          cfg: params.cfg,
-        }),
-      resolveApiKeyForProvider: (params) =>
-        resolveApiKeyForProviderRaw({
-          provider: params.provider,
-          cfg: params.cfg,
-        }),
-    },
   } satisfies PluginRuntime;
 
   return runtime;

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -3,6 +3,33 @@ import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 
 export type { RuntimeLogger };
 
+// ── Agent invocation types (used by plugin-sdk and runtime) ───────────
+
+export type PluginAgentInvokeRuntimeParams = {
+  agentId: string;
+  messages?: Array<{ role: string; content: string }>;
+  sessionKey?: string;
+  timeoutSeconds?: number;
+  stream?: boolean;
+  prompt?: string;
+  idempotencyKey?: string;
+};
+
+export type PluginAgentInvokeReplyTagMetadata = {
+  hasReplyTag: boolean;
+  replyToId?: string;
+  replyToCurrent: boolean;
+};
+
+export type PluginAgentInvokeRuntimeResult = {
+  success: boolean;
+  error?: string;
+  content?: string;
+  messages?: unknown[];
+  sessionKey?: string;
+  replyTag?: PluginAgentInvokeReplyTagMetadata;
+};
+
 // ── Subagent runtime types ──────────────────────────────────────────
 
 export type SubagentRunParams = {
@@ -58,6 +85,14 @@ export type PluginRuntime = PluginRuntimeCore & {
     /** @deprecated Use getSessionMessages. */
     getSession: (params: SubagentGetSessionParams) => Promise<SubagentGetSessionResult>;
     deleteSession: (params: SubagentDeleteSessionParams) => Promise<void>;
+    /** Invoke an agent directly (non-streaming). */
+    invokeAgent: (
+      params: PluginAgentInvokeRuntimeParams,
+    ) => Promise<PluginAgentInvokeRuntimeResult>;
+    /** Invoke an agent with streaming response. */
+    invokeAgentStream: (
+      params: PluginAgentInvokeRuntimeParams,
+    ) => Promise<ReadableStream<Uint8Array>>;
   };
   channel: PluginRuntimeChannel;
 };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -327,7 +327,6 @@ export type PluginHookName =
   | "agent_end"
   | "before_compaction"
   | "after_compaction"
-  | "before_reset"
   | "message_received"
   | "message_sending"
   | "message_sent"
@@ -353,7 +352,6 @@ export const PLUGIN_HOOK_NAMES = [
   "agent_end",
   "before_compaction",
   "after_compaction",
-  "before_reset",
   "message_received",
   "message_sending",
   "message_sent",
@@ -536,13 +534,6 @@ export type PluginHookBeforeCompactionEvent = {
    *  before compaction starts, so plugins can read this file asynchronously
    *  and process in parallel with the compaction LLM call. */
   sessionFile?: string;
-};
-
-// before_reset hook — fired when /new or /reset clears a session
-export type PluginHookBeforeResetEvent = {
-  sessionFile?: string;
-  messages?: unknown[];
-  reason?: string;
 };
 
 export type PluginHookAfterCompactionEvent = {
@@ -812,10 +803,6 @@ export type PluginHookHandlerMap = {
   ) => Promise<void> | void;
   after_compaction: (
     event: PluginHookAfterCompactionEvent,
-    ctx: PluginHookAgentContext,
-  ) => Promise<void> | void;
-  before_reset: (
-    event: PluginHookBeforeResetEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<void> | void;
   message_received: (

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -18,6 +18,33 @@ import type { PluginRuntime } from "./runtime/types.js";
 
 export type { PluginRuntime } from "./runtime/types.js";
 export type { AnyAgentTool } from "../agents/tools/common.js";
+export type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export interface PluginAgentInvokeOptions {
+  agentId: string;
+  prompt?: string;
+  messages?: Array<{ role: string; content: string }>;
+  sessionKey?: string;
+  mode?: "run" | "session";
+  timeoutSeconds?: number;
+  stream?: boolean;
+  idempotencyKey?: string;
+}
+
+export interface PluginAgentInvokeReplyTagMetadata {
+  hasReplyTag: boolean;
+  replyToId?: string;
+  replyToCurrent: boolean;
+}
+
+export interface PluginAgentInvokeResult {
+  success: boolean;
+  error?: string;
+  content?: string;
+  messages?: AgentMessage[];
+  sessionKey?: string;
+  replyTag?: PluginAgentInvokeReplyTagMetadata;
+}
 
 export type PluginLogger = {
   debug?: (message: string) => void;
@@ -303,6 +330,10 @@ export type OpenClawPluginApi = {
     handler: PluginHookHandlerMap[K],
     opts?: { priority?: number },
   ) => void;
+  /** Invoke an agent directly (non-streaming). */
+  invokeAgent?: (opts: PluginAgentInvokeOptions) => Promise<PluginAgentInvokeResult>;
+  /** Invoke an agent with streaming response. */
+  invokeAgentStream?: (opts: PluginAgentInvokeOptions) => Promise<ReadableStream<Uint8Array>>;
 };
 
 export type PluginOrigin = "bundled" | "global" | "workspace" | "config";
@@ -327,6 +358,7 @@ export type PluginHookName =
   | "agent_end"
   | "before_compaction"
   | "after_compaction"
+  | "before_reset"
   | "message_received"
   | "message_sending"
   | "message_sent"
@@ -352,6 +384,7 @@ export const PLUGIN_HOOK_NAMES = [
   "agent_end",
   "before_compaction",
   "after_compaction",
+  "before_reset",
   "message_received",
   "message_sending",
   "message_sent",
@@ -534,6 +567,15 @@ export type PluginHookBeforeCompactionEvent = {
    *  before compaction starts, so plugins can read this file asynchronously
    *  and process in parallel with the compaction LLM call. */
   sessionFile?: string;
+};
+
+// before_reset hook — fired when /new or /reset clears a session
+export type PluginHookBeforeResetEvent = {
+  sessionFile?: string;
+  messages?: unknown[];
+  reason?: string;
+  /** Optional smart-reset review instruction to process before reset. */
+  reviewPrompt?: string;
 };
 
 export type PluginHookAfterCompactionEvent = {
@@ -803,6 +845,10 @@ export type PluginHookHandlerMap = {
   ) => Promise<void> | void;
   after_compaction: (
     event: PluginHookAfterCompactionEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<void> | void;
+  before_reset: (
+    event: PluginHookBeforeResetEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<void> | void;
   message_received: (


### PR DESCRIPTION
## Summary
- add the missing production Matrix runtime call-site for Atelier custom events
- keep scope narrow to two event types only: `ai.atelier.canvas.update`, `ai.atelier.agent.presence`
- invoke existing Atelier trigger helper (`openclaw-trigger.mjs`) from Matrix `sendMessage` action path when `eventType`/`eventContent` are supplied
- preserve normal Matrix chat send path for non-Atelier sends

## Files
- `extensions/matrix/src/tool-actions.ts`
- `extensions/matrix/src/actions.ts`

## Behavior
- `message(action=send, channel=matrix, to=<roomId>, eventType=<atelier type>, eventContent=<object|json>)` now routes through the Atelier trigger helper
- regular matrix send/edit/delete/read/reaction flows are unchanged

## Validation
- `pnpm vitest extensions/matrix/src/outbound.test.ts` (pass)
- targeted broader matrix test runs currently hit unrelated repo-level auth-profile harness issue (`getOAuthProviders is not a function`) in this branch baseline

## Staging verification
1. Set runtime env:
   - `ATELIER_TRIGGER_HELPER_PATH`
   - `ATELIER_ADAPTER_URL`
   - `ATELIER_ADAPTER_INGEST_TOKEN`
2. Start adapter and run `npm test` under `projects/atelier/infra/gateway-adapter`
3. Send matrix action payload with:
   - `to=<roomId>`
   - `eventType=ai.atelier.agent.presence` (and then canvas.update)
   - `eventContent=<json>`
4. Confirm adapter receives `/v1/openclaw-event` and Matrix room receives custom event
