### PR TITLE
Infra: block GIT_EXEC_PATH in host env sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Docs: https://docs.openclaw.ai
 - Dependencies: refresh workspace dependencies except the pinned Carbon package, and harden ACP session-config writes against non-string SDK values so newer ACP clients fail fast instead of tripping type/runtime mismatches.
 - Gateway/config errors: surface up to three validation issues in top-level `config.set`, `config.patch`, and `config.apply` error messages while preserving structured issue details. (#42664) Thanks @huntharo.
 - Hooks/plugin context parity followup: pass `trigger` and `channelId` through embedded `llm_input`, `agent_end`, and `llm_output` hook contexts so plugins receive the same agent metadata across hook phases. (#42362) Thanks @zhoulf1006.
+- Security/host env: block inherited `GIT_EXEC_PATH` from sanitized host exec environments so Git helper resolution cannot be steered by host environment state. (#43685) Thanks @vincentkoc.
 
 ## 2026.3.8
 

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -17,6 +17,7 @@ enum HostEnvSecurityPolicy {
         "BASH_ENV",
         "ENV",
         "GIT_EXTERNAL_DIFF",
+        "GIT_EXEC_PATH",
         "SHELL",
         "SHELLOPTS",
         "PS4",

--- a/src/infra/host-env-security-policy.json
+++ b/src/infra/host-env-security-policy.json
@@ -11,6 +11,7 @@
     "BASH_ENV",
     "ENV",
     "GIT_EXTERNAL_DIFF",
+    "GIT_EXEC_PATH",
     "SHELL",
     "SHELLOPTS",
     "PS4",

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -18,6 +18,7 @@ describe("isDangerousHostEnvVarName", () => {
     expect(isDangerousHostEnvVarName("bash_env")).toBe(true);
     expect(isDangerousHostEnvVarName("SHELL")).toBe(true);
     expect(isDangerousHostEnvVarName("GIT_EXTERNAL_DIFF")).toBe(true);
+    expect(isDangerousHostEnvVarName("git_exec_path")).toBe(true);
     expect(isDangerousHostEnvVarName("SHELLOPTS")).toBe(true);
     expect(isDangerousHostEnvVarName("ps4")).toBe(true);
     expect(isDangerousHostEnvVarName("DYLD_INSERT_LIBRARIES")).toBe(true);
@@ -60,6 +61,7 @@ describe("sanitizeHostExecEnv", () => {
         ZDOTDIR: "/tmp/evil-zdotdir",
         BASH_ENV: "/tmp/pwn.sh",
         GIT_SSH_COMMAND: "touch /tmp/pwned",
+        GIT_EXEC_PATH: "/tmp/git-exec-path",
         EDITOR: "/tmp/editor",
         NPM_CONFIG_USERCONFIG: "/tmp/npmrc",
         GIT_CONFIG_GLOBAL: "/tmp/gitconfig",
@@ -73,6 +75,7 @@ describe("sanitizeHostExecEnv", () => {
     expect(env.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
     expect(env.BASH_ENV).toBeUndefined();
     expect(env.GIT_SSH_COMMAND).toBeUndefined();
+    expect(env.GIT_EXEC_PATH).toBeUndefined();
     expect(env.EDITOR).toBeUndefined();
     expect(env.NPM_CONFIG_USERCONFIG).toBeUndefined();
     expect(env.GIT_CONFIG_GLOBAL).toBeUndefined();
@@ -211,6 +214,60 @@ describe("shell wrapper exploit regression", () => {
 });
 
 describe("git env exploit regression", () => {
+  it("blocks inherited GIT_EXEC_PATH so git cannot execute helper payloads", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const gitPath = "/usr/bin/git";
+    if (!fs.existsSync(gitPath)) {
+      return;
+    }
+
+    const helperDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), `openclaw-git-exec-path-${process.pid}-${Date.now()}-`),
+    );
+    const helperPath = path.join(helperDir, "git-remote-https");
+    const marker = path.join(
+      os.tmpdir(),
+      `openclaw-git-exec-path-marker-${process.pid}-${Date.now()}`,
+    );
+    try {
+      fs.unlinkSync(marker);
+    } catch {
+      // no-op
+    }
+    fs.writeFileSync(helperPath, `#!/bin/sh\ntouch ${JSON.stringify(marker)}\nexit 1\n`, "utf8");
+    fs.chmodSync(helperPath, 0o755);
+
+    const target = "https://127.0.0.1:1/does-not-matter";
+    const unsafeEnv = {
+      PATH: process.env.PATH ?? "/usr/bin:/bin",
+      GIT_EXEC_PATH: helperDir,
+      GIT_TERMINAL_PROMPT: "0",
+    };
+
+    await new Promise<void>((resolve) => {
+      const child = spawn(gitPath, ["ls-remote", target], { env: unsafeEnv, stdio: "ignore" });
+      child.once("error", () => resolve());
+      child.once("close", () => resolve());
+    });
+
+    expect(fs.existsSync(marker)).toBe(true);
+    fs.unlinkSync(marker);
+
+    const safeEnv = sanitizeHostExecEnv({
+      baseEnv: unsafeEnv,
+    });
+
+    await new Promise<void>((resolve) => {
+      const child = spawn(gitPath, ["ls-remote", target], { env: safeEnv, stdio: "ignore" });
+      child.once("error", () => resolve());
+      child.once("close", () => resolve());
+    });
+
+    expect(fs.existsSync(marker)).toBe(false);
+  });
+
   it("blocks GIT_SSH_COMMAND override so git cannot execute helper payloads", async () => {
     if (process.platform === "win32") {
       return;


### PR DESCRIPTION
## Summary

- Problem: `sanitizeHostExecEnv()` filtered several high-risk exec variables but still allowed inherited or override `GIT_EXEC_PATH` to survive.
- Why it matters: Git resolves remote helpers from `GIT_EXEC_PATH`, so inherited host env state could still steer helper execution inside OpenClaw-spawned commands.
- What changed: added `GIT_EXEC_PATH` to the shared blocked env keys, regenerated the mirrored macOS policy, and added a regression test that proves an unsanitized git exec path runs a fake helper while the sanitized env does not.
- What did NOT change (scope boundary): this is defense-in-depth hardening for GHSA-jf5v-pqgw-gm5m, not a reclassification of the advisory into an in-scope auth/approval/allowlist bypass under `SECURITY.md`.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related GHSA-jf5v-pqgw-gm5m

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: OpenClaw now strips inherited/override `GIT_EXEC_PATH` before spawning sanitized host commands, reducing helper-path influence from the host environment.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): none

### Steps

1. Create a fake `git-remote-https` helper in a temporary directory.
2. Run `git ls-remote https://127.0.0.1:1/does-not-matter` with `GIT_EXEC_PATH` pointing at that directory.
3. Rerun through `sanitizeHostExecEnv()` and confirm the marker helper no longer executes.

### Expected

- The sanitized env should drop `GIT_EXEC_PATH`, and the fake helper should not run.

### Actual

- Before this change, inherited `GIT_EXEC_PATH` was preserved and the fake helper executed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the helper execution with unsanitized env, then reran with `sanitizeHostExecEnv()` and confirmed the marker was not created; ran `pnpm test -- src/infra/host-env-security.test.ts src/infra/host-env-security.policy-parity.test.ts`.
- Edge cases checked: override stripping still blocks `GIT_SSH_COMMAND`; macOS generated policy stays in sync with the shared JSON source.
- What you did **not** verify: Windows-specific Git helper behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `01a88fc7f0`.
- Files/config to restore: `src/infra/host-env-security-policy.json`, `apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift`, `src/infra/host-env-security.test.ts`.
- Known bad symptoms reviewers should watch for: OpenClaw-spawned Git commands would stop inheriting custom helper paths from `GIT_EXEC_PATH`.

## Risks and Mitigations

- Risk: environments that intentionally rely on inherited `GIT_EXEC_PATH` inside OpenClaw-spawned Git commands will lose that override.
  - Mitigation: the sanitizer change is limited to OpenClaw-managed exec environments and only removes a high-risk helper-resolution variable.
