### PR TITLE
CLI: support OpenAI Codex OAuth profile aliases

### DIFF
--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -308,6 +308,10 @@ export function registerModelsCli(program: Command) {
     .description("Run a provider plugin auth flow (OAuth/API key)")
     .option("--provider <id>", "Provider id registered by a plugin")
     .option("--method <id>", "Provider auth method id")
+    .option(
+      "--profile-alias <name>",
+      "OAuth profile alias (built-in openai-codex; profile id: <provider>:<alias>)",
+    )
     .option("--set-default", "Apply the provider's default model recommendation", false)
     .action(async (opts) => {
       await runModelsCommand(async () => {
@@ -315,6 +319,7 @@ export function registerModelsCli(program: Command) {
           {
             provider: opts.provider as string | undefined,
             method: opts.method as string | undefined,
+            profileAlias: opts.profileAlias as string | undefined,
             setDefault: Boolean(opts.setDefault),
           },
           defaultRuntime,

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -183,7 +183,7 @@ describe("modelsAuthLoginCommand", () => {
       "Auth profile: openai-codex:user@example.com (openai-codex/oauth)",
     );
     expect(runtime.log).toHaveBeenCalledWith(
-      "Default model available: openai-codex/gpt-5.3-codex (use --set-default to apply)",
+      "Default model available: openai-codex/gpt-5.4 (use --set-default to apply)",
     );
   });
 
@@ -193,9 +193,39 @@ describe("modelsAuthLoginCommand", () => {
     await modelsAuthLoginCommand({ provider: "openai-codex", setDefault: true }, runtime);
 
     expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
-      primary: "openai-codex/gpt-5.3-codex",
+      primary: "openai-codex/gpt-5.4",
     });
-    expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.3-codex");
+    expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.4");
+  });
+
+  it("supports openai-codex profile alias for same-account OAuth logins", async () => {
+    const runtime = createRuntime();
+    mocks.writeOAuthCredentials.mockResolvedValue("openai-codex:team-billing");
+
+    await modelsAuthLoginCommand(
+      {
+        provider: "openai-codex",
+        profileAlias: "Team Billing",
+      },
+      runtime,
+    );
+
+    expect(mocks.writeOAuthCredentials).toHaveBeenCalledWith(
+      "openai-codex",
+      expect.any(Object),
+      "/tmp/openclaw/agents/main",
+      {
+        syncSiblingAgents: true,
+        profileName: "Team Billing",
+      },
+    );
+    expect(lastUpdatedConfig?.auth?.profiles?.["openai-codex:team-billing"]).toMatchObject({
+      provider: "openai-codex",
+      mode: "oauth",
+    });
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Auth profile: openai-codex:team-billing (openai-codex/oauth)",
+    );
   });
 
   it("keeps existing plugin error behavior for non built-in providers", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -262,6 +262,7 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
 type LoginOptions = {
   provider?: string;
   method?: string;
+  profileAlias?: string;
   setDefault?: boolean;
 };
 
@@ -318,6 +319,7 @@ async function runBuiltInOpenAICodexLogin(params: {
 
   const profileId = await writeOAuthCredentials("openai-codex", creds, params.agentDir, {
     syncSiblingAgents: true,
+    ...(params.opts.profileAlias?.trim() ? { profileName: params.opts.profileAlias.trim() } : {}),
   });
   await updateConfig((cfg) => {
     let next = applyAuthProfileConfig(cfg, {

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -13,6 +13,7 @@ import {
 import { KILOCODE_DEFAULT_MODEL_REF } from "../providers/kilocode-shared.js";
 import { PROVIDER_ENV_VARS } from "../secrets/provider-env-vars.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+import { normalizeTokenProfileName } from "./auth-token.js";
 import type { SecretInputMode } from "./onboard-types.js";
 export { CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF } from "../agents/cloudflare-ai-gateway.js";
 export { MISTRAL_DEFAULT_MODEL_REF, XAI_DEFAULT_MODEL_REF } from "./onboard-auth.models.js";
@@ -101,6 +102,7 @@ function buildApiKeyCredential(
 
 export type WriteOAuthCredentialsOptions = {
   syncSiblingAgents?: boolean;
+  profileName?: string;
 };
 
 /** Resolve real path, returning null if the target doesn't exist. */
@@ -157,9 +159,12 @@ export async function writeOAuthCredentials(
   agentDir?: string,
   options?: WriteOAuthCredentialsOptions,
 ): Promise<string> {
+  const profileName = options?.profileName?.trim()
+    ? normalizeTokenProfileName(options.profileName)
+    : undefined;
   const email =
     typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
-  const profileId = `${provider}:${email}`;
+  const profileId = `${provider}:${profileName ?? email}`;
   const resolvedAgentDir = path.resolve(resolveAuthAgentDir(agentDir));
   const targetAgentDirs = options?.syncSiblingAgents
     ? resolveSiblingAgentDirs(resolvedAgentDir)

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -157,6 +157,33 @@ describe("writeOAuthCredentials", () => {
     ).rejects.toThrow();
   });
 
+  it("uses explicit OAuth profile alias when provided", async () => {
+    const env = await setupAuthTestEnv("openclaw-oauth-alias-");
+    lifecycle.setStateDir(env.stateDir);
+
+    const creds = {
+      refresh: "refresh-token",
+      access: "access-token",
+      expires: Date.now() + 60_000,
+      email: "same-account@example.com",
+    } satisfies OAuthCredentials;
+
+    await writeOAuthCredentials("openai-codex", creds, env.agentDir, {
+      profileName: "Team Billing",
+    });
+
+    const parsed = await readAuthProfilesForAgent<{
+      profiles?: Record<string, OAuthCredentials & { type?: string }>;
+    }>(env.agentDir);
+    expect(parsed.profiles?.["openai-codex:team-billing"]).toMatchObject({
+      refresh: "refresh-token",
+      access: "access-token",
+      email: "same-account@example.com",
+      type: "oauth",
+    });
+    expect(parsed.profiles?.["openai-codex:same-account@example.com"]).toBeUndefined();
+  });
+
   it("writes OAuth credentials to all sibling agent dirs when syncSiblingAgents=true", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-sync-"));
     process.env.OPENCLAW_STATE_DIR = tempStateDir;


### PR DESCRIPTION
## Summary
- add `--profile-alias <name>` to `openclaw models auth login` for the built-in `openai-codex` OAuth flow
- pass the alias through login handling so OAuth credentials can be saved under a distinct profile id instead of only `${provider}:${email|default}`
- extend `writeOAuthCredentials` with optional `profileName` support and normalize aliases to profile-safe slugs
- add coverage for alias-based profile creation and login wiring
- refresh stale Codex default-model expectations in existing `models auth` tests

## Validation
- `pnpm test src/commands/models/auth.test.ts src/commands/onboard-auth.test.ts src/cli/models-cli.test.ts`
  - Passed: 3 files, 41 tests

Closes #43681
