### PR TITLE
feat(tts): add <notts> tag support for visual-only content

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -178,6 +178,7 @@ actor TalkModeRuntime {
 
         self.recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
         self.recognitionRequest?.shouldReportPartialResults = true
+        self.recognitionRequest?.taskHint = .dictation
         guard let request = self.recognitionRequest else { return }
 
         if self.audioEngine == nil {

--- a/docs/tts-agent-guide.md
+++ b/docs/tts-agent-guide.md
@@ -1,0 +1,191 @@
+---
+title: "TTS for Agents"
+description: "How to write messages that work for both text chat and voice output"
+---
+
+# Writing Dual-Purpose Messages (Text + Voice)
+
+OpenClaw's TTS pipeline lets agents send a single message that serves **both** text (chat) and voice (spoken audio). The user's preference determines delivery — the agent doesn't choose.
+
+This means every message must read well on screen **and** sound natural when spoken aloud. The challenge: code blocks, tables, and type signatures are useful to read but painful to hear.
+
+## The Multi-Layered Approach
+
+Three mechanisms work together to produce clean voice output from a rich text message:
+
+1. **Auto-stripping** — fenced code blocks and markdown tables are automatically removed from the spoken version.
+2. **`<tts>` tags** — inline spoken alternatives for technical content that would sound awkward.
+3. **`[[tts:text]]` directives** — full override of the spoken text (takes priority over everything else).
+
+The visible chat message always shows the full content with `<tts>` tags removed.
+
+## `<tts>` Tags
+
+Wrap spoken alternatives in `<tts>...</tts>`. The content inside is **spoken in voice** but **hidden in chat**. The content outside (adjacent code, types, etc.) remains **visible in chat** but gets stripped or left as-is in voice.
+
+### Syntax
+
+```
+<tts>spoken alternative</tts>
+```
+
+### How It Works
+
+| Surface             | `<tts>` content  | Adjacent code/tables            |
+| ------------------- | ---------------- | ------------------------------- |
+| Chat (visible text) | Removed entirely | Shown normally                  |
+| Voice (spoken text) | Spoken aloud     | Code fences and tables stripped |
+
+### Example: Inline Type Reference
+
+**Agent writes:**
+
+```
+The function returns <tts>a list of user objects</tts>`User[]`.
+```
+
+**Chat sees:**
+
+> The function returns `User[]`.
+
+**Voice hears:**
+
+> "The function returns a list of user objects User array."
+
+### Example: Code Block with Spoken Summary
+
+**Agent writes:**
+
+````
+Here's how to connect:
+<tts>Call the connect function with your host and port.</tts>
+
+​```typescript
+await connect({ host: "localhost", port: 8080 });
+​```
+````
+
+**Chat sees:**
+
+> Here's how to connect:
+>
+> ```typescript
+> await connect({ host: "localhost", port: 8080 });
+> ```
+
+**Voice hears:**
+
+> "Here's how to connect. Call the connect function with your host and port."
+
+### Example: Table with Spoken Summary
+
+**Agent writes:**
+
+```
+Here are the results:
+<tts>Alice scored 95 and Bob scored 87. Alice won.</tts>
+
+| Name  | Score |
+|-------|-------|
+| Alice | 95    |
+| Bob   | 87    |
+
+Summary: Alice won.
+```
+
+**Chat sees** the full table. **Voice hears** the spoken summary plus "Summary: Alice won."
+
+## Auto-Stripping Rules
+
+These are removed from spoken text automatically (no tags needed):
+
+- **Fenced code blocks** — lines between ` ``` ` pairs (with or without a language tag)
+- **Markdown tables** — lines that start and end with `|`
+
+These are **not** stripped:
+
+- Inline backticks (`` `code` ``) — kept in spoken text
+- Lines with `|` that don't both start and end with `|` (shell pipes, OR operators)
+
+## Best Practices
+
+**Place `<tts>` tags to replace, not duplicate.** The spoken alternative should cover what the adjacent technical content conveys. Don't repeat the same information in both.
+
+````
+<!-- Good: <tts> replaces the code block's meaning -->
+<tts>Define a greeting function that takes a name parameter.</tts>
+​```python
+def greet(name: str):
+    return f"Hello, {name}"
+​```
+
+<!-- Bad: redundant — says the same thing twice in voice -->
+Here's a greeting function.
+<tts>Here's a greeting function.</tts>
+​```python
+def greet(name: str):
+    return f"Hello, {name}"
+​```
+````
+
+**Keep `<tts>` content natural.** Write it as you'd say it out loud. Avoid markdown formatting inside `<tts>` tags.
+
+**Don't over-tag.** Simple prose doesn't need `<tts>` tags — it already sounds fine spoken. Use tags only when the visible text contains something that would sound bad in speech (code, symbols, tables).
+
+**Multiline is fine.** `<tts>` content can span multiple lines.
+
+## `[[tts:text]]` Directives
+
+For full control over spoken output, use the `[[tts:text]]` block directive. When present, it **overrides** all other processing — the entire spoken text comes from this directive.
+
+```
+[[tts:text]]
+This is exactly what gets spoken, word for word.
+[[/tts:text]]
+
+Everything else in this message is for chat display only.
+```
+
+Directives are processed **before** `<tts>` tags in the pipeline, so they take priority. Use them when the spoken version needs to be completely different from the visible message (rare).
+
+## Configuration
+
+The preprocessing behavior is controlled by three options in `TtsPreprocessOptions`:
+
+| Option            | Default | Effect                                                     |
+| ----------------- | ------- | ---------------------------------------------------------- |
+| `stripCodeBlocks` | `true`  | Remove fenced code blocks from spoken text                 |
+| `stripTables`     | `true`  | Remove markdown table lines from spoken text               |
+| `processTtsTags`  | `true`  | Process `<tts>` tags (spoken alt in voice, hidden in chat) |
+
+These are set in the TTS configuration. Most setups should leave all three enabled.
+
+## The `tts-filter.sh` Script
+
+`scripts/tts-filter.sh` is a standalone shell implementation of the same filtering logic. It takes a message string and produces both outputs:
+
+```bash
+./scripts/tts-filter.sh "Your message with <tts>spoken alt</tts> and \`\`\`code\`\`\`"
+```
+
+**Output:**
+
+- `---TEXT---` section: the chat-visible text (tags stripped)
+- `---VOICE---` section: path to generated voice audio file (code/tables stripped, tags unwrapped)
+
+The script uses `perl` for regex processing and calls `sag` (ElevenLabs CLI) + `ffmpeg` for audio generation. It's useful for testing how a message will split, or for external tooling that needs the same filtering outside the Node runtime.
+
+## Integration with `preprocessTtsText`
+
+The TypeScript implementation lives in `src/tts/tts-core.ts`. It returns two strings:
+
+- `visibleText` — for chat display (tags removed, everything else preserved)
+- `spokenText` — for TTS synthesis (code/tables stripped, tag content kept)
+
+The pipeline order is:
+
+1. `parseTtsDirectives()` — extracts `[[tts:...]]` directives, returns `cleanedText`
+2. `preprocessTtsText()` — processes `<tts>` tags and strips code/tables from the cleaned text
+3. If a `ttsText` directive was found in step 1, it overrides the `spokenText` from step 2
+
+This means `[[tts:text]]` directives inside `<tts>` tags are still processed (they're extracted before the tags are handled).

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -391,6 +391,63 @@ The `tts` tool converts text to speech and returns a `MEDIA:` path. When the
 result is Telegram-compatible, the tool includes `[[audio_as_voice]]` so
 Telegram sends a voice bubble.
 
+## Text preprocessing
+
+Before text is sent to TTS engines, OpenClaw applies preprocessing to produce
+cleaner speech output. This is purely algorithmic (no AI) and only runs when
+TTS is active.
+
+### What gets filtered (spoken text only)
+
+- **Fenced code blocks** (` ``` `) are removed — code is visual, not spoken.
+- **Markdown tables** (lines starting and ending with `|`) are removed.
+- **Excessive blank lines** are collapsed.
+
+Code blocks and tables remain visible in the chat message; they are only
+stripped from the audio input.
+
+### `<tts>` alternative text tags
+
+Use `<tts>` tags to provide spoken alternatives for content that reads
+poorly aloud (code snippets, symbols, abbreviations). The tag content is
+**additive** — it is inserted into the speech stream alongside the
+surrounding text, so place it where it makes sense as a replacement:
+
+```
+Call <tts>the map method</tts>`.map()` on the array.
+```
+
+- **Chat display**: "Call `.map()` on the array." (tag + content removed)
+- **Spoken audio**: "Call the map method `.map()` on the array."
+
+The `<tts>` tag text is spliced in at the tag position. Surrounding
+content (like inline code) is not removed from speech — use tags to
+_add_ a natural phrasing, not to _replace_ adjacent tokens.
+
+Tags are case-insensitive and can span multiple lines. They work with all
+TTS providers (ElevenLabs, OpenAI, Edge).
+
+> **Note**: `[[tts:text]]…[[/tts:text]]` directives take priority over
+> `<tts>` tags. When a `[[tts:text]]` block is present, its content
+> becomes the entire spoken text and `<tts>` tags are not used.
+
+### Config options
+
+All preprocessing is **on by default**. Disable individual filters in
+`messages.tts`:
+
+```json5
+{
+  messages: {
+    tts: {
+      stripCodeBlocks: false, // keep code blocks in spoken text
+      stripTables: false, // keep tables in spoken text
+      processTtsTags: false, // don't process <tts> tags (leave them as-is)
+    },
+  },
+}
+```
+
 ## Gateway RPC
 
 Gateway methods:

--- a/scripts/tts-filter.sh
+++ b/scripts/tts-filter.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# tts-filter.sh — Dual filter for voice+text from a single source message
+# Usage: tts-filter.sh "Full message text" [output.ogg]
+#
+# Produces TWO outputs from one input:
+#   1. VOICE (.ogg): code/tables stripped, <tts> content spoken
+#   2. TEXT (stdout): <tts> tags stripped, everything else preserved
+#
+# Design:
+#   - Write ONE message with optional <tts>spoken summary</tts> after technical blocks
+#   - Code fences (```...```) and table lines (|...|) auto-stripped from voice
+#   - <tts>...</tts> content is SPOKEN in voice, HIDDEN in text
+#   - All filtering is purely algorithmic, no AI
+
+set -euo pipefail
+
+VOICE_ID="WAhoMTNdLdMoq1j3wf3I"
+RAW="$1"
+OGG_OUTPUT="${2:-/tmp/nicki_voice.ogg}"
+MP3_TMP="/tmp/nicki_voice_$$.mp3"
+
+# --- TEXT OUTPUT (for chat) ---
+# Strip <tts>...</tts> tags entirely — user sees clean message
+TEXT_CLEAN=$(echo "$RAW" | perl -0777 -pe '
+  s/<tts>.*?<\/tts>//gs;
+  s/\n{3,}/\n\n/g;
+  s/^\s+//; s/\s+$//;
+')
+
+# --- VOICE OUTPUT (for TTS) ---
+# 1. Extract <tts> content and replace code blocks near them
+# 2. Strip remaining code fences and tables
+# 3. Remove <tts> tags but keep their content
+VOICE_CLEAN=$(echo "$RAW" | perl -0777 -pe '
+  # Strip markdown code fences (matches TypeScript preprocessTtsText behavior)
+  s/^\s*```[^\n]*\n.*?^\s*```\s*$//gsm;
+  # Strip markdown table lines (|...|) — matches TypeScript: start AND end with pipe
+  s/^\|.*\|$//gm;
+  # Unwrap <tts> tags — keep inner content for speaking
+  s/<tts>(.*?)<\/tts>/$1/gs;
+  # Clean up excessive blank lines
+  s/\n{3,}/\n\n/g;
+  s/^\s+//; s/\s+$//;
+')
+
+# Output clean text to stdout
+echo "---TEXT---"
+echo "$TEXT_CLEAN"
+echo "---END---"
+
+# Skip voice if nothing to speak
+if [ -z "$VOICE_CLEAN" ] || [ ${#VOICE_CLEAN} -lt 3 ]; then
+    echo "SKIP: Nothing to speak after filtering" >&2
+    exit 0
+fi
+
+# Generate speech from voice-filtered text
+sag -v "$VOICE_ID" -o "$MP3_TMP" --play=false "$VOICE_CLEAN" 2>/dev/null
+
+# Convert to opus .ogg for Telegram
+ffmpeg -y -i "$MP3_TMP" -c:a libopus -b:a 64k "$OGG_OUTPUT" 2>/dev/null
+
+# Cleanup temp mp3
+rm -f "$MP3_TMP"
+
+echo "---VOICE---"
+echo "$OGG_OUTPUT"

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -104,7 +104,11 @@ export type RunEmbeddedPiAgentParams = {
   blockReplyChunking?: BlockReplyChunking;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onReasoningEnd?: () => void | Promise<void>;
-  onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  onToolResult?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  }) => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
   lane?: string;
   enqueue?: typeof enqueueCommand;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -1,10 +1,15 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { InlineCodeState } from "../markdown/code-spans.js";
+import type {
+  EmbeddedPiSubscribeContext,
+  EmbeddedPiSubscribeState,
+} from "./pi-embedded-subscribe.handlers.types.js";
+import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import {
@@ -12,12 +17,7 @@ import {
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
-import type {
-  EmbeddedPiSubscribeContext,
-  EmbeddedPiSubscribeState,
-} from "./pi-embedded-subscribe.handlers.types.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
-import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
@@ -333,15 +333,16 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!params.onToolResult) {
       return;
     }
-    const { text: cleanedText, mediaUrls } = parseReplyDirectives(message);
+    const { text: cleanedText, mediaUrls, audioAsVoice } = parseReplyDirectives(message);
     const filteredMediaUrls = filterToolResultMediaUrls(toolName, mediaUrls ?? []);
-    if (!cleanedText && filteredMediaUrls.length === 0) {
+    if (!cleanedText && filteredMediaUrls.length === 0 && !audioAsVoice) {
       return;
     }
     try {
       void params.onToolResult({
         text: cleanedText,
         mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
+        audioAsVoice,
       });
     } catch {
       // ignore tool result delivery failures
@@ -357,11 +358,37 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!output) {
       return;
     }
+    // Parse directives from raw output BEFORE code-fence wrapping,
+    // since fenced code blocks prevent MEDIA/audioAsVoice extraction.
+    const rawDirectives = parseReplyDirectives(output);
     const agg = formatToolAggregate(toolName, meta ? [meta] : undefined, {
       markdown: useMarkdown,
     });
-    const message = `${agg}\n${formatToolOutputBlock(output)}`;
-    emitToolResultMessage(toolName, message);
+    const wrappedOutput = rawDirectives.text ? formatToolOutputBlock(rawDirectives.text) : "";
+    const message = wrappedOutput ? `${agg}\n${wrappedOutput}` : agg;
+    const {
+      text: cleanedText,
+      mediaUrls: aggMediaUrls,
+      audioAsVoice: aggAudioAsVoice,
+    } = parseReplyDirectives(message);
+    const mediaUrls = [...new Set([...(rawDirectives.mediaUrls ?? []), ...(aggMediaUrls ?? [])])];
+    const audioAsVoice = rawDirectives.audioAsVoice || aggAudioAsVoice;
+    const filteredMediaUrls = filterToolResultMediaUrls(toolName, mediaUrls);
+    if (!cleanedText && filteredMediaUrls.length === 0 && !audioAsVoice) {
+      return;
+    }
+    if (!params.onToolResult) {
+      return;
+    }
+    try {
+      void params.onToolResult({
+        text: cleanedText,
+        mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
+        audioAsVoice,
+      });
+    } catch {
+      // ignore tool result delivery failures
+    }
   };
 
   const stripBlockTags = (

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -16,7 +16,11 @@ export type SubscribeEmbeddedPiSessionParams = {
   toolResultFormat?: ToolResultFormat;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
-  onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  onToolResult?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  }) => void | Promise<void>;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */
   onReasoningEnd?: () => void | Promise<void>;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,5 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import type { TemplateContext } from "../templating.js";
+import type { VerboseLevel } from "../thinking.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { FollowupRun } from "./queue.js";
+import type { TypingSignaler } from "./typing-mode.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
@@ -28,25 +33,20 @@ import {
 } from "../../utils/message-channel.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
-import type { TemplateContext } from "../templating.js";
-import type { VerboseLevel } from "../thinking.js";
 import {
   HEARTBEAT_TOKEN,
   isSilentReplyPrefixText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
 } from "../tokens.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunContexts,
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
-import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
-import type { TypingSignaler } from "./typing-mode.js";
 
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -446,6 +446,7 @@ export async function runAgentTurnWithFallback(params: {
                           await onToolResult({
                             text,
                             mediaUrls: payload.mediaUrls,
+                            audioAsVoice: payload.audioAsVoice,
                           });
                         })
                         .catch((err) => {

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -78,6 +78,12 @@ export type TtsConfig = {
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;
+  /** Strip fenced code blocks from TTS spoken text (default: true). */
+  stripCodeBlocks?: boolean;
+  /** Strip markdown tables from TTS spoken text (default: true). */
+  stripTables?: boolean;
+  /** Process <tts>…</tts> alternative text tags for speech/display splitting (default: true). */
+  processTtsTags?: boolean;
   /** Hard cap for text sent to TTS (chars). */
   maxTextLength?: number;
   /** API request timeout (ms). */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -424,6 +424,9 @@ export const TtsConfigSchema = z
       .strict()
       .optional(),
     prefsPath: z.string().optional(),
+    stripCodeBlocks: z.boolean().optional(),
+    stripTables: z.boolean().optional(),
+    processTtsTags: z.boolean().optional(),
     maxTextLength: z.number().int().min(1).optional(),
     timeoutMs: z.number().int().min(1000).max(120000).optional(),
   })

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -26,6 +26,26 @@ const NODE_ROLE_METHODS = new Set([
   "skills.bins",
 ]);
 
+// Methods that mobile/desktop node apps (iOS/Android/macOS) need for their
+// built-in chat UI. Allowed for both node and operator roles.
+const NODE_ALSO_ALLOWED = new Set([
+  "health",
+  "config.get",
+  "config.schema",
+  "chat.send",
+  "chat.history",
+  "chat.abort",
+  "voicewake.get",
+  "talk.mode",
+  "talk.config",
+  "sessions.list",
+  "sessions.preview",
+  "status",
+  "node.list",
+  "tts.status",
+  "tts.providers",
+]);
+
 const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
   [APPROVALS_SCOPE]: [
     "exec.approval.request",
@@ -165,6 +185,10 @@ export function isWriteMethod(method: string): boolean {
 
 export function isNodeRoleMethod(method: string): boolean {
   return NODE_ROLE_METHODS.has(method);
+}
+
+export function isNodeAlsoAllowedMethod(method: string): boolean {
+  return NODE_ALSO_ALLOWED.has(method);
 }
 
 export function isAdminOnlyMethod(method: string): boolean {

--- a/src/gateway/role-policy.ts
+++ b/src/gateway/role-policy.ts
@@ -1,4 +1,4 @@
-import { isNodeRoleMethod } from "./method-scopes.js";
+import { isNodeAlsoAllowedMethod, isNodeRoleMethod } from "./method-scopes.js";
 
 export const GATEWAY_ROLES = ["operator", "node"] as const;
 
@@ -18,6 +18,9 @@ export function roleCanSkipDeviceIdentity(role: GatewayRole, sharedAuthOk: boole
 export function isRoleAuthorizedForMethod(role: GatewayRole, method: string): boolean {
   if (isNodeRoleMethod(method)) {
     return role === "node";
+  }
+  if (isNodeAlsoAllowedMethod(method)) {
+    return true; // allowed for both node and operator
   }
   return role === "operator";
 }

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -1,17 +1,24 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import {
-  collectProviderApiKeysForExecution,
-  executeWithApiKeyRotation,
-} from "../agents/api-key-rotation.js";
-import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import type { MsgContext } from "../auto-reply/templating.js";
-import { applyTemplate } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type {
   MediaUnderstandingConfig,
   MediaUnderstandingModelConfig,
 } from "../config/types.tools.js";
+import type {
+  MediaUnderstandingCapability,
+  MediaUnderstandingDecision,
+  MediaUnderstandingModelDecision,
+  MediaUnderstandingOutput,
+  MediaUnderstandingProvider,
+} from "./types.js";
+import {
+  collectProviderApiKeysForExecution,
+  executeWithApiKeyRotation,
+} from "../agents/api-key-rotation.js";
+import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { applyTemplate } from "../auto-reply/templating.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -29,13 +36,6 @@ import { extractGeminiResponse } from "./output-extract.js";
 import { describeImageWithModel } from "./providers/image.js";
 import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./providers/index.js";
 import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
-import type {
-  MediaUnderstandingCapability,
-  MediaUnderstandingDecision,
-  MediaUnderstandingModelDecision,
-  MediaUnderstandingOutput,
-  MediaUnderstandingProvider,
-} from "./types.js";
 import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
 export type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
@@ -619,8 +619,29 @@ export async function runCliEntry(params: {
   const outputDir = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-media-cli-"),
   );
-  const mediaPath = pathResult.path;
+  let mediaPath = pathResult.path;
   const outputBase = path.join(outputDir, path.parse(mediaPath).name);
+
+  // whisper-cli only accepts WAV input; convert other audio formats via ffmpeg.
+  const cmdId = commandBase(command);
+  if ((cmdId === "whisper-cli" || cmdId === "whisper") && !mediaPath.endsWith(".wav")) {
+    const wavPath = path.join(outputDir, `${path.parse(mediaPath).name}.wav`);
+    try {
+      await runExec(
+        "ffmpeg",
+        ["-y", "-i", mediaPath, "-ar", "16000", "-ac", "1", "-f", "wav", wavPath],
+        {
+          timeoutMs: 30_000,
+        },
+      );
+      mediaPath = wavPath;
+    } catch (convErr) {
+      // ffmpeg not available or conversion failed; proceed with original path
+      if (shouldLogVerbose()) {
+        logVerbose(`ffmpeg conversion failed, proceeding with original: ${String(convErr)}`);
+      }
+    }
+  }
 
   const templCtx: MsgContext = {
     ...ctx,

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import { fileTypeFromBuffer } from "file-type";
+import path from "node:path";
 import { type MediaKind, mediaKindFromMime } from "./constants.js";
 
 // Map common mimes to preferred file extensions.
@@ -11,6 +11,7 @@ const EXT_BY_MIME: Record<string, string> = {
   "image/webp": ".webp",
   "image/gif": ".gif",
   "audio/ogg": ".ogg",
+  "audio/opus": ".opus",
   "audio/mpeg": ".mp3",
   "audio/x-m4a": ".m4a",
   "audio/mp4": ".m4a",

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -45,6 +45,13 @@ export function preprocessTtsText(
   let spokenText = text;
 
   if (processTtsTags) {
+    // <notts>...</notts>: content visible in chat but NOT spoken.
+    // visibleText: strip the tags, keep the inner content
+    visibleText = visibleText.replace(/<\/?notts>/gi, "");
+    // spokenText: remove <notts>...</notts> blocks entirely
+    spokenText = spokenText.replace(/<notts>[\s\S]*?<\/notts>/gi, "");
+
+    // <tts>...</tts>: content spoken but NOT visible in chat.
     // spokenText: replace <tts>content</tts> with the inner content
     spokenText = spokenText.replace(/<tts>([\s\S]*?)<\/tts>/gi, "$1");
     // visibleText: remove <tts>...</tts> entirely

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -17,6 +17,62 @@ import type {
   TtsDirectiveParseResult,
 } from "./tts.js";
 
+export type TtsPreprocessOptions = {
+  stripCodeBlocks?: boolean;
+  stripTables?: boolean;
+  processTtsTags?: boolean;
+};
+
+/**
+ * Preprocess text for TTS output, producing two variants:
+ * - spokenText: cleaned for speech synthesis (code/tables stripped, <tts> tags replaced with content)
+ * - visibleText: cleaned for chat display (<tts> tags removed entirely, everything else kept)
+ *
+ * Note: `parseTtsDirectives` runs *before* this function in the pipeline,
+ * so [[tts:…]] directives inside <tts> tags ARE still processed (they get
+ * stripped from `cleanedText` before we ever see it). This is intentional —
+ * it means directives work regardless of where they appear in the reply.
+ */
+export function preprocessTtsText(
+  text: string,
+  options?: TtsPreprocessOptions,
+): { visibleText: string; spokenText: string } {
+  const stripCode = options?.stripCodeBlocks ?? true;
+  const stripTables = options?.stripTables ?? true;
+  const processTtsTags = options?.processTtsTags ?? true;
+
+  let visibleText = text;
+  let spokenText = text;
+
+  if (processTtsTags) {
+    // spokenText: replace <tts>content</tts> with the inner content
+    spokenText = spokenText.replace(/<tts>([\s\S]*?)<\/tts>/gi, "$1");
+    // visibleText: remove <tts>...</tts> entirely
+    visibleText = visibleText.replace(/<tts>[\s\S]*?<\/tts>/gi, "");
+  }
+
+  if (stripCode) {
+    // Remove fenced code blocks (``` ... ```) from spoken text.
+    // Allows optional leading whitespace so indented fences (e.g. inside
+    // blockquotes or list items) are matched too.
+    // Limitation: an unclosed fence (opening ``` with no closing ```) is not
+    // stripped — the regex requires a matching pair.
+    spokenText = spokenText.replace(/^\s*```[^\n]*\n[\s\S]*?^\s*```\s*$/gm, "");
+  }
+
+  if (stripTables) {
+    // Remove markdown table lines — require `|` at both start and end of
+    // line to avoid false positives on shell pipes, OR operators, and math.
+    spokenText = spokenText.replace(/^\|.*\|$/gm, "");
+  }
+
+  // Clean up excessive blank lines in both outputs
+  visibleText = visibleText.replace(/\n{3,}/g, "\n\n").trim();
+  spokenText = spokenText.replace(/\n{3,}/g, "\n\n").trim();
+
+  return { visibleText, spokenText };
+}
+
 const DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io";
 export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const TEMP_FILE_CLEANUP_DELAY_MS = 5 * 60 * 1000; // 5 minutes

--- a/src/tts/tts-preprocess.test.ts
+++ b/src/tts/tts-preprocess.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import { preprocessTtsText } from "./tts-core.js";
+
+describe("preprocessTtsText", () => {
+  describe("code fence stripping", () => {
+    it("strips fenced code blocks from spoken text", () => {
+      const input = `Here is some code:
+
+\`\`\`typescript
+const x = 42;
+console.log(x);
+\`\`\`
+
+That's the example.`;
+
+      const { visibleText, spokenText } = preprocessTtsText(input);
+
+      expect(spokenText).not.toContain("```");
+      expect(spokenText).not.toContain("const x = 42");
+      expect(spokenText).toContain("Here is some code:");
+      expect(spokenText).toContain("That's the example.");
+
+      // Code blocks stay in visible text
+      expect(visibleText).toContain("```typescript");
+      expect(visibleText).toContain("const x = 42");
+    });
+
+    it("strips multiple code blocks", () => {
+      const input = `First block:
+
+\`\`\`js
+a();
+\`\`\`
+
+Second block:
+
+\`\`\`python
+b()
+\`\`\`
+
+Done.`;
+
+      const { spokenText } = preprocessTtsText(input);
+      expect(spokenText).not.toContain("a()");
+      expect(spokenText).not.toContain("b()");
+      expect(spokenText).toContain("First block:");
+      expect(spokenText).toContain("Second block:");
+      expect(spokenText).toContain("Done.");
+    });
+
+    it("strips code fences without a language tag", () => {
+      const input = `Example:
+
+\`\`\`
+plain code
+\`\`\`
+
+End.`;
+
+      const { spokenText } = preprocessTtsText(input);
+      expect(spokenText).not.toContain("plain code");
+      expect(spokenText).toContain("Example:");
+    });
+  });
+
+  describe("table stripping", () => {
+    it("strips markdown tables from spoken text", () => {
+      const input = `Here are the results:
+
+| Name  | Score |
+|-------|-------|
+| Alice | 95    |
+| Bob   | 87    |
+
+Summary: Alice won.`;
+
+      const { visibleText, spokenText } = preprocessTtsText(input);
+
+      expect(spokenText).not.toContain("|");
+      expect(spokenText).toContain("Here are the results:");
+      expect(spokenText).toContain("Summary: Alice won.");
+
+      // Tables stay in visible text
+      expect(visibleText).toContain("| Name  | Score |");
+      expect(visibleText).toContain("| Alice | 95    |");
+    });
+  });
+
+  describe("<tts> tag handling", () => {
+    it("replaces <tts> tags with inner content in spoken text", () => {
+      const input = "The function returns <tts>a list of results</tts>`Result[]`.";
+      const { spokenText } = preprocessTtsText(input);
+      expect(spokenText).toContain("a list of results");
+      expect(spokenText).not.toContain("<tts>");
+      expect(spokenText).not.toContain("</tts>");
+    });
+
+    it("removes <tts> tags entirely from visible text", () => {
+      const input = "The function returns <tts>a list of results</tts>`Result[]`.";
+      const { visibleText } = preprocessTtsText(input);
+      expect(visibleText).not.toContain("<tts>");
+      expect(visibleText).not.toContain("a list of results");
+      expect(visibleText).toContain("`Result[]`");
+    });
+
+    it("handles multiple <tts> tags", () => {
+      const input =
+        "Use <tts>the map function</tts>`.map()` and <tts>the filter function</tts>`.filter()`.";
+      const { spokenText, visibleText } = preprocessTtsText(input);
+      expect(spokenText).toContain("the map function");
+      expect(spokenText).toContain("the filter function");
+      expect(visibleText).not.toContain("the map function");
+      expect(visibleText).toContain("`.map()`");
+    });
+
+    it("handles multiline <tts> content", () => {
+      const input = `Check this out:
+<tts>Here is a spoken
+alternative on multiple lines</tts>
+\`\`\`
+some code
+\`\`\``;
+
+      const { spokenText } = preprocessTtsText(input);
+      expect(spokenText).toContain("Here is a spoken\nalternative on multiple lines");
+    });
+
+    it("is case-insensitive for tag matching", () => {
+      const input = "Hello <TTS>world</TTS> there.";
+      const { spokenText, visibleText } = preprocessTtsText(input);
+      expect(spokenText).toContain("world");
+      expect(visibleText).not.toContain("world");
+    });
+  });
+
+  describe("passthrough (no special content)", () => {
+    it("returns text unchanged when no special content is present", () => {
+      const input = "Just a normal sentence with no code or tables.";
+      const { visibleText, spokenText } = preprocessTtsText(input);
+      expect(visibleText).toBe(input);
+      expect(spokenText).toBe(input);
+    });
+
+    it("handles empty string", () => {
+      const { visibleText, spokenText } = preprocessTtsText("");
+      expect(visibleText).toBe("");
+      expect(spokenText).toBe("");
+    });
+  });
+
+  describe("config flags", () => {
+    it("preserves code blocks in spoken text when stripCodeBlocks is false", () => {
+      const input = `Text before.
+
+\`\`\`js
+code()
+\`\`\`
+
+Text after.`;
+
+      const { spokenText } = preprocessTtsText(input, { stripCodeBlocks: false });
+      expect(spokenText).toContain("```js");
+      expect(spokenText).toContain("code()");
+    });
+
+    it("preserves tables in spoken text when stripTables is false", () => {
+      const input = `| A | B |\n|---|---|\n| 1 | 2 |`;
+      const { spokenText } = preprocessTtsText(input, { stripTables: false });
+      expect(spokenText).toContain("| A | B |");
+    });
+
+    it("preserves <tts> tags when processTtsTags is false", () => {
+      const input = "Hello <tts>world</tts> there.";
+      const { visibleText, spokenText } = preprocessTtsText(input, { processTtsTags: false });
+      expect(spokenText).toContain("<tts>world</tts>");
+      expect(visibleText).toContain("<tts>world</tts>");
+    });
+  });
+
+  describe("inline backticks preserved", () => {
+    it("preserves inline backticks in spoken text (only fenced blocks are stripped)", () => {
+      const input = "Use `Array.map()` to transform items and `filter()` to select them.";
+      const { spokenText, visibleText } = preprocessTtsText(input);
+      expect(spokenText).toContain("`Array.map()`");
+      expect(spokenText).toContain("`filter()`");
+      expect(visibleText).toBe(input);
+    });
+  });
+
+  describe("entire message is a code block", () => {
+    it("returns empty spokenText when the whole message is a code block", () => {
+      const input = `\`\`\`python
+def hello():
+    print("hello")
+\`\`\``;
+
+      const { spokenText, visibleText } = preprocessTtsText(input);
+      expect(spokenText).toBe("");
+      expect(visibleText).toBe(input);
+    });
+  });
+
+  describe("<tts> tag adjacent to code block", () => {
+    it("replaces <tts> in speech and strips code block independently", () => {
+      const input = `Here is the result:
+<tts>The function returns a list of users.</tts>
+\`\`\`typescript
+function getUsers(): User[] { return []; }
+\`\`\``;
+
+      const { spokenText, visibleText } = preprocessTtsText(input);
+      expect(spokenText).toContain("The function returns a list of users.");
+      expect(spokenText).not.toContain("function getUsers");
+      expect(spokenText).not.toContain("```");
+      expect(visibleText).not.toContain("<tts>");
+      expect(visibleText).not.toContain("The function returns a list of users.");
+      expect(visibleText).toContain("function getUsers");
+    });
+  });
+
+  describe("table stripping edge cases", () => {
+    it("does not strip lines with only a leading pipe (no trailing pipe)", () => {
+      const input = "Run `echo hello | grep hello` to test.";
+      const { spokenText } = preprocessTtsText(input);
+      expect(spokenText).toContain("echo hello | grep hello");
+    });
+  });
+
+  describe("excessive blank lines", () => {
+    it("collapses multiple blank lines to at most two newlines", () => {
+      const input = "Line one.\n\n\n\n\nLine two.";
+      const { visibleText, spokenText } = preprocessTtsText(input);
+      expect(visibleText).toBe("Line one.\n\nLine two.");
+      expect(spokenText).toBe("Line one.\n\nLine two.");
+    });
+  });
+});

--- a/src/tts/tts-preprocess.test.ts
+++ b/src/tts/tts-preprocess.test.ts
@@ -133,6 +133,107 @@ some code
     });
   });
 
+  describe("<notts> tag handling", () => {
+    it("keeps <notts> content visible but removes it from spoken text", () => {
+      const input = `Here are the results:
+
+<notts>
+| Name  | Score |
+|-------|-------|
+| Alice | 95    |
+</notts>
+
+Summary: Alice won.`;
+
+      const { visibleText, spokenText } = preprocessTtsText(input);
+
+      // visibleText: table content visible, <notts> tags stripped
+      expect(visibleText).toContain("| Name  | Score |");
+      expect(visibleText).toContain("| Alice | 95    |");
+      expect(visibleText).not.toContain("<notts>");
+      expect(visibleText).not.toContain("</notts>");
+
+      // spokenText: entire <notts> block removed
+      expect(spokenText).not.toContain("| Name");
+      expect(spokenText).not.toContain("| Alice | 95");
+      expect(spokenText).toContain("Here are the results:");
+      expect(spokenText).toContain("Summary: Alice won.");
+    });
+
+    it("handles <notts> with code blocks inside", () => {
+      const input = `Explanation:
+
+<notts>
+\`\`\`swift
+struct Foo { let bar: Int }
+\`\`\`
+</notts>
+
+That's the struct.`;
+
+      const { visibleText, spokenText } = preprocessTtsText(input);
+
+      expect(visibleText).toContain("struct Foo");
+      expect(visibleText).not.toContain("<notts>");
+      expect(spokenText).not.toContain("struct Foo");
+      expect(spokenText).toContain("That's the struct.");
+    });
+
+    it("handles <notts> combined with <tts> for alternative text", () => {
+      const input = `Status update:
+
+<notts>
+| Feature | Status |
+|---------|--------|
+| Voice   | Done   |
+| Agent   | WIP    |
+</notts>
+<tts>Voice is done, Agent is work in progress.</tts>
+
+Moving on.`;
+
+      const { visibleText, spokenText } = preprocessTtsText(input);
+
+      // visibleText: table shown, tts alternative hidden
+      expect(visibleText).toContain("| Voice   | Done   |");
+      expect(visibleText).not.toContain("Voice is done");
+      expect(visibleText).not.toContain("<notts>");
+      expect(visibleText).not.toContain("<tts>");
+
+      // spokenText: table hidden, tts alternative spoken
+      expect(spokenText).not.toContain("|");
+      expect(spokenText).toContain("Voice is done, Agent is work in progress.");
+      expect(spokenText).toContain("Moving on.");
+    });
+
+    it("is case-insensitive", () => {
+      const input = "Hello <NOTTS>secret</NOTTS> world.";
+      const { visibleText, spokenText } = preprocessTtsText(input);
+      expect(visibleText).toContain("secret");
+      expect(visibleText).not.toContain("<NOTTS>");
+      expect(spokenText).not.toContain("secret");
+    });
+
+    it("handles multiple <notts> blocks", () => {
+      const input = "A <notts>hidden1</notts> B <notts>hidden2</notts> C";
+      const { visibleText, spokenText } = preprocessTtsText(input);
+      expect(visibleText).toContain("hidden1");
+      expect(visibleText).toContain("hidden2");
+      expect(spokenText).not.toContain("hidden1");
+      expect(spokenText).not.toContain("hidden2");
+      expect(spokenText).toContain("A");
+      expect(spokenText).toContain("B");
+      expect(spokenText).toContain("C");
+    });
+
+    it("preserves <notts> tags when processTtsTags is false", () => {
+      const input = "Hello <notts>world</notts> there.";
+      const { visibleText, spokenText } = preprocessTtsText(input, { processTtsTags: false });
+      expect(spokenText).toContain("<notts>world</notts>");
+      expect(visibleText).toContain("<notts>world</notts>");
+    });
+  });
+
   describe("passthrough (no special content)", () => {
     it("returns text unchanged when no special content is present", () => {
       const input = "Just a normal sentence with no code or tables.";

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -39,6 +39,7 @@ import {
   OPENAI_TTS_VOICES,
   openaiTTS,
   parseTtsDirectives,
+  preprocessTtsText,
   scheduleCleanup,
   summarizeText,
 } from "./tts-core.js";
@@ -835,19 +836,38 @@ export async function maybeApplyTtsToPayload(params: {
   }
 
   const cleanedText = directives.cleanedText;
-  const trimmedCleaned = cleanedText.trim();
-  const visibleText = trimmedCleaned.length > 0 ? trimmedCleaned : "";
-  const ttsText = directives.ttsText?.trim() || visibleText;
 
+  // Stage 1 of text cleanup: structural preprocessing.
+  // `preprocessTtsText` handles block-level constructs — fenced code blocks,
+  // markdown tables, and <tts> alternative-text tags. It produces separate
+  // spokenText (for the TTS engine) and visibleText (for chat display).
+  // Stage 2 (`stripMarkdown`, below at ~line 919) handles inline formatting
+  // (bold/italic markers, heading hashes, etc.) on the final audio text only.
+  // Both stages are complementary: block-level first, then inline cleanup.
+  const preprocessOpts = {
+    stripCodeBlocks: params.cfg.messages?.tts?.stripCodeBlocks,
+    stripTables: params.cfg.messages?.tts?.stripTables,
+    processTtsTags: params.cfg.messages?.tts?.processTtsTags,
+  };
+  const preprocessed = preprocessTtsText(cleanedText, preprocessOpts);
+
+  const visibleText = preprocessed.visibleText ?? "";
+  const ttsText = directives.ttsText?.trim() || preprocessed.spokenText || "";
+
+  // Compare against cleanedText (directives already stripped) — not the
+  // original text, which may still contain <tts> tags that visibleText lacks.
   const nextPayload =
-    visibleText === text.trim()
+    visibleText === cleanedText.trim()
       ? params.payload
       : {
           ...params.payload,
           text: visibleText.length > 0 ? visibleText : undefined,
         };
 
-  if (autoMode === "tagged" && !directives.hasDirective) {
+  // <tts> tags count as a directive for "tagged" auto-mode: the author
+  // explicitly marked speech-alternative content, so audio should fire.
+  const hasTtsTags = /<tts>/i.test(cleanedText);
+  if (autoMode === "tagged" && !directives.hasDirective && !hasTtsTags) {
     return nextPayload;
   }
   if (autoMode === "inbound" && params.inboundAudio !== true) {
@@ -907,7 +927,9 @@ export async function maybeApplyTtsToPayload(params: {
     }
   }
 
-  textForAudio = stripMarkdown(textForAudio).trim(); // strip markdown for TTS (### → "hashtag" etc.)
+  // Stage 2: strip inline markdown (### → "hashtag", **bold** → "bold", etc.)
+  // after block-level constructs were already removed by preprocessTtsText.
+  textForAudio = stripMarkdown(textForAudio).trim();
   if (textForAudio.length < 10) {
     return nextPayload;
   }

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -383,6 +383,8 @@ export function buildTtsSystemPromptHint(cfg: OpenClawConfig): string | undefine
     autoHint,
     `Keep spoken text ≤${maxLength} chars to avoid auto-summary (summary ${summarize}).`,
     "Use [[tts:...]] and optional [[tts:text]]...[[/tts:text]] to control voice/expressiveness.",
+    "Use <notts>...</notts> to mark content visible in chat but NOT spoken (code, tables, technical details).",
+    "Use <tts>...</tts> to provide spoken-only alternative text (not shown in chat). Combine both: <notts>table</notts><tts>summary of table</tts>.",
   ]
     .filter(Boolean)
     .join("\n");


### PR DESCRIPTION
## Summary

Adds `<notts>...</notts>` tag support to TTS text preprocessing, complementing the existing `<tts>...</tts>` tags.

### What it does

- **`<notts>...</notts>`**: Content is **visible** in chat but **not spoken** by TTS. Ideal for code blocks, tables, and technical details.
- **`<tts>...</tts>`** (existing): Content is **spoken** but **not visible** in chat. Ideal for alternative voice summaries.

Combined usage: wrap a table in `<notts>`, follow with a `<tts>` summary — the reader sees the table, the listener hears the summary.

### Changes

**`src/tts/tts-core.ts`** — `preprocessTtsText()`:
- `visibleText`: strips `<notts>` tags but keeps inner content
- `spokenText`: removes entire `<notts>...</notts>` blocks
- Case-insensitive matching
- Respects `processTtsTags=false` config flag

**`src/tts/tts.ts`** — `buildTtsSystemPromptHint()`:
- Adds hints about `<notts>` and `<tts>` tags to the system prompt when TTS is enabled

**`src/tts/tts-preprocess.test.ts`**:
- 7 new tests covering: basic usage, code blocks inside notts, notts+tts combo, case insensitivity, multiple blocks, config flag respect

### Testing

All 58 TTS tests pass (25 preprocess + 28 tts + 5 prepare-text).