### PR TITLE
fix(acp): persist initial sessions_spawn task for ACP sessions

### DIFF
--- a/.github/actions/ensure-base-commit/action.yml
+++ b/.github/actions/ensure-base-commit/action.yml
@@ -7,6 +7,10 @@ inputs:
   fetch-ref:
     description: Branch or ref to deepen/fetch from origin when base-sha is missing.
     required: true
+  remote-url:
+    description: Optional remote URL to fetch the base ref from instead of origin.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -15,8 +19,14 @@ runs:
       env:
         BASE_SHA: ${{ inputs.base-sha }}
         FETCH_REF: ${{ inputs.fetch-ref }}
+        REMOTE_URL: ${{ inputs.remote-url }}
       run: |
         set -euo pipefail
+
+        REMOTE_TARGET="origin"
+        if [ -n "$REMOTE_URL" ]; then
+          REMOTE_TARGET="$REMOTE_URL"
+        fi
 
         if [ -z "$BASE_SHA" ] || [[ "$BASE_SHA" =~ ^0+$ ]]; then
           echo "No concrete base SHA available; skipping targeted fetch."
@@ -30,7 +40,7 @@ runs:
 
         for deepen_by in 25 100 300; do
           echo "Base commit missing; deepening $FETCH_REF by $deepen_by."
-          git fetch --no-tags --deepen="$deepen_by" origin "$FETCH_REF" || true
+          git fetch --no-tags --deepen="$deepen_by" "$REMOTE_TARGET" "$FETCH_REF" || true
           if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
             echo "Resolved base commit after deepening: $BASE_SHA"
             exit 0
@@ -38,7 +48,7 @@ runs:
         done
 
         echo "Base commit still missing; fetching full history for $FETCH_REF."
-        git fetch --no-tags origin "$FETCH_REF" || true
+        git fetch --no-tags "$REMOTE_TARGET" "$FETCH_REF" || true
         if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
           echo "Resolved base commit after full ref fetch: $BASE_SHA"
           exit 0

--- a/.github/actions/prepare-pr-merge-result/action.yml
+++ b/.github/actions/prepare-pr-merge-result/action.yml
@@ -1,0 +1,50 @@
+name: Prepare PR merge result
+description: Reconstruct the pull_request merge result locally without fetching refs/pull/*/merge.
+inputs:
+  base-repo:
+    description: Base repository in owner/name form.
+    required: true
+  base-ref:
+    description: Base branch/ref name to fetch from the base repository.
+    required: true
+  base-sha:
+    description: Base commit SHA from the pull_request event payload.
+    required: true
+  head-ref:
+    description: Head branch/ref name from the pull_request event payload.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Merge base into checked out PR head
+      shell: bash
+      env:
+        BASE_REMOTE_URL: ${{ github.server_url }}/${{ inputs.base-repo }}.git
+        BASE_REF: ${{ inputs.base-ref }}
+        BASE_SHA: ${{ inputs.base-sha }}
+        HEAD_REF: ${{ inputs.head-ref }}
+      run: |
+        set -euo pipefail
+
+        git remote add pr-base "$BASE_REMOTE_URL" 2>/dev/null || git remote set-url pr-base "$BASE_REMOTE_URL"
+
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          git fetch --no-tags --prune --unshallow origin "$HEAD_REF"
+        else
+          git fetch --no-tags --prune origin "$HEAD_REF"
+        fi
+
+        git fetch --no-tags --prune pr-base "$BASE_REF"
+
+        if ! git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+          git fetch --no-tags pr-base "$BASE_SHA"
+        fi
+
+        if git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+          echo "PR head already contains base commit $BASE_SHA; using checked out head as merge result."
+          exit 0
+        fi
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git merge --no-ff --no-edit "$BASE_SHA"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
           fetch-tags: false
           submodules: false
@@ -34,6 +36,7 @@ jobs:
         with:
           base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+          remote-url: ${{ github.server_url }}/${{ github.repository }}.git
 
       - name: Detect docs-only changes
         id: check
@@ -56,6 +59,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
           fetch-tags: false
           submodules: false
@@ -65,6 +70,7 @@ jobs:
         with:
           base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+          remote-url: ${{ github.server_url }}/${{ github.repository }}.git
 
       - name: Detect changed scopes
         id: scope
@@ -89,6 +95,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Ensure secrets base commit (PR fast path)
@@ -97,6 +105,7 @@ jobs:
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}
           fetch-ref: ${{ github.event.pull_request.base.ref }}
+          remote-url: ${{ github.server_url }}/${{ github.repository }}.git
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -123,6 +132,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -169,6 +180,8 @@ jobs:
         if: github.event_name != 'push' || matrix.runtime != 'bun'
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -200,6 +213,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -226,6 +241,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -245,6 +262,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Python
@@ -269,6 +288,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Ensure secrets base commit
@@ -276,6 +297,7 @@ jobs:
         with:
           base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+          remote-url: ${{ github.server_url }}/${{ github.repository }}.git
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -381,6 +403,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Try to exclude workspace from Windows Defender (best-effort)
@@ -467,6 +491,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -539,6 +565,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Select Xcode 26.1
@@ -708,6 +736,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,17 @@ jobs:
           fetch-depth: 1
           fetch-tags: false
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Ensure docs-scope base commit
         uses: ./.github/actions/ensure-base-commit
@@ -60,6 +71,17 @@ jobs:
           fetch-depth: 1
           fetch-tags: false
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Ensure changed-scope base commit
         uses: ./.github/actions/ensure-base-commit
@@ -92,6 +114,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Ensure secrets base commit (PR fast path)
         if: github.event_name == 'pull_request'
@@ -173,6 +206,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Node environment
         if: matrix.runtime != 'bun' || github.event_name != 'push'
@@ -204,6 +248,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -230,6 +285,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -249,6 +315,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -273,6 +350,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Ensure secrets base commit
         uses: ./.github/actions/ensure-base-commit
@@ -386,6 +474,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Try to exclude workspace from Windows Defender (best-effort)
         shell: pwsh
@@ -472,6 +571,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -544,6 +654,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Select Xcode 26.1
         run: |
@@ -713,6 +834,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
           fetch-tags: false
           submodules: false
@@ -59,8 +57,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
           fetch-tags: false
           submodules: false
@@ -95,8 +91,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Ensure secrets base commit (PR fast path)
@@ -132,8 +126,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -180,8 +172,6 @@ jobs:
         if: github.event_name != 'push' || matrix.runtime != 'bun'
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -213,8 +203,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -241,8 +229,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -262,8 +248,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Python
@@ -288,8 +272,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Ensure secrets base commit
@@ -403,8 +385,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Try to exclude workspace from Windows Defender (best-effort)
@@ -491,8 +471,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Node environment
@@ -565,8 +543,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Select Xcode 26.1
@@ -736,8 +712,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Setup Java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  actions: read
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -15,7 +15,26 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  fork-pr-guard:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - id: decide
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" || "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "External fork pull request detected; skipping install smoke jobs because GitHub does not provide a usable token for PR merge-ref checkout and third-party action downloads in this context."
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+
   docs-scope:
+    needs: [fork-pr-guard]
+    if: needs.fork-pr-guard.outputs.should_run == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     outputs:
       docs_only: ${{ steps.check.outputs.docs_only }}
@@ -37,8 +56,8 @@ jobs:
         uses: ./.github/actions/detect-docs-changes
 
   install-smoke:
-    needs: [docs-scope]
-    if: needs.docs-scope.outputs.docs_only != 'true'
+    needs: [fork-pr-guard, docs-scope]
+    if: needs.fork-pr-guard.outputs.should_run == 'true' && needs.docs-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout CLI

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -15,26 +15,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  fork-pr-guard:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
-    outputs:
-      should_run: ${{ steps.decide.outputs.should_run }}
-    steps:
-      - id: decide
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${{ github.event_name }}" != "pull_request" || "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "External fork pull request detected; skipping install smoke jobs because GitHub does not provide a usable token for PR merge-ref checkout and third-party action downloads in this context."
-          echo "should_run=false" >> "$GITHUB_OUTPUT"
-
   docs-scope:
-    needs: [fork-pr-guard]
-    if: needs.fork-pr-guard.outputs.should_run == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     outputs:
       docs_only: ${{ steps.check.outputs.docs_only }}
@@ -42,6 +23,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
           fetch-tags: false
 
@@ -50,18 +33,22 @@ jobs:
         with:
           base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+          remote-url: ${{ github.server_url }}/${{ github.repository }}.git
 
       - name: Detect docs-only changes
         id: check
         uses: ./.github/actions/detect-docs-changes
 
   install-smoke:
-    needs: [fork-pr-guard, docs-scope]
-    if: needs.fork-pr-guard.outputs.should_run == 'true' && needs.docs-scope.outputs.docs_only != 'true'
+    needs: [docs-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout CLI
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Docker Builder
         uses: useblacksmith/setup-docker-builder@v1

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+
 concurrency:
   group: install-smoke-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -23,8 +23,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
           fetch-tags: false
 
@@ -46,9 +44,6 @@ jobs:
     steps:
       - name: Checkout CLI
         uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Docker Builder
         uses: useblacksmith/setup-docker-builder@v1

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -25,6 +25,17 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Ensure docs-scope base commit
         uses: ./.github/actions/ensure-base-commit
@@ -44,6 +55,18 @@ jobs:
     steps:
       - name: Checkout CLI
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Set up Docker Builder
         uses: useblacksmith/setup-docker-builder@v1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Labeler
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] trusted-only labeling workflow; does not check out or execute PR code
     types: [opened, synchronize, reopened]
   issues:
     types: [opened]
@@ -22,6 +22,7 @@ jobs:
   label:
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
@@ -30,22 +31,52 @@ jobs:
         continue-on-error: true
         with:
           app-id: "2729701"
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] GitHub App key must be passed directly to the token action
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }} # zizmor: ignore[secrets-outside-env] GitHub App key must be passed directly to the token action
+      - name: Resolve GitHub auth token
+        id: auth-token
+        shell: bash
+        env:
+          PRIMARY_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK_TOKEN: ${{ steps.app-token-fallback.outputs.token }}
+          DEFAULT_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          for candidate in "$PRIMARY_TOKEN" "$FALLBACK_TOKEN" "$DEFAULT_TOKEN"; do
+            if [ -z "$candidate" ]; then
+              continue
+            fi
+
+            status="$(
+              curl -sS -o /dev/null -w "%{http_code}" \
+                -H "Authorization: Bearer $candidate" \
+                -H "Accept: application/vnd.github+json" \
+                https://api.github.com/rate_limit
+            )"
+            if [ "$status" = "200" ]; then
+              echo "::add-mask::$candidate"
+              echo "token=$candidate" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "No valid GitHub token available for labeler workflow." >&2
+          exit 1
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml
-          repo-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          repo-token: ${{ steps.auth-token.outputs.token }}
           sync-labels: true
       - name: Apply PR size label
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.auth-token.outputs.token }}
           script: |
             const pullRequest = context.payload.pull_request;
             if (!pullRequest) {
@@ -134,7 +165,7 @@ jobs:
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.auth-token.outputs.token }}
           script: |
             const login = context.payload.pull_request?.user?.login;
             if (!login) {
@@ -205,7 +236,7 @@ jobs:
       - name: Apply too-many-prs label
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.auth-token.outputs.token }}
           script: |
             const pullRequest = context.payload.pull_request;
             if (!pullRequest) {
@@ -378,6 +409,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
@@ -386,17 +418,47 @@ jobs:
         continue-on-error: true
         with:
           app-id: "2729701"
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] GitHub App key must be passed directly to the token action
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }} # zizmor: ignore[secrets-outside-env] GitHub App key must be passed directly to the token action
+      - name: Resolve GitHub auth token
+        id: auth-token
+        shell: bash
+        env:
+          PRIMARY_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK_TOKEN: ${{ steps.app-token-fallback.outputs.token }}
+          DEFAULT_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          for candidate in "$PRIMARY_TOKEN" "$FALLBACK_TOKEN" "$DEFAULT_TOKEN"; do
+            if [ -z "$candidate" ]; then
+              continue
+            fi
+
+            status="$(
+              curl -sS -o /dev/null -w "%{http_code}" \
+                -H "Authorization: Bearer $candidate" \
+                -H "Accept: application/vnd.github+json" \
+                https://api.github.com/rate_limit
+            )"
+            if [ "$status" = "200" ]; then
+              echo "::add-mask::$candidate"
+              echo "token=$candidate" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "No valid GitHub token available for labeler workflow." >&2
+          exit 1
       - name: Backfill PR labels
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.auth-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -634,17 +696,47 @@ jobs:
         continue-on-error: true
         with:
           app-id: "2729701"
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] GitHub App key must be passed directly to the token action
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }} # zizmor: ignore[secrets-outside-env] GitHub App key must be passed directly to the token action
+      - name: Resolve GitHub auth token
+        id: auth-token
+        shell: bash
+        env:
+          PRIMARY_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK_TOKEN: ${{ steps.app-token-fallback.outputs.token }}
+          DEFAULT_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          for candidate in "$PRIMARY_TOKEN" "$FALLBACK_TOKEN" "$DEFAULT_TOKEN"; do
+            if [ -z "$candidate" ]; then
+              continue
+            fi
+
+            status="$(
+              curl -sS -o /dev/null -w "%{http_code}" \
+                -H "Authorization: Bearer $candidate" \
+                -H "Accept: application/vnd.github+json" \
+                https://api.github.com/rate_limit
+            )"
+            if [ "$status" = "200" ]; then
+              echo "::add-mask::$candidate"
+              echo "token=$candidate" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "No valid GitHub token available for labeler workflow." >&2
+          exit 1
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.auth-token.outputs.token }}
           script: |
             const login = context.payload.issue?.user?.login;
             if (!login) {

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -22,7 +22,26 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  fork-pr-guard:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - id: decide
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" || "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "External fork pull request detected; skipping sandbox-common smoke because GitHub does not provide a usable token for PR merge-ref checkout and third-party action downloads in this context."
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+
   sandbox-common-smoke:
+    needs: [fork-pr-guard]
+    if: needs.fork-pr-guard.outputs.should_run == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -22,31 +22,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  fork-pr-guard:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
-    outputs:
-      should_run: ${{ steps.decide.outputs.should_run }}
-    steps:
-      - id: decide
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${{ github.event_name }}" != "pull_request" || "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "External fork pull request detected; skipping sandbox-common smoke because GitHub does not provide a usable token for PR merge-ref checkout and third-party action downloads in this context."
-          echo "should_run=false" >> "$GITHUB_OUTPUT"
-
   sandbox-common-smoke:
-    needs: [fork-pr-guard]
-    if: needs.fork-pr-guard.outputs.should_run == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Set up Docker Builder

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -13,6 +13,10 @@ on:
       - Dockerfile.sandbox-common
       - scripts/sandbox-common-setup.sh
 
+permissions:
+  actions: read
+  contents: read
+
 concurrency:
   group: sandbox-common-smoke-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -29,6 +29,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Set up Docker Builder
         uses: useblacksmith/setup-docker-builder@v1

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -28,8 +28,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: false
 
       - name: Set up Docker Builder

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Fail on tabs in workflow files
         run: |
@@ -50,6 +53,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Install actionlint
         shell: bash

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -19,6 +19,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Fail on tabs in workflow files
         run: |
@@ -50,6 +62,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Prepare PR merge result
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/prepare-pr-merge-result
+        with:
+          base-repo: ${{ github.repository }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Install actionlint
         shell: bash

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -19,9 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Fail on tabs in workflow files
         run: |
@@ -53,9 +50,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Install actionlint
         shell: bash

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  actions: read
+  contents: read
+
 concurrency:
   group: workflow-sanity-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Docs: https://docs.openclaw.ai
 - ACP/follow-up hardening: make session restore and prompt completion degrade gracefully on transcript/update failures, enforce bounded tool-location traversal, and skip non-image ACPX turns the runtime cannot serialize. (#41464) Thanks @mbelinky.
 - ACP/sessions_spawn: implicitly stream `mode="run"` ACP spawns to parent only for eligible subagent orchestrator sessions (heartbeat `target: "last"` with a usable session-local route), restoring parent progress relays without thread binding. (#42404) Thanks @davidguttman.
 - ACP/main session aliases: canonicalize `main` before ACP session lookup so restarted ACP main sessions rehydrate instead of failing closed with `Session is not ACP-enabled: main`. (#43285, fixes #25692)
+- ACP/sessions_spawn: seed new ACP session transcripts with the initial spawn task and return delivery confirmation so fresh ACP threads no longer start with empty history. Fixes #43518.
 - Plugins/context-engine model auth: expose `runtime.modelAuth` and plugin-sdk auth helpers so plugins can resolve provider/model API keys through the normal auth pipeline. (#41090) thanks @xinhuagu.
 - Hooks/plugin context parity followup: pass `trigger` and `channelId` through embedded `llm_input`, `agent_end`, and `llm_output` hook contexts so plugins receive the same agent metadata across hook phases. (#42362) Thanks @zhoulf1006.
 - Plugins/global hook runner: harden singleton state handling so shared global hook runner reuse does not leak or corrupt runner state across executions. (#40184) Thanks @vincentkoc.

--- a/src/acp/session-transcript.test.ts
+++ b/src/acp/session-transcript.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const hoisted = vi.hoisted(() => ({
   resolveSessionTranscriptFileMock: vi.fn(),
   warnMock: vi.fn(),
+  emitSessionTranscriptUpdateMock: vi.fn(),
 }));
 
 vi.mock("../config/sessions/transcript.js", async (importOriginal) => {
@@ -35,6 +36,10 @@ vi.mock("../logging/subsystem.js", () => {
   return { createSubsystemLogger: () => makeLogger() };
 });
 
+vi.mock("../sessions/transcript-events.js", () => ({
+  emitSessionTranscriptUpdate: hoisted.emitSessionTranscriptUpdateMock,
+}));
+
 const { persistAcpPromptTranscript, persistAcpTurnTranscript } =
   await import("./session-transcript.js");
 
@@ -45,11 +50,27 @@ function readTranscriptMessages(sessionFile: string): AgentMessage[] {
     .map((entry) => (entry as { message: AgentMessage }).message);
 }
 
+async function waitForAssertion(assertion: () => void): Promise<void> {
+  const startedAt = Date.now();
+  while (true) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() - startedAt >= 1_000) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+}
+
 describe("ACP session transcript persistence", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
     hoisted.warnMock.mockReset();
+    hoisted.emitSessionTranscriptUpdateMock.mockReset();
     vi.restoreAllMocks();
     await Promise.all(
       tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
@@ -242,5 +263,59 @@ describe("ACP session transcript persistence", () => {
     expect(hoisted.warnMock).toHaveBeenCalledWith(
       "ACP prompt-only transcript flush skipped because SessionManager._rewriteFile is unavailable",
     );
+  });
+
+  it("waits for an async SessionManager private flush hook before emitting transcript updates", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-transcript-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "sess-5.jsonl");
+    const sessionEntry = {
+      sessionId: "sess-5",
+      updatedAt: Date.now(),
+      sessionFile,
+    };
+    hoisted.resolveSessionTranscriptFileMock.mockReset().mockImplementation(async () => ({
+      sessionFile,
+      sessionEntry,
+    }));
+
+    let resolveRewrite: (() => void) | undefined;
+    const rewritePromise = new Promise<void>((resolve) => {
+      resolveRewrite = resolve;
+    });
+    const realManager = SessionManager.open(sessionFile);
+    (
+      realManager as unknown as {
+        isPersisted?: () => boolean;
+        _rewriteFile?: () => Promise<void>;
+      }
+    ).isPersisted = () => true;
+    const rewriteSpy = vi.fn(() => rewritePromise);
+    (
+      realManager as unknown as {
+        _rewriteFile?: () => Promise<void>;
+      }
+    )._rewriteFile = rewriteSpy;
+
+    vi.spyOn(SessionManager, "open").mockReturnValue(realManager);
+
+    const persistPromise = persistAcpPromptTranscript({
+      promptText: "Investigate flaky tests",
+      sessionId: "sess-5",
+      sessionKey: "agent:codex:acp:5",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+    });
+
+    await waitForAssertion(() => {
+      expect(rewriteSpy).toHaveBeenCalledOnce();
+    });
+    expect(hoisted.emitSessionTranscriptUpdateMock).not.toHaveBeenCalled();
+
+    resolveRewrite?.();
+    await persistPromise;
+
+    expect(hoisted.emitSessionTranscriptUpdateMock).toHaveBeenCalledWith(sessionFile);
   });
 });

--- a/src/acp/session-transcript.test.ts
+++ b/src/acp/session-transcript.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   resolveSessionTranscriptFileMock: vi.fn(),
+  warnMock: vi.fn(),
 }));
 
 vi.mock("../config/sessions/transcript.js", async (importOriginal) => {
@@ -16,6 +17,22 @@ vi.mock("../config/sessions/transcript.js", async (importOriginal) => {
     resolveSessionTranscriptFile: (params: unknown) =>
       hoisted.resolveSessionTranscriptFileMock(params),
   };
+});
+
+vi.mock("../logging/subsystem.js", () => {
+  const makeLogger = () => ({
+    subsystem: "acp/session-transcript",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: hoisted.warnMock,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: () => makeLogger(),
+  });
+  return { createSubsystemLogger: () => makeLogger() };
 });
 
 const { persistAcpPromptTranscript, persistAcpTurnTranscript } =
@@ -32,6 +49,8 @@ describe("ACP session transcript persistence", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    hoisted.warnMock.mockReset();
+    vi.restoreAllMocks();
     await Promise.all(
       tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
     );
@@ -137,5 +156,91 @@ describe("ACP session transcript persistence", () => {
     const messages = readTranscriptMessages(sessionFile);
     expect(messages).toHaveLength(2);
     expect(messages.map((message) => message.role)).toEqual(["user", "user"]);
+  });
+
+  it("flushes prompt-only transcripts even when SessionManager.isPersisted is unavailable", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-transcript-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "sess-3.jsonl");
+    const sessionEntry = {
+      sessionId: "sess-3",
+      updatedAt: Date.now(),
+      sessionFile,
+    };
+    hoisted.resolveSessionTranscriptFileMock.mockReset().mockImplementation(async () => ({
+      sessionFile,
+      sessionEntry,
+    }));
+
+    const realManager = SessionManager.open(sessionFile);
+    const rewriteSpy = vi.fn();
+    (
+      realManager as unknown as {
+        isPersisted?: undefined;
+        _rewriteFile?: () => void;
+      }
+    ).isPersisted = undefined;
+    (
+      realManager as unknown as {
+        _rewriteFile?: () => void;
+      }
+    )._rewriteFile = rewriteSpy;
+
+    vi.spyOn(SessionManager, "open").mockReturnValue(realManager);
+
+    await persistAcpPromptTranscript({
+      promptText: "Investigate flaky tests",
+      sessionId: "sess-3",
+      sessionKey: "agent:codex:acp:3",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+    });
+
+    expect(rewriteSpy).toHaveBeenCalledOnce();
+    expect(hoisted.warnMock).not.toHaveBeenCalled();
+  });
+
+  it("warns when the SessionManager private flush hook is unavailable", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-transcript-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "sess-4.jsonl");
+    const sessionEntry = {
+      sessionId: "sess-4",
+      updatedAt: Date.now(),
+      sessionFile,
+    };
+    hoisted.resolveSessionTranscriptFileMock.mockReset().mockImplementation(async () => ({
+      sessionFile,
+      sessionEntry,
+    }));
+
+    const realManager = SessionManager.open(sessionFile);
+    (
+      realManager as unknown as {
+        isPersisted?: () => boolean;
+        _rewriteFile?: undefined;
+      }
+    ).isPersisted = () => true;
+    (
+      realManager as unknown as {
+        _rewriteFile?: undefined;
+      }
+    )._rewriteFile = undefined;
+
+    vi.spyOn(SessionManager, "open").mockReturnValue(realManager);
+
+    await persistAcpPromptTranscript({
+      promptText: "Investigate flaky tests",
+      sessionId: "sess-4",
+      sessionKey: "agent:codex:acp:4",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+    });
+
+    expect(hoisted.warnMock).toHaveBeenCalledWith(
+      "ACP prompt-only transcript flush skipped because SessionManager._rewriteFile is unavailable",
+    );
   });
 });

--- a/src/acp/session-transcript.test.ts
+++ b/src/acp/session-transcript.test.ts
@@ -238,6 +238,52 @@ describe("ACP session transcript persistence", () => {
     expect(messages.map((message) => message.role)).toEqual(["user", "user"]);
   });
 
+  it("preserves interrupted prompt-only history when a later ACP turn adds an assistant reply", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-transcript-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "sess-interrupted.jsonl");
+    const sessionEntry = {
+      sessionId: "sess-interrupted",
+      updatedAt: Date.now(),
+      sessionFile,
+    };
+    hoisted.resolveSessionTranscriptFileMock.mockReset().mockImplementation(async () => ({
+      sessionFile,
+      sessionEntry,
+    }));
+
+    await persistAcpTurnTranscript({
+      body: "first prompt",
+      finalText: "",
+      sessionId: "sess-interrupted",
+      sessionKey: "agent:codex:acp:interrupted",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+    });
+
+    await persistAcpTurnTranscript({
+      body: "second prompt",
+      finalText: "assistant reply",
+      sessionId: "sess-interrupted",
+      sessionKey: "agent:codex:acp:interrupted",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+    });
+
+    const messages = readTranscriptMessages(sessionFile);
+    expect(messages).toHaveLength(3);
+    expect(messages).toMatchObject([
+      { role: "user", content: "first prompt" },
+      { role: "user", content: "second prompt" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "assistant reply" }],
+      },
+    ]);
+  });
+
   it("flushes prompt-only transcripts even when SessionManager.isPersisted is unavailable", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-transcript-"));
     tempDirs.push(tempDir);

--- a/src/acp/session-transcript.test.ts
+++ b/src/acp/session-transcript.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  resolveSessionTranscriptFileMock: vi.fn(),
+}));
+
+vi.mock("../config/sessions/transcript.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/transcript.js")>();
+  return {
+    ...actual,
+    resolveSessionTranscriptFile: (params: unknown) =>
+      hoisted.resolveSessionTranscriptFileMock(params),
+  };
+});
+
+const { persistAcpPromptTranscript, persistAcpTurnTranscript } =
+  await import("./session-transcript.js");
+
+function readTranscriptMessages(sessionFile: string): AgentMessage[] {
+  return SessionManager.open(sessionFile)
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => (entry as { message: AgentMessage }).message);
+}
+
+describe("ACP session transcript persistence", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("keeps the seeded sessions_spawn prompt when the ACP turn later persists the same task", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-transcript-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "sess-1.jsonl");
+    const sessionEntry = {
+      sessionId: "sess-1",
+      updatedAt: Date.now(),
+      sessionFile,
+    };
+    hoisted.resolveSessionTranscriptFileMock.mockReset().mockImplementation(async () => ({
+      sessionFile,
+      sessionEntry,
+    }));
+    const inputProvenance = {
+      kind: "inter_session" as const,
+      sourceSessionKey: "agent:main:main",
+      sourceChannel: "discord",
+      sourceTool: "sessions_spawn",
+    };
+
+    await persistAcpPromptTranscript({
+      promptText: "Investigate flaky tests",
+      sessionId: "sess-1",
+      sessionKey: "agent:codex:acp:1",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+      inputProvenance,
+    });
+
+    await persistAcpTurnTranscript({
+      body: "[Thu 2026-03-12 10:00 UTC] Investigate flaky tests",
+      finalText: "I checked the failing run.",
+      sessionId: "sess-1",
+      sessionKey: "agent:codex:acp:1",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+      inputProvenance,
+    });
+
+    const messages = readTranscriptMessages(sessionFile);
+    expect(messages).toHaveLength(2);
+    expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(messages[0]).toMatchObject({
+      role: "user",
+      content: "Investigate flaky tests",
+      provenance: {
+        kind: "inter_session",
+        sourceTool: "sessions_spawn",
+      },
+    });
+    expect(messages[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "I checked the failing run." }],
+    });
+  });
+
+  it("does not collapse a later identical prompt from a different provenance", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-transcript-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "sess-2.jsonl");
+    const sessionEntry = {
+      sessionId: "sess-2",
+      updatedAt: Date.now(),
+      sessionFile,
+    };
+    hoisted.resolveSessionTranscriptFileMock.mockReset().mockImplementation(async () => ({
+      sessionFile,
+      sessionEntry,
+    }));
+
+    await persistAcpPromptTranscript({
+      promptText: "Investigate flaky tests",
+      sessionId: "sess-2",
+      sessionKey: "agent:codex:acp:2",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:main",
+        sourceTool: "sessions_spawn",
+      },
+    });
+
+    await persistAcpTurnTranscript({
+      body: "[Thu 2026-03-12 10:00 UTC] Investigate flaky tests",
+      finalText: "",
+      sessionId: "sess-2",
+      sessionKey: "agent:codex:acp:2",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+      inputProvenance: undefined,
+    });
+
+    const messages = readTranscriptMessages(sessionFile);
+    expect(messages).toHaveLength(2);
+    expect(messages.map((message) => message.role)).toEqual(["user", "user"]);
+  });
+});

--- a/src/acp/session-transcript.test.ts
+++ b/src/acp/session-transcript.test.ts
@@ -179,6 +179,65 @@ describe("ACP session transcript persistence", () => {
     expect(messages.map((message) => message.role)).toEqual(["user", "user"]);
   });
 
+  it("records later prompt-only retries after the seeded replay dedupe window is consumed", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-transcript-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "sess-retry.jsonl");
+    const sessionEntry = {
+      sessionId: "sess-retry",
+      updatedAt: Date.now(),
+      sessionFile,
+    };
+    hoisted.resolveSessionTranscriptFileMock.mockReset().mockImplementation(async () => ({
+      sessionFile,
+      sessionEntry,
+    }));
+    const inputProvenance = {
+      kind: "inter_session" as const,
+      sourceSessionKey: "agent:main:main",
+      sourceChannel: "discord",
+      sourceTool: "sessions_spawn",
+    };
+
+    await persistAcpPromptTranscript({
+      promptText: "Investigate flaky tests",
+      sessionId: "sess-retry",
+      sessionKey: "agent:codex:acp:retry",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+      inputProvenance,
+    });
+
+    await persistAcpTurnTranscript({
+      body: "[Thu 2026-03-12 10:00 UTC] Investigate flaky tests",
+      finalText: "",
+      sessionId: "sess-retry",
+      sessionKey: "agent:codex:acp:retry",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+      inputProvenance,
+    });
+
+    expect(readTranscriptMessages(sessionFile)).toHaveLength(1);
+
+    await persistAcpTurnTranscript({
+      body: "[Thu 2026-03-12 10:05 UTC] Investigate flaky tests",
+      finalText: "",
+      sessionId: "sess-retry",
+      sessionKey: "agent:codex:acp:retry",
+      sessionEntry,
+      sessionAgentId: "codex",
+      sessionCwd: tempDir,
+      inputProvenance,
+    });
+
+    const messages = readTranscriptMessages(sessionFile);
+    expect(messages).toHaveLength(2);
+    expect(messages.map((message) => message.role)).toEqual(["user", "user"]);
+  });
+
   it("flushes prompt-only transcripts even when SessionManager.isPersisted is unavailable", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-transcript-"));
     tempDirs.push(tempDir);

--- a/src/acp/session-transcript.ts
+++ b/src/acp/session-transcript.ts
@@ -4,6 +4,7 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   applyInputProvenanceToUserMessage,
   normalizeInputProvenance,
@@ -12,6 +13,7 @@ import {
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 
 const TIMESTAMP_ENVELOPE_PATTERN = /^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*]\s*/;
+const log = createSubsystemLogger("acp/session-transcript");
 
 export const ACP_TRANSCRIPT_USAGE = {
   input: 0,
@@ -195,10 +197,16 @@ function forcePersistPromptOnlyTranscript(
     isPersisted?: () => boolean;
     _rewriteFile?: () => void;
   };
-  if (!manager.isPersisted?.()) {
+  if (typeof manager.isPersisted === "function" && !manager.isPersisted()) {
     return;
   }
   // pi-coding-agent keeps prompt-only sessions in memory until the first assistant
   // message arrives. ACP spawn needs the initial task on disk immediately.
-  manager._rewriteFile?.();
+  if (typeof manager._rewriteFile !== "function") {
+    log.warn(
+      "ACP prompt-only transcript flush skipped because SessionManager._rewriteFile is unavailable",
+    );
+    return;
+  }
+  manager._rewriteFile();
 }

--- a/src/acp/session-transcript.ts
+++ b/src/acp/session-transcript.ts
@@ -231,6 +231,7 @@ async function forcePersistPromptOnlyTranscript(
   const manager = sessionManager as unknown as {
     isPersisted?: () => boolean;
     _rewriteFile?: () => Promise<void> | void;
+    flushed?: boolean;
   };
   if (typeof manager.isPersisted === "function" && !manager.isPersisted()) {
     return;
@@ -244,4 +245,5 @@ async function forcePersistPromptOnlyTranscript(
     return;
   }
   await manager._rewriteFile();
+  manager.flushed = true;
 }

--- a/src/acp/session-transcript.ts
+++ b/src/acp/session-transcript.ts
@@ -14,6 +14,7 @@ import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 
 const TIMESTAMP_ENVELOPE_PATTERN = /^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*]\s*/;
 const log = createSubsystemLogger("acp/session-transcript");
+const ACP_SPAWN_SEED_CUSTOM_TYPE = "openclaw.acp_spawn_seed";
 
 export const ACP_TRANSCRIPT_USAGE = {
   input: 0,
@@ -49,6 +50,7 @@ export async function persistAcpPromptTranscript(
 ): Promise<SessionEntry | undefined> {
   return await persistAcpTranscriptMessages({
     ...params,
+    seedSpawnPrompt: true,
     replyText: "",
   });
 }
@@ -63,6 +65,7 @@ export async function persistAcpTurnTranscript(
     ...params,
     promptText: params.body,
     replyText: params.finalText,
+    seedSpawnPrompt: false,
   });
 }
 
@@ -70,6 +73,7 @@ async function persistAcpTranscriptMessages(
   params: PersistAcpTranscriptParams & {
     promptText: string;
     replyText: string;
+    seedSpawnPrompt: boolean;
   },
 ): Promise<SessionEntry | undefined> {
   const promptText = params.promptText;
@@ -101,7 +105,16 @@ async function persistAcpTranscriptMessages(
   });
 
   let changed = false;
-  if (promptText && shouldAppendPrompt(sessionManager, promptText, params.inputProvenance)) {
+  const consumedPendingSpawnSeedReplay =
+    !params.seedSpawnPrompt &&
+    Boolean(promptText) &&
+    consumePendingSpawnSeedReplayDedup(sessionManager, promptText, params.inputProvenance);
+  if (consumedPendingSpawnSeedReplay) {
+    // Persist the consumed seed marker before any later assistant append so the
+    // dedupe window closes even when the replayed turn produces no text.
+    await forcePersistPromptOnlyTranscript(sessionManager);
+  }
+  if (promptText && !consumedPendingSpawnSeedReplay) {
     const userMessage = applyInputProvenanceToUserMessage(
       {
         role: "user",
@@ -111,6 +124,11 @@ async function persistAcpTranscriptMessages(
       params.inputProvenance,
     );
     sessionManager.appendMessage(userMessage as Parameters<typeof sessionManager.appendMessage>[0]);
+    if (params.seedSpawnPrompt) {
+      sessionManager.appendCustomEntry(ACP_SPAWN_SEED_CUSTOM_TYPE, {
+        pendingReplayDedup: true,
+      });
+    }
     changed = true;
   }
 
@@ -138,38 +156,42 @@ async function persistAcpTranscriptMessages(
   return sessionEntry;
 }
 
-function shouldAppendPrompt(
+function consumePendingSpawnSeedReplayDedup(
   sessionManager: ReturnType<typeof SessionManager.open>,
   promptText: string,
   inputProvenance: InputProvenance | undefined,
 ): boolean {
+  // Only dedupe the replay of the one seeded `sessions_spawn` prompt. Once that
+  // replay is consumed, later identical prompt-only retries must still persist.
+  const leafEntry = sessionManager.getLeafEntry() as
+    | {
+        type?: string;
+        customType?: string;
+        data?: { pendingReplayDedup?: boolean };
+      }
+    | undefined;
+  if (
+    leafEntry?.type !== "custom" ||
+    leafEntry.customType !== ACP_SPAWN_SEED_CUSTOM_TYPE ||
+    leafEntry.data?.pendingReplayDedup !== true
+  ) {
+    return false;
+  }
   const lastMessage = getTranscriptMessages(sessionManager).at(-1);
   if (!lastMessage || lastMessage.role !== "user") {
-    return true;
+    return false;
   }
   if (typeof lastMessage.content !== "string") {
-    return true;
+    return false;
   }
   if (normalizePromptForDedup(lastMessage.content) !== normalizePromptForDedup(promptText)) {
-    return true;
+    return false;
   }
-  return !sameInputProvenance(
-    (lastMessage as { provenance?: unknown }).provenance,
-    inputProvenance,
-  );
-}
-
-function getTranscriptMessages(
-  sessionManager: ReturnType<typeof SessionManager.open>,
-): AgentMessage[] {
-  return sessionManager
-    .getEntries()
-    .filter((entry) => entry.type === "message")
-    .map((entry) => (entry as { message: AgentMessage }).message);
-}
-
-function normalizePromptForDedup(text: string): string {
-  return text.replace(TIMESTAMP_ENVELOPE_PATTERN, "").trim();
+  if (!sameInputProvenance((lastMessage as { provenance?: unknown }).provenance, inputProvenance)) {
+    return false;
+  }
+  leafEntry.data = { ...leafEntry.data, pendingReplayDedup: false };
+  return true;
 }
 
 function sameInputProvenance(existing: unknown, incoming: InputProvenance | undefined): boolean {
@@ -188,6 +210,19 @@ function sameInputProvenance(existing: unknown, incoming: InputProvenance | unde
     normalizedExisting.sourceChannel === normalizedIncoming.sourceChannel &&
     normalizedExisting.sourceTool === normalizedIncoming.sourceTool
   );
+}
+
+function getTranscriptMessages(
+  sessionManager: ReturnType<typeof SessionManager.open>,
+): AgentMessage[] {
+  return sessionManager
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => (entry as { message: AgentMessage }).message);
+}
+
+function normalizePromptForDedup(text: string): string {
+  return text.replace(TIMESTAMP_ENVELOPE_PATTERN, "").trim();
 }
 
 async function forcePersistPromptOnlyTranscript(

--- a/src/acp/session-transcript.ts
+++ b/src/acp/session-transcript.ts
@@ -129,7 +129,7 @@ async function persistAcpTranscriptMessages(
   }
 
   if (changed && promptText && !replyText) {
-    forcePersistPromptOnlyTranscript(sessionManager);
+    await forcePersistPromptOnlyTranscript(sessionManager);
   }
 
   if (changed) {
@@ -190,12 +190,12 @@ function sameInputProvenance(existing: unknown, incoming: InputProvenance | unde
   );
 }
 
-function forcePersistPromptOnlyTranscript(
+async function forcePersistPromptOnlyTranscript(
   sessionManager: ReturnType<typeof SessionManager.open>,
-): void {
+): Promise<void> {
   const manager = sessionManager as unknown as {
     isPersisted?: () => boolean;
-    _rewriteFile?: () => void;
+    _rewriteFile?: () => Promise<void> | void;
   };
   if (typeof manager.isPersisted === "function" && !manager.isPersisted()) {
     return;
@@ -208,5 +208,5 @@ function forcePersistPromptOnlyTranscript(
     );
     return;
   }
-  manager._rewriteFile();
+  await manager._rewriteFile();
 }

--- a/src/acp/session-transcript.ts
+++ b/src/acp/session-transcript.ts
@@ -1,0 +1,204 @@
+import fs from "node:fs/promises";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
+import type { SessionEntry } from "../config/sessions.js";
+import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
+import {
+  applyInputProvenanceToUserMessage,
+  normalizeInputProvenance,
+  type InputProvenance,
+} from "../sessions/input-provenance.js";
+import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+
+const TIMESTAMP_ENVELOPE_PATTERN = /^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*]\s*/;
+
+export const ACP_TRANSCRIPT_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+} as const;
+
+type PersistAcpTranscriptParams = {
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry | undefined;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  sessionAgentId: string;
+  threadId?: string | number;
+  sessionCwd: string;
+  inputProvenance?: InputProvenance;
+};
+
+export async function persistAcpPromptTranscript(
+  params: PersistAcpTranscriptParams & {
+    promptText: string;
+  },
+): Promise<SessionEntry | undefined> {
+  return await persistAcpTranscriptMessages({
+    ...params,
+    replyText: "",
+  });
+}
+
+export async function persistAcpTurnTranscript(
+  params: PersistAcpTranscriptParams & {
+    body: string;
+    finalText: string;
+  },
+): Promise<SessionEntry | undefined> {
+  return await persistAcpTranscriptMessages({
+    ...params,
+    promptText: params.body,
+    replyText: params.finalText,
+  });
+}
+
+async function persistAcpTranscriptMessages(
+  params: PersistAcpTranscriptParams & {
+    promptText: string;
+    replyText: string;
+  },
+): Promise<SessionEntry | undefined> {
+  const promptText = params.promptText;
+  const replyText = params.replyText;
+  if (!promptText && !replyText) {
+    return params.sessionEntry;
+  }
+
+  const { sessionFile, sessionEntry } = await resolveSessionTranscriptFile({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore,
+    storePath: params.storePath,
+    agentId: params.sessionAgentId,
+    threadId: params.threadId,
+  });
+  const hadSessionFile = await fs
+    .access(sessionFile)
+    .then(() => true)
+    .catch(() => false);
+  const sessionManager = SessionManager.open(sessionFile);
+  await prepareSessionManagerForRun({
+    sessionManager,
+    sessionFile,
+    hadSessionFile,
+    sessionId: params.sessionId,
+    cwd: params.sessionCwd,
+  });
+
+  let changed = false;
+  if (promptText && shouldAppendPrompt(sessionManager, promptText, params.inputProvenance)) {
+    const userMessage = applyInputProvenanceToUserMessage(
+      {
+        role: "user",
+        content: promptText,
+        timestamp: Date.now(),
+      } as AgentMessage,
+      params.inputProvenance,
+    );
+    sessionManager.appendMessage(userMessage as Parameters<typeof sessionManager.appendMessage>[0]);
+    changed = true;
+  }
+
+  if (replyText) {
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: replyText }],
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "acp-runtime",
+      usage: ACP_TRANSCRIPT_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+    changed = true;
+  }
+
+  if (changed && promptText && !replyText) {
+    forcePersistPromptOnlyTranscript(sessionManager);
+  }
+
+  if (changed) {
+    emitSessionTranscriptUpdate(sessionFile);
+  }
+  return sessionEntry;
+}
+
+function shouldAppendPrompt(
+  sessionManager: ReturnType<typeof SessionManager.open>,
+  promptText: string,
+  inputProvenance: InputProvenance | undefined,
+): boolean {
+  const lastMessage = getTranscriptMessages(sessionManager).at(-1);
+  if (!lastMessage || lastMessage.role !== "user") {
+    return true;
+  }
+  if (typeof lastMessage.content !== "string") {
+    return true;
+  }
+  if (normalizePromptForDedup(lastMessage.content) !== normalizePromptForDedup(promptText)) {
+    return true;
+  }
+  return !sameInputProvenance(
+    (lastMessage as { provenance?: unknown }).provenance,
+    inputProvenance,
+  );
+}
+
+function getTranscriptMessages(
+  sessionManager: ReturnType<typeof SessionManager.open>,
+): AgentMessage[] {
+  return sessionManager
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => (entry as { message: AgentMessage }).message);
+}
+
+function normalizePromptForDedup(text: string): string {
+  return text.replace(TIMESTAMP_ENVELOPE_PATTERN, "").trim();
+}
+
+function sameInputProvenance(existing: unknown, incoming: InputProvenance | undefined): boolean {
+  const normalizedExisting = normalizeInputProvenance(existing);
+  const normalizedIncoming = normalizeInputProvenance(incoming);
+  if (!normalizedExisting && !normalizedIncoming) {
+    return true;
+  }
+  if (!normalizedExisting || !normalizedIncoming) {
+    return false;
+  }
+  return (
+    normalizedExisting.kind === normalizedIncoming.kind &&
+    normalizedExisting.originSessionId === normalizedIncoming.originSessionId &&
+    normalizedExisting.sourceSessionKey === normalizedIncoming.sourceSessionKey &&
+    normalizedExisting.sourceChannel === normalizedIncoming.sourceChannel &&
+    normalizedExisting.sourceTool === normalizedIncoming.sourceTool
+  );
+}
+
+function forcePersistPromptOnlyTranscript(
+  sessionManager: ReturnType<typeof SessionManager.open>,
+): void {
+  const manager = sessionManager as unknown as {
+    isPersisted?: () => boolean;
+    _rewriteFile?: () => void;
+  };
+  if (!manager.isPersisted?.()) {
+    return;
+  }
+  // pi-coding-agent keeps prompt-only sessions in memory until the first assistant
+  // message arrives. ACP spawn needs the initial task on disk immediately.
+  manager._rewriteFile?.();
+}

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1,6 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionBindingRecord } from "../infra/outbound/session-binding-service.js";
+
+const tempDirs: string[] = [];
+
+function readTranscriptMessages(sessionFile: string): AgentMessage[] {
+  return SessionManager.open(sessionFile)
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => (entry as { message: AgentMessage }).message);
+}
 
 function createDefaultSpawnConfig(): OpenClawConfig {
   return {
@@ -200,6 +214,12 @@ function expectResolvedIntroTextInBindMetadata(): void {
 }
 
 describe("spawnAcpDirect", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
   beforeEach(() => {
     hoisted.state.cfg = createDefaultSpawnConfig();
     hoisted.areHeartbeatsEnabledMock.mockReset().mockReturnValue(true);
@@ -381,9 +401,10 @@ describe("spawnAcpDirect", () => {
     const transcriptCalls = hoisted.resolveSessionTranscriptFileMock.mock.calls.map(
       (call: unknown[]) => call[0] as { threadId?: string },
     );
-    expect(transcriptCalls).toHaveLength(2);
+    expect(transcriptCalls).toHaveLength(3);
     expect(transcriptCalls[0]?.threadId).toBeUndefined();
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
+    expect(transcriptCalls[2]?.threadId).toBe("child-thread");
   });
 
   it("does not inline delivery for fresh oneshot ACP runs", async () => {
@@ -420,6 +441,61 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.channel).toBeUndefined();
     expect(agentCall?.params?.to).toBeUndefined();
     expect(agentCall?.params?.threadId).toBeUndefined();
+  });
+
+  it("seeds the ACP transcript with the initial spawn task before the run completes", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-spawn-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "sess-123.jsonl");
+    hoisted.resolveSessionTranscriptFileMock.mockReset().mockImplementation(async () => ({
+      sessionFile,
+      sessionEntry: {
+        sessionId: "sess-123",
+        updatedAt: Date.now(),
+        sessionFile,
+      },
+    }));
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "run",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      taskDelivered: true,
+    });
+
+    const messages = readTranscriptMessages(sessionFile);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      role: "user",
+      content: "Investigate flaky tests",
+      provenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:main",
+        sourceChannel: "discord",
+        sourceTool: "sessions_spawn",
+      },
+    });
+
+    const agentCall = hoisted.callGatewayMock.mock.calls
+      .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
+      .find((request) => request.method === "agent");
+    expect(agentCall?.params?.message).toBe("Investigate flaky tests");
+    expect(agentCall?.params?.inputProvenance).toMatchObject({
+      kind: "inter_session",
+      sourceTool: "sessions_spawn",
+    });
   });
 
   it("keeps ACP spawn running when session-file persistence fails", async () => {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -722,6 +722,41 @@ describe("spawnAcpDirect", () => {
     expect(secondHandle.notifyStarted).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps seed transcript routing aligned with dispatch when thread=true streams to parent", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+        streamTo: "parent",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+        agentThreadId: "requester-thread",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.mode).toBe("session");
+    const agentCall = hoisted.callGatewayMock.mock.calls
+      .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
+      .find((request) => request.method === "agent");
+    expect(agentCall?.params?.deliver).toBe(false);
+    expect(agentCall?.params?.threadId).toBeUndefined();
+
+    const transcriptCalls = hoisted.resolveSessionTranscriptFileMock.mock.calls.map(
+      (call: unknown[]) => call[0] as { threadId?: string },
+    );
+    expect(transcriptCalls).toHaveLength(3);
+    expect(transcriptCalls[0]?.threadId).toBeUndefined();
+    expect(transcriptCalls[1]?.threadId).toBe("child-thread");
+    expect(transcriptCalls[2]?.threadId).toBeUndefined();
+  });
+
   it("implicitly streams mode=run ACP spawns for subagent requester sessions", async () => {
     hoisted.state.cfg = {
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -704,6 +704,7 @@ export async function spawnAcpDirect(
   // decide how to relay status. Inline delivery is reserved for thread-bound sessions.
   const useInlineDelivery =
     hasDeliveryTarget && spawnMode === "session" && !effectiveStreamToParent;
+  const dispatchThreadId = useInlineDelivery ? deliveryThreadId : undefined;
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
   const streamLogPath =
@@ -726,7 +727,7 @@ export async function spawnAcpDirect(
         sessionStore,
         storePath,
         sessionAgentId: targetAgentId,
-        threadId: boundThreadId ?? undefined,
+        threadId: dispatchThreadId,
         sessionCwd: resolveAcpSessionCwd(initializedMeta) ?? params.cwd ?? process.cwd(),
         inputProvenance: taskInputProvenance,
       });
@@ -757,7 +758,7 @@ export async function spawnAcpDirect(
         channel: useInlineDelivery ? requesterOrigin?.channel : undefined,
         to: useInlineDelivery ? inferredDeliveryTo : undefined,
         accountId: useInlineDelivery ? (requesterOrigin?.accountId ?? undefined) : undefined,
-        threadId: useInlineDelivery ? deliveryThreadId : undefined,
+        threadId: dispatchThreadId,
         idempotencyKey: childIdem,
         deliver: useInlineDelivery,
         label: params.label || undefined,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -10,6 +10,7 @@ import {
   resolveAcpThreadSessionDetailLines,
 } from "../acp/runtime/session-identifiers.js";
 import type { AcpRuntimeSessionMode } from "../acp/runtime/types.js";
+import { persistAcpPromptTranscript } from "../acp/session-transcript.js";
 import { DEFAULT_HEARTBEAT_EVERY } from "../auto-reply/heartbeat.js";
 import {
   resolveThreadBindingIntroText,
@@ -27,6 +28,7 @@ import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadSessionStore, resolveStorePath, type SessionEntry } from "../config/sessions.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
+import type { SessionAcpMeta } from "../config/sessions/types.js";
 import { callGateway } from "../gateway/call.js";
 import { areHeartbeatsEnabled } from "../infra/heartbeat-wake.js";
 import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
@@ -41,6 +43,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import { deliveryContextFromSession, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import {
   type AcpSpawnParentRelayHandle,
@@ -86,6 +89,7 @@ export type SpawnAcpResult = {
   childSessionKey?: string;
   runId?: string;
   mode?: SpawnAcpMode;
+  taskDelivered?: boolean;
   streamLogPath?: string;
   note?: string;
   error?: string;
@@ -400,6 +404,26 @@ function prepareAcpThreadBinding(params: {
   };
 }
 
+function resolveAcpSpawnInputProvenance(params: {
+  parentSessionKey?: string;
+  parentChannel?: string;
+}): InputProvenance {
+  const sourceSessionKey = params.parentSessionKey?.trim();
+  const sourceChannel = params.parentChannel?.trim();
+  if (sourceSessionKey || sourceChannel) {
+    return {
+      kind: "inter_session",
+      sourceSessionKey,
+      sourceChannel,
+      sourceTool: "sessions_spawn",
+    };
+  }
+  return {
+    kind: "internal_system",
+    sourceTool: "sessions_spawn",
+  };
+}
+
 export async function spawnAcpDirect(
   params: SpawnAcpParams,
   ctx: SpawnAcpContext,
@@ -539,6 +563,11 @@ export async function spawnAcpDirect(
   let binding: SessionBindingRecord | null = null;
   let sessionCreated = false;
   let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
+  let initializedMeta: SessionAcpMeta | undefined;
+  let storePath: string | undefined;
+  let sessionStore: Record<string, SessionEntry> | undefined;
+  let sessionEntry: SessionEntry | undefined;
+  let sessionId: string | undefined;
   try {
     await callGateway({
       method: "sessions.patch",
@@ -550,10 +579,10 @@ export async function spawnAcpDirect(
       timeoutMs: 10_000,
     });
     sessionCreated = true;
-    const storePath = resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
-    const sessionStore = loadSessionStore(storePath);
-    let sessionEntry: SessionEntry | undefined = sessionStore[sessionKey];
-    const sessionId = sessionEntry?.sessionId;
+    storePath = resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
+    sessionStore = loadSessionStore(storePath);
+    sessionEntry = sessionStore[sessionKey];
+    sessionId = sessionEntry?.sessionId;
     if (sessionId) {
       sessionEntry = await persistAcpSpawnSessionFileBestEffort({
         sessionId,
@@ -578,6 +607,7 @@ export async function spawnAcpDirect(
       runtime: initialized.runtime,
       handle: initialized.handle,
     };
+    initializedMeta = initialized.meta;
 
     if (preparedBinding) {
       binding = await bindingService.bind({
@@ -682,6 +712,30 @@ export async function spawnAcpDirect(
           childSessionKey: sessionKey,
         })
       : undefined;
+  const taskInputProvenance = resolveAcpSpawnInputProvenance({
+    parentSessionKey,
+    parentChannel: ctx.agentChannel,
+  });
+  if (sessionId) {
+    try {
+      sessionEntry = await persistAcpPromptTranscript({
+        promptText: params.task,
+        sessionId,
+        sessionKey,
+        sessionEntry,
+        sessionStore,
+        storePath,
+        sessionAgentId: targetAgentId,
+        threadId: boundThreadId ?? undefined,
+        sessionCwd: resolveAcpSessionCwd(initializedMeta) ?? params.cwd ?? process.cwd(),
+        inputProvenance: taskInputProvenance,
+      });
+    } catch (error) {
+      log.warn(
+        `ACP spawn transcript persistence failed for ${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
   let parentRelay: AcpSpawnParentRelayHandle | undefined;
   if (effectiveStreamToParent && parentSessionKey) {
     // Register relay before dispatch so fast lifecycle failures are not missed.
@@ -707,6 +761,7 @@ export async function spawnAcpDirect(
         idempotencyKey: childIdem,
         deliver: useInlineDelivery,
         label: params.label || undefined,
+        inputProvenance: taskInputProvenance,
       },
       timeoutMs: 10_000,
     });
@@ -747,6 +802,7 @@ export async function spawnAcpDirect(
       childSessionKey: sessionKey,
       runId: childRunId,
       mode: spawnMode,
+      taskDelivered: true,
       ...(streamLogPath ? { streamLogPath } : {}),
       note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
     };
@@ -757,6 +813,7 @@ export async function spawnAcpDirect(
     childSessionKey: sessionKey,
     runId: childRunId,
     mode: spawnMode,
+    taskDelivered: true,
     note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
   };
 }

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -30,7 +30,6 @@ export async function prepareSessionManagerForRun(params: {
   };
 
   const header = sm.fileEntries.find((e): e is SessionHeaderEntry => e.type === "session");
-  const hasMessages = sm.fileEntries.some((e) => e.type === "message");
   const hasAssistant = sm.fileEntries.some(
     (e) => e.type === "message" && (e as SessionMessageEntry).message?.role === "assistant",
   );
@@ -42,13 +41,10 @@ export async function prepareSessionManagerForRun(params: {
     return;
   }
 
-  if (params.hadSessionFile && header && !hasAssistant && !hasMessages) {
-    // Reset file so the first assistant flush includes header+user+assistant in order.
+  if (params.hadSessionFile && header && !hasAssistant) {
+    // Truncate prompt-only session files so the next flush rewrites the complete
+    // in-memory transcript once an assistant message arrives.
     await fs.writeFile(params.sessionFile, "", "utf-8");
-    sm.fileEntries = [header];
-    sm.byId?.clear?.();
-    sm.labelsById?.clear?.();
-    sm.leafId = null;
     sm.flushed = false;
   }
 }

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -30,6 +30,7 @@ export async function prepareSessionManagerForRun(params: {
   };
 
   const header = sm.fileEntries.find((e): e is SessionHeaderEntry => e.type === "session");
+  const hasMessages = sm.fileEntries.some((e) => e.type === "message");
   const hasAssistant = sm.fileEntries.some(
     (e) => e.type === "message" && (e as SessionMessageEntry).message?.role === "assistant",
   );
@@ -41,7 +42,7 @@ export async function prepareSessionManagerForRun(params: {
     return;
   }
 
-  if (params.hadSessionFile && header && !hasAssistant) {
+  if (params.hadSessionFile && header && !hasAssistant && !hasMessages) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
     await fs.writeFile(params.sessionFile, "", "utf-8");
     sm.fileEntries = [header];

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,9 +1,8 @@
-import fs from "node:fs/promises";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../acp/policy.js";
 import { toAcpRuntimeError } from "../acp/runtime/errors.js";
 import { resolveAcpSessionCwd } from "../acp/runtime/session-identifiers.js";
+import { persistAcpTurnTranscript } from "../acp/session-transcript.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("commands/agent");
@@ -36,7 +35,6 @@ import {
   resolveDefaultModelForAgent,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
-import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
@@ -86,7 +84,6 @@ import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
-import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { resolveMessageChannel } from "../utils/message-channel.js";
 import { deliverAgentCommandResult } from "./agent/delivery.js";
 import { resolveAgentRunContext } from "./agent/run-context.js";
@@ -235,86 +232,6 @@ function createAcpVisibleTextAccumulator() {
       return visibleText;
     },
   };
-}
-
-const ACP_TRANSCRIPT_USAGE = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: {
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    total: 0,
-  },
-} as const;
-
-async function persistAcpTurnTranscript(params: {
-  body: string;
-  finalText: string;
-  sessionId: string;
-  sessionKey: string;
-  sessionEntry: SessionEntry | undefined;
-  sessionStore?: Record<string, SessionEntry>;
-  storePath?: string;
-  sessionAgentId: string;
-  threadId?: string | number;
-  sessionCwd: string;
-}): Promise<SessionEntry | undefined> {
-  const promptText = params.body;
-  const replyText = params.finalText;
-  if (!promptText && !replyText) {
-    return params.sessionEntry;
-  }
-
-  const { sessionFile, sessionEntry } = await resolveSessionTranscriptFile({
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    sessionEntry: params.sessionEntry,
-    sessionStore: params.sessionStore,
-    storePath: params.storePath,
-    agentId: params.sessionAgentId,
-    threadId: params.threadId,
-  });
-  const hadSessionFile = await fs
-    .access(sessionFile)
-    .then(() => true)
-    .catch(() => false);
-  const sessionManager = SessionManager.open(sessionFile);
-  await prepareSessionManagerForRun({
-    sessionManager,
-    sessionFile,
-    hadSessionFile,
-    sessionId: params.sessionId,
-    cwd: params.sessionCwd,
-  });
-
-  if (promptText) {
-    sessionManager.appendMessage({
-      role: "user",
-      content: promptText,
-      timestamp: Date.now(),
-    });
-  }
-
-  if (replyText) {
-    sessionManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: replyText }],
-      api: "openai-responses",
-      provider: "openclaw",
-      model: "acp-runtime",
-      usage: ACP_TRANSCRIPT_USAGE,
-      stopReason: "stop",
-      timestamp: Date.now(),
-    });
-  }
-
-  emitSessionTranscriptUpdate(sessionFile);
-  return sessionEntry;
 }
 
 function runAgentAttempt(params: {
@@ -830,6 +747,7 @@ async function agentCommandInternal(
           sessionAgentId,
           threadId: opts.threadId,
           sessionCwd: resolveAcpSessionCwd(acpResolution.meta) ?? workspaceDir,
+          inputProvenance: opts.inputProvenance,
         });
       } catch (error) {
         log.warn(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–4 bullets:

- Problem: `sessions_spawn(..., runtime: "acp")` could create an ACP session successfully, but the initial `task` was not written to transcript/history until a later assistant reply landed.
- Why it matters: a freshly spawned ACP session could appear to have empty history immediately after spawn, making the initial task look missing.
- What changed: seed the ACP transcript with the initial spawn task as soon as the session is created, pass `inputProvenance` through the first ACP dispatch, and dedupe the later persisted prompt so the same task is not stored twice.
- What did NOT change (scope boundary): non-ACP spawn flows and normal post-turn transcript persistence semantics are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43518
- Related #

## User-visible / Behavior Changes

- ACP sessions spawned via `sessions_spawn` now show the initial task in transcript/history immediately, before the first assistant reply arrives.
- The later ACP turn no longer duplicates that same seeded prompt in transcript/history.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): ACP runtime via `sessions_spawn`
- Relevant config (redacted): `runtime: "acp"`

### Steps

1. Spawn a session with `sessions_spawn` using `runtime: "acp"` and an initial `task`.
2. Inspect the spawned session transcript/history immediately after spawn, before any assistant reply lands.
3. Let the first ACP turn complete and inspect the transcript again.

### Expected

- The initial task is visible in transcript/history immediately after spawn.
- The later ACP turn does not append a duplicate copy of the same prompt.

### Actual

- Before this fix, the spawned ACP session could appear to have empty history until the first assistant reply arrived.
- The initial task only showed up later, which made the spawn task look missing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - ACP spawn writes the initial `task` into transcript/history immediately.
  - The first ACP turn does not append a duplicate copy of the seeded prompt.
  - The same prompt text with different provenance still persists as separate entries.
- Edge cases checked:
  - Session-manager init no longer wipes intentionally pre-seeded prompt-only transcripts.
- What you did **not** verify:
  - I did not rely on the repo's `pnpm build` wrapper on this Windows machine because the local `bash` shim is broken; CI should cover the standard entrypoint.

Local verification run:
- `pnpm exec vitest run --config vitest.unit.config.ts src/acp/session-transcript.test.ts`
- `pnpm exec vitest run --config vitest.config.ts src/agents/acp-spawn.test.ts src/agents/tools/sessions-spawn-tool.test.ts`
- `pnpm check`

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: ACP transcript persistence behavior only; no config or migration rollback is required.
- Known bad symptoms reviewers should watch for: duplicated initial prompts in ACP transcripts, or spawned ACP sessions still showing empty history immediately after spawn.

## Risks and Mitigations

- Risk: seeding the spawn prompt could cause the later ACP turn to persist a duplicate message.
  - Mitigation: transcript persistence now dedupes by normalized text plus provenance, with regression coverage.
- Risk: prompt-only transcripts seeded at spawn time could be wiped during session-manager initialization.
  - Mitigation: session-manager init now preserves intentionally seeded
