### PR TITLE
fix(reply): reset sessions after all-model timeout failures

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -478,6 +478,7 @@ export async function runAgentTurnWithFallback(params: {
       if (
         embeddedError &&
         isTimeoutError(embeddedError.message) &&
+        !params.isHeartbeat &&
         !didResetAfterTimeout &&
         (await params.resetSessionAfterTimeout(embeddedError.message))
       ) {
@@ -524,20 +525,6 @@ export async function runAgentTurnWithFallback(params: {
           };
         }
       }
-      if (
-        isTimeoutFailure &&
-        !didResetAfterTimeout &&
-        (await params.resetSessionAfterTimeout(message))
-      ) {
-        didResetAfterTimeout = true;
-        return {
-          kind: "final",
-          payload: {
-            text: TIMEOUT_RESET_REPLY_TEXT,
-          },
-        };
-      }
-
       // Auto-recover from Gemini session corruption by resetting the session
       if (
         isSessionCorruption &&
@@ -583,12 +570,11 @@ export async function runAgentTurnWithFallback(params: {
         };
       }
 
+      // Let transient HTTP errors (502/504/521) retry before considering a
+      // session reset — these are often temporary and do not indicate a
+      // session-bloat death spiral.
       if (isTransientHttp && !didRetryTransientHttpError) {
         didRetryTransientHttpError = true;
-        // Retry the full runWithModelFallback() cycle — transient errors
-        // (502/521/etc.) typically affect the whole provider, so falling
-        // back to an alternate model first would not help. Instead we wait
-        // and retry the complete primary→fallback chain.
         defaultRuntime.error(
           `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
         );
@@ -596,6 +582,25 @@ export async function runAgentTurnWithFallback(params: {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
         });
         continue;
+      }
+
+      // Only reset session for definitive timeouts: skip heartbeat turns
+      // (background pings should not discard conversation history) and skip
+      // transient HTTP errors (already retried above).
+      if (
+        isTimeoutFailure &&
+        !isTransientHttp &&
+        !params.isHeartbeat &&
+        !didResetAfterTimeout &&
+        (await params.resetSessionAfterTimeout(message))
+      ) {
+        didResetAfterTimeout = true;
+        return {
+          kind: "final",
+          payload: {
+            text: TIMEOUT_RESET_REPLY_TEXT,
+          },
+        };
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
+import { isTimeoutError } from "../../agents/failover-error.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
@@ -90,6 +91,7 @@ export async function runAgentTurnWithFallback(params: {
   pendingToolTasks: Set<Promise<void>>;
   resetSessionAfterCompactionFailure: (reason: string) => Promise<boolean>;
   resetSessionAfterRoleOrderingConflict: (reason: string) => Promise<boolean>;
+  resetSessionAfterTimeout: (reason: string) => Promise<boolean>;
   isHeartbeat: boolean;
   sessionKey?: string;
   getActiveSessionEntry: () => SessionEntry | undefined;
@@ -98,6 +100,10 @@ export async function runAgentTurnWithFallback(params: {
   resolvedVerboseLevel: VerboseLevel;
 }): Promise<AgentRunLoopResult> {
   const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
+  const TIMEOUT_RESET_REPLY_TEXT =
+    "⏱️ The last request timed out. I've reset the conversation to a fresh session - please send it again.";
+  const TIMEOUT_RETRY_FALLBACK_TEXT =
+    "⏱️ The last request timed out. Please try again or use /new to start a fresh session.";
   let didLogHeartbeatStrip = false;
   let autoCompactionCompleted = false;
   // Track payloads sent directly (not via pipeline) during tool flush to avoid duplicates.
@@ -124,6 +130,7 @@ export async function runAgentTurnWithFallback(params: {
   let fallbackModel = params.followupRun.run.model;
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
   let didResetAfterCompactionFailure = false;
+  let didResetAfterTimeout = false;
   let didRetryTransientHttpError = false;
 
   while (true) {
@@ -468,6 +475,20 @@ export async function runAgentTurnWithFallback(params: {
           };
         }
       }
+      if (
+        embeddedError &&
+        isTimeoutError(embeddedError.message) &&
+        !didResetAfterTimeout &&
+        (await params.resetSessionAfterTimeout(embeddedError.message))
+      ) {
+        didResetAfterTimeout = true;
+        return {
+          kind: "final",
+          payload: {
+            text: TIMEOUT_RESET_REPLY_TEXT,
+          },
+        };
+      }
 
       break;
     } catch (err) {
@@ -476,6 +497,7 @@ export async function runAgentTurnWithFallback(params: {
       const isCompactionFailure = isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
+      const isTimeoutFailure = isTimeoutError(err);
       const isTransientHttp = isTransientHttpError(message);
 
       if (
@@ -501,6 +523,19 @@ export async function runAgentTurnWithFallback(params: {
             },
           };
         }
+      }
+      if (
+        isTimeoutFailure &&
+        !didResetAfterTimeout &&
+        (await params.resetSessionAfterTimeout(message))
+      ) {
+        didResetAfterTimeout = true;
+        return {
+          kind: "final",
+          payload: {
+            text: TIMEOUT_RESET_REPLY_TEXT,
+          },
+        };
       }
 
       // Auto-recover from Gemini session corruption by resetting the session
@@ -572,7 +607,9 @@ export async function runAgentTurnWithFallback(params: {
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+          : isTimeoutFailure
+            ? TIMEOUT_RETRY_FALLBACK_TEXT
+            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -1516,6 +1516,47 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("does not reset session on timeout during heartbeat turns", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-heartbeat-timeout";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const sessionEntry = { sessionId, updatedAt: Date.now(), sessionFile: transcriptPath };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "ok", "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error(
+          "All models failed (3): openai-codex/gpt-5.3-codex: LLM request timed out.",
+        );
+      });
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: true },
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+
+      // Heartbeat timeout should NOT reset the session
+      expect(sessionStore.main.sessionId).toBe(sessionId);
+      const payload = Array.isArray(res) ? res[0] : res;
+      expect(payload).toMatchObject({
+        text: expect.stringContaining("timed out"),
+      });
+      // Should get the fallback text, not the reset text
+      expect(payload).toMatchObject({
+        text: expect.not.stringContaining("reset"),
+      });
+    });
+  });
+
   it("rewrites Bun socket errors into friendly text", async () => {
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
       payloads: [

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -1284,6 +1284,95 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("resets the session after timeout errors", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-timeout";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const sessionEntry = { sessionId, updatedAt: Date.now(), sessionFile: transcriptPath };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "ok", "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error(
+          "All models failed (3): openai-codex/gpt-5.3-codex: LLM request timed out.",
+        );
+      });
+
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+
+      const payload = Array.isArray(res) ? res[0] : res;
+      expect(payload).toMatchObject({
+        text: expect.stringContaining("timed out"),
+      });
+      if (!payload) {
+        throw new Error("expected payload");
+      }
+      expect(payload.text?.toLowerCase()).toContain("reset");
+      expect(sessionStore.main.sessionId).not.toBe(sessionId);
+
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main.sessionId).toBe(sessionStore.main.sessionId);
+    });
+  });
+
+  it("resets the session after timeout errors surfaced in meta.error", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-timeout-meta";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const sessionEntry = { sessionId, updatedAt: Date.now(), sessionFile: transcriptPath };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "ok", "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+        payloads: [{ text: "timed out", isError: true }],
+        meta: {
+          durationMs: 1,
+          error: {
+            kind: "timeout",
+            message: "All models failed (3): openai-codex/gpt-5.3-codex: LLM request timed out.",
+          },
+        },
+      }));
+
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+
+      const payload = Array.isArray(res) ? res[0] : res;
+      expect(payload).toMatchObject({
+        text: expect.stringContaining("timed out"),
+      });
+      if (!payload) {
+        throw new Error("expected payload");
+      }
+      expect(payload.text?.toLowerCase()).toContain("reset");
+      expect(sessionStore.main.sessionId).not.toBe(sessionId);
+
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main.sessionId).toBe(sessionStore.main.sessionId);
+    });
+  });
+
   it("resets corrupted Gemini sessions and deletes transcripts", async () => {
     await withTempStateDir(async (stateDir) => {
       const { storePath, sessionEntry, sessionStore, transcriptPath } =
@@ -1406,6 +1495,24 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     expect(res).toMatchObject({
       text: expect.not.stringContaining("400"),
+    });
+  });
+
+  it("returns friendly message for timeout errors when session reset is unavailable", async () => {
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      throw new Error("All models failed (3): openai-codex/gpt-5.3-codex: LLM request timed out.");
+    });
+
+    const { run } = createMinimalRun({
+      sessionKey: "",
+    });
+    const res = await run();
+
+    expect(res).toMatchObject({
+      text: expect.stringContaining("timed out"),
+    });
+    expect(res).toMatchObject({
+      text: expect.not.stringContaining("Agent failed before reply"),
     });
   });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -362,6 +362,12 @@ export async function runReplyAgent(params: {
         `Role ordering conflict (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
       cleanupTranscripts: true,
     });
+  const resetSessionAfterTimeout = async (reason: string): Promise<boolean> =>
+    resetSession({
+      failureLabel: "timeout",
+      buildLogMessage: (nextSessionId) =>
+        `Request timed out (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
+    });
   try {
     const runStartedAt = Date.now();
     const runOutcome = await runAgentTurnWithFallback({
@@ -380,6 +386,7 @@ export async function runReplyAgent(params: {
       pendingToolTasks,
       resetSessionAfterCompactionFailure,
       resetSessionAfterRoleOrderingConflict,
+      resetSessionAfterTimeout,
       isHeartbeat,
       sessionKey,
       getActiveSessionEntry: () => activeSessionEntry,


### PR DESCRIPTION
## Problem
When every model in the fallback chain times out, `runReplyAgent` currently leaves the conversation on the same session and returns a generic failure. The next user message then retries the same bloated or stuck session and can keep looping indefinitely.

Fixes #20910.

## What this changes
- detect timeout failures in the embedded fallback runner
- reset the session before replying so the next retry starts from a fresh transcript
- return a user-facing retry message after the reset succeeds
- add focused coverage for the timeout-reset path

## Why here
`runReplyAgent` already auto-recovers from compaction failures and role-order corruption by rotating the session. Timeout-driven session death spirals are the same class of failure: retrying on the same session is usually the wrong thing to do.

## Testing
- pnpm exec vitest run --config vitest.unit.config.ts src/auto-reply/reply/agent-runner.runreplyagent.test.ts