### PR TITLE
fix(feishu): guard response.code in docx table operations

### DIFF
--- a/extensions/feishu/src/docx-table-ops.ts
+++ b/extensions/feishu/src/docx-table-ops.ts
@@ -210,7 +210,7 @@ export async function insertTableRow(
     path: { document_id: docToken, block_id: blockId },
     data: { insert_table_row: { row_index: rowIndex } },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
   return { success: true, block: res.data?.block };
@@ -226,7 +226,7 @@ export async function insertTableColumn(
     path: { document_id: docToken, block_id: blockId },
     data: { insert_table_column: { column_index: columnIndex } },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
   return { success: true, block: res.data?.block };
@@ -243,7 +243,7 @@ export async function deleteTableRows(
     path: { document_id: docToken, block_id: blockId },
     data: { delete_table_rows: { row_start_index: rowStart, row_end_index: rowStart + rowCount } },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
   return { success: true, rows_deleted: rowCount, block: res.data?.block };
@@ -265,7 +265,7 @@ export async function deleteTableColumns(
       },
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
   return { success: true, columns_deleted: columnCount, block: res.data?.block };
@@ -291,7 +291,7 @@ export async function mergeTableCells(
       },
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
   return { success: true, block: res.data?.block };


### PR DESCRIPTION
## Problem

Five functions in `extensions/feishu/src/docx-table-ops.ts` check `res.code !== 0` without first verifying that `code` is defined. The Lark SDK types `code` as optional (`code?: number`). When the SDK returns a success response without the `code` field (documented behaviour since SDK v1.30+), `undefined !== 0` evaluates to `true` and the helper throws on a **successful** call.

## Fix

Add an explicit `!== undefined` guard before comparing to `0`, matching the pattern already used in `media.ts` (lines 33, 209, 282) and `wiki.ts`.

```diff
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
```

## Affected functions (5 call sites)

- `insertTableRow`
- `insertTableColumn`
- `deleteTableRows`
- `deleteTableColumns`
- `mergeTableCells`

---

lobster-biscuit