### PR TITLE
test(gateway): widen before tool hook mock typing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1
       file-type:
-        specifier: ^21.3.1
+        specifier: 21.3.1
         version: 21.3.1
       grammy:
         specifier: ^1.41.1

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -1,14 +1,21 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { runBeforeToolCallHook as runBeforeToolCallHookType } from "../agents/pi-tools.before-tool-call.js";
+
+type RunBeforeToolCallHook = typeof runBeforeToolCallHookType;
+type RunBeforeToolCallHookArgs = Parameters<RunBeforeToolCallHook>[0];
+type RunBeforeToolCallHookResult = Awaited<ReturnType<RunBeforeToolCallHook>>;
 
 const TEST_GATEWAY_TOKEN = "test-gateway-token-1234567890";
 const hookMocks = vi.hoisted(() => ({
   resolveToolLoopDetectionConfig: vi.fn(() => ({ warnAt: 3 })),
-  runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
-    blocked: false as const,
-    params,
-  })),
+  runBeforeToolCallHook: vi.fn(
+    async (args: RunBeforeToolCallHookArgs): Promise<RunBeforeToolCallHookResult> => ({
+      blocked: false,
+      params: args.params,
+    }),
+  ),
 }));
 
 let cfg: Record<string, unknown> = {};
@@ -224,10 +231,12 @@ beforeEach(() => {
   hookMocks.resolveToolLoopDetectionConfig.mockClear();
   hookMocks.resolveToolLoopDetectionConfig.mockImplementation(() => ({ warnAt: 3 }));
   hookMocks.runBeforeToolCallHook.mockClear();
-  hookMocks.runBeforeToolCallHook.mockImplementation(async ({ params }: { params: unknown }) => ({
-    blocked: false,
-    params,
-  }));
+  hookMocks.runBeforeToolCallHook.mockImplementation(
+    async (args: RunBeforeToolCallHookArgs): Promise<RunBeforeToolCallHookResult> => ({
+      blocked: false,
+      params: args.params,
+    }),
+  );
 });
 
 const resolveGatewayToken = (): string => TEST_GATEWAY_TOKEN;


### PR DESCRIPTION
## Summary
- widen the mocked `runBeforeToolCallHook` typing in `src/gateway/tools-invoke-http.test.ts`
- remove the `blocked: false as const` workaround so the blocked and pass-through branches both typecheck

## Changes
- derive the mock arg and return types from `runBeforeToolCallHook`
- reuse those types for the default mock and the `beforeEach` reset implementation

## Validation
- `pnpm exec vitest run src/gateway/tools-invoke-http.test.ts`
- `pnpm tsgo --pretty false`

## Linked Issues
- none
