### PR TITLE
feat(tools): add allowedRoots config for fs tools

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -170,6 +170,34 @@ describe("applyPatch", () => {
     });
   });
 
+  it.runIf(process.platform !== "win32")(
+    "uses pinned writes for workspaceOnly add-file operations",
+    async () => {
+      await withTempDir(async (dir) => {
+        const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-apply-patch-pinned-"));
+        const target = path.join(allowedDir, "nested", "shared.txt");
+        const mkdirSpy = vi.spyOn(fs, "mkdir");
+        const patch = `*** Begin Patch
+*** Add File: ${target}
++shared
+*** End Patch`;
+
+        try {
+          await applyPatch(patch, {
+            cwd: dir,
+            workspaceOnly: true,
+            allowedRoots: [allowedDir],
+          });
+          await expect(fs.readFile(target, "utf8")).resolves.toBe("shared\n");
+          expect(mkdirSpy).not.toHaveBeenCalled();
+        } finally {
+          mkdirSpy.mockRestore();
+          await fs.rm(allowedDir, { recursive: true, force: true });
+        }
+      });
+    },
+  );
+
   it("resolves delete targets before calling fs.rm", async () => {
     await withTempDir(async (dir) => {
       const target = path.join(dir, "delete-me.txt");

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -217,6 +217,28 @@ describe("applyPatch", () => {
     });
   });
 
+  it("rejects deleting an allowlisted root directory itself", async () => {
+    await withTempDir(async (dir) => {
+      const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-apply-patch-root-"));
+      const patch = `*** Begin Patch
+*** Delete File: ${allowedDir}
+*** End Patch`;
+
+      try {
+        await expect(
+          applyPatch(patch, {
+            cwd: dir,
+            workspaceOnly: true,
+            allowedRoots: [allowedDir],
+          }),
+        ).rejects.toThrow(/Cannot delete root directory itself/);
+        await expect(fs.stat(allowedDir)).resolves.toBeDefined();
+      } finally {
+        await fs.rm(allowedDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   it("rejects symlink escape attempts by default", async () => {
     // File symlinks require SeCreateSymbolicLinkPrivilege on Windows.
     if (process.platform === "win32") {
@@ -305,7 +327,7 @@ describe("applyPatch", () => {
     });
   });
 
-  it("allows symlinks that resolve within cwd by default", async () => {
+  it("rejects final symlink targets even when they resolve within cwd", async () => {
     // File symlinks require SeCreateSymbolicLinkPrivilege on Windows.
     if (process.platform === "win32") {
       return;
@@ -323,9 +345,11 @@ describe("applyPatch", () => {
 +updated
 *** End Patch`;
 
-      await applyPatch(patch, { cwd: dir });
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /symlink|invalid-path|regular file under root/i,
+      );
       const contents = await fs.readFile(target, "utf8");
-      expect(contents).toBe("updated\n");
+      expect(contents).toBe("initial\n");
     });
   });
 

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -147,6 +147,29 @@ describe("applyPatch", () => {
     });
   });
 
+  it("allows absolute paths inside configured allowedRoots", async () => {
+    await withTempDir(async (dir) => {
+      const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-apply-patch-allowed-"));
+      const target = path.join(allowedDir, "shared.txt");
+      const patch = `*** Begin Patch
+*** Add File: ${target}
++shared
+*** End Patch`;
+
+      try {
+        await applyPatch(patch, {
+          cwd: dir,
+          workspaceOnly: true,
+          allowedRoots: [allowedDir],
+        });
+        const contents = await fs.readFile(target, "utf8");
+        expect(contents).toBe("shared\n");
+      } finally {
+        await fs.rm(allowedDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   it("resolves delete targets before calling fs.rm", async () => {
     await withTempDir(async (dir) => {
       const target = path.join(dir, "delete-me.txt");

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -305,6 +305,9 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
           allowFinalSymlinkForUnlink: true,
           allowFinalHardlinkForUnlink: true,
         });
+        if (!sandboxResult.relative) {
+          throw new Error(`Cannot delete root directory itself: ${filePath}`);
+        }
         await fs.rm(sandboxResult.resolved);
         return;
       }

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { openBoundaryFile, type BoundaryFileOpenResult } from "../infra/boundary-file-read.js";
+import { writeFileWithinRoot } from "../infra/fs-safe.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
 import { resolvePathFromInput } from "./path-policy.js";
@@ -286,8 +287,13 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
       if (!sandboxResult.relative) {
         throw new Error(`Cannot write to root directory itself: ${filePath}`);
       }
-      await fs.mkdir(path.dirname(sandboxResult.resolved), { recursive: true });
-      await fs.writeFile(sandboxResult.resolved, content, "utf8");
+      await writeFileWithinRoot({
+        rootDir: sandboxResult.matchedRoot,
+        relativePath: sandboxResult.relative,
+        data: content,
+        encoding: "utf8",
+        mkdir: true,
+      });
     },
     remove: async (filePath) => {
       if (workspaceOnly) {
@@ -306,13 +312,12 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     },
     mkdirp: async (dir) => {
       if (workspaceOnly) {
-        const sandboxResult = await assertSandboxPath({
+        await assertSandboxPath({
           filePath: dir,
           cwd: options.cwd,
           root: options.cwd,
           additionalRoots: allowedRoots,
         });
-        await fs.mkdir(sandboxResult.resolved, { recursive: true });
         return;
       }
       await fs.mkdir(dir, { recursive: true });

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -4,10 +4,9 @@ import path from "node:path";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { openBoundaryFile, type BoundaryFileOpenResult } from "../infra/boundary-file-read.js";
-import { writeFileWithinRoot } from "../infra/fs-safe.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
-import { toRelativeSandboxPath, resolvePathFromInput } from "./path-policy.js";
+import { resolvePathFromInput } from "./path-policy.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
@@ -66,6 +65,7 @@ export type ApplyPatchToolDetails = {
 type SandboxApplyPatchConfig = {
   root: string;
   bridge: SandboxFsBridge;
+  allowedRoots?: string[];
 };
 
 type ApplyPatchOptions = {
@@ -73,6 +73,7 @@ type ApplyPatchOptions = {
   sandbox?: SandboxApplyPatchConfig;
   /** Restrict patch paths to the workspace root (cwd). Default: true. Set false to opt out. */
   workspaceOnly?: boolean;
+  allowedRoots?: string[];
   signal?: AbortSignal;
 };
 
@@ -83,11 +84,17 @@ const applyPatchSchema = Type.Object({
 });
 
 export function createApplyPatchTool(
-  options: { cwd?: string; sandbox?: SandboxApplyPatchConfig; workspaceOnly?: boolean } = {},
+  options: {
+    cwd?: string;
+    sandbox?: SandboxApplyPatchConfig;
+    workspaceOnly?: boolean;
+    allowedRoots?: string[];
+  } = {},
 ): AgentTool<typeof applyPatchSchema, ApplyPatchToolDetails> {
   const cwd = options.cwd ?? process.cwd();
   const sandbox = options.sandbox;
   const workspaceOnly = options.workspaceOnly !== false;
+  const allowedRoots = options.allowedRoots ?? [];
 
   return {
     name: "apply_patch",
@@ -111,6 +118,7 @@ export function createApplyPatchTool(
         cwd,
         sandbox,
         workspaceOnly,
+        allowedRoots,
         signal,
       });
 
@@ -240,14 +248,21 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     };
   }
   const workspaceOnly = options.workspaceOnly !== false;
+  const allowedRoots = options.allowedRoots;
   return {
     readFile: async (filePath) => {
       if (!workspaceOnly) {
         return await fs.readFile(filePath, "utf8");
       }
+      const sandboxResult = await assertSandboxPath({
+        filePath,
+        cwd: options.cwd,
+        root: options.cwd,
+        additionalRoots: allowedRoots,
+      });
       const opened = await openBoundaryFile({
-        absolutePath: filePath,
-        rootPath: options.cwd,
+        absolutePath: sandboxResult.resolved,
+        rootPath: sandboxResult.matchedRoot,
         boundaryLabel: "workspace root",
       });
       assertBoundaryRead(opened, filePath);
@@ -262,33 +277,43 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
         await fs.writeFile(filePath, content, "utf8");
         return;
       }
-      const relative = toRelativeSandboxPath(options.cwd, filePath);
-      await writeFileWithinRoot({
-        rootDir: options.cwd,
-        relativePath: relative,
-        data: content,
-        encoding: "utf8",
+      const sandboxResult = await assertSandboxPath({
+        filePath,
+        cwd: options.cwd,
+        root: options.cwd,
+        additionalRoots: allowedRoots,
       });
+      if (!sandboxResult.relative) {
+        throw new Error(`Cannot write to root directory itself: ${filePath}`);
+      }
+      await fs.mkdir(path.dirname(sandboxResult.resolved), { recursive: true });
+      await fs.writeFile(sandboxResult.resolved, content, "utf8");
     },
     remove: async (filePath) => {
       if (workspaceOnly) {
-        await assertSandboxPath({
+        const sandboxResult = await assertSandboxPath({
           filePath,
           cwd: options.cwd,
           root: options.cwd,
+          additionalRoots: allowedRoots,
           allowFinalSymlinkForUnlink: true,
           allowFinalHardlinkForUnlink: true,
         });
+        await fs.rm(sandboxResult.resolved);
+        return;
       }
       await fs.rm(filePath);
     },
     mkdirp: async (dir) => {
       if (workspaceOnly) {
-        await assertSandboxPath({
+        const sandboxResult = await assertSandboxPath({
           filePath: dir,
           cwd: options.cwd,
           root: options.cwd,
+          additionalRoots: allowedRoots,
         });
+        await fs.mkdir(sandboxResult.resolved, { recursive: true });
+        return;
       }
       await fs.mkdir(dir, { recursive: true });
     },
@@ -314,13 +339,18 @@ async function resolvePatchPath(
       cwd: options.cwd,
     });
     if (options.workspaceOnly !== false && resolved.hostPath) {
-      await assertSandboxPath({
+      const sandboxResult = await assertSandboxPath({
         filePath: resolved.hostPath,
         cwd: options.cwd,
         root: options.cwd,
+        additionalRoots: options.allowedRoots ?? options.sandbox.allowedRoots,
         allowFinalSymlinkForUnlink: aliasPolicy.allowFinalSymlinkForUnlink,
         allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
       });
+      return {
+        resolved: sandboxResult.resolved,
+        display: resolved.relativePath || resolved.containerPath,
+      };
     }
     return {
       resolved: resolved.hostPath ?? resolved.containerPath,
@@ -335,6 +365,7 @@ async function resolvePatchPath(
           filePath,
           cwd: options.cwd,
           root: options.cwd,
+          additionalRoots: options.allowedRoots,
           allowFinalSymlinkForUnlink: aliasPolicy.allowFinalSymlinkForUnlink,
           allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
         })

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -95,7 +95,7 @@ import {
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
-import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
+import { resolveEffectiveToolFsWorkspaceOnly, resolveToolFsConfig } from "../../tool-fs-policy.js";
 import { normalizeToolName } from "../../tool-policy.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
@@ -1490,6 +1490,11 @@ export async function runEmbeddedAttempt(
       config: params.config,
       sessionAgentId,
     });
+    const effectiveFsAllowedRoots =
+      resolveToolFsConfig({
+        cfg: params.config,
+        agentId: sessionAgentId,
+      }).allowedRoots ?? [];
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
     let yieldMessage: string | null = null;
@@ -2509,6 +2514,7 @@ export async function runEmbeddedAttempt(
             maxBytes: MAX_IMAGE_BYTES,
             maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
             workspaceOnly: effectiveFsWorkspaceOnly,
+            allowedRoots: effectiveFsAllowedRoots,
             // Enforce sandbox path restrictions when sandbox is enabled
             sandbox:
               sandbox?.enabled && sandbox?.fsBridge

--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolvePreferredOpenClawTmpDir } from "../../../infra/tmp-openclaw-dir.js";
 import { createHostSandboxFsBridge } from "../../test-helpers/host-sandbox-fs-bridge.js";
 import { createUnsafeMountedSandbox } from "../../test-helpers/unsafe-mounted-sandbox.js";
 import {
@@ -330,6 +331,36 @@ describe("detectAndLoadPromptImages", () => {
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
       await fs.rm(allowedDir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows prompt image refs inside default media roots when workspaceOnly is enabled", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-image-ws-"));
+    const defaultRoot = resolvePreferredOpenClawTmpDir();
+    await fs.mkdir(defaultRoot, { recursive: true });
+    const imageDir = await fs.mkdtemp(
+      path.join(defaultRoot, "openclaw-native-image-default-root-"),
+    );
+    const pngB64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    const imagePath = path.join(imageDir, "generated.png");
+    await fs.writeFile(imagePath, Buffer.from(pngB64, "base64"));
+
+    try {
+      const result = await detectAndLoadPromptImages({
+        prompt: `Inspect ${imagePath}`,
+        workspaceDir,
+        model: { input: ["text", "image"] },
+        workspaceOnly: true,
+      });
+
+      expect(result.detectedRefs).toHaveLength(1);
+      expect(result.loadedCount).toBe(1);
+      expect(result.skippedCount).toBe(0);
+      expect(result.images).toHaveLength(1);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      await fs.rm(imageDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -305,4 +305,31 @@ describe("detectAndLoadPromptImages", () => {
       await fs.rm(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("allows prompt image refs inside configured allowedRoots", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-image-ws-"));
+    const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-image-allowed-"));
+    const pngB64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    const imagePath = path.join(allowedDir, "shared.png");
+    await fs.writeFile(imagePath, Buffer.from(pngB64, "base64"));
+
+    try {
+      const result = await detectAndLoadPromptImages({
+        prompt: `Inspect ${imagePath}`,
+        workspaceDir,
+        model: { input: ["text", "image"] },
+        workspaceOnly: true,
+        allowedRoots: [allowedDir],
+      });
+
+      expect(result.detectedRefs).toHaveLength(1);
+      expect(result.loadedCount).toBe(1);
+      expect(result.skippedCount).toBe(0);
+      expect(result.images).toHaveLength(1);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      await fs.rm(allowedDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -227,13 +227,20 @@ export async function loadImageFromRef(
     } else if (!path.isAbsolute(targetPath)) {
       targetPath = path.resolve(workspaceDir, targetPath);
     }
+    const localRoots = options?.sandbox
+      ? undefined
+      : resolveMediaToolLocalRoots(workspaceDir, {
+          workspaceOnly: options?.workspaceOnly,
+          allowedRoots: options?.allowedRoots,
+        });
+
     if (options?.workspaceOnly && !options?.sandbox) {
       const root = options?.sandbox?.root ?? workspaceDir;
       await assertSandboxPath({
         filePath: targetPath,
         cwd: root,
         root,
-        additionalRoots: options.allowedRoots,
+        additionalRoots: localRoots,
       });
     }
 
@@ -246,10 +253,7 @@ export async function loadImageFromRef(
         })
       : await loadWebMedia(targetPath, {
           maxBytes: options?.maxBytes,
-          localRoots: resolveMediaToolLocalRoots(workspaceDir, {
-            workspaceOnly: options?.workspaceOnly,
-            allowedRoots: options?.allowedRoots,
-          }),
+          localRoots,
         });
 
     if (media.kind !== "image") {

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -11,6 +11,7 @@ import {
 import { assertSandboxPath } from "../../sandbox-paths.js";
 import type { SandboxFsBridge } from "../../sandbox/fs-bridge.js";
 import { sanitizeImageBlocks } from "../../tool-images.js";
+import { resolveMediaToolLocalRoots } from "../../tools/media-tool-shared.js";
 import { log } from "../logger.js";
 
 /**
@@ -197,6 +198,7 @@ export async function loadImageFromRef(
   options?: {
     maxBytes?: number;
     workspaceOnly?: boolean;
+    allowedRoots?: string[];
     sandbox?: { root: string; bridge: SandboxFsBridge };
   },
 ): Promise<ImageContent | null> {
@@ -211,6 +213,7 @@ export async function loadImageFromRef(
             root: options.sandbox.root,
             bridge: options.sandbox.bridge,
             workspaceOnly: options.workspaceOnly,
+            allowedRoots: options.allowedRoots,
           },
           mediaPath: targetPath,
         });
@@ -230,6 +233,7 @@ export async function loadImageFromRef(
         filePath: targetPath,
         cwd: root,
         root,
+        additionalRoots: options.allowedRoots,
       });
     }
 
@@ -240,7 +244,13 @@ export async function loadImageFromRef(
           sandboxValidated: true,
           readFile: createSandboxBridgeReadFile({ sandbox: options.sandbox }),
         })
-      : await loadWebMedia(targetPath, options?.maxBytes);
+      : await loadWebMedia(targetPath, {
+          maxBytes: options?.maxBytes,
+          localRoots: resolveMediaToolLocalRoots(workspaceDir, {
+            workspaceOnly: options?.workspaceOnly,
+            allowedRoots: options?.allowedRoots,
+          }),
+        });
 
     if (media.kind !== "image") {
       log.debug(`Native image: not an image file: ${targetPath} (got ${media.kind})`);
@@ -290,6 +300,7 @@ export async function detectAndLoadPromptImages(params: {
   maxBytes?: number;
   maxDimensionPx?: number;
   workspaceOnly?: boolean;
+  allowedRoots?: string[];
   sandbox?: { root: string; bridge: SandboxFsBridge };
 }): Promise<{
   /** Images for the current prompt (existingImages + detected in current prompt) */
@@ -331,6 +342,7 @@ export async function detectAndLoadPromptImages(params: {
     const image = await loadImageFromRef(ref, params.workspaceDir, {
       maxBytes: params.maxBytes,
       workspaceOnly: params.workspaceOnly,
+      allowedRoots: params.allowedRoots,
       sandbox: params.sandbox,
     });
     if (image) {

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -233,7 +233,7 @@ describe("Agent-specific tool filtering", () => {
     );
   });
 
-  it("passes tools.fs.allowedRoots through to apply_patch", async () => {
+  it("passes tools.fs.allowedRoots through to apply_patch when fs workspaceOnly is enabled", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-tools-ws-"));
     const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-tools-allowed-"));
     const target = path.join(allowedDir, "shared.txt");
@@ -270,6 +270,51 @@ describe("Agent-specific tool filtering", () => {
 
       await applyPatchTool.execute("tc3", { input: patch });
       expect(await fs.readFile(target, "utf8")).toBe("shared\n");
+    } finally {
+      await fs.rm(allowedDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not widen apply_patch with allowedRoots when fs workspaceOnly is disabled", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-tools-ws-"));
+    const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-tools-allowed-"));
+    const target = path.join(allowedDir, "shared.txt");
+
+    try {
+      const cfg: OpenClawConfig = {
+        tools: {
+          fs: { workspaceOnly: false, allowedRoots: [allowedDir] },
+          allow: ["read", "exec"],
+          exec: { applyPatch: { enabled: true } },
+        },
+      };
+
+      const tools = createOpenClawCodingTools({
+        config: cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+        agentDir: "/tmp/agent",
+        modelProvider: "openai",
+        modelId: "gpt-5.2",
+      });
+
+      const applyPatchTool = tools.find((t) => t.name === "apply_patch") as
+        | ToolWithExecute
+        | undefined;
+      if (!applyPatchTool) {
+        throw new Error("apply_patch tool missing");
+      }
+
+      const patch = `*** Begin Patch
+*** Add File: ${target}
++shared
+*** End Patch`;
+
+      await expect(applyPatchTool.execute("tc4", { input: patch })).rejects.toThrow(
+        /Path escapes sandbox root/,
+      );
+      await expect(fs.readFile(target, "utf8")).rejects.toBeDefined();
     } finally {
       await fs.rm(allowedDir, { recursive: true, force: true });
       await fs.rm(workspaceDir, { recursive: true, force: true });

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -233,6 +233,49 @@ describe("Agent-specific tool filtering", () => {
     );
   });
 
+  it("passes tools.fs.allowedRoots through to apply_patch", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-tools-ws-"));
+    const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-tools-allowed-"));
+    const target = path.join(allowedDir, "shared.txt");
+
+    try {
+      const cfg: OpenClawConfig = {
+        tools: {
+          fs: { workspaceOnly: true, allowedRoots: [allowedDir] },
+          allow: ["read", "exec"],
+          exec: { applyPatch: { enabled: true } },
+        },
+      };
+
+      const tools = createOpenClawCodingTools({
+        config: cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+        agentDir: "/tmp/agent",
+        modelProvider: "openai",
+        modelId: "gpt-5.2",
+      });
+
+      const applyPatchTool = tools.find((t) => t.name === "apply_patch") as
+        | ToolWithExecute
+        | undefined;
+      if (!applyPatchTool) {
+        throw new Error("apply_patch tool missing");
+      }
+
+      const patch = `*** Begin Patch
+*** Add File: ${target}
++shared
+*** End Patch`;
+
+      await applyPatchTool.execute("tc3", { input: patch });
+      expect(await fs.readFile(target, "utf8")).toBe("shared\n");
+    } finally {
+      await fs.rm(allowedDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("should apply agent-specific tool policy", () => {
     const cfg: OpenClawConfig = {
       tools: {

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -810,7 +810,7 @@ function createHostEditOperations(
         rootDir: sandboxResult.matchedRoot,
         relativePath: sandboxResult.relative,
       });
-      return safeRead.buffer.toString("utf-8");
+      return safeRead.buffer;
     },
     writeFile: async (absolutePath: string, content: string) => {
       const sandboxResult = await assertSandboxPath({

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -810,7 +810,7 @@ function createHostEditOperations(
         rootDir: sandboxResult.matchedRoot,
         relativePath: sandboxResult.relative,
       });
-      return safeRead.content.toString("utf-8");
+      return safeRead.buffer.toString("utf-8");
     },
     writeFile: async (absolutePath: string, content: string) => {
       const sandboxResult = await assertSandboxPath({

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
-import { appendFileWithinRoot, writeFileWithinRoot } from "../infra/fs-safe.js";
+import { appendFileWithinRoot, readFileWithinRoot, writeFileWithinRoot } from "../infra/fs-safe.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -758,9 +758,12 @@ function createHostWriteOperations(
         root,
         additionalRoots: allowedRoots,
       });
+      if (!sandboxResult.relative) {
+        throw new Error(`Cannot write to root directory itself: ${absolutePath}`);
+      }
       await writeFileWithinRoot({
         rootDir: sandboxResult.matchedRoot,
-        relativePath: sandboxResult.relative || path.basename(sandboxResult.resolved),
+        relativePath: sandboxResult.relative,
         data: content,
         encoding: "utf-8",
         mkdir: true,
@@ -800,7 +803,14 @@ function createHostEditOperations(
         root,
         additionalRoots: allowedRoots,
       });
-      return await fs.readFile(sandboxResult.resolved);
+      if (!sandboxResult.relative) {
+        throw new Error(`Cannot read root directory itself: ${absolutePath}`);
+      }
+      const safeRead = await readFileWithinRoot({
+        rootDir: sandboxResult.matchedRoot,
+        relativePath: sandboxResult.relative,
+      });
+      return safeRead.content.toString("utf-8");
     },
     writeFile: async (absolutePath: string, content: string) => {
       const sandboxResult = await assertSandboxPath({
@@ -809,9 +819,12 @@ function createHostEditOperations(
         root,
         additionalRoots: allowedRoots,
       });
+      if (!sandboxResult.relative) {
+        throw new Error(`Cannot write to root directory itself: ${absolutePath}`);
+      }
       await writeFileWithinRoot({
         rootDir: sandboxResult.matchedRoot,
-        relativePath: sandboxResult.relative || path.basename(sandboxResult.resolved),
+        relativePath: sandboxResult.relative,
         data: content,
         encoding: "utf-8",
         mkdir: true,

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -16,7 +16,7 @@ import {
   wrapToolParamNormalization,
 } from "./pi-tools.params.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
-import { assertSandboxPath } from "./sandbox-paths.js";
+import { assertSandboxPath, resolveSandboxInputPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
 
@@ -559,6 +559,22 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
   };
 }
 
+function normalizeWrappedToolPathForExecution(filePath: string, root: string): string {
+  const trimmed = filePath.trim();
+  if (!trimmed) {
+    return filePath;
+  }
+  if (
+    trimmed === "~" ||
+    trimmed.startsWith("~/") ||
+    trimmed.startsWith("~\\") ||
+    trimmed.startsWith("@")
+  ) {
+    return resolveSandboxInputPath(trimmed, root);
+  }
+  return filePath;
+}
+
 export function wrapToolWorkspaceRootGuardWithOptions(
   tool: AnyAgentTool,
   root: string,
@@ -574,6 +590,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
       const record =
         normalized ??
         (args && typeof args === "object" ? (args as Record<string, unknown>) : undefined);
+      let executionArgs = normalized ?? args;
       const filePath = record?.path;
       if (typeof filePath === "string" && filePath.trim()) {
         const sandboxPath = mapContainerPathToWorkspaceRoot({
@@ -582,8 +599,12 @@ export function wrapToolWorkspaceRootGuardWithOptions(
           containerWorkdir: options?.containerWorkdir,
         });
         await assertSandboxPath({ filePath: sandboxPath, cwd: root, root, additionalRoots });
+        const normalizedPath = normalizeWrappedToolPathForExecution(sandboxPath, root);
+        if (normalizedPath !== filePath && record) {
+          executionArgs = { ...record, path: normalizedPath };
+        }
       }
-      return tool.execute(toolCallId, normalized ?? args, signal, onUpdate);
+      return tool.execute(toolCallId, executionArgs, signal, onUpdate);
     },
   };
 }

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -3,17 +3,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
-import {
-  appendFileWithinRoot,
-  SafeOpenError,
-  openFileWithinRoot,
-  readFileWithinRoot,
-  writeFileWithinRoot,
-} from "../infra/fs-safe.js";
+import { appendFileWithinRoot } from "../infra/fs-safe.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
-import { toRelativeWorkspacePath } from "./path-policy.js";
 import { wrapHostEditToolWithPostWriteRecovery } from "./pi-tools.host-edit.js";
 import {
   CLAUDE_PARAM_GROUPS,
@@ -351,8 +344,12 @@ async function normalizeReadImageResult(
   return { ...result, content: nextContent };
 }
 
-export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): AnyAgentTool {
-  return wrapToolWorkspaceRootGuardWithOptions(tool, root);
+export function wrapToolWorkspaceRootGuard(
+  tool: AnyAgentTool,
+  root: string,
+  additionalRoots?: string[],
+): AnyAgentTool {
+  return wrapToolWorkspaceRootGuardWithOptions(tool, root, undefined, additionalRoots);
 }
 
 function mapContainerPathToWorkspaceRoot(params: {
@@ -568,6 +565,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
   options?: {
     containerWorkdir?: string;
   },
+  additionalRoots?: string[],
 ): AnyAgentTool {
   return {
     ...tool,
@@ -583,7 +581,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
           root,
           containerWorkdir: options?.containerWorkdir,
         });
-        await assertSandboxPath({ filePath: sandboxPath, cwd: root, root });
+        await assertSandboxPath({ filePath: sandboxPath, cwd: root, root, additionalRoots });
       }
       return tool.execute(toolCallId, normalized ?? args, signal, onUpdate);
     },
@@ -621,14 +619,20 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
 }
 
-export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {
+export function createHostWorkspaceWriteTool(
+  root: string,
+  options?: { workspaceOnly?: boolean; allowedRoots?: string[] },
+) {
   const base = createWriteTool(root, {
     operations: createHostWriteOperations(root, options),
   }) as unknown as AnyAgentTool;
   return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.write);
 }
 
-export function createHostWorkspaceEditTool(root: string, options?: { workspaceOnly?: boolean }) {
+export function createHostWorkspaceEditTool(
+  root: string,
+  options?: { workspaceOnly?: boolean; allowedRoots?: string[] },
+) {
   const base = createEditTool(root, {
     operations: createHostEditOperations(root, options),
   }) as unknown as AnyAgentTool;
@@ -718,8 +722,12 @@ async function writeHostFile(absolutePath: string, content: string) {
   await fs.writeFile(resolved, content, "utf-8");
 }
 
-function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {
+function createHostWriteOperations(
+  root: string,
+  options?: { workspaceOnly?: boolean; allowedRoots?: string[] },
+) {
   const workspaceOnly = options?.workspaceOnly ?? false;
+  const allowedRoots = options?.allowedRoots;
 
   if (!workspaceOnly) {
     // When workspaceOnly is false, allow writes anywhere on the host
@@ -732,28 +740,38 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
     } as const;
   }
 
-  // When workspaceOnly is true, enforce workspace boundary
+  // When workspaceOnly is true, enforce workspace boundary (with optional allowedRoots)
   return {
     mkdir: async (dir: string) => {
-      const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
-      const resolved = relative ? path.resolve(root, relative) : path.resolve(root);
-      await assertSandboxPath({ filePath: resolved, cwd: root, root });
+      const resolved = path.resolve(dir);
+      await assertSandboxPath({
+        filePath: resolved,
+        cwd: root,
+        root,
+        additionalRoots: allowedRoots,
+      });
       await fs.mkdir(resolved, { recursive: true });
     },
     writeFile: async (absolutePath: string, content: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
-      await writeFileWithinRoot({
-        rootDir: root,
-        relativePath: relative,
-        data: content,
-        mkdir: true,
+      const sandboxResult = await assertSandboxPath({
+        filePath: absolutePath,
+        cwd: root,
+        root,
+        additionalRoots: allowedRoots,
       });
+      const resolvedPath = sandboxResult.resolved;
+      await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+      await fs.writeFile(resolvedPath, content, "utf-8");
     },
   } as const;
 }
 
-function createHostEditOperations(root: string, options?: { workspaceOnly?: boolean }) {
+function createHostEditOperations(
+  root: string,
+  options?: { workspaceOnly?: boolean; allowedRoots?: string[] },
+) {
   const workspaceOnly = options?.workspaceOnly ?? false;
+  const allowedRoots = options?.allowedRoots;
 
   if (!workspaceOnly) {
     // When workspaceOnly is false, allow edits anywhere on the host
@@ -770,51 +788,49 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
     } as const;
   }
 
-  // When workspaceOnly is true, enforce workspace boundary
+  // When workspaceOnly is true, enforce workspace boundary (with optional allowedRoots)
   return {
     readFile: async (absolutePath: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
-      const safeRead = await readFileWithinRoot({
-        rootDir: root,
-        relativePath: relative,
+      const sandboxResult = await assertSandboxPath({
+        filePath: absolutePath,
+        cwd: root,
+        root,
+        additionalRoots: allowedRoots,
       });
-      return safeRead.buffer;
+      return await fs.readFile(sandboxResult.resolved);
     },
     writeFile: async (absolutePath: string, content: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
-      await writeFileWithinRoot({
-        rootDir: root,
-        relativePath: relative,
-        data: content,
-        mkdir: true,
+      const sandboxResult = await assertSandboxPath({
+        filePath: absolutePath,
+        cwd: root,
+        root,
+        additionalRoots: allowedRoots,
       });
+      const resolvedPath = sandboxResult.resolved;
+      await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+      await fs.writeFile(resolvedPath, content, "utf-8");
     },
     access: async (absolutePath: string) => {
-      let relative: string;
       try {
-        relative = toRelativeWorkspacePath(root, absolutePath);
+        await assertSandboxPath({
+          filePath: absolutePath,
+          cwd: root,
+          root,
+          additionalRoots: allowedRoots,
+        });
       } catch {
-        // Path escapes workspace root.  Don't throw here – the upstream
-        // library replaces any `access` error with a misleading "File not
-        // found" message.  By returning silently the subsequent `readFile`
-        // call will throw the same "Path escapes workspace root" error
-        // through a code-path that propagates the original message.
+        // Don't throw here – the upstream library replaces any `access` error
+        // with a misleading "File not found" message. By returning silently the
+        // subsequent `readFile` call will throw through a code-path that
+        // propagates the original message.
         return;
       }
+      const resolved = path.resolve(absolutePath);
       try {
-        const opened = await openFileWithinRoot({
-          rootDir: root,
-          relativePath: relative,
-        });
-        await opened.handle.close().catch(() => {});
+        await fs.access(resolved);
       } catch (error) {
-        if (error instanceof SafeOpenError && error.code === "not-found") {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
           throw createFsAccessError("ENOENT", absolutePath);
-        }
-        if (error instanceof SafeOpenError && error.code === "outside-workspace") {
-          // Don't throw here – see the comment above about the upstream
-          // library swallowing access errors as "File not found".
-          return;
         }
         throw error;
       }

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
-import { appendFileWithinRoot } from "../infra/fs-safe.js";
+import { appendFileWithinRoot, writeFileWithinRoot } from "../infra/fs-safe.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -743,14 +743,13 @@ function createHostWriteOperations(
   // When workspaceOnly is true, enforce workspace boundary (with optional allowedRoots)
   return {
     mkdir: async (dir: string) => {
-      const resolved = path.resolve(dir);
-      await assertSandboxPath({
-        filePath: resolved,
+      const sandboxResult = await assertSandboxPath({
+        filePath: dir,
         cwd: root,
         root,
         additionalRoots: allowedRoots,
       });
-      await fs.mkdir(resolved, { recursive: true });
+      await fs.mkdir(sandboxResult.resolved, { recursive: true });
     },
     writeFile: async (absolutePath: string, content: string) => {
       const sandboxResult = await assertSandboxPath({
@@ -759,9 +758,13 @@ function createHostWriteOperations(
         root,
         additionalRoots: allowedRoots,
       });
-      const resolvedPath = sandboxResult.resolved;
-      await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
-      await fs.writeFile(resolvedPath, content, "utf-8");
+      await writeFileWithinRoot({
+        rootDir: sandboxResult.matchedRoot,
+        relativePath: sandboxResult.relative || path.basename(sandboxResult.resolved),
+        data: content,
+        encoding: "utf-8",
+        mkdir: true,
+      });
     },
   } as const;
 }
@@ -806,13 +809,18 @@ function createHostEditOperations(
         root,
         additionalRoots: allowedRoots,
       });
-      const resolvedPath = sandboxResult.resolved;
-      await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
-      await fs.writeFile(resolvedPath, content, "utf-8");
+      await writeFileWithinRoot({
+        rootDir: sandboxResult.matchedRoot,
+        relativePath: sandboxResult.relative || path.basename(sandboxResult.resolved),
+        data: content,
+        encoding: "utf-8",
+        mkdir: true,
+      });
     },
     access: async (absolutePath: string) => {
+      let sandboxResult;
       try {
-        await assertSandboxPath({
+        sandboxResult = await assertSandboxPath({
           filePath: absolutePath,
           cwd: root,
           root,
@@ -825,9 +833,8 @@ function createHostEditOperations(
         // propagates the original message.
         return;
       }
-      const resolved = path.resolve(absolutePath);
       try {
-        await fs.access(resolved);
+        await fs.access(sandboxResult.resolved);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") {
           throw createFsAccessError("ENOENT", absolutePath);

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -5,10 +5,12 @@ import type { AnyAgentTool } from "./pi-tools.types.js";
 
 const mocks = vi.hoisted(() => ({
   assertSandboxPath: vi.fn(async () => ({ resolved: "/tmp/root", relative: "" })),
+  resolveSandboxInputPath: vi.fn((filePath: string) => filePath),
 }));
 
 vi.mock("./sandbox-paths.js", () => ({
   assertSandboxPath: mocks.assertSandboxPath,
+  resolveSandboxInputPath: mocks.resolveSandboxInputPath,
 }));
 
 function createToolHarness() {
@@ -29,6 +31,8 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
 
   beforeEach(() => {
     mocks.assertSandboxPath.mockClear();
+    mocks.resolveSandboxInputPath.mockClear();
+    mocks.resolveSandboxInputPath.mockImplementation((filePath: string) => filePath);
   });
 
   it("maps container workspace paths to host workspace root", async () => {
@@ -89,6 +93,28 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
       cwd: root,
       root,
     });
+  });
+
+  it("normalizes Windows-style tilde paths before calling the wrapped tool", async () => {
+    const { execute, tool } = createToolHarness();
+    mocks.resolveSandboxInputPath.mockReturnValue("C:/Users/me/projects/note.txt");
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/workspace",
+    });
+
+    await wrapped.execute("tc-tilde-win", { path: "~\\projects\\note.txt" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: "~\\projects\\note.txt",
+      cwd: root,
+      root,
+    });
+    expect(execute).toHaveBeenCalledWith(
+      "tc-tilde-win",
+      { path: "C:/Users/me/projects/note.txt" },
+      undefined,
+      undefined,
+    );
   });
 
   it("does not remap absolute paths outside the configured container workdir", async () => {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -352,6 +352,7 @@ export function createOpenClawCodingTools(options?: {
   const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
   const workspaceOnly = fsPolicy.workspaceOnly;
   const allowedRoots = fsPolicy.allowedRoots;
+  const applyPatchAllowedRoots = workspaceOnly ? allowedRoots : [];
   const applyPatchConfig = execConfig.applyPatch;
   // Secure by default: apply_patch is workspace-contained unless explicitly disabled.
   // (tools.fs.workspaceOnly is a separate umbrella flag for read/write/edit/apply_patch.)
@@ -473,10 +474,14 @@ export function createOpenClawCodingTools(options?: {
           cwd: sandboxRoot ?? workspaceRoot,
           sandbox:
             sandboxRoot && allowWorkspaceWrites
-              ? { root: sandboxRoot, bridge: sandboxFsBridge!, allowedRoots }
+              ? {
+                  root: sandboxRoot,
+                  bridge: sandboxFsBridge!,
+                  allowedRoots: applyPatchAllowedRoots,
+                }
               : undefined,
           workspaceOnly: applyPatchWorkspaceOnly,
-          allowedRoots,
+          allowedRoots: applyPatchAllowedRoots,
         });
   const tools: AnyAgentTool[] = [
     ...base,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -344,12 +344,14 @@ export function createOpenClawCodingTools(options?: {
   const fsConfig = resolveToolFsConfig({ cfg: options?.config, agentId });
   const fsPolicy = createToolFsPolicy({
     workspaceOnly: isMemoryFlushRun || fsConfig.workspaceOnly,
+    allowedRoots: fsConfig.allowedRoots,
   });
   const sandboxRoot = sandbox?.workspaceDir;
   const sandboxFsBridge = sandbox?.fsBridge;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
   const workspaceOnly = fsPolicy.workspaceOnly;
+  const allowedRoots = fsPolicy.allowedRoots;
   const applyPatchConfig = execConfig.applyPatch;
   // Secure by default: apply_patch is workspace-contained unless explicitly disabled.
   // (tools.fs.workspaceOnly is a separate umbrella flag for read/write/edit/apply_patch.)
@@ -379,9 +381,14 @@ export function createOpenClawCodingTools(options?: {
         });
         return [
           workspaceOnly
-            ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
-                containerWorkdir: sandbox.containerWorkdir,
-              })
+            ? wrapToolWorkspaceRootGuardWithOptions(
+                sandboxed,
+                sandboxRoot,
+                {
+                  containerWorkdir: sandbox.containerWorkdir,
+                },
+                allowedRoots,
+              )
             : sandboxed,
         ];
       }
@@ -390,7 +397,9 @@ export function createOpenClawCodingTools(options?: {
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,
       });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      return [
+        workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot, allowedRoots) : wrapped,
+      ];
     }
     if (tool.name === "bash" || tool.name === execToolName) {
       return [];
@@ -399,15 +408,19 @@ export function createOpenClawCodingTools(options?: {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly, allowedRoots });
+      return [
+        workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot, allowedRoots) : wrapped,
+      ];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly, allowedRoots });
+      return [
+        workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot, allowedRoots) : wrapped,
+      ];
     }
     return [tool];
   });
@@ -476,6 +489,7 @@ export function createOpenClawCodingTools(options?: {
                   {
                     containerWorkdir: sandbox.containerWorkdir,
                   },
+                  allowedRoots,
                 )
               : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
             workspaceOnly
@@ -485,6 +499,7 @@ export function createOpenClawCodingTools(options?: {
                   {
                     containerWorkdir: sandbox.containerWorkdir,
                   },
+                  allowedRoots,
                 )
               : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
           ]

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -473,9 +473,10 @@ export function createOpenClawCodingTools(options?: {
           cwd: sandboxRoot ?? workspaceRoot,
           sandbox:
             sandboxRoot && allowWorkspaceWrites
-              ? { root: sandboxRoot, bridge: sandboxFsBridge! }
+              ? { root: sandboxRoot, bridge: sandboxFsBridge!, allowedRoots }
               : undefined,
           workspaceOnly: applyPatchWorkspaceOnly,
+          allowedRoots,
         });
   const tools: AnyAgentTool[] = [
     ...base,

--- a/src/agents/sandbox-media-paths.test.ts
+++ b/src/agents/sandbox-media-paths.test.ts
@@ -1,4 +1,8 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import {
   createSandboxBridgeReadFile,
   resolveSandboxedBridgeMediaPath,
@@ -41,5 +45,36 @@ describe("createSandboxBridgeReadFile", () => {
 
     expect(resolved).toEqual({ resolved: "/sandbox/image.png" });
     expect(stat).not.toHaveBeenCalled();
+  });
+
+  it("allows default media roots when workspaceOnly is enabled", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sandbox-root-"));
+    const defaultRoot = resolvePreferredOpenClawTmpDir();
+    await fs.mkdir(defaultRoot, { recursive: true });
+    const mediaDir = await fs.mkdtemp(path.join(defaultRoot, "openclaw-sandbox-media-"));
+    const mediaPath = path.join(mediaDir, "generated.png");
+    await fs.writeFile(mediaPath, Buffer.from("ok"));
+
+    try {
+      const resolved = await resolveSandboxedBridgeMediaPath({
+        sandbox: {
+          root: sandboxRoot,
+          workspaceOnly: true,
+          bridge: {
+            resolvePath: ({ filePath }: { filePath: string }) => ({
+              relativePath: path.basename(filePath),
+              containerPath: filePath,
+              hostPath: filePath,
+            }),
+          } as unknown as SandboxFsBridge,
+        },
+        mediaPath,
+      });
+
+      expect(resolved).toEqual({ resolved: mediaPath });
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+      await fs.rm(mediaDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/sandbox-media-paths.ts
+++ b/src/agents/sandbox-media-paths.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { getDefaultLocalRoots } from "../plugin-sdk/web-media.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
@@ -27,6 +28,9 @@ export async function resolveSandboxedBridgeMediaPath(params: {
   const normalizeFileUrl = (rawPath: string) =>
     rawPath.startsWith("file://") ? rawPath.slice("file://".length) : rawPath;
   const filePath = normalizeFileUrl(params.mediaPath);
+  const mediaBoundaryRoots = params.sandbox.workspaceOnly
+    ? Array.from(new Set([...(params.sandbox.allowedRoots ?? []), ...getDefaultLocalRoots()]))
+    : params.sandbox.allowedRoots;
   const enforceWorkspaceBoundary = async (hostPath: string) => {
     if (!params.sandbox.workspaceOnly) {
       return;
@@ -35,7 +39,7 @@ export async function resolveSandboxedBridgeMediaPath(params: {
       filePath: hostPath,
       cwd: params.sandbox.root,
       root: params.sandbox.root,
-      additionalRoots: params.sandbox.allowedRoots,
+      additionalRoots: mediaBoundaryRoots,
     });
   };
 

--- a/src/agents/sandbox-media-paths.ts
+++ b/src/agents/sandbox-media-paths.ts
@@ -6,6 +6,7 @@ export type SandboxedBridgeMediaPathConfig = {
   root: string;
   bridge: SandboxFsBridge;
   workspaceOnly?: boolean;
+  allowedRoots?: string[];
 };
 
 export function createSandboxBridgeReadFile(params: {
@@ -34,6 +35,7 @@ export async function resolveSandboxedBridgeMediaPath(params: {
       filePath: hostPath,
       cwd: params.sandbox.root,
       root: params.sandbox.root,
+      additionalRoots: params.sandbox.allowedRoots,
     });
   };
 

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
-import { resolveSandboxedMediaSource } from "./sandbox-paths.js";
+import {
+  assertSandboxPath,
+  resolveSandboxPath,
+  resolveSandboxedMediaSource,
+} from "./sandbox-paths.js";
 
 async function withSandboxRoot<T>(run: (sandboxDir: string) => Promise<T>) {
   const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-media-"));
@@ -276,5 +280,232 @@ describe("resolveSandboxedMediaSource", () => {
       sandboxRoot: "/any/path",
     });
     expect(result).toBe("");
+  });
+});
+
+describe("resolveSandboxPath with additionalRoots", () => {
+  it("resolves a path inside the primary root without additionalRoots", () => {
+    const result = resolveSandboxPath({
+      filePath: "file.txt",
+      cwd: "/workspace",
+      root: "/workspace",
+    });
+    expect(result.resolved).toBe("/workspace/file.txt");
+    expect(result.relative).toBe("file.txt");
+    expect(result.matchedRoot).toBe("/workspace");
+  });
+
+  it("resolves a path inside an additional root", () => {
+    const result = resolveSandboxPath({
+      filePath: "/extra/data/file.txt",
+      cwd: "/workspace",
+      root: "/workspace",
+      additionalRoots: ["/extra/data"],
+    });
+    expect(result.resolved).toBe("/extra/data/file.txt");
+    expect(result.relative).toBe("file.txt");
+    expect(result.matchedRoot).toBe("/extra/data");
+  });
+
+  it("rejects a path outside both primary and additional roots", () => {
+    expect(() =>
+      resolveSandboxPath({
+        filePath: "/etc/passwd",
+        cwd: "/workspace",
+        root: "/workspace",
+        additionalRoots: ["/extra/data"],
+      }),
+    ).toThrow(/sandbox/i);
+  });
+
+  it("applies tilde expansion for additionalRoots entries", () => {
+    const homeDir = os.homedir();
+    const result = resolveSandboxPath({
+      filePath: path.join(homeDir, "notes", "file.txt"),
+      cwd: "/workspace",
+      root: "/workspace",
+      additionalRoots: ["~/notes"],
+    });
+    expect(result.resolved).toBe(path.join(homeDir, "notes", "file.txt"));
+    expect(result.relative).toBe("file.txt");
+    expect(result.matchedRoot).toBe(path.resolve(homeDir, "notes"));
+  });
+
+  it("empty additionalRoots behaves same as no additionalRoots (backward compat)", () => {
+    // Path inside root works
+    const result = resolveSandboxPath({
+      filePath: "file.txt",
+      cwd: "/workspace",
+      root: "/workspace",
+      additionalRoots: [],
+    });
+    expect(result.resolved).toBe("/workspace/file.txt");
+    expect(result.matchedRoot).toBe("/workspace");
+
+    // Path outside root throws
+    expect(() =>
+      resolveSandboxPath({
+        filePath: "/etc/passwd",
+        cwd: "/workspace",
+        root: "/workspace",
+        additionalRoots: [],
+      }),
+    ).toThrow(/sandbox/i);
+  });
+
+  it("returns matchedRoot for primary root when path is inside primary root", () => {
+    const result = resolveSandboxPath({
+      filePath: "/workspace/deep/file.txt",
+      cwd: "/workspace",
+      root: "/workspace",
+      additionalRoots: ["/extra"],
+    });
+    expect(result.matchedRoot).toBe("/workspace");
+  });
+
+  it("prefers primary root when path matches both primary and additional root", () => {
+    // If /workspace/sub is an additionalRoot, a file inside /workspace should match primary first
+    const result = resolveSandboxPath({
+      filePath: "/workspace/sub/file.txt",
+      cwd: "/workspace",
+      root: "/workspace",
+      additionalRoots: ["/workspace/sub"],
+    });
+    expect(result.matchedRoot).toBe("/workspace");
+  });
+});
+
+describe("assertSandboxPath with additionalRoots", () => {
+  async function withTempDirs<T>(
+    run: (dirs: { primary: string; extra: string }) => Promise<T>,
+  ): Promise<T> {
+    const primary = await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-primary-"));
+    const extra = await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-extra-"));
+    try {
+      return await run({ primary, extra });
+    } finally {
+      await fs.rm(primary, { recursive: true, force: true });
+      await fs.rm(extra, { recursive: true, force: true });
+    }
+  }
+
+  it("accepts a file inside an additional root", async () => {
+    await withTempDirs(async ({ primary, extra }) => {
+      const filePath = path.join(extra, "file.txt");
+      await fs.writeFile(filePath, "content");
+      const result = await assertSandboxPath({
+        filePath,
+        cwd: primary,
+        root: primary,
+        additionalRoots: [extra],
+      });
+      expect(result.resolved).toBe(filePath);
+      expect(result.matchedRoot).toBe(path.resolve(extra));
+    });
+  });
+
+  it("rejects a path outside both primary and additional roots", async () => {
+    await withTempDirs(async ({ primary, extra }) => {
+      await expect(
+        assertSandboxPath({
+          filePath: "/etc/passwd",
+          cwd: primary,
+          root: primary,
+          additionalRoots: [extra],
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    });
+  });
+
+  it("rejects a symlink inside an additional root that points outside it", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withTempDirs(async ({ primary, extra }) => {
+      // Create a file outside both roots
+      const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-outside-"));
+      const outsideFile = path.join(outsideDir, "secret.txt");
+      await fs.writeFile(outsideFile, "secret");
+
+      // Create a symlink inside the additional root pointing outside
+      const symlinkPath = path.join(extra, "escape-link");
+      await fs.symlink(outsideFile, symlinkPath);
+
+      try {
+        await expect(
+          assertSandboxPath({
+            filePath: symlinkPath,
+            cwd: primary,
+            root: primary,
+            additionalRoots: [extra],
+          }),
+        ).rejects.toThrow(/symlink|sandbox/i);
+      } finally {
+        await fs.rm(symlinkPath, { force: true });
+        await fs.rm(outsideDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it("accepts a file inside the primary root when additionalRoots are set", async () => {
+    await withTempDirs(async ({ primary, extra }) => {
+      const filePath = path.join(primary, "file.txt");
+      await fs.writeFile(filePath, "content");
+      const result = await assertSandboxPath({
+        filePath,
+        cwd: primary,
+        root: primary,
+        additionalRoots: [extra],
+      });
+      expect(result.resolved).toBe(filePath);
+      expect(result.matchedRoot).toBe(path.resolve(primary));
+    });
+  });
+
+  it("works with tilde-expanded additional roots", async () => {
+    await withTempDirs(async ({ primary, extra }) => {
+      // Create a file inside extra root
+      const filePath = path.join(extra, "note.txt");
+      await fs.writeFile(filePath, "content");
+
+      // Construct a tilde-based path if extra is under homedir
+      const homeDir = os.homedir();
+      const tildeRoot = extra.startsWith(homeDir) ? "~" + extra.slice(homeDir.length) : extra;
+
+      const result = await assertSandboxPath({
+        filePath,
+        cwd: primary,
+        root: primary,
+        additionalRoots: [tildeRoot],
+      });
+      expect(result.resolved).toBe(filePath);
+    });
+  });
+
+  it("empty additionalRoots behaves same as without additionalRoots", async () => {
+    await withTempDirs(async ({ primary, extra }) => {
+      // File in primary root works
+      const filePath = path.join(primary, "file.txt");
+      await fs.writeFile(filePath, "content");
+      const result = await assertSandboxPath({
+        filePath,
+        cwd: primary,
+        root: primary,
+        additionalRoots: [],
+      });
+      expect(result.resolved).toBe(filePath);
+
+      // File in extra root fails (not in additionalRoots)
+      const extraFile = path.join(extra, "file.txt");
+      await fs.writeFile(extraFile, "content");
+      await expect(
+        assertSandboxPath({
+          filePath: extraFile,
+          cwd: primary,
+          root: primary,
+          additionalRoots: [],
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    });
   });
 });

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -318,6 +318,17 @@ describe("resolveSandboxPath with additionalRoots", () => {
     ).toThrow(/sandbox/i);
   });
 
+  it("rejects relative additionalRoots entries", () => {
+    expect(() =>
+      resolveSandboxPath({
+        filePath: "/etc/passwd",
+        cwd: "/workspace",
+        root: "/workspace",
+        additionalRoots: ["relative/root"],
+      }),
+    ).toThrow(/allowedRoots entries must be absolute paths/i);
+  });
+
   it("applies tilde expansion for additionalRoots entries", () => {
     const homeDir = os.homedir();
     const result = resolveSandboxPath({

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -331,6 +331,19 @@ describe("resolveSandboxPath with additionalRoots", () => {
     expect(result.matchedRoot).toBe(path.resolve(homeDir, "notes"));
   });
 
+  it("applies tilde expansion for Windows-style additionalRoots entries", () => {
+    const homeDir = os.homedir();
+    const result = resolveSandboxPath({
+      filePath: path.join(homeDir, "notes", "file.txt"),
+      cwd: "/workspace",
+      root: "/workspace",
+      additionalRoots: ["~\\notes"],
+    });
+    expect(result.resolved).toBe(path.join(homeDir, "notes", "file.txt"));
+    expect(result.relative).toBe("file.txt");
+    expect(result.matchedRoot).toBe(path.resolve(homeDir, "notes"));
+  });
+
   it("empty additionalRoots behaves same as no additionalRoots (backward compat)", () => {
     // Path inside root works
     const result = resolveSandboxPath({

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -41,26 +41,49 @@ export function resolveSandboxInputPath(filePath: string, cwd: string): string {
   return resolveToCwd(filePath, cwd);
 }
 
-export function resolveSandboxPath(params: { filePath: string; cwd: string; root: string }): {
+export function resolveSandboxPath(params: {
+  filePath: string;
+  cwd: string;
+  root: string;
+  additionalRoots?: string[];
+}): {
   resolved: string;
   relative: string;
+  matchedRoot: string;
 } {
   const resolved = resolveSandboxInputPath(params.filePath, params.cwd);
   const rootResolved = path.resolve(params.root);
   const relative = path.relative(rootResolved, resolved);
   if (!relative || relative === "") {
-    return { resolved, relative: "" };
+    return { resolved, relative: "", matchedRoot: rootResolved };
   }
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    throw new Error(`Path escapes sandbox root (${shortPath(rootResolved)}): ${params.filePath}`);
+  if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+    return { resolved, relative, matchedRoot: rootResolved };
   }
-  return { resolved, relative };
+
+  // Check additional roots
+  if (params.additionalRoots?.length) {
+    for (const extraRoot of params.additionalRoots) {
+      const expandedExtra = expandPath(extraRoot);
+      const resolvedExtra = path.resolve(expandedExtra);
+      const extraRelative = path.relative(resolvedExtra, resolved);
+      if (
+        extraRelative === "" ||
+        (!extraRelative.startsWith("..") && !path.isAbsolute(extraRelative))
+      ) {
+        return { resolved, relative: extraRelative, matchedRoot: resolvedExtra };
+      }
+    }
+  }
+
+  throw new Error(`Path escapes sandbox root (${shortPath(rootResolved)}): ${params.filePath}`);
 }
 
 export async function assertSandboxPath(params: {
   filePath: string;
   cwd: string;
   root: string;
+  additionalRoots?: string[];
   allowFinalSymlinkForUnlink?: boolean;
   allowFinalHardlinkForUnlink?: boolean;
 }) {
@@ -71,7 +94,7 @@ export async function assertSandboxPath(params: {
   };
   await assertNoPathAliasEscape({
     absolutePath: resolved.resolved,
-    rootPath: params.root,
+    rootPath: resolved.matchedRoot,
     boundaryLabel: "sandbox root",
     policy,
   });

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -23,8 +23,8 @@ function expandPath(filePath: string): string {
   if (normalized === "~") {
     return os.homedir();
   }
-  if (normalized.startsWith("~/")) {
-    return os.homedir() + normalized.slice(1);
+  if (normalized.startsWith("~/") || normalized.startsWith("~\\")) {
+    return path.join(os.homedir(), normalized.slice(2));
   }
   return normalized;
 }

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -65,6 +65,9 @@ export function resolveSandboxPath(params: {
   if (params.additionalRoots?.length) {
     for (const extraRoot of params.additionalRoots) {
       const expandedExtra = expandPath(extraRoot);
+      if (!path.isAbsolute(expandedExtra)) {
+        throw new Error(`allowedRoots entries must be absolute paths: ${extraRoot}`);
+      }
       const resolvedExtra = path.resolve(expandedExtra);
       const extraRelative = path.relative(resolvedExtra, resolved);
       if (

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -3,16 +3,22 @@ import { resolveAgentConfig } from "./agent-scope.js";
 
 export type ToolFsPolicy = {
   workspaceOnly: boolean;
+  allowedRoots: string[];
 };
 
-export function createToolFsPolicy(params: { workspaceOnly?: boolean }): ToolFsPolicy {
+export function createToolFsPolicy(params: {
+  workspaceOnly?: boolean;
+  allowedRoots?: string[];
+}): ToolFsPolicy {
   return {
     workspaceOnly: params.workspaceOnly === true,
+    allowedRoots: params.allowedRoots ?? [],
   };
 }
 
 export function resolveToolFsConfig(params: { cfg?: OpenClawConfig; agentId?: string }): {
   workspaceOnly?: boolean;
+  allowedRoots?: string[];
 } {
   const cfg = params.cfg;
   const globalFs = cfg?.tools?.fs;
@@ -20,6 +26,7 @@ export function resolveToolFsConfig(params: { cfg?: OpenClawConfig; agentId?: st
     cfg && params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools?.fs : undefined;
   return {
     workspaceOnly: agentFs?.workspaceOnly ?? globalFs?.workspaceOnly,
+    allowedRoots: agentFs?.allowedRoots ?? globalFs?.allowedRoots,
   };
 }
 

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -313,6 +313,65 @@ describe("createImageGenerateTool", () => {
     );
   });
 
+  it("passes fsPolicy.allowedRoots through for reference image loading", async () => {
+    vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "google",
+      model: "gemini-3-pro-image-preview",
+      attempts: [],
+      images: [
+        {
+          buffer: Buffer.from("png-out"),
+          mimeType: "image/png",
+          fileName: "edited.png",
+        },
+      ],
+    });
+    const loadSpy = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      kind: "image",
+      buffer: Buffer.from("input-image"),
+      contentType: "image/png",
+    });
+    vi.spyOn(imageOps, "getImageMetadata").mockResolvedValue({
+      width: 3200,
+      height: 1800,
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/edited.png",
+      id: "edited.png",
+      size: 7,
+      contentType: "image/png",
+    });
+
+    const tool = createImageGenerateTool({
+      config: {
+        agents: {
+          defaults: {
+            imageGenerationModel: {
+              primary: "google/gemini-3-pro-image-preview",
+            },
+          },
+        },
+      },
+      workspaceDir: "/workspace",
+      fsPolicy: { workspaceOnly: true, allowedRoots: ["/shared/media"] },
+    });
+
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("expected image_generate tool");
+    }
+
+    await tool.execute("call-edit-allowed", {
+      prompt: "edit",
+      image: "/shared/media/reference.png",
+    });
+
+    expect(loadSpy).toHaveBeenCalledWith(
+      "/shared/media/reference.png",
+      expect.objectContaining({ localRoots: expect.arrayContaining(["/shared/media"]) }),
+    );
+  });
+
   it("forwards explicit aspect ratio and supports up to 5 reference images", async () => {
     const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
       provider: "google",

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -354,7 +354,12 @@ async function loadReferenceImages(params: {
   imageInputs: string[];
   maxBytes?: number;
   localRoots: string[];
-  sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
+  sandboxConfig: {
+    root: string;
+    bridge: SandboxFsBridge;
+    workspaceOnly: boolean;
+    allowedRoots?: string[];
+  } | null;
 }): Promise<
   Array<{
     sourceImage: ImageGenerationSourceImage;
@@ -484,6 +489,7 @@ export function createImageGenerateTool(options?: {
     applyImageGenerationModelConfigDefaults(cfg, imageGenerationModelConfig) ?? cfg;
   const localRoots = resolveMediaToolLocalRoots(options?.workspaceDir, {
     workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
+    allowedRoots: options?.fsPolicy?.allowedRoots,
   });
   const sandboxConfig =
     options?.sandbox && options.sandbox.root.trim()
@@ -491,6 +497,7 @@ export function createImageGenerateTool(options?: {
           root: options.sandbox.root.trim(),
           bridge: options.sandbox.bridge,
           workspaceOnly: options.fsPolicy?.workspaceOnly === true,
+          allowedRoots: options.fsPolicy?.allowedRoots,
         }
       : null;
 

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -539,7 +539,7 @@ describe("image tool implicit imageModel config", () => {
           config: cfg,
           agentDir,
           workspaceDir,
-          fsPolicy: { workspaceOnly: true },
+          fsPolicy: { workspaceOnly: true, allowedRoots: [] },
         });
 
         // File inside workspace is allowed.

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -561,6 +561,32 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("allows non-sandbox image paths inside fsPolicy.allowedRoots", async () => {
+    await withTempWorkspacePng(async ({ workspaceDir }) => {
+      const fetch = stubMinimaxOkFetch();
+      await withTempAgentDir(async (agentDir) => {
+        const cfg = createMinimaxImageConfig();
+        const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-allowed-"));
+        const allowedImage = path.join(allowedDir, "shared.png");
+        await fs.writeFile(allowedImage, Buffer.from(ONE_PIXEL_PNG_B64, "base64"));
+
+        try {
+          const tool = createRequiredImageTool({
+            config: cfg,
+            agentDir,
+            workspaceDir,
+            fsPolicy: { workspaceOnly: true, allowedRoots: [allowedDir] },
+          });
+
+          await expectImageToolExecOk(tool, allowedImage);
+          expect(fetch).toHaveBeenCalledTimes(1);
+        } finally {
+          await fs.rm(allowedDir, { recursive: true, force: true });
+        }
+      });
+    });
+  });
+
   it("allows workspace images via createOpenClawCodingTools default workspace root", async () => {
     await withTempWorkspacePng(async ({ imagePath }) => {
       const fetch = stubMinimaxOkFetch();

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -255,6 +255,7 @@ export function createImageTool(options?: {
 
   const localRoots = resolveMediaToolLocalRoots(options?.workspaceDir, {
     workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
+    allowedRoots: options?.fsPolicy?.allowedRoots,
   });
 
   return {
@@ -333,6 +334,7 @@ export function createImageTool(options?: {
               root: options.sandbox.root.trim(),
               bridge: options.sandbox.bridge,
               workspaceOnly: options.fsPolicy?.workspaceOnly === true,
+              allowedRoots: options.fsPolicy?.allowedRoots,
             }
           : null;
 

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -25,6 +25,16 @@ describe("resolveMediaToolLocalRoots", () => {
     expect(result).not.toContain(path.resolve("@/shared/media"));
   });
 
+  it("preserves default media roots when workspaceOnly is true", () => {
+    const result = resolveMediaToolLocalRoots("/workspace", {
+      workspaceOnly: true,
+      allowedRoots: ["/shared/media"],
+    });
+
+    expect(result).toEqual(expect.arrayContaining(getDefaultLocalRoots() as string[]));
+    expect(result).toEqual(expect.arrayContaining(["/workspace", "/shared/media"]));
+  });
+
   it("ignores allowedRoots when workspaceOnly is false", () => {
     const result = resolveMediaToolLocalRoots("/workspace", {
       workspaceOnly: false,

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -15,6 +15,16 @@ describe("resolveMediaToolLocalRoots", () => {
     );
   });
 
+  it("normalizes @-prefixed allowedRoots when workspaceOnly is true", () => {
+    const result = resolveMediaToolLocalRoots("/workspace", {
+      workspaceOnly: true,
+      allowedRoots: ["@/shared/media"],
+    });
+
+    expect(result).toEqual(expect.arrayContaining(["/workspace", "/shared/media"]));
+    expect(result).not.toContain(path.resolve("@/shared/media"));
+  });
+
   it("ignores allowedRoots when workspaceOnly is false", () => {
     const result = resolveMediaToolLocalRoots("/workspace", {
       workspaceOnly: false,

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -35,6 +35,15 @@ describe("resolveMediaToolLocalRoots", () => {
     expect(result).toEqual(expect.arrayContaining(["/workspace", "/shared/media"]));
   });
 
+  it("rejects relative allowedRoots when workspaceOnly is true", () => {
+    expect(() =>
+      resolveMediaToolLocalRoots("/workspace", {
+        workspaceOnly: true,
+        allowedRoots: ["relative/media"],
+      }),
+    ).toThrow(/allowedRoots entries must be absolute paths/i);
+  });
+
   it("ignores allowedRoots when workspaceOnly is false", () => {
     const result = resolveMediaToolLocalRoots("/workspace", {
       workspaceOnly: false,

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -1,0 +1,27 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveMediaToolLocalRoots } from "./media-tool-shared.js";
+
+describe("resolveMediaToolLocalRoots", () => {
+  it("expands tilde allowedRoots when workspaceOnly is true", () => {
+    const result = resolveMediaToolLocalRoots("/workspace", {
+      workspaceOnly: true,
+      allowedRoots: ["~/projects/media"],
+    });
+
+    expect(result).toEqual(
+      expect.arrayContaining(["/workspace", path.join(os.homedir(), "projects/media")]),
+    );
+  });
+
+  it("ignores allowedRoots when workspaceOnly is false", () => {
+    const result = resolveMediaToolLocalRoots("/workspace", {
+      workspaceOnly: false,
+      allowedRoots: ["/shared/media"],
+    });
+
+    expect(result).toContain("/workspace");
+    expect(result).not.toContain("/shared/media");
+  });
+});

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { getDefaultLocalRoots } from "../../plugin-sdk/web-media.js";
 import { resolveMediaToolLocalRoots } from "./media-tool-shared.js";
 
 describe("resolveMediaToolLocalRoots", () => {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -59,13 +59,14 @@ function normalizeMediaAllowedRoot(root: string): string {
   if (!trimmed) {
     return trimmed;
   }
-  if (trimmed === "~") {
+  const normalized = trimmed.startsWith("@") ? trimmed.slice(1) : trimmed;
+  if (normalized === "~") {
     return os.homedir();
   }
-  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
-    return path.join(os.homedir(), trimmed.slice(2));
+  if (normalized.startsWith("~/") || normalized.startsWith("~\\")) {
+    return path.join(os.homedir(), normalized.slice(2));
   }
-  return path.resolve(trimmed);
+  return path.resolve(normalized);
 }
 
 export function resolveMediaToolLocalRoots(

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -74,15 +74,17 @@ export function resolveMediaToolLocalRoots(
   options?: { workspaceOnly?: boolean; allowedRoots?: string[] },
 ): string[] {
   const workspaceDir = normalizeWorkspaceDir(workspaceDirRaw);
+  const defaultRoots = getDefaultLocalRoots();
   const allowedRoots =
     options?.workspaceOnly === true
       ? (options?.allowedRoots ?? []).map(normalizeMediaAllowedRoot).filter(Boolean)
       : [];
   if (options?.workspaceOnly) {
-    return Array.from(new Set([...(workspaceDir ? [workspaceDir] : []), ...allowedRoots]));
+    return Array.from(
+      new Set([...defaultRoots, ...(workspaceDir ? [workspaceDir] : []), ...allowedRoots]),
+    );
   }
-  const roots = getDefaultLocalRoots();
-  return Array.from(new Set([...roots, ...(workspaceDir ? [workspaceDir] : [])]));
+  return Array.from(new Set([...defaultRoots, ...(workspaceDir ? [workspaceDir] : [])]));
 }
 
 export function resolvePromptAndModelOverride(

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -66,6 +66,9 @@ function normalizeMediaAllowedRoot(root: string): string {
   if (normalized.startsWith("~/") || normalized.startsWith("~\\")) {
     return path.join(os.homedir(), normalized.slice(2));
   }
+  if (!path.isAbsolute(normalized)) {
+    throw new Error(`allowedRoots entries must be absolute paths: ${root}`);
+  }
   return path.resolve(normalized);
 }
 

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { type Api, type Model } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getDefaultLocalRoots } from "../../plugin-sdk/web-media.js";
@@ -52,17 +54,34 @@ function applyAgentDefaultModelConfig(
   };
 }
 
+function normalizeMediaAllowedRoot(root: string): string {
+  const trimmed = root.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed === "~") {
+    return os.homedir();
+  }
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return path.join(os.homedir(), trimmed.slice(2));
+  }
+  return path.resolve(trimmed);
+}
+
 export function resolveMediaToolLocalRoots(
   workspaceDirRaw: string | undefined,
   options?: { workspaceOnly?: boolean; allowedRoots?: string[] },
 ): string[] {
   const workspaceDir = normalizeWorkspaceDir(workspaceDirRaw);
-  const allowedRoots = options?.allowedRoots ?? [];
+  const allowedRoots =
+    options?.workspaceOnly === true
+      ? (options?.allowedRoots ?? []).map(normalizeMediaAllowedRoot).filter(Boolean)
+      : [];
   if (options?.workspaceOnly) {
     return Array.from(new Set([...(workspaceDir ? [workspaceDir] : []), ...allowedRoots]));
   }
   const roots = getDefaultLocalRoots();
-  return Array.from(new Set([...roots, ...(workspaceDir ? [workspaceDir] : []), ...allowedRoots]));
+  return Array.from(new Set([...roots, ...(workspaceDir ? [workspaceDir] : [])]));
 }
 
 export function resolvePromptAndModelOverride(

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -54,17 +54,15 @@ function applyAgentDefaultModelConfig(
 
 export function resolveMediaToolLocalRoots(
   workspaceDirRaw: string | undefined,
-  options?: { workspaceOnly?: boolean },
+  options?: { workspaceOnly?: boolean; allowedRoots?: string[] },
 ): string[] {
   const workspaceDir = normalizeWorkspaceDir(workspaceDirRaw);
+  const allowedRoots = options?.allowedRoots ?? [];
   if (options?.workspaceOnly) {
-    return workspaceDir ? [workspaceDir] : [];
+    return Array.from(new Set([...(workspaceDir ? [workspaceDir] : []), ...allowedRoots]));
   }
   const roots = getDefaultLocalRoots();
-  if (!workspaceDir) {
-    return [...roots];
-  }
-  return Array.from(new Set([...roots, workspaceDir]));
+  return Array.from(new Set([...roots, ...(workspaceDir ? [workspaceDir] : []), ...allowedRoots]));
 }
 
 export function resolvePromptAndModelOverride(

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -415,6 +415,47 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("allows non-sandbox pdf paths inside fsPolicy.allowedRoots", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("ANTHROPIC_API_KEY", "anthropic-test");
+      const { loadSpy } = await stubPdfToolInfra(agentDir, {
+        provider: "anthropic",
+        input: ["text", "document"],
+      });
+      const nativeProviders = await import("./pdf-native-providers.js");
+      vi.spyOn(nativeProviders, "anthropicAnalyzePdf").mockResolvedValue("native summary");
+
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pdf-ws-"));
+      const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pdf-allowed-"));
+      try {
+        const cfg = withDefaultModel(ANTHROPIC_PDF_MODEL);
+        const tool = requirePdfTool(
+          createPdfTool({
+            config: cfg,
+            agentDir,
+            workspaceDir,
+            fsPolicy: { workspaceOnly: true, allowedRoots: [allowedDir] },
+          }),
+        );
+
+        const allowedPdf = path.join(allowedDir, "shared.pdf");
+        await fs.writeFile(allowedPdf, "%PDF-1.4 fake");
+
+        const result = await tool.execute("t1", { prompt: "test", pdf: allowedPdf });
+        expect(result).toMatchObject({
+          content: [{ type: "text", text: "native summary" }],
+        });
+        expect(loadSpy).toHaveBeenCalledWith(
+          allowedPdf,
+          expect.objectContaining({ localRoots: expect.arrayContaining([allowedDir]) }),
+        );
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+        await fs.rm(allowedDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   it("rejects unsupported scheme references", async () => {
     await withAnthropicPdfTool(async (tool) => {
       const result = await tool.execute("t1", {

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -398,7 +398,7 @@ describe("createPdfTool", () => {
             config: cfg,
             agentDir,
             workspaceDir,
-            fsPolicy: { workspaceOnly: true },
+            fsPolicy: { workspaceOnly: true, allowedRoots: [] },
           }),
         );
 

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -329,6 +329,7 @@ export function createPdfTool(options?: {
 
   const localRoots = resolveMediaToolLocalRoots(options?.workspaceDir, {
     workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
+    allowedRoots: options?.fsPolicy?.allowedRoots,
   });
 
   const description =
@@ -414,6 +415,7 @@ export function createPdfTool(options?: {
               root: options.sandbox.root.trim(),
               bridge: options.sandbox.bridge,
               workspaceOnly: options.fsPolicy?.workspaceOnly === true,
+              allowedRoots: options.fsPolicy?.allowedRoots,
             }
           : null;
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -650,6 +650,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional thread/topic target for channels that support threaded delivery of forwarded approvals. Use this to keep approval traffic contained in operational threads instead of main channels.",
   "tools.fs.workspaceOnly":
     "Restrict filesystem tools (read/write/edit/apply_patch) to the workspace directory (default: false).",
+  "tools.fs.allowedRoots":
+    "Additional allowed directory paths for filesystem tools when workspaceOnly is true. Supports tilde expansion (e.g., ~/projects). Default: [].",
   "tools.sessions.visibility":
     'Controls which sessions can be targeted by sessions_list/sessions_history/sessions_send. ("tree" default = current session + spawned subagent sessions; "self" = only current; "agent" = any session in the current agent id; "all" = any session; cross-agent still requires tools.agentToAgent).',
   "tools.message.allowCrossContextSend":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -174,6 +174,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.loopDetection.detectors.knownPollNoProgress": "Tool-loop Poll No-Progress Detection",
   "tools.loopDetection.detectors.pingPong": "Tool-loop Ping-Pong Detection",
   "tools.fs.workspaceOnly": "Workspace-only FS tools",
+  "tools.fs.allowedRoots": "Allowed FS roots",
   "tools.sessions.visibility": "Session Tools Visibility",
   "tools.exec.notifyOnExit": "Exec Notify On Exit",
   "tools.exec.notifyOnExitEmptySuccess": "Exec Notify On Empty Success",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -280,6 +280,12 @@ export type FsToolsConfig = {
    * Default: false (unrestricted, matches legacy behavior).
    */
   workspaceOnly?: boolean;
+  /**
+   * Additional allowed directory paths for filesystem tools when workspaceOnly is true.
+   * Supports tilde expansion (e.g., `~/projects`).
+   * Default: [] (no additional roots).
+   */
+  allowedRoots?: string[];
 };
 
 export type AgentToolsConfig = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -446,7 +446,7 @@ const ToolExecSchema = z.object(ToolExecBaseShape).strict().optional();
 const ToolFsSchema = z
   .object({
     workspaceOnly: z.boolean().optional(),
-    allowedRoots: z.array(z.string()).default([]),
+    allowedRoots: z.array(z.string()).optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -446,6 +446,7 @@ const ToolExecSchema = z.object(ToolExecBaseShape).strict().optional();
 const ToolFsSchema = z
   .object({
     workspaceOnly: z.boolean().optional(),
+    allowedRoots: z.array(z.string()).default([]).optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -446,7 +446,7 @@ const ToolExecSchema = z.object(ToolExecBaseShape).strict().optional();
 const ToolFsSchema = z
   .object({
     workspaceOnly: z.boolean().optional(),
-    allowedRoots: z.array(z.string()).default([]).optional(),
+    allowedRoots: z.array(z.string()).default([]),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary
Implements `tools.fs.allowedRoots` — an array of additional allowed path prefixes for read/write/edit tools.

Closes #33635

## Changes
- Config schema: added `tools.fs.allowedRoots: string[]` (default: `[]`)
- `resolveSandboxPath`: accepts `additionalRoots`, returns `matchedRoot`
- `assertSandboxPath`: uses matched root for symlink escape guard
- Host write/edit tools: wired to respect allowedRoots
- Tests: integration tests for assertSandboxPath with additionalRoots

## Previous attempt
PR #33708 was closed due to bugs found in review. This PR addresses all review findings:
1. ✅ Tilde expansion via `expandPath()` (was missing)
2. ✅ Correct root passed to `assertNoPathAliasEscape` (was using workspace root for all)
3. ✅ Integration tests for `assertSandboxPath` including symlink escape scenarios

## Config example
```json
{
  "tools": {
    "fs": {
      "workspaceOnly": true,
      "allowedRoots": ["~/projects", "/shared/data"]
    }
  }
}
```
