### PR TITLE
docs: update Raspberry Pi dashboard access instructions

### DIFF
--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -178,6 +178,8 @@ Then open the printed Dashboard URL in your local browser.
 If the UI asks for auth, paste the token from `gateway.auth.token`
 (or `OPENCLAW_GATEWAY_TOKEN`) into Control UI settings.
 
+For always-on remote access, see [Tailscale](/gateway/tailscale).
+
 ---
 
 ## Performance Optimizations

--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -153,29 +153,37 @@ sudo systemctl status openclaw
 journalctl -u openclaw -f
 ```
 
-## 9) Access the Dashboard
+## 9) Access the OpenClaw Dashboard
 
-Since the Pi is headless, use an SSH tunnel:
+Replace `user@gateway-host` with your Pi username and hostname or IP address.
+
+On a terminal on your local machine, run:
 
 ```bash
-# From your laptop/desktop
+ssh user@gateway-host
+```
+
+Then run:
+
+```bash
+openclaw dashboard
+```
+
+The output will look something like:
+
+```text
+Dashboard URL: http://127.0.0.1:18789#token=<token>
+```
+
+Open another terminal and run:
+
+```bash
 ssh -L 18789:localhost:18789 user@gateway-host
-
-# Then open in browser
-open http://localhost:18789
 ```
 
-Or use Tailscale for always-on access:
+Then paste the Dashboard URL printed by `openclaw dashboard` into your browser.
 
-```bash
-# On the Pi
-curl -fsSL https://tailscale.com/install.sh | sh
-sudo tailscale up
-
-# Update config
-openclaw config set gateway.bind tailnet
-sudo systemctl restart openclaw
-```
+You should see the OpenClaw dashboard.
 
 ---
 

--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -157,33 +157,26 @@ journalctl -u openclaw -f
 
 Replace `user@gateway-host` with your Pi username and hostname or IP address.
 
-On a terminal on your local machine, run:
+On your computer, ask the Pi to print a fresh dashboard URL:
 
 ```bash
-ssh user@gateway-host
+ssh user@gateway-host 'openclaw dashboard --no-open'
 ```
 
-Then run:
+The command prints `Dashboard URL:`. Depending on how `gateway.auth.token`
+is configured, the URL may be a plain `http://127.0.0.1:18789/` link or one
+that includes `#token=...`.
+
+In another terminal on your computer, create the SSH tunnel:
 
 ```bash
-openclaw dashboard
+ssh -N -L 18789:127.0.0.1:18789 user@gateway-host
 ```
 
-The output will look something like:
+Then open the printed Dashboard URL in your local browser.
 
-```text
-Dashboard URL: http://127.0.0.1:18789#token=<token>
-```
-
-Open another terminal and run:
-
-```bash
-ssh -L 18789:localhost:18789 user@gateway-host
-```
-
-Then paste the Dashboard URL printed by `openclaw dashboard` into your browser.
-
-You should see the OpenClaw dashboard.
+If the UI asks for auth, paste the token from `gateway.auth.token`
+(or `OPENCLAW_GATEWAY_TOKEN`) into Control UI settings.
 
 ---
 

--- a/docs/zh-CN/platforms/raspberry-pi.md
+++ b/docs/zh-CN/platforms/raspberry-pi.md
@@ -160,29 +160,37 @@ sudo systemctl status openclaw
 journalctl -u openclaw -f
 ```
 
-## 9) 访问仪表板
+## 9) 访问 OpenClaw 仪表板
 
-由于 Pi 是无头的，使用 SSH 隧道：
+将 `user@gateway-host` 替换为你的 Pi 用户名以及主机名或 IP 地址。
+
+在你本地机器的终端中，运行：
 
 ```bash
-# 从你的笔记本电脑/台式机
+ssh user@gateway-host
+```
+
+然后运行：
+
+```bash
+openclaw dashboard
+```
+
+输出大致如下：
+
+```text
+Dashboard URL: http://127.0.0.1:18789#token=<token>
+```
+
+打开另一个终端并运行：
+
+```bash
 ssh -L 18789:localhost:18789 user@gateway-host
-
-# 然后在浏览器中打开
-open http://localhost:18789
 ```
 
-或使用 Tailscale 实现常驻访问：
+然后将 `openclaw dashboard` 输出的 Dashboard URL 粘贴到浏览器中。
 
-```bash
-# 在 Pi 上
-curl -fsSL https://tailscale.com/install.sh | sh
-sudo tailscale up
-
-# 更新配置
-openclaw config set gateway.bind tailnet
-sudo systemctl restart openclaw
-```
+你应该会看到 OpenClaw 仪表板。
 
 ---
 

--- a/docs/zh-CN/platforms/raspberry-pi.md
+++ b/docs/zh-CN/platforms/raspberry-pi.md
@@ -6,10 +6,10 @@ read_when:
 summary: 在 Raspberry Pi 上运行 OpenClaw（低成本自托管设置）
 title: Raspberry Pi
 x-i18n:
-  generated_at: "2026-02-03T07:53:30Z"
+  generated_at: "2026-03-12T02:06:39Z"
   model: claude-opus-4-5
   provider: pi
-  source_hash: 6741eaf0115a4fa0efd6599a99e0526a20ceb30eda1d9b04cba9dd5dec84bee2
+  source_hash: 9c17d2d0ee7f0a3d671e9ea3b2512c41f7f59b7b9d43c3d06ea19751c0f3c1dc
   source_path: platforms/raspberry-pi.md
   workflow: 15
 ---

--- a/docs/zh-CN/platforms/raspberry-pi.md
+++ b/docs/zh-CN/platforms/raspberry-pi.md
@@ -6,10 +6,10 @@ read_when:
 summary: 在 Raspberry Pi 上运行 OpenClaw（低成本自托管设置）
 title: Raspberry Pi
 x-i18n:
-  generated_at: "2026-03-12T02:06:39Z"
+  generated_at: "2026-02-03T07:53:30Z"
   model: claude-opus-4-5
   provider: pi
-  source_hash: 9c17d2d0ee7f0a3d671e9ea3b2512c41f7f59b7b9d43c3d06ea19751c0f3c1dc
+  source_hash: 6741eaf0115a4fa0efd6599a99e0526a20ceb30eda1d9b04cba9dd5dec84bee2
   source_path: platforms/raspberry-pi.md
   workflow: 15
 ---
@@ -160,37 +160,29 @@ sudo systemctl status openclaw
 journalctl -u openclaw -f
 ```
 
-## 9) 访问 OpenClaw 仪表板
+## 9) 访问仪表板
 
-将 `user@gateway-host` 替换为你的 Pi 用户名以及主机名或 IP 地址。
-
-在你本地机器的终端中，运行：
+由于 Pi 是无头的，使用 SSH 隧道：
 
 ```bash
-ssh user@gateway-host
-```
-
-然后运行：
-
-```bash
-openclaw dashboard
-```
-
-输出大致如下：
-
-```text
-Dashboard URL: http://127.0.0.1:18789#token=<token>
-```
-
-打开另一个终端并运行：
-
-```bash
+# 从你的笔记本电脑/台式机
 ssh -L 18789:localhost:18789 user@gateway-host
+
+# 然后在浏览器中打开
+open http://localhost:18789
 ```
 
-然后将 `openclaw dashboard` 输出的 Dashboard URL 粘贴到浏览器中。
+或使用 Tailscale 实现常驻访问：
 
-你应该会看到 OpenClaw 仪表板。
+```bash
+# 在 Pi 上
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+
+# 更新配置
+openclaw config set gateway.bind tailnet
+sudo systemctl restart openclaw
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- update the Raspberry Pi dashboard access steps to use the current `openclaw dashboard` flow
- replace the outdated dashboard section with placeholder-safe host examples and clarify that users should paste the actual URL printed by `openclaw dashboard`
- sync the matching `docs/zh-CN/platforms/raspberry-pi.md` section with the same updated flow

## Testing
- `pnpm install && pnpm build && pnpm check && pnpm test` in a clean clone from the latest `origin/main` plus this branch
- Manual: tested on a Raspberry Pi and confirmed the dashboard is accessible with this method

## Notes
- AI-assisted PR
- I only found corresponding Raspberry Pi docs in `docs/platforms/raspberry-pi.md` and `docs/zh-CN/platforms/raspberry-pi.md`; there were no `ja-JP` or other localized Raspberry Pi copies in this repo
