### PR TITLE
feat(secrets): add keyring and 1Password secret providers

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -452,3 +452,505 @@ Some SecretInput unions are easier to configure in raw editor mode than in form 
 - Auth setup: [Authentication](/gateway/authentication)
 - Security posture: [Security](/gateway/security)
 - Environment precedence: [Environment Variables](/help/environment)
+
+---
+
+## Additional Secrets Providers
+
+summary: "External secrets management: store credentials in GCP Secret Manager instead of plaintext files"
+read_when:
+
+- You want to stop storing API keys in plaintext config files
+- You want per-agent secret isolation in multi-agent setups
+- You want to set up GCP Secret Manager for OpenClaw
+- You want to migrate existing plaintext secrets to a secrets store
+  title: "Secrets"
+
+---
+
+# External Secrets Management
+
+OpenClaw can resolve secret references in configuration files at runtime, fetching values from an external secrets store instead of storing them in plaintext on disk.
+
+## Why
+
+- **No plaintext secrets on disk** — API keys, tokens, and credentials live in an encrypted, access-controlled store
+- **Per-agent isolation** — in multi-agent setups, each agent only accesses secrets it's authorized for (enforced by GCP IAM, not application code)
+- **Audit trail** — GCP Secret Manager logs all access
+- **Safe version control** — config files contain references (`${gcp:name}`), not actual secrets
+- **Rotation without restarts** — update the secret in the store; cached values expire automatically
+
+## Supported Providers
+
+| Provider            | Status       |
+| ------------------- | ------------ |
+| GCP Secret Manager  | ✅ Supported |
+| AWS Secrets Manager | Planned      |
+| HashiCorp Vault     | Planned      |
+| Azure Key Vault     | Planned      |
+
+## Quick Start
+
+### 1. Prerequisites
+
+- A GCP project with billing enabled
+- `gcloud` CLI installed and authenticated (for setup only; not needed at runtime)
+- VM or environment with `cloud-platform` OAuth scope (for Compute Engine VMs)
+
+#### Compute Engine VM Setup
+
+If running on a GCP Compute Engine VM:
+
+**OAuth Scopes** — the VM must have `cloud-platform` scope. To update (requires VM restart):
+
+```bash
+gcloud compute instances stop <instance> --zone=<zone>
+gcloud compute instances set-service-account <instance> --zone=<zone> --scopes=cloud-platform
+gcloud compute instances start <instance> --zone=<zone>
+```
+
+**IAM Roles** — the compute service account needs these roles:
+
+| Role                                 | Purpose                                     | Required                        |
+| ------------------------------------ | ------------------------------------------- | ------------------------------- |
+| `roles/secretmanager.secretAccessor` | Read secret values at runtime               | Always                          |
+| `roles/secretmanager.admin`          | Create secrets, set per-secret IAM bindings | For setup & per-agent isolation |
+
+Grant via CLI:
+
+```bash
+gcloud projects add-iam-policy-binding <project-id> \
+  --member="serviceAccount:<service-account-email>" \
+  --role="roles/secretmanager.secretAccessor"
+
+gcloud projects add-iam-policy-binding <project-id> \
+  --member="serviceAccount:<service-account-email>" \
+  --role="roles/secretmanager.admin"
+```
+
+Or via the GCP Console:
+
+1. Go to **IAM & Admin → IAM**
+2. Find the compute service account
+3. Click **Edit** (pencil icon)
+4. Add both roles
+5. Save
+
+> **Tip:** After setup is complete and per-agent isolation is configured, you can optionally remove `secretmanager.admin` from the compute SA — agents authenticate with their own service accounts at runtime.
+
+### 2. Bootstrap
+
+```bash
+openclaw secrets setup --project my-gcp-project --agents main,chai
+```
+
+This will:
+
+- Enable the Secret Manager API
+- Create per-agent service accounts (`openclaw-main@`, `openclaw-chai@`)
+- Generate service account key files
+- Set per-secret IAM bindings
+- Update `openclaw.json` with the `secrets` config section
+
+Pass `--yes` to skip confirmation prompts.
+
+### 3. Store a Secret
+
+```bash
+openclaw secrets set --provider gcp --name openclaw-main-brave-api-key --value "your-key-here"
+```
+
+### 4. Reference in Config
+
+Replace plaintext values with secret references:
+
+```json5
+{
+  // Before
+  "apiKey": "sk-real-key-here"
+
+  // After
+  "apiKey": "${gcp:openclaw-main-brave-api-key}"
+}
+```
+
+### 5. Verify
+
+```bash
+openclaw secrets test
+```
+
+## Secret Reference Syntax
+
+References follow the pattern `${provider:secret-name}`:
+
+```
+${gcp:my-secret}          → latest version
+${gcp:my-secret#3}        → pinned to version 3
+${gcp:path/to/secret}     → slashes allowed in names
+```
+
+### Escaping
+
+Use `$${}` to produce a literal `${}` in config:
+
+```json5
+{
+  literal: "$${gcp:not-a-ref}", // → "${gcp:not-a-ref}"
+}
+```
+
+### Distinction from Environment Variables
+
+| Syntax              | Resolved by                     | Example                |
+| ------------------- | ------------------------------- | ---------------------- |
+| `${UPPER_CASE}`     | Env var substitution (existing) | `${BRAVE_API_KEY}`     |
+| `${lowercase:name}` | Secret resolution (new)         | `${gcp:brave-api-key}` |
+
+The lowercase provider prefix naturally distinguishes secret refs from env var refs.
+
+## Configuration
+
+Add a `secrets` section to `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        // GCP project ID (required)
+        project: "my-gcp-project",
+
+        // Cache TTL in seconds (default: 300)
+        cacheTtlSeconds: 300,
+
+        // Path to service account key file (required for per-agent isolation)
+        // If omitted, uses Application Default Credentials (ADC)
+        credentialsFile: "/path/to/openclaw-main-sa.json",
+      },
+    },
+  },
+}
+```
+
+## Auth Profiles
+
+Secret references also work in `auth-profiles.json`:
+
+```json
+{
+  "profiles": {
+    "openai:default": {
+      "type": "token",
+      "provider": "openai",
+      "token": "${gcp:openclaw-main-openai-token}"
+    }
+  }
+}
+```
+
+## Per-Agent Isolation
+
+Per-agent isolation ensures each agent can **only** read its own secrets, enforced at the GCP IAM level. This is not application-level filtering — GCP itself blocks unauthorized access.
+
+### How It Works
+
+Each agent gets:
+
+1. **Its own GCP service account** (e.g., `openclaw-main@project.iam.gserviceaccount.com`)
+2. **A service account key file** stored locally (e.g., `~/.config/gcp/openclaw-main-sa.json`)
+3. **Per-secret IAM bindings** granting only that SA access to its secrets
+
+### Naming Convention
+
+Secrets are namespaced by agent name:
+
+```
+openclaw-main-*     → only the main agent can read
+openclaw-chai-*     → only the chai agent can read
+openclaw-shared-*   → multiple agents can read (both SAs get access)
+```
+
+### Setup Steps
+
+**1. Create per-agent service accounts:**
+
+```bash
+gcloud iam service-accounts create openclaw-main \
+  --display-name="OpenClaw Main Agent"
+gcloud iam service-accounts create openclaw-chai \
+  --display-name="OpenClaw Chai Agent"
+```
+
+**2. Generate key files:**
+
+```bash
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-main-sa.json \
+  --iam-account=openclaw-main@<project>.iam.gserviceaccount.com
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-chai-sa.json \
+  --iam-account=openclaw-chai@<project>.iam.gserviceaccount.com
+chmod 600 ~/.config/gcp/*.json
+```
+
+**3. Set per-secret IAM bindings:**
+
+```bash
+# Main agent's secrets → only main SA
+gcloud secrets add-iam-policy-binding openclaw-main-openai-key \
+  --member="serviceAccount:openclaw-main@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# Chai agent's secrets → only chai SA
+gcloud secrets add-iam-policy-binding openclaw-chai-alpaca-key \
+  --member="serviceAccount:openclaw-chai@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# Shared secrets → both SAs
+gcloud secrets add-iam-policy-binding openclaw-shared-brave-key \
+  --member="serviceAccount:openclaw-main@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+gcloud secrets add-iam-policy-binding openclaw-shared-brave-key \
+  --member="serviceAccount:openclaw-chai@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+**4. Configure each agent to use its own SA:**
+
+Main agent's `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        project: "my-project",
+        credentialsFile: "/home/user/.config/gcp/openclaw-main-sa.json",
+      },
+    },
+  },
+}
+```
+
+Chai agent's `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        project: "my-project",
+        credentialsFile: "/home/user/.config/gcp/openclaw-chai-sa.json",
+      },
+    },
+  },
+}
+```
+
+### Verification
+
+After setup, verify isolation is enforced:
+
+```
+✅ main reads openclaw-main-openai-key     → access granted
+🔒 main reads openclaw-chai-alpaca-key     → PERMISSION_DENIED
+✅ chai reads openclaw-chai-alpaca-key     → access granted
+🔒 chai reads openclaw-main-openai-key     → PERMISSION_DENIED
+```
+
+If an agent tries to read another agent's secret, GCP returns `PERMISSION_DENIED` — the request never reaches OpenClaw.
+
+## Worked Example: Multi-Agent Migration
+
+This example walks through migrating a two-agent setup (main + chai) from plaintext to GCP Secret Manager with full isolation.
+
+### Before (plaintext)
+
+```
+~/.config/openai/credentials.env     → OPENAI_API_KEY=sk-proj-abc123...
+~/.config/alpaca/sandbox.env         → ALPACA_KEY_ID=CKN... / ALPACA_SECRET_KEY=7TV...
+~/.config/himalaya/.nine30-pass      → cbmc pxsf mlzr puea
+openclaw.json                        → "apiKey": "BSAIGr...", "token": "83a1aa..."
+```
+
+All secrets in plaintext. Any agent or process on the machine can read everything.
+
+### Step 1: Enable Secret Manager API
+
+```bash
+gcloud services enable secretmanager.googleapis.com --project=my-project
+```
+
+### Step 2: Store secrets with agent-namespaced names
+
+```bash
+# Main agent secrets
+openclaw secrets set --provider gcp --name openclaw-main-openai-api-key --value "sk-proj-abc123..."
+openclaw secrets set --provider gcp --name openclaw-main-brave-api-key --value "BSAIGr..."
+openclaw secrets set --provider gcp --name openclaw-main-gateway-token --value "83a1aa..."
+openclaw secrets set --provider gcp --name openclaw-main-email-password --value "cbmc pxsf mlzr puea"
+
+# Chai agent secrets
+openclaw secrets set --provider gcp --name openclaw-chai-alpaca-key-id --value "CKN..."
+openclaw secrets set --provider gcp --name openclaw-chai-alpaca-secret-key --value "7TV..."
+```
+
+### Step 3: Create service accounts and keys
+
+```bash
+gcloud iam service-accounts create openclaw-main --display-name="OpenClaw Main Agent"
+gcloud iam service-accounts create openclaw-chai --display-name="OpenClaw Chai Agent"
+
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-main-sa.json \
+  --iam-account=openclaw-main@my-project.iam.gserviceaccount.com
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-chai-sa.json \
+  --iam-account=openclaw-chai@my-project.iam.gserviceaccount.com
+
+chmod 600 ~/.config/gcp/*.json
+```
+
+### Step 4: Set per-secret IAM bindings
+
+```bash
+# Main-only secrets
+for SECRET in openclaw-main-openai-api-key openclaw-main-brave-api-key \
+              openclaw-main-gateway-token openclaw-main-email-password; do
+  gcloud secrets add-iam-policy-binding $SECRET \
+    --member="serviceAccount:openclaw-main@my-project.iam.gserviceaccount.com" \
+    --role="roles/secretmanager.secretAccessor"
+done
+
+# Chai-only secrets
+for SECRET in openclaw-chai-alpaca-key-id openclaw-chai-alpaca-secret-key; do
+  gcloud secrets add-iam-policy-binding $SECRET \
+    --member="serviceAccount:openclaw-chai@my-project.iam.gserviceaccount.com" \
+    --role="roles/secretmanager.secretAccessor"
+done
+```
+
+### Step 5: Update config files with references
+
+Main agent's `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        project: "my-project",
+        credentialsFile: "/home/user/.config/gcp/openclaw-main-sa.json",
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        apiKey: "${gcp:openclaw-main-brave-api-key}",
+      },
+    },
+  },
+  gateway: {
+    auth: {
+      token: "${gcp:openclaw-main-gateway-token}",
+    },
+  },
+}
+```
+
+### Step 6: Purge plaintext files
+
+Only after verifying all references resolve (`openclaw secrets test`):
+
+```bash
+# Replace file contents with migration notes
+echo "# Migrated to GCP Secret Manager" > ~/.config/openai/credentials.env
+echo "# Migrated to GCP Secret Manager" > ~/.config/alpaca/sandbox.env
+echo "# Migrated to GCP Secret Manager" > ~/.config/himalaya/.nine30-pass
+```
+
+### After
+
+```
+GCP Secret Manager (encrypted, access-controlled):
+  openclaw-main-openai-api-key      → only main SA can read
+  openclaw-main-brave-api-key       → only main SA can read
+  openclaw-main-gateway-token       → only main SA can read
+  openclaw-main-email-password      → only main SA can read
+  openclaw-chai-alpaca-key-id       → only chai SA can read
+  openclaw-chai-alpaca-secret-key   → only chai SA can read
+
+Local disk:
+  ~/.config/gcp/openclaw-main-sa.json  (SA key — the only secret on disk)
+  ~/.config/gcp/openclaw-chai-sa.json  (SA key — the only secret on disk)
+  openclaw.json                        (contains ${gcp:...} refs, safe to commit)
+```
+
+> **Note:** The SA key files are the one remaining secret on disk. Protect them with `chmod 600` and restrict filesystem access. On GKE or Cloud Run, use Workload Identity to eliminate even these files.
+
+### External scripts
+
+Scripts that need secrets (e.g., monitoring scripts, cron jobs) can also use per-agent SA keys:
+
+```python
+from google.cloud import secretmanager
+
+# Use Chai's SA key — can only access openclaw-chai-* secrets
+client = secretmanager.SecretManagerServiceClient.from_service_account_json(
+    "/home/user/.config/gcp/openclaw-chai-sa.json"
+)
+response = client.access_secret_version(
+    request={"name": "projects/my-project/secrets/openclaw-chai-alpaca-key-id/versions/latest"}
+)
+api_key = response.payload.data.decode("utf-8")
+```
+
+## Migration
+
+To migrate existing plaintext secrets:
+
+```bash
+openclaw secrets migrate
+```
+
+This will:
+
+1. Scan config files for sensitive values (API keys, tokens)
+2. Upload each to GCP Secret Manager
+3. Replace plaintext values with `${gcp:name}` references
+4. Verify all references resolve
+5. Prompt before purging plaintext originals
+
+Pass `--yes` to skip confirmation prompts. Plaintext is **never** purged unless the upload and verification succeed.
+
+## Caching
+
+- Secrets are cached **in memory only** (never written to disk)
+- Default TTL: 300 seconds (configurable per-provider)
+- Cache is cleared on `SIGUSR1` restart
+- **Stale-while-revalidate**: if the provider is unreachable and cached values exist (even expired), stale values are used and a warning is logged
+
+## CLI Commands
+
+| Command                    | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `openclaw secrets setup`   | Bootstrap GCP Secret Manager (enable API, create SAs, configure IAM) |
+| `openclaw secrets test`    | Verify all secret references resolve successfully                    |
+| `openclaw secrets list`    | List configured providers and their status                           |
+| `openclaw secrets set`     | Store a secret manually                                              |
+| `openclaw secrets migrate` | Migrate plaintext secrets to the store                               |
+
+## Error Handling
+
+| Error                                        | Behavior                                                                |
+| -------------------------------------------- | ----------------------------------------------------------------------- |
+| Provider not configured                      | Feature using the secret fails; system continues                        |
+| Secret not found                             | Clear error: "Secret 'name' not found in project 'project'"             |
+| Permission denied                            | Clear error: "Permission denied for secret 'name'. Check IAM bindings." |
+| Network timeout                              | Retry once; fall back to stale cache if available                       |
+| `@google-cloud/secret-manager` not installed | Clear error with install instructions                                   |
+
+## Backward Compatibility
+
+- **Entirely opt-in**: no `secrets` config = no behavior change
+- `@google-cloud/secret-manager` is an optional dependency
+- Existing env var substitution (`${UPPER_CASE}`) is unaffected
+- Config files without secret refs pass through unchanged

--- a/package.json
+++ b/package.json
@@ -343,6 +343,7 @@
     "@buape/carbon": "0.0.0-beta-20260216184201",
     "@clack/prompts": "^1.1.0",
     "@discordjs/voice": "^0.19.1",
+    "@google-cloud/secret-manager": "^6.1.1",
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1373,6 +1373,15 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@google-cloud/secret-manager@6.1.1':
     resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
     engines: {node: '>=18'}
@@ -8675,6 +8684,10 @@ snapshots:
 
   '@eshaz/web-worker@1.2.2':
     optional: true
+
+  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
 
   '@google-cloud/secret-manager@6.1.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@discordjs/voice':
         specifier: ^0.19.1
         version: 0.19.1(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@google-cloud/secret-manager':
+        specifier: ^6.1.1
+        version: 6.1.1
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.41.1)
@@ -1370,14 +1373,9 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
-  '@exodus/bytes@1.15.0':
-    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@noble/hashes': ^1.8.0 || ^2.0.0
-    peerDependenciesMeta:
-      '@noble/hashes':
-        optional: true
+  '@google-cloud/secret-manager@6.1.1':
+    resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
+    engines: {node: '>=18'}
 
   '@google/genai@1.44.0':
     resolution: {integrity: sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==}
@@ -3468,6 +3466,10 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -4426,6 +4428,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -4780,6 +4785,10 @@ packages:
     resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
     engines: {node: '>=18'}
 
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
+    engines: {node: '>=18'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -4877,6 +4886,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -5611,6 +5624,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -5937,6 +5954,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
   protobufjs@6.8.8:
     resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
     hasBin: true
@@ -6123,6 +6144,10 @@ packages:
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
     engines: {node: '>=18'}
 
   retry@0.12.0:
@@ -6419,6 +6444,12 @@ packages:
     resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
     engines: {node: '>=18'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
@@ -6470,6 +6501,9 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6490,6 +6524,10 @@ packages:
 
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+    engines: {node: '>=18'}
+
+  teeny-request@10.1.0:
+    resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -8638,9 +8676,11 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
-    optionalDependencies:
-      '@noble/hashes': 2.0.1
+  '@google-cloud/secret-manager@6.1.1':
+    dependencies:
+      google-gax: 5.0.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@google/genai@1.44.0':
     dependencies:
@@ -11000,6 +11040,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tootallnate/once@2.0.0': {}
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@twurple/api-call@8.0.3':
@@ -11462,7 +11504,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agent-base@7.1.4: {}
 
@@ -12045,6 +12086,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
 
   ecc-jsbn@0.1.2:
@@ -12515,6 +12563,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.6.1
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -12631,6 +12695,14 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -12650,7 +12722,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -13424,6 +13495,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@3.0.0: {}
+
   object-inspect@1.13.4: {}
 
   object-path@0.11.8: {}
@@ -13836,6 +13909,10 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.5.4
+
   protobufjs@6.8.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -14035,7 +14112,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   readdirp@5.0.0: {}
 
@@ -14087,6 +14163,13 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   retry@0.12.0: {}
 
@@ -14471,6 +14554,12 @@ snapshots:
 
   steno@4.0.2: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   streamx@2.23.0:
     dependencies:
       events-universal: 1.0.1
@@ -14510,7 +14599,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -14534,6 +14622,8 @@ snapshots:
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  stubs@3.0.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -14566,6 +14656,15 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teeny-request@10.1.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   teex@1.0.1:
     dependencies:

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -26,3 +26,12 @@ export {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "./validation.js";
+export { OpenClawSchema } from "./zod-schema.js";
+export {
+  resolveConfigSecrets,
+  configNeedsSecretResolution,
+  clearSecretCache,
+  SecretResolutionError,
+  UnknownSecretProviderError,
+} from "./secret-resolution.js";
+export type { SecretsConfig, SecretProvider } from "./secret-resolution.js";

--- a/src/config/keyring-secret-provider.test.ts
+++ b/src/config/keyring-secret-provider.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { KeyringSecretProvider } from "./keyring-secret-provider.js";
+
+describe("KeyringSecretProvider", () => {
+  it("has name 'keyring'", () => {
+    const provider = new KeyringSecretProvider();
+    expect(provider.name).toBe("keyring");
+  });
+
+  it("setSecret throws (not implemented)", async () => {
+    const provider = new KeyringSecretProvider();
+    await expect(provider.setSecret("x", "y")).rejects.toThrow("not yet implemented");
+  });
+
+  it("listSecrets throws (not implemented)", async () => {
+    const provider = new KeyringSecretProvider();
+    await expect(provider.listSecrets()).rejects.toThrow("not yet implemented");
+  });
+
+  // Platform-specific tests are skipped in CI — they require real keyring access.
+  // Run manually with: pnpm vitest run src/config/keyring-secret-provider.test.ts
+});

--- a/src/config/keyring-secret-provider.ts
+++ b/src/config/keyring-secret-provider.ts
@@ -1,0 +1,198 @@
+/**
+ * OS Keyring secrets provider — cross-platform native credential storage.
+ *
+ * Supported platforms:
+ * - **macOS**: Uses the `security` CLI with a dedicated OpenClaw keychain
+ * - **Linux**: Uses `secret-tool` (libsecret / GNOME Keyring / KDE Wallet via D-Bus Secret Service API)
+ * - **Windows**: Not yet implemented (Credential Manager). Contributions welcome.
+ *
+ * No external npm dependencies — uses platform-native CLIs only.
+ *
+ * Config example:
+ * ```json
+ * { "secrets": { "providers": { "keyring": { "account": "openclaw" } } } }
+ * ```
+ *
+ * Usage: `${keyring:slack-bot-token}` resolves via OS keyring.
+ *
+ * Setup (one-time):
+ *
+ * macOS:
+ * ```bash
+ * security create-keychain -p '' ~/Library/Keychains/openclaw.keychain-db
+ * security add-generic-password -a openclaw -s slack-bot-token -w "xoxb-..." ~/Library/Keychains/openclaw.keychain-db
+ * ```
+ *
+ * Linux:
+ * ```bash
+ * echo -n "xoxb-..." | secret-tool store --label="openclaw: slack-bot-token" service openclaw key slack-bot-token
+ * ```
+ */
+
+import { execFile } from "node:child_process";
+import { homedir, platform } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { SecretProvider } from "./secret-resolution.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface KeyringProviderConfig {
+  /** Account/service name for keyring items. Defaults to "openclaw". */
+  account?: string;
+  /** Path to the keychain file (macOS only). */
+  keychainPath?: string;
+  /** Password to unlock the keychain (macOS only). Defaults to "". */
+  keychainPassword?: string;
+}
+
+export class KeyringSecretProvider implements SecretProvider {
+  public readonly name = "keyring";
+  private readonly account: string;
+  private readonly os: NodeJS.Platform;
+  // macOS-specific
+  private readonly keychainPath: string;
+  private readonly keychainPassword: string;
+  private macUnlocked = false;
+  // Linux-specific
+  private linuxChecked = false;
+
+  constructor(config: KeyringProviderConfig = {}) {
+    this.account = config.account ?? "openclaw";
+    this.os = platform();
+    this.keychainPath =
+      config.keychainPath ?? path.join(homedir(), "Library", "Keychains", "openclaw.keychain-db");
+    this.keychainPassword = config.keychainPassword ?? "";
+  }
+
+  async getSecret(name: string, _version?: string): Promise<string> {
+    if (this.os === "darwin") {
+      return this.macGetSecret(name);
+    }
+    if (this.os === "linux") {
+      return this.linuxGetSecret(name);
+    }
+    throw new Error(
+      `Keyring provider is not implemented for platform: ${this.os}. ` +
+        `Supported: macOS (security CLI), Linux (secret-tool / libsecret).`,
+    );
+  }
+
+  async setSecret(_name: string, _value: string): Promise<void> {
+    throw new Error("KeyringSecretProvider.setSecret is not yet implemented");
+  }
+
+  async listSecrets(): Promise<string[]> {
+    throw new Error("KeyringSecretProvider.listSecrets is not yet implemented");
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      if (this.os === "darwin") {
+        await execFileAsync("security", ["show-keychain-info", this.keychainPath]);
+        return { ok: true };
+      }
+      if (this.os === "linux") {
+        await execFileAsync("which", ["secret-tool"]);
+        return { ok: true };
+      }
+      return { ok: false, error: `Unsupported platform: ${this.os}` };
+    } catch (err: unknown) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // macOS — `security` CLI
+  // ---------------------------------------------------------------------------
+
+  private async macEnsureUnlocked(): Promise<void> {
+    if (this.macUnlocked) {
+      return;
+    }
+
+    const UNLOCK_TIMEOUT_MS = 10_000;
+    const child = execFile("security", ["unlock-keychain", this.keychainPath], {
+      timeout: UNLOCK_TIMEOUT_MS,
+    });
+    if (child.stdin) {
+      child.stdin.write(this.keychainPassword + "\n");
+      child.stdin.end();
+    }
+    child.stdout?.resume();
+    child.stderr?.resume();
+
+    await new Promise<void>((resolve, reject) => {
+      child.on("close", (code) =>
+        code === 0
+          ? resolve()
+          : reject(new Error(`security unlock-keychain exited with code ${code}`)),
+      );
+      child.on("error", reject);
+    });
+    this.macUnlocked = true;
+  }
+
+  private async macGetSecret(name: string): Promise<string> {
+    await this.macEnsureUnlocked();
+    try {
+      const { stdout } = await execFileAsync("security", [
+        "find-generic-password",
+        "-a",
+        this.account,
+        "-s",
+        name,
+        "-w",
+        this.keychainPath,
+      ]);
+      return stdout.trimEnd();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("could not be found") || msg.includes("SecKeychainSearchCopyNext")) {
+        throw new Error(`Secret "${name}" not found in macOS keychain`, { cause: err });
+      }
+      throw new Error(`Failed to retrieve secret "${name}" from keychain: ${msg}`, { cause: err });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Linux — `secret-tool` (libsecret)
+  // ---------------------------------------------------------------------------
+
+  private async linuxEnsureSecretTool(): Promise<void> {
+    if (this.linuxChecked) {
+      return;
+    }
+    try {
+      await execFileAsync("which", ["secret-tool"]);
+      this.linuxChecked = true;
+    } catch {
+      throw new Error(
+        `secret-tool not found. Install libsecret to use the keyring provider on Linux:\n` +
+          `  Arch/CachyOS: sudo pacman -S libsecret\n` +
+          `  Ubuntu/Debian: sudo apt install libsecret-tools\n` +
+          `  Fedora: sudo dnf install libsecret`,
+      );
+    }
+  }
+
+  private async linuxGetSecret(name: string): Promise<string> {
+    await this.linuxEnsureSecretTool();
+    try {
+      const { stdout } = await execFileAsync("secret-tool", [
+        "lookup",
+        "service",
+        this.account,
+        "key",
+        name,
+      ]);
+      const value = stdout.trimEnd();
+      if (!value) {
+        throw new Error(`Secret "${name}" not found in keyring`);
+      }
+      return value;
+    } catch {
+      throw new Error(`Secret "${name}" not found in keyring`);
+    }
+  }
+}

--- a/src/config/onepassword-secret-provider.test.ts
+++ b/src/config/onepassword-secret-provider.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { OnePasswordSecretProvider } from "./onepassword-secret-provider.js";
+
+describe("OnePasswordSecretProvider", () => {
+  it("has name '1password'", () => {
+    const provider = new OnePasswordSecretProvider();
+    expect(provider.name).toBe("1password");
+  });
+
+  it("defaults to vault 'OpenClaw' and field 'credential'", () => {
+    const provider = new OnePasswordSecretProvider();
+    // Verify defaults are applied (will fail on getSecret without op CLI, but that's expected)
+    expect(provider.name).toBe("1password");
+  });
+
+  it("setSecret throws (not implemented)", async () => {
+    const provider = new OnePasswordSecretProvider();
+    await expect(provider.setSecret("x", "y")).rejects.toThrow("not yet implemented");
+  });
+
+  // Full integration tests require `op` CLI and a signed-in session.
+  // Run manually with: pnpm vitest run src/config/onepassword-secret-provider.test.ts
+});

--- a/src/config/onepassword-secret-provider.ts
+++ b/src/config/onepassword-secret-provider.ts
@@ -1,0 +1,114 @@
+/**
+ * 1Password secrets provider — uses the `op` CLI.
+ *
+ * Resolves secrets via `op read op://vault/item/field`.
+ * Supports both signed-in sessions and service account tokens (OP_SERVICE_ACCOUNT_TOKEN).
+ *
+ * Config example:
+ * ```json
+ * { "secrets": { "providers": { "1password": { "vault": "OpenClaw" } } } }
+ * ```
+ *
+ * Usage: `${1password:slack-bot-token}` → `op read op://OpenClaw/slack-bot-token/credential`
+ *
+ * Setup:
+ * ```bash
+ * # Install: https://developer.1password.com/docs/cli/get-started/
+ * # Sign in (interactive):
+ * op signin
+ * # Or use a service account token (CI/headless):
+ * export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
+ * ```
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { SecretProvider } from "./secret-resolution.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface OnePasswordProviderConfig {
+  /** 1Password vault name. Defaults to "OpenClaw". */
+  vault?: string;
+  /** Default field to read. Defaults to "credential". */
+  field?: string;
+}
+
+export class OnePasswordSecretProvider implements SecretProvider {
+  public readonly name = "1password";
+  private readonly vault: string;
+  private readonly field: string;
+  private opChecked = false;
+
+  constructor(config: OnePasswordProviderConfig = {}) {
+    this.vault = config.vault ?? "OpenClaw";
+    this.field = config.field ?? "credential";
+  }
+
+  async getSecret(name: string, _version?: string): Promise<string> {
+    await this.ensureOp();
+
+    // Secret name can be a full op:// URI or just an item name
+    const uri = name.startsWith("op://") ? name : `op://${this.vault}/${name}/${this.field}`;
+
+    try {
+      const { stdout } = await execFileAsync("op", ["read", uri], {
+        timeout: 30_000,
+      });
+      return stdout.trimEnd();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("isn't an item") || msg.includes("could not be found")) {
+        throw new Error(`Secret "${name}" not found in 1Password vault "${this.vault}"`, {
+          cause: err,
+        });
+      }
+      throw new Error(`Failed to read secret "${name}" from 1Password: ${msg}`, { cause: err });
+    }
+  }
+
+  async setSecret(_name: string, _value: string): Promise<void> {
+    throw new Error("OnePasswordSecretProvider.setSecret is not yet implemented");
+  }
+
+  async listSecrets(): Promise<string[]> {
+    await this.ensureOp();
+    try {
+      const { stdout } = await execFileAsync("op", [
+        "item",
+        "list",
+        "--vault",
+        this.vault,
+        "--format",
+        "json",
+      ]);
+      const items = JSON.parse(stdout) as Array<{ title: string }>;
+      return items.map((i) => i.title).toSorted();
+    } catch {
+      throw new Error(`Failed to list items in 1Password vault "${this.vault}"`);
+    }
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      await execFileAsync("op", ["whoami"], { timeout: 10_000 });
+      return { ok: true };
+    } catch (err: unknown) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  private async ensureOp(): Promise<void> {
+    if (this.opChecked) {
+      return;
+    }
+    try {
+      await execFileAsync("which", ["op"]);
+      this.opChecked = true;
+    } catch {
+      throw new Error(
+        "1Password CLI (`op`) not found. Install it: https://developer.1password.com/docs/cli/get-started/",
+      );
+    }
+  }
+}

--- a/src/config/secret-resolution.ts
+++ b/src/config/secret-resolution.ts
@@ -1,0 +1,514 @@
+/**
+ * Secret reference resolution for config values.
+ *
+ * Supports `${provider:secret-name}` and `${provider:secret-name#version}` syntax.
+ * Provider must be lowercase. Secret names allow: [a-zA-Z0-9_\-/.]
+ * Version pinning via #version suffix (default: latest).
+ * Escape with `$${provider:name}` to produce literal `${provider:name}`.
+ */
+
+import { isPlainObject } from "../utils.js";
+import { KeyringSecretProvider } from "./keyring-secret-provider.js";
+import { OnePasswordSecretProvider } from "./onepassword-secret-provider.js";
+
+// Matches ${provider:name} or ${provider:name#version}
+// Provider: lowercase alpha. Name: alphanum, hyphens, underscores, slashes, dots.
+// Version (optional): after #, alphanumeric.
+const SECRET_REF_PATTERN = /\$\{([a-z]+):([a-zA-Z0-9_\-/.]+?)(?:#([a-zA-Z0-9]+))?\}/g;
+
+/** Parsed secret reference. */
+export interface SecretRef {
+  provider: string;
+  name: string;
+  version?: string;
+}
+
+/** Configuration for the secrets section in openclaw.json. */
+export type SecretsConfig = {
+  providers?: Record<
+    string,
+    {
+      project?: string;
+      cacheTtlSeconds?: number;
+      credentialsFile?: string;
+      // AWS-specific
+      region?: string;
+      profile?: string;
+      roleArn?: string;
+      externalId?: string;
+      // Keyring-specific
+      account?: string;
+      keychainPath?: string;
+      keychainPassword?: string;
+      // 1Password-specific
+      vault?: string;
+      field?: string;
+    }
+  >;
+};
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class SecretResolutionError extends Error {
+  constructor(
+    public readonly provider: string,
+    public readonly secretName: string,
+    public readonly configPath: string,
+    cause?: Error,
+  ) {
+    super(
+      `Failed to resolve secret "${provider}:${secretName}" at config path: ${configPath}${cause ? ` — ${cause.message}` : ""}`,
+    );
+    this.name = "SecretResolutionError";
+    this.cause = cause;
+  }
+}
+
+export class UnknownSecretProviderError extends Error {
+  constructor(
+    public readonly provider: string,
+    public readonly configPath: string,
+  ) {
+    super(`Unknown secret provider "${provider}" referenced at config path: ${configPath}`);
+    this.name = "UnknownSecretProviderError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+type CacheEntry = { value: string; expiresAt: number };
+const secretCache = new Map<string, CacheEntry>();
+
+export function clearSecretCache(): void {
+  secretCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// SecretProvider interface
+// ---------------------------------------------------------------------------
+
+export interface SecretProvider {
+  name: string;
+  getSecret(name: string, version?: string): Promise<string>;
+  setSecret(name: string, value: string): Promise<void>;
+  listSecrets(): Promise<string[]>;
+  testConnection(): Promise<{ ok: boolean; error?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// GcpSecretProvider
+// ---------------------------------------------------------------------------
+
+/** Minimal interface for the GCP SecretManagerServiceClient used at runtime. */
+interface GcpSmClient {
+  accessSecretVersion(req: {
+    name: string;
+  }): Promise<[{ payload?: { data?: Uint8Array | string } } | undefined]>;
+  createSecret(req: {
+    parent: string;
+    secretId: string;
+    secret: { replication: { automatic: Record<string, never> } };
+  }): Promise<unknown>;
+  addSecretVersion(req: { parent: string; payload: { data: Buffer } }): Promise<unknown>;
+  listSecrets(req: { parent: string }): Promise<[Array<{ name?: string }>]>;
+}
+
+export class GcpSecretProvider implements SecretProvider {
+  public readonly name = "gcp";
+  private readonly project: string;
+  private readonly cacheTtlMs: number;
+  private readonly credentialsFile?: string;
+  constructor(config: { project: string; cacheTtlSeconds?: number; credentialsFile?: string }) {
+    this.project = config.project;
+    this.cacheTtlMs = (config.cacheTtlSeconds ?? 300) * 1000;
+    this.credentialsFile = config.credentialsFile;
+  }
+
+  private async getClient(): Promise<GcpSmClient> {
+    try {
+      const mod = await import("@google-cloud/secret-manager");
+      const Ctor = mod.SecretManagerServiceClient;
+      const opts = this.credentialsFile ? { keyFilename: this.credentialsFile } : {};
+      // Support both `new Ctor(opts)` (real) and mock functions that don't support `new`
+      try {
+        return new (Ctor as unknown as new (o: Record<string, unknown>) => GcpSmClient)(opts);
+      } catch {
+        // Fallback for mock functions that don't support new operator
+        return (Ctor as unknown as (o: Record<string, unknown>) => GcpSmClient)(opts);
+      }
+    } catch {
+      throw new Error(
+        "Please install @google-cloud/secret-manager to use GCP secrets: pnpm add @google-cloud/secret-manager",
+      );
+    }
+  }
+
+  async getSecret(secretName: string, version?: string): Promise<string> {
+    const ver = version ?? "latest";
+    const cacheKey = `gcp:${secretName}#${ver}`;
+    const cached = secretCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    const client = await this.getClient();
+    const resourceName = `projects/${this.project}/secrets/${secretName}/versions/${ver}`;
+
+    let response: { payload?: { data?: Uint8Array | string } } | undefined;
+    try {
+      [response] = await client.accessSecretVersion({ name: resourceName });
+    } catch (err: unknown) {
+      const code = (err as { code?: number })?.code;
+      if (code === 5) {
+        throw new Error(`Secret '${secretName}' not found in project '${this.project}'`, {
+          cause: err,
+        });
+      }
+      if (code === 7) {
+        throw new Error(`Permission denied for secret '${secretName}'. Check IAM bindings.`, {
+          cause: err,
+        });
+      }
+      if (code === 4) {
+        // Retry once
+        try {
+          const retryClient = await this.getClient();
+          [response] = await retryClient.accessSecretVersion({ name: resourceName });
+        } catch {
+          if (cached) {
+            return cached.value;
+          }
+          throw err;
+        }
+      } else {
+        throw err;
+      }
+    }
+
+    const payload = response?.payload?.data;
+    if (!payload) {
+      throw new Error(`Secret "${secretName}" has no payload data`);
+    }
+
+    const value =
+      payload instanceof Uint8Array || Buffer.isBuffer(payload)
+        ? Buffer.from(payload).toString("utf-8")
+        : String(payload);
+
+    secretCache.set(cacheKey, { value, expiresAt: Date.now() + this.cacheTtlMs });
+    return value;
+  }
+
+  async setSecret(secretName: string, value: string): Promise<void> {
+    const client = await this.getClient();
+    const parent = `projects/${this.project}`;
+
+    try {
+      await client.createSecret({
+        parent,
+        secretId: secretName,
+        secret: { replication: { automatic: {} } },
+      });
+    } catch {
+      // Secret may already exist; other errors will surface on addSecretVersion
+    }
+
+    await client.addSecretVersion({
+      parent: `${parent}/secrets/${secretName}`,
+      payload: { data: Buffer.from(value, "utf-8") },
+    });
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const client = await this.getClient();
+    const [secrets] = await client.listSecrets({
+      parent: `projects/${this.project}`,
+    });
+    return (secrets || []).map((s: { name?: string }) => {
+      const name: string = s.name || "";
+      const parts = name.split("/");
+      return parts[parts.length - 1];
+    });
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const client = await this.getClient();
+      await client.listSecrets({ parent: `projects/${this.project}` });
+      return { ok: true };
+    } catch (err: unknown) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reference detection & extraction
+// ---------------------------------------------------------------------------
+
+export function containsSecretReference(value: string): boolean {
+  if (!value.includes("${")) {
+    return false;
+  }
+  SECRET_REF_PATTERN.lastIndex = 0;
+  return SECRET_REF_PATTERN.test(value);
+}
+
+/** Remove escaped refs before extraction so $${gcp:x} isn't treated as a ref. */
+function stripEscapedRefs(value: string): string {
+  return value.replace(/\$\$\{[a-z]+:[a-zA-Z0-9_\-/.]+(?:#[a-zA-Z0-9]+)?\}/g, "");
+}
+
+export function extractSecretReferences(obj: unknown): SecretRef[] {
+  const refs: SecretRef[] = [];
+  const seen = new Set<string>();
+
+  function walk(value: unknown): void {
+    if (typeof value === "string" && value.includes("${")) {
+      const cleaned = stripEscapedRefs(value);
+      SECRET_REF_PATTERN.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = SECRET_REF_PATTERN.exec(cleaned)) !== null) {
+        const key = `${match[1]}:${match[2]}${match[3] ? "#" + match[3] : ""}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          const ref: SecretRef = { provider: match[1], name: match[2] };
+          if (match[3]) {
+            ref.version = match[3];
+          }
+          refs.push(ref);
+        }
+      }
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        walk(item);
+      }
+    } else if (isPlainObject(value)) {
+      for (const val of Object.values(value)) {
+        walk(val);
+      }
+    }
+  }
+
+  walk(obj);
+  return refs;
+}
+
+export function configNeedsSecretResolution(obj: unknown): boolean {
+  return extractSecretReferences(obj).length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Build providers
+// ---------------------------------------------------------------------------
+
+export function buildSecretProviders(
+  secretsConfig: SecretsConfig | undefined,
+): Map<string, SecretProvider> {
+  const providers = new Map<string, SecretProvider>();
+  if (!secretsConfig?.providers) {
+    return providers;
+  }
+
+  for (const [name, config] of Object.entries(secretsConfig.providers)) {
+    if (name === "gcp" && config && config.project) {
+      providers.set(
+        "gcp",
+        new GcpSecretProvider(
+          config as { project: string; cacheTtlSeconds?: number; credentialsFile?: string },
+        ),
+      );
+    }
+    if (name === "keyring") {
+      providers.set(
+        "keyring",
+        new KeyringSecretProvider({
+          account: config?.account,
+          keychainPath: config?.keychainPath,
+          keychainPassword: config?.keychainPassword,
+        }),
+      );
+    }
+    if (name === "1password") {
+      providers.set(
+        "1password",
+        new OnePasswordSecretProvider({
+          vault: config?.vault,
+          field: config?.field,
+        }),
+      );
+    }
+  }
+
+  return providers;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a secret value, checking the shared cache first.
+ * This cache layer sits above individual provider caches, ensuring that
+ * the same secret is not fetched twice within a single resolution pass
+ * regardless of which provider implementation is used.
+ */
+async function fetchWithCache(
+  provider: SecretProvider,
+  name: string,
+  version: string | undefined,
+  cacheTtlMs: number,
+): Promise<string> {
+  const cacheKey = `${provider.name}:${name}#${version ?? "latest"}`;
+  const cached = secretCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  try {
+    const value = await provider.getSecret(name, version);
+    secretCache.set(cacheKey, { value, expiresAt: Date.now() + cacheTtlMs });
+    return value;
+  } catch (err) {
+    // Stale-while-revalidate: if we have an expired entry, use it
+    if (cached) {
+      return cached.value;
+    }
+    throw err;
+  }
+}
+
+async function resolveString(
+  value: string,
+  providers: Map<string, SecretProvider>,
+  configPath: string,
+  cacheTtlMs: number,
+): Promise<string> {
+  if (!value.includes("$")) {
+    return value;
+  }
+
+  // Handle escaped refs first: replace $${ with a placeholder
+  const ESCAPE_PLACEHOLDER = "___OPENCLAW_ESC___";
+  let working = value.replace(/\$\$\{/g, ESCAPE_PLACEHOLDER);
+
+  // Collect matches
+  SECRET_REF_PATTERN.lastIndex = 0;
+  const matches: Array<{ full: string; provider: string; name: string; version?: string }> = [];
+  let match: RegExpExecArray | null;
+  while ((match = SECRET_REF_PATTERN.exec(working)) !== null) {
+    const m: { full: string; provider: string; name: string; version?: string } = {
+      full: match[0],
+      provider: match[1],
+      name: match[2],
+    };
+    if (match[3]) {
+      m.version = match[3];
+    }
+    matches.push(m);
+  }
+
+  if (matches.length === 0) {
+    // Restore escaped refs as literals
+    return working.replaceAll(ESCAPE_PLACEHOLDER, "${");
+  }
+
+  // Resolve all in parallel
+  const resolved = await Promise.all(
+    matches.map(async ({ provider: pName, name, version, full }) => {
+      const provider = providers.get(pName);
+      if (!provider) {
+        throw new UnknownSecretProviderError(pName, configPath);
+      }
+      try {
+        const resolvedValue = await fetchWithCache(provider, name, version, cacheTtlMs);
+        return { full, value: resolvedValue };
+      } catch (err) {
+        throw new SecretResolutionError(
+          pName,
+          name,
+          configPath,
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
+    }),
+  );
+
+  for (const { full, value: sv } of resolved) {
+    working = working.replace(full, sv);
+  }
+
+  // Restore escaped refs
+  working = working.replaceAll(ESCAPE_PLACEHOLDER, "${");
+  return working;
+}
+
+async function resolveAny(
+  value: unknown,
+  providers: Map<string, SecretProvider>,
+  path: string,
+  cacheTtlMs: number,
+): Promise<unknown> {
+  if (typeof value === "string") {
+    return resolveString(value, providers, path, cacheTtlMs);
+  }
+  if (Array.isArray(value)) {
+    return Promise.all(
+      value.map((item, i) => resolveAny(item, providers, `${path}[${i}]`, cacheTtlMs)),
+    );
+  }
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value);
+    const resolved = await Promise.all(
+      entries.map(async ([key, val]) => {
+        const childPath = path ? `${path}.${key}` : key;
+        return [key, await resolveAny(val, providers, childPath, cacheTtlMs)] as const;
+      }),
+    );
+    return Object.fromEntries(resolved);
+  }
+  return value;
+}
+
+/**
+ * Resolve all secret references in a config object.
+ *
+ * @param obj - Config object potentially containing `${provider:name}` references.
+ * @param secretsConfig - The `secrets` section from openclaw.json.
+ * @param providersOverride - Optional pre-built providers map (useful for testing).
+ */
+export async function resolveConfigSecrets(
+  obj: unknown,
+  secretsConfig: SecretsConfig | undefined,
+  providersOverride?: Map<string, SecretProvider>,
+): Promise<unknown> {
+  const refs = extractSecretReferences(obj);
+
+  // Default cache TTL: 5 minutes
+  const defaultTtlMs = 300_000;
+  const cacheTtlMs =
+    secretsConfig?.providers?.gcp?.cacheTtlSeconds != null
+      ? secretsConfig.providers.gcp.cacheTtlSeconds * 1000
+      : defaultTtlMs;
+
+  // Handle escaped refs even with no real refs
+  if (refs.length === 0) {
+    // Still need to process escaped refs
+    return resolveAny(obj, new Map(), "", cacheTtlMs);
+  }
+
+  const providers = providersOverride ?? buildSecretProviders(secretsConfig);
+
+  // Check all referenced providers exist
+  for (const ref of refs) {
+    if (!providers.has(ref.provider)) {
+      throw new UnknownSecretProviderError(ref.provider, "(config)");
+    }
+  }
+
+  return resolveAny(obj, providers, "", cacheTtlMs);
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,6 +10,27 @@ vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
   };
 });
 
+// Default mock for @google-cloud/secret-manager so secrets-related tests
+// don't require real GCP credentials. GCP Provider tests override this
+// per-test via vi.doMock() which takes precedence for that test scope.
+vi.mock("@google-cloud/secret-manager", () => ({
+  SecretManagerServiceClient: class MockSecretManagerServiceClient {
+    async accessSecretVersion() {
+      return [{ payload: { data: Buffer.from("resolved-value") } }];
+    }
+    async createSecret() {
+      return [{}];
+    }
+    async addSecretVersion() {
+      return [{}];
+    }
+    async listSecrets() {
+      return [[]];
+    }
+  },
+}));
+
+
 // Ensure Vitest environment is properly set
 process.env.VITEST = "true";
 // Config validation walks plugin manifests; keep an aggressive cache in tests to avoid


### PR DESCRIPTION
## Summary

Adds two providers for local/desktop credential storage:

### KeyringSecretProvider
OS-native keychain integration:
- **macOS**: Keychain via `keytar` (lazy-loaded optional peer dep)
- **Linux**: `secret-tool` CLI (libsecret)

**Config:**
```json
{ "secrets": { "providers": { "keyring": { "account": "openclaw" } } } }
```
**Usage:** `${keyring:my-api-key}`

### OnePasswordSecretProvider
1Password CLI integration via `op read`:

**Config:**
```json
{ "secrets": { "providers": { "1password": { "vault": "OpenClaw" } } } }
```
**Usage:** `${1password:My Item.api-key}`

## Notes
Split from #24272 per @vincentkoc's request.