### PR TITLE
fix: show expired OAuth profiles as 'expired' even when refreshable

### DIFF
--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -58,13 +58,15 @@ describe("buildAuthHealthSummary", () => {
     const statuses = profileStatuses(summary);
 
     expect(statuses["anthropic:ok"]).toBe("ok");
-    // OAuth credentials with refresh tokens are auto-renewable, so they report "ok"
+    // OAuth credentials with refresh tokens are auto-renewable, so expiring reports "ok"
     expect(statuses["anthropic:expiring"]).toBe("ok");
-    expect(statuses["anthropic:expired"]).toBe("ok");
+    // Expired tokens report "expired" even when refreshable (honest status)
+    expect(statuses["anthropic:expired"]).toBe("expired");
     expect(statuses["anthropic:api"]).toBe("static");
 
     const provider = summary.providers.find((entry) => entry.provider === "anthropic");
-    expect(provider?.status).toBe("ok");
+    // Provider status reflects the worst profile status
+    expect(provider?.status).toBe("expired");
   });
 
   it("reports expired for OAuth without a refresh token", () => {

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -168,10 +168,10 @@ function buildProfileHealth(params: {
     now,
     warnAfterMs,
   );
-  // OAuth credentials with a valid refresh token auto-renew on first API call,
-  // so don't warn about access token expiration.
-  const status =
-    hasRefreshToken && (rawStatus === "expired" || rawStatus === "expiring") ? "ok" : rawStatus;
+  // OAuth credentials with a valid refresh token auto-renew on first API call.
+  // For expiring tokens with refresh, show as "ok" (will auto-refresh).
+  // For expired tokens with refresh, still show as "expired" to be honest about the state.
+  const status = hasRefreshToken && rawStatus === "expiring" ? "ok" : rawStatus;
   return {
     profileId,
     provider: credential.provider,


### PR DESCRIPTION
## Problem

Previously, expired OAuth profiles with refresh tokens were shown as `ok`, misleading users about the actual state of their credentials. This made it impossible to distinguish between:
- Valid tokens that will auto-refresh
- Expired tokens that have expired but can be refreshed

## Solution

Updated `buildProfileHealth` to be honest about expired token states:

**Before:**
- `expiring` + refresh → `ok`
- `expired` + refresh → `ok`

**After:**
- `expiring` + refresh → `ok` (will auto-refresh)
- `expired` + refresh → `expired` (honest about state)

### Changes
- Modified `src/agents/auth-health.ts`
- Only promote `expiring` to `ok` when refresh token exists
- Keep `expired` status even with refresh token

## Benefits

1. Users are aware of expired tokens
2. Still know they can be refreshed
3. More accurate health status reporting
4. Better debugging experience

Fixes #42721