### PR TITLE
Fix JSON-wrapped assistant text for openai-completions custom APIs

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -473,6 +473,22 @@ File contents here`,
       expect(extractAssistantText(msg), testCase.name).toBe(testCase.expected);
     }
   });
+
+  it("unwraps nested serialized text blocks from openai-compatible responses", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "[{'type': 'text', 'text': '[{\\'type\\': \\'text\\', \\'text\\': \\'The current time is 11:06 AM (UTC+8).\\'}]'}]",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("The current time is 11:06 AM (UTC+8).");
+  });
 });
 
 describe("formatReasoningMessage", () => {

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -474,9 +474,10 @@ File contents here`,
     }
   });
 
-  it("unwraps nested serialized text blocks from openai-compatible responses", () => {
+  it("unwraps nested JSON5-serialized text blocks for openai-completions", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
+      api: "openai-completions",
       content: [
         {
           type: "text",
@@ -488,6 +489,57 @@ File contents here`,
 
     const result = extractAssistantText(msg);
     expect(result).toBe("The current time is 11:06 AM (UTC+8).");
+  });
+
+  it("unwraps standard JSON serialized text blocks for openai-completions", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      api: "openai-completions",
+      content: [{ type: "text", text: '[{"type":"text","text":"Hello."}]' }],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Hello.");
+  });
+
+  it("does not unwrap serialized text blocks for non-openai-completions APIs", () => {
+    const serialized = '[{"type":"text","text":"Literal payload."}]';
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      api: "openai-responses",
+      content: [{ type: "text", text: serialized }],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe(serialized);
+  });
+
+  it("preserves JSON object payloads for openai-completions", () => {
+    const payload = '{"type":"text","text":"Literal object payload."}';
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      api: "openai-completions",
+      content: [{ type: "text", text: payload }],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe(payload);
+  });
+
+  it("does not unwrap typed-block arrays with no text blocks", () => {
+    const raw = '[{"type":"image","url":"https://example.com/img.png"}]';
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      api: "openai-completions",
+      content: [{ type: "text", text: raw }],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe(raw);
   });
 });
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
+import JSON5 from "json5";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 import { sanitizeUserFacingText } from "./pi-embedded-helpers.js";
@@ -207,12 +208,63 @@ export function stripThinkingTagsFromText(text: string): string {
   return stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
 }
 
+function extractTextFromSerializedChatBlocks(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const chunks: string[] = [];
+  let sawTypedBlock = false;
+  for (const block of value) {
+    if (!block || typeof block !== "object") {
+      return null;
+    }
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typeof typed.type !== "string") {
+      return null;
+    }
+    sawTypedBlock = true;
+    if (typed.type === "text" && typeof typed.text === "string" && typed.text.trim()) {
+      chunks.push(typed.text);
+    }
+  }
+
+  if (!sawTypedBlock || chunks.length === 0) {
+    return null;
+  }
+  return chunks.join("\n");
+}
+
+function unwrapSerializedAssistantText(text: string): string {
+  let current = text;
+  for (let i = 0; i < 3; i += 1) {
+    const trimmed = current.trim();
+    if (!trimmed || (trimmed[0] !== "[" && trimmed[0] !== "{")) {
+      break;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON5.parse(trimmed);
+    } catch {
+      break;
+    }
+
+    const extracted = extractTextFromSerializedChatBlocks(parsed);
+    if (!extracted || extracted === current) {
+      break;
+    }
+    current = extracted;
+  }
+  return current;
+}
+
 export function extractAssistantText(msg: AssistantMessage): string {
   const extracted =
     extractTextFromChatContent(msg.content, {
       sanitizeText: (text) =>
         stripThinkingTagsFromText(
-          stripDowngradedToolCallText(stripMinimaxToolCallXml(text)),
+          stripDowngradedToolCallText(stripMinimaxToolCallXml(unwrapSerializedAssistantText(text))),
         ).trim(),
       joinWith: "\n",
       normalizeText: (text) => text.trim(),

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -239,7 +239,8 @@ function unwrapSerializedAssistantText(text: string): string {
   let current = text;
   for (let i = 0; i < 3; i += 1) {
     const trimmed = current.trim();
-    if (!trimmed || (trimmed[0] !== "[" && trimmed[0] !== "{")) {
+    // Serialized typed chat blocks are always wrapped as arrays.
+    if (!trimmed || trimmed[0] !== "[") {
       break;
     }
 
@@ -260,11 +261,16 @@ function unwrapSerializedAssistantText(text: string): string {
 }
 
 export function extractAssistantText(msg: AssistantMessage): string {
+  const shouldUnwrapSerializedText = msg.api === "openai-completions";
   const extracted =
     extractTextFromChatContent(msg.content, {
       sanitizeText: (text) =>
         stripThinkingTagsFromText(
-          stripDowngradedToolCallText(stripMinimaxToolCallXml(unwrapSerializedAssistantText(text))),
+          stripDowngradedToolCallText(
+            stripMinimaxToolCallXml(
+              shouldUnwrapSerializedText ? unwrapSerializedAssistantText(text) : text,
+            ),
+          ),
         ).trim(),
       joinWith: "\n",
       normalizeText: (text) => text.trim(),


### PR DESCRIPTION
## Summary

- Problem: Some custom `openai-completions` backends return assistant text as serialized chat-content blocks (for example `[{"type":"text","text":"..."}]` or JSON5/python-style variants), which was surfaced verbatim to end users.
- Why it matters: Web/chat users receive nested JSON-wrapped payloads instead of readable plain text replies.
- What changed: Added a strict unwrapping step in `extractAssistantText` to parse serialized text-block arrays (including nested wraps) and extract the plain text before existing sanitization.
- What did NOT change (scope boundary): No model routing/provider selection changes and no transport/protocol changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43657
- Related #34134

## User-visible / Behavior Changes

- Assistant replies that arrive as serialized text-block arrays are now unwrapped and shown as plain text.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22 + Vitest
- Model/provider: OpenAI-compatible path (`openai-completions`)
- Integration/channel (if any): Embedded runner assistant text extraction
- Relevant config (redacted): N/A (unit-level coverage)

### Steps

1. Construct assistant message text that matches the nested serialized payload shape reported in #43657.
2. Call `extractAssistantText`.
3. Assert returned text is fully unwrapped plain text.

### Expected

- Plain text output (no JSON/list wrapper leakage).

### Actual

- Regression test now passes and returns plain text.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Nested serialized text blocks with JSON5/python-style quoting are unwrapped to plain text via `extractAssistantText`.
- Edge cases checked: Non-serialized normal assistant text continues through existing sanitization path; unwrapping is bounded and requires typed-block array structure.
- What you did **not** verify: End-to-end Docker/webchat reproduction against the reporter's custom provider.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/agents/pi-embedded-utils.ts`
- Known bad symptoms reviewers should watch for: Assistant messages that are intentionally literal serialized block arrays could be unwrapped unexpectedly.

## Risks and Mitigations

- Risk: Over-eager unwrapping could alter literal text that looks like a chat-content array.
  - Mitigation: Unwrapping only applies when parsing succeeds and value is a typed block array with at least one non-empty `text` block; loop is bounded.

## Validation Commands Run

- `pnpm test src/agents/pi-embedded-utils.test.ts`
  - Result: pass (1 file, 34 tests)
