### PR TITLE
OpenRouter: surface free Hunter and Healer stealth models for the next week

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- OpenRouter/models: add temporary Hunter Alpha and Healer Alpha entries to the built-in catalog so OpenRouter users can try the new free stealth models during their roughly one-week availability window. (#43642) Thanks @ping-Toven.
 - iOS/Home canvas: add a bundled welcome screen with a live agent overview that refreshes on connect, reconnect, and foreground return, and move the compact connection pill off the top-left canvas overlay. (#42456) Thanks @ngutman.
 - iOS/Home canvas: replace floating controls with a docked toolbar, make the bundled home scaffold adapt to smaller phones, and open chat in the resolved main session instead of a synthetic `ios` session. (#42456) Thanks @ngutman.
 - macOS/chat UI: add a chat model picker, persist explicit thinking-level selections across relaunch, and harden provider-aware session model sync for the shared chat composer. (#42314) Thanks @ImLukeF.

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -430,7 +430,7 @@ export function buildOpenrouterProvider(): ProviderConfig {
         maxTokens: OPENROUTER_DEFAULT_MAX_TOKENS,
       },
       {
-        id: "hunter-alpha",
+        id: "openrouter/hunter-alpha",
         name: "Hunter Alpha",
         reasoning: true,
         input: ["text"],
@@ -439,7 +439,7 @@ export function buildOpenrouterProvider(): ProviderConfig {
         maxTokens: 65536,
       },
       {
-        id: "healer-alpha",
+        id: "openrouter/healer-alpha",
         name: "Healer Alpha",
         reasoning: true,
         input: ["text", "image"],

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -429,6 +429,24 @@ export function buildOpenrouterProvider(): ProviderConfig {
         contextWindow: OPENROUTER_DEFAULT_CONTEXT_WINDOW,
         maxTokens: OPENROUTER_DEFAULT_MAX_TOKENS,
       },
+      {
+        id: "hunter-alpha",
+        name: "Hunter Alpha",
+        reasoning: true,
+        input: ["text"],
+        cost: OPENROUTER_DEFAULT_COST,
+        contextWindow: 1048576,
+        maxTokens: 65536,
+      },
+      {
+        id: "healer-alpha",
+        name: "Healer Alpha",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: OPENROUTER_DEFAULT_COST,
+        contextWindow: 262144,
+        maxTokens: 65536,
+      },
     ],
   };
 }

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -382,6 +382,40 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
+  it("matches prefixed OpenRouter native ids in configured fallback models", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("openrouter/healer-alpha"),
+                reasoning: true,
+                input: ["text", "image"],
+                contextWindow: 262144,
+                maxTokens: 65536,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("openrouter", "openrouter/healer-alpha", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openrouter",
+      id: "openrouter/healer-alpha",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 262144,
+      maxTokens: 65536,
+    });
+  });
+
   it("prefers configured provider api metadata over discovered registry model", () => {
     mockDiscoveredModel({
       provider: "onehub",


### PR DESCRIPTION
## Summary

- Problem: new openrouter stealth models failed the tool probe due to probe using `tool_choice: required` which the models don't support
- Why it matters: the new hunter and healer alpha stealth models are quite good, and are available for free
- What changed: added two hardcoded model configs to the built in openrouter provider catalog
- What did NOT change (scope boundary): didn't change the `tool_choice` use of the probe, didn't change the default model.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [X] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

OpenRouter users will now see hunter and healer alpha in the models list, hardcoded.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: verified existing probe fails on the stealth models
- Edge cases checked:
- What you did **not** verify: did not run openclaw locally on my machine, as I am blocked by company policy - we have our claws on cloud VMs, sorry!

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: We forget to remove this model config in a week or so when the stealth models go offline, and users end up trying to use a model that has gone down.
  - Mitigation: OpenRouter will throw clear error messages when the model goes offline and begins to 404 not found. Will also own cleaning this up myself ( I am an OpenRouter Eng)
