### PR TITLE
feat: configure metadata (contextWindow, maxTokens, etc.) for custom provider setup

### DIFF
--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -135,7 +135,9 @@ export async function promptAuthConfig(
     }
   }
 
-  next = await promptModelMetadataForPrimary(next, prompter);
+  if (authChoice === "custom-api-key") {
+    next = await promptModelMetadataForPrimary(next, prompter);
+  }
 
   return next;
 }

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -5,6 +5,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { promptAuthChoiceGrouped } from "./auth-choice-prompt.js";
 import { applyAuthChoice, resolvePreferredProviderForAuthChoice } from "./auth-choice.js";
+import { promptModelMetadataForPrimary } from "./model-metadata.js";
 import {
   applyModelAllowlist,
   applyModelFallbacksFromSelection,
@@ -133,6 +134,8 @@ export async function promptAuthConfig(
       next = applyModelFallbacksFromSelection(next, allowlistSelection.models);
     }
   }
+
+  next = await promptModelMetadataForPrimary(next, prompter);
 
   return next;
 }

--- a/src/commands/model-metadata.test.ts
+++ b/src/commands/model-metadata.test.ts
@@ -171,7 +171,6 @@ describe("promptModelMetadata", () => {
     const confirmResponses = [
       true, // reasoning
       false, // configure cost
-      false, // configure compat
     ];
 
     const prompter = createWizardPrompter({
@@ -193,7 +192,6 @@ describe("promptModelMetadata", () => {
     expect(result.maxTokens).toBe(4096);
     expect(result.api).toBeUndefined();
     expect(result.cost).toBeUndefined();
-    expect(result.compat).toBeUndefined();
   });
 
   it("prefills with current values when editing", async () => {
@@ -241,7 +239,7 @@ describe("promptModelMetadataForPrimary", () => {
         if (confirmCall++ === 0) {
           return true;
         } // yes, configure metadata
-        return false; // no to reasoning, cost, compat
+        return false; // no to reasoning, cost
       }),
       text: vi.fn(async (params: { message: string; initialValue?: string }) => {
         if (params.message === "Context window (tokens)") {

--- a/src/commands/model-metadata.test.ts
+++ b/src/commands/model-metadata.test.ts
@@ -286,4 +286,13 @@ describe("promptModelMetadataForPrimary", () => {
     const result = await promptModelMetadataForPrimary(cfg, prompter);
     expect(result).toBe(cfg);
   });
+
+  it("skips silently when primary model not in providers (built-in)", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-4o" } } },
+    };
+    const prompter = createWizardPrompter({});
+    const result = await promptModelMetadataForPrimary(cfg, prompter);
+    expect(result).toBe(cfg);
+  });
 });

--- a/src/commands/model-metadata.test.ts
+++ b/src/commands/model-metadata.test.ts
@@ -163,7 +163,6 @@ describe("formatTokenCount", () => {
 describe("promptModelMetadata", () => {
   it("prompts for all fields and returns metadata", async () => {
     const textResponses: Record<string, string> = {
-      "Model ID": "test-model",
       "Display name": "Test Model",
       "Context window (tokens)": "128000",
       "Max output tokens": "4096",
@@ -186,7 +185,7 @@ describe("promptModelMetadata", () => {
 
     const result = await promptModelMetadata(prompter);
 
-    expect(result.id).toBe("test-model");
+    expect(result.id).toBeUndefined();
     expect(result.name).toBe("Test Model");
     expect(result.reasoning).toBe(true);
     expect(result.input).toEqual(["text", "image"]);
@@ -218,7 +217,6 @@ describe("promptModelMetadata", () => {
 
     await promptModelMetadata(prompter, current);
 
-    expect(capturedInitialValues["Model ID"]).toBe("existing");
     expect(capturedInitialValues["Display name"]).toBe("Existing Model");
     expect(capturedInitialValues["Context window (tokens)"]).toBe("64000");
     expect(capturedInitialValues["Max output tokens"]).toBe("2048");

--- a/src/commands/model-metadata.test.ts
+++ b/src/commands/model-metadata.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import {
+  applyModelDefinitionUpdate,
+  collectConfiguredModels,
+  findModelInConfig,
+  findPrimaryModelEntry,
+  formatTokenCount,
+  promptModelMetadata,
+  promptModelMetadataForPrimary,
+} from "./model-metadata.js";
+import { createWizardPrompter } from "./test-wizard-helpers.js";
+
+function makeModel(id: string, overrides?: Partial<ModelDefinitionConfig>): ModelDefinitionConfig {
+  return {
+    id,
+    name: id,
+    contextWindow: 128_000,
+    maxTokens: 4096,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    reasoning: false,
+    ...overrides,
+  };
+}
+
+function makeConfig(
+  providers: Record<string, { baseUrl: string; models: ModelDefinitionConfig[] }>,
+  primaryModel?: string,
+): OpenClawConfig {
+  const providersCfg: Record<
+    string,
+    { baseUrl: string; api: string; models: ModelDefinitionConfig[] }
+  > = {};
+  for (const [id, p] of Object.entries(providers)) {
+    providersCfg[id] = { baseUrl: p.baseUrl, api: "openai-completions", models: p.models };
+  }
+  return {
+    models: { providers: providersCfg },
+    ...(primaryModel ? { agents: { defaults: { model: { primary: primaryModel } } } } : {}),
+  };
+}
+
+describe("collectConfiguredModels", () => {
+  it("collects models from all providers", () => {
+    const cfg = makeConfig({
+      openai: { baseUrl: "https://api.openai.com/v1", models: [makeModel("gpt-4o")] },
+      custom: {
+        baseUrl: "https://example.com/v1",
+        models: [makeModel("llama3"), makeModel("mistral")],
+      },
+    });
+    const models = collectConfiguredModels(cfg);
+    expect(models).toHaveLength(3);
+    expect(models.map((m) => m.modelKey)).toEqual([
+      "openai/gpt-4o",
+      "custom/llama3",
+      "custom/mistral",
+    ]);
+  });
+
+  it("returns empty array when no providers configured", () => {
+    expect(collectConfiguredModels({})).toEqual([]);
+  });
+});
+
+describe("findModelInConfig", () => {
+  it("finds a model by provider and id", () => {
+    const cfg = makeConfig({
+      custom: { baseUrl: "https://example.com/v1", models: [makeModel("my-model")] },
+    });
+    const entry = findModelInConfig(cfg, "custom", "my-model");
+    expect(entry).toBeDefined();
+    expect(entry!.modelKey).toBe("custom/my-model");
+    expect(entry!.modelIndex).toBe(0);
+  });
+
+  it("returns undefined for non-existent model", () => {
+    const cfg = makeConfig({
+      custom: { baseUrl: "https://example.com/v1", models: [makeModel("my-model")] },
+    });
+    expect(findModelInConfig(cfg, "custom", "other")).toBeUndefined();
+    expect(findModelInConfig(cfg, "unknown", "my-model")).toBeUndefined();
+  });
+});
+
+describe("findPrimaryModelEntry", () => {
+  it("finds the primary model entry", () => {
+    const cfg = makeConfig(
+      { thegrid: { baseUrl: "https://api.thegrid.ai/v1", models: [makeModel("text-prime")] } },
+      "thegrid/text-prime",
+    );
+    const entry = findPrimaryModelEntry(cfg);
+    expect(entry).toBeDefined();
+    expect(entry!.modelKey).toBe("thegrid/text-prime");
+  });
+
+  it("returns undefined when no primary model set", () => {
+    const cfg = makeConfig({
+      custom: { baseUrl: "https://example.com/v1", models: [makeModel("m1")] },
+    });
+    expect(findPrimaryModelEntry(cfg)).toBeUndefined();
+  });
+
+  it("returns undefined when primary model not in providers", () => {
+    const cfg = makeConfig(
+      { custom: { baseUrl: "https://example.com/v1", models: [makeModel("m1")] } },
+      "other/missing",
+    );
+    expect(findPrimaryModelEntry(cfg)).toBeUndefined();
+  });
+});
+
+describe("applyModelDefinitionUpdate", () => {
+  it("updates the model at the correct index", () => {
+    const cfg = makeConfig({
+      custom: {
+        baseUrl: "https://example.com/v1",
+        models: [makeModel("m1"), makeModel("m2", { contextWindow: 32_000 })],
+      },
+    });
+    const entry = findModelInConfig(cfg, "custom", "m2")!;
+    const updated = { ...entry.model, contextWindow: 256_000, maxTokens: 16_384 };
+    const result = applyModelDefinitionUpdate(cfg, entry, updated);
+
+    expect(result.models?.providers?.custom?.models?.[0]?.id).toBe("m1");
+    expect(result.models?.providers?.custom?.models?.[1]?.contextWindow).toBe(256_000);
+    expect(result.models?.providers?.custom?.models?.[1]?.maxTokens).toBe(16_384);
+  });
+
+  it("returns config unchanged if provider not found", () => {
+    const cfg = makeConfig({
+      custom: { baseUrl: "https://example.com/v1", models: [makeModel("m1")] },
+    });
+    const fakeEntry = {
+      provider: "nonexistent",
+      modelIndex: 0,
+      model: makeModel("m1"),
+      modelKey: "nonexistent/m1",
+    };
+    expect(applyModelDefinitionUpdate(cfg, fakeEntry, makeModel("m1"))).toBe(cfg);
+  });
+});
+
+describe("formatTokenCount", () => {
+  it("formats large numbers with k suffix", () => {
+    expect(formatTokenCount(128_000)).toBe("128k");
+    expect(formatTokenCount(200_000)).toBe("200k");
+  });
+
+  it("formats small numbers as-is", () => {
+    expect(formatTokenCount(500)).toBe("500");
+  });
+
+  it("returns empty string for undefined/zero", () => {
+    expect(formatTokenCount(undefined)).toBe("");
+    expect(formatTokenCount(0)).toBe("");
+  });
+});
+
+describe("promptModelMetadata", () => {
+  it("prompts for all fields and returns metadata", async () => {
+    const textResponses: Record<string, string> = {
+      "Model ID": "test-model",
+      "Display name": "Test Model",
+      "Context window (tokens)": "128000",
+      "Max output tokens": "4096",
+    };
+    let confirmCall = 0;
+    const confirmResponses = [
+      true, // reasoning
+      false, // configure cost
+      false, // configure compat
+    ];
+
+    const prompter = createWizardPrompter({
+      text: vi.fn(async (params: { message: string; initialValue?: string }) => {
+        return textResponses[params.message] ?? params.initialValue ?? "";
+      }) as unknown as WizardPrompter["text"],
+      select: vi.fn(async () => "__auto" as never),
+      confirm: vi.fn(async () => confirmResponses[confirmCall++] ?? false),
+      multiselect: vi.fn(async () => ["text", "image"]),
+    });
+
+    const result = await promptModelMetadata(prompter);
+
+    expect(result.id).toBe("test-model");
+    expect(result.name).toBe("Test Model");
+    expect(result.reasoning).toBe(true);
+    expect(result.input).toEqual(["text", "image"]);
+    expect(result.contextWindow).toBe(128_000);
+    expect(result.maxTokens).toBe(4096);
+    expect(result.api).toBeUndefined();
+    expect(result.cost).toBeUndefined();
+    expect(result.compat).toBeUndefined();
+  });
+
+  it("prefills with current values when editing", async () => {
+    const current = makeModel("existing", {
+      name: "Existing Model",
+      contextWindow: 64_000,
+      maxTokens: 2048,
+      reasoning: true,
+    });
+
+    const capturedInitialValues: Record<string, string | undefined> = {};
+    const prompter = createWizardPrompter({
+      text: vi.fn(async (params: { message: string; initialValue?: string }) => {
+        capturedInitialValues[params.message] = params.initialValue;
+        return params.initialValue ?? "";
+      }) as unknown as WizardPrompter["text"],
+      select: vi.fn(async () => "__auto" as never),
+      confirm: vi.fn(async (params: { initialValue?: boolean }) => params.initialValue ?? false),
+      multiselect: vi.fn(async () => ["text"]),
+    });
+
+    await promptModelMetadata(prompter, current);
+
+    expect(capturedInitialValues["Model ID"]).toBe("existing");
+    expect(capturedInitialValues["Display name"]).toBe("Existing Model");
+    expect(capturedInitialValues["Context window (tokens)"]).toBe("64000");
+    expect(capturedInitialValues["Max output tokens"]).toBe("2048");
+  });
+});
+
+describe("promptModelMetadataForPrimary", () => {
+  it("prompts for metadata when user confirms", async () => {
+    const cfg = makeConfig(
+      {
+        custom: {
+          baseUrl: "https://example.com/v1",
+          models: [makeModel("m1", { contextWindow: 16_000 })],
+        },
+      },
+      "custom/m1",
+    );
+
+    let confirmCall = 0;
+    const prompter = createWizardPrompter({
+      confirm: vi.fn(async () => {
+        if (confirmCall++ === 0) {
+          return true;
+        } // yes, configure metadata
+        return false; // no to reasoning, cost, compat
+      }),
+      text: vi.fn(async (params: { message: string; initialValue?: string }) => {
+        if (params.message === "Context window (tokens)") {
+          return "200000";
+        }
+        if (params.message === "Max output tokens") {
+          return "8192";
+        }
+        return params.initialValue ?? "";
+      }) as unknown as WizardPrompter["text"],
+      select: vi.fn(async () => "__auto" as never),
+      multiselect: vi.fn(async () => ["text"]),
+    });
+
+    const result = await promptModelMetadataForPrimary(cfg, prompter);
+
+    expect(result.models?.providers?.custom?.models?.[0]?.contextWindow).toBe(200_000);
+    expect(result.models?.providers?.custom?.models?.[0]?.maxTokens).toBe(8192);
+  });
+
+  it("skips when user declines", async () => {
+    const cfg = makeConfig(
+      { custom: { baseUrl: "https://example.com/v1", models: [makeModel("m1")] } },
+      "custom/m1",
+    );
+
+    const prompter = createWizardPrompter({
+      confirm: vi.fn(async () => false),
+    });
+
+    const result = await promptModelMetadataForPrimary(cfg, prompter);
+    expect(result).toBe(cfg);
+  });
+
+  it("returns config unchanged when no primary model", async () => {
+    const cfg = makeConfig({
+      custom: { baseUrl: "https://example.com/v1", models: [makeModel("m1")] },
+    });
+    const prompter = createWizardPrompter({});
+    const result = await promptModelMetadataForPrimary(cfg, prompter);
+    expect(result).toBe(cfg);
+  });
+});

--- a/src/commands/model-metadata.test.ts
+++ b/src/commands/model-metadata.test.ts
@@ -32,10 +32,10 @@ function makeConfig(
 ): OpenClawConfig {
   const providersCfg: Record<
     string,
-    { baseUrl: string; api: string; models: ModelDefinitionConfig[] }
+    { baseUrl: string; api: "openai-completions"; models: ModelDefinitionConfig[] }
   > = {};
   for (const [id, p] of Object.entries(providers)) {
-    providersCfg[id] = { baseUrl: p.baseUrl, api: "openai-completions", models: p.models };
+    providersCfg[id] = { baseUrl: p.baseUrl, api: "openai-completions" as const, models: p.models };
   }
   return {
     models: { providers: providersCfg },
@@ -179,7 +179,7 @@ describe("promptModelMetadata", () => {
       }) as unknown as WizardPrompter["text"],
       select: vi.fn(async () => "__auto" as never),
       confirm: vi.fn(async () => confirmResponses[confirmCall++] ?? false),
-      multiselect: vi.fn(async () => ["text", "image"]),
+      multiselect: vi.fn(async () => ["text", "image"]) as unknown as WizardPrompter["multiselect"],
     });
 
     const result = await promptModelMetadata(prompter);
@@ -210,7 +210,7 @@ describe("promptModelMetadata", () => {
       }) as unknown as WizardPrompter["text"],
       select: vi.fn(async () => "__auto" as never),
       confirm: vi.fn(async (params: { initialValue?: boolean }) => params.initialValue ?? false),
-      multiselect: vi.fn(async () => ["text"]),
+      multiselect: vi.fn(async () => ["text"]) as unknown as WizardPrompter["multiselect"],
     });
 
     await promptModelMetadata(prompter, current);
@@ -251,7 +251,7 @@ describe("promptModelMetadataForPrimary", () => {
         return params.initialValue ?? "";
       }) as unknown as WizardPrompter["text"],
       select: vi.fn(async () => "__auto" as never),
-      multiselect: vi.fn(async () => ["text"]),
+      multiselect: vi.fn(async () => ["text"]) as unknown as WizardPrompter["multiselect"],
     });
 
     const result = await promptModelMetadataForPrimary(cfg, prompter);

--- a/src/commands/model-metadata.ts
+++ b/src/commands/model-metadata.ts
@@ -96,7 +96,7 @@ function parsePositiveInt(raw: string): number | undefined {
 }
 
 function parseNonNegativeNumber(raw: string): number | undefined {
-  const n = Number.parseFloat(raw.trim());
+  const n = Number(raw.trim());
   return Number.isFinite(n) && n >= 0 ? n : undefined;
 }
 

--- a/src/commands/model-metadata.ts
+++ b/src/commands/model-metadata.ts
@@ -91,8 +91,8 @@ export function formatTokenCount(n: number | undefined): string {
 }
 
 function parsePositiveInt(raw: string): number | undefined {
-  const n = Number.parseInt(raw.trim(), 10);
-  return Number.isFinite(n) && n > 0 ? n : undefined;
+  const n = Number(raw.trim());
+  return Number.isInteger(n) && n > 0 ? n : undefined;
 }
 
 function parseNonNegativeNumber(raw: string): number | undefined {
@@ -116,6 +116,7 @@ export async function promptModelMetadata(
     message: "Display name",
     initialValue: current?.name ?? modelId,
     placeholder: modelId,
+    validate: (v) => (v.trim() ? undefined : "Display name cannot be empty"),
   });
 
   const apiOptions = [

--- a/src/commands/model-metadata.ts
+++ b/src/commands/model-metadata.ts
@@ -1,0 +1,304 @@
+import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import { MODEL_APIS } from "../config/types.models.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+
+const DEFAULT_MAX_TOKENS = 8192;
+
+export type ConfiguredModel = {
+  provider: string;
+  modelIndex: number;
+  model: ModelDefinitionConfig;
+  modelKey: string;
+};
+
+export function collectConfiguredModels(cfg: OpenClawConfig): ConfiguredModel[] {
+  const result: ConfiguredModel[] = [];
+  const providers = cfg.models?.providers ?? {};
+  for (const [provider, providerCfg] of Object.entries(providers)) {
+    if (!providerCfg?.models) {
+      continue;
+    }
+    for (let i = 0; i < providerCfg.models.length; i++) {
+      const model = providerCfg.models[i];
+      if (!model) {
+        continue;
+      }
+      result.push({
+        provider,
+        modelIndex: i,
+        model,
+        modelKey: `${provider}/${model.id}`,
+      });
+    }
+  }
+  return result;
+}
+
+export function applyModelDefinitionUpdate(
+  cfg: OpenClawConfig,
+  entry: ConfiguredModel,
+  updated: ModelDefinitionConfig,
+): OpenClawConfig {
+  const providers = { ...cfg.models?.providers };
+  const providerCfg = providers[entry.provider];
+  if (!providerCfg) {
+    return cfg;
+  }
+
+  const models = [...providerCfg.models];
+  models[entry.modelIndex] = updated;
+  providers[entry.provider] = { ...providerCfg, models };
+
+  return {
+    ...cfg,
+    models: { ...cfg.models, providers },
+  };
+}
+
+export function findModelInConfig(
+  cfg: OpenClawConfig,
+  provider: string,
+  modelId: string,
+): ConfiguredModel | undefined {
+  const models = collectConfiguredModels(cfg);
+  return models.find((m) => m.provider === provider && m.model.id === modelId);
+}
+
+/** Find the model entry matching the current primary model key. */
+export function findPrimaryModelEntry(cfg: OpenClawConfig): ConfiguredModel | undefined {
+  const primaryKey = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model);
+  if (!primaryKey) {
+    return undefined;
+  }
+  const parts = primaryKey.split("/");
+  const provider = parts[0];
+  const modelId = parts.slice(1).join("/");
+  return findModelInConfig(cfg, provider, modelId);
+}
+
+export function formatTokenCount(n: number | undefined): string {
+  if (!n) {
+    return "";
+  }
+  if (n >= 1000) {
+    return `${Math.round(n / 1000)}k`;
+  }
+  return String(n);
+}
+
+function parsePositiveInt(raw: string): number | undefined {
+  const n = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function parseNonNegativeNumber(raw: string): number | undefined {
+  const n = Number.parseFloat(raw.trim());
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+export async function promptModelMetadata(
+  prompter: WizardPrompter,
+  current?: Partial<ModelDefinitionConfig>,
+): Promise<Partial<ModelDefinitionConfig>> {
+  const result: Partial<ModelDefinitionConfig> = {};
+
+  await prompter.note("Configure model metadata. Press Enter to keep defaults.", "Model metadata");
+
+  result.id = await prompter.text({
+    message: "Model ID",
+    initialValue: current?.id ?? "",
+    placeholder: "e.g. llama3, claude-sonnet-4-6",
+    validate: (v) => (v.trim() ? undefined : "Model ID is required"),
+  });
+
+  result.name = await prompter.text({
+    message: "Display name",
+    initialValue: current?.name ?? result.id,
+    placeholder: result.id,
+  });
+
+  const apiOptions = [
+    { value: "__auto", label: "Auto (inherit from provider)", hint: "default" },
+    ...MODEL_APIS.map((api) => ({ value: api, label: api })),
+  ];
+  const apiChoice = await prompter.select({
+    message: "API adapter",
+    options: apiOptions,
+    initialValue: (current?.api as string) ?? "__auto",
+  });
+  if (apiChoice !== "__auto") {
+    result.api = apiChoice as (typeof MODEL_APIS)[number];
+  }
+
+  result.reasoning = await prompter.confirm({
+    message: "Supports reasoning/thinking?",
+    initialValue: current?.reasoning ?? false,
+  });
+
+  const inputOptions = [
+    { value: "text", label: "Text" },
+    { value: "image", label: "Image" },
+  ];
+  const inputChoice = await prompter.multiselect({
+    message: "Input modalities",
+    options: inputOptions,
+    initialValues: (current?.input as string[]) ?? ["text"],
+  });
+  result.input = inputChoice as Array<"text" | "image">;
+
+  const cwRaw = await prompter.text({
+    message: "Context window (tokens)",
+    initialValue: String(current?.contextWindow ?? DEFAULT_CONTEXT_TOKENS),
+    validate: (v) => {
+      const n = parsePositiveInt(v);
+      if (!n) {
+        return "Must be a positive integer";
+      }
+      if (n < CONTEXT_WINDOW_HARD_MIN_TOKENS) {
+        return `Minimum: ${CONTEXT_WINDOW_HARD_MIN_TOKENS}`;
+      }
+      return undefined;
+    },
+  });
+  result.contextWindow = parsePositiveInt(cwRaw)!;
+
+  const defaultMaxTokens = Math.min(DEFAULT_MAX_TOKENS, result.contextWindow);
+  const mtRaw = await prompter.text({
+    message: "Max output tokens",
+    initialValue: String(current?.maxTokens ?? defaultMaxTokens),
+    validate: (v) => {
+      const n = parsePositiveInt(v);
+      if (!n) {
+        return "Must be a positive integer";
+      }
+      if (n > result.contextWindow!) {
+        return `Cannot exceed context window (${result.contextWindow})`;
+      }
+      return undefined;
+    },
+  });
+  result.maxTokens = parsePositiveInt(mtRaw)!;
+
+  const configureCost = await prompter.confirm({
+    message: "Configure token pricing?",
+    initialValue: Boolean(current?.cost),
+  });
+
+  if (configureCost) {
+    const costInput = await prompter.text({
+      message: "Input cost (per million tokens)",
+      initialValue: String(current?.cost?.input ?? 0),
+      validate: (v) => (parseNonNegativeNumber(v) !== undefined ? undefined : "Must be >= 0"),
+    });
+    const costOutput = await prompter.text({
+      message: "Output cost (per million tokens)",
+      initialValue: String(current?.cost?.output ?? 0),
+      validate: (v) => (parseNonNegativeNumber(v) !== undefined ? undefined : "Must be >= 0"),
+    });
+    const costCacheRead = await prompter.text({
+      message: "Cache read cost (per million tokens)",
+      initialValue: String(current?.cost?.cacheRead ?? 0),
+      validate: (v) => (parseNonNegativeNumber(v) !== undefined ? undefined : "Must be >= 0"),
+    });
+    const costCacheWrite = await prompter.text({
+      message: "Cache write cost (per million tokens)",
+      initialValue: String(current?.cost?.cacheWrite ?? 0),
+      validate: (v) => (parseNonNegativeNumber(v) !== undefined ? undefined : "Must be >= 0"),
+    });
+    result.cost = {
+      input: parseNonNegativeNumber(costInput)!,
+      output: parseNonNegativeNumber(costOutput)!,
+      cacheRead: parseNonNegativeNumber(costCacheRead)!,
+      cacheWrite: parseNonNegativeNumber(costCacheWrite)!,
+    };
+  }
+
+  const configureCompat = await prompter.confirm({
+    message: "Configure advanced compatibility settings?",
+    initialValue: false,
+  });
+
+  if (configureCompat) {
+    const compat: Record<string, unknown> = { ...current?.compat };
+
+    compat.supportsTools = await prompter.confirm({
+      message: "Supports tool/function calling?",
+      initialValue: (current?.compat?.supportsTools as boolean) ?? true,
+    });
+
+    compat.supportsStore = await prompter.confirm({
+      message: "Supports store parameter?",
+      initialValue: (current?.compat?.supportsStore as boolean) ?? false,
+    });
+
+    compat.supportsDeveloperRole = await prompter.confirm({
+      message: "Supports developer role?",
+      initialValue: (current?.compat?.supportsDeveloperRole as boolean) ?? false,
+    });
+
+    compat.supportsReasoningEffort = await prompter.confirm({
+      message: "Supports reasoning effort parameter?",
+      initialValue: (current?.compat?.supportsReasoningEffort as boolean) ?? false,
+    });
+
+    compat.supportsStrictMode = await prompter.confirm({
+      message: "Supports strict mode for tool schemas?",
+      initialValue: (current?.compat?.supportsStrictMode as boolean) ?? false,
+    });
+
+    const maxTokensFieldChoice = await prompter.select({
+      message: "Max tokens field name",
+      options: [
+        { value: "max_tokens", label: "max_tokens", hint: "default" },
+        { value: "max_completion_tokens", label: "max_completion_tokens", hint: "OpenAI-style" },
+      ],
+      initialValue: (current?.compat?.maxTokensField as string) ?? "max_tokens",
+    });
+    compat.maxTokensField = maxTokensFieldChoice;
+
+    for (const [k, v] of Object.entries(compat)) {
+      if (v === false) {
+        delete compat[k];
+      }
+    }
+    if (Object.keys(compat).length > 0) {
+      result.compat = compat as ModelDefinitionConfig["compat"];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * After provider/model setup, offer to configure metadata for the primary model.
+ * Used by both `configure --section model` and `models configure`.
+ */
+export async function promptModelMetadataForPrimary(
+  cfg: OpenClawConfig,
+  prompter: WizardPrompter,
+): Promise<OpenClawConfig> {
+  const entry = findPrimaryModelEntry(cfg);
+  if (!entry) {
+    return cfg;
+  }
+
+  const editMeta = await prompter.confirm({
+    message: `Configure metadata for ${entry.modelKey}? (context window, max tokens, etc.)`,
+    initialValue: true,
+  });
+  if (!editMeta) {
+    return cfg;
+  }
+
+  const updated = await promptModelMetadata(prompter, entry.model);
+  const merged: ModelDefinitionConfig = {
+    ...entry.model,
+    ...updated,
+    id: entry.model.id,
+  } as ModelDefinitionConfig;
+  return applyModelDefinitionUpdate(cfg, entry, merged);
+}

--- a/src/commands/model-metadata.ts
+++ b/src/commands/model-metadata.ts
@@ -274,8 +274,9 @@ export async function promptModelMetadata(
 }
 
 /**
- * After provider/model setup, offer to configure metadata for the primary model.
- * Used by both `configure --section model` and `models configure`.
+ * After custom provider setup, offer to configure metadata for the primary model.
+ * Custom providers always write explicit model entries to config, so the entry
+ * is guaranteed to exist when this is called from the custom-api-key path.
  */
 export async function promptModelMetadataForPrimary(
   cfg: OpenClawConfig,

--- a/src/commands/model-metadata.ts
+++ b/src/commands/model-metadata.ts
@@ -257,14 +257,7 @@ export async function promptModelMetadata(
     });
     compat.maxTokensField = maxTokensFieldChoice;
 
-    for (const [k, v] of Object.entries(compat)) {
-      if (v === false && k !== "supportsTools") {
-        delete compat[k];
-      }
-    }
-    if (Object.keys(compat).length > 0) {
-      result.compat = compat as ModelDefinitionConfig["compat"];
-    }
+    result.compat = compat as ModelDefinitionConfig["compat"];
   }
 
   return result;

--- a/src/commands/model-metadata.ts
+++ b/src/commands/model-metadata.ts
@@ -106,19 +106,16 @@ export async function promptModelMetadata(
 ): Promise<Partial<ModelDefinitionConfig>> {
   const result: Partial<ModelDefinitionConfig> = {};
 
-  await prompter.note("Configure model metadata. Press Enter to keep defaults.", "Model metadata");
-
-  result.id = await prompter.text({
-    message: "Model ID",
-    initialValue: current?.id ?? "",
-    placeholder: "e.g. llama3, claude-sonnet-4-6",
-    validate: (v) => (v.trim() ? undefined : "Model ID is required"),
-  });
+  const modelId = current?.id ?? "unknown";
+  await prompter.note(
+    `Editing metadata for model: ${modelId}\nPress Enter to keep defaults.`,
+    "Model metadata",
+  );
 
   result.name = await prompter.text({
     message: "Display name",
-    initialValue: current?.name ?? result.id,
-    placeholder: result.id,
+    initialValue: current?.name ?? modelId,
+    placeholder: modelId,
   });
 
   const apiOptions = [
@@ -261,7 +258,7 @@ export async function promptModelMetadata(
     compat.maxTokensField = maxTokensFieldChoice;
 
     for (const [k, v] of Object.entries(compat)) {
-      if (v === false) {
+      if (v === false && k !== "supportsTools") {
         delete compat[k];
       }
     }

--- a/src/commands/model-metadata.ts
+++ b/src/commands/model-metadata.ts
@@ -261,7 +261,7 @@ export async function promptModelMetadata(
     compat.maxTokensField = maxTokensFieldChoice;
 
     for (const [k, v] of Object.entries(compat)) {
-      if (v === false) {
+      if (v === false && k !== "supportsTools") {
         delete compat[k];
       }
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: `openclaw configure --section model` sets up providers and auth but never prompts for model metadata (contextWindow, maxTokens, reasoning, input types, cost). Users must hand-edit config or run many `config set` calls to configure these.
- Why it matters: Custom/self-hosted endpoints default to contextWindow=16000 and maxTokens=4096, which are often wrong. Users have no interactive way to correct this during setup.
- What changed: After custom provider setup in `promptAuthConfig`, the wizard now asks "Configure metadata for `<provider>/<model>`?" and walks through the core `ModelDefinitionConfig` fields (identity, capabilities, limits, cost) with current values prefilled. Built-in providers (OpenAI, Anthropic, etc.) are unaffected. Their catalog already provides defaults.
- What did NOT change (scope boundary): The existing provider/auth flow is untouched. The metadata prompt is purely additive (appended after the custom provider path only). No config schema changes. No new CLI commands. Declining the prompt preserves the previous behavior exactly. Built-in provider flows are not modified. Compat flags (supportsStore, supportsTools, etc.) are not prompted for; they use sensible runtime defaults when absent and can be set manually in config by advanced users.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

- `openclaw configure --section model` with a **custom provider**: after provider setup completes, a new confirm prompt appears: "Configure metadata for `<provider>/<model>`? (context window, max tokens, etc.)". Answering Yes walks through all model metadata fields. Answering No preserves previous behavior.
- **Built-in providers** (OpenAI, Anthropic, Ollama, etc.): no change. The metadata prompt does not appear.
- Fields prompted (custom only): display name, API adapter, reasoning, input modalities, context window, max output tokens, token pricing (gated behind its own confirm).
- All fields prefilled with current values; pressing Enter keeps defaults.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (darwin 25.2.0)
- Runtime/container: Node 22+, pnpm
- Model/provider: Custom OpenAI-compatible endpoint ([thegrid.ai](https://thegrid.ai/))
- Integration/channel (if any): N/A
- Relevant config (redacted): Standard `~/.openclaw/openclaw.json` with custom provider

### Steps

1. Run `pnpm openclaw configure --section model`
2. Select "Custom Provider" and complete auth/model setup
3. Observe the new prompt: "Configure metadata for `<provider>/<model>`? (context window, max tokens, etc.)"
4. Answer Yes and walk through the fields, or answer No to skip
5. (Optional) Repeat with a built-in provider (e.g. OpenAI) and confirm the metadata prompt does **not** appear

### Expected

- After custom provider setup, a metadata configuration prompt appears
- Answering Yes allows editing all core `ModelDefinitionConfig` fields
- Answering No skips metadata editing (same behavior as before this change)
- Updated metadata is written to `models.providers.<name>.models[]` in config
- Built-in providers skip the metadata prompt entirely

### Actual

- Works as expected

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

18 unit tests in `src/commands/model-metadata.test.ts` covering: `collectConfiguredModels`, `findModelInConfig`, `findPrimaryModelEntry`, `applyModelDefinitionUpdate`, `formatTokenCount`, `promptModelMetadata`, `promptModelMetadataForPrimary` (including skip for built-in providers). All passing. Existing `configure.wizard.test.ts` tests also pass.

<img width="762" height="585" alt="Screenshot 2026-03-11 at 6 22 52 PM" src="https://github.com/user-attachments/assets/8ed0b230-12b4-4ab6-9157-145a20b16949" />

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `pnpm openclaw configure --section model` end-to-end with a custom provider (thegrid-ai), confirmed metadata prompt appears after model setup. Ran with OpenAI, confirmed metadata prompt does **not** appear.
- Edge cases checked: Declining metadata prompt preserves config unchanged; missing primary model gracefully skips; provider with no models returns empty list; built-in providers silently skip the prompt
- What you did **not** verify: All built-in provider auth paths (only tested OpenAI). Other built-in providers use the same `authChoice !== "custom-api-key"` code path so are expected to behave identically.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`: declining the new prompt produces identical config to before
- Config/env changes? `No`: writes to existing `models.providers.*.models[]` fields
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the three-line addition in `configure.gateway-auth.ts` (lines 138-140: the `if (authChoice === "custom-api-key")` block calling `promptModelMetadataForPrimary`)
- Files/config to restore: `src/commands/configure.gateway-auth.ts` (remove import + call), delete `src/commands/model-metadata.ts` and `src/commands/model-metadata.test.ts`
- Known bad symptoms reviewers should watch for: If the metadata prompt throws, it would interrupt the configure wizard after custom provider setup but before config write. The `WizardCancelledError` path is handled by the parent wizard.

## Risks and Mitigations

- Risk: Metadata prompt adds extra steps to the custom provider configure flow, potentially annoying for users who don't need it.
  - Mitigation: Gated behind a confirm ("Configure metadata?") defaulting to Yes but skippable with a single keypress. Cost is further gated behind its own confirm.
