### PR TITLE
fix(pdf): add fetch timeout to Anthropic and Gemini PDF analysis

### DIFF
--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -60,9 +60,9 @@ export async function anthropicAnalyzePdf(params: {
   content.push({ type: "text", text: params.prompt });
 
   const baseUrl = (params.baseUrl ?? "https://api.anthropic.com").replace(/\/+$/, "");
-  let json: unknown;
+  let res: Response;
   try {
-    const res = await fetch(`${baseUrl}/v1/messages`, {
+    res = await fetch(`${baseUrl}/v1/messages`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -77,21 +77,27 @@ export async function anthropicAnalyzePdf(params: {
       }),
       signal: AbortSignal.timeout(120_000),
     });
-
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      throw new Error(
-        `Anthropic PDF request failed (${res.status} ${res.statusText})${body ? `: ${body.slice(0, 400)}` : ""}`,
-      );
-    }
-
-    json = (await res.json().catch(() => null)) as unknown;
   } catch (err) {
-    if (err instanceof Error && err.message.startsWith("Anthropic PDF request failed")) {
-      throw err;
-    }
     throw new Error(
       `Anthropic PDF request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Anthropic PDF request failed (${res.status} ${res.statusText})${body ? `: ${body.slice(0, 400)}` : ""}`,
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch (err) {
+    throw new Error(
+      `Anthropic PDF request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
   if (!isRecord(json)) {
@@ -153,9 +159,9 @@ export async function geminiAnalyzePdf(params: {
     .replace(/\/v1beta$/, "");
   const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
-  let json: unknown;
+  let res: Response;
   try {
-    const res = await fetch(url, {
+    res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -163,21 +169,27 @@ export async function geminiAnalyzePdf(params: {
       }),
       signal: AbortSignal.timeout(120_000),
     });
-
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      throw new Error(
-        `Gemini PDF request failed (${res.status} ${res.statusText})${body ? `: ${body.slice(0, 400)}` : ""}`,
-      );
-    }
-
-    json = (await res.json().catch(() => null)) as unknown;
   } catch (err) {
-    if (err instanceof Error && err.message.startsWith("Gemini PDF request failed")) {
-      throw err;
-    }
     throw new Error(
       `Gemini PDF request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Gemini PDF request failed (${res.status} ${res.statusText})${body ? `: ${body.slice(0, 400)}` : ""}`,
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch (err) {
+    throw new Error(
+      `Gemini PDF request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
   if (!isRecord(json)) {

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -60,29 +60,40 @@ export async function anthropicAnalyzePdf(params: {
   content.push({ type: "text", text: params.prompt });
 
   const baseUrl = (params.baseUrl ?? "https://api.anthropic.com").replace(/\/+$/, "");
-  const res = await fetch(`${baseUrl}/v1/messages`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-      "anthropic-beta": "pdfs-2024-09-25",
-    },
-    body: JSON.stringify({
-      model: params.modelId,
-      max_tokens: params.maxTokens ?? 4096,
-      messages: [{ role: "user", content }],
-    }),
-  });
+  let json: unknown;
+  try {
+    const res = await fetch(`${baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "anthropic-beta": "pdfs-2024-09-25",
+      },
+      body: JSON.stringify({
+        model: params.modelId,
+        max_tokens: params.maxTokens ?? 4096,
+        messages: [{ role: "user", content }],
+      }),
+      signal: AbortSignal.timeout(120_000),
+    });
 
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `Anthropic PDF request failed (${res.status} ${res.statusText})${body ? `: ${body.slice(0, 400)}` : ""}`,
+      );
+    }
+
+    json = (await res.json().catch(() => null)) as unknown;
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("Anthropic PDF request failed")) {
+      throw err;
+    }
     throw new Error(
-      `Anthropic PDF request failed (${res.status} ${res.statusText})${body ? `: ${body.slice(0, 400)}` : ""}`,
+      `Anthropic PDF request failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
-
-  const json = (await res.json().catch(() => null)) as unknown;
   if (!isRecord(json)) {
     throw new Error("Anthropic PDF response was not JSON.");
   }
@@ -142,22 +153,33 @@ export async function geminiAnalyzePdf(params: {
     .replace(/\/v1beta$/, "");
   const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      contents: [{ role: "user", parts }],
-    }),
-  });
+  let json: unknown;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ role: "user", parts }],
+      }),
+      signal: AbortSignal.timeout(120_000),
+    });
 
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `Gemini PDF request failed (${res.status} ${res.statusText})${body ? `: ${body.slice(0, 400)}` : ""}`,
+      );
+    }
+
+    json = (await res.json().catch(() => null)) as unknown;
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("Gemini PDF request failed")) {
+      throw err;
+    }
     throw new Error(
-      `Gemini PDF request failed (${res.status} ${res.statusText})${body ? `: ${body.slice(0, 400)}` : ""}`,
+      `Gemini PDF request failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
-
-  const json = (await res.json().catch(() => null)) as unknown;
   if (!isRecord(json)) {
     throw new Error("Gemini PDF response was not JSON.");
   }


### PR DESCRIPTION
## Problem

Both `anthropicAnalyzePdf()` and `geminiAnalyzePdf()` in `src/agents/tools/pdf-native-providers.ts` call `fetch()` without an `AbortSignal.timeout`. PDF payloads can be large, so a slow or unresponsive provider API can hang the request indefinitely.

## Fix

Add `signal: AbortSignal.timeout(120_000)` (120 s — generous for large PDF uploads) to both functions and restructure the error handling so that **all** response-body reads (`res.text()`, `res.json()`) are inside the `try/catch` block. This prevents a raw `DOMException` from leaking when the timeout fires during body streaming.

## Changes

- `src/agents/tools/pdf-native-providers.ts` — wrap fetch + body reads in try/catch with 120 s timeout for both Anthropic and Gemini paths

---

lobster-biscuit