### PR TITLE
fix: keep QMD session search paths roundtrip-safe

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -2139,6 +2139,74 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("returns collection-scoped qmd paths when session exports live under the workspace qmd directory", async () => {
+    workspaceDir = path.join(stateDir, "agents", agentId);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    cfg = {
+      ...cfg,
+      agents: {
+        list: [{ id: agentId, default: true, workspace: workspaceDir }],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          sessions: { enabled: true },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        const payload = args.includes(`sessions-${agentId}`)
+          ? [{ docid: "s1", score: 0.9, snippet: "@@ -1,1\nsession hit" }]
+          : [];
+        emitAndClose(child, "stdout", JSON.stringify(payload));
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const exportPath = path.join(stateDir, "agents", agentId, "qmd", "sessions", "session-1.md");
+    await fs.mkdir(path.dirname(exportPath), { recursive: true });
+    await fs.writeFile(exportPath, "# Session 1\n\nhello", "utf-8");
+
+    const { manager } = await createManager();
+    const inner = manager as unknown as {
+      db: { prepare: (_query: string) => { all: (arg: unknown) => unknown }; close: () => void };
+    };
+    inner.db = {
+      prepare: (_query: string) => ({
+        all: (arg: unknown) => {
+          if (arg === "s1") {
+            return [{ collection: `sessions-${agentId}`, path: "session-1.md" }];
+          }
+          return [];
+        },
+      }),
+      close: () => {},
+    };
+
+    const results = await manager.search("hello", {
+      maxResults: 1,
+      sessionKey: "agent:main:discord:dm:u123",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.path).toBe(`qmd/sessions-${agentId}/session-1.md`);
+
+    const readBack = await manager.readFile({ relPath: results[0].path });
+    expect(readBack).toEqual({
+      text: "# Session 1\n\nhello",
+      path: `qmd/sessions-${agentId}/session-1.md`,
+    });
+
+    await manager.close();
+  });
+
   it("reads only requested line ranges without loading the whole file", async () => {
     const readFileSpy = vi.spyOn(fs, "readFile");
     const text = Array.from({ length: 50 }, (_, index) => `line-${index + 1}`).join("\n");

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1769,15 +1769,18 @@ export class QmdMemoryManager implements MemorySearchManager {
     relativeToWorkspace: string,
     absPath: string,
   ): string {
+    const sanitized = collectionRelativePath.replace(/^\/+/, "");
     const insideWorkspace = this.isInsideWorkspace(relativeToWorkspace);
     if (insideWorkspace) {
       const normalized = relativeToWorkspace.replace(/\\/g, "/");
       if (!normalized) {
         return path.basename(absPath);
       }
+      if (normalized === "qmd" || normalized.startsWith("qmd/")) {
+        return `qmd/${collection}/${sanitized}`;
+      }
       return normalized;
     }
-    const sanitized = collectionRelativePath.replace(/^\/+/, "");
     return `qmd/${collection}/${sanitized}`;
   }
 


### PR DESCRIPTION
## Summary

Closes #43519.

When an agent workspace lives under the OpenClaw state directory, exported QMD session markdown files can end up inside the workspace under `qmd/sessions/...`.
In that case, `memory_search` was returning the workspace-relative path:

- `qmd/sessions/<file>.md`

But `memory_get` treats the `qmd/<collection>/...` prefix as a virtual QMD path and therefore expects a real collection name such as:

- `qmd/sessions-coder/<file>.md`

That made `memory_search -> memory_get` non-roundtrip-safe for session hits.

## Fix

If a workspace-relative QMD hit would serialize to the reserved `qmd/` prefix, return the collection-scoped virtual path instead:

- `qmd/<real-collection>/<file>.md`

This preserves roundtrip safety while keeping normal in-workspace paths unchanged.

## Tests

Added a regression test covering the exact case where session exports live under the workspace `qmd/` directory and verifying that:

- search returns `qmd/sessions-<agentId>/...`
- read succeeds with that exact returned path

## Verification

- `pnpm -s exec vitest run src/memory/qmd-manager.test.ts -t 'returns collection-scoped qmd paths when session exports live under the workspace qmd directory'`
- `pnpm -s exec vitest run src/memory/qmd-manager.test.ts -t 'returns collection-scoped qmd paths when session exports live under the workspace qmd directory|diversifies mixed session and memory search results so memory hits are retained|blocks non-markdown or symlink reads for qmd paths'`
