### PR TITLE
fix(agents): truncate tool call IDs for OpenAI-compat proxies

### DIFF
--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -60,6 +60,15 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
     openAiCompatTurnValidation: false,
     geminiThoughtSignatureSanitization: true,
     geminiThoughtSignatureModelHints: ["gemini"],
+    transcriptToolCallIdModelHints: [
+      "mistral",
+      "mixtral",
+      "codestral",
+      "pixtral",
+      "devstral",
+      "ministral",
+      "mistralai",
+    ],
   },
   opencode: {
     openAiCompatTurnValidation: false,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -78,7 +78,13 @@ export function resolveTranscriptPolicy(params: {
       provider,
       modelId,
     });
-  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  // OpenAI-compatible APIs need tool ID sanitization:
+  // - openai-completions: Always sanitize (existing behavior for all providers)
+  // - openai-responses with non-OpenAI providers: Sanitize because proxies may
+  //   enforce the 64-char ID limit that native OpenAI handles internally.
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" ||
+    (!isOpenAi && params.modelApi === "openai-responses");
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").


### PR DESCRIPTION
## Summary

Fixes #43305

Custom providers using `openai-responses` API were sending tool call IDs exceeding the 64-character limit that many OpenAI-compatible proxies enforce. This caused HTTP 400 errors like `Invalid 'input[n].id': string too long. Expected a string with maximum length 64, but got a string with length 408`.

## Changes

- **`transcript-policy.ts`**: Enable tool ID sanitization for `openai-responses` with non-OpenAI providers
- **`provider-capabilities.ts`**: Add `transcriptToolCallIdModelHints` for Mistral models on OpenRouter (fixes a pre-existing test that was failing)

Tool IDs are now truncated to 40 characters (well under the 64-char limit) for custom providers using OpenAI-compatible APIs.

## Root Cause

The `requiresOpenAiCompatibleToolIdSanitization` flag only checked for `openai-completions` API, but not `openai-responses`. This meant custom providers (proxies) using `openai-responses` were not having their tool call IDs sanitized, allowing IDs up to 408+ characters to be sent.

## Test Plan

- [x] `pnpm test -- src/agents/transcript-policy.test.ts` passes
- [x] `pnpm test -- src/agents/pi-embedded-runner.sanitize-session-history.test.ts` passes
- [x] `pnpm test -- src/agents/tool-call-id.test.ts` passes
- [x] `pnpm test -- src/agents/provider-capabilities.test.ts` passes
- [x] `pnpm tsgo` passes

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)