### PR TITLE
feat(secrets): add Azure Key Vault secret provider

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -452,3 +452,505 @@ Some SecretInput unions are easier to configure in raw editor mode than in form 
 - Auth setup: [Authentication](/gateway/authentication)
 - Security posture: [Security](/gateway/security)
 - Environment precedence: [Environment Variables](/help/environment)
+
+---
+
+## Additional Secrets Providers
+
+summary: "External secrets management: store credentials in GCP Secret Manager instead of plaintext files"
+read_when:
+
+- You want to stop storing API keys in plaintext config files
+- You want per-agent secret isolation in multi-agent setups
+- You want to set up GCP Secret Manager for OpenClaw
+- You want to migrate existing plaintext secrets to a secrets store
+  title: "Secrets"
+
+---
+
+# External Secrets Management
+
+OpenClaw can resolve secret references in configuration files at runtime, fetching values from an external secrets store instead of storing them in plaintext on disk.
+
+## Why
+
+- **No plaintext secrets on disk** — API keys, tokens, and credentials live in an encrypted, access-controlled store
+- **Per-agent isolation** — in multi-agent setups, each agent only accesses secrets it's authorized for (enforced by GCP IAM, not application code)
+- **Audit trail** — GCP Secret Manager logs all access
+- **Safe version control** — config files contain references (`${gcp:name}`), not actual secrets
+- **Rotation without restarts** — update the secret in the store; cached values expire automatically
+
+## Supported Providers
+
+| Provider            | Status       |
+| ------------------- | ------------ |
+| GCP Secret Manager  | ✅ Supported |
+| AWS Secrets Manager | Planned      |
+| HashiCorp Vault     | Planned      |
+| Azure Key Vault     | Planned      |
+
+## Quick Start
+
+### 1. Prerequisites
+
+- A GCP project with billing enabled
+- `gcloud` CLI installed and authenticated (for setup only; not needed at runtime)
+- VM or environment with `cloud-platform` OAuth scope (for Compute Engine VMs)
+
+#### Compute Engine VM Setup
+
+If running on a GCP Compute Engine VM:
+
+**OAuth Scopes** — the VM must have `cloud-platform` scope. To update (requires VM restart):
+
+```bash
+gcloud compute instances stop <instance> --zone=<zone>
+gcloud compute instances set-service-account <instance> --zone=<zone> --scopes=cloud-platform
+gcloud compute instances start <instance> --zone=<zone>
+```
+
+**IAM Roles** — the compute service account needs these roles:
+
+| Role                                 | Purpose                                     | Required                        |
+| ------------------------------------ | ------------------------------------------- | ------------------------------- |
+| `roles/secretmanager.secretAccessor` | Read secret values at runtime               | Always                          |
+| `roles/secretmanager.admin`          | Create secrets, set per-secret IAM bindings | For setup & per-agent isolation |
+
+Grant via CLI:
+
+```bash
+gcloud projects add-iam-policy-binding <project-id> \
+  --member="serviceAccount:<service-account-email>" \
+  --role="roles/secretmanager.secretAccessor"
+
+gcloud projects add-iam-policy-binding <project-id> \
+  --member="serviceAccount:<service-account-email>" \
+  --role="roles/secretmanager.admin"
+```
+
+Or via the GCP Console:
+
+1. Go to **IAM & Admin → IAM**
+2. Find the compute service account
+3. Click **Edit** (pencil icon)
+4. Add both roles
+5. Save
+
+> **Tip:** After setup is complete and per-agent isolation is configured, you can optionally remove `secretmanager.admin` from the compute SA — agents authenticate with their own service accounts at runtime.
+
+### 2. Bootstrap
+
+```bash
+openclaw secrets setup --project my-gcp-project --agents main,chai
+```
+
+This will:
+
+- Enable the Secret Manager API
+- Create per-agent service accounts (`openclaw-main@`, `openclaw-chai@`)
+- Generate service account key files
+- Set per-secret IAM bindings
+- Update `openclaw.json` with the `secrets` config section
+
+Pass `--yes` to skip confirmation prompts.
+
+### 3. Store a Secret
+
+```bash
+openclaw secrets set --provider gcp --name openclaw-main-brave-api-key --value "your-key-here"
+```
+
+### 4. Reference in Config
+
+Replace plaintext values with secret references:
+
+```json5
+{
+  // Before
+  "apiKey": "sk-real-key-here"
+
+  // After
+  "apiKey": "${gcp:openclaw-main-brave-api-key}"
+}
+```
+
+### 5. Verify
+
+```bash
+openclaw secrets test
+```
+
+## Secret Reference Syntax
+
+References follow the pattern `${provider:secret-name}`:
+
+```
+${gcp:my-secret}          → latest version
+${gcp:my-secret#3}        → pinned to version 3
+${gcp:path/to/secret}     → slashes allowed in names
+```
+
+### Escaping
+
+Use `$${}` to produce a literal `${}` in config:
+
+```json5
+{
+  literal: "$${gcp:not-a-ref}", // → "${gcp:not-a-ref}"
+}
+```
+
+### Distinction from Environment Variables
+
+| Syntax              | Resolved by                     | Example                |
+| ------------------- | ------------------------------- | ---------------------- |
+| `${UPPER_CASE}`     | Env var substitution (existing) | `${BRAVE_API_KEY}`     |
+| `${lowercase:name}` | Secret resolution (new)         | `${gcp:brave-api-key}` |
+
+The lowercase provider prefix naturally distinguishes secret refs from env var refs.
+
+## Configuration
+
+Add a `secrets` section to `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        // GCP project ID (required)
+        project: "my-gcp-project",
+
+        // Cache TTL in seconds (default: 300)
+        cacheTtlSeconds: 300,
+
+        // Path to service account key file (required for per-agent isolation)
+        // If omitted, uses Application Default Credentials (ADC)
+        credentialsFile: "/path/to/openclaw-main-sa.json",
+      },
+    },
+  },
+}
+```
+
+## Auth Profiles
+
+Secret references also work in `auth-profiles.json`:
+
+```json
+{
+  "profiles": {
+    "openai:default": {
+      "type": "token",
+      "provider": "openai",
+      "token": "${gcp:openclaw-main-openai-token}"
+    }
+  }
+}
+```
+
+## Per-Agent Isolation
+
+Per-agent isolation ensures each agent can **only** read its own secrets, enforced at the GCP IAM level. This is not application-level filtering — GCP itself blocks unauthorized access.
+
+### How It Works
+
+Each agent gets:
+
+1. **Its own GCP service account** (e.g., `openclaw-main@project.iam.gserviceaccount.com`)
+2. **A service account key file** stored locally (e.g., `~/.config/gcp/openclaw-main-sa.json`)
+3. **Per-secret IAM bindings** granting only that SA access to its secrets
+
+### Naming Convention
+
+Secrets are namespaced by agent name:
+
+```
+openclaw-main-*     → only the main agent can read
+openclaw-chai-*     → only the chai agent can read
+openclaw-shared-*   → multiple agents can read (both SAs get access)
+```
+
+### Setup Steps
+
+**1. Create per-agent service accounts:**
+
+```bash
+gcloud iam service-accounts create openclaw-main \
+  --display-name="OpenClaw Main Agent"
+gcloud iam service-accounts create openclaw-chai \
+  --display-name="OpenClaw Chai Agent"
+```
+
+**2. Generate key files:**
+
+```bash
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-main-sa.json \
+  --iam-account=openclaw-main@<project>.iam.gserviceaccount.com
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-chai-sa.json \
+  --iam-account=openclaw-chai@<project>.iam.gserviceaccount.com
+chmod 600 ~/.config/gcp/*.json
+```
+
+**3. Set per-secret IAM bindings:**
+
+```bash
+# Main agent's secrets → only main SA
+gcloud secrets add-iam-policy-binding openclaw-main-openai-key \
+  --member="serviceAccount:openclaw-main@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# Chai agent's secrets → only chai SA
+gcloud secrets add-iam-policy-binding openclaw-chai-alpaca-key \
+  --member="serviceAccount:openclaw-chai@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# Shared secrets → both SAs
+gcloud secrets add-iam-policy-binding openclaw-shared-brave-key \
+  --member="serviceAccount:openclaw-main@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+gcloud secrets add-iam-policy-binding openclaw-shared-brave-key \
+  --member="serviceAccount:openclaw-chai@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+**4. Configure each agent to use its own SA:**
+
+Main agent's `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        project: "my-project",
+        credentialsFile: "/home/user/.config/gcp/openclaw-main-sa.json",
+      },
+    },
+  },
+}
+```
+
+Chai agent's `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        project: "my-project",
+        credentialsFile: "/home/user/.config/gcp/openclaw-chai-sa.json",
+      },
+    },
+  },
+}
+```
+
+### Verification
+
+After setup, verify isolation is enforced:
+
+```
+✅ main reads openclaw-main-openai-key     → access granted
+🔒 main reads openclaw-chai-alpaca-key     → PERMISSION_DENIED
+✅ chai reads openclaw-chai-alpaca-key     → access granted
+🔒 chai reads openclaw-main-openai-key     → PERMISSION_DENIED
+```
+
+If an agent tries to read another agent's secret, GCP returns `PERMISSION_DENIED` — the request never reaches OpenClaw.
+
+## Worked Example: Multi-Agent Migration
+
+This example walks through migrating a two-agent setup (main + chai) from plaintext to GCP Secret Manager with full isolation.
+
+### Before (plaintext)
+
+```
+~/.config/openai/credentials.env     → OPENAI_API_KEY=sk-proj-abc123...
+~/.config/alpaca/sandbox.env         → ALPACA_KEY_ID=CKN... / ALPACA_SECRET_KEY=7TV...
+~/.config/himalaya/.nine30-pass      → cbmc pxsf mlzr puea
+openclaw.json                        → "apiKey": "BSAIGr...", "token": "83a1aa..."
+```
+
+All secrets in plaintext. Any agent or process on the machine can read everything.
+
+### Step 1: Enable Secret Manager API
+
+```bash
+gcloud services enable secretmanager.googleapis.com --project=my-project
+```
+
+### Step 2: Store secrets with agent-namespaced names
+
+```bash
+# Main agent secrets
+openclaw secrets set --provider gcp --name openclaw-main-openai-api-key --value "sk-proj-abc123..."
+openclaw secrets set --provider gcp --name openclaw-main-brave-api-key --value "BSAIGr..."
+openclaw secrets set --provider gcp --name openclaw-main-gateway-token --value "83a1aa..."
+openclaw secrets set --provider gcp --name openclaw-main-email-password --value "cbmc pxsf mlzr puea"
+
+# Chai agent secrets
+openclaw secrets set --provider gcp --name openclaw-chai-alpaca-key-id --value "CKN..."
+openclaw secrets set --provider gcp --name openclaw-chai-alpaca-secret-key --value "7TV..."
+```
+
+### Step 3: Create service accounts and keys
+
+```bash
+gcloud iam service-accounts create openclaw-main --display-name="OpenClaw Main Agent"
+gcloud iam service-accounts create openclaw-chai --display-name="OpenClaw Chai Agent"
+
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-main-sa.json \
+  --iam-account=openclaw-main@my-project.iam.gserviceaccount.com
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-chai-sa.json \
+  --iam-account=openclaw-chai@my-project.iam.gserviceaccount.com
+
+chmod 600 ~/.config/gcp/*.json
+```
+
+### Step 4: Set per-secret IAM bindings
+
+```bash
+# Main-only secrets
+for SECRET in openclaw-main-openai-api-key openclaw-main-brave-api-key \
+              openclaw-main-gateway-token openclaw-main-email-password; do
+  gcloud secrets add-iam-policy-binding $SECRET \
+    --member="serviceAccount:openclaw-main@my-project.iam.gserviceaccount.com" \
+    --role="roles/secretmanager.secretAccessor"
+done
+
+# Chai-only secrets
+for SECRET in openclaw-chai-alpaca-key-id openclaw-chai-alpaca-secret-key; do
+  gcloud secrets add-iam-policy-binding $SECRET \
+    --member="serviceAccount:openclaw-chai@my-project.iam.gserviceaccount.com" \
+    --role="roles/secretmanager.secretAccessor"
+done
+```
+
+### Step 5: Update config files with references
+
+Main agent's `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        project: "my-project",
+        credentialsFile: "/home/user/.config/gcp/openclaw-main-sa.json",
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        apiKey: "${gcp:openclaw-main-brave-api-key}",
+      },
+    },
+  },
+  gateway: {
+    auth: {
+      token: "${gcp:openclaw-main-gateway-token}",
+    },
+  },
+}
+```
+
+### Step 6: Purge plaintext files
+
+Only after verifying all references resolve (`openclaw secrets test`):
+
+```bash
+# Replace file contents with migration notes
+echo "# Migrated to GCP Secret Manager" > ~/.config/openai/credentials.env
+echo "# Migrated to GCP Secret Manager" > ~/.config/alpaca/sandbox.env
+echo "# Migrated to GCP Secret Manager" > ~/.config/himalaya/.nine30-pass
+```
+
+### After
+
+```
+GCP Secret Manager (encrypted, access-controlled):
+  openclaw-main-openai-api-key      → only main SA can read
+  openclaw-main-brave-api-key       → only main SA can read
+  openclaw-main-gateway-token       → only main SA can read
+  openclaw-main-email-password      → only main SA can read
+  openclaw-chai-alpaca-key-id       → only chai SA can read
+  openclaw-chai-alpaca-secret-key   → only chai SA can read
+
+Local disk:
+  ~/.config/gcp/openclaw-main-sa.json  (SA key — the only secret on disk)
+  ~/.config/gcp/openclaw-chai-sa.json  (SA key — the only secret on disk)
+  openclaw.json                        (contains ${gcp:...} refs, safe to commit)
+```
+
+> **Note:** The SA key files are the one remaining secret on disk. Protect them with `chmod 600` and restrict filesystem access. On GKE or Cloud Run, use Workload Identity to eliminate even these files.
+
+### External scripts
+
+Scripts that need secrets (e.g., monitoring scripts, cron jobs) can also use per-agent SA keys:
+
+```python
+from google.cloud import secretmanager
+
+# Use Chai's SA key — can only access openclaw-chai-* secrets
+client = secretmanager.SecretManagerServiceClient.from_service_account_json(
+    "/home/user/.config/gcp/openclaw-chai-sa.json"
+)
+response = client.access_secret_version(
+    request={"name": "projects/my-project/secrets/openclaw-chai-alpaca-key-id/versions/latest"}
+)
+api_key = response.payload.data.decode("utf-8")
+```
+
+## Migration
+
+To migrate existing plaintext secrets:
+
+```bash
+openclaw secrets migrate
+```
+
+This will:
+
+1. Scan config files for sensitive values (API keys, tokens)
+2. Upload each to GCP Secret Manager
+3. Replace plaintext values with `${gcp:name}` references
+4. Verify all references resolve
+5. Prompt before purging plaintext originals
+
+Pass `--yes` to skip confirmation prompts. Plaintext is **never** purged unless the upload and verification succeed.
+
+## Caching
+
+- Secrets are cached **in memory only** (never written to disk)
+- Default TTL: 300 seconds (configurable per-provider)
+- Cache is cleared on `SIGUSR1` restart
+- **Stale-while-revalidate**: if the provider is unreachable and cached values exist (even expired), stale values are used and a warning is logged
+
+## CLI Commands
+
+| Command                    | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `openclaw secrets setup`   | Bootstrap GCP Secret Manager (enable API, create SAs, configure IAM) |
+| `openclaw secrets test`    | Verify all secret references resolve successfully                    |
+| `openclaw secrets list`    | List configured providers and their status                           |
+| `openclaw secrets set`     | Store a secret manually                                              |
+| `openclaw secrets migrate` | Migrate plaintext secrets to the store                               |
+
+## Error Handling
+
+| Error                                        | Behavior                                                                |
+| -------------------------------------------- | ----------------------------------------------------------------------- |
+| Provider not configured                      | Feature using the secret fails; system continues                        |
+| Secret not found                             | Clear error: "Secret 'name' not found in project 'project'"             |
+| Permission denied                            | Clear error: "Permission denied for secret 'name'. Check IAM bindings." |
+| Network timeout                              | Retry once; fall back to stale cache if available                       |
+| `@google-cloud/secret-manager` not installed | Clear error with install instructions                                   |
+
+## Backward Compatibility
+
+- **Entirely opt-in**: no `secrets` config = no behavior change
+- `@google-cloud/secret-manager` is an optional dependency
+- Existing env var substitution (`${UPPER_CASE}`) is unaffected
+- Config files without secret refs pass through unchanged

--- a/package.json
+++ b/package.json
@@ -343,6 +343,7 @@
     "@buape/carbon": "0.0.0-beta-20260216184201",
     "@clack/prompts": "^1.1.0",
     "@discordjs/voice": "^0.19.1",
+    "@google-cloud/secret-manager": "^6.1.1",
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1373,6 +1373,15 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@google-cloud/secret-manager@6.1.1':
     resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
     engines: {node: '>=18'}
@@ -8675,6 +8684,10 @@ snapshots:
 
   '@eshaz/web-worker@1.2.2':
     optional: true
+
+  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
 
   '@google-cloud/secret-manager@6.1.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@discordjs/voice':
         specifier: ^0.19.1
         version: 0.19.1(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@google-cloud/secret-manager':
+        specifier: ^6.1.1
+        version: 6.1.1
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.41.1)
@@ -1370,14 +1373,9 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
-  '@exodus/bytes@1.15.0':
-    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@noble/hashes': ^1.8.0 || ^2.0.0
-    peerDependenciesMeta:
-      '@noble/hashes':
-        optional: true
+  '@google-cloud/secret-manager@6.1.1':
+    resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
+    engines: {node: '>=18'}
 
   '@google/genai@1.44.0':
     resolution: {integrity: sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==}
@@ -3468,6 +3466,10 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -4426,6 +4428,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -4780,6 +4785,10 @@ packages:
     resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
     engines: {node: '>=18'}
 
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
+    engines: {node: '>=18'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -4877,6 +4886,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -5611,6 +5624,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -5937,6 +5954,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
   protobufjs@6.8.8:
     resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
     hasBin: true
@@ -6123,6 +6144,10 @@ packages:
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
     engines: {node: '>=18'}
 
   retry@0.12.0:
@@ -6419,6 +6444,12 @@ packages:
     resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
     engines: {node: '>=18'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
@@ -6470,6 +6501,9 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6490,6 +6524,10 @@ packages:
 
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+    engines: {node: '>=18'}
+
+  teeny-request@10.1.0:
+    resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -8638,9 +8676,11 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
-    optionalDependencies:
-      '@noble/hashes': 2.0.1
+  '@google-cloud/secret-manager@6.1.1':
+    dependencies:
+      google-gax: 5.0.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@google/genai@1.44.0':
     dependencies:
@@ -11000,6 +11040,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tootallnate/once@2.0.0': {}
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@twurple/api-call@8.0.3':
@@ -11462,7 +11504,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agent-base@7.1.4: {}
 
@@ -12045,6 +12086,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
 
   ecc-jsbn@0.1.2:
@@ -12515,6 +12563,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.6.1
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -12631,6 +12695,14 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -12650,7 +12722,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -13424,6 +13495,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@3.0.0: {}
+
   object-inspect@1.13.4: {}
 
   object-path@0.11.8: {}
@@ -13836,6 +13909,10 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.5.4
+
   protobufjs@6.8.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -14035,7 +14112,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   readdirp@5.0.0: {}
 
@@ -14087,6 +14163,13 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   retry@0.12.0: {}
 
@@ -14471,6 +14554,12 @@ snapshots:
 
   steno@4.0.2: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   streamx@2.23.0:
     dependencies:
       events-universal: 1.0.1
@@ -14510,7 +14599,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -14534,6 +14622,8 @@ snapshots:
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  stubs@3.0.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -14566,6 +14656,15 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teeny-request@10.1.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   teex@1.0.1:
     dependencies:

--- a/src/config/azure-secret-provider.test.ts
+++ b/src/config/azure-secret-provider.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AzureSecretProvider,
+  validateAzureSecretName,
+  parseAzureRotationTags,
+  buildAzureRotationTags,
+  checkSecretVersionChanged,
+  type AzureSecretClient,
+  type AzureSecretConfig,
+  type AzureRotationMetadata,
+} from "./azure-secret-provider.js";
+
+// ---------------------------------------------------------------------------
+// Mock client factory
+// ---------------------------------------------------------------------------
+
+function createMockClient(
+  secrets: Record<string, { value: string; version?: string; tags?: Record<string, string> }> = {},
+): AzureSecretClient {
+  return {
+    getSecret: vi.fn(async (name: string, opts?: { version?: string }) => {
+      const entry = secrets[name];
+      if (!entry) {
+        const err = new Error(`Secret '${name}' not found`) as Error & {
+          statusCode: number;
+          code: string;
+        };
+        err.statusCode = 404;
+        err.code = "SecretNotFound";
+        throw err;
+      }
+      return {
+        value: entry.value,
+        properties: { version: opts?.version ?? entry.version ?? "v1", tags: entry.tags ?? {} },
+      };
+    }),
+    setSecret: vi.fn(async (_name: string, _value: string) => ({
+      properties: { version: "v2" },
+    })),
+    listPropertiesOfSecrets: vi.fn(function (): AsyncIterable<{ name: string }> {
+      const names = Object.keys(secrets);
+      let i = 0;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              if (i < names.length) {
+                return { value: { name: names[i++] }, done: false };
+              }
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      };
+    }),
+  };
+}
+
+function makeProvider(
+  client: AzureSecretClient,
+  configOverrides?: Partial<AzureSecretConfig>,
+): AzureSecretProvider {
+  return new AzureSecretProvider(
+    { vaultUrl: "https://test-vault.vault.azure.net", ...configOverrides },
+    client,
+  );
+}
+
+// ===========================================================================
+// Name Validation
+// ===========================================================================
+
+describe("validateAzureSecretName", () => {
+  it("accepts valid names", () => {
+    expect(() => validateAzureSecretName("my-secret")).not.toThrow();
+    expect(() => validateAzureSecretName("MySecret123")).not.toThrow();
+    expect(() => validateAzureSecretName("a")).not.toThrow();
+  });
+
+  it("rejects names with underscores", () => {
+    expect(() => validateAzureSecretName("my_secret")).toThrow(/only allow alphanumeric/);
+  });
+
+  it("rejects names with dots", () => {
+    expect(() => validateAzureSecretName("my.secret")).toThrow(/only allow alphanumeric/);
+  });
+
+  it("rejects names with slashes", () => {
+    expect(() => validateAzureSecretName("path/to/secret")).toThrow(/only allow alphanumeric/);
+  });
+
+  it("rejects empty string", () => {
+    expect(() => validateAzureSecretName("")).toThrow(/only allow alphanumeric/);
+  });
+});
+
+// ===========================================================================
+// AzureSecretProvider
+// ===========================================================================
+
+describe("AzureSecretProvider", () => {
+  describe("constructor / properties", () => {
+    it("has name 'azure'", () => {
+      const provider = makeProvider(createMockClient());
+      expect(provider.name).toBe("azure");
+    });
+
+    it("defaults cacheTtl to 300s", () => {
+      const provider = makeProvider(createMockClient());
+      expect(provider.cacheTtlMillis).toBe(300_000);
+    });
+
+    it("respects custom cacheTtlSeconds", () => {
+      const provider = makeProvider(createMockClient(), { cacheTtlSeconds: 60 });
+      expect(provider.cacheTtlMillis).toBe(60_000);
+    });
+  });
+
+  describe("getSecret", () => {
+    it("resolves a secret by name", async () => {
+      const client = createMockClient({ "my-secret": { value: "s3cret" } });
+      const provider = makeProvider(client);
+
+      const val = await provider.getSecret("my-secret");
+      expect(val).toBe("s3cret");
+      expect(vi.mocked(client.getSecret)).toHaveBeenCalledWith("my-secret", undefined);
+    });
+
+    it("resolves a versioned secret", async () => {
+      const client = createMockClient({ "my-secret": { value: "old-val", version: "v1" } });
+      const provider = makeProvider(client);
+
+      await provider.getSecret("my-secret", "v1");
+      expect(vi.mocked(client.getSecret)).toHaveBeenCalledWith("my-secret", { version: "v1" });
+    });
+
+    it("throws on not found (404)", async () => {
+      const client = createMockClient({});
+      const provider = makeProvider(client);
+
+      await expect(provider.getSecret("missing")).rejects.toThrow(
+        "Secret 'missing' not found in vault",
+      );
+    });
+
+    it("throws on permission denied (403)", async () => {
+      const client = createMockClient({});
+      (client.getSecret as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        Object.assign(new Error("Forbidden"), { statusCode: 403, code: "Forbidden" }),
+      );
+      const provider = makeProvider(client);
+
+      await expect(provider.getSecret("restricted")).rejects.toThrow(/Permission denied/);
+    });
+
+    it("throws on CredentialUnavailableError", async () => {
+      const client = createMockClient({});
+      (client.getSecret as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        Object.assign(new Error("No creds"), { code: "CredentialUnavailableError" }),
+      );
+      const provider = makeProvider(client);
+
+      await expect(provider.getSecret("any-secret")).rejects.toThrow(/az login/);
+    });
+
+    it("throws on undefined value", async () => {
+      const client = createMockClient({});
+      (client.getSecret as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        value: undefined,
+        properties: { version: "v1" },
+      });
+      const provider = makeProvider(client);
+
+      await expect(provider.getSecret("empty-secret")).rejects.toThrow(/has no value/);
+    });
+
+    it("validates secret name before fetching", async () => {
+      const client = createMockClient({});
+      const provider = makeProvider(client);
+
+      await expect(provider.getSecret("invalid_name")).rejects.toThrow(/only allow alphanumeric/);
+      expect(vi.mocked(client.getSecret)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("setSecret", () => {
+    it("stores a secret", async () => {
+      const client = createMockClient({});
+      const provider = makeProvider(client);
+
+      await provider.setSecret("new-secret", "value123");
+      expect(vi.mocked(client.setSecret)).toHaveBeenCalledWith("new-secret", "value123");
+    });
+
+    it("validates name before storing", async () => {
+      const client = createMockClient({});
+      const provider = makeProvider(client);
+
+      await expect(provider.setSecret("bad.name", "val")).rejects.toThrow(
+        /only allow alphanumeric/,
+      );
+      expect(vi.mocked(client.setSecret)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listSecrets", () => {
+    it("returns all secret names", async () => {
+      const client = createMockClient({
+        "secret-a": { value: "a" },
+        "secret-b": { value: "b" },
+      });
+      const provider = makeProvider(client);
+
+      const names = await provider.listSecrets();
+      expect(names).toEqual(["secret-a", "secret-b"]);
+    });
+
+    it("returns empty array when no secrets", async () => {
+      const client = createMockClient({});
+      const provider = makeProvider(client);
+
+      const names = await provider.listSecrets();
+      expect(names).toEqual([]);
+    });
+  });
+
+  describe("testConnection", () => {
+    it("returns ok:true on success", async () => {
+      const client = createMockClient({ s: { value: "v" } });
+      const provider = makeProvider(client);
+
+      const result = await provider.testConnection();
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("returns ok:false with error message on failure", async () => {
+      const client = createMockClient({});
+      (client.listPropertiesOfSecrets as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              throw new Error("Connection refused");
+            },
+          };
+        },
+      });
+      const provider = makeProvider(client);
+
+      const result = await provider.testConnection();
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("Connection refused");
+    });
+  });
+
+  describe("SDK not installed", () => {
+    it("throws helpful message when @azure/identity is missing", async () => {
+      // Create provider without client override — will try real import
+      const provider = new AzureSecretProvider({
+        vaultUrl: "https://test.vault.azure.net",
+      });
+
+      await expect(provider.getSecret("test")).rejects.toThrow(/pnpm add/);
+    });
+  });
+});
+
+// ===========================================================================
+// Rotation Tags
+// ===========================================================================
+
+describe("Azure Rotation Tags", () => {
+  describe("parseAzureRotationTags", () => {
+    it("parses complete tags", () => {
+      const tags = {
+        "rotation-type": "manual",
+        "rotation-interval-days": "30",
+        "last-rotated": "2026-01-15T10:00:00.000Z",
+        "expires-at": "2026-04-15T10:00:00.000Z",
+      };
+      const meta = parseAzureRotationTags(tags);
+      expect(meta.rotationType).toBe("manual");
+      expect(meta.rotationIntervalDays).toBe(30);
+      expect(meta.lastRotated).toEqual(new Date("2026-01-15T10:00:00.000Z"));
+      expect(meta.expiresAt).toEqual(new Date("2026-04-15T10:00:00.000Z"));
+    });
+
+    it("defaults to manual/90 days for empty tags", () => {
+      const meta = parseAzureRotationTags({});
+      expect(meta.rotationType).toBe("manual");
+      expect(meta.rotationIntervalDays).toBe(90);
+      expect(meta.lastRotated).toBeUndefined();
+    });
+
+    it("handles auto rotation type", () => {
+      const meta = parseAzureRotationTags({ "rotation-type": "auto" });
+      expect(meta.rotationType).toBe("auto");
+    });
+
+    it("handles invalid dates gracefully", () => {
+      const meta = parseAzureRotationTags({ "last-rotated": "not-a-date" });
+      expect(meta.lastRotated).toBeUndefined();
+    });
+
+    it("handles invalid interval gracefully", () => {
+      const meta = parseAzureRotationTags({ "rotation-interval-days": "abc" });
+      expect(meta.rotationIntervalDays).toBe(90);
+    });
+
+    it("handles negative interval gracefully", () => {
+      const meta = parseAzureRotationTags({ "rotation-interval-days": "-5" });
+      expect(meta.rotationIntervalDays).toBe(90);
+    });
+  });
+
+  describe("buildAzureRotationTags", () => {
+    it("builds tags from metadata", () => {
+      const meta: AzureRotationMetadata = {
+        rotationType: "manual",
+        rotationIntervalDays: 30,
+        lastRotated: new Date("2026-01-15T10:00:00.000Z"),
+      };
+      const tags = buildAzureRotationTags(meta);
+      expect(tags["rotation-type"]).toBe("manual");
+      expect(tags["rotation-interval-days"]).toBe("30");
+      expect(tags["last-rotated"]).toBe("2026-01-15T10:00:00.000Z");
+      expect(tags["expires-at"]).toBeUndefined();
+    });
+
+    it("round-trips through parse", () => {
+      const original: AzureRotationMetadata = {
+        rotationType: "dynamic",
+        rotationIntervalDays: 7,
+        lastRotated: new Date("2026-02-01T00:00:00.000Z"),
+        expiresAt: new Date("2026-03-01T00:00:00.000Z"),
+        snoozedUntil: new Date("2026-02-10T00:00:00.000Z"),
+      };
+      const tags = buildAzureRotationTags(original);
+      const parsed = parseAzureRotationTags(tags);
+      expect(parsed).toEqual(original);
+    });
+  });
+});
+
+// ===========================================================================
+// Rotation Detection (Version Polling)
+// ===========================================================================
+
+describe("checkSecretVersionChanged", () => {
+  it("detects version change", async () => {
+    const client = createMockClient({ "my-secret": { value: "new", version: "v2" } });
+    const result = await checkSecretVersionChanged(client, "my-secret", "v1");
+    expect(result.changed).toBe(true);
+    expect(result.currentVersion).toBe("v2");
+  });
+
+  it("returns false when version matches", async () => {
+    const client = createMockClient({ "my-secret": { value: "val", version: "v1" } });
+    const result = await checkSecretVersionChanged(client, "my-secret", "v1");
+    expect(result.changed).toBe(false);
+  });
+
+  it("returns false when no cached version", async () => {
+    const client = createMockClient({ "my-secret": { value: "val", version: "v1" } });
+    const result = await checkSecretVersionChanged(client, "my-secret", undefined);
+    expect(result.changed).toBe(false);
+    expect(result.currentVersion).toBe("v1");
+  });
+});
+
+// ===========================================================================
+// SecretProvider interface compliance
+// ===========================================================================
+
+describe("SecretProvider interface compliance", () => {
+  it("implements all required methods", () => {
+    const provider = makeProvider(createMockClient());
+    expect(typeof provider.getSecret).toBe("function");
+    expect(typeof provider.setSecret).toBe("function");
+    expect(typeof provider.listSecrets).toBe("function");
+    expect(typeof provider.testConnection).toBe("function");
+    expect(provider.name).toBe("azure");
+  });
+});

--- a/src/config/azure-secret-provider.ts
+++ b/src/config/azure-secret-provider.ts
@@ -1,0 +1,302 @@
+/**
+ * Azure Key Vault secret provider for OpenClaw.
+ *
+ * Uses `@azure/keyvault-secrets` + `@azure/identity` (lazy-loaded, optional peer deps).
+ * Auth: DefaultAzureCredential chain (env vars, managed identity, Azure CLI, service principal).
+ *
+ * Config:
+ *   secrets.providers.azure = {
+ *     vaultUrl: "https://my-vault.vault.azure.net",
+ *     tenantId?: string,
+ *     clientId?: string,
+ *     clientSecret?: string,
+ *     credentialsFile?: string,
+ *     cacheTtlSeconds?: number   // default 300
+ *   }
+ */
+
+import type { SecretProvider } from "./secret-resolution.js";
+
+// ---------------------------------------------------------------------------
+// Types (mirrors Azure SDK types for testability)
+// ---------------------------------------------------------------------------
+
+export interface AzureSecretConfig {
+  vaultUrl: string;
+  tenantId?: string;
+  clientId?: string;
+  clientSecret?: string;
+  credentialsFile?: string;
+  cacheTtlSeconds?: number;
+}
+
+/** Minimal SecretClient interface for mocking. */
+export interface AzureSecretClient {
+  getSecret: (
+    name: string,
+    options?: { version?: string },
+  ) => Promise<{ value?: string; properties: { version?: string; tags?: Record<string, string> } }>;
+  setSecret: (
+    name: string,
+    value: string,
+    options?: { tags?: Record<string, string> },
+  ) => Promise<{ properties: { version?: string } }>;
+  listPropertiesOfSecrets: () => AsyncIterable<{ name: string }>;
+}
+
+/** Minimal credential interface. */
+export interface AzureCredential {
+  getToken(scope: string): Promise<{ token: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy import helper
+// ---------------------------------------------------------------------------
+
+async function lazyImport<T>(pkg: string): Promise<T> {
+  try {
+    return await import(pkg);
+  } catch {
+    throw new Error(`Please install ${pkg}: pnpm add ${pkg}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Name validation
+// ---------------------------------------------------------------------------
+
+const AZURE_SECRET_NAME_RE = /^[a-zA-Z0-9-]+$/;
+
+export function validateAzureSecretName(name: string): void {
+  if (!AZURE_SECRET_NAME_RE.test(name)) {
+    throw new Error(
+      `Azure Key Vault secret names only allow alphanumeric characters and hyphens. Got: "${name}"`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+function mapAzureError(err: unknown, secretName: string, vaultUrl: string): Error {
+  const statusCode = (err as { statusCode?: number })?.statusCode;
+  const code = (err as { code?: string })?.code;
+
+  if (statusCode === 404 || code === "SecretNotFound") {
+    return new Error(`Secret '${secretName}' not found in vault '${vaultUrl}'`);
+  }
+  if (statusCode === 403 || code === "Forbidden") {
+    return new Error(
+      `Permission denied for secret '${secretName}'. Check Key Vault access policy or RBAC.`,
+    );
+  }
+  if (code === "CredentialUnavailableError") {
+    return new Error("Azure credentials not found. Run `az login` or set AZURE_* env vars.");
+  }
+
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+// ---------------------------------------------------------------------------
+// AzureSecretProvider
+// ---------------------------------------------------------------------------
+
+export class AzureSecretProvider implements SecretProvider {
+  public readonly name = "azure";
+  private readonly vaultUrl: string;
+  private readonly cacheTtlMs: number;
+  private readonly config: AzureSecretConfig;
+
+  // Injected for testing; otherwise lazily created
+  private _clientOverride?: AzureSecretClient;
+
+  constructor(config: AzureSecretConfig, clientOverride?: AzureSecretClient) {
+    this.vaultUrl = config.vaultUrl;
+    this.cacheTtlMs = (config.cacheTtlSeconds ?? 300) * 1000;
+    this.config = config;
+    this._clientOverride = clientOverride;
+  }
+
+  /** Cache TTL in ms — exposed for integration with shared fetchWithCache. */
+  get cacheTtlMillis(): number {
+    return this.cacheTtlMs;
+  }
+
+  private async getClient(): Promise<AzureSecretClient> {
+    if (this._clientOverride) {
+      return this._clientOverride;
+    }
+
+    const identityMod = await lazyImport<{
+      DefaultAzureCredential: new () => AzureCredential;
+      ClientSecretCredential: new (
+        tenantId: string,
+        clientId: string,
+        clientSecret: string,
+      ) => AzureCredential;
+    }>("@azure/identity");
+
+    const kvMod = await lazyImport<{
+      SecretClient: new (url: string, credential: AzureCredential) => AzureSecretClient;
+    }>("@azure/keyvault-secrets");
+
+    let credential: AzureCredential;
+
+    if (this.config.credentialsFile) {
+      // Read credentials from file
+      const fs = await import("node:fs/promises");
+      const raw = await fs.readFile(this.config.credentialsFile, "utf-8");
+      const creds = JSON.parse(raw) as {
+        tenantId: string;
+        clientId: string;
+        clientSecret: string;
+      };
+      credential = new identityMod.ClientSecretCredential(
+        creds.tenantId,
+        creds.clientId,
+        creds.clientSecret,
+      );
+    } else if (this.config.tenantId && this.config.clientId && this.config.clientSecret) {
+      credential = new identityMod.ClientSecretCredential(
+        this.config.tenantId,
+        this.config.clientId,
+        this.config.clientSecret,
+      );
+    } else {
+      credential = new identityMod.DefaultAzureCredential();
+    }
+
+    return new kvMod.SecretClient(this.vaultUrl, credential);
+  }
+
+  async getSecret(secretName: string, version?: string): Promise<string> {
+    validateAzureSecretName(secretName);
+
+    const client = await this.getClient();
+    try {
+      const opts = version ? { version } : undefined;
+      const result = await client.getSecret(secretName, opts);
+      if (result.value === undefined) {
+        throw new Error(`Secret "${secretName}" has no value`);
+      }
+      return result.value;
+    } catch (err) {
+      throw mapAzureError(err, secretName, this.vaultUrl);
+    }
+  }
+
+  async setSecret(secretName: string, value: string): Promise<void> {
+    validateAzureSecretName(secretName);
+
+    const client = await this.getClient();
+    try {
+      await client.setSecret(secretName, value);
+    } catch (err) {
+      throw mapAzureError(err, secretName, this.vaultUrl);
+    }
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const client = await this.getClient();
+    const names: string[] = [];
+    try {
+      for await (const props of client.listPropertiesOfSecrets()) {
+        if (props.name) {
+          names.push(props.name);
+        }
+      }
+    } catch (err) {
+      throw mapAzureError(err, "(list)", this.vaultUrl);
+    }
+    return names;
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const client = await this.getClient();
+      // Try to list at least one secret to verify connectivity + auth
+      const iter = client.listPropertiesOfSecrets();
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of iter) {
+        break; // just need one iteration
+      }
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rotation metadata helpers (Azure secret tags)
+// ---------------------------------------------------------------------------
+
+export type AzureRotationType = "auto" | "manual" | "dynamic";
+
+export interface AzureRotationMetadata {
+  rotationType: AzureRotationType;
+  rotationIntervalDays: number;
+  lastRotated?: Date;
+  expiresAt?: Date;
+  snoozedUntil?: Date;
+}
+
+export function parseAzureRotationTags(tags: Record<string, string>): AzureRotationMetadata {
+  const VALID = new Set<AzureRotationType>(["auto", "manual", "dynamic"]);
+  const rawType = tags["rotation-type"] as AzureRotationType | undefined;
+  const rotationType: AzureRotationType = rawType && VALID.has(rawType) ? rawType : "manual";
+
+  const rawInterval = parseInt(tags["rotation-interval-days"] ?? "", 10);
+  const rotationIntervalDays = isNaN(rawInterval) || rawInterval <= 0 ? 90 : rawInterval;
+
+  const parseDate = (s?: string): Date | undefined => {
+    if (!s) {
+      return undefined;
+    }
+    const d = new Date(s);
+    return isNaN(d.getTime()) ? undefined : d;
+  };
+
+  return {
+    rotationType,
+    rotationIntervalDays,
+    lastRotated: parseDate(tags["last-rotated"]),
+    expiresAt: parseDate(tags["expires-at"]),
+    snoozedUntil: parseDate(tags["snoozed-until"]),
+  };
+}
+
+export function buildAzureRotationTags(meta: AzureRotationMetadata): Record<string, string> {
+  const tags: Record<string, string> = {
+    "rotation-type": meta.rotationType,
+    "rotation-interval-days": String(meta.rotationIntervalDays),
+  };
+  if (meta.lastRotated) {
+    tags["last-rotated"] = meta.lastRotated.toISOString();
+  }
+  if (meta.expiresAt) {
+    tags["expires-at"] = meta.expiresAt.toISOString();
+  }
+  if (meta.snoozedUntil) {
+    tags["snoozed-until"] = meta.snoozedUntil.toISOString();
+  }
+  return tags;
+}
+
+/**
+ * Check if a secret's version has changed (rotation detection via polling).
+ * Compare cached version ID with current version from Key Vault.
+ */
+export async function checkSecretVersionChanged(
+  client: AzureSecretClient,
+  secretName: string,
+  cachedVersion?: string,
+): Promise<{ changed: boolean; currentVersion?: string }> {
+  const result = await client.getSecret(secretName);
+  const currentVersion = result.properties.version;
+  if (!cachedVersion || !currentVersion) {
+    return { changed: false, currentVersion };
+  }
+  return { changed: cachedVersion !== currentVersion, currentVersion };
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -26,3 +26,12 @@ export {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "./validation.js";
+export { OpenClawSchema } from "./zod-schema.js";
+export {
+  resolveConfigSecrets,
+  configNeedsSecretResolution,
+  clearSecretCache,
+  SecretResolutionError,
+  UnknownSecretProviderError,
+} from "./secret-resolution.js";
+export type { SecretsConfig, SecretProvider } from "./secret-resolution.js";

--- a/src/config/secret-resolution.ts
+++ b/src/config/secret-resolution.ts
@@ -1,0 +1,512 @@
+/**
+ * Secret reference resolution for config values.
+ *
+ * Supports `${provider:secret-name}` and `${provider:secret-name#version}` syntax.
+ * Provider must be lowercase. Secret names allow: [a-zA-Z0-9_\-/.]
+ * Version pinning via #version suffix (default: latest).
+ * Escape with `$${provider:name}` to produce literal `${provider:name}`.
+ */
+
+import { isPlainObject } from "../utils.js";
+import { AzureSecretProvider } from "./azure-secret-provider.js";
+
+// Matches ${provider:name} or ${provider:name#version}
+// Provider: lowercase alpha. Name: alphanum, hyphens, underscores, slashes, dots.
+// Version (optional): after #, alphanumeric.
+const SECRET_REF_PATTERN = /\$\{([a-z]+):([a-zA-Z0-9_\-/.]+?)(?:#([a-zA-Z0-9]+))?\}/g;
+
+/** Parsed secret reference. */
+export interface SecretRef {
+  provider: string;
+  name: string;
+  version?: string;
+}
+
+/** Configuration for the secrets section in openclaw.json. */
+export type SecretsConfig = {
+  providers?: Record<
+    string,
+    {
+      project?: string;
+      cacheTtlSeconds?: number;
+      credentialsFile?: string;
+      // AWS-specific
+      region?: string;
+      profile?: string;
+      roleArn?: string;
+      externalId?: string;
+      // Keyring-specific
+      account?: string;
+      keychainPath?: string;
+      keychainPassword?: string;
+      // 1Password-specific
+      vault?: string;
+      field?: string;
+      // Azure-specific
+      vaultUrl?: string;
+      tenantId?: string;
+      clientId?: string;
+      clientSecret?: string;
+    }
+  >;
+};
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class SecretResolutionError extends Error {
+  constructor(
+    public readonly provider: string,
+    public readonly secretName: string,
+    public readonly configPath: string,
+    cause?: Error,
+  ) {
+    super(
+      `Failed to resolve secret "${provider}:${secretName}" at config path: ${configPath}${cause ? ` — ${cause.message}` : ""}`,
+    );
+    this.name = "SecretResolutionError";
+    this.cause = cause;
+  }
+}
+
+export class UnknownSecretProviderError extends Error {
+  constructor(
+    public readonly provider: string,
+    public readonly configPath: string,
+  ) {
+    super(`Unknown secret provider "${provider}" referenced at config path: ${configPath}`);
+    this.name = "UnknownSecretProviderError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+type CacheEntry = { value: string; expiresAt: number };
+const secretCache = new Map<string, CacheEntry>();
+
+export function clearSecretCache(): void {
+  secretCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// SecretProvider interface
+// ---------------------------------------------------------------------------
+
+export interface SecretProvider {
+  name: string;
+  getSecret(name: string, version?: string): Promise<string>;
+  setSecret(name: string, value: string): Promise<void>;
+  listSecrets(): Promise<string[]>;
+  testConnection(): Promise<{ ok: boolean; error?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// GcpSecretProvider
+// ---------------------------------------------------------------------------
+
+/** Minimal interface for the GCP SecretManagerServiceClient used at runtime. */
+interface GcpSmClient {
+  accessSecretVersion(req: {
+    name: string;
+  }): Promise<[{ payload?: { data?: Uint8Array | string } } | undefined]>;
+  createSecret(req: {
+    parent: string;
+    secretId: string;
+    secret: { replication: { automatic: Record<string, never> } };
+  }): Promise<unknown>;
+  addSecretVersion(req: { parent: string; payload: { data: Buffer } }): Promise<unknown>;
+  listSecrets(req: { parent: string }): Promise<[Array<{ name?: string }>]>;
+}
+
+export class GcpSecretProvider implements SecretProvider {
+  public readonly name = "gcp";
+  private readonly project: string;
+  private readonly cacheTtlMs: number;
+  private readonly credentialsFile?: string;
+  constructor(config: { project: string; cacheTtlSeconds?: number; credentialsFile?: string }) {
+    this.project = config.project;
+    this.cacheTtlMs = (config.cacheTtlSeconds ?? 300) * 1000;
+    this.credentialsFile = config.credentialsFile;
+  }
+
+  private async getClient(): Promise<GcpSmClient> {
+    try {
+      const mod = await import("@google-cloud/secret-manager");
+      const Ctor = mod.SecretManagerServiceClient;
+      const opts = this.credentialsFile ? { keyFilename: this.credentialsFile } : {};
+      // Support both `new Ctor(opts)` (real) and mock functions that don't support `new`
+      try {
+        return new (Ctor as unknown as new (o: Record<string, unknown>) => GcpSmClient)(opts);
+      } catch {
+        // Fallback for mock functions that don't support new operator
+        return (Ctor as unknown as (o: Record<string, unknown>) => GcpSmClient)(opts);
+      }
+    } catch {
+      throw new Error(
+        "Please install @google-cloud/secret-manager to use GCP secrets: pnpm add @google-cloud/secret-manager",
+      );
+    }
+  }
+
+  async getSecret(secretName: string, version?: string): Promise<string> {
+    const ver = version ?? "latest";
+    const cacheKey = `gcp:${secretName}#${ver}`;
+    const cached = secretCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    const client = await this.getClient();
+    const resourceName = `projects/${this.project}/secrets/${secretName}/versions/${ver}`;
+
+    let response: { payload?: { data?: Uint8Array | string } } | undefined;
+    try {
+      [response] = await client.accessSecretVersion({ name: resourceName });
+    } catch (err: unknown) {
+      const code = (err as { code?: number })?.code;
+      if (code === 5) {
+        throw new Error(`Secret '${secretName}' not found in project '${this.project}'`, {
+          cause: err,
+        });
+      }
+      if (code === 7) {
+        throw new Error(`Permission denied for secret '${secretName}'. Check IAM bindings.`, {
+          cause: err,
+        });
+      }
+      if (code === 4) {
+        // Retry once
+        try {
+          const retryClient = await this.getClient();
+          [response] = await retryClient.accessSecretVersion({ name: resourceName });
+        } catch {
+          if (cached) {
+            return cached.value;
+          }
+          throw err;
+        }
+      } else {
+        throw err;
+      }
+    }
+
+    const payload = response?.payload?.data;
+    if (!payload) {
+      throw new Error(`Secret "${secretName}" has no payload data`);
+    }
+
+    const value =
+      payload instanceof Uint8Array || Buffer.isBuffer(payload)
+        ? Buffer.from(payload).toString("utf-8")
+        : String(payload);
+
+    secretCache.set(cacheKey, { value, expiresAt: Date.now() + this.cacheTtlMs });
+    return value;
+  }
+
+  async setSecret(secretName: string, value: string): Promise<void> {
+    const client = await this.getClient();
+    const parent = `projects/${this.project}`;
+
+    try {
+      await client.createSecret({
+        parent,
+        secretId: secretName,
+        secret: { replication: { automatic: {} } },
+      });
+    } catch {
+      // Secret may already exist; other errors will surface on addSecretVersion
+    }
+
+    await client.addSecretVersion({
+      parent: `${parent}/secrets/${secretName}`,
+      payload: { data: Buffer.from(value, "utf-8") },
+    });
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const client = await this.getClient();
+    const [secrets] = await client.listSecrets({
+      parent: `projects/${this.project}`,
+    });
+    return (secrets || []).map((s: { name?: string }) => {
+      const name: string = s.name || "";
+      const parts = name.split("/");
+      return parts[parts.length - 1];
+    });
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const client = await this.getClient();
+      await client.listSecrets({ parent: `projects/${this.project}` });
+      return { ok: true };
+    } catch (err: unknown) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reference detection & extraction
+// ---------------------------------------------------------------------------
+
+export function containsSecretReference(value: string): boolean {
+  if (!value.includes("${")) {
+    return false;
+  }
+  SECRET_REF_PATTERN.lastIndex = 0;
+  return SECRET_REF_PATTERN.test(value);
+}
+
+/** Remove escaped refs before extraction so $${gcp:x} isn't treated as a ref. */
+function stripEscapedRefs(value: string): string {
+  return value.replace(/\$\$\{[a-z]+:[a-zA-Z0-9_\-/.]+(?:#[a-zA-Z0-9]+)?\}/g, "");
+}
+
+export function extractSecretReferences(obj: unknown): SecretRef[] {
+  const refs: SecretRef[] = [];
+  const seen = new Set<string>();
+
+  function walk(value: unknown): void {
+    if (typeof value === "string" && value.includes("${")) {
+      const cleaned = stripEscapedRefs(value);
+      SECRET_REF_PATTERN.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = SECRET_REF_PATTERN.exec(cleaned)) !== null) {
+        const key = `${match[1]}:${match[2]}${match[3] ? "#" + match[3] : ""}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          const ref: SecretRef = { provider: match[1], name: match[2] };
+          if (match[3]) {
+            ref.version = match[3];
+          }
+          refs.push(ref);
+        }
+      }
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        walk(item);
+      }
+    } else if (isPlainObject(value)) {
+      for (const val of Object.values(value)) {
+        walk(val);
+      }
+    }
+  }
+
+  walk(obj);
+  return refs;
+}
+
+export function configNeedsSecretResolution(obj: unknown): boolean {
+  return extractSecretReferences(obj).length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Build providers
+// ---------------------------------------------------------------------------
+
+export function buildSecretProviders(
+  secretsConfig: SecretsConfig | undefined,
+): Map<string, SecretProvider> {
+  const providers = new Map<string, SecretProvider>();
+  if (!secretsConfig?.providers) {
+    return providers;
+  }
+
+  for (const [name, config] of Object.entries(secretsConfig.providers)) {
+    if (name === "gcp" && config && config.project) {
+      providers.set(
+        "gcp",
+        new GcpSecretProvider(
+          config as { project: string; cacheTtlSeconds?: number; credentialsFile?: string },
+        ),
+      );
+    }
+    if (name === "azure") {
+      providers.set(
+        "azure",
+        new AzureSecretProvider({
+          vaultUrl: config?.vaultUrl ?? "",
+          tenantId: config?.tenantId,
+          clientId: config?.clientId,
+          clientSecret: config?.clientSecret,
+          credentialsFile: config?.credentialsFile,
+          cacheTtlSeconds: config?.cacheTtlSeconds,
+        }),
+      );
+    }
+  }
+
+  return providers;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a secret value, checking the shared cache first.
+ * This cache layer sits above individual provider caches, ensuring that
+ * the same secret is not fetched twice within a single resolution pass
+ * regardless of which provider implementation is used.
+ */
+async function fetchWithCache(
+  provider: SecretProvider,
+  name: string,
+  version: string | undefined,
+  cacheTtlMs: number,
+): Promise<string> {
+  const cacheKey = `${provider.name}:${name}#${version ?? "latest"}`;
+  const cached = secretCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  try {
+    const value = await provider.getSecret(name, version);
+    secretCache.set(cacheKey, { value, expiresAt: Date.now() + cacheTtlMs });
+    return value;
+  } catch (err) {
+    // Stale-while-revalidate: if we have an expired entry, use it
+    if (cached) {
+      return cached.value;
+    }
+    throw err;
+  }
+}
+
+async function resolveString(
+  value: string,
+  providers: Map<string, SecretProvider>,
+  configPath: string,
+  cacheTtlMs: number,
+): Promise<string> {
+  if (!value.includes("$")) {
+    return value;
+  }
+
+  // Handle escaped refs first: replace $${ with a placeholder
+  const ESCAPE_PLACEHOLDER = "___OPENCLAW_ESC___";
+  let working = value.replace(/\$\$\{/g, ESCAPE_PLACEHOLDER);
+
+  // Collect matches
+  SECRET_REF_PATTERN.lastIndex = 0;
+  const matches: Array<{ full: string; provider: string; name: string; version?: string }> = [];
+  let match: RegExpExecArray | null;
+  while ((match = SECRET_REF_PATTERN.exec(working)) !== null) {
+    const m: { full: string; provider: string; name: string; version?: string } = {
+      full: match[0],
+      provider: match[1],
+      name: match[2],
+    };
+    if (match[3]) {
+      m.version = match[3];
+    }
+    matches.push(m);
+  }
+
+  if (matches.length === 0) {
+    // Restore escaped refs as literals
+    return working.replaceAll(ESCAPE_PLACEHOLDER, "${");
+  }
+
+  // Resolve all in parallel
+  const resolved = await Promise.all(
+    matches.map(async ({ provider: pName, name, version, full }) => {
+      const provider = providers.get(pName);
+      if (!provider) {
+        throw new UnknownSecretProviderError(pName, configPath);
+      }
+      try {
+        const resolvedValue = await fetchWithCache(provider, name, version, cacheTtlMs);
+        return { full, value: resolvedValue };
+      } catch (err) {
+        throw new SecretResolutionError(
+          pName,
+          name,
+          configPath,
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
+    }),
+  );
+
+  for (const { full, value: sv } of resolved) {
+    working = working.replace(full, sv);
+  }
+
+  // Restore escaped refs
+  working = working.replaceAll(ESCAPE_PLACEHOLDER, "${");
+  return working;
+}
+
+async function resolveAny(
+  value: unknown,
+  providers: Map<string, SecretProvider>,
+  path: string,
+  cacheTtlMs: number,
+): Promise<unknown> {
+  if (typeof value === "string") {
+    return resolveString(value, providers, path, cacheTtlMs);
+  }
+  if (Array.isArray(value)) {
+    return Promise.all(
+      value.map((item, i) => resolveAny(item, providers, `${path}[${i}]`, cacheTtlMs)),
+    );
+  }
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value);
+    const resolved = await Promise.all(
+      entries.map(async ([key, val]) => {
+        const childPath = path ? `${path}.${key}` : key;
+        return [key, await resolveAny(val, providers, childPath, cacheTtlMs)] as const;
+      }),
+    );
+    return Object.fromEntries(resolved);
+  }
+  return value;
+}
+
+/**
+ * Resolve all secret references in a config object.
+ *
+ * @param obj - Config object potentially containing `${provider:name}` references.
+ * @param secretsConfig - The `secrets` section from openclaw.json.
+ * @param providersOverride - Optional pre-built providers map (useful for testing).
+ */
+export async function resolveConfigSecrets(
+  obj: unknown,
+  secretsConfig: SecretsConfig | undefined,
+  providersOverride?: Map<string, SecretProvider>,
+): Promise<unknown> {
+  const refs = extractSecretReferences(obj);
+
+  // Default cache TTL: 5 minutes
+  const defaultTtlMs = 300_000;
+  const cacheTtlMs =
+    secretsConfig?.providers?.gcp?.cacheTtlSeconds != null
+      ? secretsConfig.providers.gcp.cacheTtlSeconds * 1000
+      : defaultTtlMs;
+
+  // Handle escaped refs even with no real refs
+  if (refs.length === 0) {
+    // Still need to process escaped refs
+    return resolveAny(obj, new Map(), "", cacheTtlMs);
+  }
+
+  const providers = providersOverride ?? buildSecretProviders(secretsConfig);
+
+  // Check all referenced providers exist
+  for (const ref of refs) {
+    if (!providers.has(ref.provider)) {
+      throw new UnknownSecretProviderError(ref.provider, "(config)");
+    }
+  }
+
+  return resolveAny(obj, providers, "", cacheTtlMs);
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,6 +10,27 @@ vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
   };
 });
 
+// Default mock for @google-cloud/secret-manager so secrets-related tests
+// don't require real GCP credentials. GCP Provider tests override this
+// per-test via vi.doMock() which takes precedence for that test scope.
+vi.mock("@google-cloud/secret-manager", () => ({
+  SecretManagerServiceClient: class MockSecretManagerServiceClient {
+    async accessSecretVersion() {
+      return [{ payload: { data: Buffer.from("resolved-value") } }];
+    }
+    async createSecret() {
+      return [{}];
+    }
+    async addSecretVersion() {
+      return [{}];
+    }
+    async listSecrets() {
+      return [[]];
+    }
+  },
+}));
+
+
 // Ensure Vitest environment is properly set
 process.env.VITEST = "true";
 // Config validation walks plugin manifests; keep an aggressive cache in tests to avoid


### PR DESCRIPTION
## Summary

Adds `AzureSecretProvider` for resolving secrets from Azure Key Vault.

Azure SDK packages (`@azure/keyvault-secrets` + `@azure/identity`) are **lazy-loaded** as optional peer dependencies — no startup cost unless the provider is configured.

## Authentication
DefaultAzureCredential chain:
- Environment variables (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`)
- Managed Identity (Azure VMs, App Service, etc.)
- Azure CLI (`az login`)
- Service Principal

## Features
- Version pinning: `${azure:my-secret#<version-id>}`
- Configurable TTL caching (default 5 min)
- Supports tenantId/clientId/clientSecret overrides per provider config

## Config
```json
{
  "secrets": {
    "providers": {
      "azure": {
        "vaultUrl": "https://my-vault.vault.azure.net",
        "tenantId": "<tenant-id>"
      }
    }
  }
}
```

**Usage:** `${azure:my-secret-name}`

## Notes
Split from #24272 per @vincentkoc's request.