### PR TITLE
fix(message): fall back to target param when to is not set

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -396,7 +396,9 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   } = ctx;
   throwIfAborted(abortSignal);
   const action: ChannelMessageActionName = "send";
-  const to = readStringParam(params, "to", { required: true });
+  // Support both 'to' (set by normalization from 'target') and 'target' directly
+  // for resilience if normalization is bypassed or fails.
+  const to = readStringParam(params, "to") ?? readStringParam(params, "target", { required: true });
   // Support media, path, and filePath parameters for attachments
   const mediaHint =
     readStringParam(params, "media", { trim: false }) ??
@@ -569,7 +571,8 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
   const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal } = ctx;
   throwIfAborted(abortSignal);
   const action: ChannelMessageActionName = "poll";
-  const to = readStringParam(params, "to", { required: true });
+  // Support both 'to' (set by normalization from 'target') and 'target' directly.
+  const to = readStringParam(params, "to") ?? readStringParam(params, "target", { required: true });
   const question = readStringParam(params, "pollQuestion", {
     required: true,
   });


### PR DESCRIPTION
## Summary

Fixes #43391. The message tool schema defines `target` as the parameter for specifying recipients, but `handleSendAction` and `handlePollAction` were reading only `to`. While normalization should map `target` → `to`, this change adds a defensive fallback to read `target` directly if `to` is not set, making the code more resilient.

## Changes

- `handleSendAction`: Fall back to `target` param when `to` is not set
- `handlePollAction`: Same defensive fallback

## Test plan

- [x] Existing `message-action-runner.test.ts` tests pass (40 tests)
- [x] Type check passes

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
