### PR TITLE
fix(minimax-vlm): add fetch timeout to VLM image analysis request

### DIFF
--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -91,29 +91,30 @@ export async function minimaxUnderstandImage(params: {
   } catch (err) {
     throw new Error(
       `MiniMax VLM request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 
   const traceId = res.headers.get("Trace-Id") ?? "";
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    const trace = traceId ? ` Trace-Id: ${traceId}` : "";
+    throw new Error(
+      `MiniMax VLM request failed (${res.status} ${res.statusText}).${trace}${
+        body ? ` Body: ${body.slice(0, 400)}` : ""
+      }`,
+    );
+  }
+
   let json: unknown;
   try {
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      const trace = traceId ? ` Trace-Id: ${traceId}` : "";
-      throw new Error(
-        `MiniMax VLM request failed (${res.status} ${res.statusText}).${trace}${
-          body ? ` Body: ${body.slice(0, 400)}` : ""
-        }`,
-      );
-    }
-
-    json = (await res.json().catch(() => null)) as unknown;
+    json = await res.json();
   } catch (err) {
-    if (err instanceof Error && err.message.startsWith("MiniMax VLM request failed")) {
-      throw err;
-    }
+    const trace = traceId ? ` Trace-Id: ${traceId}` : "";
     throw new Error(
-      `MiniMax VLM request failed: ${err instanceof Error ? err.message : String(err)}`,
+      `MiniMax VLM request failed: ${err instanceof Error ? err.message : String(err)}.${trace}`,
+      { cause: err },
     );
   }
   if (!isRecord(json)) {

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -73,31 +73,49 @@ export async function minimaxUnderstandImage(params: {
   });
   const url = new URL("/v1/coding_plan/vlm", host).toString();
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-      "MM-API-Source": "OpenClaw",
-    },
-    body: JSON.stringify({
-      prompt,
-      image_url: imageDataUrl,
-    }),
-  });
-
-  const traceId = res.headers.get("Trace-Id") ?? "";
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    const trace = traceId ? ` Trace-Id: ${traceId}` : "";
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "MM-API-Source": "OpenClaw",
+      },
+      body: JSON.stringify({
+        prompt,
+        image_url: imageDataUrl,
+      }),
+      signal: AbortSignal.timeout(60_000),
+    });
+  } catch (err) {
     throw new Error(
-      `MiniMax VLM request failed (${res.status} ${res.statusText}).${trace}${
-        body ? ` Body: ${body.slice(0, 400)}` : ""
-      }`,
+      `MiniMax VLM request failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
-  const json = (await res.json().catch(() => null)) as unknown;
+  const traceId = res.headers.get("Trace-Id") ?? "";
+  let json: unknown;
+  try {
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      const trace = traceId ? ` Trace-Id: ${traceId}` : "";
+      throw new Error(
+        `MiniMax VLM request failed (${res.status} ${res.statusText}).${trace}${
+          body ? ` Body: ${body.slice(0, 400)}` : ""
+        }`,
+      );
+    }
+
+    json = (await res.json().catch(() => null)) as unknown;
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("MiniMax VLM request failed")) {
+      throw err;
+    }
+    throw new Error(
+      `MiniMax VLM request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   if (!isRecord(json)) {
     const trace = traceId ? ` Trace-Id: ${traceId}` : "";
     throw new Error(`MiniMax VLM response was not JSON.${trace}`);


### PR DESCRIPTION
## Problem

The `minimaxUnderstandImage()` function in `src/agents/minimax-vlm.ts` calls `fetch()` without an `AbortSignal.timeout`, so the request can hang indefinitely if the MiniMax VLM API is slow or unresponsive.

## Fix

Add `signal: AbortSignal.timeout(60_000)` (60 s) and restructure the error handling so that **all** response-body reads (`res.text()`, `res.json()`) are inside the `try/catch` block. This prevents a raw `DOMException` from leaking when the timeout fires during body streaming.

## Changes

- `src/agents/minimax-vlm.ts` — wrap fetch + body reads in try/catch with 60 s timeout

---

lobster-biscuit