### PR TITLE
fix(agents): enforce post-compaction retry start/end ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Docs: https://docs.openclaw.ai
 ## Unreleased
 
 ### Security
+
 - Security/exec approvals: escape invisible Unicode format characters in approval prompts so zero-width command text renders as visible `\u{...}` escapes instead of spoofing the reviewed command. (`GHSA-pcqg-f7rg-xfvv`)(#43687) Thanks @EkiXu and @vincentkoc.
 - Security/device pairing: cap issued and verified device-token scopes to each paired device's approved scope baseline so stale or overbroad tokens cannot exceed approved access. (`GHSA-2pwv-x786-56f8`)(#43686) Thanks @tdjackey and @vincentkoc.
 - Security/proxy attachments: restore the shared media-store size cap for persisted browser proxy files so oversized payloads are rejected instead of overriding the intended 5 MB limit. (`GHSA-6rph-mmhp-h7h9`)(#43684) Thanks @tdjackey and @vincentkoc.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,10 +341,9 @@ importers:
       google-auth-library:
         specifier: ^10.6.1
         version: 10.6.1
-    devDependencies:
       openclaw:
-        specifier: workspace:*
-        version: link:../..
+        specifier: '>=2026.3.7'
+        version: 2026.3.8(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.7)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -402,10 +401,10 @@ importers:
         version: 4.3.6
 
   extensions/memory-core:
-    devDependencies:
+    dependencies:
       openclaw:
-        specifier: workspace:*
-        version: link:../..
+        specifier: '>=2026.3.7'
+        version: 2026.3.8(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.7)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/memory-lancedb:
     dependencies:
@@ -5525,6 +5524,14 @@ packages:
         optional: true
       zod:
         optional: true
+
+  openclaw@2026.3.8:
+    resolution: {integrity: sha512-e5Rk2Aj55sD/5LyX94mdYCQj7zpHXo0xIZsl+k140+nRopePfPAxC7nsu0V/NyypPRtaotP1riFfzK7IhaYkuQ==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.89
+      node-llama-cpp: 3.16.2
 
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
@@ -12830,6 +12837,81 @@ snapshots:
     optionalDependencies:
       ws: 8.19.0
       zod: 4.3.6
+
+  openclaw@2026.3.8(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.7)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.15.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock': 3.1007.0
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.7)(opusscript@0.1.1)
+      '@clack/prompts': 1.1.0
+      '@discordjs/voice': 0.19.1(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@grammyjs/runner': 2.0.3(grammy@1.41.1)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.1)
+      '@homebridge/ciao': 1.3.5
+      '@larksuiteoapi/node-sdk': 1.59.0
+      '@line/bot-sdk': 10.6.0
+      '@lydell/node-pty': 1.2.0-beta.3
+      '@mariozechner/pi-agent-core': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.57.1
+      '@mozilla/readability': 0.6.0
+      '@napi-rs/canvas': 0.1.95
+      '@sinclair/typebox': 0.34.48
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/web-api': 7.14.1
+      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      ajv: 8.18.0
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      cli-highlight: 2.1.11
+      commander: 14.0.3
+      croner: 10.0.1
+      discord-api-types: 0.38.42
+      dotenv: 17.3.1
+      express: 5.2.1
+      file-type: 21.3.1
+      grammy: 1.41.1
+      https-proxy-agent: 7.0.6
+      ipaddr.js: 2.3.0
+      jiti: 2.6.1
+      json5: 2.2.3
+      jszip: 3.10.1
+      linkedom: 0.18.12
+      long: 5.3.2
+      markdown-it: 14.1.1
+      node-edge-tts: 1.2.10
+      node-llama-cpp: 3.16.2(typescript@5.9.3)
+      opusscript: 0.1.1
+      osc-progress: 0.3.0
+      pdfjs-dist: 5.5.207
+      playwright-core: 1.58.2
+      qrcode-terminal: 0.12.0
+      sharp: 0.34.5
+      sqlite-vec: 0.1.7-alpha.2
+      tar: 7.5.11
+      tslog: 4.10.2
+      undici: 7.22.0
+      ws: 8.19.0
+      yaml: 2.8.2
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - '@modelcontextprotocol/sdk'
+      - '@types/express'
+      - audio-decode
+      - aws-crt
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - ffmpeg-static
+      - hono
+      - jimp
+      - link-preview-js
+      - node-opus
+      - supports-color
+      - utf-8-validate
 
   opus-decoder@0.7.11:
     dependencies:

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -21,6 +21,7 @@ function createContext(
     state: {
       lastAssistant: lastAssistant as EmbeddedPiSubscribeContext["state"]["lastAssistant"],
       pendingCompactionRetry: 0,
+      pendingCompactionRetryStarts: 0,
       blockState: {
         thinking: true,
         final: true,
@@ -32,6 +33,7 @@ function createContext(
       warn: vi.fn(),
     },
     flushBlockReplyBuffer: vi.fn(),
+    markCompactionRetryStarted: vi.fn(),
     resolveCompactionRetry: vi.fn(),
     maybeResolveCompactionWait: vi.fn(),
   } as unknown as EmbeddedPiSubscribeContext;

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -15,6 +15,10 @@ export {
 } from "./pi-embedded-subscribe.handlers.compaction.js";
 
 export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
+  // auto_compaction_end(willRetry=true) lands before pi-coding-agent schedules continue()
+  if (ctx.state.pendingCompactionRetryStarts > 0) {
+    ctx.markCompactionRetryStarted();
+  }
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
   emitAgentEvent({
     runId: ctx.params.runId,
@@ -105,9 +109,12 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
   ctx.state.blockState.final = false;
   ctx.state.blockState.inlineCode = createInlineCodeState();
 
-  if (ctx.state.pendingCompactionRetry > 0) {
+  // Ignore the pre-retry agent_end from the original run; only started retries can clear the wait.
+  const startedCompactionRetries =
+    ctx.state.pendingCompactionRetry - ctx.state.pendingCompactionRetryStarts;
+  if (startedCompactionRetries > 0) {
     ctx.resolveCompactionRetry();
-  } else {
+  } else if (ctx.state.pendingCompactionRetry === 0) {
     ctx.maybeResolveCompactionWait();
   }
 }

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -63,6 +63,7 @@ export type EmbeddedPiSubscribeState = {
 
   compactionInFlight: boolean;
   pendingCompactionRetry: number;
+  pendingCompactionRetryStarts: number;
   compactionRetryResolve?: () => void;
   compactionRetryReject?: (reason?: unknown) => void;
   compactionRetryPromise: Promise<void> | null;
@@ -118,6 +119,7 @@ export type EmbeddedPiSubscribeContext = {
   trimMessagingToolSent: () => void;
   ensureCompactionPromise: () => void;
   noteCompactionRetry: () => void;
+  markCompactionRetryStarted: () => void;
   resolveCompactionRetry: () => void;
   maybeResolveCompactionWait: () => void;
   recordAssistantUsage: (usage: unknown) => void;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts
@@ -25,7 +25,7 @@ describe("subscribeEmbeddedPiSession", () => {
     emitAssistantTextDeltaAndEnd({ emit, text });
     expectFencedChunks(onBlockReply.mock.calls, "```json");
   });
-  it("waits for auto-compaction retry and clears buffered text", async () => {
+  it("waits for auto-compaction retry to resume before clearing the wait", async () => {
     const listeners: SessionEventHandler[] = [];
     const session = {
       subscribe: (listener: SessionEventHandler) => {
@@ -74,6 +74,14 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(resolved).toBe(false);
 
     for (const listener of listeners) {
+      listener({ type: "agent_end" });
+    }
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    for (const listener of listeners) {
+      listener({ type: "agent_start" });
       listener({ type: "agent_end" });
     }
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
@@ -3,7 +3,7 @@ import { onAgentEvent } from "../infra/agent-events.js";
 import { createSubscribedSessionHarness } from "./pi-embedded-subscribe.e2e-harness.js";
 
 describe("subscribeEmbeddedPiSession", () => {
-  it("waits for multiple compaction retries before resolving", async () => {
+  it("waits for compaction retries to actually start and finish before resolving", async () => {
     const { emit, subscription } = createSubscribedSessionHarness({
       runId: "run-3",
     });
@@ -19,8 +19,17 @@ describe("subscribeEmbeddedPiSession", () => {
     await Promise.resolve();
     expect(resolved).toBe(false);
 
+    // The original run ends before pi-coding-agent schedules the retry via continue().
     emit({ type: "agent_end" });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
 
+    emit({ type: "agent_start" });
+    emit({ type: "agent_end" });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    emit({ type: "agent_start" });
     await Promise.resolve();
     expect(resolved).toBe(false);
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -66,6 +66,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     lastReasoningSent: undefined,
     compactionInFlight: false,
     pendingCompactionRetry: 0,
+    pendingCompactionRetryStarts: 0,
     compactionRetryResolve: undefined,
     compactionRetryReject: undefined,
     compactionRetryPromise: null,
@@ -245,6 +246,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
 
   const noteCompactionRetry = () => {
     state.pendingCompactionRetry += 1;
+    state.pendingCompactionRetryStarts += 1;
     ensureCompactionPromise();
   };
 
@@ -259,6 +261,14 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       state.compactionRetryReject = undefined;
       state.compactionRetryPromise = null;
     }
+  };
+
+  const markCompactionRetryStarted = () => {
+    if (state.pendingCompactionRetryStarts <= 0) {
+      return;
+    }
+    state.pendingCompactionRetryStarts -= 1;
+    ensureCompactionPromise();
   };
 
   const maybeResolveCompactionWait = () => {
@@ -633,6 +643,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     trimMessagingToolSent,
     ensureCompactionPromise,
     noteCompactionRetry,
+    markCompactionRetryStarted,
     resolveCompactionRetry,
     maybeResolveCompactionWait,
     recordAssistantUsage,


### PR DESCRIPTION
## Bug scenario
After auto-compaction finishes with `willRetry=true`, some runs do not continue from compacted context.

### Repro trigger sequence
1. `auto_compaction_end { willRetry: true }`
2. `waitForCompactionRetry()` starts waiting
3. original run emits `agent_end`
4. wait resolves too early (bug)
5. only afterwards retried run emits `agent_start` / `agent_end`

## Why it bugged (root cause)
Embedded subscribe lifecycle bookkeeping treated the original pre-retry `agent_end` as if it completed the compaction retry.

So `waitForCompactionRetry()` could resolve **before retry start**, which cuts the `compact -> retry -> continue` chain.

## Fix approach
- Track retries that are announced but not started yet (`pendingCompactionRetryStarts`).
- On `noteCompactionRetry()`, increment both:
  - pending retry completions
  - pending retry starts
- On `handleAgentStart()`, consume one pending retry start.
- On `handleAgentEnd()`, only resolve compaction wait if a retry that actually started has ended.

## Verification
Ran on this branch:

```bash
/Users/programcaicai/clawd/projects/openclaw/node_modules/.bin/vitest run \
  src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts \
  src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
# 2 files passed, 13 tests passed
```

```bash
/Users/programcaicai/clawd/projects/openclaw/node_modules/.bin/vitest run \
  src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts \
  -t "waits for auto-compaction retry to resume before clearing the wait"
# 1 passed, 3 skipped
```

## Scope boundaries
- Narrow state-machine fix in embedded subscribe path only.
- No gateway restart/reload logic changes.
