### PR TITLE
Runner: normalize kimi-coding XML tool calls

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -13,6 +13,7 @@ import {
   shouldInjectOllamaCompatNumCtx,
   decodeHtmlEntitiesInObject,
   wrapOllamaCompatNumCtx,
+  wrapStreamFnNormalizeKimiXmlToolCalls,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.js";
 
@@ -421,6 +422,140 @@ describe("wrapStreamFnTrimToolCallNames", () => {
 
     expect(finalToolCall.name).toBe("read");
     expect(finalToolCall.id).toBe("call_42");
+  });
+});
+
+describe("wrapStreamFnNormalizeKimiXmlToolCalls", () => {
+  function createFakeStream(params: { events: unknown[]; resultMessage: unknown }): {
+    result: () => Promise<unknown>;
+    [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+  } {
+    return {
+      async result() {
+        return params.resultMessage;
+      },
+      [Symbol.asyncIterator]() {
+        return (async function* () {
+          for (const event of params.events) {
+            yield event;
+          }
+        })();
+      },
+    };
+  }
+
+  async function invokeWrappedStream(baseFn: (...args: never[]) => unknown) {
+    const wrappedFn = wrapStreamFnNormalizeKimiXmlToolCalls(baseFn as never);
+    return await wrappedFn({} as never, {} as never, {} as never);
+  }
+
+  it("converts kimi XML function_calls text blocks into toolCall blocks", async () => {
+    const xml = `<function_calls>
+  <invoke name="exec">
+    <parameter name="command">cat ~/.openclaw/logs/cron.log</parameter>
+  </invoke>
+</function_calls>`;
+    const event = {
+      partial: { role: "assistant", content: [{ type: "text", text: xml }] },
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: `I will run this now.\n${xml}\nDone.` }],
+      },
+    };
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: xml }],
+    };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [event],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    for await (const _item of stream) {
+      // drain
+    }
+    const result = await stream.result();
+
+    expect((event.partial.content as unknown[])[0]).toEqual({
+      type: "toolCall",
+      name: "exec",
+      arguments: { command: "cat ~/.openclaw/logs/cron.log" },
+    });
+    expect(event.message.content as unknown[]).toEqual([
+      { type: "text", text: "I will run this now.\n\nDone." },
+      {
+        type: "toolCall",
+        name: "exec",
+        arguments: { command: "cat ~/.openclaw/logs/cron.log" },
+      },
+    ]);
+    expect((result as { content: unknown[] }).content).toEqual([
+      {
+        type: "toolCall",
+        name: "exec",
+        arguments: { command: "cat ~/.openclaw/logs/cron.log" },
+      },
+    ]);
+    expect(baseFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles multiple invokes and decodes escaped parameter values", async () => {
+    const xml = `<function_calls>
+  <invoke name="exec">
+    <parameter name="command">echo &lt;ok&gt;</parameter>
+  </invoke>
+  <invoke name="read">
+    <parameter name="path">/tmp/a.txt</parameter>
+  </invoke>
+</function_calls>`;
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: xml }],
+    };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    const result = await stream.result();
+
+    expect((result as { content: unknown[] }).content).toEqual([
+      {
+        type: "toolCall",
+        name: "exec",
+        arguments: { command: "echo <ok>" },
+      },
+      {
+        type: "toolCall",
+        name: "read",
+        arguments: { path: "/tmp/a.txt" },
+      },
+    ]);
+  });
+
+  it("keeps invoke snippets that are not wrapped in function_calls", async () => {
+    const text = `<invoke name="exec"><parameter name="command">ls</parameter></invoke>`;
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text }],
+    };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    const result = await stream.result();
+
+    expect((result as { content: unknown[] }).content).toEqual([{ type: "text", text }]);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -433,6 +433,165 @@ export function wrapStreamFnTrimToolCallNames(
   };
 }
 
+const KIMI_FUNCTION_CALLS_BLOCK_RE = /<function_calls\b[^>]*>[\s\S]*?<\/function_calls>/i;
+const KIMI_INVOKE_BLOCK_RE =
+  /<invoke\b[^>]*\bname\s*=\s*["']([^"']+)["'][^>]*>([\s\S]*?)<\/invoke>/i;
+const KIMI_PARAMETER_BLOCK_RE =
+  /<parameter\b[^>]*\bname\s*=\s*["']([^"']+)["'][^>]*>([\s\S]*?)<\/parameter>/i;
+
+function parseKimiXmlToolCallsFromBlock(block: string): Array<{
+  name: string;
+  arguments: Record<string, string>;
+}> {
+  const invokeRe = new RegExp(KIMI_INVOKE_BLOCK_RE.source, "gi");
+  const parameterRe = new RegExp(KIMI_PARAMETER_BLOCK_RE.source, "gi");
+  const calls: Array<{ name: string; arguments: Record<string, string> }> = [];
+  for (const invokeMatch of block.matchAll(invokeRe)) {
+    const name = decodeHtmlEntities(String(invokeMatch[1] ?? "")).trim();
+    if (!name) {
+      continue;
+    }
+    const args: Record<string, string> = {};
+    const body = String(invokeMatch[2] ?? "");
+    for (const parameterMatch of body.matchAll(parameterRe)) {
+      const key = decodeHtmlEntities(String(parameterMatch[1] ?? "")).trim();
+      if (!key) {
+        continue;
+      }
+      args[key] = decodeHtmlEntities(String(parameterMatch[2] ?? "").trim());
+    }
+    calls.push({ name, arguments: args });
+  }
+  return calls;
+}
+
+function extractKimiXmlToolCallsFromText(text: string):
+  | {
+      textWithoutCalls: string;
+      toolCalls: Array<{ name: string; arguments: Record<string, string> }>;
+    }
+  | undefined {
+  if (!KIMI_FUNCTION_CALLS_BLOCK_RE.test(text) || !KIMI_INVOKE_BLOCK_RE.test(text)) {
+    return undefined;
+  }
+
+  const blockRe = new RegExp(KIMI_FUNCTION_CALLS_BLOCK_RE.source, "gi");
+  const parsedCalls: Array<{ name: string; arguments: Record<string, string> }> = [];
+  let converted = false;
+  const textWithoutCalls = text
+    .replace(blockRe, (match) => {
+      const calls = parseKimiXmlToolCallsFromBlock(match);
+      if (calls.length === 0) {
+        return match;
+      }
+      parsedCalls.push(...calls);
+      converted = true;
+      return "";
+    })
+    .trim();
+
+  if (!converted || parsedCalls.length === 0) {
+    return undefined;
+  }
+  return { textWithoutCalls, toolCalls: parsedCalls };
+}
+
+function normalizeKimiXmlToolCallsInMessage(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return;
+  }
+
+  let changed = false;
+  const normalizedContent: unknown[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      normalizedContent.push(block);
+      continue;
+    }
+    const textBlock = block as { type?: unknown; text?: unknown };
+    if (textBlock.type !== "text" || typeof textBlock.text !== "string") {
+      normalizedContent.push(block);
+      continue;
+    }
+
+    const parsed = extractKimiXmlToolCallsFromText(textBlock.text);
+    if (!parsed) {
+      normalizedContent.push(block);
+      continue;
+    }
+
+    changed = true;
+    if (parsed.textWithoutCalls) {
+      normalizedContent.push({
+        ...(block as Record<string, unknown>),
+        text: parsed.textWithoutCalls,
+      });
+    }
+    for (const toolCall of parsed.toolCalls) {
+      normalizedContent.push({
+        type: "toolCall",
+        name: toolCall.name,
+        arguments: toolCall.arguments,
+      });
+    }
+  }
+
+  if (changed) {
+    (message as { content?: unknown }).content = normalizedContent;
+  }
+}
+
+function wrapStreamNormalizeKimiXmlToolCalls(
+  stream: ReturnType<typeof streamSimple>,
+): ReturnType<typeof streamSimple> {
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = await originalResult();
+    normalizeKimiXmlToolCallsInMessage(message);
+    return message;
+  };
+
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
+    function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          const result = await iterator.next();
+          if (!result.done && result.value && typeof result.value === "object") {
+            const event = result.value as { partial?: unknown; message?: unknown };
+            normalizeKimiXmlToolCallsInMessage(event.partial);
+            normalizeKimiXmlToolCallsInMessage(event.message);
+          }
+          return result;
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+        },
+      };
+    };
+  return stream;
+}
+
+export function wrapStreamFnNormalizeKimiXmlToolCalls(baseFn: StreamFn): StreamFn {
+  return (model, context, options) => {
+    const maybeStream = baseFn(model, context, options);
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) =>
+        wrapStreamNormalizeKimiXmlToolCalls(stream),
+      );
+    }
+    return wrapStreamNormalizeKimiXmlToolCalls(maybeStream);
+  };
+}
+
 // ---------------------------------------------------------------------------
 // xAI / Grok: decode HTML entities in tool call arguments
 // ---------------------------------------------------------------------------
@@ -535,6 +694,30 @@ function wrapStreamFnDecodeXaiToolCallArguments(baseFn: StreamFn): StreamFn {
     }
     return wrapStreamDecodeXaiToolCallArguments(maybeStream);
   };
+}
+
+function shouldNormalizeKimiXmlToolCalls(model: {
+  api?: string;
+  provider?: string;
+  baseUrl?: string;
+}): boolean {
+  if (model.api !== "anthropic-messages") {
+    return false;
+  }
+  if (typeof model.provider === "string" && normalizeProviderId(model.provider) === "kimi-coding") {
+    return true;
+  }
+  if (typeof model.baseUrl !== "string" || !model.baseUrl.trim()) {
+    return false;
+  }
+  try {
+    const parsed = new URL(model.baseUrl);
+    const host = parsed.hostname.toLowerCase();
+    const pathname = parsed.pathname.toLowerCase();
+    return host.endsWith("kimi.com") && pathname.startsWith("/coding");
+  } catch {
+    return model.baseUrl.toLowerCase().includes("kimi.com/coding");
+  }
 }
 
 export async function resolvePromptBuildHookResult(params: {
@@ -1363,6 +1546,12 @@ export async function runEmbeddedAttempt(
           } as unknown;
           return inner(model, nextContext as typeof context, options);
         };
+      }
+
+      if (shouldNormalizeKimiXmlToolCalls(params.model)) {
+        activeSession.agent.streamFn = wrapStreamFnNormalizeKimiXmlToolCalls(
+          activeSession.agent.streamFn,
+        );
       }
 
       // Some models emit tool names with surrounding whitespace (e.g. " read ").


### PR DESCRIPTION
## Summary

- Problem: kimi-coding/k2p5 can return XML `<function_calls><invoke ...>` blocks as plain assistant text instead of structured tool calls.
- Why it matters: raw XML leaks to users and tool execution is skipped.
- What changed: added a stream wrapper that converts Kimi XML function-call text blocks into `toolCall` content blocks before dispatch.
- What did NOT change (scope boundary): no changes to tool definitions, provider config, or non-kimi response handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43595
- Related #

## User-visible / Behavior Changes

- kimi-coding XML function call payloads are now converted into executable tool calls instead of being surfaced as raw XML text.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: kimi-coding/k2p5
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Run OpenClaw with `kimi-coding/k2p5` and a prompt that triggers a tool call.
2. Observe assistant output containing `<function_calls><invoke ...>` XML text.
3. Apply this patch and run again.

### Expected

- XML function-call blocks are normalized into tool calls and executed.

### Actual

- After patch, XML blocks are converted into `toolCall` content blocks on the stream path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing checks:

- `pnpm test src/agents/pi-embedded-runner/run/attempt.test.ts` -> passed (45/45)
- `pnpm exec oxlint src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.test.ts` -> passed (0 warnings, 0 errors)
- `pnpm exec oxfmt --check src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.test.ts` -> passed

## Human Verification (required)

- Verified scenarios: XML `<function_calls>` with single and multiple `<invoke>` entries are converted into tool calls.
- Edge cases checked: escaped parameter values are decoded; standalone `<invoke>` snippets without `<function_calls>` are preserved.
- What you did **not** verify: live end-to-end run against the external kimi-coding API.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c7270be40`.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts` and `src/agents/pi-embedded-runner/run/attempt.test.ts`.
- Known bad symptoms reviewers should watch for: missing tool dispatch on kimi-coding responses containing XML function calls.

## Risks and Mitigations

- Risk: malformed XML that resembles function calls could be converted unexpectedly for kimi-coding anthropic runs.
  - Mitigation: conversion only applies when `<function_calls>` wrappers are present and valid `<invoke name=...>` entries parse successfully.
