### PR TITLE
feat(secrets): add HashiCorp Vault KV v2 secret provider

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -452,3 +452,505 @@ Some SecretInput unions are easier to configure in raw editor mode than in form 
 - Auth setup: [Authentication](/gateway/authentication)
 - Security posture: [Security](/gateway/security)
 - Environment precedence: [Environment Variables](/help/environment)
+
+---
+
+## Additional Secrets Providers
+
+summary: "External secrets management: store credentials in GCP Secret Manager instead of plaintext files"
+read_when:
+
+- You want to stop storing API keys in plaintext config files
+- You want per-agent secret isolation in multi-agent setups
+- You want to set up GCP Secret Manager for OpenClaw
+- You want to migrate existing plaintext secrets to a secrets store
+  title: "Secrets"
+
+---
+
+# External Secrets Management
+
+OpenClaw can resolve secret references in configuration files at runtime, fetching values from an external secrets store instead of storing them in plaintext on disk.
+
+## Why
+
+- **No plaintext secrets on disk** — API keys, tokens, and credentials live in an encrypted, access-controlled store
+- **Per-agent isolation** — in multi-agent setups, each agent only accesses secrets it's authorized for (enforced by GCP IAM, not application code)
+- **Audit trail** — GCP Secret Manager logs all access
+- **Safe version control** — config files contain references (`${gcp:name}`), not actual secrets
+- **Rotation without restarts** — update the secret in the store; cached values expire automatically
+
+## Supported Providers
+
+| Provider            | Status       |
+| ------------------- | ------------ |
+| GCP Secret Manager  | ✅ Supported |
+| AWS Secrets Manager | Planned      |
+| HashiCorp Vault     | Planned      |
+| Azure Key Vault     | Planned      |
+
+## Quick Start
+
+### 1. Prerequisites
+
+- A GCP project with billing enabled
+- `gcloud` CLI installed and authenticated (for setup only; not needed at runtime)
+- VM or environment with `cloud-platform` OAuth scope (for Compute Engine VMs)
+
+#### Compute Engine VM Setup
+
+If running on a GCP Compute Engine VM:
+
+**OAuth Scopes** — the VM must have `cloud-platform` scope. To update (requires VM restart):
+
+```bash
+gcloud compute instances stop <instance> --zone=<zone>
+gcloud compute instances set-service-account <instance> --zone=<zone> --scopes=cloud-platform
+gcloud compute instances start <instance> --zone=<zone>
+```
+
+**IAM Roles** — the compute service account needs these roles:
+
+| Role                                 | Purpose                                     | Required                        |
+| ------------------------------------ | ------------------------------------------- | ------------------------------- |
+| `roles/secretmanager.secretAccessor` | Read secret values at runtime               | Always                          |
+| `roles/secretmanager.admin`          | Create secrets, set per-secret IAM bindings | For setup & per-agent isolation |
+
+Grant via CLI:
+
+```bash
+gcloud projects add-iam-policy-binding <project-id> \
+  --member="serviceAccount:<service-account-email>" \
+  --role="roles/secretmanager.secretAccessor"
+
+gcloud projects add-iam-policy-binding <project-id> \
+  --member="serviceAccount:<service-account-email>" \
+  --role="roles/secretmanager.admin"
+```
+
+Or via the GCP Console:
+
+1. Go to **IAM & Admin → IAM**
+2. Find the compute service account
+3. Click **Edit** (pencil icon)
+4. Add both roles
+5. Save
+
+> **Tip:** After setup is complete and per-agent isolation is configured, you can optionally remove `secretmanager.admin` from the compute SA — agents authenticate with their own service accounts at runtime.
+
+### 2. Bootstrap
+
+```bash
+openclaw secrets setup --project my-gcp-project --agents main,chai
+```
+
+This will:
+
+- Enable the Secret Manager API
+- Create per-agent service accounts (`openclaw-main@`, `openclaw-chai@`)
+- Generate service account key files
+- Set per-secret IAM bindings
+- Update `openclaw.json` with the `secrets` config section
+
+Pass `--yes` to skip confirmation prompts.
+
+### 3. Store a Secret
+
+```bash
+openclaw secrets set --provider gcp --name openclaw-main-brave-api-key --value "your-key-here"
+```
+
+### 4. Reference in Config
+
+Replace plaintext values with secret references:
+
+```json5
+{
+  // Before
+  "apiKey": "sk-real-key-here"
+
+  // After
+  "apiKey": "${gcp:openclaw-main-brave-api-key}"
+}
+```
+
+### 5. Verify
+
+```bash
+openclaw secrets test
+```
+
+## Secret Reference Syntax
+
+References follow the pattern `${provider:secret-name}`:
+
+```
+${gcp:my-secret}          → latest version
+${gcp:my-secret#3}        → pinned to version 3
+${gcp:path/to/secret}     → slashes allowed in names
+```
+
+### Escaping
+
+Use `$${}` to produce a literal `${}` in config:
+
+```json5
+{
+  literal: "$${gcp:not-a-ref}", // → "${gcp:not-a-ref}"
+}
+```
+
+### Distinction from Environment Variables
+
+| Syntax              | Resolved by                     | Example                |
+| ------------------- | ------------------------------- | ---------------------- |
+| `${UPPER_CASE}`     | Env var substitution (existing) | `${BRAVE_API_KEY}`     |
+| `${lowercase:name}` | Secret resolution (new)         | `${gcp:brave-api-key}` |
+
+The lowercase provider prefix naturally distinguishes secret refs from env var refs.
+
+## Configuration
+
+Add a `secrets` section to `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        // GCP project ID (required)
+        project: "my-gcp-project",
+
+        // Cache TTL in seconds (default: 300)
+        cacheTtlSeconds: 300,
+
+        // Path to service account key file (required for per-agent isolation)
+        // If omitted, uses Application Default Credentials (ADC)
+        credentialsFile: "/path/to/openclaw-main-sa.json",
+      },
+    },
+  },
+}
+```
+
+## Auth Profiles
+
+Secret references also work in `auth-profiles.json`:
+
+```json
+{
+  "profiles": {
+    "openai:default": {
+      "type": "token",
+      "provider": "openai",
+      "token": "${gcp:openclaw-main-openai-token}"
+    }
+  }
+}
+```
+
+## Per-Agent Isolation
+
+Per-agent isolation ensures each agent can **only** read its own secrets, enforced at the GCP IAM level. This is not application-level filtering — GCP itself blocks unauthorized access.
+
+### How It Works
+
+Each agent gets:
+
+1. **Its own GCP service account** (e.g., `openclaw-main@project.iam.gserviceaccount.com`)
+2. **A service account key file** stored locally (e.g., `~/.config/gcp/openclaw-main-sa.json`)
+3. **Per-secret IAM bindings** granting only that SA access to its secrets
+
+### Naming Convention
+
+Secrets are namespaced by agent name:
+
+```
+openclaw-main-*     → only the main agent can read
+openclaw-chai-*     → only the chai agent can read
+openclaw-shared-*   → multiple agents can read (both SAs get access)
+```
+
+### Setup Steps
+
+**1. Create per-agent service accounts:**
+
+```bash
+gcloud iam service-accounts create openclaw-main \
+  --display-name="OpenClaw Main Agent"
+gcloud iam service-accounts create openclaw-chai \
+  --display-name="OpenClaw Chai Agent"
+```
+
+**2. Generate key files:**
+
+```bash
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-main-sa.json \
+  --iam-account=openclaw-main@<project>.iam.gserviceaccount.com
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-chai-sa.json \
+  --iam-account=openclaw-chai@<project>.iam.gserviceaccount.com
+chmod 600 ~/.config/gcp/*.json
+```
+
+**3. Set per-secret IAM bindings:**
+
+```bash
+# Main agent's secrets → only main SA
+gcloud secrets add-iam-policy-binding openclaw-main-openai-key \
+  --member="serviceAccount:openclaw-main@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# Chai agent's secrets → only chai SA
+gcloud secrets add-iam-policy-binding openclaw-chai-alpaca-key \
+  --member="serviceAccount:openclaw-chai@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# Shared secrets → both SAs
+gcloud secrets add-iam-policy-binding openclaw-shared-brave-key \
+  --member="serviceAccount:openclaw-main@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+gcloud secrets add-iam-policy-binding openclaw-shared-brave-key \
+  --member="serviceAccount:openclaw-chai@<project>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+**4. Configure each agent to use its own SA:**
+
+Main agent's `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        project: "my-project",
+        credentialsFile: "/home/user/.config/gcp/openclaw-main-sa.json",
+      },
+    },
+  },
+}
+```
+
+Chai agent's `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        project: "my-project",
+        credentialsFile: "/home/user/.config/gcp/openclaw-chai-sa.json",
+      },
+    },
+  },
+}
+```
+
+### Verification
+
+After setup, verify isolation is enforced:
+
+```
+✅ main reads openclaw-main-openai-key     → access granted
+🔒 main reads openclaw-chai-alpaca-key     → PERMISSION_DENIED
+✅ chai reads openclaw-chai-alpaca-key     → access granted
+🔒 chai reads openclaw-main-openai-key     → PERMISSION_DENIED
+```
+
+If an agent tries to read another agent's secret, GCP returns `PERMISSION_DENIED` — the request never reaches OpenClaw.
+
+## Worked Example: Multi-Agent Migration
+
+This example walks through migrating a two-agent setup (main + chai) from plaintext to GCP Secret Manager with full isolation.
+
+### Before (plaintext)
+
+```
+~/.config/openai/credentials.env     → OPENAI_API_KEY=sk-proj-abc123...
+~/.config/alpaca/sandbox.env         → ALPACA_KEY_ID=CKN... / ALPACA_SECRET_KEY=7TV...
+~/.config/himalaya/.nine30-pass      → cbmc pxsf mlzr puea
+openclaw.json                        → "apiKey": "BSAIGr...", "token": "83a1aa..."
+```
+
+All secrets in plaintext. Any agent or process on the machine can read everything.
+
+### Step 1: Enable Secret Manager API
+
+```bash
+gcloud services enable secretmanager.googleapis.com --project=my-project
+```
+
+### Step 2: Store secrets with agent-namespaced names
+
+```bash
+# Main agent secrets
+openclaw secrets set --provider gcp --name openclaw-main-openai-api-key --value "sk-proj-abc123..."
+openclaw secrets set --provider gcp --name openclaw-main-brave-api-key --value "BSAIGr..."
+openclaw secrets set --provider gcp --name openclaw-main-gateway-token --value "83a1aa..."
+openclaw secrets set --provider gcp --name openclaw-main-email-password --value "cbmc pxsf mlzr puea"
+
+# Chai agent secrets
+openclaw secrets set --provider gcp --name openclaw-chai-alpaca-key-id --value "CKN..."
+openclaw secrets set --provider gcp --name openclaw-chai-alpaca-secret-key --value "7TV..."
+```
+
+### Step 3: Create service accounts and keys
+
+```bash
+gcloud iam service-accounts create openclaw-main --display-name="OpenClaw Main Agent"
+gcloud iam service-accounts create openclaw-chai --display-name="OpenClaw Chai Agent"
+
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-main-sa.json \
+  --iam-account=openclaw-main@my-project.iam.gserviceaccount.com
+gcloud iam service-accounts keys create ~/.config/gcp/openclaw-chai-sa.json \
+  --iam-account=openclaw-chai@my-project.iam.gserviceaccount.com
+
+chmod 600 ~/.config/gcp/*.json
+```
+
+### Step 4: Set per-secret IAM bindings
+
+```bash
+# Main-only secrets
+for SECRET in openclaw-main-openai-api-key openclaw-main-brave-api-key \
+              openclaw-main-gateway-token openclaw-main-email-password; do
+  gcloud secrets add-iam-policy-binding $SECRET \
+    --member="serviceAccount:openclaw-main@my-project.iam.gserviceaccount.com" \
+    --role="roles/secretmanager.secretAccessor"
+done
+
+# Chai-only secrets
+for SECRET in openclaw-chai-alpaca-key-id openclaw-chai-alpaca-secret-key; do
+  gcloud secrets add-iam-policy-binding $SECRET \
+    --member="serviceAccount:openclaw-chai@my-project.iam.gserviceaccount.com" \
+    --role="roles/secretmanager.secretAccessor"
+done
+```
+
+### Step 5: Update config files with references
+
+Main agent's `openclaw.json`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      gcp: {
+        project: "my-project",
+        credentialsFile: "/home/user/.config/gcp/openclaw-main-sa.json",
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        apiKey: "${gcp:openclaw-main-brave-api-key}",
+      },
+    },
+  },
+  gateway: {
+    auth: {
+      token: "${gcp:openclaw-main-gateway-token}",
+    },
+  },
+}
+```
+
+### Step 6: Purge plaintext files
+
+Only after verifying all references resolve (`openclaw secrets test`):
+
+```bash
+# Replace file contents with migration notes
+echo "# Migrated to GCP Secret Manager" > ~/.config/openai/credentials.env
+echo "# Migrated to GCP Secret Manager" > ~/.config/alpaca/sandbox.env
+echo "# Migrated to GCP Secret Manager" > ~/.config/himalaya/.nine30-pass
+```
+
+### After
+
+```
+GCP Secret Manager (encrypted, access-controlled):
+  openclaw-main-openai-api-key      → only main SA can read
+  openclaw-main-brave-api-key       → only main SA can read
+  openclaw-main-gateway-token       → only main SA can read
+  openclaw-main-email-password      → only main SA can read
+  openclaw-chai-alpaca-key-id       → only chai SA can read
+  openclaw-chai-alpaca-secret-key   → only chai SA can read
+
+Local disk:
+  ~/.config/gcp/openclaw-main-sa.json  (SA key — the only secret on disk)
+  ~/.config/gcp/openclaw-chai-sa.json  (SA key — the only secret on disk)
+  openclaw.json                        (contains ${gcp:...} refs, safe to commit)
+```
+
+> **Note:** The SA key files are the one remaining secret on disk. Protect them with `chmod 600` and restrict filesystem access. On GKE or Cloud Run, use Workload Identity to eliminate even these files.
+
+### External scripts
+
+Scripts that need secrets (e.g., monitoring scripts, cron jobs) can also use per-agent SA keys:
+
+```python
+from google.cloud import secretmanager
+
+# Use Chai's SA key — can only access openclaw-chai-* secrets
+client = secretmanager.SecretManagerServiceClient.from_service_account_json(
+    "/home/user/.config/gcp/openclaw-chai-sa.json"
+)
+response = client.access_secret_version(
+    request={"name": "projects/my-project/secrets/openclaw-chai-alpaca-key-id/versions/latest"}
+)
+api_key = response.payload.data.decode("utf-8")
+```
+
+## Migration
+
+To migrate existing plaintext secrets:
+
+```bash
+openclaw secrets migrate
+```
+
+This will:
+
+1. Scan config files for sensitive values (API keys, tokens)
+2. Upload each to GCP Secret Manager
+3. Replace plaintext values with `${gcp:name}` references
+4. Verify all references resolve
+5. Prompt before purging plaintext originals
+
+Pass `--yes` to skip confirmation prompts. Plaintext is **never** purged unless the upload and verification succeed.
+
+## Caching
+
+- Secrets are cached **in memory only** (never written to disk)
+- Default TTL: 300 seconds (configurable per-provider)
+- Cache is cleared on `SIGUSR1` restart
+- **Stale-while-revalidate**: if the provider is unreachable and cached values exist (even expired), stale values are used and a warning is logged
+
+## CLI Commands
+
+| Command                    | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `openclaw secrets setup`   | Bootstrap GCP Secret Manager (enable API, create SAs, configure IAM) |
+| `openclaw secrets test`    | Verify all secret references resolve successfully                    |
+| `openclaw secrets list`    | List configured providers and their status                           |
+| `openclaw secrets set`     | Store a secret manually                                              |
+| `openclaw secrets migrate` | Migrate plaintext secrets to the store                               |
+
+## Error Handling
+
+| Error                                        | Behavior                                                                |
+| -------------------------------------------- | ----------------------------------------------------------------------- |
+| Provider not configured                      | Feature using the secret fails; system continues                        |
+| Secret not found                             | Clear error: "Secret 'name' not found in project 'project'"             |
+| Permission denied                            | Clear error: "Permission denied for secret 'name'. Check IAM bindings." |
+| Network timeout                              | Retry once; fall back to stale cache if available                       |
+| `@google-cloud/secret-manager` not installed | Clear error with install instructions                                   |
+
+## Backward Compatibility
+
+- **Entirely opt-in**: no `secrets` config = no behavior change
+- `@google-cloud/secret-manager` is an optional dependency
+- Existing env var substitution (`${UPPER_CASE}`) is unaffected
+- Config files without secret refs pass through unchanged

--- a/package.json
+++ b/package.json
@@ -343,6 +343,7 @@
     "@buape/carbon": "0.0.0-beta-20260216184201",
     "@clack/prompts": "^1.1.0",
     "@discordjs/voice": "^0.19.1",
+    "@google-cloud/secret-manager": "^6.1.1",
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1373,6 +1373,15 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@google-cloud/secret-manager@6.1.1':
     resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
     engines: {node: '>=18'}
@@ -8675,6 +8684,10 @@ snapshots:
 
   '@eshaz/web-worker@1.2.2':
     optional: true
+
+  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
 
   '@google-cloud/secret-manager@6.1.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@discordjs/voice':
         specifier: ^0.19.1
         version: 0.19.1(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@google-cloud/secret-manager':
+        specifier: ^6.1.1
+        version: 6.1.1
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.41.1)
@@ -1370,14 +1373,9 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
-  '@exodus/bytes@1.15.0':
-    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@noble/hashes': ^1.8.0 || ^2.0.0
-    peerDependenciesMeta:
-      '@noble/hashes':
-        optional: true
+  '@google-cloud/secret-manager@6.1.1':
+    resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
+    engines: {node: '>=18'}
 
   '@google/genai@1.44.0':
     resolution: {integrity: sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==}
@@ -3468,6 +3466,10 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -4426,6 +4428,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -4780,6 +4785,10 @@ packages:
     resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
     engines: {node: '>=18'}
 
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
+    engines: {node: '>=18'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -4877,6 +4886,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -5611,6 +5624,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -5937,6 +5954,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
   protobufjs@6.8.8:
     resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
     hasBin: true
@@ -6123,6 +6144,10 @@ packages:
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
     engines: {node: '>=18'}
 
   retry@0.12.0:
@@ -6419,6 +6444,12 @@ packages:
     resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
     engines: {node: '>=18'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
@@ -6470,6 +6501,9 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6490,6 +6524,10 @@ packages:
 
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+    engines: {node: '>=18'}
+
+  teeny-request@10.1.0:
+    resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -8638,9 +8676,11 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
-    optionalDependencies:
-      '@noble/hashes': 2.0.1
+  '@google-cloud/secret-manager@6.1.1':
+    dependencies:
+      google-gax: 5.0.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@google/genai@1.44.0':
     dependencies:
@@ -11000,6 +11040,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tootallnate/once@2.0.0': {}
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@twurple/api-call@8.0.3':
@@ -11462,7 +11504,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agent-base@7.1.4: {}
 
@@ -12045,6 +12086,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
 
   ecc-jsbn@0.1.2:
@@ -12515,6 +12563,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.6.1
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -12631,6 +12695,14 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -12650,7 +12722,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -13424,6 +13495,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@3.0.0: {}
+
   object-inspect@1.13.4: {}
 
   object-path@0.11.8: {}
@@ -13836,6 +13909,10 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.5.4
+
   protobufjs@6.8.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -14035,7 +14112,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   readdirp@5.0.0: {}
 
@@ -14087,6 +14163,13 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   retry@0.12.0: {}
 
@@ -14471,6 +14554,12 @@ snapshots:
 
   steno@4.0.2: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   streamx@2.23.0:
     dependencies:
       events-universal: 1.0.1
@@ -14510,7 +14599,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -14534,6 +14622,8 @@ snapshots:
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  stubs@3.0.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -14566,6 +14656,15 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teeny-request@10.1.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   teex@1.0.1:
     dependencies:

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -26,3 +26,12 @@ export {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "./validation.js";
+export { OpenClawSchema } from "./zod-schema.js";
+export {
+  resolveConfigSecrets,
+  configNeedsSecretResolution,
+  clearSecretCache,
+  SecretResolutionError,
+  UnknownSecretProviderError,
+} from "./secret-resolution.js";
+export type { SecretsConfig, SecretProvider } from "./secret-resolution.js";

--- a/src/config/secret-resolution.ts
+++ b/src/config/secret-resolution.ts
@@ -1,0 +1,519 @@
+/**
+ * Secret reference resolution for config values.
+ *
+ * Supports `${provider:secret-name}` and `${provider:secret-name#version}` syntax.
+ * Provider must be lowercase. Secret names allow: [a-zA-Z0-9_\-/.]
+ * Version pinning via #version suffix (default: latest).
+ * Escape with `$${provider:name}` to produce literal `${provider:name}`.
+ */
+
+import { isPlainObject } from "../utils.js";
+import { VaultSecretProvider } from "./vault-secret-provider.js";
+
+// Matches ${provider:name} or ${provider:name#version}
+// Provider: lowercase alpha. Name: alphanum, hyphens, underscores, slashes, dots.
+// Version (optional): after #, alphanumeric.
+const SECRET_REF_PATTERN = /\$\{([a-z]+):([a-zA-Z0-9_\-/.]+?)(?:#([a-zA-Z0-9]+))?\}/g;
+
+/** Parsed secret reference. */
+export interface SecretRef {
+  provider: string;
+  name: string;
+  version?: string;
+}
+
+/** Configuration for the secrets section in openclaw.json. */
+export type SecretsConfig = {
+  providers?: Record<
+    string,
+    {
+      project?: string;
+      cacheTtlSeconds?: number;
+      credentialsFile?: string;
+      // AWS-specific
+      region?: string;
+      profile?: string;
+      roleArn?: string;
+      externalId?: string;
+      // Keyring-specific
+      account?: string;
+      keychainPath?: string;
+      keychainPassword?: string;
+      // 1Password-specific
+      vault?: string;
+      field?: string;
+      // Vault-specific
+      address?: string;
+      namespace?: string;
+      mountPath?: string;
+      authMethod?: string;
+      token?: string;
+      tokenFile?: string;
+      roleId?: string;
+      secretId?: string;
+    }
+  >;
+};
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class SecretResolutionError extends Error {
+  constructor(
+    public readonly provider: string,
+    public readonly secretName: string,
+    public readonly configPath: string,
+    cause?: Error,
+  ) {
+    super(
+      `Failed to resolve secret "${provider}:${secretName}" at config path: ${configPath}${cause ? ` — ${cause.message}` : ""}`,
+    );
+    this.name = "SecretResolutionError";
+    this.cause = cause;
+  }
+}
+
+export class UnknownSecretProviderError extends Error {
+  constructor(
+    public readonly provider: string,
+    public readonly configPath: string,
+  ) {
+    super(`Unknown secret provider "${provider}" referenced at config path: ${configPath}`);
+    this.name = "UnknownSecretProviderError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+type CacheEntry = { value: string; expiresAt: number };
+const secretCache = new Map<string, CacheEntry>();
+
+export function clearSecretCache(): void {
+  secretCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// SecretProvider interface
+// ---------------------------------------------------------------------------
+
+export interface SecretProvider {
+  name: string;
+  getSecret(name: string, version?: string): Promise<string>;
+  setSecret(name: string, value: string): Promise<void>;
+  listSecrets(): Promise<string[]>;
+  testConnection(): Promise<{ ok: boolean; error?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// GcpSecretProvider
+// ---------------------------------------------------------------------------
+
+/** Minimal interface for the GCP SecretManagerServiceClient used at runtime. */
+interface GcpSmClient {
+  accessSecretVersion(req: {
+    name: string;
+  }): Promise<[{ payload?: { data?: Uint8Array | string } } | undefined]>;
+  createSecret(req: {
+    parent: string;
+    secretId: string;
+    secret: { replication: { automatic: Record<string, never> } };
+  }): Promise<unknown>;
+  addSecretVersion(req: { parent: string; payload: { data: Buffer } }): Promise<unknown>;
+  listSecrets(req: { parent: string }): Promise<[Array<{ name?: string }>]>;
+}
+
+export class GcpSecretProvider implements SecretProvider {
+  public readonly name = "gcp";
+  private readonly project: string;
+  private readonly cacheTtlMs: number;
+  private readonly credentialsFile?: string;
+  constructor(config: { project: string; cacheTtlSeconds?: number; credentialsFile?: string }) {
+    this.project = config.project;
+    this.cacheTtlMs = (config.cacheTtlSeconds ?? 300) * 1000;
+    this.credentialsFile = config.credentialsFile;
+  }
+
+  private async getClient(): Promise<GcpSmClient> {
+    try {
+      const mod = await import("@google-cloud/secret-manager");
+      const Ctor = mod.SecretManagerServiceClient;
+      const opts = this.credentialsFile ? { keyFilename: this.credentialsFile } : {};
+      // Support both `new Ctor(opts)` (real) and mock functions that don't support `new`
+      try {
+        return new (Ctor as unknown as new (o: Record<string, unknown>) => GcpSmClient)(opts);
+      } catch {
+        // Fallback for mock functions that don't support new operator
+        return (Ctor as unknown as (o: Record<string, unknown>) => GcpSmClient)(opts);
+      }
+    } catch {
+      throw new Error(
+        "Please install @google-cloud/secret-manager to use GCP secrets: pnpm add @google-cloud/secret-manager",
+      );
+    }
+  }
+
+  async getSecret(secretName: string, version?: string): Promise<string> {
+    const ver = version ?? "latest";
+    const cacheKey = `gcp:${secretName}#${ver}`;
+    const cached = secretCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    const client = await this.getClient();
+    const resourceName = `projects/${this.project}/secrets/${secretName}/versions/${ver}`;
+
+    let response: { payload?: { data?: Uint8Array | string } } | undefined;
+    try {
+      [response] = await client.accessSecretVersion({ name: resourceName });
+    } catch (err: unknown) {
+      const code = (err as { code?: number })?.code;
+      if (code === 5) {
+        throw new Error(`Secret '${secretName}' not found in project '${this.project}'`, {
+          cause: err,
+        });
+      }
+      if (code === 7) {
+        throw new Error(`Permission denied for secret '${secretName}'. Check IAM bindings.`, {
+          cause: err,
+        });
+      }
+      if (code === 4) {
+        // Retry once
+        try {
+          const retryClient = await this.getClient();
+          [response] = await retryClient.accessSecretVersion({ name: resourceName });
+        } catch {
+          if (cached) {
+            return cached.value;
+          }
+          throw err;
+        }
+      } else {
+        throw err;
+      }
+    }
+
+    const payload = response?.payload?.data;
+    if (!payload) {
+      throw new Error(`Secret "${secretName}" has no payload data`);
+    }
+
+    const value =
+      payload instanceof Uint8Array || Buffer.isBuffer(payload)
+        ? Buffer.from(payload).toString("utf-8")
+        : String(payload);
+
+    secretCache.set(cacheKey, { value, expiresAt: Date.now() + this.cacheTtlMs });
+    return value;
+  }
+
+  async setSecret(secretName: string, value: string): Promise<void> {
+    const client = await this.getClient();
+    const parent = `projects/${this.project}`;
+
+    try {
+      await client.createSecret({
+        parent,
+        secretId: secretName,
+        secret: { replication: { automatic: {} } },
+      });
+    } catch {
+      // Secret may already exist; other errors will surface on addSecretVersion
+    }
+
+    await client.addSecretVersion({
+      parent: `${parent}/secrets/${secretName}`,
+      payload: { data: Buffer.from(value, "utf-8") },
+    });
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const client = await this.getClient();
+    const [secrets] = await client.listSecrets({
+      parent: `projects/${this.project}`,
+    });
+    return (secrets || []).map((s: { name?: string }) => {
+      const name: string = s.name || "";
+      const parts = name.split("/");
+      return parts[parts.length - 1];
+    });
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const client = await this.getClient();
+      await client.listSecrets({ parent: `projects/${this.project}` });
+      return { ok: true };
+    } catch (err: unknown) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reference detection & extraction
+// ---------------------------------------------------------------------------
+
+export function containsSecretReference(value: string): boolean {
+  if (!value.includes("${")) {
+    return false;
+  }
+  SECRET_REF_PATTERN.lastIndex = 0;
+  return SECRET_REF_PATTERN.test(value);
+}
+
+/** Remove escaped refs before extraction so $${gcp:x} isn't treated as a ref. */
+function stripEscapedRefs(value: string): string {
+  return value.replace(/\$\$\{[a-z]+:[a-zA-Z0-9_\-/.]+(?:#[a-zA-Z0-9]+)?\}/g, "");
+}
+
+export function extractSecretReferences(obj: unknown): SecretRef[] {
+  const refs: SecretRef[] = [];
+  const seen = new Set<string>();
+
+  function walk(value: unknown): void {
+    if (typeof value === "string" && value.includes("${")) {
+      const cleaned = stripEscapedRefs(value);
+      SECRET_REF_PATTERN.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = SECRET_REF_PATTERN.exec(cleaned)) !== null) {
+        const key = `${match[1]}:${match[2]}${match[3] ? "#" + match[3] : ""}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          const ref: SecretRef = { provider: match[1], name: match[2] };
+          if (match[3]) {
+            ref.version = match[3];
+          }
+          refs.push(ref);
+        }
+      }
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        walk(item);
+      }
+    } else if (isPlainObject(value)) {
+      for (const val of Object.values(value)) {
+        walk(val);
+      }
+    }
+  }
+
+  walk(obj);
+  return refs;
+}
+
+export function configNeedsSecretResolution(obj: unknown): boolean {
+  return extractSecretReferences(obj).length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Build providers
+// ---------------------------------------------------------------------------
+
+export function buildSecretProviders(
+  secretsConfig: SecretsConfig | undefined,
+): Map<string, SecretProvider> {
+  const providers = new Map<string, SecretProvider>();
+  if (!secretsConfig?.providers) {
+    return providers;
+  }
+
+  for (const [name, config] of Object.entries(secretsConfig.providers)) {
+    if (name === "gcp" && config && config.project) {
+      providers.set(
+        "gcp",
+        new GcpSecretProvider(
+          config as { project: string; cacheTtlSeconds?: number; credentialsFile?: string },
+        ),
+      );
+    }
+    if (name === "vault") {
+      providers.set(
+        "vault",
+        new VaultSecretProvider({
+          address: config?.address ?? "http://127.0.0.1:8200",
+          namespace: config?.namespace,
+          mountPath: config?.mountPath,
+          authMethod: config?.authMethod as "token" | "approle" | "kubernetes" | undefined,
+          token: config?.token,
+          tokenFile: config?.tokenFile,
+          roleId: config?.roleId,
+          secretId: config?.secretId,
+          cacheTtlSeconds: config?.cacheTtlSeconds,
+        }),
+      );
+    }
+  }
+
+  return providers;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a secret value, checking the shared cache first.
+ * This cache layer sits above individual provider caches, ensuring that
+ * the same secret is not fetched twice within a single resolution pass
+ * regardless of which provider implementation is used.
+ */
+async function fetchWithCache(
+  provider: SecretProvider,
+  name: string,
+  version: string | undefined,
+  cacheTtlMs: number,
+): Promise<string> {
+  const cacheKey = `${provider.name}:${name}#${version ?? "latest"}`;
+  const cached = secretCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  try {
+    const value = await provider.getSecret(name, version);
+    secretCache.set(cacheKey, { value, expiresAt: Date.now() + cacheTtlMs });
+    return value;
+  } catch (err) {
+    // Stale-while-revalidate: if we have an expired entry, use it
+    if (cached) {
+      return cached.value;
+    }
+    throw err;
+  }
+}
+
+async function resolveString(
+  value: string,
+  providers: Map<string, SecretProvider>,
+  configPath: string,
+  cacheTtlMs: number,
+): Promise<string> {
+  if (!value.includes("$")) {
+    return value;
+  }
+
+  // Handle escaped refs first: replace $${ with a placeholder
+  const ESCAPE_PLACEHOLDER = "___OPENCLAW_ESC___";
+  let working = value.replace(/\$\$\{/g, ESCAPE_PLACEHOLDER);
+
+  // Collect matches
+  SECRET_REF_PATTERN.lastIndex = 0;
+  const matches: Array<{ full: string; provider: string; name: string; version?: string }> = [];
+  let match: RegExpExecArray | null;
+  while ((match = SECRET_REF_PATTERN.exec(working)) !== null) {
+    const m: { full: string; provider: string; name: string; version?: string } = {
+      full: match[0],
+      provider: match[1],
+      name: match[2],
+    };
+    if (match[3]) {
+      m.version = match[3];
+    }
+    matches.push(m);
+  }
+
+  if (matches.length === 0) {
+    // Restore escaped refs as literals
+    return working.replaceAll(ESCAPE_PLACEHOLDER, "${");
+  }
+
+  // Resolve all in parallel
+  const resolved = await Promise.all(
+    matches.map(async ({ provider: pName, name, version, full }) => {
+      const provider = providers.get(pName);
+      if (!provider) {
+        throw new UnknownSecretProviderError(pName, configPath);
+      }
+      try {
+        const resolvedValue = await fetchWithCache(provider, name, version, cacheTtlMs);
+        return { full, value: resolvedValue };
+      } catch (err) {
+        throw new SecretResolutionError(
+          pName,
+          name,
+          configPath,
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
+    }),
+  );
+
+  for (const { full, value: sv } of resolved) {
+    working = working.replace(full, sv);
+  }
+
+  // Restore escaped refs
+  working = working.replaceAll(ESCAPE_PLACEHOLDER, "${");
+  return working;
+}
+
+async function resolveAny(
+  value: unknown,
+  providers: Map<string, SecretProvider>,
+  path: string,
+  cacheTtlMs: number,
+): Promise<unknown> {
+  if (typeof value === "string") {
+    return resolveString(value, providers, path, cacheTtlMs);
+  }
+  if (Array.isArray(value)) {
+    return Promise.all(
+      value.map((item, i) => resolveAny(item, providers, `${path}[${i}]`, cacheTtlMs)),
+    );
+  }
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value);
+    const resolved = await Promise.all(
+      entries.map(async ([key, val]) => {
+        const childPath = path ? `${path}.${key}` : key;
+        return [key, await resolveAny(val, providers, childPath, cacheTtlMs)] as const;
+      }),
+    );
+    return Object.fromEntries(resolved);
+  }
+  return value;
+}
+
+/**
+ * Resolve all secret references in a config object.
+ *
+ * @param obj - Config object potentially containing `${provider:name}` references.
+ * @param secretsConfig - The `secrets` section from openclaw.json.
+ * @param providersOverride - Optional pre-built providers map (useful for testing).
+ */
+export async function resolveConfigSecrets(
+  obj: unknown,
+  secretsConfig: SecretsConfig | undefined,
+  providersOverride?: Map<string, SecretProvider>,
+): Promise<unknown> {
+  const refs = extractSecretReferences(obj);
+
+  // Default cache TTL: 5 minutes
+  const defaultTtlMs = 300_000;
+  const cacheTtlMs =
+    secretsConfig?.providers?.gcp?.cacheTtlSeconds != null
+      ? secretsConfig.providers.gcp.cacheTtlSeconds * 1000
+      : defaultTtlMs;
+
+  // Handle escaped refs even with no real refs
+  if (refs.length === 0) {
+    // Still need to process escaped refs
+    return resolveAny(obj, new Map(), "", cacheTtlMs);
+  }
+
+  const providers = providersOverride ?? buildSecretProviders(secretsConfig);
+
+  // Check all referenced providers exist
+  for (const ref of refs) {
+    if (!providers.has(ref.provider)) {
+      throw new UnknownSecretProviderError(ref.provider, "(config)");
+    }
+  }
+
+  return resolveAny(obj, providers, "", cacheTtlMs);
+}

--- a/src/config/vault-secret-provider.test.ts
+++ b/src/config/vault-secret-provider.test.ts
@@ -1,0 +1,535 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import {
+  VaultSecretProvider,
+  VaultLeaseManager,
+  type VaultConfig,
+} from "./vault-secret-provider.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(responses: Array<{ status: number; body?: unknown; ok?: boolean }>) {
+  let callIndex = 0;
+  return vi.fn(async (_url: string | URL | Request, _opts?: RequestInit) => {
+    const r = responses[callIndex] ?? responses[responses.length - 1];
+    callIndex++;
+    return {
+      ok: r.ok ?? (r.status >= 200 && r.status < 300),
+      status: r.status,
+      json: async () => r.body ?? {},
+      text: async () => JSON.stringify(r.body ?? {}),
+    } as unknown as Response;
+  });
+}
+
+function createProvider(
+  overrides: Partial<VaultConfig> = {},
+  fetchFn?: ReturnType<typeof mockFetch>,
+): VaultSecretProvider {
+  const provider = new VaultSecretProvider({
+    address: "http://127.0.0.1:8200",
+    token: "s.test-token",
+    ...overrides,
+  });
+  if (fetchFn) {
+    provider._fetchFn = fetchFn;
+  }
+  return provider;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ===========================================================================
+// Auth
+// ===========================================================================
+
+describe("VaultSecretProvider — Auth", () => {
+  it("uses token from config", async () => {
+    const fetch = mockFetch([
+      { status: 200, body: { data: { data: { value: "my-secret-value" } } } },
+    ]);
+    const p = createProvider({ token: "s.my-token" }, fetch);
+    await p.getSecret("test");
+    expect(fetch).toHaveBeenCalledOnce();
+    const [, opts] = fetch.mock.calls[0];
+    expect(opts?.headers).toHaveProperty("X-Vault-Token", "s.my-token");
+  });
+
+  it("uses VAULT_TOKEN env var when no config token", async () => {
+    const orig = process.env.VAULT_TOKEN;
+    process.env.VAULT_TOKEN = "s.env-token";
+    try {
+      const fetch = mockFetch([{ status: 200, body: { data: { data: { value: "v" } } } }]);
+      const p = createProvider({ token: undefined }, fetch);
+      await p.getSecret("test");
+      const [, opts] = fetch.mock.calls[0];
+      expect(opts?.headers).toHaveProperty("X-Vault-Token", "s.env-token");
+    } finally {
+      if (orig === undefined) {
+        delete process.env.VAULT_TOKEN;
+      } else {
+        process.env.VAULT_TOKEN = orig;
+      }
+    }
+  });
+
+  it("throws when no token available", async () => {
+    const orig = process.env.VAULT_TOKEN;
+    delete process.env.VAULT_TOKEN;
+    try {
+      const p = createProvider({ token: undefined }, mockFetch([]));
+      await expect(p.getSecret("test")).rejects.toThrow("No Vault token");
+    } finally {
+      if (orig !== undefined) {
+        process.env.VAULT_TOKEN = orig;
+      }
+    }
+  });
+
+  it("AppRole login fetches token then uses it", async () => {
+    const fetch = mockFetch([
+      // AppRole login
+      {
+        status: 200,
+        body: { auth: { client_token: "s.approle-token", lease_duration: 3600, renewable: true } },
+      },
+      // Actual secret read
+      { status: 200, body: { data: { data: { value: "secret-val" } } } },
+    ]);
+    const p = createProvider(
+      { token: undefined, authMethod: "approle", roleId: "role-123", secretId: "secret-456" },
+      fetch,
+    );
+    const val = await p.getSecret("test");
+    expect(val).toBe("secret-val");
+    // First call is AppRole login
+    expect(fetch.mock.calls[0][0]).toContain("/v1/auth/approle/login");
+    // Second call has the token
+    const [, opts] = fetch.mock.calls[1];
+    expect(opts?.headers).toHaveProperty("X-Vault-Token", "s.approle-token");
+  });
+
+  it("AppRole login throws when roleId/secretId missing", async () => {
+    const p = createProvider({ token: undefined, authMethod: "approle" }, mockFetch([]));
+    await expect(p.getSecret("test")).rejects.toThrow("roleId and secretId");
+  });
+
+  it("includes X-Vault-Namespace header when namespace set", async () => {
+    const fetch = mockFetch([{ status: 200, body: { data: { data: { value: "v" } } } }]);
+    const p = createProvider({ namespace: "admin/team-a" }, fetch);
+    await p.getSecret("test");
+    const [, opts] = fetch.mock.calls[0];
+    expect(opts?.headers).toHaveProperty("X-Vault-Namespace", "admin/team-a");
+  });
+});
+
+// ===========================================================================
+// Secret Resolution (KV v2)
+// ===========================================================================
+
+describe("VaultSecretProvider — getSecret", () => {
+  it("reads KV v2 secret and extracts value field", async () => {
+    const fetch = mockFetch([
+      { status: 200, body: { data: { data: { value: "hunter2" }, metadata: { version: 3 } } } },
+    ]);
+    const p = createProvider({}, fetch);
+    const val = await p.getSecret("my-app/db-password");
+    expect(val).toBe("hunter2");
+    expect(fetch.mock.calls[0][0]).toBe("http://127.0.0.1:8200/v1/secret/data/my-app/db-password");
+  });
+
+  it("passes version query param when specified", async () => {
+    const fetch = mockFetch([
+      { status: 200, body: { data: { data: { value: "old-value" }, metadata: { version: 2 } } } },
+    ]);
+    const p = createProvider({}, fetch);
+    await p.getSecret("my-secret", "2");
+    expect(fetch.mock.calls[0][0]).toContain("?version=2");
+  });
+
+  it("uses custom mountPath", async () => {
+    const fetch = mockFetch([{ status: 200, body: { data: { data: { value: "v" } } } }]);
+    const p = createProvider({ mountPath: "kv" }, fetch);
+    await p.getSecret("app/key");
+    expect(fetch.mock.calls[0][0]).toBe("http://127.0.0.1:8200/v1/kv/data/app/key");
+  });
+
+  it("returns JSON when no value field exists", async () => {
+    const fetch = mockFetch([
+      { status: 200, body: { data: { data: { username: "admin", password: "pw123" } } } },
+    ]);
+    const p = createProvider({}, fetch);
+    const val = await p.getSecret("multi-field");
+    expect(JSON.parse(val)).toEqual({ username: "admin", password: "pw123" });
+  });
+
+  it("throws on 404", async () => {
+    const fetch = mockFetch([{ status: 404, ok: false, body: { errors: [] } }]);
+    const p = createProvider({}, fetch);
+    await expect(p.getSecret("missing")).rejects.toThrow("not found");
+  });
+
+  it("throws on 403 with policy guidance", async () => {
+    const fetch = mockFetch([{ status: 403, ok: false, body: { errors: ["permission denied"] } }]);
+    const p = createProvider({}, fetch);
+    await expect(p.getSecret("forbidden")).rejects.toThrow("Permission denied");
+  });
+
+  it("throws on 503 (sealed)", async () => {
+    const fetch = mockFetch([{ status: 503, ok: false, body: { errors: ["Vault is sealed"] } }]);
+    const p = createProvider({}, fetch);
+    await expect(p.getSecret("any")).rejects.toThrow("sealed");
+  });
+
+  it("throws on connection failure", async () => {
+    const fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const p = createProvider({}, fetch as unknown as ReturnType<typeof mockFetch>);
+    await expect(p.getSecret("test")).rejects.toThrow("Cannot connect to Vault");
+  });
+});
+
+// ===========================================================================
+// setSecret
+// ===========================================================================
+
+describe("VaultSecretProvider — setSecret", () => {
+  it("writes KV v2 secret", async () => {
+    const fetch = mockFetch([{ status: 200, body: { data: { metadata: { version: 1 } } } }]);
+    const p = createProvider({}, fetch);
+    await p.setSecret("my-app/api-key", "sk-12345");
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8200/v1/secret/data/my-app/api-key");
+    expect(opts?.method).toBe("POST");
+    expect(JSON.parse(opts?.body as string)).toEqual({ data: { value: "sk-12345" } });
+  });
+});
+
+// ===========================================================================
+// listSecrets
+// ===========================================================================
+
+describe("VaultSecretProvider — listSecrets", () => {
+  it("lists secrets via LIST method on metadata endpoint", async () => {
+    const fetch = mockFetch([
+      { status: 200, body: { data: { keys: ["secret-a", "secret-b", "folder/"] } } },
+    ]);
+    const p = createProvider({}, fetch);
+    const keys = await p.listSecrets();
+    expect(keys).toEqual(["secret-a", "secret-b", "folder/"]);
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8200/v1/secret/metadata/");
+    expect(opts?.method).toBe("LIST");
+  });
+
+  it("returns empty array on 404", async () => {
+    const fetch = mockFetch([{ status: 404, ok: false, body: { errors: [] } }]);
+    const p = createProvider({}, fetch);
+    const keys = await p.listSecrets();
+    expect(keys).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// testConnection
+// ===========================================================================
+
+describe("VaultSecretProvider — testConnection", () => {
+  it("returns ok on healthy vault", async () => {
+    const fetch = mockFetch([{ status: 200, body: { initialized: true, sealed: false } }]);
+    const p = createProvider({}, fetch);
+    const result = await p.testConnection();
+    expect(result).toEqual({ ok: true });
+    expect(fetch.mock.calls[0][0]).toBe("http://127.0.0.1:8200/v1/sys/health");
+  });
+
+  it("returns error on sealed vault", async () => {
+    const fetch = mockFetch([{ status: 503, ok: false, body: { sealed: true } }]);
+    const p = createProvider({}, fetch);
+    const result = await p.testConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("sealed");
+  });
+
+  it("returns error on connection failure", async () => {
+    const fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const p = createProvider({}, fetch as unknown as ReturnType<typeof mockFetch>);
+    const result = await p.testConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Cannot connect");
+  });
+});
+
+// ===========================================================================
+// Error Handling — re-auth on 403 for AppRole
+// ===========================================================================
+
+describe("VaultSecretProvider — re-auth on 403", () => {
+  it("retries with fresh token on 403 for approle auth", async () => {
+    const fetch = mockFetch([
+      // Initial AppRole login
+      { status: 200, body: { auth: { client_token: "s.token-1" } } },
+      // First attempt → 403 (expired token)
+      { status: 403, ok: false, body: { errors: ["permission denied"] } },
+      // Re-login
+      { status: 200, body: { auth: { client_token: "s.token-2" } } },
+      // Retry → success
+      { status: 200, body: { data: { data: { value: "refreshed" } } } },
+    ]);
+    const p = createProvider(
+      { token: undefined, authMethod: "approle", roleId: "r", secretId: "s" },
+      fetch,
+    );
+    const val = await p.getSecret("test");
+    expect(val).toBe("refreshed");
+    expect(fetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("does NOT retry for token auth on 403", async () => {
+    const fetch = mockFetch([{ status: 403, ok: false, body: { errors: ["permission denied"] } }]);
+    const p = createProvider({ authMethod: "token" }, fetch);
+    await expect(p.getSecret("test")).rejects.toThrow("Permission denied");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ===========================================================================
+// Dynamic Secrets / Lease Management
+// ===========================================================================
+
+describe("VaultSecretProvider — Dynamic Secrets", () => {
+  it("requests dynamic credentials", async () => {
+    const fetch = mockFetch([
+      {
+        status: 200,
+        body: {
+          lease_id: "database/creds/my-role/abc123",
+          lease_duration: 3600,
+          renewable: true,
+          data: { username: "v-approle-my-role-abc", password: "A1B2C3" },
+        },
+      },
+    ]);
+    const p = createProvider({}, fetch);
+    const lease = await p.requestDynamic("database", "my-role");
+    expect(lease.leaseId).toBe("database/creds/my-role/abc123");
+    expect(lease.ttl).toBe(3600);
+    expect(lease.renewable).toBe(true);
+    expect(fetch.mock.calls[0][0]).toContain("/v1/database/creds/my-role");
+  });
+
+  it("renews a lease", async () => {
+    const fetch = mockFetch([
+      {
+        status: 200,
+        body: {
+          lease_id: "database/creds/my-role/abc123",
+          lease_duration: 3600,
+          renewable: true,
+        },
+      },
+    ]);
+    const p = createProvider({}, fetch);
+    const renewed = await p.renewLease("database/creds/my-role/abc123");
+    expect(renewed.ttl).toBe(3600);
+    const [, opts] = fetch.mock.calls[0];
+    expect(JSON.parse(opts?.body as string)).toEqual({ lease_id: "database/creds/my-role/abc123" });
+  });
+
+  it("revokes a lease", async () => {
+    const fetch = mockFetch([{ status: 204 }]);
+    const p = createProvider({}, fetch);
+    await p.revokeLease("database/creds/my-role/abc123");
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toContain("/v1/sys/leases/revoke");
+    expect(opts?.method).toBe("PUT");
+  });
+});
+
+// ===========================================================================
+// Static Rotation Polling
+// ===========================================================================
+
+describe("VaultSecretProvider — Static Creds", () => {
+  it("fetches static credentials with last_vault_rotation", async () => {
+    const fetch = mockFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            data: {
+              username: "static-user",
+              password: "rotated-pw",
+              last_vault_rotation: "2026-02-15T10:00:00Z",
+              ttl: 86400,
+            },
+          },
+        },
+      },
+    ]);
+    const p = createProvider({}, fetch);
+    const creds = await p.getStaticCreds("database", "my-static-role");
+    expect(creds.username).toBe("static-user");
+    expect(creds.password).toBe("rotated-pw");
+    expect(creds.lastVaultRotation).toBe("2026-02-15T10:00:00Z");
+  });
+});
+
+// ===========================================================================
+// Rotation Metadata (custom_metadata)
+// ===========================================================================
+
+describe("VaultSecretProvider — Rotation Metadata", () => {
+  it("reads custom_metadata from KV v2 metadata endpoint", async () => {
+    const fetch = mockFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            custom_metadata: { "rotation-type": "manual", "rotation-interval-days": "90" },
+            current_version: 5,
+          },
+        },
+      },
+    ]);
+    const p = createProvider({}, fetch);
+    const meta = await p.getSecretMetadata("my-secret");
+    expect(meta.customMetadata).toEqual({
+      "rotation-type": "manual",
+      "rotation-interval-days": "90",
+    });
+    expect(meta.currentVersion).toBe(5);
+    expect(fetch.mock.calls[0][0]).toContain("/v1/secret/metadata/my-secret");
+  });
+
+  it("writes custom_metadata to KV v2 metadata endpoint", async () => {
+    const fetch = mockFetch([{ status: 204 }]);
+    const p = createProvider({}, fetch);
+    await p.updateSecretMetadata("my-secret", {
+      "rotation-type": "manual",
+      "last-rotated": "2026-02-15",
+    });
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toContain("/v1/secret/metadata/my-secret");
+    expect(JSON.parse(opts?.body as string)).toEqual({
+      custom_metadata: { "rotation-type": "manual", "last-rotated": "2026-02-15" },
+    });
+  });
+
+  it("handles null custom_metadata gracefully", async () => {
+    const fetch = mockFetch([
+      { status: 200, body: { data: { custom_metadata: null, current_version: 1 } } },
+    ]);
+    const p = createProvider({}, fetch);
+    const meta = await p.getSecretMetadata("test");
+    expect(meta.customMetadata).toEqual({});
+  });
+});
+
+// ===========================================================================
+// VaultLeaseManager
+// ===========================================================================
+
+describe("VaultLeaseManager", () => {
+  it("tracks requested dynamic leases", async () => {
+    const fetch = mockFetch([
+      {
+        status: 200,
+        body: {
+          lease_id: "db/creds/role/1",
+          lease_duration: 3600,
+          renewable: true,
+          data: { username: "u", password: "p" },
+        },
+      },
+    ]);
+    const p = createProvider({}, fetch);
+    const mgr = new VaultLeaseManager(p);
+    const lease = await mgr.requestDynamic("db", "role");
+    expect(lease.leaseId).toBe("db/creds/role/1");
+    expect(mgr.listActiveLeases()).toHaveLength(1);
+  });
+
+  it("revokeAll clears all leases", async () => {
+    const fetch = mockFetch([
+      // requestDynamic
+      {
+        status: 200,
+        body: { lease_id: "lease-1", lease_duration: 60, renewable: false, data: {} },
+      },
+      // revokeLease
+      { status: 204 },
+    ]);
+    const p = createProvider({}, fetch);
+    const mgr = new VaultLeaseManager(p);
+    await mgr.requestDynamic("db", "role");
+    expect(mgr.listActiveLeases()).toHaveLength(1);
+    await mgr.revokeAll();
+    expect(mgr.listActiveLeases()).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// SecretProvider interface compliance
+// ===========================================================================
+
+describe("VaultSecretProvider — SecretProvider interface", () => {
+  it("has name 'vault'", () => {
+    const p = createProvider();
+    expect(p.name).toBe("vault");
+  });
+
+  it("implements all SecretProvider methods", () => {
+    const p = createProvider();
+    expect(typeof p.getSecret).toBe("function");
+    expect(typeof p.setSecret).toBe("function");
+    expect(typeof p.listSecrets).toBe("function");
+    expect(typeof p.testConnection).toBe("function");
+  });
+});
+
+// ===========================================================================
+// Config defaults
+// ===========================================================================
+
+describe("VaultSecretProvider — Config", () => {
+  it("defaults mountPath to 'secret'", async () => {
+    const fetch = mockFetch([{ status: 200, body: { data: { data: { value: "v" } } } }]);
+    const p = createProvider({ mountPath: undefined }, fetch);
+    await p.getSecret("test");
+    expect(fetch.mock.calls[0][0]).toContain("/v1/secret/data/test");
+  });
+
+  it("defaults authMethod to 'token'", () => {
+    const p = createProvider({ authMethod: undefined });
+    // No way to directly check, but it should work with token
+    expect(p.name).toBe("vault");
+  });
+
+  it("strips trailing slash from address", async () => {
+    const fetch = mockFetch([{ status: 200, body: { data: { data: { value: "v" } } } }]);
+    const p = createProvider({ address: "http://vault.local:8200/" }, fetch);
+    await p.getSecret("test");
+    expect(fetch.mock.calls[0][0]).toBe("http://vault.local:8200/v1/secret/data/test");
+  });
+
+  it("cacheTtlMs defaults to 300000 (5 min)", () => {
+    const p = createProvider({ cacheTtlSeconds: undefined });
+    expect(p.cacheTtlMs).toBe(300_000);
+  });
+
+  it("cacheTtlMs respects custom value", () => {
+    const p = createProvider({ cacheTtlSeconds: 60 });
+    expect(p.cacheTtlMs).toBe(60_000);
+  });
+});

--- a/src/config/vault-secret-provider.ts
+++ b/src/config/vault-secret-provider.ts
@@ -1,0 +1,509 @@
+/**
+ * HashiCorp Vault secret provider (KV v2 engine).
+ *
+ * Uses native `fetch()` — no SDK dependency. Supports:
+ * - Token, AppRole, Kubernetes auth methods
+ * - KV v2 read/write/list with version pinning
+ * - Lease management for dynamic secrets
+ * - Rotation tracking via custom_metadata on KV v2
+ */
+
+import { readFile } from "node:fs/promises";
+import type { SecretProvider } from "./secret-resolution.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VaultConfig {
+  address: string;
+  namespace?: string;
+  mountPath?: string; // default: "secret"
+  authMethod?: "token" | "approle" | "kubernetes";
+  token?: string;
+  tokenFile?: string;
+  roleId?: string;
+  secretId?: string;
+  cacheTtlSeconds?: number;
+}
+
+export interface VaultLease {
+  leaseId: string;
+  data: Record<string, string>;
+  ttl: number;
+  renewable: boolean;
+  expiresAt: Date;
+}
+
+interface VaultResponse {
+  data?: {
+    data?: Record<string, unknown>;
+    metadata?: {
+      version?: number;
+      custom_metadata?: Record<string, string> | null;
+    };
+    keys?: string[];
+  };
+  auth?: {
+    client_token?: string;
+    lease_duration?: number;
+    renewable?: boolean;
+  };
+  lease_id?: string;
+  lease_duration?: number;
+  renewable?: boolean;
+  errors?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class VaultError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly vaultErrors?: string[],
+  ) {
+    super(message);
+    this.name = "VaultError";
+  }
+}
+
+function mapVaultHttpError(
+  statusCode: number,
+  path: string,
+  body?: { errors?: string[] },
+): VaultError {
+  const errors = body?.errors;
+  switch (statusCode) {
+    case 403:
+      return new VaultError(
+        `Permission denied. Check Vault policy for path '${path}'.`,
+        403,
+        errors,
+      );
+    case 404:
+      return new VaultError(`Secret not found at path '${path}'.`, 404, errors);
+    case 503:
+      return new VaultError("Vault is sealed. Unseal before use.", 503, errors);
+    default:
+      return new VaultError(
+        `Vault request failed (HTTP ${statusCode}) for path '${path}'${errors?.length ? `: ${errors.join(", ")}` : ""}`,
+        statusCode,
+        errors,
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// VaultSecretProvider
+// ---------------------------------------------------------------------------
+
+export class VaultSecretProvider implements SecretProvider {
+  public readonly name = "vault";
+  private readonly address: string;
+  private readonly namespace?: string;
+  private readonly mountPath: string;
+  private readonly authMethod: "token" | "approle" | "kubernetes";
+  private readonly configToken?: string;
+  private readonly tokenFile?: string;
+  private readonly roleId?: string;
+  private readonly secretId?: string;
+  public readonly cacheTtlMs: number;
+
+  private cachedToken?: string;
+
+  // Allow injection for testing
+  public _fetchFn: typeof globalThis.fetch = globalThis.fetch;
+
+  constructor(config: VaultConfig) {
+    this.address = config.address.replace(/\/+$/, "");
+    this.namespace = config.namespace;
+    this.mountPath = config.mountPath ?? "secret";
+    this.authMethod = config.authMethod ?? "token";
+    this.configToken = config.token;
+    this.tokenFile = config.tokenFile;
+    this.roleId = config.roleId;
+    this.secretId = config.secretId;
+    this.cacheTtlMs = (config.cacheTtlSeconds ?? 300) * 1000;
+  }
+
+  // -------------------------------------------------------------------------
+  // Auth
+  // -------------------------------------------------------------------------
+
+  private async getToken(): Promise<string> {
+    if (this.cachedToken) {
+      return this.cachedToken;
+    }
+
+    let token: string | undefined;
+
+    switch (this.authMethod) {
+      case "token":
+        token = this.configToken ?? process.env.VAULT_TOKEN;
+        if (!token && this.tokenFile) {
+          token = (await readFile(this.tokenFile, "utf-8")).trim();
+        }
+        if (!token) {
+          throw new VaultError(
+            "No Vault token. Set VAULT_TOKEN, use token config, or configure AppRole.",
+          );
+        }
+        break;
+
+      case "approle":
+        if (!this.roleId || !this.secretId) {
+          throw new VaultError("AppRole auth requires roleId and secretId.");
+        }
+        token = await this.loginAppRole(this.roleId, this.secretId);
+        break;
+
+      case "kubernetes":
+        token = await this.loginKubernetes();
+        break;
+    }
+
+    this.cachedToken = token;
+    return token;
+  }
+
+  private async loginAppRole(roleId: string, secretId: string): Promise<string> {
+    const resp = await this.rawRequest("POST", "/v1/auth/approle/login", {
+      role_id: roleId,
+      secret_id: secretId,
+    });
+    const token = resp.auth?.client_token;
+    if (!token) {
+      throw new VaultError("AppRole login did not return a token.");
+    }
+    return token;
+  }
+
+  private async loginKubernetes(): Promise<string> {
+    let jwt: string;
+    try {
+      jwt = (await readFile("/var/run/secrets/kubernetes.io/serviceaccount/token", "utf-8")).trim();
+    } catch {
+      throw new VaultError(
+        "Kubernetes auth: cannot read service account token at /var/run/secrets/kubernetes.io/serviceaccount/token",
+      );
+    }
+    const resp = await this.rawRequest("POST", "/v1/auth/kubernetes/login", {
+      role: "openclaw",
+      jwt,
+    });
+    const token = resp.auth?.client_token;
+    if (!token) {
+      throw new VaultError("Kubernetes login did not return a token.");
+    }
+    return token;
+  }
+
+  /** Clear cached token to force re-auth. */
+  public clearTokenCache(): void {
+    this.cachedToken = undefined;
+  }
+
+  // -------------------------------------------------------------------------
+  // HTTP
+  // -------------------------------------------------------------------------
+
+  private async rawRequest(
+    method: string,
+    path: string,
+    body?: unknown,
+    skipAuth = false,
+  ): Promise<VaultResponse> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (!skipAuth) {
+      // For login endpoints, we don't need a token yet
+      if (!path.startsWith("/v1/auth/")) {
+        const token = await this.getToken();
+        headers["X-Vault-Token"] = token;
+      }
+    }
+
+    if (this.namespace) {
+      headers["X-Vault-Namespace"] = this.namespace;
+    }
+
+    const url = `${this.address}${path}`;
+    let resp: Response;
+    try {
+      resp = await this._fetchFn(url, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+    } catch (err) {
+      throw new VaultError(
+        `Cannot connect to Vault at '${this.address}': ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (!resp.ok) {
+      let parsed: { errors?: string[] } | undefined;
+      try {
+        parsed = (await resp.json()) as { errors?: string[] };
+      } catch {
+        /* ignore parse errors */
+      }
+      throw mapVaultHttpError(resp.status, path, parsed);
+    }
+
+    // Some endpoints return 204 with no body
+    if (resp.status === 204) {
+      return {};
+    }
+
+    return (await resp.json()) as VaultResponse;
+  }
+
+  private async request(method: string, path: string, body?: unknown): Promise<VaultResponse> {
+    try {
+      return await this.rawRequest(method, path, body);
+    } catch (err) {
+      // On 403, try re-auth for renewable auth methods, then retry once
+      if (err instanceof VaultError && err.statusCode === 403 && this.authMethod !== "token") {
+        this.clearTokenCache();
+        return await this.rawRequest(method, path, body);
+      }
+      throw err;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // SecretProvider interface
+  // -------------------------------------------------------------------------
+
+  async getSecret(secretName: string, version?: string): Promise<string> {
+    const versionQuery = version ? `?version=${version}` : "";
+    const path = `/v1/${this.mountPath}/data/${secretName}${versionQuery}`;
+    const resp = await this.request("GET", path);
+    const data = resp.data?.data;
+    if (!data) {
+      throw new VaultError(`Secret '${secretName}' has no data.`, 404);
+    }
+    // Extract the 'value' field, or return the whole JSON if no 'value' key
+    if ("value" in data) {
+      return String(data.value);
+    }
+    return JSON.stringify(data);
+  }
+
+  async setSecret(secretName: string, value: string): Promise<void> {
+    const path = `/v1/${this.mountPath}/data/${secretName}`;
+    await this.request("POST", path, { data: { value } });
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const path = `/v1/${this.mountPath}/metadata/`;
+    // Vault LIST is done via the LIST HTTP method or GET with ?list=true
+    try {
+      const resp = await this.request("LIST", path);
+      return (resp.data?.keys as string[]) ?? [];
+    } catch (err) {
+      if (err instanceof VaultError && err.statusCode === 404) {
+        return [];
+      }
+      throw err;
+    }
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const resp = await this._fetchFn(`${this.address}/v1/sys/health`, {
+        headers: this.namespace ? { "X-Vault-Namespace": this.namespace } : {},
+      });
+      if (resp.ok) {
+        return { ok: true };
+      }
+      if (resp.status === 503) {
+        return { ok: false, error: "Vault is sealed." };
+      }
+      return { ok: false, error: `Vault health check returned HTTP ${resp.status}` };
+    } catch (err) {
+      return {
+        ok: false,
+        error: `Cannot connect to Vault at '${this.address}': ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Dynamic Secrets / Lease Management
+  // -------------------------------------------------------------------------
+
+  async requestDynamic(backend: string, role: string): Promise<VaultLease> {
+    const path = `/v1/${backend}/creds/${role}`;
+    const resp = await this.request("GET", path);
+    const data = resp.data?.data ?? (resp as unknown as { data?: Record<string, unknown> }).data;
+    const leaseData: Record<string, string> = {};
+    if (data && typeof data === "object") {
+      for (const [k, v] of Object.entries(data)) {
+        leaseData[k] = String(v);
+      }
+    }
+    const ttl = resp.lease_duration ?? 0;
+    return {
+      leaseId: resp.lease_id ?? "",
+      data: leaseData,
+      ttl,
+      renewable: resp.renewable ?? false,
+      expiresAt: new Date(Date.now() + ttl * 1000),
+    };
+  }
+
+  async renewLease(leaseId: string, increment?: number): Promise<VaultLease> {
+    const body: Record<string, unknown> = { lease_id: leaseId };
+    if (increment !== undefined) {
+      body.increment = increment;
+    }
+    const resp = await this.request("PUT", "/v1/sys/leases/renew", body);
+    const ttl = resp.lease_duration ?? 0;
+    return {
+      leaseId: resp.lease_id ?? leaseId,
+      data: {},
+      ttl,
+      renewable: resp.renewable ?? false,
+      expiresAt: new Date(Date.now() + ttl * 1000),
+    };
+  }
+
+  async revokeLease(leaseId: string): Promise<void> {
+    await this.request("PUT", "/v1/sys/leases/revoke", { lease_id: leaseId });
+  }
+
+  // -------------------------------------------------------------------------
+  // Static Rotation Polling
+  // -------------------------------------------------------------------------
+
+  async getStaticCreds(
+    mount: string,
+    role: string,
+  ): Promise<{ username: string; password: string; lastVaultRotation: string; ttl: number }> {
+    const path = `/v1/${mount}/static-creds/${role}`;
+    const resp = await this.request("GET", path);
+    const data = resp.data?.data as Record<string, string | number> | undefined;
+    return {
+      username: typeof data?.username === "string" ? data.username : "",
+      password: typeof data?.password === "string" ? data.password : "",
+      lastVaultRotation:
+        typeof data?.last_vault_rotation === "string" ? data.last_vault_rotation : "",
+      ttl: typeof data?.ttl === "number" ? data.ttl : 0,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Rotation Metadata (KV v2 custom_metadata)
+  // -------------------------------------------------------------------------
+
+  async getSecretMetadata(
+    secretName: string,
+  ): Promise<{ customMetadata: Record<string, string>; currentVersion: number }> {
+    const path = `/v1/${this.mountPath}/metadata/${secretName}`;
+    const resp = await this.request("GET", path);
+    const meta = resp.data as unknown as {
+      custom_metadata?: Record<string, string> | null;
+      current_version?: number;
+    };
+    return {
+      customMetadata: meta?.custom_metadata ?? {},
+      currentVersion: meta?.current_version ?? 0,
+    };
+  }
+
+  async updateSecretMetadata(
+    secretName: string,
+    customMetadata: Record<string, string>,
+  ): Promise<void> {
+    const path = `/v1/${this.mountPath}/metadata/${secretName}`;
+    await this.request("POST", path, { custom_metadata: customMetadata });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// VaultLeaseManager — tracks active leases, handles renewal scheduling
+// ---------------------------------------------------------------------------
+
+export class VaultLeaseManager {
+  private activeLeases = new Map<string, VaultLease>();
+  private renewalTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly renewalBuffer: number; // fraction of TTL remaining to trigger renewal
+
+  constructor(
+    private readonly provider: VaultSecretProvider,
+    opts?: { renewalBuffer?: number },
+  ) {
+    this.renewalBuffer = opts?.renewalBuffer ?? 0.33;
+  }
+
+  async requestDynamic(backend: string, role: string): Promise<VaultLease> {
+    const lease = await this.provider.requestDynamic(backend, role);
+    this.trackLease(lease);
+    return lease;
+  }
+
+  private trackLease(lease: VaultLease): void {
+    this.activeLeases.set(lease.leaseId, lease);
+    if (lease.renewable && lease.ttl > 0) {
+      this.scheduleRenewal(lease);
+    }
+  }
+
+  private scheduleRenewal(lease: VaultLease): void {
+    // Clear existing timer
+    const existing = this.renewalTimers.get(lease.leaseId);
+    if (existing) {
+      clearTimeout(existing);
+    }
+
+    const renewAt = lease.ttl * (1 - this.renewalBuffer) * 1000;
+    const timer = setTimeout(async () => {
+      try {
+        const renewed = await this.provider.renewLease(lease.leaseId);
+        renewed.data = lease.data; // preserve original creds
+        this.activeLeases.set(lease.leaseId, renewed);
+        if (renewed.renewable && renewed.ttl > 0) {
+          this.scheduleRenewal(renewed);
+        }
+      } catch {
+        // Renewal failed — remove lease
+        this.activeLeases.delete(lease.leaseId);
+        this.renewalTimers.delete(lease.leaseId);
+      }
+    }, renewAt);
+
+    // Unref so it doesn't keep the process alive
+    if (typeof timer === "object" && "unref" in timer) {
+      timer.unref();
+    }
+    this.renewalTimers.set(lease.leaseId, timer);
+  }
+
+  listActiveLeases(): VaultLease[] {
+    return Array.from(this.activeLeases.values());
+  }
+
+  async revokeAll(): Promise<void> {
+    for (const [id] of this.renewalTimers) {
+      clearTimeout(this.renewalTimers.get(id));
+    }
+    this.renewalTimers.clear();
+
+    const revocations = Array.from(this.activeLeases.keys()).map(async (id) => {
+      try {
+        await this.provider.revokeLease(id);
+      } catch {
+        // best-effort
+      }
+    });
+    await Promise.allSettled(revocations);
+    this.activeLeases.clear();
+  }
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,6 +10,27 @@ vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
   };
 });
 
+// Default mock for @google-cloud/secret-manager so secrets-related tests
+// don't require real GCP credentials. GCP Provider tests override this
+// per-test via vi.doMock() which takes precedence for that test scope.
+vi.mock("@google-cloud/secret-manager", () => ({
+  SecretManagerServiceClient: class MockSecretManagerServiceClient {
+    async accessSecretVersion() {
+      return [{ payload: { data: Buffer.from("resolved-value") } }];
+    }
+    async createSecret() {
+      return [{}];
+    }
+    async addSecretVersion() {
+      return [{}];
+    }
+    async listSecrets() {
+      return [[]];
+    }
+  },
+}));
+
+
 // Ensure Vitest environment is properly set
 process.env.VITEST = "true";
 // Config validation walks plugin manifests; keep an aggressive cache in tests to avoid


### PR DESCRIPTION
## Summary

Adds `VaultSecretProvider` for resolving secrets from HashiCorp Vault KV v2.

Uses **native `fetch()`** — no SDK dependency required.

## Authentication Methods
- **Token**: via `VAULT_TOKEN` env var or `tokenFile`
- **AppRole**: `roleId` + `secretId`
- **Kubernetes**: service account JWT auto-mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`

## Features
- KV v2 with version pinning: `${vault:path/to/secret#5}`
- Namespace support (Vault Enterprise)
- Configurable mount path (default: `secret`)
- Rotation tracking via KV v2 custom metadata
- Configurable TTL caching (default 5 min)

## Config
```json
{
  "secrets": {
    "providers": {
      "vault": {
        "address": "https://vault.example.com",
        "authMethod": "approle",
        "roleId": "<role-id>",
        "secretId": "<secret-id>"
      }
    }
  }
}
```

**Usage:** `${vault:my/secret/path}`

## Notes
Split from #24272 per @vincentkoc's request.