### PR TITLE
guard: block malformed internal orchestration from leaking into outbound replies

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -13,8 +13,9 @@ import {
   type ResponsePrefixContext,
 } from "./response-prefix-template.js";
 import { hasSlackDirectives, parseSlackDirectives } from "./slack-directives.js";
+import { hasSuspiciousReplyLeakage } from "./suspicious-reply.js";
 
-export type NormalizeReplySkipReason = "empty" | "silent" | "heartbeat";
+export type NormalizeReplySkipReason = "empty" | "silent" | "heartbeat" | "suspicious";
 
 export type NormalizeReplyOptions = {
   responsePrefix?: string;
@@ -80,6 +81,10 @@ export function normalizeReplyPayload(
 
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
+  }
+  if (text && hasSuspiciousReplyLeakage(text) && !hasMedia && !hasChannelData) {
+    opts.onSkip?.("suspicious");
+    return null;
   }
   if (!text?.trim() && !hasMedia && !hasChannelData) {
     opts.onSkip?.("empty");

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -82,7 +82,7 @@ export function normalizeReplyPayload(
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
   }
-  if (text && hasSuspiciousReplyLeakage(text)) {
+  if (text && hasSuspiciousReplyLeakage(text, { silentToken })) {
     if (!hasMedia && !hasChannelData) {
       opts.onSkip?.("suspicious");
       return null;

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -82,9 +82,12 @@ export function normalizeReplyPayload(
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
   }
-  if (text && hasSuspiciousReplyLeakage(text) && !hasMedia && !hasChannelData) {
-    opts.onSkip?.("suspicious");
-    return null;
+  if (text && hasSuspiciousReplyLeakage(text)) {
+    if (!hasMedia && !hasChannelData) {
+      opts.onSkip?.("suspicious");
+      return null;
+    }
+    text = "";
   }
   if (!text?.trim() && !hasMedia && !hasChannelData) {
     opts.onSkip?.("empty");

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1745,7 +1745,7 @@ describe("followup queue drain restart after idle window", () => {
 const emptyCfg = {} as OpenClawConfig;
 
 describe("createReplyDispatcher", () => {
-  it("drops empty payloads and exact silent tokens without media", async () => {
+  it("drops empty payloads, exact silent tokens, and suspicious leaked orchestration", async () => {
     const deliver = vi.fn().mockResolvedValue(undefined);
     const dispatcher = createReplyDispatcher({ deliver });
 
@@ -1754,6 +1754,11 @@ describe("createReplyDispatcher", () => {
     expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(false);
     expect(dispatcher.sendFinalReply({ text: `${SILENT_REPLY_TOKEN} -- nope` })).toBe(true);
     expect(dispatcher.sendFinalReply({ text: `interject.${SILENT_REPLY_TOKEN}` })).toBe(true);
+    expect(
+      dispatcher.sendFinalReply({
+        text: `${SILENT_REPLY_TOKEN}\nassistant to=functions.exec\n{"command":"ls","yieldMs":1000}`,
+      }),
+    ).toBe(false);
 
     await dispatcher.waitForIdle();
     expect(deliver).toHaveBeenCalledTimes(2);

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -11,6 +11,7 @@ import {
   resolveResponsePrefixTemplate,
 } from "./response-prefix-template.js";
 import { createStreamingDirectiveAccumulator } from "./streaming-directives.js";
+import { hasSuspiciousReplyLeakage } from "./suspicious-reply.js";
 import { createMockTypingController } from "./test-helpers.js";
 import { createTypingSignaler, resolveTypingMode } from "./typing-mode.js";
 import { createTypingController } from "./typing.js";
@@ -210,6 +211,40 @@ describe("normalizeReplyPayload", () => {
         ],
       },
     });
+  });
+
+  it("suppresses suspicious internal orchestration leakage", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      {
+        text: [
+          "NO_REPLY",
+          "assistant to=functions.exec commentary to=functions.exec ＿json",
+          '{"command":"ls ~/.openclaw/agents/main/sessions/ | head -20","yieldMs":10000}',
+        ].join("\n"),
+      },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["suspicious"]);
+  });
+
+  it("keeps explanatory text that merely mentions leaked markers", () => {
+    const result = normalizeReplyPayload({
+      text: "The leaked prefix was assistant to=functions.exec, which should never be sent.",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("assistant to=functions.exec");
+  });
+
+  it("does not flag fenced code samples as suspicious by default", () => {
+    expect(
+      hasSuspiciousReplyLeakage(
+        ["```text", "assistant to=functions.exec", '{"command":"ls","yieldMs":1000}', "```"].join(
+          "\n",
+        ),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -312,6 +312,20 @@ describe("normalizeReplyPayload", () => {
     ).toBe(true);
   });
 
+  it("flags structured route marker text paired with pretty-printed tool JSON", () => {
+    expect(
+      hasSuspiciousReplyLeakage(
+        [
+          "assistant to=functions.exec commentary to=functions.exec",
+          "{",
+          '"command":"ls",',
+          '"yieldMs":1000',
+          "}",
+        ].join("\n"),
+      ),
+    ).toBe(true);
+  });
+
   it("does not flag NO_REPLY explanations with tool JSON lines", () => {
     expect(
       hasSuspiciousReplyLeakage(
@@ -325,7 +339,10 @@ describe("normalizeReplyPayload", () => {
       hasSuspiciousReplyLeakage(
         [
           "assistant to=functions.exec",
-          '{"command":"ls","yieldMs":1000}',
+          "{",
+          '"command":"ls",',
+          '"yieldMs":1000',
+          "}",
           "This is an example of leaked orchestration text.",
         ].join("\n"),
       ),

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -321,6 +321,38 @@ describe("normalizeReplyPayload", () => {
     expect(reasons).toEqual(["suspicious"]);
   });
 
+  it("suppresses standalone route-marker leakage without tool JSON", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      {
+        text: "assistant to=functions.exec",
+      },
+      {
+        onSkip: (reason) => reasons.push(reason),
+      },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["suspicious"]);
+  });
+
+  it("suppresses multiple standalone route-marker leakage lines", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      {
+        text: [
+          "assistant to=functions.exec",
+          "commentary to=functions.exec",
+          "user to=functions.exec",
+        ].join("\n"),
+      },
+      {
+        onSkip: (reason) => reasons.push(reason),
+      },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["suspicious"]);
+  });
+
   it("does not flag fenced code samples as suspicious by default", () => {
     expect(
       hasSuspiciousReplyLeakage(
@@ -352,6 +384,15 @@ describe("normalizeReplyPayload", () => {
           '"yieldMs":1000',
           "}",
         ].join("\n"),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags standalone route-marker leakage without tool JSON", () => {
+    expect(hasSuspiciousReplyLeakage("assistant to=functions.exec")).toBe(true);
+    expect(
+      hasSuspiciousReplyLeakage(
+        ["assistant to=functions.exec", "commentary to=functions.exec"].join("\n"),
       ),
     ).toBe(true);
   });

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -388,6 +388,23 @@ describe("normalizeReplyPayload", () => {
     ).toBe(true);
   });
 
+  it("flags structured route marker text paired with array values in tool JSON", () => {
+    expect(
+      hasSuspiciousReplyLeakage(
+        [
+          "assistant to=functions.exec commentary to=functions.exec",
+          "{",
+          '"command":"ls",',
+          '"paths": [',
+          '"a",',
+          '"b"',
+          "]",
+          "}",
+        ].join("\n"),
+      ),
+    ).toBe(true);
+  });
+
   it("flags standalone route-marker leakage without tool JSON", () => {
     expect(hasSuspiciousReplyLeakage("assistant to=functions.exec")).toBe(true);
     expect(

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -291,6 +291,17 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toContain("This is an example of leaked orchestration text.");
   });
 
+  it("keeps single-line JSON examples when prose follows on the same line", () => {
+    const result = normalizeReplyPayload({
+      text: [
+        "assistant to=functions.exec",
+        '{"command":"ls","yieldMs":1000} is an example payload.',
+      ].join("\n"),
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain('{"command":"ls","yieldMs":1000} is an example payload.');
+  });
+
   it("suppresses suspicious leakage when using a custom silent token", () => {
     const reasons: string[] = [];
     const result = normalizeReplyPayload(
@@ -363,6 +374,17 @@ describe("normalizeReplyPayload", () => {
           '"yieldMs":1000',
           "}",
           "This is an example of leaked orchestration text.",
+        ].join("\n"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not flag route-marker examples when prose follows single-line JSON", () => {
+    expect(
+      hasSuspiciousReplyLeakage(
+        [
+          "assistant to=functions.exec",
+          '{"command":"ls","yieldMs":1000} is an example payload.',
         ].join("\n"),
       ),
     ).toBe(false);

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -259,6 +259,14 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toContain("assistant to=functions.exec");
   });
 
+  it("keeps route-marker explanations with inline JSON examples", () => {
+    const result = normalizeReplyPayload({
+      text: 'assistant to=functions.exec is internal; example: {"path":"/tmp"}',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain('{"path":"/tmp"}');
+  });
+
   it("does not flag fenced code samples as suspicious by default", () => {
     expect(
       hasSuspiciousReplyLeakage(
@@ -267,6 +275,17 @@ describe("normalizeReplyPayload", () => {
         ),
       ),
     ).toBe(false);
+  });
+
+  it("flags structured route marker text paired with tool JSON lines", () => {
+    expect(
+      hasSuspiciousReplyLeakage(
+        [
+          "assistant to=functions.exec commentary to=functions.exec",
+          '{"command":"ls","yieldMs":1000}',
+        ].join("\n"),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -229,9 +229,31 @@ describe("normalizeReplyPayload", () => {
     expect(reasons).toEqual(["suspicious"]);
   });
 
+  it("strips suspicious text but keeps media payload", () => {
+    const result = normalizeReplyPayload({
+      text: [
+        "NO_REPLY",
+        "assistant to=functions.exec commentary to=functions.exec ＿json",
+        '{"command":"ls ~/.openclaw/agents/main/sessions/ | head -20","yieldMs":10000}',
+      ].join("\n"),
+      mediaUrl: "https://example.com/img.png",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("");
+    expect(result!.mediaUrl).toBe("https://example.com/img.png");
+  });
+
   it("keeps explanatory text that merely mentions leaked markers", () => {
     const result = normalizeReplyPayload({
       text: "The leaked prefix was assistant to=functions.exec, which should never be sent.",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("assistant to=functions.exec");
+  });
+
+  it("keeps explanatory text that starts with a route marker mention", () => {
+    const result = normalizeReplyPayload({
+      text: "assistant to=functions.exec is an internal prefix and should never reach users.",
     });
     expect(result).not.toBeNull();
     expect(result!.text).toContain("assistant to=functions.exec");

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -291,6 +291,25 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toContain("This is an example of leaked orchestration text.");
   });
 
+  it("suppresses suspicious leakage when using a custom silent token", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      {
+        text: [
+          "QUIET_MODE",
+          "assistant to=functions.exec commentary to=functions.exec",
+          '{"command":"ls","yieldMs":1000}',
+        ].join("\n"),
+      },
+      {
+        silentToken: "QUIET_MODE",
+        onSkip: (reason) => reasons.push(reason),
+      },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["suspicious"]);
+  });
+
   it("does not flag fenced code samples as suspicious by default", () => {
     expect(
       hasSuspiciousReplyLeakage(

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -267,6 +267,17 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toContain('{"path":"/tmp"}');
   });
 
+  it("keeps NO_REPLY explanations with tool-style JSON examples", () => {
+    const result = normalizeReplyPayload({
+      text: ['NO_REPLY means "do not answer". Example:', '{"command":"ls","yieldMs":1000}'].join(
+        "\n",
+      ),
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain('NO_REPLY means "do not answer".');
+    expect(result!.text).toContain('{"command":"ls","yieldMs":1000}');
+  });
+
   it("does not flag fenced code samples as suspicious by default", () => {
     expect(
       hasSuspiciousReplyLeakage(
@@ -286,6 +297,16 @@ describe("normalizeReplyPayload", () => {
         ].join("\n"),
       ),
     ).toBe(true);
+  });
+
+  it("does not flag NO_REPLY explanations with tool JSON lines", () => {
+    expect(
+      hasSuspiciousReplyLeakage(
+        ['NO_REPLY means "do not answer". Example:', '{"command":"ls","yieldMs":1000}'].join(
+          "\n",
+        ),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -278,6 +278,19 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toContain('{"command":"ls","yieldMs":1000}');
   });
 
+  it("keeps multiline route-marker examples when prose explains them", () => {
+    const result = normalizeReplyPayload({
+      text: [
+        "assistant to=functions.exec",
+        '{"command":"ls","yieldMs":1000}',
+        "This is an example of leaked orchestration text.",
+      ].join("\n"),
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("assistant to=functions.exec");
+    expect(result!.text).toContain("This is an example of leaked orchestration text.");
+  });
+
   it("does not flag fenced code samples as suspicious by default", () => {
     expect(
       hasSuspiciousReplyLeakage(
@@ -302,9 +315,19 @@ describe("normalizeReplyPayload", () => {
   it("does not flag NO_REPLY explanations with tool JSON lines", () => {
     expect(
       hasSuspiciousReplyLeakage(
-        ['NO_REPLY means "do not answer". Example:', '{"command":"ls","yieldMs":1000}'].join(
-          "\n",
-        ),
+        ['NO_REPLY means "do not answer". Example:', '{"command":"ls","yieldMs":1000}'].join("\n"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not flag route-marker examples when prose follows the JSON block", () => {
+    expect(
+      hasSuspiciousReplyLeakage(
+        [
+          "assistant to=functions.exec",
+          '{"command":"ls","yieldMs":1000}',
+          "This is an example of leaked orchestration text.",
+        ].join("\n"),
       ),
     ).toBe(false);
   });

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -104,5 +104,8 @@ export function hasSuspiciousReplyLeakage(
   ) {
     routeMarkerLineCount += 1;
   }
+  if (routeMarkerLineCount === lines.length) {
+    return true;
+  }
   return hasStructuredToolJsonBlock(lines.slice(routeMarkerLineCount));
 }

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -34,16 +34,33 @@ function isStructuredToolJsonLine(line: string): boolean {
   return trimmed.startsWith("{") && TOOL_JSON_KEY_RE.test(trimmed);
 }
 
-function hasStructuredToolJsonLine(text: string): boolean {
-  return nonEmptyLines(text).some(isStructuredToolJsonLine);
+function isJsonBlockLine(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed === "{" ||
+    trimmed === "}" ||
+    trimmed === "[" ||
+    trimmed === "]" ||
+    trimmed === "}," ||
+    trimmed === "]," ||
+    /^"(?:\\.|[^"])+\"\s*:/.test(trimmed)
+  );
 }
 
-function hasOnlyStructuredLeakageLines(text: string): boolean {
-  const lines = nonEmptyLines(text);
-  return (
-    lines.length > 0 &&
-    lines.every((line) => isStructuredRouteMarkerLine(line) || isStructuredToolJsonLine(line))
-  );
+function hasStructuredToolJsonBlock(lines: string[]): boolean {
+  if (lines.length === 0) {
+    return false;
+  }
+  if (lines.length === 1) {
+    return isStructuredToolJsonLine(lines[0]);
+  }
+  if (lines[0] !== "{") {
+    return false;
+  }
+  if (lines.at(-1) !== "}") {
+    return false;
+  }
+  return lines.every(isJsonBlockLine) && lines.some((line) => TOOL_JSON_KEY_RE.test(line));
 }
 
 export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
@@ -58,12 +75,17 @@ export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
   const hasLeadingSilentWithExtra =
     trimmed.toUpperCase().startsWith(SILENT_REPLY_TOKEN) && !isSilentReplyText(trimmed);
   const candidate = hasLeadingSilentWithExtra ? stripLeadingSilentToken(trimmed) : trimmed;
-  const hasStructuredRouteMarkerLead = STRUCTURED_ROUTE_MARKER_LINE_RE.test(
-    firstNonEmptyLine(candidate),
-  );
-  const hasToolJsonArgs = candidate.includes("{") && hasStructuredToolJsonLine(candidate);
-
-  return (
-    hasStructuredRouteMarkerLead && hasToolJsonArgs && hasOnlyStructuredLeakageLines(candidate)
-  );
+  const lines = nonEmptyLines(candidate);
+  const firstLine = firstNonEmptyLine(candidate);
+  if (!STRUCTURED_ROUTE_MARKER_LINE_RE.test(firstLine)) {
+    return false;
+  }
+  let routeMarkerLineCount = 0;
+  while (
+    routeMarkerLineCount < lines.length &&
+    isStructuredRouteMarkerLine(lines[routeMarkerLineCount] ?? "")
+  ) {
+    routeMarkerLineCount += 1;
+  }
+  return hasStructuredToolJsonBlock(lines.slice(routeMarkerLineCount));
 }

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -1,0 +1,34 @@
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+
+const LEADING_ROUTE_MARKER_RE = /^(?:assistant|user|commentary)\s+to=\S+/i;
+const FUNCTION_TARGET_RE = /\bfunctions\.[a-z0-9_]+\b/i;
+const TOOL_JSON_KEY_RE =
+  /"(?:command|yieldMs|workdir|path|file_path|oldText|newText|old_string|new_string|sessionId|offset|limit|timeout|background|pty|elevated|security|ask|node)"\s*:/i;
+
+export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
+  if (!text) {
+    return false;
+  }
+  const trimmed = text.trimStart();
+  if (!trimmed) {
+    return false;
+  }
+
+  const firstLine = trimmed.split(/\r?\n/, 1)[0] ?? "";
+  const hasLeadingRouteMarker = LEADING_ROUTE_MARKER_RE.test(firstLine);
+  const hasLeadingSilentWithExtra =
+    trimmed.toUpperCase().startsWith(SILENT_REPLY_TOKEN) && !isSilentReplyText(trimmed);
+  const hasInternalToolMarker = FUNCTION_TARGET_RE.test(trimmed);
+  const hasToolJsonArgs = trimmed.includes("{") && TOOL_JSON_KEY_RE.test(trimmed);
+
+  if (
+    hasLeadingSilentWithExtra &&
+    (hasLeadingRouteMarker || hasInternalToolMarker || hasToolJsonArgs)
+  ) {
+    return true;
+  }
+  if (hasLeadingRouteMarker && (hasInternalToolMarker || hasToolJsonArgs)) {
+    return true;
+  }
+  return false;
+}

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -42,7 +42,7 @@ function isStructuredRouteMarkerLine(line: string): boolean {
 
 function isStructuredToolJsonLine(line: string): boolean {
   const trimmed = line.trim();
-  return trimmed.startsWith("{") && TOOL_JSON_KEY_RE.test(trimmed);
+  return trimmed.startsWith("{") && trimmed.endsWith("}") && TOOL_JSON_KEY_RE.test(trimmed);
 }
 
 function isJsonBlockLine(line: string): boolean {
@@ -54,7 +54,7 @@ function isJsonBlockLine(line: string): boolean {
     trimmed === "]" ||
     trimmed === "}," ||
     trimmed === "]," ||
-    /^"(?:\\.|[^"])+\"\s*:/.test(trimmed)
+    /^"(?:\\.|[^"])+"\s*:/.test(trimmed)
   );
 }
 

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from "../../utils.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 
 const STRUCTURED_ROUTE_MARKER_LINE_RE =
@@ -5,8 +6,18 @@ const STRUCTURED_ROUTE_MARKER_LINE_RE =
 const TOOL_JSON_KEY_RE =
   /"(?:command|yieldMs|workdir|file_path|oldText|newText|old_string|new_string|sessionId|timeout|background|pty|elevated)"\s*:/i;
 
-function stripLeadingSilentToken(text: string): string {
-  return text.replace(new RegExp(`^\\s*${SILENT_REPLY_TOKEN}\\b`, "i"), "").trimStart();
+export type SuspiciousReplyLeakageOptions = {
+  silentToken?: string;
+};
+
+function stripLeadingSilentToken(text: string, silentToken: string): string {
+  const escapedToken = escapeRegExp(silentToken);
+  return text.replace(new RegExp(`^\\s*${escapedToken}(?=\\s|$|\\b)`, "i"), "").trimStart();
+}
+
+function startsWithSilentToken(text: string, silentToken: string): boolean {
+  const escapedToken = escapeRegExp(silentToken);
+  return new RegExp(`^\\s*${escapedToken}(?=\\s|$|\\b)`, "i").test(text);
 }
 
 function firstNonEmptyLine(text: string): string {
@@ -63,7 +74,10 @@ function hasStructuredToolJsonBlock(lines: string[]): boolean {
   return lines.every(isJsonBlockLine) && lines.some((line) => TOOL_JSON_KEY_RE.test(line));
 }
 
-export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
+export function hasSuspiciousReplyLeakage(
+  text: string | undefined,
+  opts: SuspiciousReplyLeakageOptions = {},
+): boolean {
   if (!text) {
     return false;
   }
@@ -72,9 +86,12 @@ export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
     return false;
   }
 
+  const silentToken = opts.silentToken ?? SILENT_REPLY_TOKEN;
   const hasLeadingSilentWithExtra =
-    trimmed.toUpperCase().startsWith(SILENT_REPLY_TOKEN) && !isSilentReplyText(trimmed);
-  const candidate = hasLeadingSilentWithExtra ? stripLeadingSilentToken(trimmed) : trimmed;
+    startsWithSilentToken(trimmed, silentToken) && !isSilentReplyText(trimmed, silentToken);
+  const candidate = hasLeadingSilentWithExtra
+    ? stripLeadingSilentToken(trimmed, silentToken)
+    : trimmed;
   const lines = nonEmptyLines(candidate);
   const firstLine = firstNonEmptyLine(candidate);
   if (!STRUCTURED_ROUTE_MARKER_LINE_RE.test(firstLine)) {

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -1,9 +1,29 @@
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 
-const LEADING_ROUTE_MARKER_RE = /^(?:assistant|user|commentary)\s+to=\S+/i;
-const FUNCTION_TARGET_RE = /\bfunctions\.[a-z0-9_]+\b/i;
+const STRUCTURED_ROUTE_MARKER_LINE_RE =
+  /^(?:(?:assistant|user|commentary)\s+to=\S+)(?:\s+(?:(?:assistant|user|commentary)\s+to=\S+|[_\uFF3F]?json))*\s*$/i;
 const TOOL_JSON_KEY_RE =
-  /"(?:command|yieldMs|workdir|path|file_path|oldText|newText|old_string|new_string|sessionId|offset|limit|timeout|background|pty|elevated|security|ask|node)"\s*:/i;
+  /"(?:command|yieldMs|workdir|file_path|oldText|newText|old_string|new_string|sessionId|timeout|background|pty|elevated)"\s*:/i;
+
+function stripLeadingSilentToken(text: string): string {
+  return text.replace(new RegExp(`^\\s*${SILENT_REPLY_TOKEN}\\b`, "i"), "").trimStart();
+}
+
+function firstNonEmptyLine(text: string): string {
+  for (const line of text.split(/\r?\n/)) {
+    if (line.trim()) {
+      return line.trim();
+    }
+  }
+  return "";
+}
+
+function hasStructuredToolJsonLine(text: string): boolean {
+  return text.split(/\r?\n/).some((line) => {
+    const trimmed = line.trimStart();
+    return trimmed.startsWith("{") && TOOL_JSON_KEY_RE.test(trimmed);
+  });
+}
 
 export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
   if (!text) {
@@ -14,20 +34,18 @@ export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
     return false;
   }
 
-  const firstLine = trimmed.split(/\r?\n/, 1)[0] ?? "";
-  const hasLeadingRouteMarker = LEADING_ROUTE_MARKER_RE.test(firstLine);
   const hasLeadingSilentWithExtra =
     trimmed.toUpperCase().startsWith(SILENT_REPLY_TOKEN) && !isSilentReplyText(trimmed);
-  const hasInternalToolMarker = FUNCTION_TARGET_RE.test(trimmed);
-  const hasToolJsonArgs = trimmed.includes("{") && TOOL_JSON_KEY_RE.test(trimmed);
+  const candidate = hasLeadingSilentWithExtra ? stripLeadingSilentToken(trimmed) : trimmed;
+  const hasStructuredRouteMarkerLead = STRUCTURED_ROUTE_MARKER_LINE_RE.test(
+    firstNonEmptyLine(candidate),
+  );
+  const hasToolJsonArgs = candidate.includes("{") && hasStructuredToolJsonLine(candidate);
 
-  if (
-    hasLeadingSilentWithExtra &&
-    (hasLeadingRouteMarker || hasInternalToolMarker || hasToolJsonArgs)
-  ) {
+  if (hasLeadingSilentWithExtra && (hasStructuredRouteMarkerLead || hasToolJsonArgs)) {
     return true;
   }
-  if (hasLeadingRouteMarker && hasToolJsonArgs) {
+  if (hasStructuredRouteMarkerLead && hasToolJsonArgs) {
     return true;
   }
   return false;

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -18,11 +18,32 @@ function firstNonEmptyLine(text: string): string {
   return "";
 }
 
+function nonEmptyLines(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function isStructuredRouteMarkerLine(line: string): boolean {
+  return STRUCTURED_ROUTE_MARKER_LINE_RE.test(line.trim());
+}
+
+function isStructuredToolJsonLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith("{") && TOOL_JSON_KEY_RE.test(trimmed);
+}
+
 function hasStructuredToolJsonLine(text: string): boolean {
-  return text.split(/\r?\n/).some((line) => {
-    const trimmed = line.trimStart();
-    return trimmed.startsWith("{") && TOOL_JSON_KEY_RE.test(trimmed);
-  });
+  return nonEmptyLines(text).some(isStructuredToolJsonLine);
+}
+
+function hasOnlyStructuredLeakageLines(text: string): boolean {
+  const lines = nonEmptyLines(text);
+  return (
+    lines.length > 0 &&
+    lines.every((line) => isStructuredRouteMarkerLine(line) || isStructuredToolJsonLine(line))
+  );
 }
 
 export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
@@ -42,5 +63,7 @@ export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
   );
   const hasToolJsonArgs = candidate.includes("{") && hasStructuredToolJsonLine(candidate);
 
-  return hasStructuredRouteMarkerLead && hasToolJsonArgs;
+  return (
+    hasStructuredRouteMarkerLead && hasToolJsonArgs && hasOnlyStructuredLeakageLines(candidate)
+  );
 }

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -42,11 +42,5 @@ export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
   );
   const hasToolJsonArgs = candidate.includes("{") && hasStructuredToolJsonLine(candidate);
 
-  if (hasLeadingSilentWithExtra && (hasStructuredRouteMarkerLead || hasToolJsonArgs)) {
-    return true;
-  }
-  if (hasStructuredRouteMarkerLead && hasToolJsonArgs) {
-    return true;
-  }
-  return false;
+  return hasStructuredRouteMarkerLead && hasToolJsonArgs;
 }

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -45,6 +45,15 @@ function isStructuredToolJsonLine(line: string): boolean {
   return trimmed.startsWith("{") && trimmed.endsWith("}") && TOOL_JSON_KEY_RE.test(trimmed);
 }
 
+function isJsonValueLine(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    /^"(?:\\.|[^"])*",?$/.test(trimmed) ||
+    /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?,?$/.test(trimmed) ||
+    /^(?:true|false|null),?$/.test(trimmed)
+  );
+}
+
 function isJsonBlockLine(line: string): boolean {
   const trimmed = line.trim();
   return (
@@ -54,7 +63,8 @@ function isJsonBlockLine(line: string): boolean {
     trimmed === "]" ||
     trimmed === "}," ||
     trimmed === "]," ||
-    /^"(?:\\.|[^"])+"\s*:/.test(trimmed)
+    /^"(?:\\.|[^"])+"\s*:/.test(trimmed) ||
+    isJsonValueLine(trimmed)
   );
 }
 
@@ -97,6 +107,7 @@ export function hasSuspiciousReplyLeakage(
   if (!STRUCTURED_ROUTE_MARKER_LINE_RE.test(firstLine)) {
     return false;
   }
+
   let routeMarkerLineCount = 0;
   while (
     routeMarkerLineCount < lines.length &&
@@ -104,6 +115,7 @@ export function hasSuspiciousReplyLeakage(
   ) {
     routeMarkerLineCount += 1;
   }
+
   if (routeMarkerLineCount === lines.length) {
     return true;
   }

--- a/src/auto-reply/reply/suspicious-reply.ts
+++ b/src/auto-reply/reply/suspicious-reply.ts
@@ -27,7 +27,7 @@ export function hasSuspiciousReplyLeakage(text: string | undefined): boolean {
   ) {
     return true;
   }
-  if (hasLeadingRouteMarker && (hasInternalToolMarker || hasToolJsonArgs)) {
+  if (hasLeadingRouteMarker && hasToolJsonArgs) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary
This PR adds a small, channel-agnostic guard in the shared auto-reply normalization path to prevent malformed internal orchestration text from being delivered as user-visible assistant output.

## Problem
In the reported failure mode, the model returned plain text that looked like internal orchestration state rather than a normal reply, for example:

- `NO_REPLY` followed by additional text
- `assistant to=functions.exec`
- `user to=functions.exec`
- `commentary to=...`
- raw tool-style JSON such as `{"command":"...","yieldMs":1000}`

Because this content arrived as ordinary text instead of a structured tool call/result, OpenClaw could treat it as a normal assistant reply and send it to an outbound channel.

## Approach
This change adds a lightweight detector for **suspicious combinations** of leakage markers and suppresses those payloads before delivery.

The guard is intentionally narrow:

- it does **not** change exact `NO_REPLY` handling
- it does **not** block ordinary discussion that merely mentions these tokens
- it does **not** add a Discord-specific workaround

Instead, it operates in the shared reply normalization path so the protection applies consistently across channels.

## Changes
- add `hasSuspiciousReplyLeakage()` in `src/auto-reply/reply/suspicious-reply.ts`
- extend `normalizeReplyPayload()` with a new `suspicious` skip reason
- add focused tests covering both blocking and non-blocking cases

## Notes on scope
This PR is intentionally conservative. It is meant to block obviously malformed leakage patterns, not to fully parse or validate every possible model output shape.

## Tests
Ran:

```bash
corepack pnpm vitest run src/auto-reply/reply/reply-utils.test.ts src/auto-reply/reply/reply-flow.test.ts
```

Result:
- 2 test files passed
- 86 tests passed
