### PR TITLE
fix(gateway): skip device pairing when auth.mode=none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/media errors: redact Telegram file URLs before building media fetch errors so failed inbound downloads do not leak bot tokens into logs. Thanks @space08.
 - Agents/failover: normalize abort-wrapped `429 RESOURCE_EXHAUSTED` provider failures before abort short-circuiting so wrapped Google/Vertex rate limits continue across configured fallback models, including the embedded runner prompt-error path. (#39820) Thanks @lupuletic.
 - Mattermost/thread routing: non-inbound reply paths (TUI/WebUI turns, tool-call callbacks, subagent responses) now correctly route to the originating Mattermost thread when `replyToMode: "all"` is active; also prevents stale `origin.threadId` metadata from resurrecting cleared thread routes. (#44283) thanks @teconomix
+- Gateway/websocket pairing bypass for disabled auth: skip device-pairing enforcement when `gateway.auth.mode=none` so Control UI connections behind reverse proxies no longer get stuck on `pairing required` (code 1008) despite auth being explicitly disabled. (#42931)
 
 ## 2026.3.12
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -674,7 +674,10 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
+        // auth.mode=none disables all authentication — device pairing is an
+        // auth mechanism and must also be skipped when the operator opted out.
         const skipPairing =
+          resolvedAuth.mode === "none" ||
           shouldSkipBackendSelfPairing({
             connectParams,
             isLocalClient,


### PR DESCRIPTION
## Summary

- Skip device-pairing enforcement when `gateway.auth.mode=none` so Control UI connections behind reverse proxies (Tailscale Serve, Cloudflare Tunnel, etc.) no longer get stuck on `pairing required` (code 1008) despite auth being explicitly disabled.

## Root Cause

`sharedAuthOk` in `auth-context.ts` only recognises `password` and `token` methods. When `auth.mode=none`, `authMethod` is `"none"` and `sharedAuthOk` stays `false`, so `shouldSkipBackendSelfPairing` never fires. The `skipPairing` computation then falls through to requiring device pairing - which contradicts the operator's explicit intent to disable all auth.

## Fix

Add `resolvedAuth.mode === "none"` as the first condition in the `skipPairing` computation in `message-handler.ts`. When auth is explicitly disabled, pairing (which is itself an auth mechanism) must also be skipped.

## Test plan

- [ ] `pnpm check` passes locally (types + lint + format)
- [ ] Gateway ws-connection tests pass (13/13)
- [ ] Manual: set `gateway.auth.mode=none` + connect remote Control UI - should connect without pairing prompt

Fixes #42931

## CHANGELOG

```
- Gateway/websocket pairing bypass for disabled auth: skip device-pairing enforcement when `gateway.auth.mode=none` so Control UI connections behind reverse proxies no longer get stuck on `pairing required` (code 1008) despite auth being explicitly disabled. (#42931)
```