### PR TITLE
docs: update Raspberry Pi dashboard access instructions

### DIFF
--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -153,29 +153,37 @@ sudo systemctl status openclaw
 journalctl -u openclaw -f
 ```
 
-## 9) Access the Dashboard
+## 9) Access the OpenClaw Dashboard
 
-Since the Pi is headless, use an SSH tunnel:
+On a terminal on your local machine, run:
 
 ```bash
-# From your laptop/desktop
+ssh user@gateway-host
+```
+
+Then run:
+
+```bash
+openclaw dashboard
+```
+
+Replace `user@gateway-host` with your Pi username and hostname or IP address.
+
+The output will look something like:
+
+```text
+Dashboard URL: http://127.0.0.1:18789#token=<token>
+```
+
+Open another terminal and run:
+
+```bash
 ssh -L 18789:localhost:18789 user@gateway-host
-
-# Then open in browser
-open http://localhost:18789
 ```
 
-Or use Tailscale for always-on access:
+Then open your browser and go to `http://127.0.0.1:18789#token=<token>`.
 
-```bash
-# On the Pi
-curl -fsSL https://tailscale.com/install.sh | sh
-sudo tailscale up
-
-# Update config
-openclaw config set gateway.bind tailnet
-sudo systemctl restart openclaw
-```
+You should see the OpenClaw dashboard.
 
 ---
 

--- a/docs/zh-CN/platforms/raspberry-pi.md
+++ b/docs/zh-CN/platforms/raspberry-pi.md
@@ -160,29 +160,37 @@ sudo systemctl status openclaw
 journalctl -u openclaw -f
 ```
 
-## 9) 访问仪表板
+## 9) 访问 OpenClaw 仪表板
 
-由于 Pi 是无头的，使用 SSH 隧道：
+在你本地机器的终端中，运行：
 
 ```bash
-# 从你的笔记本电脑/台式机
+ssh user@gateway-host
+```
+
+然后运行：
+
+```bash
+openclaw dashboard
+```
+
+将 `user@gateway-host` 替换为你的 Pi 用户名以及主机名或 IP 地址。
+
+输出大致如下：
+
+```text
+Dashboard URL: http://127.0.0.1:18789#token=<token>
+```
+
+打开另一个终端并运行：
+
+```bash
 ssh -L 18789:localhost:18789 user@gateway-host
-
-# 然后在浏览器中打开
-open http://localhost:18789
 ```
 
-或使用 Tailscale 实现常驻访问：
+然后在浏览器中访问 `http://127.0.0.1:18789#token=<token>`。
 
-```bash
-# 在 Pi 上
-curl -fsSL https://tailscale.com/install.sh | sh
-sudo tailscale up
-
-# 更新配置
-openclaw config set gateway.bind tailnet
-sudo systemctl restart openclaw
-```
+你应该会看到 OpenClaw 仪表板。
 
 ---
 


### PR DESCRIPTION
## Summary
- update the Raspberry Pi dashboard access steps to use the current `openclaw dashboard` flow with placeholder host examples
- replace the original outdated dashboard documentation and avoid real-looking username or IP examples in the docs
- sync the matching `docs/zh-CN/platforms/raspberry-pi.md` section with the same placeholder-based flow

## Testing
- `pnpm build && pnpm check && pnpm test` *(fails before tests due to unrelated pre-existing type errors in `src/config/model-alias-defaults.test.ts` from local worktree changes)*
- `ReadLints` on the edited docs files

## Notes
- AI-assisted PR
- Testing degree: lightly tested (docs-only change)
- I only found corresponding Raspberry Pi docs in `docs/platforms/raspberry-pi.md` and `docs/zh-CN/platforms/raspberry-pi.md`; there were no `ja-JP` or other localized Raspberry Pi copies in this repo
