### PR TITLE
fix(gateway): keep plugin fallback context in sync after config hot-reload

### DIFF
--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -41,7 +41,9 @@ const fallbackGatewayContextState = (() => {
 })();
 
 export function setFallbackGatewayContext(ctx: GatewayRequestContext): void {
-  // TODO: This startup snapshot can become stale if runtime config/context changes.
+  // Fallback is used by plugin subagent dispatch when no per-request scope exists
+  // (e.g. Telegram polling, cron). server.impl keeps this context in sync after
+  // config hot-reload by mutating ctx.cron and ctx.cronStorePath in setState.
   fallbackGatewayContextState.context = ctx;
 }
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -967,6 +967,10 @@ export async function startGatewayServer(
             cronStorePath = cronState.storePath;
             browserControl = nextState.browserControl;
             channelHealthMonitor = nextState.channelHealthMonitor;
+            // Keep plugin fallback gateway context in sync so subagent dispatch from
+            // non-WS paths (Telegram, cron, etc.) uses the current cron after hot-reload.
+            gatewayRequestContext.cron = cron;
+            gatewayRequestContext.cronStorePath = cronStorePath;
           },
           startChannel,
           stopChannel,


### PR DESCRIPTION
## Summary

The plugin fallback gateway context is used when subagent dispatch runs from non-WebSocket paths (e.g. Telegram polling, cron, WhatsApp). It was set once at startup and never updated. After a config hot-reload (e.g. SIGUSR1), the reload logic replaced the cron service (and related state) but the fallback context still held references to the **old** cron. Plugin runs triggered from Telegram or cron after reload could then use a stopped or stale cron, leading to confusing failures or stale behavior.

This PR keeps the fallback context in sync by mutating the same context object after hot-reload: when `setState` runs in the config reload path, we update `gatewayRequestContext.cron` and `gatewayRequestContext.cronStorePath` to the new values. The fallback still points at the same object, so it now sees the current cron and store path.

## Changes

| File | Change |
|------|--------|
| **`src/gateway/server.impl.ts`** | In the `setState` callback passed to `createGatewayReloadHandlers`, after updating local `cronState`, `cron`, and `cronStorePath`, also set `gatewayRequestContext.cron = cron` and `gatewayRequestContext.cronStorePath = cronStorePath`. Added a short comment explaining that this keeps the plugin fallback context in sync for subagent dispatch from non-WS paths. |
| **`src/gateway/server-plugins.ts`** | Replaced the TODO about the startup snapshot becoming stale with a comment that the fallback is kept in sync by server.impl after hot-reload (by mutating cron/cronStorePath on the context). |

## Why this approach

- **Single context object**: The fallback holds a reference to `gatewayRequestContext`. We avoid replacing the fallback with a new context (which would require building a full new context after every reload). Instead we mutate the existing context’s reload-affected fields so the fallback stays correct.
- **Minimal surface**: Only fields that are actually replaced during hot-reload are updated on the context. Today that is cron and cronStorePath; other reloaded state (e.g. browserControl, channelHealthMonitor) is not on `GatewayRequestContext`, so no change there.

## Testing

- `pnpm test --run src/gateway/server-plugins.test.ts` — all tests passed.
- No new unit test added: the existing test covers fallback context usage across “reloads” (replacing the fallback via `setFallbackGatewayContext`). This fix keeps the same fallback object and updates its fields; behavior is covered by existing integration and the fact that setState runs with the new cron after reload.

## Checklist

- [x] Code follows repo conventions.
- [x] No new tests added (existing tests pass; fix is a small sync in an existing callback).
- [x] No docs change (internal reliability fix).
- [x] No changelog entry (optional; add under Fixes if maintainers want).