### PR TITLE
fix(agent): handle "sensitive" stop reason to avoid crash and polling stall (#43607)

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -85,7 +85,9 @@ Format/invalid‑request errors (for example Cloud Code Assist tool call ID
 validation failures) are treated as failover‑worthy and use the same cooldowns.
 OpenAI-compatible stop-reason errors such as `Unhandled stop reason: error`,
 `stop reason: error`, and `reason: error` are classified as timeout/failover
-signals.
+signals. The `sensitive` stop reason (content policy rejection) is handled
+separately: the run completes with a user-facing message and does not trigger
+failover or cooldown.
 
 Cooldowns use exponential backoff:
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -289,6 +289,13 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ message: "reason: error" })).toBe("timeout");
   });
 
+  it("infers timeout from sensitive stop-reason message (#43607)", () => {
+    expect(resolveFailoverReasonFromError({ message: "Unhandled stop reason: sensitive" })).toBe(
+      "timeout",
+    );
+    expect(resolveFailoverReasonFromError({ message: "stop reason: sensitive" })).toBe("timeout");
+  });
+
   it("infers timeout from connection/network error messages", () => {
     expect(resolveFailoverReasonFromError({ message: "Connection error." })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ message: "fetch failed" })).toBe("timeout");

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -522,6 +522,19 @@ describe("isFailoverErrorMessage", () => {
     }
   });
 
+  it("matches sensitive stop reason as timeout (#43607)", () => {
+    const samples = [
+      "Unhandled stop reason: sensitive",
+      "stop reason: sensitive",
+      "reason: sensitive",
+    ];
+    for (const sample of samples) {
+      expect(isTimeoutErrorMessage(sample)).toBe(true);
+      expect(classifyFailoverReason(sample)).toBe("timeout");
+      expect(isFailoverErrorMessage(sample)).toBe(true);
+    }
+  });
+
   it("matches Gemini MALFORMED_RESPONSE stop reason as timeout (#42149)", () => {
     const samples = [
       "Unhandled stop reason: MALFORMED_RESPONSE",

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -40,9 +40,9 @@ const ERROR_PATTERNS = {
     /\benotfound\b/i,
     /\beai_again\b/i,
     /without sending (?:any )?chunks?/i,
-    /\bstop reason:\s*(?:abort|error|malformed_response)\b/i,
-    /\breason:\s*(?:abort|error|malformed_response)\b/i,
-    /\bunhandled stop reason:\s*(?:abort|error|malformed_response)\b/i,
+    /\bstop reason:\s*(?:abort|error|malformed_response|sensitive)\b/i,
+    /\breason:\s*(?:abort|error|malformed_response|sensitive)\b/i,
+    /\bunhandled stop reason:\s*(?:abort|error|malformed_response|sensitive)\b/i,
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1163,6 +1163,32 @@ export async function runEmbeddedPiAgent(
               authRetryPending = true;
               continue;
             }
+            // Handle Claude/content-policy "sensitive" stop reason: return user-facing
+            // message and complete the run so polling does not stall (#43607).
+            if (/\b(?:unhandled\s+)?stop\s+reason:\s*sensitive\b/i.test(errorText)) {
+              return {
+                payloads: [
+                  {
+                    text: "I cannot process this request as it contains content that violates our usage policies. Please rephrase your question.",
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: buildErrorAgentMeta({
+                    sessionId: sessionIdUsed,
+                    provider,
+                    model: model.id,
+                    usageAccumulator,
+                    lastRunPromptUsage,
+                    lastAssistant,
+                    lastTurnTotal,
+                  }),
+                  systemPromptReport: attempt.systemPromptReport,
+                  aborted: false,
+                  stopReason: "sensitive",
+                },
+              };
+            }
             // Handle role ordering errors with a user-friendly message
             if (/incorrect role information|roles must alternate/i.test(errorText)) {
               return {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 


### PR DESCRIPTION
## Summary

When the Claude API (or other providers) returns `stop_reason: "sensitive"` for content-policy rejection, the underlying pi-ai layer throws an error: `Unhandled stop reason: sensitive`. The pi-embedded runner only handled `abort`, `error`, and `malformed_response`, so this error was unhandled. The run then threw, the agent crashed, and Telegram polling stalled (e.g. "Polling stall detected (no getUpdates for 955.5s); forcing restart") until manual restart (`openclaw daemon restart`).

This PR treats `sensitive` as a **normal completion**: the run finishes with a short user-facing message and `meta.stopReason: "sensitive"`, so the agent does not crash and channel polling continues.

Fixes #43607

## Changes

| Area | Change |
|------|--------|
| **`src/agents/pi-embedded-runner/run.ts`** | After `describeUnknownError(promptError)`, detect errors matching `(unhandled )?stop reason: sensitive` (case-insensitive). Return a successful result with a single payload text ("I cannot process this request as it contains content that violates our usage policies. Please rephrase your question.") and `meta: { durationMs, agentMeta, systemPromptReport, aborted: false, stopReason: "sensitive" }`. No throw, so no crash and no polling stall. |
| **`src/agents/pi-embedded-helpers/failover-matches.ts`** | Add `sensitive` to the three stop-reason timeout regexes so `Unhandled stop reason: sensitive` / `stop reason: sensitive` / `reason: sensitive` are recognized consistently (e.g. for `isTimeoutErrorMessage` / `classifyFailoverReason`). |
| **Tests** | In `pi-embedded-helpers.isbillingerrormessage.test.ts`: new test "matches sensitive stop reason as timeout (#43607)" for the three message variants. In `failover-error.test.ts`: new test "infers timeout from sensitive stop-reason message (#43607)" for `resolveFailoverReasonFromError`. |
| **Docs** | In `docs/concepts/model-failover.md` (Cooldowns): add one sentence that the `sensitive` stop reason is handled separately and completes with a user-facing message without triggering failover or cooldown. |

## Expected behavior after fix

- User sends content that triggers provider content-policy → API returns `stop_reason: "sensitive"` → pi-ai throws `Unhandled stop reason: sensitive`.
- Runner catches this, returns a normal completion with the policy message and `stopReason: "sensitive"`.
- Agent does not crash; Telegram (and other channels) polling continues; no manual restart needed.

## Testing

- **Unit:** `pnpm test --run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/failover-error.test.ts` — all passed.
- **Lint/format:** Modified files formatted with `pnpm format:fix`; no new linter issues in changed files.
- **Manual:** Not run; suggest testing with a channel that can trigger content-policy (e.g. Telegram) and verifying that after a "sensitive" response the agent stays up and accepts the next message.

## Checklist

- [x] Code follows repo conventions (see CLAUDE.md / AGENTS.md).
- [x] Added tests for the new behavior.
- [x] Updated docs where relevant (model-failover).
- [x] No changelog entry (internal/behavioral fix; add to CHANGELOG only if maintainers prefer user-facing note).

## Related

- Issue: #43607