### PR TITLE
fix(feishu): clear stale streamingStartPromise on card creation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: classify HTTP 422 malformed-request responses as `format` and recognize OpenRouter "requires more credits" billing errors so provider fallback triggers instead of surfacing raw errors. (#43823) thanks @jnMetaCode.
 - Memory/QMD Windows: fail closed when `qmd.cmd` or `mcporter.cmd` wrappers cannot be resolved to a direct entrypoint, so memory search no longer falls back to shell execution on Windows.
 - macOS/remote gateway: stop PortGuardian from killing Docker Desktop and other external listeners on the gateway port in remote mode, so containerized and tunneled gateway setups no longer lose their port-forward owner on app startup. (#6755) Thanks @teslamint.
+- Feishu/streaming recovery: clear stale `streamingStartPromise` when card creation fails (HTTP 400) so subsequent messages can retry streaming instead of silently dropping all future replies. Fixes #43322.
 
 ## 2026.3.8
 

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -527,32 +527,33 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       return origPush.apply(this, args);
     } as any;
 
-    createFeishuReplyDispatcher({
-      cfg: {} as never,
-      agentId: "agent",
-      runtime: { log: vi.fn(), error: errorMock } as never,
-      chatId: "oc_chat",
-    });
+    try {
+      createFeishuReplyDispatcher({
+        cfg: {} as never,
+        agentId: "agent",
+        runtime: { log: vi.fn(), error: errorMock } as never,
+        chatId: "oc_chat",
+      });
 
-    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+      const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
 
-    // First deliver with markdown triggers startStreaming - which will fail
-    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "block" });
+      // First deliver with markdown triggers startStreaming - which will fail
+      await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "block" });
 
-    // Wait for the async error to propagate
-    await vi.waitFor(() => {
-      expect(errorMock).toHaveBeenCalledWith(expect.stringContaining("streaming start failed"));
-    });
+      // Wait for the async error to propagate
+      await vi.waitFor(() => {
+        expect(errorMock).toHaveBeenCalledWith(expect.stringContaining("streaming start failed"));
+      });
 
-    // Second deliver should create a NEW streaming session (not stuck)
-    await options.deliver({ text: "```ts\nconst y = 2\n```" }, { kind: "final" });
+      // Second deliver should create a NEW streaming session (not stuck)
+      await options.deliver({ text: "```ts\nconst y = 2\n```" }, { kind: "final" });
 
-    // Restore original push
-    streamingInstances.push = origPush;
-
-    // Two instances created: first failed, second succeeded and closed
-    expect(streamingInstances).toHaveLength(2);
-    expect(streamingInstances[1].start).toHaveBeenCalled();
-    expect(streamingInstances[1].close).toHaveBeenCalled();
+      // Two instances created: first failed, second succeeded and closed
+      expect(streamingInstances).toHaveLength(2);
+      expect(streamingInstances[1].start).toHaveBeenCalled();
+      expect(streamingInstances[1].close).toHaveBeenCalled();
+    } finally {
+      streamingInstances.push = origPush;
+    }
   });
 });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -510,4 +510,49 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       }),
     );
   });
+
+  it("recovers streaming after start() throws (HTTP 400)", async () => {
+    const errorMock = vi.fn();
+    let shouldFailStart = true;
+
+    // Intercept streaming instance creation to make first start() reject
+    const origPush = streamingInstances.push;
+    streamingInstances.push = function (this: any[], ...args: any[]) {
+      if (shouldFailStart) {
+        args[0].start = vi
+          .fn()
+          .mockRejectedValue(new Error("Create card request failed with HTTP 400"));
+        shouldFailStart = false;
+      }
+      return origPush.apply(this, args);
+    } as any;
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: errorMock } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+
+    // First deliver with markdown triggers startStreaming - which will fail
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "block" });
+
+    // Wait for the async error to propagate
+    await vi.waitFor(() => {
+      expect(errorMock).toHaveBeenCalledWith(expect.stringContaining("streaming start failed"));
+    });
+
+    // Second deliver should create a NEW streaming session (not stuck)
+    await options.deliver({ text: "```ts\nconst y = 2\n```" }, { kind: "final" });
+
+    // Restore original push
+    streamingInstances.push = origPush;
+
+    // Two instances created: first failed, second succeeded and closed
+    expect(streamingInstances).toHaveLength(2);
+    expect(streamingInstances[1].start).toHaveBeenCalled();
+    expect(streamingInstances[1].close).toHaveBeenCalled();
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -202,6 +202,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;
+        streamingStartPromise = null; // allow retry on next deliver
       }
     })();
   };


### PR DESCRIPTION
## Summary

- When `FeishuStreamingSession.start()` throws (e.g. HTTP 400 from CardKit v1 API), the catch block nulls `streaming` but leaves `streamingStartPromise` set
- The guard in `startStreaming()` checks `streamingStartPromise` first, so all future `deliver()` calls silently skip streaming
- Session locks permanently - all subsequent messages are dropped

One-line fix: clear `streamingStartPromise` in the catch block alongside `streaming`.

Fixes #43322

## Changes

| File | Change |
|------|--------|
| `extensions/feishu/src/reply-dispatcher.ts` | Clear `streamingStartPromise = null` in the `start()` catch block |
| `extensions/feishu/src/reply-dispatcher.test.ts` | Regression test: first `deliver()` triggers a failing `start()`, second `deliver()` creates a new session successfully |
| `CHANGELOG.md` | Added fix entry |

## Test plan

- [x] `pnpm vitest run extensions/feishu/src/reply-dispatcher.test.ts` - 23/23 passing (22 existing + 1 new regression test)
- [x] `pnpm format` clean
- [x] New test uses push-intercept pattern to make first `start()` reject, verifies second `deliver()` creates a fresh streaming session