### PR TITLE
fix(whatsapp): trim leading whitespace in direct outbound sends

### DIFF
--- a/src/channels/plugins/outbound/whatsapp.sendpayload.test.ts
+++ b/src/channels/plugins/outbound/whatsapp.sendpayload.test.ts
@@ -1,4 +1,4 @@
-import { describe, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ReplyPayload } from "../../../auto-reply/types.js";
 import {
   installSendPayloadContractSuite,
@@ -33,5 +33,93 @@ describe("whatsappOutbound sendPayload", () => {
     channel: "whatsapp",
     chunking: { mode: "split", longTextLength: 5000, maxChunkLength: 4000 },
     createHarness,
+  });
+
+  it("trims leading whitespace for direct text sends", async () => {
+    const sendWhatsApp = vi.fn(async () => ({ messageId: "wa-1", toJid: "jid" }));
+
+    await whatsappOutbound.sendText!({
+      cfg: {},
+      to: "5511999999999@c.us",
+      text: "\n \thello",
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledWith("5511999999999@c.us", "hello", {
+      verbose: false,
+      cfg: {},
+      accountId: undefined,
+      gifPlayback: undefined,
+    });
+  });
+
+  it("trims leading whitespace for direct media captions", async () => {
+    const sendWhatsApp = vi.fn(async () => ({ messageId: "wa-1", toJid: "jid" }));
+
+    await whatsappOutbound.sendMedia!({
+      cfg: {},
+      to: "5511999999999@c.us",
+      text: "\n \tcaption",
+      mediaUrl: "/tmp/test.png",
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledWith("5511999999999@c.us", "caption", {
+      verbose: false,
+      cfg: {},
+      mediaUrl: "/tmp/test.png",
+      mediaLocalRoots: undefined,
+      accountId: undefined,
+      gifPlayback: undefined,
+    });
+  });
+
+  it("trims leading whitespace for sendPayload text and caption delivery", async () => {
+    const sendWhatsApp = vi.fn(async () => ({ messageId: "wa-1", toJid: "jid" }));
+
+    await whatsappOutbound.sendPayload!({
+      cfg: {},
+      to: "5511999999999@c.us",
+      text: "",
+      payload: { text: "\n\nhello" },
+      deps: { sendWhatsApp },
+    });
+    await whatsappOutbound.sendPayload!({
+      cfg: {},
+      to: "5511999999999@c.us",
+      text: "",
+      payload: { text: "\n\ncaption", mediaUrl: "/tmp/test.png" },
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenNthCalledWith(1, "5511999999999@c.us", "hello", {
+      verbose: false,
+      cfg: {},
+      accountId: undefined,
+      gifPlayback: undefined,
+    });
+    expect(sendWhatsApp).toHaveBeenNthCalledWith(2, "5511999999999@c.us", "caption", {
+      verbose: false,
+      cfg: {},
+      mediaUrl: "/tmp/test.png",
+      mediaLocalRoots: undefined,
+      accountId: undefined,
+      gifPlayback: undefined,
+    });
+  });
+
+  it("skips whitespace-only text payloads", async () => {
+    const sendWhatsApp = vi.fn();
+
+    const result = await whatsappOutbound.sendPayload!({
+      cfg: {},
+      to: "5511999999999@c.us",
+      text: "",
+      payload: { text: "\n \t" },
+      deps: { sendWhatsApp },
+    });
+
+    expect(result).toEqual({ channel: "whatsapp", messageId: "" });
+    expect(sendWhatsApp).not.toHaveBeenCalled();
   });
 });

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -5,6 +5,10 @@ import { resolveWhatsAppOutboundTarget } from "../../../whatsapp/resolve-outboun
 import type { ChannelOutboundAdapter } from "../types.js";
 import { sendTextMediaPayload } from "./direct-text-media.js";
 
+function trimLeadingWhitespace(text: string | undefined): string {
+  return text?.trimStart() ?? "";
+}
+
 export const whatsappOutbound: ChannelOutboundAdapter = {
   deliveryMode: "gateway",
   chunker: chunkText,
@@ -13,12 +17,32 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   pollMaxOptions: 12,
   resolveTarget: ({ to, allowFrom, mode }) =>
     resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
-  sendPayload: async (ctx) =>
-    await sendTextMediaPayload({ channel: "whatsapp", ctx, adapter: whatsappOutbound }),
+  sendPayload: async (ctx) => {
+    const text = trimLeadingWhitespace(ctx.payload.text);
+    const hasMedia = Boolean(ctx.payload.mediaUrl) || (ctx.payload.mediaUrls?.length ?? 0) > 0;
+    if (!text && !hasMedia) {
+      return { channel: "whatsapp", messageId: "" };
+    }
+    return await sendTextMediaPayload({
+      channel: "whatsapp",
+      ctx: {
+        ...ctx,
+        payload: {
+          ...ctx.payload,
+          text,
+        },
+      },
+      adapter: whatsappOutbound,
+    });
+  },
   sendText: async ({ cfg, to, text, accountId, deps, gifPlayback }) => {
+    const normalizedText = trimLeadingWhitespace(text);
+    if (!normalizedText) {
+      return { channel: "whatsapp", messageId: "" };
+    }
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
-    const result = await send(to, text, {
+    const result = await send(to, normalizedText, {
       verbose: false,
       cfg,
       accountId: accountId ?? undefined,
@@ -27,9 +51,10 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
     return { channel: "whatsapp", ...result };
   },
   sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback }) => {
+    const normalizedText = trimLeadingWhitespace(text);
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
-    const result = await send(to, text, {
+    const result = await send(to, normalizedText, {
       verbose: false,
       cfg,
       mediaUrl,

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -48,6 +48,23 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenCalledWith("+1555", "hi", undefined, undefined);
   });
 
+  it("trims leading whitespace before sending text and captions", async () => {
+    await sendMessageWhatsApp("+1555", "\n \thello", { verbose: false });
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "hello", undefined, undefined);
+
+    const buf = Buffer.from("img");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "image/jpeg",
+      kind: "image",
+    });
+    await sendMessageWhatsApp("+1555", "\n \tcaption", {
+      verbose: false,
+      mediaUrl: "/tmp/pic.jpg",
+    });
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "caption", buf, "image/jpeg");
+  });
+
   it("throws a helpful error when no active listener exists", async () => {
     setActiveWebListener(null);
     await expect(

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -65,6 +65,17 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenLastCalledWith("+1555", "caption", buf, "image/jpeg");
   });
 
+  it("skips whitespace-only text sends without media", async () => {
+    const result = await sendMessageWhatsApp("+1555", "\n \t", { verbose: false });
+
+    expect(result).toEqual({
+      messageId: "",
+      toJid: "1555@s.whatsapp.net",
+    });
+    expect(sendComposingTo).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("throws a helpful error when no active listener exists", async () => {
     setActiveWebListener(null);
     await expect(

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -26,7 +26,7 @@ export async function sendMessageWhatsApp(
     accountId?: string;
   },
 ): Promise<{ messageId: string; toJid: string }> {
-  let text = body;
+  let text = body.trimStart();
   const correlationId = generateSecureUuid();
   const startedAt = Date.now();
   const { listener: active, accountId: resolvedAccountId } = requireActiveWebListener(

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -27,6 +27,10 @@ export async function sendMessageWhatsApp(
   },
 ): Promise<{ messageId: string; toJid: string }> {
   let text = body.trimStart();
+  const jid = toWhatsappJid(to);
+  if (!text && !options.mediaUrl) {
+    return { messageId: "", toJid: jid };
+  }
   const correlationId = generateSecureUuid();
   const startedAt = Date.now();
   const { listener: active, accountId: resolvedAccountId } = requireActiveWebListener(
@@ -51,7 +55,6 @@ export async function sendMessageWhatsApp(
     to: redactedTo,
   });
   try {
-    const jid = toWhatsappJid(to);
     const redactedJid = redactIdentifier(jid);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: direct WhatsApp outbound calls could still preserve leading newlines/spaces even though the main outbound delivery path already trims them.
- Why it matters: direct sends and caption sends can render with blank space at the top of the WhatsApp bubble, which looks broken on mobile.
- What changed: trimmed leading whitespace in the WhatsApp adapter boundary and in `sendMessageWhatsApp`, and added regression tests for direct text, direct media captions, sendPayload, and whitespace-only payloads.
- What did NOT change (scope boundary): the existing auto-reply normalization path was already trimming earlier in the pipeline; this PR does not change non-WhatsApp channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #8036
- Related #8052

## User-visible / Behavior Changes

- WhatsApp direct outbound text sends now strip leading whitespace before sending.
- WhatsApp direct outbound media captions now strip leading whitespace before sending.
- Whitespace-only direct WhatsApp text payloads are dropped instead of attempting an empty send.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): mocked outbound sender in unit tests; no live credentials required

### Steps

1. Reproduced current behavior locally by invoking `whatsappOutbound.sendText`, `whatsappOutbound.sendMedia`, and `whatsappOutbound.sendPayload` with mocked `sendWhatsApp` and leading-whitespace text/captions.
2. Patched the adapter and `sendMessageWhatsApp` to trim leading whitespace at the direct-send boundary.
3. Added regression tests and reran targeted outbound/build/security checks.

### Expected

- Direct WhatsApp text and caption sends arrive without leading blank space.
- Whitespace-only text payloads are skipped.

### Actual

- Before the patch, direct adapter sends preserved leading whitespace.
- After the patch, targeted tests and local mocked repro show trimmed text/captions.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: local mocked repro for `deliverOutboundPayloads`, `whatsappOutbound.sendText`, `whatsappOutbound.sendMedia`, `whatsappOutbound.sendPayload`, and `sendMessageWhatsApp`.
- Edge cases checked: leading spaces plus newlines, media captions, and whitespace-only text payloads.
- What you did **not** verify: live WhatsApp delivery against a real linked account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `29ec53982` and `0f926e7e0`.
- Files/config to restore: `src/channels/plugins/outbound/whatsapp.ts`, `src/web/outbound.ts`, and the paired tests.
- Known bad symptoms reviewers should watch for: unexpected dropped WhatsApp messages when the payload is intentionally whitespace-only.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: trimming at both the adapter and web sender could hide callers that intentionally rely on leading whitespace.
  - Mitigation: scope is WhatsApp-only, behavior matches the existing normalized outbound path, and tests cover both text and caption sends.
