### PR TITLE
Compaction: add model fallback support for safeguard summarization

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -583,6 +583,9 @@ export async function compactEmbeddedPiSessionDirect(
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
+        agentDir,
+        agentId: sessionAgentId,
+        sessionKey: params.sessionKey,
         provider,
         modelId,
         model,

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -1,6 +1,7 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ExtensionFactory, SessionManager } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveRunModelFallbacksOverride } from "../agent-scope.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { setCompactionSafeguardRuntime } from "../pi-extensions/compaction-safeguard-runtime.js";
@@ -64,6 +65,9 @@ function resolveCompactionMode(cfg?: OpenClawConfig): "default" | "safeguard" {
 export function buildEmbeddedExtensionFactories(params: {
   cfg: OpenClawConfig | undefined;
   sessionManager: SessionManager;
+  agentDir?: string;
+  agentId?: string;
+  sessionKey?: string;
   provider: string;
   modelId: string;
   model: Model<Api> | undefined;
@@ -80,6 +84,15 @@ export function buildEmbeddedExtensionFactories(params: {
       defaultTokens: DEFAULT_CONTEXT_TOKENS,
     });
     setCompactionSafeguardRuntime(params.sessionManager, {
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+      provider: params.provider,
+      modelId: params.modelId,
+      fallbacksOverride: resolveRunModelFallbacksOverride({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      }),
       maxHistoryShare: compactionCfg?.maxHistoryShare,
       contextWindowTokens: contextWindowInfo.tokens,
       identifierPolicy: compactionCfg?.identifierPolicy,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1127,6 +1127,9 @@ export async function runEmbeddedAttempt(
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
+        agentDir,
+        agentId: sessionAgentId,
+        sessionKey: params.sessionKey,
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,8 +1,14 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
+import type { OpenClawConfig } from "../../config/config.js";
 import type { AgentCompactionIdentifierPolicy } from "../../config/types.agent-defaults.js";
 import { createSessionManagerRuntimeRegistry } from "./session-manager-runtime-registry.js";
 
 export type CompactionSafeguardRuntimeValue = {
+  cfg?: OpenClawConfig;
+  agentDir?: string;
+  provider?: string;
+  modelId?: string;
+  fallbacksOverride?: string[];
   maxHistoryShare?: number;
   contextWindowTokens?: number;
   identifierPolicy?: AgentCompactionIdentifierPolicy;

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -116,12 +116,14 @@ const createCompactionEvent = (params: { messageText: string; tokensBefore: numb
 const createCompactionContext = (params: {
   sessionManager: ExtensionContext["sessionManager"];
   getApiKeyMock: ReturnType<typeof vi.fn>;
+  findModelMock?: ReturnType<typeof vi.fn>;
 }) =>
   ({
     model: undefined,
     sessionManager: params.sessionManager,
     modelRegistry: {
       getApiKey: params.getApiKeyMock,
+      find: params.findModelMock,
     },
   }) as unknown as Partial<ExtensionContext>;
 
@@ -1450,6 +1452,122 @@ describe("compaction-safeguard recent-turn preservation", () => {
 });
 
 describe("compaction-safeguard extension model fallback", () => {
+  it("falls back to configured models when compaction summarization hits rate limits", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages
+      .mockRejectedValueOnce(
+        new Error(
+          "Cloud Code Assist API error (429): You have exhausted your capacity on this model.",
+        ),
+      )
+      .mockResolvedValueOnce(
+        [
+          "## Decisions",
+          "Use fallback model.",
+          "## Open TODOs",
+          "None.",
+          "## Constraints/Rules",
+          "Preserve identifiers.",
+          "## Pending user asks",
+          "Summarize latest context.",
+          "## Exact identifiers",
+          "None.",
+        ].join("\n"),
+      );
+
+    const sessionManager = stubSessionManager();
+    const primaryModel = createAnthropicModelFixture();
+    const fallbackModel = createAnthropicModelFixture({
+      id: "gpt-4.1-mini",
+      name: "GPT-4.1 mini",
+      provider: "openai",
+      api: "openai-responses" as Model<Api>["api"],
+      baseUrl: "https://api.openai.com/v1",
+    });
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-5",
+            fallbacks: ["openai/gpt-4.1-mini"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    setCompactionSafeguardRuntime(sessionManager, {
+      cfg,
+      provider: "anthropic",
+      modelId: "claude-opus-4-5",
+      model: primaryModel,
+      recentTurnsPreserve: 0,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn(async (candidateModel: Model<Api>) => {
+      if (candidateModel.provider === "anthropic") {
+        return "anthropic-key";
+      }
+      if (candidateModel.provider === "openai") {
+        return "openai-key";
+      }
+      return null;
+    });
+    const findModelMock = vi.fn((provider: string, modelId: string) => {
+      if (provider === "openai" && modelId === "gpt-4.1-mini") {
+        return fallbackModel;
+      }
+      return null;
+    });
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+      findModelMock,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "please summarize this thread", timestamp: 1 },
+          { role: "assistant", content: "working on it", timestamp: 2 } as unknown as AgentMessage,
+        ],
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: {
+          read: [],
+          edited: [],
+          written: [],
+        },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(result.compaction?.summary).toContain("Use fallback model.");
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
+    expect(mockSummarizeInStages.mock.calls[0]?.[0]?.model).toBe(primaryModel);
+    expect(mockSummarizeInStages.mock.calls[1]?.[0]?.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-4.1-mini",
+    });
+    expect(getApiKeyMock).toHaveBeenCalledWith(primaryModel);
+    expect(getApiKeyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-4.1-mini",
+      }),
+    );
+    expect(findModelMock).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+  });
+
   it("uses runtime.model when ctx.model is undefined (compact.ts workflow)", async () => {
     // This test verifies the root-cause fix: when extensionRunner.initialize() is not called
     // (as happens in compact.ts), ctx.model is undefined but runtime.model is available.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -20,6 +20,8 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
+import { runWithModelFallback } from "../model-fallback.js";
+import { resolveModelWithRegistry } from "../pi-embedded-runner/model.js";
 import { wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -735,16 +737,20 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       return { cancel: true };
     }
 
-    const apiKey = await ctx.modelRegistry.getApiKey(model);
-    if (!apiKey) {
-      console.warn(
-        "Compaction safeguard: no API key available; cancelling compaction to preserve history.",
+    const resolvedProvider = (runtime?.provider ?? model.provider ?? "").trim();
+    const resolvedModelId = (runtime?.modelId ?? model.id ?? "").trim();
+    if (!resolvedProvider || !resolvedModelId) {
+      log.warn(
+        "Compaction safeguard: missing provider/model metadata for summarization; cancelling compaction.",
       );
       return { cancel: true };
     }
 
-    try {
-      const modelContextWindow = resolveContextWindowTokens(model);
+    const buildCompactionSummary = async (
+      summarizationModel: typeof model,
+      summarizationApiKey: string,
+    ) => {
+      const modelContextWindow = resolveContextWindowTokens(summarizationModel);
       const contextWindowTokens = runtime?.contextWindowTokens ?? modelContextWindow;
       const turnPrefixMessages = preparation.turnPrefixMessages ?? [];
       let messagesToSummarize = preparation.messagesToSummarize;
@@ -803,8 +809,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                 );
                 droppedSummary = await summarizeInStages({
                   messages: pruned.droppedMessagesList,
-                  model,
-                  apiKey,
+                  model: summarizationModel,
+                  apiKey: summarizationApiKey,
                   signal,
                   reserveTokens: Math.max(1, Math.floor(preparation.settings.reserveTokens)),
                   maxChunkTokens: droppedMaxChunkTokens,
@@ -870,8 +876,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             messagesToSummarize.length > 0
               ? await summarizeInStages({
                   messages: messagesToSummarize,
-                  model,
-                  apiKey,
+                  model: summarizationModel,
+                  apiKey: summarizationApiKey,
                   signal,
                   reserveTokens,
                   maxChunkTokens,
@@ -886,8 +892,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           if (preparation.isSplitTurn && turnPrefixMessages.length > 0) {
             const prefixSummary = await summarizeInStages({
               messages: turnPrefixMessages,
-              model,
-              apiKey,
+              model: summarizationModel,
+              apiKey: summarizationApiKey,
               signal,
               reserveTokens,
               maxChunkTokens,
@@ -968,6 +974,40 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           details: { readFiles, modifiedFiles },
         },
       };
+    };
+
+    try {
+      const fallbackResult = await runWithModelFallback({
+        cfg: runtime?.cfg,
+        provider: resolvedProvider,
+        model: resolvedModelId,
+        agentDir: runtime?.agentDir,
+        fallbacksOverride: runtime?.fallbacksOverride,
+        run: async (provider, modelId) => {
+          const candidateModel =
+            provider === resolvedProvider && modelId === resolvedModelId
+              ? model
+              : resolveModelWithRegistry({
+                  provider,
+                  modelId,
+                  modelRegistry: ctx.modelRegistry,
+                  cfg: runtime?.cfg,
+                });
+          if (!candidateModel) {
+            throw new Error(
+              `Compaction safeguard: unknown summarization model ${provider}/${modelId}`,
+            );
+          }
+          const candidateApiKey = await ctx.modelRegistry.getApiKey(candidateModel);
+          if (!candidateApiKey) {
+            throw new Error(
+              `Compaction safeguard: no API key available for ${provider}/${modelId}.`,
+            );
+          }
+          return buildCompactionSummary(candidateModel, candidateApiKey);
+        },
+      });
+      return fallbackResult.result;
     } catch (error) {
       log.warn(
         `Compaction summarization failed; cancelling compaction to preserve history: ${


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: compaction safeguard summarization used only the primary model and failed hard on quota/rate-limit errors.
- Why it matters: when the primary model returns 429 during compaction, session compaction can fail and interrupt service.
- What changed: compaction safeguard now runs summarization through `runWithModelFallback`, using the same configured fallback chain (including agent-level fallback overrides) as normal turns.
- What changed: extension runtime wiring now passes provider/model/config/agent scope metadata needed to resolve fallback candidates in both run and compact flows.
- What did NOT change (scope boundary): no changes to non-compaction turn execution fallback behavior.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #15158
- Related #

## User-visible / Behavior Changes

- Compaction safeguard now retries configured fallback models when summarization fails on the selected model (for example quota/rate-limit errors).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: compaction safeguard with configured model fallbacks
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.model.primary` + `agents.defaults.model.fallbacks`

### Steps

1. Configure a primary model and at least one fallback model.
2. Trigger compaction safeguard summarization where the primary model returns a 429/quota failure.
3. Observe compaction summarization proceeds via fallback model.

### Expected

- Compaction summarization should continue using fallback models instead of failing immediately on the primary model.

### Actual

- Verified by test: summarization fails once on primary and then succeeds on fallback model.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added coverage proving fallback model is used when primary compaction summarization fails with 429-like error.
  - Verified extension runtime wiring still works in both run and compact code paths.
- Edge cases checked:
  - Runtime-model fallback path (`ctx.model` undefined) remains covered.
  - Existing compaction safeguard tests remain passing.
- What you did **not** verify:
  - Live end-to-end run against external providers.

Validation commands run:

- `pnpm test -- src/agents/pi-extensions/compaction-safeguard.test.ts src/agents/pi-embedded-runner/extensions.test.ts` (pass)
- `pnpm format` (pass)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: switch compaction mode away from safeguard or revert this PR commit.
- Files/config to restore: compaction safeguard runtime/fallback wiring and extension handler.
- Known bad symptoms reviewers should watch for: compaction cancellations with repeated unknown-model/no-api-key warnings.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: fallback candidate resolution could fail for misconfigured fallback model ids.
  - Mitigation: existing fallback runner surfaces clear errors and compaction remains safely canceled (history preserved).
