### PR TITLE
fix(status): clarify bootstrap summary wording

### DIFF
--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -62,7 +62,7 @@ export function buildStatusAgentsValue(params: {
   const pending =
     params.agentStatus.bootstrapPendingCount > 0
       ? `${params.agentStatus.bootstrapPendingCount} bootstrap file${params.agentStatus.bootstrapPendingCount === 1 ? "" : "s"} present`
-      : "no bootstrap files";
+      : "no workspaces bootstrapping";
   const def = params.agentStatus.agents.find((a) => a.id === params.agentStatus.defaultId);
   const defActive =
     def?.lastActiveAgeMs != null ? params.formatTimeAgo(def.lastActiveAgeMs) : "unknown";

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1059,7 +1059,7 @@ describe("statusCommand", () => {
       "Plugin compatibility",
       "Channels",
       "WhatsApp",
-      "bootstrap files",
+      "no workspaces bootstrapping",
       "Tasks",
       "Sessions",
       "+1000",
@@ -1181,6 +1181,12 @@ describe("statusCommand", () => {
     expect(joined).not.toContain("Gateway: local · ws://127.0.0.1:18789");
     expect(joined).toContain("openclaw --profile isolated node status");
     expect(joined).not.toContain("Fix reachability first");
+  });
+
+  it("describes mature workspaces as not actively bootstrapping", async () => {
+    const joined = await runStatusAndGetJoinedLogs();
+    expect(joined).toContain("no workspaces bootstrapping");
+    expect(joined).not.toContain("no bootstrap files");
   });
 
   it("shows gateway auth when reachable", async () => {


### PR DESCRIPTION
## Summary
- clarify the `openclaw status` agent summary when no workspace is actively bootstrapping
- stop describing mature workspaces without `BOOTSTRAP.md` as having `no bootstrap files`
- add regression coverage for the steady-state wording

## Problem
`status` was using `bootstrapPendingCount === 0` to print `no bootstrap files`, but that signal only means no workspace is currently in the one-shot bootstrap phase. Mature workspaces can still inject `AGENTS.md`, `SOUL.md`, `TOOLS.md`, and related files normally.

## Testing
- `G:\Rust\openclaw\node_modules\.bin\vitest.cmd run src/commands/status.test.ts --reporter=dot -t "prints formatted lines otherwise|describes mature workspaces as not actively bootstrapping"`

## Linked Issue
- Closes #43527

## Transparency
- AI-assisted: implemented with Codex
