### PR TITLE
Backup: stream archive writes to avoid silent partial tmp files

### DIFF
--- a/src/commands/backup.atomic.test.ts
+++ b/src/commands/backup.atomic.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 
@@ -37,7 +38,14 @@ describe("backupCreateCommand atomic archive write", () => {
       await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
       await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
 
-      tarCreateMock.mockRejectedValueOnce(new Error("disk full"));
+      tarCreateMock.mockImplementationOnce(() => {
+        const stream = new Readable({ read() {} });
+        setImmediate(() => {
+          stream.push(Buffer.from("1f8b08000000000000ff", "hex"));
+          stream.emit("error", new Error("disk full"));
+        });
+        return stream;
+      });
 
       const runtime = {
         log: vi.fn(),
@@ -69,9 +77,7 @@ describe("backupCreateCommand atomic archive write", () => {
       await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
       await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
 
-      tarCreateMock.mockImplementationOnce(async ({ file }: { file: string }) => {
-        await fs.writeFile(file, "archive-bytes", "utf8");
-      });
+      tarCreateMock.mockImplementationOnce(() => Readable.from(["archive-bytes"]));
       linkSpy.mockImplementationOnce(async (existingPath, newPath) => {
         await fs.writeFile(newPath, "concurrent-archive", "utf8");
         return await realLink(existingPath, newPath);
@@ -105,9 +111,7 @@ describe("backupCreateCommand atomic archive write", () => {
       await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
       await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
 
-      tarCreateMock.mockImplementationOnce(async ({ file }: { file: string }) => {
-        await fs.writeFile(file, "archive-bytes", "utf8");
-      });
+      tarCreateMock.mockImplementationOnce(() => Readable.from(["archive-bytes"]));
       linkSpy.mockRejectedValueOnce(
         Object.assign(new Error("hard links not supported"), { code: "EOPNOTSUPP" }),
       );

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
 import * as tar from "tar";
 import {
   buildBackupArchiveBasename,
@@ -342,21 +343,23 @@ export async function createBackupArchive(
     });
     await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 
-    await tar.c(
-      {
-        file: tempArchivePath,
-        gzip: true,
-        portable: true,
-        preservePaths: true,
-        onWriteEntry: (entry) => {
-          entry.path = remapArchiveEntryPath({
-            entryPath: entry.path,
-            manifestPath,
-            archiveRoot,
-          });
+    await pipeline(
+      tar.c(
+        {
+          gzip: true,
+          portable: true,
+          preservePaths: true,
+          onWriteEntry: (entry) => {
+            entry.path = remapArchiveEntryPath({
+              entryPath: entry.path,
+              manifestPath,
+              archiveRoot,
+            });
+          },
         },
-      },
-      [manifestPath, ...result.assets.map((asset) => asset.sourcePath)],
+        [manifestPath, ...result.assets.map((asset) => asset.sourcePath)],
+      ),
+      createWriteStream(tempArchivePath),
     );
     await publishTempArchive({ tempArchivePath, outputPath });
   } finally {


### PR DESCRIPTION
## Summary

- Problem: `openclaw backup create` could leave a partial `.tmp` gzip file and exit without producing a finalized archive.
- Why it matters: users can get a false-success backup run while ending up without a valid `.tar.gz` backup artifact.
- What changed: switched backup archive writing from `tar.c({ file })` to an explicit stream pipeline (`tar.c(...)` -> `createWriteStream(...)`) so stream write errors/finalization are propagated and handled deterministically.
- What did NOT change (scope boundary): backup planning logic, manifest format, verification command behavior, and backup inclusion/exclusion semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41258
- Related #42282

## User-visible / Behavior Changes

- `openclaw backup create` now writes archives through an explicit stream pipeline; partial write failures propagate as command failures instead of silently leaving an unusable partial temp archive.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): temporary test home/state dirs

### Steps

1. Run backup command tests with stream-failure and publication race paths.
2. Run standard backup command tests for archive structure and behavior.
3. Run manual backup creation against a large random payload state directory.

### Expected

- Archive writes complete with finalized `.tar.gz` output.
- Stream errors fail the command and leave no orphan `.tmp` archive.

### Actual

- Matches expected after this change.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/commands/backup.atomic.test.ts src/commands/backup.test.ts` (all passing)
  - Manual archive creation via `createBackupArchive` with a 64 MiB random state payload (produced finalized non-empty `.tar.gz`)
- Edge cases checked:
  - Stream error after partial gzip-header bytes leaves no final archive and no orphan `.tmp`
  - Publish race still refuses overwrite
  - Hard-link fallback path still publishes via exclusive copy
- What you did **not** verify:
  - End-to-end CLI run from built `dist` because repo-wide `pnpm build` currently fails in this environment due unrelated upstream TypeScript issues.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `9eb0561db`.
- Files/config to restore:
  - `src/infra/backup-create.ts`
  - `src/commands/backup.atomic.test.ts`
- Known bad symptoms reviewers should watch for:
  - Backup create fails despite healthy disk paths.
  - Orphan `.tmp` backup files after failed writes.

## Risks and Mitigations

- Risk:
  - Stream pipeline behavior differs from `tar.c({ file })` path on edge filesystem behaviors.
  - Mitigation:
    - Focused regression coverage for stream failure, publish race, and hard-link fallback remains in `backup.atomic` tests.
