### PR TITLE
Infra: cap device tokens to approved scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Docs: https://docs.openclaw.ai
 - Dependencies: refresh workspace dependencies except the pinned Carbon package, and harden ACP session-config writes against non-string SDK values so newer ACP clients fail fast instead of tripping type/runtime mismatches.
 - Gateway/config errors: surface up to three validation issues in top-level `config.set`, `config.patch`, and `config.apply` error messages while preserving structured issue details. (#42664) Thanks @huntharo.
 - Hooks/plugin context parity followup: pass `trigger` and `channelId` through embedded `llm_input`, `agent_end`, and `llm_output` hook contexts so plugins receive the same agent metadata across hook phases. (#42362) Thanks @zhoulf1006.
+- Security/device pairing: cap issued and verified device-token scopes to each paired device's approved scope baseline so stale or overbroad tokens cannot exceed approved access. (#43686) Thanks @vincentkoc.
 
 ## 2026.3.8
 

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1,16 +1,19 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 import {
   approveDevicePairing,
   clearDevicePairing,
+  ensureDeviceToken,
   getPairedDevice,
   removePairedDevice,
   requestDevicePairing,
   rotateDeviceToken,
   verifyDeviceToken,
+  type PairedDevice,
 } from "./device-pairing.js";
+import { resolvePairingPaths } from "./pairing-files.js";
 
 async function setupPairedOperatorDevice(baseDir: string, scopes: string[]) {
   const request = await requestDevicePairing(
@@ -49,6 +52,21 @@ function requireToken(token: string | undefined): string {
     throw new Error("expected operator token to be issued");
   }
   return token;
+}
+
+async function overwritePairedOperatorTokenScopes(baseDir: string, scopes: string[]) {
+  const { pairedPath } = resolvePairingPaths(baseDir, "devices");
+  const pairedByDeviceId = JSON.parse(await readFile(pairedPath, "utf8")) as Record<
+    string,
+    PairedDevice
+  >;
+  const device = pairedByDeviceId["device-1"];
+  expect(device?.tokens?.operator).toBeDefined();
+  if (!device?.tokens?.operator) {
+    throw new Error("expected paired operator token");
+  }
+  device.tokens.operator.scopes = scopes;
+  await writeFile(pairedPath, JSON.stringify(pairedByDeviceId, null, 2));
 }
 
 describe("device pairing tokens", () => {
@@ -180,6 +198,26 @@ describe("device pairing tokens", () => {
     expect(after?.approvedScopes).toEqual(["operator.read"]);
   });
 
+  test("rejects scope escalation when ensuring a token and leaves state unchanged", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    await setupPairedOperatorDevice(baseDir, ["operator.read"]);
+    const before = await getPairedDevice("device-1", baseDir);
+
+    const ensured = await ensureDeviceToken({
+      deviceId: "device-1",
+      role: "operator",
+      scopes: ["operator.admin"],
+      baseDir,
+    });
+    expect(ensured).toBeNull();
+
+    const after = await getPairedDevice("device-1", baseDir);
+    expect(after?.tokens?.operator?.token).toEqual(before?.tokens?.operator?.token);
+    expect(after?.tokens?.operator?.scopes).toEqual(["operator.read"]);
+    expect(after?.scopes).toEqual(["operator.read"]);
+    expect(after?.approvedScopes).toEqual(["operator.read"]);
+  });
+
   test("verifies token and rejects mismatches", async () => {
     const { baseDir, token } = await setupOperatorToken(["operator.read"]);
 
@@ -197,6 +235,19 @@ describe("device pairing tokens", () => {
     });
     expect(mismatch.ok).toBe(false);
     expect(mismatch.reason).toBe("token-mismatch");
+  });
+
+  test("rejects persisted tokens whose scopes exceed the approved scope baseline", async () => {
+    const { baseDir, token } = await setupOperatorToken(["operator.read"]);
+    await overwritePairedOperatorTokenScopes(baseDir, ["operator.admin"]);
+
+    await expect(
+      verifyOperatorToken({
+        baseDir,
+        token,
+        scopes: ["operator.admin"],
+      }),
+    ).resolves.toEqual({ ok: false, reason: "scope-mismatch" });
   });
 
   test("accepts operator.read/operator.write requests with an operator.admin token scope", async () => {

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -494,6 +494,12 @@ export async function verifyDeviceToken(params: {
     if (!verifyPairingToken(params.token, entry.token)) {
       return { ok: false, reason: "token-mismatch" };
     }
+    const approvedScopes = normalizeDeviceAuthScopes(
+      device.approvedScopes ?? device.scopes ?? entry.scopes,
+    );
+    if (!scopesAllowWithImplications(entry.scopes, approvedScopes)) {
+      return { ok: false, reason: "scope-mismatch" };
+    }
     const requestedScopes = normalizeDeviceAuthScopes(params.scopes);
     if (!roleScopesAllow({ role, requestedScopes, allowedScopes: entry.scopes })) {
       return { ok: false, reason: "scope-mismatch" };
@@ -525,8 +531,18 @@ export async function ensureDeviceToken(params: {
       return null;
     }
     const { device, role, tokens, existing } = context;
+    const approvedScopes = normalizeDeviceAuthScopes(
+      device.approvedScopes ?? device.scopes ?? existing?.scopes,
+    );
+    if (!scopesAllowWithImplications(requestedScopes, approvedScopes)) {
+      return null;
+    }
     if (existing && !existing.revokedAtMs) {
-      if (roleScopesAllow({ role, requestedScopes, allowedScopes: existing.scopes })) {
+      const existingWithinApproved = scopesAllowWithImplications(existing.scopes, approvedScopes);
+      if (
+        existingWithinApproved &&
+        roleScopesAllow({ role, requestedScopes, allowedScopes: existing.scopes })
+      ) {
         return existing;
       }
     }


### PR DESCRIPTION
## Summary

- Problem: the low-level device token helpers could mint or validate token scopes that exceeded a paired device's `approvedScopes` baseline.
- Why it matters: even though the reachable gateway connect flow still forces re-pairing on remote scope upgrades, persisted overbroad tokens violated the pairing-store invariant.
- What changed: `ensureDeviceToken()` now rejects requests above `approvedScopes`, `verifyDeviceToken()` now rejects persisted tokens whose stored scopes already exceed that baseline, and new regression tests cover both paths.
- What did NOT change (scope boundary): this hardens GHSA-2pwv-x786-56f8 without reclassifying it as a demonstrated external authorization bypass under `SECURITY.md`.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related GHSA-2pwv-x786-56f8

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: device token issuance and validation now enforce the existing `approvedScopes` boundary, preventing persisted tokens from drifting above the approved scope baseline.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): gateway websocket auth / device pairing store
- Relevant config (redacted): none

### Steps

1. Pair a device with `operator.read` approval only.
2. Attempt to ensure an `operator.admin` token or tamper the stored token scopes above the approved baseline.
3. Verify the admin-scoped token request fails and persisted overbroad token verification also fails.

### Expected

- Low-level token helpers should never mint or accept scopes beyond the device's approved scope baseline.

### Actual

- Before this change, `ensureDeviceToken()` could mint an admin-scoped token and `verifyDeviceToken()` would accept persisted overbroad scopes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the low-level admin token mint/verify behavior on a read-approved device before the fix; after the change, `ensureDeviceToken()` returns `null` for scope escalation and `verifyDeviceToken()` rejects tampered persisted scopes; ran `pnpm test -- src/infra/device-pairing.test.ts`.
- Edge cases checked: rotation still rejects scope escalation; valid admin-approved tokens still verify for `operator.read` and `operator.write` requests.
- What you did **not** verify: a full gateway websocket reconnect flow after tampering persisted token state.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `9239058b97`.
- Files/config to restore: `src/infra/device-pairing.ts`, `src/infra/device-pairing.test.ts`.
- Known bad symptoms reviewers should watch for: devices with stale overbroad persisted token scopes would stop authenticating until the token is reissued within the approved scope baseline.

## Risks and Mitigations

- Risk: previously persisted devices with invalid overbroad token scopes may start failing low-level token verification.
  - Mitigation: the failure is intentional hardening; reconnect or re-pair flows will reissue a token bounded by `approvedScopes`.
