### PR TITLE
fix(matrix): prioritize top-level allowFrom over dm.allowFrom (fixes #43688)

### DIFF
--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -101,7 +101,7 @@ function buildMatrixConfigUpdate(
 const matrixConfigAccessors = createScopedAccountConfigAccessors({
   resolveAccount: ({ cfg, accountId }) =>
     resolveMatrixAccountConfig({ cfg: cfg as CoreConfig, accountId }),
-  resolveAllowFrom: (account) => account.dm?.allowFrom,
+  resolveAllowFrom: (account) => account.config.allowFrom ?? account.config.dm?.allowFrom,
   formatAllowFrom: (allowFrom) => normalizeMatrixAllowList(allowFrom),
 });
 
@@ -124,7 +124,7 @@ const matrixConfigBase = createScopedChannelConfigBase<ResolvedMatrixAccount, Co
 const resolveMatrixDmPolicy = createScopedDmSecurityResolver<ResolvedMatrixAccount>({
   channelKey: "matrix",
   resolvePolicy: (account) => account.config.dm?.policy,
-  resolveAllowFrom: (account) => account.config.dm?.allowFrom,
+  resolveAllowFrom: (account) => account.config.allowFrom ?? account.config.dm?.allowFrom,
   allowFromPathSuffix: "dm.",
   normalizeEntry: (raw) => normalizeMatrixUserId(raw),
 });
@@ -222,7 +222,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount> = {
       const q = query?.trim().toLowerCase() || "";
       const ids = new Set<string>();
 
-      for (const entry of account.config.dm?.allowFrom ?? []) {
+      for (const entry of account.config.allowFrom ?? account.config.dm?.allowFrom ?? []) {
         const raw = String(entry).trim();
         if (!raw || raw === "*") {
           continue;

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -214,7 +214,7 @@ async function resolveMatrixMonitorConfig(params: {
     cfg: params.cfg,
     runtime: params.runtime,
     label: "matrix dm allowlist",
-    list: params.accountConfig.dm?.allowFrom ?? [],
+    list: params.accountConfig.allowFrom ?? params.accountConfig.dm?.allowFrom ?? [],
   });
   const groupAllowFrom = await resolveMatrixUserAllowlist({
     cfg: params.cfg,


### PR DESCRIPTION
## Summary

The Matrix extension was only reading allowFrom from `channels.matrix.dm.allowFrom`, ignoring the top-level `channels.matrix.allowFrom`. This was inconsistent with other channel plugins (Discord, Google Chat, etc.) and caused slash commands to silently fail with `isAuthorizedSender=false` when allowFrom was set at the top level.

## Changes

This fix updates the resolveAllowFrom logic in three places:

1. **matrixConfigAccessors** (`channel.ts:104`) - for UI/config display
2. **resolveMatrixDmPolicy** (`channel.ts:127`) - for DM security policy resolution  
3. **resolveMatrixMonitorConfig** (`matrix/monitor/index.ts:217`) - for runtime allowlist resolution

The pattern now matches other channels: `channelConfig.allowFrom ?? channelConfig.dm?.allowFrom`

## Testing

All 129 Matrix extension tests pass.

Fixes #43688