### PR TITLE
docs: add Agent37 install guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -772,6 +772,10 @@
       "destination": "/install/render"
     },
     {
+      "source": "/agent37",
+      "destination": "/install/agent37"
+    },
+    {
       "source": "/gcp",
       "destination": "/install/gcp"
     },
@@ -802,6 +806,10 @@
     {
       "source": "/platforms/render",
       "destination": "/install/render"
+    },
+    {
+      "source": "/platforms/agent37",
+      "destination": "/install/agent37"
     },
     {
       "source": "/platforms/northflank",
@@ -882,6 +890,7 @@
                   "install/gcp",
                   "install/macos-vm",
                   "install/exe-dev",
+                  "install/agent37",
                   "install/railway",
                   "install/render",
                   "install/northflank"

--- a/docs/install/agent37.mdx
+++ b/docs/install/agent37.mdx
@@ -1,0 +1,59 @@
+---
+title: Deploy on Agent37
+---
+
+Deploy OpenClaw on Agent37 with managed hosting and finish setup in your browser.
+Agent37 provisions an isolated OpenClaw instance for you, including HTTPS and terminal
+access, so you can skip VM setup and go straight to OpenClaw.
+
+## How to get started
+
+1. Open [Agent37 OpenClaw](https://www.agent37.com/openclaw).
+2. Sign up or log in to Agent37.
+3. Choose a plan and complete checkout.
+4. Wait for your instance to finish provisioning. Agent37 says access is typically ready
+   in about 30 to 60 seconds.
+5. Open the instance URL shown in your Agent37 dashboard.
+6. Complete the OpenClaw setup flow at `/setup`.
+7. Open the Control UI at `/openclaw`.
+
+## What you get
+
+- Hosted OpenClaw Gateway + Control UI
+- HTTPS-enabled public URL
+- Web setup wizard at `/setup`
+- Full terminal or shell access from the Agent37 dashboard
+- Managed shared infrastructure, so you do not need to provision your own VM
+
+## Setup flow
+
+1. Open the URL for your instance from the Agent37 dashboard.
+2. Visit `/setup` on that URL.
+3. If your instance prompts for a setup password, use the password configured for that instance.
+4. Choose a model or auth provider and paste your key.
+5. Optional: add Telegram, Discord, Slack, or other channel tokens.
+6. Click **Run setup**.
+7. Open the Control UI at `/openclaw`.
+
+## Terminal access
+
+Agent37 includes terminal access for your OpenClaw instance. That gives you a path to:
+
+- inspect logs
+- run `openclaw` CLI commands
+- approve device pairings if needed
+- export data before migrating away from Agent37
+
+## Backup and migration
+
+OpenClaw's standard backup export is available at:
+
+- `https://<your-agent37-instance>/setup/export`
+
+Use the instance URL from the Agent37 dashboard in place of `<your-agent37-instance>`.
+This lets you move your state and workspace to another OpenClaw host later.
+
+## Notes
+
+- Plan selection, billing, and hosted infrastructure are managed by Agent37.
+- For the latest pricing and availability, check [Agent37 OpenClaw](https://www.agent37.com/openclaw).

--- a/docs/install/agent37.mdx
+++ b/docs/install/agent37.mdx
@@ -2,46 +2,52 @@
 title: Deploy on Agent37
 ---
 
-Deploy OpenClaw on Agent37 with managed hosting and finish setup in your browser.
-Agent37 provisions an isolated OpenClaw instance for you, including HTTPS and terminal
-access, so you can skip VM setup and go straight to OpenClaw.
+Deploy OpenClaw on Agent37 with managed hosting and start using it from the Agent37
+dashboard. Agent37 provisions the instance for you, so there is no separate OpenClaw
+server setup flow to complete.
 
 ## How to get started
 
 1. Open [Agent37 OpenClaw](https://www.agent37.com/openclaw).
 2. Sign up or log in to Agent37.
-3. Choose a plan and complete checkout.
-4. Wait for your instance to finish provisioning. Agent37 says access is typically ready
-   in about 30 to 60 seconds.
-5. Open the instance URL shown in your Agent37 dashboard.
-6. Complete the OpenClaw setup flow at `/setup`.
-7. Open the Control UI at `/openclaw`.
+3. Go to the [Agent37 dashboard](https://www.agent37.com/dashboard).
+4. Click **Create Bot** to launch a new OpenClaw instance.
+5. Wait about a minute for the bot to finish provisioning.
+6. In the bot row, click **Web Chat** to start chatting.
+7. Click **Terminal** any time you want shell access to that instance.
 
 ## What you get
 
 - Hosted OpenClaw Gateway + Control UI
-- HTTPS-enabled public URL
-- Web setup wizard at `/setup`
-- Full terminal or shell access from the Agent37 dashboard
+- Agent37 dashboard with one-click bot launch
+- `Web Chat` button for immediate access
+- `Terminal` button for shell access to the running instance
 - Managed shared infrastructure, so you do not need to provision your own VM
 
-## Setup flow
+## Dashboard flow
 
-1. Open the URL for your instance from the Agent37 dashboard.
-2. Visit `/setup` on that URL.
-3. If your instance prompts for a setup password, use the password configured for that instance.
-4. Choose a model or auth provider and paste your key.
-5. Optional: add Telegram, Discord, Slack, or other channel tokens.
-6. Click **Run setup**.
-7. Open the Control UI at `/openclaw`.
+After the instance is created, Agent37 shows it in the dashboard with actions such as:
+
+- **Manage** for instance controls
+- **Web Chat** to open the hosted chat UI
+- **Terminal** to open a shell in the bot's machine
+
+That means the practical setup flow is just:
+
+1. Sign up.
+2. Open the dashboard.
+3. Launch the bot.
+4. Wait about one minute.
+5. Click **Web Chat** and use OpenClaw.
 
 ## Terminal access
 
-Agent37 includes terminal access for your OpenClaw instance. That gives you a path to:
+The **Terminal** button opens shell access to the running machine for that bot. That gives
+you a path to:
 
 - inspect logs
 - run `openclaw` CLI commands
-- approve device pairings if needed
+- make manual changes inside the instance if you want them
 - export data before migrating away from Agent37
 
 ## Backup and migration
@@ -50,7 +56,7 @@ OpenClaw's standard backup export is available at:
 
 - `https://<your-agent37-instance>/setup/export`
 
-Use the instance URL from the Agent37 dashboard in place of `<your-agent37-instance>`.
+Use the hosted URL for your bot in place of `<your-agent37-instance>`.
 This lets you move your state and workspace to another OpenClaw host later.
 
 ## Notes

--- a/docs/install/agent37.mdx
+++ b/docs/install/agent37.mdx
@@ -4,7 +4,8 @@ title: Deploy on Agent37
 
 Deploy OpenClaw on Agent37 with managed hosting and start using it from the Agent37
 dashboard. Agent37 provisions the instance for you, so there is no separate OpenClaw
-server setup flow to complete.
+server setup flow to complete. Agent37's OpenClaw page currently advertises plans
+starting at $3.99/month.
 
 ## How to get started
 
@@ -22,6 +23,8 @@ server setup flow to complete.
 - Agent37 dashboard with one-click bot launch
 - `Web Chat` button for immediate access
 - `Terminal` button for shell access to the running instance
+- Plans starting at $3.99/month
+- 850+ integrations pre-wired with no extra server configuration
 - Managed shared infrastructure, so you do not need to provision your own VM
 
 ## Dashboard flow
@@ -48,18 +51,3 @@ you a path to:
 - inspect logs
 - run `openclaw` CLI commands
 - make manual changes inside the instance if you want them
-- export data before migrating away from Agent37
-
-## Backup and migration
-
-OpenClaw's standard backup export is available at:
-
-- `https://<your-agent37-instance>/setup/export`
-
-Use the hosted URL for your bot in place of `<your-agent37-instance>`.
-This lets you move your state and workspace to another OpenClaw host later.
-
-## Notes
-
-- Plan selection, billing, and hosted infrastructure are managed by Agent37.
-- For the latest pricing and availability, check [Agent37 OpenClaw](https://www.agent37.com/openclaw).

--- a/docs/install/agent37.mdx
+++ b/docs/install/agent37.mdx
@@ -4,8 +4,8 @@ title: Deploy on Agent37
 
 Deploy OpenClaw on Agent37 with managed hosting and start using it from the Agent37
 dashboard. Agent37 provisions the instance for you, so there is no separate OpenClaw
-server setup flow to complete. Agent37's OpenClaw page currently advertises plans
-starting at $3.99/month.
+server setup flow to complete. See [Agent37](https://www.agent37.com/) for current
+pricing and plan details.
 
 ## How to get started
 
@@ -23,8 +23,7 @@ starting at $3.99/month.
 - Agent37 dashboard with one-click bot launch
 - `Web Chat` button for immediate access
 - `Terminal` button for shell access to the running instance
-- Plans starting at $3.99/month
-- 850+ integrations pre-wired with no extra server configuration
+- Plans and pricing managed by Agent37
 - Managed shared infrastructure, so you do not need to provision your own VM
 
 ## Dashboard flow

--- a/docs/install/agent37.mdx
+++ b/docs/install/agent37.mdx
@@ -23,6 +23,7 @@ pricing and plan details.
 - Agent37 dashboard with one-click bot launch
 - `Web Chat` button for immediate access
 - `Terminal` button for shell access to the running instance
+- Integrations managed by Agent37 with no extra server configuration
 - Plans and pricing managed by Agent37
 - Managed shared infrastructure, so you do not need to provision your own VM
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -26,6 +26,7 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 ## VPS & hosting
 
 - VPS hub: [VPS hosting](/vps)
+- Agent37 (managed shared hosting): [Agent37](/install/agent37)
 - Fly.io: [Fly.io](/install/fly)
 - Hetzner (Docker): [Hetzner](/install/hetzner)
 - GCP (Compute Engine): [GCP](/install/gcp)

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -15,6 +15,7 @@ deployments work at a high level.
 
 - **Railway** (one‑click + browser setup): [Railway](/install/railway)
 - **Northflank** (one‑click + browser setup): [Northflank](/install/northflank)
+- **Agent37** (managed shared hosting + browser setup): [Agent37](/install/agent37)
 - **Oracle Cloud (Always Free)**: [Oracle](/platforms/oracle) — $0/month (Always Free, ARM; capacity/signup can be finicky)
 - **Fly.io**: [Fly.io](/install/fly)
 - **Hetzner (Docker)**: [Hetzner](/install/hetzner)


### PR DESCRIPTION
## Summary
- add an Agent37 managed-hosting install guide under `docs/install/agent37.mdx`
- register Agent37 in the Install -> Hosting and deployment nav
- add Agent37 to the VPS and Platforms hub pages
- add short redirects for `/agent37` and `/platforms/agent37`

## Why
OpenClaw already documents multiple hosted install paths such as Railway, Render, Northflank, and `exe.dev`.
This adds Agent37 as another hosted OpenClaw path using the same docs-driven pattern, without changing runtime behavior.

## Notes
- docs-only change
- kept Agent37-specific instructions conservative and based on the public flow currently shown on `agent37.com`
- avoided hard-coding pricing in the docs so the page does not go stale as pricing changes

## Testing
- [x] AI-assisted
- [x] Lightly tested
- [x] `jq empty docs/docs.json`
- [x] `corepack pnpm dlx markdownlint-cli2 docs/install/agent37.mdx docs/vps.md docs/platforms/index.md`
- [ ] Full `pnpm build && pnpm check && pnpm test`

## Sources used
- https://docs.openclaw.ai/install
- https://github.com/openclaw/openclaw
- https://www.agent37.com/openclaw
