### PR TITLE
feat(gateway): add queue diagnostics snapshot

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -88,6 +88,30 @@ Pass `--token` or `--password` explicitly. Missing explicit credentials is an er
 openclaw gateway health --url ws://127.0.0.1:18789
 ```
 
+### `gateway diagnostics queue`
+
+Show a live snapshot of command lanes and tracked session backlog/stuck state.
+
+```bash
+openclaw gateway diagnostics queue
+openclaw gateway diagnostics queue --json
+```
+
+Options:
+
+- `--all`: include idle lanes and tracked idle session states.
+- `--url <url>`: Gateway WebSocket URL.
+- `--token <token>`: token auth for the probe.
+- `--password <password>`: password auth for the probe.
+- `--timeout <ms>`: RPC timeout (default `10000`).
+- `--json`: machine-readable output.
+
+Notes:
+
+- This is the operator-facing queue snapshot for debugging lane backlog and stuck sessions.
+- JSON output is the stable scripting surface.
+- The command reads live in-memory state from the running gateway; it does not reconstruct queue state from log files.
+
 ### `gateway status`
 
 `gateway status` shows the Gateway service (launchd/systemd/schtasks) plus an optional RPC probe.

--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -86,4 +86,4 @@ Defaults: `debounceMs: 1000`, `cap: 20`, `drop: summarize`.
 ## Troubleshooting
 
 - If commands seem stuck, enable verbose logs and look for “queued for …ms” lines to confirm the queue is draining.
-- If you need queue depth, enable verbose logs and watch for queue timing lines.
+- For a live queue snapshot, run `openclaw gateway diagnostics queue --json`.

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -128,6 +128,51 @@ describe("gateway-cli coverage", () => {
     expect(runtimeLogs.join("\n")).toContain('"ok": true');
   });
 
+  it("registers gateway diagnostics queue and routes to diagnostics.queue", async () => {
+    resetRuntimeCapture();
+    callGateway.mockClear();
+    callGateway.mockResolvedValueOnce({
+      ts: 123,
+      stuckSessionWarnMs: 60_000,
+      summary: {
+        lanes: 1,
+        queued: 2,
+        active: 1,
+        draining: 0,
+        sessions: 1,
+        stuckSessions: 1,
+      },
+      lanes: [
+        {
+          lane: "session:agent:alpha",
+          queued: 2,
+          active: 1,
+          maxConcurrent: 1,
+          draining: false,
+          generation: 0,
+          oldestQueuedAgeMs: 5_000,
+          oldestActiveAgeMs: 6_000,
+        },
+      ],
+      sessions: [
+        {
+          sessionKey: "agent:alpha",
+          lane: "session:agent:alpha",
+          state: "processing",
+          queueDepth: 2,
+          lastActivityAgeMs: 6_000,
+          stuck: true,
+        },
+      ],
+    });
+
+    await runGatewayCommand(["gateway", "diagnostics", "queue", "--json"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(callGateway.mock.calls[0]?.[0]).toMatchObject({ method: "diagnostics.queue" });
+    expect(runtimeLogs.join("\n")).toContain('"stuckSessions": 1');
+  });
+
   it("registers gateway probe and routes to gatewayStatusCommand", async () => {
     resetRuntimeCapture();
     gatewayStatusCommand.mockClear();

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -8,7 +8,7 @@ type DiscoveredBeacon = Awaited<
   ReturnType<typeof import("../infra/bonjour-discovery.js").discoverGatewayBeacons>
 >[number];
 
-const callGateway = vi.fn<(opts: unknown) => Promise<{ ok: true }>>(async () => ({ ok: true }));
+const callGateway = vi.fn<(opts: unknown) => Promise<unknown>>(async () => ({ ok: true }));
 const startGatewayServer = vi.fn<
   (port: number, opts?: unknown) => Promise<{ close: () => Promise<void> }>
 >(async () => ({

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -3,6 +3,8 @@ import { gatewayStatusCommand } from "../../commands/gateway-status.js";
 import { formatHealthChannelLines, type HealthSummary } from "../../commands/health.js";
 import { readBestEffortConfig } from "../../config/config.js";
 import { discoverGatewayBeacons } from "../../infra/bonjour-discovery.js";
+import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
+import type { QueueDiagnosticsSnapshot } from "../../infra/queue-diagnostics.js";
 import type { CostUsageSummary } from "../../infra/session-cost-usage.js";
 import { resolveWideAreaDiscoveryDomain } from "../../infra/widearea-dns.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -86,6 +88,70 @@ function renderCostUsageSummary(summary: CostUsageSummary, days: number, rich: b
   return lines;
 }
 
+function formatAgeLabel(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "n/a";
+  }
+  return formatDurationPrecise(Math.max(0, value), { decimals: 1 });
+}
+
+function renderQueueDiagnostics(snapshot: QueueDiagnosticsSnapshot, rich: boolean): string[] {
+  const lines = [
+    colorize(rich, theme.heading, "Gateway Queue Diagnostics"),
+    `${colorize(rich, theme.muted, "Summary:")} ${snapshot.summary.active} active · ${snapshot.summary.queued} queued · ${snapshot.summary.lanes} lanes · ${snapshot.summary.sessions} sessions`,
+  ];
+
+  if (snapshot.summary.stuckSessions > 0) {
+    lines.push(
+      `${colorize(rich, theme.warn, "Stuck sessions:")} ${snapshot.summary.stuckSessions} (threshold ${formatAgeLabel(snapshot.stuckSessionWarnMs)})`,
+    );
+  }
+
+  if (snapshot.lanes.length === 0) {
+    lines.push(colorize(rich, theme.muted, "No active or queued lanes."));
+  } else {
+    lines.push(colorize(rich, theme.heading, "Lanes"));
+    for (const lane of snapshot.lanes) {
+      const parts = [
+        lane.lane,
+        `${lane.active}/${lane.maxConcurrent} active`,
+        `${lane.queued} queued`,
+      ];
+      if (lane.draining) {
+        parts.push("draining");
+      }
+      if (lane.oldestQueuedAgeMs != null) {
+        parts.push(`oldest queued ${formatAgeLabel(lane.oldestQueuedAgeMs)}`);
+      }
+      if (lane.oldestActiveAgeMs != null) {
+        parts.push(`oldest active ${formatAgeLabel(lane.oldestActiveAgeMs)}`);
+      }
+      lines.push(`- ${parts.join(" · ")}`);
+    }
+  }
+
+  if (snapshot.sessions.length > 0) {
+    lines.push(colorize(rich, theme.heading, "Sessions"));
+    for (const session of snapshot.sessions) {
+      const parts = [
+        session.sessionKey ?? session.sessionId ?? "unknown",
+        session.state,
+        `queueDepth ${session.queueDepth}`,
+        `age ${formatAgeLabel(session.lastActivityAgeMs)}`,
+      ];
+      if (session.lane) {
+        parts.push(`lane ${session.lane}`);
+      }
+      if (session.stuck) {
+        parts.push(colorize(rich, theme.warn, "stuck"));
+      }
+      lines.push(`- ${parts.join(" · ")}`);
+    }
+  }
+
+  return lines;
+}
+
 export function registerGatewayCli(program: Command) {
   const gateway = addGatewayRunCommand(
     program
@@ -97,6 +163,10 @@ export function registerGatewayCli(program: Command) {
           `\n${theme.heading("Examples:")}\n${formatHelpExamples([
             ["openclaw gateway run", "Run the gateway in the foreground."],
             ["openclaw gateway status", "Show service status and probe reachability."],
+            [
+              "openclaw gateway diagnostics queue --json",
+              "Show live lane and session queue state.",
+            ],
             ["openclaw gateway discover", "Find local and wide-area gateway beacons."],
             ["openclaw gateway call health", "Call a gateway RPC method directly."],
           ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/gateway", "docs.openclaw.ai/cli/gateway")}\n`,
@@ -186,6 +256,36 @@ export function registerGatewayCli(program: Command) {
             }
           }
         });
+      }),
+  );
+
+  const diagnostics = gateway
+    .command("diagnostics")
+    .description("Inspect live Gateway diagnostics");
+
+  gatewayCallOpts(
+    diagnostics
+      .command("queue")
+      .description("Fetch queue and session lane diagnostics")
+      .option("--all", "Include idle lanes and tracked idle session states", false)
+      .action(async (opts, command) => {
+        await runGatewayCommand(async () => {
+          const rpcOpts = resolveGatewayRpcOptions(opts, command);
+          const config = await readBestEffortConfig();
+          const result = (await callGatewayCli(
+            "diagnostics.queue",
+            { ...rpcOpts, config },
+            { all: opts.all === true },
+          )) as QueueDiagnosticsSnapshot;
+          if (rpcOpts.json) {
+            defaultRuntime.log(JSON.stringify(result, null, 2));
+            return;
+          }
+          const rich = isRich();
+          for (const line of renderQueueDiagnostics(result, rich)) {
+            defaultRuntime.log(line);
+          }
+        }, "Gateway diagnostics queue failed");
       }),
   );
 

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -112,6 +112,13 @@ describe("ensureConfigReady", () => {
 
     const gatewayRuntime = await runEnsureConfigReady(["gateway", "health"]);
     expect(gatewayRuntime.exit).not.toHaveBeenCalled();
+
+    const gatewayDiagnosticsRuntime = await runEnsureConfigReady([
+      "gateway",
+      "diagnostics",
+      "queue",
+    ]);
+    expect(gatewayDiagnosticsRuntime.exit).not.toHaveBeenCalled();
   });
 
   it("runs doctor migration flow only once per module instance", async () => {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -12,6 +12,7 @@ const ALLOWED_INVALID_GATEWAY_SUBCOMMANDS = new Set([
   "status",
   "probe",
   "health",
+  "diagnostics",
   "discover",
   "call",
   "install",

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -12,6 +12,9 @@ describe("method scope resolution", () => {
     expect(resolveLeastPrivilegeOperatorScopesForMethod("sessions.resolve")).toEqual([
       "operator.read",
     ]);
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("diagnostics.queue")).toEqual([
+      "operator.read",
+    ]);
     expect(resolveLeastPrivilegeOperatorScopesForMethod("config.schema.lookup")).toEqual([
       "operator.read",
     ]);
@@ -30,6 +33,9 @@ describe("method scope resolution", () => {
 describe("operator scope authorization", () => {
   it("allows read methods with operator.read or operator.write", () => {
     expect(authorizeOperatorScopesForMethod("health", ["operator.read"])).toEqual({
+      allowed: true,
+    });
+    expect(authorizeOperatorScopesForMethod("diagnostics.queue", ["operator.read"])).toEqual({
       allowed: true,
     });
     expect(authorizeOperatorScopesForMethod("health", ["operator.write"])).toEqual({

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -51,6 +51,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
   ],
   [READ_SCOPE]: [
     "health",
+    "diagnostics.queue",
     "doctor.memory.status",
     "logs.tail",
     "channels.status",

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -3,6 +3,7 @@ import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 
 const BASE_METHODS = [
   "health",
+  "diagnostics.queue",
   "doctor.memory.status",
   "logs.tail",
   "channels.status",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -13,6 +13,7 @@ import { configHandlers } from "./server-methods/config.js";
 import { connectHandlers } from "./server-methods/connect.js";
 import { cronHandlers } from "./server-methods/cron.js";
 import { deviceHandlers } from "./server-methods/devices.js";
+import { diagnosticsHandlers } from "./server-methods/diagnostics.js";
 import { doctorHandlers } from "./server-methods/doctor.js";
 import { execApprovalsHandlers } from "./server-methods/exec-approvals.js";
 import { healthHandlers } from "./server-methods/health.js";
@@ -74,6 +75,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...chatHandlers,
   ...cronHandlers,
   ...deviceHandlers,
+  ...diagnosticsHandlers,
   ...doctorHandlers,
   ...execApprovalsHandlers,
   ...webHandlers,

--- a/src/gateway/server-methods/diagnostics.test.ts
+++ b/src/gateway/server-methods/diagnostics.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+const loadConfig = vi.hoisted(() => vi.fn(() => ({}) as OpenClawConfig));
+const buildQueueDiagnosticsSnapshot = vi.hoisted(() => vi.fn());
+const resolveStuckSessionWarnMs = vi.hoisted(() => vi.fn(() => 60_000));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig,
+}));
+
+vi.mock("../../infra/queue-diagnostics.js", () => ({
+  buildQueueDiagnosticsSnapshot,
+}));
+
+vi.mock("../../logging/diagnostic.js", () => ({
+  resolveStuckSessionWarnMs,
+}));
+
+import { diagnosticsHandlers } from "./diagnostics.js";
+
+describe("diagnostics.queue", () => {
+  beforeEach(() => {
+    loadConfig.mockClear();
+    buildQueueDiagnosticsSnapshot.mockReset();
+    resolveStuckSessionWarnMs.mockClear();
+    buildQueueDiagnosticsSnapshot.mockReturnValue({
+      ts: 123,
+      stuckSessionWarnMs: 60_000,
+      summary: {
+        lanes: 0,
+        queued: 0,
+        active: 0,
+        draining: 0,
+        sessions: 0,
+        stuckSessions: 0,
+      },
+      lanes: [],
+      sessions: [],
+    });
+  });
+
+  it("handles missing params and defaults includeIdle to false", async () => {
+    const respond = vi.fn();
+
+    await diagnosticsHandlers["diagnostics.queue"]({
+      req: {} as never,
+      params: undefined,
+      respond: respond as never,
+      context: {} as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(resolveStuckSessionWarnMs).toHaveBeenCalledWith(expect.any(Object));
+    expect(buildQueueDiagnosticsSnapshot).toHaveBeenCalledWith({
+      includeIdle: false,
+      stuckSessionWarnMs: 60_000,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        stuckSessionWarnMs: 60_000,
+      }),
+      undefined,
+    );
+  });
+});

--- a/src/gateway/server-methods/diagnostics.test.ts
+++ b/src/gateway/server-methods/diagnostics.test.ts
@@ -45,7 +45,7 @@ describe("diagnostics.queue", () => {
 
     await diagnosticsHandlers["diagnostics.queue"]({
       req: {} as never,
-      params: undefined,
+      params: undefined as never,
       respond: respond as never,
       context: {} as never,
       client: null,

--- a/src/gateway/server-methods/diagnostics.ts
+++ b/src/gateway/server-methods/diagnostics.ts
@@ -1,0 +1,18 @@
+import { loadConfig } from "../../config/config.js";
+import { buildQueueDiagnosticsSnapshot } from "../../infra/queue-diagnostics.js";
+import { resolveStuckSessionWarnMs } from "../../logging/diagnostic.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+export const diagnosticsHandlers: GatewayRequestHandlers = {
+  "diagnostics.queue": async ({ respond, params }) => {
+    const config = loadConfig();
+    respond(
+      true,
+      buildQueueDiagnosticsSnapshot({
+        includeIdle: params?.all === true,
+        stuckSessionWarnMs: resolveStuckSessionWarnMs(config),
+      }),
+      undefined,
+    );
+  },
+};

--- a/src/infra/queue-diagnostics.test.ts
+++ b/src/infra/queue-diagnostics.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
+import {
+  getDiagnosticSessionState,
+  resetDiagnosticSessionStateForTest,
+} from "../logging/diagnostic-session-state.js";
+import {
+  enqueueCommandInLane,
+  resetAllLanes,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
+import { buildQueueDiagnosticsSnapshot } from "./queue-diagnostics.js";
+
+describe("buildQueueDiagnosticsSnapshot", () => {
+  beforeEach(() => {
+    resetDiagnosticSessionStateForTest();
+    resetAllLanes();
+  });
+
+  it("merges lane backlog with tracked session state and flags stuck sessions", async () => {
+    const sessionKey = "agent:alpha:main";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+    setCommandLaneConcurrency(lane, 1);
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      let release!: () => void;
+      const blocker = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      const first = enqueueCommandInLane(lane, async () => {
+        await blocker;
+      });
+      await Promise.resolve();
+
+      vi.setSystemTime(1_500);
+      const second = enqueueCommandInLane(lane, async () => "done");
+
+      const sessionState = getDiagnosticSessionState({
+        sessionId: "sess-1",
+        sessionKey,
+      });
+      sessionState.state = "processing";
+      sessionState.queueDepth = 2;
+      sessionState.lastActivity = 1_000;
+
+      const snapshot = buildQueueDiagnosticsSnapshot({
+        now: 200_000,
+        stuckSessionWarnMs: 60_000,
+      });
+
+      expect(snapshot.summary).toMatchObject({
+        active: 1,
+        queued: 1,
+        sessions: 1,
+        stuckSessions: 1,
+      });
+      expect(snapshot.lanes[0]).toMatchObject({
+        lane,
+        active: 1,
+        queued: 1,
+      });
+      expect(snapshot.sessions[0]).toMatchObject({
+        sessionId: "sess-1",
+        sessionKey,
+        lane,
+        state: "processing",
+        queueDepth: 2,
+        stuck: true,
+      });
+
+      release();
+      await expect(first).resolves.toBeUndefined();
+      await expect(second).resolves.toBe("done");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("omits idle lanes and sessions by default", () => {
+    const sessionState = getDiagnosticSessionState({
+      sessionId: "idle-1",
+      sessionKey: "main",
+    });
+    sessionState.state = "idle";
+    sessionState.queueDepth = 0;
+    sessionState.lastActivity = 10;
+
+    const hidden = buildQueueDiagnosticsSnapshot({
+      now: 20,
+      stuckSessionWarnMs: 10_000,
+    });
+    expect(hidden.summary.sessions).toBe(0);
+    expect(hidden.summary.lanes).toBe(0);
+
+    const visible = buildQueueDiagnosticsSnapshot({
+      now: 20,
+      includeIdle: true,
+      stuckSessionWarnMs: 10_000,
+    });
+    expect(visible.sessions).toHaveLength(1);
+  });
+});

--- a/src/infra/queue-diagnostics.ts
+++ b/src/infra/queue-diagnostics.ts
@@ -1,0 +1,142 @@
+import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
+import {
+  diagnosticSessionStates,
+  pruneDiagnosticSessionStates,
+  type SessionStateValue,
+} from "../logging/diagnostic-session-state.js";
+import {
+  getCommandQueueSnapshot,
+  type CommandQueueLaneSnapshot,
+} from "../process/command-queue.js";
+
+export type QueueDiagnosticsSessionSnapshot = {
+  sessionId?: string;
+  sessionKey?: string;
+  lane: string | null;
+  state: SessionStateValue;
+  queueDepth: number;
+  lastActivityAgeMs: number;
+  stuck: boolean;
+};
+
+export type QueueDiagnosticsSnapshot = {
+  ts: number;
+  stuckSessionWarnMs: number;
+  summary: {
+    lanes: number;
+    queued: number;
+    active: number;
+    draining: number;
+    sessions: number;
+    stuckSessions: number;
+  };
+  lanes: CommandQueueLaneSnapshot[];
+  sessions: QueueDiagnosticsSessionSnapshot[];
+};
+
+function shouldIncludeSession(params: {
+  includeIdle: boolean;
+  state: SessionStateValue;
+  queueDepth: number;
+  laneSnapshot?: CommandQueueLaneSnapshot;
+}) {
+  if (params.includeIdle) {
+    return true;
+  }
+  if (params.state !== "idle" || params.queueDepth > 0) {
+    return true;
+  }
+  return (
+    (params.laneSnapshot?.active ?? 0) > 0 ||
+    (params.laneSnapshot?.queued ?? 0) > 0 ||
+    params.laneSnapshot?.draining === true
+  );
+}
+
+export function buildQueueDiagnosticsSnapshot(params: {
+  includeIdle?: boolean;
+  stuckSessionWarnMs: number;
+  now?: number;
+}): QueueDiagnosticsSnapshot {
+  const now = params.now ?? Date.now();
+  const includeIdle = params.includeIdle === true;
+  const lanes = getCommandQueueSnapshot({ includeIdle, now });
+  const laneByName = new Map(lanes.map((lane) => [lane.lane, lane]));
+
+  pruneDiagnosticSessionStates(now, true);
+  const sessions: QueueDiagnosticsSessionSnapshot[] = [];
+  for (const state of diagnosticSessionStates.values()) {
+    const lane =
+      typeof state.sessionKey === "string" && state.sessionKey.trim()
+        ? resolveEmbeddedSessionLane(state.sessionKey)
+        : typeof state.sessionId === "string" && state.sessionId.trim()
+          ? resolveEmbeddedSessionLane(state.sessionId)
+          : null;
+    const laneSnapshot = lane ? laneByName.get(lane) : undefined;
+    if (
+      !shouldIncludeSession({
+        includeIdle,
+        state: state.state,
+        queueDepth: state.queueDepth,
+        laneSnapshot,
+      })
+    ) {
+      continue;
+    }
+
+    const lastActivityAgeMs = Math.max(0, now - state.lastActivity);
+    sessions.push({
+      sessionId: state.sessionId,
+      sessionKey: state.sessionKey,
+      lane,
+      state: state.state,
+      queueDepth: state.queueDepth,
+      lastActivityAgeMs,
+      stuck: state.state === "processing" && lastActivityAgeMs > params.stuckSessionWarnMs,
+    });
+  }
+
+  sessions.sort((a, b) => {
+    if (a.stuck !== b.stuck) {
+      return a.stuck ? -1 : 1;
+    }
+    if (a.state !== b.state) {
+      if (a.state === "processing") {
+        return -1;
+      }
+      if (b.state === "processing") {
+        return 1;
+      }
+      if (a.state === "waiting") {
+        return -1;
+      }
+      if (b.state === "waiting") {
+        return 1;
+      }
+    }
+    if (a.queueDepth !== b.queueDepth) {
+      return b.queueDepth - a.queueDepth;
+    }
+    if (a.lastActivityAgeMs !== b.lastActivityAgeMs) {
+      return b.lastActivityAgeMs - a.lastActivityAgeMs;
+    }
+    return String(a.sessionKey ?? a.sessionId ?? "").localeCompare(
+      String(b.sessionKey ?? b.sessionId ?? ""),
+    );
+  });
+
+  return {
+    ts: now,
+    stuckSessionWarnMs: params.stuckSessionWarnMs,
+    summary: {
+      lanes: lanes.length,
+      queued: lanes.reduce((sum, lane) => sum + lane.queued, 0),
+      active: lanes.reduce((sum, lane) => sum + lane.active, 0),
+      draining: lanes.filter((lane) => lane.draining).length,
+      sessions: sessions.length,
+      stuckSessions: sessions.filter((session) => session.stuck).length,
+    },
+    lanes,
+    sessions,
+  };
+}

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -23,6 +23,7 @@ import {
   enqueueCommandInLane,
   GatewayDrainingError,
   getActiveTaskCount,
+  getCommandQueueSnapshot,
   getQueueSize,
   markGatewayDraining,
   resetAllLanes,
@@ -145,6 +146,46 @@ describe("command queue", () => {
     release();
     await task;
     expect(getActiveTaskCount()).toBe(0);
+  });
+
+  it("returns queue snapshots with active and queued ages", async () => {
+    const lane = `snapshot-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 1);
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(100);
+      let release!: () => void;
+      const blocker = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const first = enqueueCommandInLane(lane, async () => {
+        await blocker;
+      });
+
+      await Promise.resolve();
+
+      vi.setSystemTime(250);
+      const second = enqueueCommandInLane(lane, async () => "second");
+
+      vi.setSystemTime(500);
+      const snapshot = getCommandQueueSnapshot({ now: 500 });
+      const laneSnapshot = snapshot.find((entry) => entry.lane === lane);
+      expect(laneSnapshot).toMatchObject({
+        lane,
+        active: 1,
+        queued: 1,
+        maxConcurrent: 1,
+        oldestActiveAgeMs: 400,
+        oldestQueuedAgeMs: 250,
+      });
+
+      release();
+      await expect(first).resolves.toBeUndefined();
+      await expect(second).resolves.toBe("second");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("waitForActiveTasks resolves immediately when no tasks are active", async () => {

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -43,10 +43,21 @@ type QueueEntry = {
 type LaneState = {
   lane: string;
   queue: QueueEntry[];
-  activeTaskIds: Set<number>;
+  activeTasks: Map<number, number>;
   maxConcurrent: number;
   draining: boolean;
   generation: number;
+};
+
+export type CommandQueueLaneSnapshot = {
+  lane: string;
+  queued: number;
+  active: number;
+  maxConcurrent: number;
+  draining: boolean;
+  generation: number;
+  oldestQueuedAgeMs: number | null;
+  oldestActiveAgeMs: number | null;
 };
 
 const lanes = new Map<string, LaneState>();
@@ -60,7 +71,7 @@ function getLaneState(lane: string): LaneState {
   const created: LaneState = {
     lane,
     queue: [],
-    activeTaskIds: new Set(),
+    activeTasks: new Map(),
     maxConcurrent: 1,
     draining: false,
     generation: 0,
@@ -73,14 +84,14 @@ function completeTask(state: LaneState, taskId: number, taskGeneration: number):
   if (taskGeneration !== state.generation) {
     return false;
   }
-  state.activeTaskIds.delete(taskId);
+  state.activeTasks.delete(taskId);
   return true;
 }
 
 function drainLane(lane: string) {
   const state = getLaneState(lane);
   if (state.draining) {
-    if (state.activeTaskIds.size === 0 && state.queue.length > 0) {
+    if (state.activeTasks.size === 0 && state.queue.length > 0) {
       diag.warn(
         `drainLane blocked: lane=${lane} draining=true active=0 queue=${state.queue.length}`,
       );
@@ -91,7 +102,7 @@ function drainLane(lane: string) {
 
   const pump = () => {
     try {
-      while (state.activeTaskIds.size < state.maxConcurrent && state.queue.length > 0) {
+      while (state.activeTasks.size < state.maxConcurrent && state.queue.length > 0) {
         const entry = state.queue.shift() as QueueEntry;
         const waitedMs = Date.now() - entry.enqueuedAt;
         if (waitedMs >= entry.warnAfterMs) {
@@ -107,7 +118,7 @@ function drainLane(lane: string) {
         logLaneDequeue(lane, waitedMs, state.queue.length);
         const taskId = nextTaskId++;
         const taskGeneration = state.generation;
-        state.activeTaskIds.add(taskId);
+        state.activeTasks.set(taskId, Date.now());
         void (async () => {
           const startTime = Date.now();
           try {
@@ -115,7 +126,7 @@ function drainLane(lane: string) {
             const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
             if (completedCurrentGeneration) {
               diag.debug(
-                `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.activeTaskIds.size} queued=${state.queue.length}`,
+                `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.activeTasks.size} queued=${state.queue.length}`,
               );
               pump();
             }
@@ -181,7 +192,7 @@ export function enqueueCommandInLane<T>(
       warnAfterMs,
       onWait: opts?.onWait,
     });
-    logLaneEnqueue(cleaned, state.queue.length + state.activeTaskIds.size);
+    logLaneEnqueue(cleaned, state.queue.length + state.activeTasks.size);
     drainLane(cleaned);
   });
 }
@@ -202,13 +213,13 @@ export function getQueueSize(lane: string = CommandLane.Main) {
   if (!state) {
     return 0;
   }
-  return state.queue.length + state.activeTaskIds.size;
+  return state.queue.length + state.activeTasks.size;
 }
 
 export function getTotalQueueSize() {
   let total = 0;
   for (const s of lanes.values()) {
-    total += s.queue.length + s.activeTaskIds.size;
+    total += s.queue.length + s.activeTasks.size;
   }
   return total;
 }
@@ -246,7 +257,7 @@ export function resetAllLanes(): void {
   const lanesToDrain: string[] = [];
   for (const state of lanes.values()) {
     state.generation += 1;
-    state.activeTaskIds.clear();
+    state.activeTasks.clear();
     state.draining = false;
     if (state.queue.length > 0) {
       lanesToDrain.push(state.lane);
@@ -265,9 +276,58 @@ export function resetAllLanes(): void {
 export function getActiveTaskCount(): number {
   let total = 0;
   for (const s of lanes.values()) {
-    total += s.activeTaskIds.size;
+    total += s.activeTasks.size;
   }
   return total;
+}
+
+export function getCommandQueueSnapshot(
+  opts: { includeIdle?: boolean; now?: number } = {},
+): CommandQueueLaneSnapshot[] {
+  const now = opts.now ?? Date.now();
+  const includeIdle = opts.includeIdle === true;
+  const snapshots: CommandQueueLaneSnapshot[] = [];
+
+  for (const state of lanes.values()) {
+    const queued = state.queue.length;
+    const active = state.activeTasks.size;
+    if (!includeIdle && queued === 0 && active === 0 && !state.draining) {
+      continue;
+    }
+
+    const oldestQueuedAt = state.queue[0]?.enqueuedAt;
+    let oldestActiveAt: number | undefined;
+    for (const startedAt of state.activeTasks.values()) {
+      if (oldestActiveAt === undefined || startedAt < oldestActiveAt) {
+        oldestActiveAt = startedAt;
+      }
+    }
+
+    snapshots.push({
+      lane: state.lane,
+      queued,
+      active,
+      maxConcurrent: state.maxConcurrent,
+      draining: state.draining,
+      generation: state.generation,
+      oldestQueuedAgeMs:
+        typeof oldestQueuedAt === "number" ? Math.max(0, now - oldestQueuedAt) : null,
+      oldestActiveAgeMs:
+        typeof oldestActiveAt === "number" ? Math.max(0, now - oldestActiveAt) : null,
+    });
+  }
+
+  return snapshots.toSorted((a, b) => {
+    const backlogDelta = b.queued + b.active - (a.queued + a.active);
+    if (backlogDelta !== 0) {
+      return backlogDelta;
+    }
+    const waitDelta = (b.oldestQueuedAgeMs ?? -1) - (a.oldestQueuedAgeMs ?? -1);
+    if (waitDelta !== 0) {
+      return waitDelta;
+    }
+    return a.lane.localeCompare(b.lane);
+  });
 }
 
 /**
@@ -284,7 +344,7 @@ export function waitForActiveTasks(timeoutMs: number): Promise<{ drained: boolea
   const deadline = Date.now() + timeoutMs;
   const activeAtStart = new Set<number>();
   for (const state of lanes.values()) {
-    for (const taskId of state.activeTaskIds) {
+    for (const taskId of state.activeTasks.keys()) {
       activeAtStart.add(taskId);
     }
   }
@@ -298,7 +358,7 @@ export function waitForActiveTasks(timeoutMs: number): Promise<{ drained: boolea
 
       let hasPending = false;
       for (const state of lanes.values()) {
-        for (const taskId of state.activeTaskIds) {
+        for (const taskId of state.activeTasks.keys()) {
           if (activeAtStart.has(taskId)) {
             hasPending = true;
             break;


### PR DESCRIPTION
## Summary

- Problem: operators and contributors have no first-class way to inspect live lane backlog, active work, and tracked stuck sessions when debugging queue stalls.
- Why it matters: queue/lane issues currently require log scraping, which makes stuck-session and lane-backlog triage slow and hard to automate.
- What changed: added a shared queue diagnostics snapshot, a read-only `diagnostics.queue` Gateway RPC, and `openclaw gateway diagnostics queue [--json|--all]` CLI output plus docs/tests.
- What did NOT change (scope boundary): this does not add an in-agent `queue_status` tool, does not change scheduling/dispatch behavior, and does not persist queue state.

AI-assisted: Yes (Codex)
Testing degree: fully tested for the touched paths

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #9797

## User-visible / Behavior Changes

- New Gateway RPC method: `diagnostics.queue`
- New CLI command: `openclaw gateway diagnostics queue`
- `--json` returns the raw snapshot for scripting
- `--all` includes idle lanes and tracked idle session states

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

Adds one new read-only operator RPC for live queue/session diagnostics. Risk is limited to exposing in-memory operational metadata to already authorized operator clients. Mitigation: method is scoped to `operator.read`, returns no secrets, and does not mutate runtime state.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm/corepack
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local dev config

### Steps

1. Enqueue work into a session lane so one task is active and another is queued.
2. Call `openclaw gateway diagnostics queue --json` or invoke `diagnostics.queue` over Gateway RPC.
3. Confirm the response shows active/queued counts, lane ages, and tracked session state.

### Expected

- Operators can see live queue/lane backlog and stuck-session candidates without parsing logs.

### Actual

- CLI and RPC now return a live snapshot built from in-memory queue state plus tracked diagnostic session state.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Vitest for queue snapshotting, RPC handler, CLI wiring, and scope authorization; targeted `oxlint`; targeted `markdownlint`; full `pnpm build`.
- Edge cases checked: missing RPC params default to `includeIdle=false`; idle lanes/sessions omitted by default; stuck sessions are flagged when age exceeds the configured threshold.
- What you did **not** verify: live Gateway output against a running service with real channel traffic.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit; stop using `diagnostics.queue` / `gateway diagnostics queue`.
- Files/config to restore: Gateway server method registration, CLI registration, and queue diagnostics helper files from `main`.
- Known bad symptoms reviewers should watch for: RPC call fails when `params` is omitted; queue snapshot output diverges from live backlog counts.

## Risks and Mitigations

- Risk: session-level diagnostics depend on tracked session state and may be less complete than raw lane counts when a code path does not update diagnostic session state.
  - Mitigation: snapshot always reports raw lane counts independently, docs frame the session section as tracked runtime state, and the RPC remains read-only so follow-up improvements can extend coverage safely.
