### PR TITLE
fix(ui): show full command/args in tool card sidebar (#43153)

### DIFF
--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -1,0 +1,52 @@
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { ToolCard } from "../types/chat-types.ts";
+import { renderToolCardSidebar } from "./tool-cards.ts";
+
+describe("tool-cards sidebar", () => {
+  it("shows full command plus output in sidebar while card detail remains truncated", () => {
+    const longCommand = `python3 ~/.openclaw/workspace/skills/node-cluster-3.connector/scripts/main.py invoke wangjx-node-host system.run --raw-command '${"x".repeat(220)}'`;
+    const onOpenSidebar = vi.fn();
+    const card: ToolCard = {
+      kind: "result",
+      name: "exec",
+      args: { command: longCommand, cwd: "/tmp/demo", timeoutMs: 5000 },
+      text: "command output line 1\ncommand output line 2",
+    };
+
+    const container = document.createElement("div");
+    render(renderToolCardSidebar(card, onOpenSidebar), container);
+
+    const detail = container.querySelector(".chat-tool-card__detail");
+    expect(detail?.textContent).toContain("…");
+
+    const clickable = container.querySelector(".chat-tool-card") as HTMLElement;
+    clickable.click();
+
+    expect(onOpenSidebar).toHaveBeenCalledTimes(1);
+    const content = onOpenSidebar.mock.calls[0][0] as string;
+    expect(content).toContain(longCommand);
+    expect(content).toContain('"cwd": "/tmp/demo"');
+    expect(content).toContain("command output line 1");
+    expect(content).toContain("**Command:**");
+    expect(content).toContain("**Args:**");
+  });
+
+  it("shows full args and explicit no-output note when no command exists", () => {
+    const onOpenSidebar = vi.fn();
+    const card: ToolCard = {
+      kind: "result",
+      name: "read",
+      args: { path: "/tmp/file.txt", offset: 10, limit: 5 },
+    };
+
+    const container = document.createElement("div");
+    render(renderToolCardSidebar(card, onOpenSidebar), container);
+    (container.querySelector(".chat-tool-card") as HTMLElement).click();
+
+    const content = onOpenSidebar.mock.calls[0][0] as string;
+    expect(content).toContain("**Args:**");
+    expect(content).toContain('"path": "/tmp/file.txt"');
+    expect(content).toContain("No output — tool completed successfully");
+  });
+});

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -16,17 +16,31 @@ export function extractToolCards(message: unknown): ToolCard[] {
   const content = normalizeContent(m.content);
   const cards: ToolCard[] = [];
 
+  // Build lookup maps from tool calls for result-card arg pairing
+  const argsByToolCallId = new Map<string, unknown>();
+  const argsByName = new Map<string, unknown>();
+
   for (const item of content) {
     const kind = (typeof item.type === "string" ? item.type : "").toLowerCase();
     const isToolCall =
       ["toolcall", "tool_call", "tooluse", "tool_use"].includes(kind) ||
       (typeof item.name === "string" && item.arguments != null);
     if (isToolCall) {
+      const name = (item.name as string) ?? "tool";
+      const args = coerceArgs(item.arguments ?? item.args);
       cards.push({
         kind: "call",
-        name: (item.name as string) ?? "tool",
-        args: coerceArgs(item.arguments ?? item.args),
+        name,
+        args,
       });
+      // Index by toolCallId if present
+      const toolCallId =
+        (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
+      if (toolCallId) {
+        argsByToolCallId.set(toolCallId, args);
+      }
+      // Also index by name (last wins for same name)
+      argsByName.set(name, args);
     }
   }
 
@@ -37,10 +51,23 @@ export function extractToolCards(message: unknown): ToolCard[] {
     }
     const text = extractToolText(item);
     const name = typeof item.name === "string" ? item.name : "tool";
+    // Try to get args from the result block first, then look up paired tool call
+    let args = coerceArgs(item.arguments ?? item.args);
+    if (args === undefined || args === null) {
+      // Try matching by toolCallId first
+      const toolCallId =
+        (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
+      if (toolCallId && argsByToolCallId.has(toolCallId)) {
+        args = argsByToolCallId.get(toolCallId);
+      } else if (argsByName.has(name)) {
+        // Fallback to name-based matching
+        args = argsByName.get(name);
+      }
+    }
     cards.push({
       kind: "result",
       name,
-      args: coerceArgs(item.arguments ?? item.args),
+      args,
       text,
     });
   }
@@ -51,7 +78,12 @@ export function extractToolCards(message: unknown): ToolCard[] {
       (typeof m.tool_name === "string" && m.tool_name) ||
       "tool";
     const text = extractTextCached(message) ?? undefined;
-    cards.push({ kind: "result", name, text, args: coerceArgs(m.arguments ?? m.args) });
+    // Also try to look up args from any prior tool call by name
+    let args = coerceArgs(m.arguments ?? m.args);
+    if ((args === undefined || args === null) && argsByName.has(name)) {
+      args = argsByName.get(name);
+    }
+    cards.push({ kind: "result", name, text, args });
   }
 
   return cards;
@@ -60,12 +92,13 @@ export function extractToolCards(message: unknown): ToolCard[] {
 export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: string) => void) {
   const display = resolveToolDisplay({ name: card.name, args: card.args });
   const detail = formatToolDetail(display);
-  const argsSections = formatToolArgsForSidebar(card.args);
   const hasText = Boolean(card.text?.trim());
 
   const canClick = Boolean(onOpenSidebar);
   const handleClick = canClick
     ? () => {
+        // Lazy compute args sections only when sidebar is opened
+        const argsSections = formatToolArgsForSidebar(card.args);
         const headerParts = [`## ${display.label}`];
         if (argsSections.length > 0) {
           headerParts.push(

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -5,7 +5,11 @@ import type { ToolCard } from "../types/chat-types.ts";
 import { TOOL_INLINE_THRESHOLD } from "./constants.ts";
 import { extractTextCached } from "./message-extract.ts";
 import { isToolResultMessage } from "./message-normalizer.ts";
-import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
+import {
+  formatToolArgsForSidebar,
+  formatToolOutputForSidebar,
+  getTruncatedPreview,
+} from "./tool-helpers.ts";
 
 export function extractToolCards(message: unknown): ToolCard[] {
   const m = message as Record<string, unknown>;
@@ -33,7 +37,12 @@ export function extractToolCards(message: unknown): ToolCard[] {
     }
     const text = extractToolText(item);
     const name = typeof item.name === "string" ? item.name : "tool";
-    cards.push({ kind: "result", name, text });
+    cards.push({
+      kind: "result",
+      name,
+      args: coerceArgs(item.arguments ?? item.args),
+      text,
+    });
   }
 
   if (isToolResultMessage(message) && !cards.some((card) => card.kind === "result")) {
@@ -42,7 +51,7 @@ export function extractToolCards(message: unknown): ToolCard[] {
       (typeof m.tool_name === "string" && m.tool_name) ||
       "tool";
     const text = extractTextCached(message) ?? undefined;
-    cards.push({ kind: "result", name, text });
+    cards.push({ kind: "result", name, text, args: coerceArgs(m.arguments ?? m.args) });
   }
 
   return cards;
@@ -51,19 +60,26 @@ export function extractToolCards(message: unknown): ToolCard[] {
 export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: string) => void) {
   const display = resolveToolDisplay({ name: card.name, args: card.args });
   const detail = formatToolDetail(display);
+  const argsSections = formatToolArgsForSidebar(card.args);
   const hasText = Boolean(card.text?.trim());
 
   const canClick = Boolean(onOpenSidebar);
   const handleClick = canClick
     ? () => {
+        const headerParts = [`## ${display.label}`];
+        if (argsSections.length > 0) {
+          headerParts.push(
+            ...argsSections.map((section) => `**${section.label}:**\n${section.body}`),
+          );
+        } else if (detail) {
+          headerParts.push(`**Command:** \`${detail}\``);
+        }
+        const header = `${headerParts.join("\n\n")}\n\n`;
         if (hasText) {
-          onOpenSidebar!(formatToolOutputForSidebar(card.text!));
+          onOpenSidebar!(`${header}${formatToolOutputForSidebar(card.text!)}`);
           return;
         }
-        const info = `## ${display.label}\n\n${
-          detail ? `**Command:** \`${detail}\`\n\n` : ""
-        }*No output — tool completed successfully.*`;
-        onOpenSidebar!(info);
+        onOpenSidebar!(`${header}*No output — tool completed successfully.*`);
       }
     : undefined;
 

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -18,7 +18,8 @@ export function extractToolCards(message: unknown): ToolCard[] {
 
   // Build lookup maps from tool calls for result-card arg pairing
   const argsByToolCallId = new Map<string, unknown>();
-  const argsByName = new Map<string, unknown>();
+  // Use per-name queue for ordered matching (FIFO) instead of last-wins
+  const argsQueueByName = new Map<string, unknown[]>();
 
   for (const item of content) {
     const kind = (typeof item.type === "string" ? item.type : "").toLowerCase();
@@ -39,8 +40,11 @@ export function extractToolCards(message: unknown): ToolCard[] {
       if (toolCallId) {
         argsByToolCallId.set(toolCallId, args);
       }
-      // Also index by name (last wins for same name)
-      argsByName.set(name, args);
+      // Push to per-name queue for ordered matching
+      if (!argsQueueByName.has(name)) {
+        argsQueueByName.set(name, []);
+      }
+      argsQueueByName.get(name)!.push(args);
     }
   }
 
@@ -59,9 +63,12 @@ export function extractToolCards(message: unknown): ToolCard[] {
         (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
       if (toolCallId && argsByToolCallId.has(toolCallId)) {
         args = argsByToolCallId.get(toolCallId);
-      } else if (argsByName.has(name)) {
-        // Fallback to name-based matching
-        args = argsByName.get(name);
+      } else if (argsQueueByName.has(name)) {
+        // FIFO: shift from per-name queue for ordered matching
+        const queue = argsQueueByName.get(name)!;
+        if (queue.length > 0) {
+          args = queue.shift();
+        }
       }
     }
     cards.push({
@@ -78,10 +85,13 @@ export function extractToolCards(message: unknown): ToolCard[] {
       (typeof m.tool_name === "string" && m.tool_name) ||
       "tool";
     const text = extractTextCached(message) ?? undefined;
-    // Also try to look up args from any prior tool call by name
+    // Also try to look up args from any prior tool call by name (FIFO)
     let args = coerceArgs(m.arguments ?? m.args);
-    if ((args === undefined || args === null) && argsByName.has(name)) {
-      args = argsByName.get(name);
+    if ((args === undefined || args === null) && argsQueueByName.has(name)) {
+      const queue = argsQueueByName.get(name)!;
+      if (queue.length > 0) {
+        args = queue.shift();
+      }
     }
     cards.push({ kind: "result", name, text, args });
   }

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -57,18 +57,29 @@ export function extractToolCards(message: unknown): ToolCard[] {
     const name = typeof item.name === "string" ? item.name : "tool";
     // Try to get args from the result block first, then look up paired tool call
     let args = coerceArgs(item.arguments ?? item.args);
-    if (args === undefined || args === null) {
-      // Try matching by toolCallId first
-      const toolCallId =
-        (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
-      if (toolCallId && argsByToolCallId.has(toolCallId)) {
-        args = argsByToolCallId.get(toolCallId);
-      } else if (argsQueueByName.has(name)) {
-        // FIFO: shift from per-name queue for ordered matching
+    // Try matching by toolCallId first
+    const toolCallId =
+      (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
+    if (toolCallId && argsByToolCallId.has(toolCallId)) {
+      args = argsByToolCallId.get(toolCallId);
+    } else if (args === undefined || args === null) {
+      // Only use queue fallback if we don't have args yet
+      if (argsQueueByName.has(name)) {
         const queue = argsQueueByName.get(name)!;
         if (queue.length > 0) {
           args = queue.shift();
         }
+      }
+    }
+    // Always consume matching queue entry to keep queue in sync
+    // (for results matched by toolCallId or with their own args)
+    if (argsQueueByName.has(name)) {
+      const queue = argsQueueByName.get(name)!;
+      // Find and remove the args we matched (by reference or position)
+      // For toolCallId match, remove the first entry (FIFO preserves order)
+      // For own-args, also remove first to keep queue aligned with call order
+      if (queue.length > 0) {
+        queue.shift();
       }
     }
     cards.push({

--- a/ui/src/ui/chat/tool-helpers.test.ts
+++ b/ui/src/ui/chat/tool-helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
+import {
+  formatToolArgsForSidebar,
+  formatToolOutputForSidebar,
+  getTruncatedPreview,
+} from "./tool-helpers.ts";
 
 describe("tool-helpers", () => {
   describe("formatToolOutputForSidebar", () => {
@@ -77,6 +81,47 @@ describe("tool-helpers", () => {
     });
   });
 
+  describe("formatToolArgsForSidebar", () => {
+    it("formats full command as shell block", () => {
+      const result = formatToolArgsForSidebar({ command: "python3 script.py --flag long-value" });
+      expect(result).toEqual([
+        {
+          label: "Command",
+          body: "```shell\npython3 script.py --flag long-value\n```",
+        },
+      ]);
+    });
+
+    it("preserves sibling args when command exists", () => {
+      const result = formatToolArgsForSidebar({
+        command: "python3 script.py --flag long-value",
+        cwd: "/tmp/demo",
+        timeoutMs: 5000,
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        label: "Command",
+        body: "```shell\npython3 script.py --flag long-value\n```",
+      });
+      expect(result[1]?.label).toBe("Args");
+      expect(result[1]?.body).toContain('"cwd": "/tmp/demo"');
+      expect(result[1]?.body).toContain('"timeoutMs": 5000');
+    });
+
+    it("uses longer fence when command contains triple backticks", () => {
+      const result = formatToolArgsForSidebar({ command: "echo ```hello```" });
+      expect(result[0]?.body).toBe("````shell\necho ```hello```\n````");
+    });
+
+    it("formats non-command args as json block", () => {
+      const result = formatToolArgsForSidebar({ path: "/tmp/demo", recursive: true });
+      expect(result[0]?.label).toBe("Args");
+      expect(result[0]?.body).toContain("```json");
+      expect(result[0]?.body).toContain('"path": "/tmp/demo"');
+      expect(result[0]?.body).toContain('"recursive": true');
+    });
+  });
+
   describe("getTruncatedPreview", () => {
     it("returns short text unchanged", () => {
       const input = "Short text";
@@ -97,7 +142,6 @@ describe("tool-helpers", () => {
       const input = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
       const result = getTruncatedPreview(input);
 
-      // Should only show first 2 lines (PREVIEW_MAX_LINES = 2)
       expect(result).toBe("Line 1\nLine 2…");
     });
 
@@ -129,12 +173,11 @@ describe("tool-helpers", () => {
     });
 
     it("truncates by chars even within line limit", () => {
-      // Two lines but very long content
       const longLine = "x".repeat(80);
       const input = `${longLine}\n${longLine}`;
       const result = getTruncatedPreview(input);
 
-      expect(result.length).toBe(101); // 100 + ellipsis
+      expect(result.length).toBe(101);
       expect(result.endsWith("…")).toBe(true);
     });
   });

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -5,7 +5,14 @@
 import { PREVIEW_MAX_CHARS, PREVIEW_MAX_LINES } from "./constants.ts";
 
 function fenceFor(text: string): string {
-  return text.includes("```") ? "````" : "```";
+  // Find longest run of consecutive backticks
+  const match = text.match(/`+/g);
+  if (!match) {
+    return "```";
+  }
+  const maxLen = Math.max(...match.map((s) => s.length));
+  // Use one more backtick than the longest run
+  return "`".repeat(maxLen + 1);
 }
 
 /**

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -4,6 +4,10 @@
 
 import { PREVIEW_MAX_CHARS, PREVIEW_MAX_LINES } from "./constants.ts";
 
+function fenceFor(text: string): string {
+  return text.includes("```") ? "````" : "```";
+}
+
 /**
  * Format tool output content for display in the sidebar.
  * Detects JSON and wraps it in a code block with formatting.
@@ -20,6 +24,71 @@ export function formatToolOutputForSidebar(text: string): string {
     }
   }
   return text;
+}
+
+export type SidebarArgsSection = {
+  label: "Command" | "Args";
+  body: string;
+};
+
+function jsonFence(value: unknown): string {
+  return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``.replace(/\`/g, "`");
+}
+
+/**
+ * Format full tool args for display in the sidebar.
+ * When a command exists, preserve it as a dedicated full command section and
+ * also keep any sibling args (cwd/env/etc) in a separate Args section.
+ */
+export function formatToolArgsForSidebar(args: unknown): SidebarArgsSection[] {
+  if (args === null || args === undefined) {
+    return [];
+  }
+
+  if (typeof args === "object") {
+    const record = args as Record<string, unknown>;
+    const sections: SidebarArgsSection[] = [];
+    if (typeof record.command === "string") {
+      const cmd = record.command;
+      const fence = fenceFor(cmd);
+      sections.push({
+        label: "Command",
+        body: `${fence}shell\n${cmd}\n${fence}`,
+      });
+      const rest = Object.fromEntries(Object.entries(record).filter(([key]) => key !== "command"));
+      if (Object.keys(rest).length > 0) {
+        sections.push({
+          label: "Args",
+          body: jsonFence(rest),
+        });
+      }
+      return sections;
+    }
+
+    return [
+      {
+        label: "Args",
+        body: jsonFence(args),
+      },
+    ];
+  }
+
+  if (typeof args === "string") {
+    const fence = fenceFor(args);
+    return [
+      {
+        label: "Args",
+        body: `${fence}\n${args}\n${fence}`,
+      },
+    ];
+  }
+
+  return [
+    {
+      label: "Args",
+      body: jsonFence(args),
+    },
+  ];
 }
 
 /**

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -11,8 +11,9 @@ function fenceFor(text: string): string {
     return "```";
   }
   const maxLen = Math.max(...match.map((s) => s.length));
-  // Use one more backtick than the longest run
-  return "`".repeat(maxLen + 1);
+  // Use one more backtick than the longest run, minimum 3
+  const fenceLen = Math.max(3, maxLen + 1);
+  return "`".repeat(fenceLen);
 }
 
 /**

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -32,7 +32,9 @@ export type SidebarArgsSection = {
 };
 
 function jsonFence(value: unknown): string {
-  return "```json\n" + JSON.stringify(value, null, 2) + "\n```";
+  const body = JSON.stringify(value, null, 2);
+  const fence = fenceFor(body);
+  return `${fence}json\n${body}\n${fence}`;
 }
 
 /**

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -32,7 +32,7 @@ export type SidebarArgsSection = {
 };
 
 function jsonFence(value: unknown): string {
-  return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``.replace(/\`/g, "`");
+  return "```json\n" + JSON.stringify(value, null, 2) + "\n```";
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Problem:** The chat tool card sidebar did not show the full long exec command. When a tool result had output, the sidebar only displayed the output text without the command/args section.
- **Why it matters:** Users could not inspect the full command used for long exec tool calls in the sidebar, making debugging difficult.
- **What changed:** 
  - Added `formatToolArgsForSidebar()` helper to render untruncated command and all sibling args (cwd, timeout, env, etc.)
  - Sidebar now shows a dedicated **Command** section (shell code block) plus an **Args** section when additional fields exist
  - In-card detail remains truncated for compactness; only sidebar shows full fidelity
- **What did NOT change:** Card preview behavior, markdown rendering, or output formatting

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue

- Closes #43153

## User-visible / Behavior Changes

- Clicking a tool card now opens a sidebar showing:
  - Full command (untruncated, shell code block)
  - All additional args (cwd, timeout, env, etc.) in JSON format
  - Tool output (if any)
- Card preview in chat remains truncated for compactness

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux 6.1.0-43-cloud-amd64 (x64)
- Runtime/container: Node v24.14.0
- Integration/channel: OpenClaw UI (browser tests)

### Steps

1. Open chat with a tool result that has a long command (>200 chars)
2. Click on the tool card to open sidebar
3. Observe sidebar content

### Expected

- Sidebar shows full command in shell code block
- Sidebar shows additional args (cwd, timeout, etc.) in JSON section
- Card detail remains truncated with ellipsis

### Actual

- Before fix: Sidebar only showed output, no command section
- After fix: Sidebar shows full command + args + output

## Evidence

- [x] Unit tests added/updated
  - `ui/src/ui/chat/tool-helpers.test.ts`: 21 tests for formatting helpers
  - `ui/src/ui/chat/tool-cards.test.ts`: 2 browser tests for sidebar content

## Human Verification

- Verified scenarios: Long command with output, command with sibling args (cwd/timeout), non-exec tools with only args
- Edge cases checked: Commands with backticks, JSON output formatting, truncated in-card detail vs full sidebar
- What I did NOT verify: Production deployment with real provider backends (only local test suite)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery

- How to disable/revert: Revert this commit
- Files/config to restore: None
- Known bad symptoms: Sidebar would revert to showing only output without command/args section

## Risks and Mitigations

- Risk: Sidebar content may be very long for tools with huge commands/args
  - Mitigation: Markdown code blocks naturally scroll; future enhancement could add collapse/expand