### PR TITLE
fix(agents): detect partial tool execution before fallback retry

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   coerceToFailoverError,
   describeFailoverError,
+  FailoverError,
   isTimeoutError,
   resolveFailoverReasonFromError,
   resolveFailoverStatus,
@@ -398,5 +399,59 @@ describe("failover-error", () => {
     const described = describeFailoverError(123);
     expect(described.message).toBe("123");
     expect(described.reason).toBeUndefined();
+  });
+
+  it("preserves partialExecution through construction", () => {
+    const err = new FailoverError("timeout", {
+      reason: "timeout",
+      partialExecution: {
+        hadToolExecution: true,
+        toolNames: ["send_message", "search"],
+        didSendViaMessagingTool: true,
+      },
+    });
+    expect(err.partialExecution).toEqual({
+      hadToolExecution: true,
+      toolNames: ["send_message", "search"],
+      didSendViaMessagingTool: true,
+    });
+  });
+
+  it("includes partialExecution in describeFailoverError", () => {
+    const err = new FailoverError("timeout", {
+      reason: "timeout",
+      partialExecution: {
+        hadToolExecution: true,
+        toolNames: ["run_shell"],
+        didSendViaMessagingTool: false,
+      },
+    });
+    const described = describeFailoverError(err);
+    expect(described.partialExecution?.toolNames).toEqual(["run_shell"]);
+    expect(described.partialExecution?.didSendViaMessagingTool).toBe(false);
+  });
+
+  it("sanitizeToolNames caps at 20 entries", () => {
+    const names = Array.from({ length: 30 }, (_, i) => `tool_${i}`);
+    const sanitized = FailoverError.sanitizeToolNames(names);
+    expect(sanitized).toHaveLength(20);
+  });
+
+  it("sanitizeToolNames strips invalid characters", () => {
+    expect(FailoverError.sanitizeToolNames(["valid_name", "has spaces!", "<script>"])).toEqual([
+      "valid_name",
+      "hasspaces",
+      "script",
+    ]);
+  });
+
+  it("sanitizeToolNames truncates to 100 characters", () => {
+    const longName = "a".repeat(150);
+    const sanitized = FailoverError.sanitizeToolNames([longName]);
+    expect(sanitized[0]).toHaveLength(100);
+  });
+
+  it("sanitizeToolNames filters empty results", () => {
+    expect(FailoverError.sanitizeToolNames(["!!!"])).toEqual([]);
   });
 });

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -8,6 +8,12 @@ import {
 
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
 
+export type PartialExecution = {
+  hadToolExecution: true;
+  toolNames: string[];
+  didSendViaMessagingTool: boolean;
+};
+
 export class FailoverError extends Error {
   readonly reason: FailoverReason;
   readonly provider?: string;
@@ -15,6 +21,7 @@ export class FailoverError extends Error {
   readonly profileId?: string;
   readonly status?: number;
   readonly code?: string;
+  readonly partialExecution?: PartialExecution;
 
   constructor(
     message: string,
@@ -26,6 +33,7 @@ export class FailoverError extends Error {
       status?: number;
       code?: string;
       cause?: unknown;
+      partialExecution?: PartialExecution;
     },
   ) {
     super(message, { cause: params.cause });
@@ -36,6 +44,15 @@ export class FailoverError extends Error {
     this.profileId = params.profileId;
     this.status = params.status;
     this.code = params.code;
+    this.partialExecution = params.partialExecution;
+  }
+
+  /** Sanitize tool names for safe inclusion in prompts and logs. */
+  static sanitizeToolNames(names: string[]): string[] {
+    return names
+      .slice(0, 20)
+      .map((n) => n.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 100))
+      .filter(Boolean);
   }
 }
 
@@ -190,6 +207,7 @@ export function describeFailoverError(err: unknown): {
   reason?: FailoverReason;
   status?: number;
   code?: string;
+  partialExecution?: PartialExecution;
 } {
   if (isFailoverError(err)) {
     return {
@@ -197,6 +215,7 @@ export function describeFailoverError(err: unknown): {
       reason: err.reason,
       status: err.status,
       code: err.code,
+      partialExecution: err.partialExecution,
     };
   }
   const message = getErrorMessage(err) || String(err);

--- a/src/agents/model-fallback-observation.ts
+++ b/src/agents/model-fallback-observation.ts
@@ -1,5 +1,6 @@
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
+import type { PartialExecution } from "./failover-error.js";
 import type { FallbackAttempt, ModelCandidate } from "./model-fallback.types.js";
 import { buildTextObservationFields } from "./pi-embedded-error-observation.js";
 import type { FailoverReason } from "./pi-embedded-helpers.js";
@@ -50,6 +51,7 @@ export function logModelFallbackDecision(params: {
   allowTransientCooldownProbe?: boolean;
   profileCount?: number;
   previousAttempts?: FallbackAttempt[];
+  partialExecution?: PartialExecution;
 }): void {
   const nextText = params.nextCandidate
     ? `${sanitizeForLog(params.nextCandidate.provider)}/${sanitizeForLog(params.nextCandidate.model)}`
@@ -78,6 +80,12 @@ export function logModelFallbackDecision(params: {
     fallbackConfigured: params.fallbackConfigured,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
     profileCount: params.profileCount,
+    partialExecution: params.partialExecution
+      ? {
+          toolCount: params.partialExecution.toolNames.length,
+          didSendViaMessagingTool: params.partialExecution.didSendViaMessagingTool,
+        }
+      : undefined,
     previousAttempts: params.previousAttempts?.map((attempt) => ({
       provider: attempt.provider,
       model: attempt.model,

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1449,6 +1449,52 @@ describe("runWithModelFallback", () => {
     expect(secondCallOptions?.previousPartialExecution).toBeUndefined();
   });
 
+  it("preserves previousPartialExecution across multi-hop when later attempts have none", async () => {
+    const { FailoverError } = await import("./failover-error.js");
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5", "google/gemini-2.5-flash"],
+          },
+        },
+      },
+    });
+    // Attempt 1: partial execution, attempt 2: rate limit (no tools), attempt 3: succeeds
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("timeout", {
+          reason: "timeout",
+          partialExecution: {
+            hadToolExecution: true,
+            toolNames: ["send_message"],
+            didSendViaMessagingTool: true,
+          },
+        }),
+      )
+      .mockRejectedValueOnce(new FailoverError("rate limited", { reason: "rate_limit" }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(3);
+    // Third call should still have the partial execution from attempt 1
+    const thirdCallOptions = run.mock.calls[2]?.[2];
+    expect(thirdCallOptions?.previousPartialExecution).toEqual({
+      hadToolExecution: true,
+      toolNames: ["send_message"],
+      didSendViaMessagingTool: true,
+    });
+  });
+
   it("stores partialExecution in attempts array", async () => {
     const { FailoverError } = await import("./failover-error.js");
     const cfg = makeCfg();

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1399,6 +1399,83 @@ describe("runWithModelFallback", () => {
       });
     });
   });
+
+  it("forwards previousPartialExecution from FailoverError to next run call", async () => {
+    const { FailoverError } = await import("./failover-error.js");
+    const cfg = makeCfg();
+    const failoverErr = new FailoverError("timeout", {
+      reason: "timeout",
+      partialExecution: {
+        hadToolExecution: true,
+        toolNames: ["send_message", "search"],
+        didSendViaMessagingTool: true,
+      },
+    });
+    const run = vi.fn().mockRejectedValueOnce(failoverErr).mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    // Second call should receive previousPartialExecution in options
+    const secondCallOptions = run.mock.calls[1]?.[2];
+    expect(secondCallOptions?.previousPartialExecution).toEqual({
+      hadToolExecution: true,
+      toolNames: ["send_message", "search"],
+      didSendViaMessagingTool: true,
+    });
+  });
+
+  it("does not forward previousPartialExecution when error has none", async () => {
+    const { FailoverError } = await import("./failover-error.js");
+    const cfg = makeCfg();
+    const failoverErr = new FailoverError("timeout", { reason: "timeout" });
+    const run = vi.fn().mockRejectedValueOnce(failoverErr).mockResolvedValueOnce("ok");
+
+    await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    // Second call should not have previousPartialExecution
+    const secondCallOptions = run.mock.calls[1]?.[2];
+    expect(secondCallOptions?.previousPartialExecution).toBeUndefined();
+  });
+
+  it("stores partialExecution in attempts array", async () => {
+    const { FailoverError } = await import("./failover-error.js");
+    const cfg = makeCfg();
+    const failoverErr = new FailoverError("timeout", {
+      reason: "timeout",
+      partialExecution: {
+        hadToolExecution: true,
+        toolNames: ["run_shell"],
+        didSendViaMessagingTool: false,
+      },
+    });
+    const run = vi.fn().mockRejectedValueOnce(failoverErr).mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0].partialExecution).toEqual({
+      hadToolExecution: true,
+      toolNames: ["run_shell"],
+      didSendViaMessagingTool: false,
+    });
+  });
 });
 
 describe("runWithImageModelFallback", () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -730,7 +730,7 @@ export async function runWithModelFallback<T>(params: {
 
       lastError = isKnownFailover ? normalized : err;
       const described = describeFailoverError(normalized);
-      lastPartialExecution = described.partialExecution;
+      lastPartialExecution = described.partialExecution ?? lastPartialExecution;
       attempts.push({
         provider: candidate.provider,
         model: candidate.model,

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -18,6 +18,7 @@ import {
   describeFailoverError,
   isFailoverError,
   isTimeoutError,
+  type PartialExecution,
 } from "./failover-error.js";
 import { logModelFallbackDecision } from "./model-fallback-observation.js";
 import type { FallbackAttempt, ModelCandidate } from "./model-fallback.types.js";
@@ -36,6 +37,7 @@ const log = createSubsystemLogger("model-fallback");
 
 export type ModelFallbackRunOptions = {
   allowTransientCooldownProbe?: boolean;
+  previousPartialExecution?: PartialExecution;
 };
 
 type ModelFallbackRunFn<T> = (
@@ -524,6 +526,7 @@ export async function runWithModelFallback<T>(params: {
     : null;
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
+  let lastPartialExecution: PartialExecution | undefined;
   const cooldownProbeUsedProviders = new Set<string>();
 
   const hasFallbackCandidates = candidates.length > 1;
@@ -652,6 +655,12 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
+    // Forward partial execution context from a prior failed attempt so the
+    // fallback model knows which tools already ran.
+    if (lastPartialExecution) {
+      runOptions = { ...runOptions, previousPartialExecution: lastPartialExecution };
+    }
+
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,
@@ -721,6 +730,7 @@ export async function runWithModelFallback<T>(params: {
 
       lastError = isKnownFailover ? normalized : err;
       const described = describeFailoverError(normalized);
+      lastPartialExecution = described.partialExecution;
       attempts.push({
         provider: candidate.provider,
         model: candidate.model,
@@ -728,6 +738,7 @@ export async function runWithModelFallback<T>(params: {
         reason: described.reason ?? "unknown",
         status: described.status,
         code: described.code,
+        partialExecution: described.partialExecution,
       });
       logModelFallbackDecision({
         decision: "candidate_failed",
@@ -745,6 +756,7 @@ export async function runWithModelFallback<T>(params: {
         isPrimary,
         requestedModelMatched: requestedModel,
         fallbackConfigured: hasFallbackCandidates,
+        partialExecution: described.partialExecution,
       });
       await params.onError?.({
         provider: candidate.provider,

--- a/src/agents/model-fallback.types.ts
+++ b/src/agents/model-fallback.types.ts
@@ -1,3 +1,4 @@
+import type { PartialExecution } from "./failover-error.js";
 import type { FailoverReason } from "./pi-embedded-helpers.js";
 
 export type ModelCandidate = {
@@ -12,4 +13,5 @@ export type FallbackAttempt = {
   reason?: FailoverReason;
   status?: number;
   code?: string;
+  partialExecution?: PartialExecution;
 };

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1418,16 +1418,22 @@ export async function runEmbeddedPiAgent(
                 model: activeErrorContext.model,
                 profileId: lastProfileId,
                 status,
-                partialExecution:
-                  attempt.toolMetas.length > 0
-                    ? {
-                        hadToolExecution: true,
-                        toolNames: FailoverError.sanitizeToolNames(
-                          attempt.toolMetas.map((t) => t.toolName),
-                        ),
-                        didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-                      }
-                    : undefined,
+                partialExecution: (() => {
+                  if (attempt.toolMetas.length === 0) {
+                    return undefined;
+                  }
+                  const sanitizedToolNames = FailoverError.sanitizeToolNames(
+                    attempt.toolMetas.map((t) => t.toolName),
+                  );
+                  if (sanitizedToolNames.length === 0) {
+                    return undefined;
+                  }
+                  return {
+                    hadToolExecution: true as const,
+                    toolNames: sanitizedToolNames,
+                    didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                  };
+                })(),
               });
             }
             logAssistantFailoverDecision("surface_error");

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1418,6 +1418,16 @@ export async function runEmbeddedPiAgent(
                 model: activeErrorContext.model,
                 profileId: lastProfileId,
                 status,
+                partialExecution:
+                  attempt.toolMetas.length > 0
+                    ? {
+                        hadToolExecution: true,
+                        toolNames: FailoverError.sanitizeToolNames(
+                          attempt.toolMetas.map((t) => t.toolName),
+                        ),
+                        didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                      }
+                    : undefined,
               });
             }
             logAssistantFailoverDecision("surface_error");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -139,11 +139,28 @@ async function persistSessionEntry(params: PersistSessionEntryParams): Promise<v
   params.sessionStore[params.sessionKey] = persisted;
 }
 
-function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boolean }): string {
+function resolveFallbackRetryPrompt(params: {
+  body: string;
+  isFallbackRetry: boolean;
+  previousPartialExecution?: { toolNames: string[]; didSendViaMessagingTool: boolean };
+}): string {
   if (!params.isFallbackRetry) {
     return params.body;
   }
-  return "Continue where you left off. The previous model attempt failed or timed out.";
+  if (!params.previousPartialExecution) {
+    return "Continue where you left off. The previous model attempt failed or timed out.";
+  }
+  const toolList = params.previousPartialExecution.toolNames.join(", ");
+  const messagingWarning = params.previousPartialExecution.didSendViaMessagingTool
+    ? " Messages were already sent to the user — do NOT re-send them."
+    : "";
+  return [
+    `[System: The previous model attempt partially executed before failing. ` +
+      `It completed these tool calls: ${toolList}.${messagingWarning} ` +
+      `Do not repeat actions that have already been performed. ` +
+      `Review the conversation history and continue from where the previous attempt left off.]`,
+    params.body,
+  ].join("\n\n");
 }
 
 function prependInternalEventContext(
@@ -344,10 +361,12 @@ function runAgentAttempt(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
+  previousPartialExecution?: { toolNames: string[]; didSendViaMessagingTool: boolean };
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
+    previousPartialExecution: params.previousPartialExecution,
   });
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,
@@ -1135,6 +1154,7 @@ async function agentCommandInternal(
             sessionStore,
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            previousPartialExecution: runOptions?.previousPartialExecution,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (


### PR DESCRIPTION
## Summary

- Detect when a model fallback retry follows partial tool execution (tool calls completed before timeout/rate-limit) and warn the fallback model about already-executed actions to prevent replaying non-idempotent operations (sending messages, shell commands, API calls)
- Add `partialExecution` field to `FailoverError` with sanitized tool names (capped at 20 entries, alphanumeric+`_-` only, 100 char limit per name)
- Thread partial execution context through `model-fallback.ts` → `agent.ts` and prepend a `[System: ...]` context block to the retry prompt listing completed tools

Closes #43482
Related: #43331 (security review that flagged this gap)

## Test plan

- [x] `pnpm build` — type-check passes
- [x] `pnpm check` — lint/format passes
- [x] New unit tests for `FailoverError.sanitizeToolNames` (capping, stripping, truncation, empty filtering)
- [x] New unit tests for `partialExecution` preservation through `FailoverError` construction and `describeFailoverError`
- [x] New unit tests for `runWithModelFallback` forwarding `previousPartialExecution` to next run call, omitting when absent, and storing in `attempts[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)