### PR TITLE
fix: respect tools.exec.ask=off in webchat/control-ui

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -133,9 +133,15 @@ export function resolveExecHostApprovalContext(params: {
     ask: params.ask,
   });
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  // An explicit ask=off policy in exec-approvals.json must be able to suppress
-  // prompts even when tool/runtime defaults are stricter (for example on-miss).
-  const hostAsk = approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask);
+  // An explicit ask=off policy (either from exec-approvals.json or tools.exec.ask)
+  // must be able to suppress prompts even when other defaults are stricter.
+  // tools.exec.ask=off takes precedence to allow users to disable prompts entirely.
+  const hostAsk =
+    params.ask === "off"
+      ? "off"
+      : approvals.agent.ask === "off"
+        ? "off"
+        : maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error(`exec denied: host=${params.host} security=deny`);


### PR DESCRIPTION
## Problem

Previously, `tools.exec.ask=off` was only respected if `exec-approvals.json` had `ask=off`, but the user's `openclaw.json` setting was ignored. This meant users couldn't disable exec prompts in webchat/control-ui via config.

## Solution

Modified `resolveExecHostApprovalContext` to check `params.ask` (from `tools.exec.ask`) first, giving it precedence over `exec-approvals.json` settings.

### Changes
- Updated priority logic in `src/agents/bash-tools.exec-host-shared.ts`
- `tools.exec.ask=off` now takes precedence
- Falls back to `exec-approvals.json` setting
- Then to `maxAsk` default

## Testing

Verified that:
1. `tools.exec.ask=off` disables prompts in webchat/control-ui
2. Existing `exec-approvals.json` behavior unchanged
3. No regression in other approval flows

Fixes #42574