### PR TITLE
fix(agents): decouple completion announce and spawn wait semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # Pin PR runs to the synthetic merge ref to avoid flaky SHA fetch auth on some runners.
+          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
           fetch-depth: 1
           fetch-tags: false
           submodules: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,10 +341,9 @@ importers:
       google-auth-library:
         specifier: ^10.6.1
         version: 10.6.1
-    devDependencies:
       openclaw:
-        specifier: workspace:*
-        version: link:../..
+        specifier: '>=2026.3.7'
+        version: 2026.3.8(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.7)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -402,10 +401,10 @@ importers:
         version: 4.3.6
 
   extensions/memory-core:
-    devDependencies:
+    dependencies:
       openclaw:
-        specifier: workspace:*
-        version: link:../..
+        specifier: '>=2026.3.7'
+        version: 2026.3.8(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.7)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/memory-lancedb:
     dependencies:
@@ -5525,6 +5524,14 @@ packages:
         optional: true
       zod:
         optional: true
+
+  openclaw@2026.3.8:
+    resolution: {integrity: sha512-e5Rk2Aj55sD/5LyX94mdYCQj7zpHXo0xIZsl+k140+nRopePfPAxC7nsu0V/NyypPRtaotP1riFfzK7IhaYkuQ==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.89
+      node-llama-cpp: 3.16.2
 
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
@@ -12830,6 +12837,81 @@ snapshots:
     optionalDependencies:
       ws: 8.19.0
       zod: 4.3.6
+
+  openclaw@2026.3.8(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.7)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.15.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock': 3.1007.0
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.7)(opusscript@0.1.1)
+      '@clack/prompts': 1.1.0
+      '@discordjs/voice': 0.19.1(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@grammyjs/runner': 2.0.3(grammy@1.41.1)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.1)
+      '@homebridge/ciao': 1.3.5
+      '@larksuiteoapi/node-sdk': 1.59.0
+      '@line/bot-sdk': 10.6.0
+      '@lydell/node-pty': 1.2.0-beta.3
+      '@mariozechner/pi-agent-core': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.57.1
+      '@mozilla/readability': 0.6.0
+      '@napi-rs/canvas': 0.1.95
+      '@sinclair/typebox': 0.34.48
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/web-api': 7.14.1
+      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      ajv: 8.18.0
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      cli-highlight: 2.1.11
+      commander: 14.0.3
+      croner: 10.0.1
+      discord-api-types: 0.38.42
+      dotenv: 17.3.1
+      express: 5.2.1
+      file-type: 21.3.1
+      grammy: 1.41.1
+      https-proxy-agent: 7.0.6
+      ipaddr.js: 2.3.0
+      jiti: 2.6.1
+      json5: 2.2.3
+      jszip: 3.10.1
+      linkedom: 0.18.12
+      long: 5.3.2
+      markdown-it: 14.1.1
+      node-edge-tts: 1.2.10
+      node-llama-cpp: 3.16.2(typescript@5.9.3)
+      opusscript: 0.1.1
+      osc-progress: 0.3.0
+      pdfjs-dist: 5.5.207
+      playwright-core: 1.58.2
+      qrcode-terminal: 0.12.0
+      sharp: 0.34.5
+      sqlite-vec: 0.1.7-alpha.2
+      tar: 7.5.11
+      tslog: 4.10.2
+      undici: 7.22.0
+      ws: 8.19.0
+      yaml: 2.8.2
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - '@modelcontextprotocol/sdk'
+      - '@types/express'
+      - audio-decode
+      - aws-crt
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - ffmpeg-static
+      - hono
+      - jimp
+      - link-preview-js
+      - node-opus
+      - supports-color
+      - utf-8-validate
 
   opus-decoder@0.7.11:
     dependencies:

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.cron-note.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.cron-note.test.ts
@@ -4,10 +4,14 @@ import {
   getCallGatewayMock,
   getSessionsSpawnTool,
   resetSessionsSpawnConfigOverride,
+  setSessionsSpawnConfigOverride,
   setupSessionsSpawnGatewayMock,
 } from "./openclaw-tools.subagents.sessions-spawn.test-harness.js";
 import { resetSubagentRegistryForTests } from "./subagent-registry.js";
-import { SUBAGENT_SPAWN_ACCEPTED_NOTE } from "./subagent-spawn.js";
+import {
+  SUBAGENT_SPAWN_FIRE_AND_FORGET_NOTE,
+  SUBAGENT_SPAWN_WAIT_FOR_CHILDREN_NOTE,
+} from "./subagent-spawn.js";
 
 const callGatewayMock = getCallGatewayMock();
 
@@ -20,7 +24,7 @@ describe("sessions_spawn: cron isolated session note suppression", () => {
     resetSessionsSpawnConfigOverride();
   });
 
-  it("suppresses ACCEPTED_NOTE for cron isolated sessions (mode=run)", async () => {
+  it("suppresses note for cron isolated sessions (mode=run)", async () => {
     setupSessionsSpawnGatewayMock({});
     const tool = await getSessionsSpawnTool({
       agentSessionKey: "agent:main:cron:dd871818:run:cf959c9f",
@@ -31,18 +35,32 @@ describe("sessions_spawn: cron isolated session note suppression", () => {
     expect(details.status).toBe("accepted");
   });
 
-  it("preserves ACCEPTED_NOTE for regular sessions (mode=run)", async () => {
+  it("returns fire-and-forget note for top-level regular run sessions", async () => {
     setupSessionsSpawnGatewayMock({});
     const tool = await getSessionsSpawnTool({
       agentSessionKey: "agent:main:telegram:63448508",
     });
     const result = await tool.execute("call-regular-run", { task: "test task", mode: "run" });
     const details = result.details as SpawnResult;
-    expect(details.note).toBe(SUBAGENT_SPAWN_ACCEPTED_NOTE);
+    expect(details.note).toBe(SUBAGENT_SPAWN_FIRE_AND_FORGET_NOTE);
     expect(details.status).toBe("accepted");
   });
 
-  it("does not suppress ACCEPTED_NOTE for non-canonical cron-like keys", async () => {
+  it("keeps wait-for-children note for nested subagent orchestrators", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
+    });
+    setupSessionsSpawnGatewayMock({});
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:main:subagent:parent-worker",
+    });
+    const result = await tool.execute("call-subagent-run", { task: "test task", mode: "run" });
+    expect((result.details as SpawnResult).status).toBe("accepted");
+    expect((result.details as SpawnResult).note).toBe(SUBAGENT_SPAWN_WAIT_FOR_CHILDREN_NOTE);
+  });
+
+  it("does not suppress note for non-canonical cron-like keys", async () => {
     setupSessionsSpawnGatewayMock({});
     const tool = await getSessionsSpawnTool({
       agentSessionKey: "agent:main:slack:cron:job:run:uuid",
@@ -51,15 +69,15 @@ describe("sessions_spawn: cron isolated session note suppression", () => {
       task: "test task",
       mode: "run",
     });
-    expect((result.details as SpawnResult).note).toBe(SUBAGENT_SPAWN_ACCEPTED_NOTE);
+    expect((result.details as SpawnResult).note).toBe(SUBAGENT_SPAWN_FIRE_AND_FORGET_NOTE);
   });
 
-  it("does not suppress note when agentSessionKey is undefined", async () => {
+  it("returns fire-and-forget note when agentSessionKey is undefined", async () => {
     setupSessionsSpawnGatewayMock({});
     const tool = await getSessionsSpawnTool({
       agentSessionKey: undefined,
     });
     const result = await tool.execute("call-no-key", { task: "test task", mode: "run" });
-    expect((result.details as SpawnResult).note).toBe(SUBAGENT_SPAWN_ACCEPTED_NOTE);
+    expect((result.details as SpawnResult).note).toBe(SUBAGENT_SPAWN_FIRE_AND_FORGET_NOTE);
   });
 });

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -8,7 +8,7 @@ import {
   setSessionsSpawnConfigOverride,
 } from "./openclaw-tools.subagents.sessions-spawn.test-harness.js";
 import { resetSubagentRegistryForTests } from "./subagent-registry.js";
-import { SUBAGENT_SPAWN_ACCEPTED_NOTE } from "./subagent-spawn.js";
+import { SUBAGENT_SPAWN_FIRE_AND_FORGET_NOTE } from "./subagent-spawn.js";
 
 const callGatewayMock = getCallGatewayMock();
 type GatewayCall = { method?: string; params?: unknown };
@@ -120,7 +120,7 @@ describe("openclaw-tools: subagents (sessions_spawn model + thinking)", () => {
     });
     expect(result.details).toMatchObject({
       status: "accepted",
-      note: SUBAGENT_SPAWN_ACCEPTED_NOTE,
+      note: SUBAGENT_SPAWN_FIRE_AND_FORGET_NOTE,
       modelApplied: true,
     });
 

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1762,6 +1762,25 @@ describe("subagent announce formatting", () => {
     );
   });
 
+  it("keeps top-level completion announce on acceptance-only delivery", async () => {
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(false);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-completion",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+      expectsCompletionMessage: true,
+      ...defaultOutcomeAnnounce,
+    });
+
+    expect(didAnnounce).toBe(true);
+    const call = agentSpy.mock.calls[0]?.[0] as { expectFinal?: boolean } | undefined;
+    expect(call?.expectFinal).toBe(false);
+  });
+
   it("retries reading subagent output when early lifecycle completion had no text", async () => {
     embeddedRunMock.isEmbeddedPiRunActive.mockReturnValueOnce(true).mockReturnValue(false);
     embeddedRunMock.waitForEmbeddedPiRunEnd.mockResolvedValue(true);

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -23,10 +23,19 @@ let fallbackRequesterResolution: {
   requesterSessionKey: string;
   requesterOrigin?: { channel?: string; to?: string; accountId?: string };
 } | null = null;
+let rejectFinalCompletionAnnounce = false;
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(async (request: GatewayCall) => {
     gatewayCalls.push(request);
+    if (
+      rejectFinalCompletionAnnounce &&
+      request.method === "agent" &&
+      request.expectFinal === true &&
+      request.params?.sessionKey === "agent:main:main"
+    ) {
+      throw new Error("unexpected final wait on requester session");
+    }
     if (request.method === "chat.history") {
       return { messages: [] };
     }
@@ -129,6 +138,7 @@ describe("subagent announce timeout config", () => {
     shouldIgnorePostCompletion = false;
     pendingDescendantRuns = 0;
     fallbackRequesterResolution = null;
+    rejectFinalCompletionAnnounce = false;
   });
 
   it("uses 60s timeout by default for direct announce agent call", async () => {
@@ -150,7 +160,7 @@ describe("subagent announce timeout config", () => {
     expect(directAgentCall?.timeoutMs).toBe(90_000);
   });
 
-  it("honors configured announce timeout for completion direct agent call", async () => {
+  it("does not wait for final completion delivery on top-level requester announces", async () => {
     setConfiguredAnnounceTimeout(90_000);
     await runAnnounceFlowForTest("run-config-timeout-send", {
       requesterOrigin: {
@@ -161,9 +171,28 @@ describe("subagent announce timeout config", () => {
     });
 
     const completionDirectAgentCall = findGatewayCall(
-      (call) => call.method === "agent" && call.expectFinal === true,
+      (call) => call.method === "agent" && call.params?.sessionKey === "agent:main:main",
     );
+    expect(completionDirectAgentCall?.expectFinal).toBe(false);
     expect(completionDirectAgentCall?.timeoutMs).toBe(90_000);
+  });
+
+  it("regression, completion announces succeed without waiting for a busy requester final turn", async () => {
+    rejectFinalCompletionAnnounce = true;
+
+    const didAnnounce = await runAnnounceFlowForTest("run-no-final-wait", {
+      requesterOrigin: {
+        channel: "discord",
+        to: "12345",
+      },
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    const completionDirectAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.params?.sessionKey === "agent:main:main",
+    );
+    expect(completionDirectAgentCall?.expectFinal).toBe(false);
   });
 
   it("regression, skips parent announce while descendants are still pending", async () => {
@@ -190,10 +219,11 @@ describe("subagent announce timeout config", () => {
 
     expect(didAnnounce).toBe(true);
     const directAgentCall = findGatewayCall(
-      (call) => call.method === "agent" && call.expectFinal === true,
+      (call) => call.method === "agent" && call.params?.sessionKey === "agent:main:main",
     );
     const internalEvents =
       (directAgentCall?.params?.internalEvents as Array<{ announceType?: string }>) ?? [];
+    expect(directAgentCall?.expectFinal).toBe(false);
     expect(internalEvents[0]?.announceType).toBe("cron job");
   });
 
@@ -210,6 +240,7 @@ describe("subagent announce timeout config", () => {
       (call) => call.method === "agent" && call.expectFinal === true,
     );
     expect(directAgentCall?.params?.sessionKey).toBe(cronSessionKey);
+    expect(directAgentCall?.expectFinal).toBe(true);
     expect(directAgentCall?.params?.deliver).toBe(false);
     expect(directAgentCall?.params?.channel).toBeUndefined();
     expect(directAgentCall?.params?.to).toBeUndefined();

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -785,6 +785,7 @@ async function sendSubagentAnnounceDirectly(params: {
         path: "none",
       };
     }
+    const waitForFinalDelivery = !params.expectsCompletionMessage || params.requesterIsSubagent;
     await runAnnounceDeliveryWithRetry({
       operation: params.expectsCompletionMessage
         ? "completion direct announce agent call"
@@ -811,7 +812,9 @@ async function sendSubagentAnnounceDirectly(params: {
             },
             idempotencyKey: params.directIdempotencyKey,
           },
-          expectFinal: true,
+          // Top-level completion announces should stop at gateway acceptance to avoid
+          // requester-lane blocking while a separate turn is already running.
+          expectFinal: waitForFinalDelivery,
           timeoutMs: announceTimeoutMs,
         }),
     });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -79,8 +79,12 @@ export type SpawnSubagentContext = {
   workspaceDir?: string;
 };
 
-export const SUBAGENT_SPAWN_ACCEPTED_NOTE =
+export const SUBAGENT_SPAWN_WAIT_FOR_CHILDREN_NOTE =
   "Auto-announce is push-based. After spawning children, do NOT call sessions_list, sessions_history, exec sleep, or any polling tool. Wait for completion events to arrive as user messages, track expected child session keys, and only send your final answer after ALL expected completions arrive. If a child completion event arrives AFTER your final answer, reply ONLY with NO_REPLY.";
+export const SUBAGENT_SPAWN_FIRE_AND_FORGET_NOTE =
+  "Auto-announce is push-based. Do not wait for child completions in this turn. Finish your current reply now, do not poll, and let completion updates arrive later as separate events.";
+// Backward-compatible alias retained for callers that still import the old constant name.
+export const SUBAGENT_SPAWN_ACCEPTED_NOTE = SUBAGENT_SPAWN_WAIT_FOR_CHILDREN_NOTE;
 export const SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE =
   "thread-bound session stays active after this task; continue in-thread for follow-ups.";
 
@@ -162,6 +166,22 @@ function resolveSpawnMode(params: {
   }
   // Thread-bound spawns should default to persistent sessions.
   return params.threadRequested ? "session" : "run";
+}
+
+function resolveSpawnAcceptedNote(params: {
+  spawnMode: SpawnSubagentMode;
+  isCronSession: boolean;
+  callerDepth: number;
+}): string | undefined {
+  if (params.spawnMode === "session") {
+    return SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE;
+  }
+  if (params.isCronSession) {
+    return undefined;
+  }
+  return params.callerDepth >= 1
+    ? SUBAGENT_SPAWN_WAIT_FOR_CHILDREN_NOTE
+    : SUBAGENT_SPAWN_FIRE_AND_FORGET_NOTE;
 }
 
 function summarizeError(err: unknown): string {
@@ -725,12 +745,11 @@ export async function spawnSubagentDirect(
   // because cron sessions end immediately after the agent produces a response,
   // so the agent needs to wait for subagent results to keep the turn alive.
   const isCronSession = isCronSessionKey(ctx.agentSessionKey);
-  const note =
-    spawnMode === "session"
-      ? SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE
-      : isCronSession
-        ? undefined
-        : SUBAGENT_SPAWN_ACCEPTED_NOTE;
+  const note = resolveSpawnAcceptedNote({
+    spawnMode,
+    isCronSession,
+    callerDepth,
+  });
 
   return {
     status: "accepted",


### PR DESCRIPTION
## Bug scenario
Two related session-flow bugs were causing unreliable orchestration under load:

1. **Completion announce stuck behind requester lane**
   - Trigger: child run finishes while requester main session already has an in-flight/queued turn.
   - Symptom: completion announce waits for requester final turn (`expectFinal: true`), then can hit the 60s timeout/retry path.

2. **Top-level `sessions_spawn(mode=run)` gives wrong waiting guidance**
   - Trigger: top-level/main session spawns a background run.
   - Symptom: accepted note still told callers to wait for all child completions in-turn, which is opposite of the intended fire-and-forget contract for top-level run mode.

## Why it bugged (root cause)
- `sendSubagentAnnounceDirectly(...)` used `expectFinal: true` for completion direct announce calls to requester sessions, coupling child completion success to requester lane drain.
- Spawn accepted-note selection did not differentiate top-level fire-and-forget run mode from nested orchestrator mode, so note semantics and runtime behavior diverged.

## Fix approach
- In `subagent-announce.ts`, make top-level completion announce acceptance-only (`expectFinal: false`) while keeping nested/subagent delivery paths on final-wait semantics.
- In `subagent-spawn.ts`, split accepted notes by context:
  - top-level run -> fire-and-forget note
  - nested subagent run -> wait-for-children note
  - session mode -> session note
  - canonical cron run session -> no note
- Add/update targeted tests to lock behavior:
  - spawn note routing
  - timeout semantics
  - formatting/e2e assertion for acceptance-only completion announce

## Verification
Ran on this branch:

```bash
/Users/programcaicai/clawd/projects/openclaw/node_modules/.bin/vitest run \
  src/agents/openclaw-tools.subagents.sessions-spawn.cron-note.test.ts \
  src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts \
  src/agents/subagent-announce.timeout.test.ts \
  src/agents/subagent-announce-dispatch.test.ts
# 4 files passed, 32 tests passed
```

```bash
/Users/programcaicai/clawd/projects/openclaw/node_modules/.bin/vitest \
  --config vitest.e2e.config.ts run \
  src/agents/subagent-announce.format.e2e.test.ts
# 1 file passed, 70 tests passed
```

## Scope boundaries
- No gateway restart/reload changes.
- No outbox redesign in this PR.
