### PR TITLE
fix: respect tools.exec.ask=off in webchat/control-ui

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -133,9 +133,15 @@ export function resolveExecHostApprovalContext(params: {
     ask: params.ask,
   });
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  // An explicit ask=off policy in exec-approvals.json must be able to suppress
-  // prompts even when tool/runtime defaults are stricter (for example on-miss).
-  const hostAsk = approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask);
+  // An explicit ask=off policy (either from exec-approvals.json or tools.exec.ask)
+  // must be able to suppress prompts even when other defaults are stricter.
+  // tools.exec.ask=off takes precedence to allow users to disable prompts entirely.
+  const hostAsk =
+    params.ask === "off"
+      ? "off"
+      : approvals.agent.ask === "off"
+        ? "off"
+        : maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error(`exec denied: host=${params.host} security=deny`);

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -137,11 +137,9 @@ export function resolveExecHostApprovalContext(params: {
   // must be able to suppress prompts even when other defaults are stricter.
   // tools.exec.ask=off takes precedence to allow users to disable prompts entirely.
   const hostAsk =
-    params.ask === "off"
+    params.ask === "off" || approvals.agent.ask === "off"
       ? "off"
-      : approvals.agent.ask === "off"
-        ? "off"
-        : maxAsk(params.ask, approvals.agent.ask);
+      : maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error(`exec denied: host=${params.host} security=deny`);

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -133,15 +133,21 @@ export function resolveExecHostApprovalContext(params: {
     ask: params.ask,
   });
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  // DESIGN DECISION: User-level tools.exec.ask=off takes precedence over exec-approvals.json policies.
-  // This allows users to disable exec prompts entirely in trusted environments (e.g., webchat/control-ui).
-  // SECURITY TRADE-OFF: A user setting tools.exec.ask=off in openclaw.json can bypass an admin-configured
-  // ask: "always" policy in exec-approvals.json. This is intentional: user opt-out wins over admin defaults.
-  // Admins requiring mandatory approvals should enforce this at the deployment level, not via exec-approvals.json.
-  const hostAsk =
-    params.ask === "off" || approvals.agent.ask === "off"
-      ? "off"
-      : maxAsk(params.ask, approvals.agent.ask);
+  // DESIGN DECISION: User-level tools.exec.ask=off takes precedence over admin policies.
+  // This allows users to disable exec prompts in trusted environments (e.g., webchat/control-ui).
+  // However, user cannot override admin's explicit "off" (security restriction).
+  // Priority order:
+  // 1. params.ask === "off" → "off" (user opt-out always wins)
+  // 2. approvals.agent.ask === "off" && params.ask !== "off" → "off" (admin restriction stands)
+  // 3. Otherwise → maxAsk(params.ask, approvals.agent.ask)
+  let hostAsk: string;
+  if (params.ask === "off") {
+    hostAsk = "off"; // User opt-out always wins
+  } else if (approvals.agent.ask === "off") {
+    hostAsk = "off"; // Admin restriction stands (user cannot override to "always")
+  } else {
+    hostAsk = maxAsk(params.ask, approvals.agent.ask);
+  }
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error(`exec denied: host=${params.host} security=deny`);

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -133,9 +133,11 @@ export function resolveExecHostApprovalContext(params: {
     ask: params.ask,
   });
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  // An explicit ask=off policy (either from exec-approvals.json or tools.exec.ask)
-  // must be able to suppress prompts even when other defaults are stricter.
-  // tools.exec.ask=off takes precedence to allow users to disable prompts entirely.
+  // DESIGN DECISION: User-level tools.exec.ask=off takes precedence over exec-approvals.json policies.
+  // This allows users to disable exec prompts entirely in trusted environments (e.g., webchat/control-ui).
+  // SECURITY TRADE-OFF: A user setting tools.exec.ask=off in openclaw.json can bypass an admin-configured
+  // ask: "always" policy in exec-approvals.json. This is intentional: user opt-out wins over admin defaults.
+  // Admins requiring mandatory approvals should enforce this at the deployment level, not via exec-approvals.json.
   const hostAsk =
     params.ask === "off" || approvals.agent.ask === "off"
       ? "off"


### PR DESCRIPTION
## Problem

Previously, `tools.exec.ask=off` set in `openclaw.json` was silently ignored in webchat/control-ui contexts. The root cause was that `resolveExecHostApprovalContext` computed `hostAsk` using `maxAsk(params.ask, approvals.agent.ask)` when `exec-approvals.json`'s resolved ask value was not `"off"`, meaning a stricter file-level value (e.g. `"always"`) would always win over the user's explicit `"off"` config.

## Solution

- `params.ask === "off"` is now checked first, giving `tools.exec.ask=off` the highest priority.
- The existing `approvals.agent.ask === "off"` short-circuit is preserved as the second priority.
- Falls back to `maxAsk(params.ask, approvals.agent.ask)` for all other combinations — identical to previous behavior.

## Changes

- **Single file**: `src/agents/bash-tools.exec-host-shared.ts`
- **Lines changed**: +9/-3

Fixes #42574