### PR TITLE
fix(android): use scheme default port for gateway setup URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/default timeout: raise the shared default agent timeout from `600s` to `48h` so long-running ACP and agent sessions do not fail unless you configure a shorter limit.
 - Gateway/Linux: auto-detect nvm-managed Node TLS CA bundle needs before CLI startup and refresh installed services that are missing `NODE_EXTRA_CA_CERTS`. (#51146) Thanks @GodsBoy.
+- Android/pairing: resolve portless secure setup URLs to `443` while preserving direct cleartext gateway defaults and explicit `:80` manual endpoints in onboarding. (#43540) Thanks @fmercurio.
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.
 - CLI/Ollama onboarding: keep the interactive model picker for explicit `openclaw onboard --auth-choice ollama` runs so setup still selects a default model without reintroducing pre-picker auto-pulls. (#49249) Thanks @BruceMacD.
 - Plugins/bundler TDZ: fix `RESERVED_COMMANDS` temporal dead zone error that prevented device-pair, phone-control, and talk-voice plugins from registering when the bundler placed the commands module after call sites in the same output chunk. Thanks @BunsDev.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -100,12 +100,18 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
   val defaultPort =
     when (scheme) {
       "wss", "https" -> 443
+      "ws", "http" -> 18789
+      else -> 443
+    }
+  val displayPort =
+    when (scheme) {
+      "wss", "https" -> 443
       "ws", "http" -> 80
       else -> 443
     }
   val port = uri.port.takeIf { it in 1..65535 } ?: defaultPort
   val displayUrl =
-    if (port == defaultPort) {
+    if (port == displayPort) {
       "${if (tls) "https" else "http"}://$host"
     } else {
       "${if (tls) "https" else "http"}://$host:$port"

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -97,8 +97,19 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
       "wss", "https" -> true
       else -> true
     }
-  val port = uri.port.takeIf { it in 1..65535 } ?: if (tls) 443 else 18789
-  val displayUrl = "${if (tls) "https" else "http"}://$host:$port"
+  val defaultPort =
+    when (scheme) {
+      "wss", "https" -> 443
+      "ws", "http" -> 80
+      else -> 443
+    }
+  val port = uri.port.takeIf { it in 1..65535 } ?: defaultPort
+  val displayUrl =
+    if (port == defaultPort) {
+      "${if (tls) "https" else "http"}://$host"
+    } else {
+      "${if (tls) "https" else "http"}://$host:$port"
+    }
 
   return GatewayEndpointConfig(host = host, port = port, tls = tls, displayUrl = displayUrl)
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -111,7 +111,7 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
     }
   val port = uri.port.takeIf { it in 1..65535 } ?: defaultPort
   val displayUrl =
-    if (port == displayPort) {
+    if (port == displayPort && defaultPort == displayPort) {
       "${if (tls) "https" else "http"}://$host"
     } else {
       "${if (tls) "https" else "http"}://$host:$port"

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -4,8 +4,71 @@ import java.util.Base64
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class GatewayConfigResolverTest {
+  @Test
+  fun parseGatewayEndpointUsesDefaultTlsPortForBareWssUrls() {
+    val parsed = parseGatewayEndpoint("wss://gateway.example")
+
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "gateway.example",
+        port = 443,
+        tls = true,
+        displayUrl = "https://gateway.example",
+      ),
+      parsed,
+    )
+  }
+
+  @Test
+  fun parseGatewayEndpointUsesDefaultCleartextPortForBareWsUrls() {
+    val parsed = parseGatewayEndpoint("ws://gateway.example")
+
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "gateway.example",
+        port = 80,
+        tls = false,
+        displayUrl = "http://gateway.example",
+      ),
+      parsed,
+    )
+  }
+
+  @Test
+  fun parseGatewayEndpointOmitsExplicitDefaultTlsPortFromDisplayUrl() {
+    val parsed = parseGatewayEndpoint("https://gateway.example:443")
+
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "gateway.example",
+        port = 443,
+        tls = true,
+        displayUrl = "https://gateway.example",
+      ),
+      parsed,
+    )
+  }
+
+  @Test
+  fun parseGatewayEndpointKeepsExplicitNonDefaultPortInDisplayUrl() {
+    val parsed = parseGatewayEndpoint("http://gateway.example:8080")
+
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "gateway.example",
+        port = 8080,
+        tls = false,
+        displayUrl = "http://gateway.example:8080",
+      ),
+      parsed,
+    )
+  }
+
   @Test
   fun resolveScannedSetupCodeAcceptsRawSetupCode() {
     val setupCode =

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -31,9 +31,9 @@ class GatewayConfigResolverTest {
     assertEquals(
       GatewayEndpointConfig(
         host = "gateway.example",
-        port = 80,
+        port = 18789,
         tls = false,
-        displayUrl = "http://gateway.example",
+        displayUrl = "http://gateway.example:18789",
       ),
       parsed,
     )

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -70,6 +70,21 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun parseGatewayEndpointKeepsExplicitCleartextPort80InDisplayUrl() {
+    val parsed = parseGatewayEndpoint("http://gateway.example:80")
+
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "gateway.example",
+        port = 80,
+        tls = false,
+        displayUrl = "http://gateway.example:80",
+      ),
+      parsed,
+    )
+  }
+
+  @Test
   fun resolveScannedSetupCodeAcceptsRawSetupCode() {
     val setupCode =
       encodeSetupCode("""{"url":"wss://gateway.example:18789","bootstrapToken":"bootstrap-1"}""")


### PR DESCRIPTION
## Summary
- use scheme-aware default ports when parsing gateway URLs in the Android app
- default to 443 for wss/https and 80 for ws/http instead of always forcing 18789
- omit the port from display URLs when it is the scheme default

## Why
Setup codes for Tailscale Serve can contain `wss://host` with no explicit port. The Android app was parsing those URLs and forcing port `18789`, which rewrote the display URL to `https://host:18789` and broke pairing/TLS for Serve-backed gateways.

## Testing
- built debug APK locally with `./gradlew :app:assembleDebug`
- verified the patched APK fixed the pairing flow in manual testing