### PR TITLE
Security: escape invisible exec approval format chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/direct delivery: bridge direct delivery sends to internal `message:sent` hooks so internal hook listeners observe successful Telegram deliveries. (#40185) Thanks @vincentkoc.
 - Dependencies: refresh workspace dependencies except the pinned Carbon package, and harden ACP session-config writes against non-string SDK values so newer ACP clients fail fast instead of tripping type/runtime mismatches.
 - Telegram/polling restarts: clear bounded cleanup timeout handles after `runner.stop()` and `bot.stop()` settle so stall recovery no longer leaves stray 15-second timers behind on clean shutdown. (#43188) thanks @kyohwang.
+- Security/exec approvals: escape invisible Unicode format characters in approval prompts so zero-width command text renders as visible `\u{...}` escapes instead of spoofing the reviewed command. (#43687)
 
 ## 2026.3.8
 

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -1,3 +1,4 @@
+import { sanitizeExecApprovalDisplayText } from "../../infra/exec-approval-command-display.js";
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
@@ -125,8 +126,11 @@ export function createExecApprovalHandlers(
         return;
       }
       const request = {
-        command: effectiveCommandText,
-        commandPreview: host === "node" ? undefined : approvalContext.commandPreview,
+        command: sanitizeExecApprovalDisplayText(effectiveCommandText),
+        commandPreview:
+          host === "node" || !approvalContext.commandPreview
+            ? undefined
+            : sanitizeExecApprovalDisplayText(approvalContext.commandPreview),
         commandArgv: host === "node" ? undefined : effectiveCommandArgv,
         envKeys: systemRunBinding?.envKeys?.length ? systemRunBinding.envKeys : undefined,
         systemRunBinding: systemRunBinding?.binding ?? null,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -641,6 +641,34 @@ describe("exec approval handlers", () => {
     );
   });
 
+  it("sanitizes invisible Unicode format chars in approval display text without changing node bindings", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+    await requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        timeoutMs: 10,
+        command: "bash safe\u200B.sh",
+        commandArgv: ["bash", "safe\u200B.sh"],
+        systemRunPlan: {
+          argv: ["bash", "safe\u200B.sh"],
+          cwd: "/real/cwd",
+          commandText: "bash safe\u200B.sh",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+        },
+      },
+    });
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    expect(requested).toBeTruthy();
+    const request = (requested?.payload as { request?: Record<string, unknown> })?.request ?? {};
+    expect(request["command"]).toBe("bash safe\\u{200B}.sh");
+    expect((request["systemRunPlan"] as { commandText?: string }).commandText).toBe(
+      "bash safe\u200B.sh",
+    );
+  });
+
   it("accepts resolve during broadcast", async () => {
     const manager = new ExecApprovalManager();
     const handlers = createExecApprovalHandlers(manager);

--- a/src/infra/exec-approval-command-display.ts
+++ b/src/infra/exec-approval-command-display.ts
@@ -1,8 +1,22 @@
 import type { ExecApprovalRequestPayload } from "./exec-approvals.js";
 
+const UNICODE_FORMAT_CHAR_REGEX = /\p{Cf}/gu;
+
+function formatCodePointEscape(char: string): string {
+  return `\\u{${char.codePointAt(0)?.toString(16).toUpperCase() ?? "FFFD"}}`;
+}
+
+export function sanitizeExecApprovalDisplayText(commandText: string): string {
+  return commandText.replace(UNICODE_FORMAT_CHAR_REGEX, formatCodePointEscape);
+}
+
 function normalizePreview(commandText: string, commandPreview?: string | null): string | null {
-  const preview = commandPreview?.trim() ?? "";
-  if (!preview || preview === commandText) {
+  const previewRaw = commandPreview?.trim() ?? "";
+  if (!previewRaw) {
+    return null;
+  }
+  const preview = sanitizeExecApprovalDisplayText(previewRaw);
+  if (preview === commandText) {
     return null;
   }
   return preview;
@@ -12,17 +26,15 @@ export function resolveExecApprovalCommandDisplay(request: ExecApprovalRequestPa
   commandText: string;
   commandPreview: string | null;
 } {
-  if (request.host === "node" && request.systemRunPlan) {
-    return {
-      commandText: request.systemRunPlan.commandText,
-      commandPreview: normalizePreview(
-        request.systemRunPlan.commandText,
-        request.systemRunPlan.commandPreview,
-      ),
-    };
-  }
+  const commandTextSource =
+    request.command ||
+    (request.host === "node" && request.systemRunPlan ? request.systemRunPlan.commandText : "");
+  const commandText = sanitizeExecApprovalDisplayText(commandTextSource);
+  const previewSource =
+    request.commandPreview ??
+    (request.host === "node" ? (request.systemRunPlan?.commandPreview ?? null) : null);
   return {
-    commandText: request.command,
-    commandPreview: normalizePreview(request.command, request.commandPreview),
+    commandText,
+    commandPreview: normalizePreview(commandText, previewSource),
   };
 }

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -294,6 +294,24 @@ describe("exec approval forwarder", () => {
     expect(text).toContain("Reply with: /approve <id> allow-once|allow-always|deny");
   });
 
+  it("renders invisible Unicode format chars as visible escapes", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await expect(
+      forwarder.handleRequested({
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          command: "bash safe\u200B.sh",
+        },
+      }),
+    ).resolves.toBe(true);
+    await Promise.resolve();
+
+    expect(getFirstDeliveryText(deliver)).toContain("Command: `bash safe\\u{200B}.sh`");
+  });
+
   it("formats complex commands as fenced code blocks", async () => {
     vi.useFakeTimers();
     const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });


### PR DESCRIPTION
## Summary

- Problem: exec approval prompts rendered raw Unicode format characters, so zero-width characters like U+200B could hide parts of the displayed command.
- Why it matters: approvers could be shown a command that looks safe while the underlying approved command text contains invisible spoofing characters.
- What changed: approval display text now escapes Unicode format characters, gateway approval requests store a UI-safe `request.command`, and regressions cover both stored payloads and forwarded approval messages.
- What did NOT change (scope boundary): command execution, argv normalization, NBSP quoting, and node `systemRunPlan.commandText` bindings remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related GHSA-pcqg-f7rg-xfvv

## User-visible / Behavior Changes

Approval prompts now render Unicode format characters as visible escapes such as `\\u{200B}` instead of displaying them invisibly.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): exec approval gateway + forwarded approval text
- Relevant config (redacted): default test fixtures

### Steps

1. Create an exec approval request whose command contains a Unicode format character such as `bash safe​ .sh` with U+200B between `safe` and `.sh`.
2. Observe the `exec.approval.requested` payload or a forwarded approval prompt.
3. Compare the displayed command text before and after this patch.

### Expected

- Invisible Unicode format characters are rendered as visible escapes in approval displays.
- Node approval bindings still keep the original raw command text for execution validation.

### Actual

- Approval payloads store `bash safe\\u{200B}.sh` for display.
- `systemRunPlan.commandText` remains `bash safe​ .sh` with the raw U+200B.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reran `CI=1 pnpm vitest run src/infra/exec-approval-forwarder.test.ts src/gateway/server-methods/server-methods.test.ts` after the change and after rebasing onto current `main`.
- Edge cases checked: raw forwarded requests with U+200B still render as `\\u{200B}`; node approval payloads keep the raw `systemRunPlan.commandText` binding unchanged.
- What you did **not** verify: manual macOS/Web UI prompting; those surfaces consume the sanitized top-level `request.command` payload.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the four commits in this PR.
- Files/config to restore: `src/infra/exec-approval-command-display.ts` and `src/gateway/server-methods/exec-approval.ts`.
- Known bad symptoms reviewers should watch for: approval prompts showing escaped sequences for characters that should stay invisible is expected; command execution output or approval binding changes would be a regression.

## Risks and Mitigations

- Risk: escaping too broadly could make legitimate approval text harder to read.
  - Mitigation: the sanitizer only targets Unicode format characters, and tests cover both the stored approval payload and forwarded display text.
