### PR TITLE
skills: add domain-trust-check skill

### DIFF
--- a/skills/domain-trust-check/SKILL.md
+++ b/skills/domain-trust-check/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: domain-trust-check
+description: "URL safety scanner and domain reputation checker. Use when: checking if a URL is safe before visiting, scanning links in emails/messages, verifying domains for phishing/malware/scam."
+homepage: https://outtake.ai
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🛡️",
+        "requires": { "env": ["OUTTAKE_API_KEY"], "bins": ["curl"] },
+        "primaryEnv": "OUTTAKE_API_KEY",
+        "homepage": "https://outtake.ai"
+      }
+  }
+---
+
+# Domain Trust Check
+
+Check any URL for phishing, malware, brand abuse, and scams before visiting or recommending it. Powered by the [Outtake](https://outtake.ai) Trust API.
+
+## Quick Start
+
+> **Already registered?** If `OUTTAKE_API_KEY` is set, skip to the curl command. Do not re-register.
+
+```bash
+curl -s -X POST https://app.outtake.ai/api/v1/trust/check \
+  -H "Authorization: Bearer $OUTTAKE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://suspicious-site.com"}'
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "url": "https://suspicious-site.com",
+    "domain": "suspicious-site.com",
+    "verdict": "malicious",
+    "confidence": 0.92,
+    "safe_to_visit": "unsafe",
+    "recommended_action": "block",
+    "checked_at": "2026-02-26T12:00:00.000Z"
+  }
+}
+```
+
+## Setup
+
+1. Register for a free API key:
+
+```bash
+curl -s -X POST https://app.outtake.ai/api/v1/agent/register \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-agent", "email": "agent@example.com"}'
+```
+
+2. Save the returned `api_key` (shown once):
+
+```bash
+export OUTTAKE_API_KEY="outtake_..."
+```
+
+Or configure in OpenClaw:
+
+```json5
+// ~/.openclaw/openclaw.json
+{
+  skills: {
+    entries: {
+      "domain-trust-check": {
+        apiKey: "outtake_..."
+      }
+    }
+  }
+}
+```
+
+| Status | Meaning |
+|---|---|
+| 409 | Email already registered — use your existing key |
+| 429 | Rate limited (5 registrations/hour) |
+
+Optional fields: `wallet_address` (Ethereum), `agent_framework` (e.g. "openclaw").
+
+## Interpreting Results
+
+| verdict | safe_to_visit | Action |
+|---|---|---|
+| `malicious` | `unsafe` | **Block.** Do NOT visit. Warn the user. |
+| `suspicious` | `safe` or `unsafe` | **Warn** the user. If `unsafe`, treat as malicious. |
+| `safe` | `safe` | Safe to visit. |
+| `unknown` | `unknown` | No data. Proceed with caution. |
+
+### Response Fields
+
+| Field | Values | Description |
+|---|---|---|
+| `verdict` | `malicious`, `suspicious`, `safe`, `unknown` | Threat classification |
+| `confidence` | `0.0` – `1.0` | `1.0` = human-reviewed, `0.7–0.99` = ML, `0.0` = no data |
+| `safe_to_visit` | `safe`, `unsafe`, `unknown` | Binary browsing safety |
+| `recommended_action` | `block`, `warn`, `proceed`, `use_caution` | Suggested action |
+
+## Batch Checking
+
+Check up to 50 URLs in one request:
+
+```bash
+curl -s -X POST https://app.outtake.ai/api/v1/trust/check-batch \
+  -H "Authorization: Bearer $OUTTAKE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"urls": ["https://link1.com", "https://link2.com"]}'
+```
+
+- Maximum 50 URLs per request
+- Results maintain input order
+- Use batch when checking 3+ URLs to reduce round trips
+
+## Best Practices
+
+- **Scan before visiting.** Check URLs before using `web_fetch` or `browser` tools.
+- **Batch when possible.** Processing a list of links? Use the batch endpoint.
+- **Respect verdicts.** If `safe_to_visit` is `unsafe`, do not proceed — warn the user.
+- **Handle unknowns.** `unknown` means no data, not safe. Proceed with caution.
+
+## Rate Limits
+
+| Limit | Window | Value |
+|---|---|---|
+| Burst | Per minute | 10 requests |
+| Daily | Per 24 hours | 10,000 URL checks |
+
+On `429`, wait `retry_after_seconds` before retrying. Do not retry `400` errors.
+
+## Support
+
+Questions or feedback? [trust-check@outtake.ai](mailto:trust-check@outtake.ai)

--- a/skills/domain-trust-check/SKILL.md
+++ b/skills/domain-trust-check/SKILL.md
@@ -9,8 +9,8 @@ metadata:
         "emoji": "🛡️",
         "requires": { "env": ["OUTTAKE_API_KEY"], "bins": ["curl"] },
         "primaryEnv": "OUTTAKE_API_KEY",
-        "homepage": "https://outtake.ai"
-      }
+        "homepage": "https://outtake.ai",
+      },
   }
 ---
 
@@ -69,37 +69,37 @@ Or configure in OpenClaw:
   skills: {
     entries: {
       "domain-trust-check": {
-        apiKey: "outtake_..."
-      }
-    }
-  }
+        apiKey: "outtake_...",
+      },
+    },
+  },
 }
 ```
 
-| Status | Meaning |
-|---|---|
-| 409 | Email already registered — use your existing key |
-| 429 | Rate limited (5 registrations/hour) |
+| Status | Meaning                                          |
+| ------ | ------------------------------------------------ |
+| 409    | Email already registered — use your existing key |
+| 429    | Rate limited (5 registrations/hour)              |
 
 Optional fields: `wallet_address` (Ethereum), `agent_framework` (e.g. "openclaw").
 
 ## Interpreting Results
 
-| verdict | safe_to_visit | Action |
-|---|---|---|
-| `malicious` | `unsafe` | **Block.** Do NOT visit. Warn the user. |
+| verdict      | safe_to_visit      | Action                                              |
+| ------------ | ------------------ | --------------------------------------------------- |
+| `malicious`  | `unsafe`           | **Block.** Do NOT visit. Warn the user.             |
 | `suspicious` | `safe` or `unsafe` | **Warn** the user. If `unsafe`, treat as malicious. |
-| `safe` | `safe` | Safe to visit. |
-| `unknown` | `unknown` | No data. Proceed with caution. |
+| `safe`       | `safe`             | Safe to visit.                                      |
+| `unknown`    | `unknown`          | No data. Proceed with caution.                      |
 
 ### Response Fields
 
-| Field | Values | Description |
-|---|---|---|
-| `verdict` | `malicious`, `suspicious`, `safe`, `unknown` | Threat classification |
-| `confidence` | `0.0` – `1.0` | `1.0` = human-reviewed, `0.7–0.99` = ML, `0.0` = no data |
-| `safe_to_visit` | `safe`, `unsafe`, `unknown` | Binary browsing safety |
-| `recommended_action` | `block`, `warn`, `proceed`, `use_caution` | Suggested action |
+| Field                | Values                                       | Description                                              |
+| -------------------- | -------------------------------------------- | -------------------------------------------------------- |
+| `verdict`            | `malicious`, `suspicious`, `safe`, `unknown` | Threat classification                                    |
+| `confidence`         | `0.0` – `1.0`                                | `1.0` = human-reviewed, `0.7–0.99` = ML, `0.0` = no data |
+| `safe_to_visit`      | `safe`, `unsafe`, `unknown`                  | Binary browsing safety                                   |
+| `recommended_action` | `block`, `warn`, `proceed`, `use_caution`    | Suggested action                                         |
 
 ## Batch Checking
 
@@ -125,9 +125,9 @@ curl -s -X POST https://app.outtake.ai/api/v1/trust/check-batch \
 
 ## Rate Limits
 
-| Limit | Window | Value |
-|---|---|---|
-| Burst | Per minute | 10 requests |
+| Limit | Window       | Value             |
+| ----- | ------------ | ----------------- |
+| Burst | Per minute   | 10 requests       |
 | Daily | Per 24 hours | 10,000 URL checks |
 
 On `429`, wait `retry_after_seconds` before retrying. Do not retry `400` errors.

--- a/skills/domain-trust-check/SKILL.md
+++ b/skills/domain-trust-check/SKILL.md
@@ -119,7 +119,7 @@ curl -s -X POST https://app.outtake.ai/api/v1/trust/check-batch \
 
 - **Scan before visiting.** Check URLs before using `web_fetch` or `browser` tools.
 - **Batch when possible.** Processing a list of links? Use the batch endpoint.
-- **Respect verdicts.** If `safe_to_visit` is `unsafe`, do not proceed — warn the user.
+- **Respect verdicts.** If `safe_to_visit` is `unsafe`, do not proceed — warn the user. Also warn if `verdict` is `suspicious`, even when `safe_to_visit` is `safe`.
 - **Handle unknowns.** `unknown` means no data, not safe. Proceed with caution.
 
 ## Rate Limits

--- a/skills/domain-trust-check/SKILL.md
+++ b/skills/domain-trust-check/SKILL.md
@@ -9,7 +9,6 @@ metadata:
         "emoji": "🛡️",
         "requires": { "env": ["OUTTAKE_API_KEY"], "bins": ["curl"] },
         "primaryEnv": "OUTTAKE_API_KEY",
-        "homepage": "https://outtake.ai",
       },
   }
 ---


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw agents that browse the web or process URLs from messages have no built-in way to check if a link is safe before visiting it.
- **Why it matters:** Agents routinely encounter URLs in user messages, email digests, and research. Without a safety check, they may visit phishing, malware, or scam sites — or recommend unsafe links to users.
- **What changed:** Added `skills/domain-trust-check/SKILL.md` — a new skill that checks URLs against the [Outtake Trust API](https://clawhub.ai/jamesOuttake/domain-trust-check) for phishing, malware, brand abuse, and scams. Returns structured verdicts (malicious/suspicious/safe/unknown) with confidence scores and recommended actions.
- **What did NOT change (scope boundary):** No core source code, extensions, or existing skills were modified. This is a skill addition only.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Discussed in **#clawtributors** on the [OpenClaw Discord](https://discord.gg/clawd) (GitHub Discussions appear to be disabled on the repo).
- Already published on [ClawHub](https://clawhub.ai/skill/domain-trust-check) (v1.2.2) — this PR promotes it to a bundled skill.

## User-visible / Behavior Changes

- Agents can now check URL safety when `OUTTAKE_API_KEY` is configured. The skill is gated — users without the key won't see it. Zero impact on existing behavior.

## Security Impact (required)

- New permissions/capabilities? `No` — skill uses `curl` to call an external API. No new system permissions.
- Secrets/tokens handling changed? `No` — API key follows standard `primaryEnv` / `skills.entries.apiKey` pattern.
- New/changed network calls? `Yes` — calls `https://app.outtake.ai/api/v1/trust/check` (and `/check-batch`). Only when agent invokes the skill.
- Command/tool execution surface changed? `No` — agent invokes `curl`, which is already available.
- Data access scope changed? `No`
- Risk + mitigation: Skill sends URLs to Outtake's API for classification. This is the intended behavior — users opt in by registering for a free API key. The API is free (10K checks/day) and requires no credit card.

## Disclosure

I work at [Outtake](https://outtake.ai), the company behind the Trust API. The API is free to use, and the skill is open source. This skill is already published on [ClawHub](https://clawhub.ai/skill/domain-trust-check) (v1.2.2) — this PR promotes it to a bundled skill. Happy to answer any questions about the API, data handling, or privacy.

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (Linux 6.x)
- Runtime: Node v22.x, OpenClaw 2026.3.8
- Model/provider: Any (skill is model-agnostic, uses curl)
- Integration: Outtake Trust API (https://app.outtake.ai)
- Config: `OUTTAKE_API_KEY` set in environment

### Steps

1. Add `OUTTAKE_API_KEY` to environment (or `skills.entries.domain-trust-check.apiKey` in config)
2. Start OpenClaw gateway
3. Ask agent: "Is https://suspicious-site.com safe to visit?"
4. Agent should invoke domain-trust-check skill and return verdict

### Expected

- Skill appears in available skills when API key is configured
- Skill does NOT appear when API key is absent
- Returns structured verdict with confidence score

### Actual

- All expectations met (see test evidence below)

## Evidence

<details>
<summary>Build & test output (click to expand)</summary>

### Build & CI Verification

```
$ pnpm build    ✅ passed
$ pnpm check    ✅ passed (oxfmt formatting applied)
$ pnpm test     ✅ 881 test files, 7,180 tests passed, 0 failures
```

### Test 1: Safe URL (google.com)
```bash
$ curl -s -X POST https://app.outtake.ai/api/v1/trust/check \
  -H "Authorization: Bearer $OUTTAKE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"url": "https://google.com"}'
```
```json
{"data":{"verdict":"safe","confidence":1,"safe_to_visit":"safe","recommended_action":"proceed"}}
```

### Test 2: Unknown/Suspicious URL
```bash
$ curl -s -X POST https://app.outtake.ai/api/v1/trust/check \
  -H "Authorization: Bearer $OUTTAKE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"url": "https://login-paypal-secure.xyz"}'
```
```json
{"data":{"verdict":"unknown","confidence":0,"safe_to_visit":"unknown","recommended_action":"use_caution"}}
```

### Test 3: Batch Check (3 URLs)
```bash
$ curl -s -X POST https://app.outtake.ai/api/v1/trust/check-batch \
  -H "Authorization: Bearer $OUTTAKE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"urls": ["https://google.com", "https://github.com", "https://login-paypal-secure.xyz"]}'
```
```json
{"data":{"results":[{"index":0,"data":{"verdict":"safe","confidence":1}},{"index":1,"data":{"verdict":"safe","confidence":1}},{"index":2,"data":{"verdict":"unknown","confidence":0}}],"success_count":3,"failure_count":0}}
```

### Test 4: Bad API Key (auth rejection)
```bash
$ curl -s -X POST https://app.outtake.ai/api/v1/trust/check \
  -H "Authorization: Bearer bad_key_12345" \
  -H "Content-Type: application/json" \
  -d '{"url": "https://google.com"}'
```
```json
{"error":"Unauthorized"}
```

</details>

- [x] Trace/log snippets — see above
- [ ] Screenshot/recording — N/A (no UI changes)
- [ ] Perf numbers — N/A

## Human Verification (required)

- **Verified scenarios:** Skill loads with API key, does not load without. Single check, batch check, auth rejection all work correctly. `pnpm build && pnpm check && pnpm test` all pass (7,180 tests, 0 failures). Interactive onboarding wizard correctly prompts for `OUTTAKE_API_KEY` and saves to config.
- **Edge cases checked:** Missing API key (skill hidden), invalid API key (401 Unauthorized), malformed URL (validation error with ZodError), batch with 50 URLs (max limit — passes), batch with 51 URLs (rejects with "Array must contain at most 50 element(s)").
- **What I did NOT verify:** Behavior on Windows/macOS (tested on Linux only). Rate limit (429) response — would require exhausting quota to trigger. Did not test with every model provider — skill is model-agnostic (curl-based) so provider shouldn't matter.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — purely additive. No existing files modified.
- Config/env changes? `No` — uses standard `primaryEnv` pattern. Optional API key.
- Migration needed? `No`

## Failure Recovery (if this breaks)

- **How to disable/revert:** Delete `skills/domain-trust-check/SKILL.md` or revert this single commit.
- **Files/config to restore:** None — single file addition.
- **Known bad symptoms:** If Outtake API is down, skill will return curl errors. Agent should handle gracefully (proceed with caution). No impact on other skills or core functionality.

## Risks and Mitigations

- **Risk:** External API dependency — if Outtake API is unavailable, skill fails.
  - **Mitigation:** Skill is opt-in (gated on API key). Failure is graceful (curl error, not crash). Agent instructions say to proceed with caution on unknown/error.
- **Risk:** Data sent to third-party API (URLs being checked).
  - **Mitigation:** Explicitly disclosed. Users opt in by registering. Only URLs are sent — no user data, messages, or context. API is HTTPS-only.

## AI Assistance

Skill content drafted with AI assistance (Claude via OpenClaw). Process:
1. Audited bundled skills for structure/conventions
2. Identified closest analogs: `notion`, `weather` (external API with env key)
3. Drafted SKILL.md matching bundled conventions
4. Human review and approval before submission