### PR TITLE
fix(matrix): honor top-level allowFrom for DM command auth

### DIFF
--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_STARTUP_GRACE_MS, isConfiguredMatrixRoomEntry } from "./index.js";
+import {
+  DEFAULT_STARTUP_GRACE_MS,
+  isConfiguredMatrixRoomEntry,
+  resolveMatrixMonitorConfig,
+} from "./index.js";
 
 describe("monitorMatrixProvider helpers", () => {
   it("treats !-prefixed room IDs as configured room entries", () => {
@@ -14,5 +18,18 @@ describe("monitorMatrixProvider helpers", () => {
 
   it("uses a non-zero startup grace window", () => {
     expect(DEFAULT_STARTUP_GRACE_MS).toBe(5000);
+  });
+
+  it("prefers top-level allowFrom for DM command authorization", async () => {
+    const resolved = await resolveMatrixMonitorConfig({
+      cfg: {},
+      runtime: {},
+      accountConfig: {
+        allowFrom: ["*"],
+        dm: { allowFrom: ["@narrow:example.org"] },
+      },
+    });
+
+    expect(resolved.allowFrom).toEqual(["*"]);
   });
 });

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -201,7 +201,7 @@ async function resolveMatrixRoomsConfig(params: {
   return nextRoomsWithUsers;
 }
 
-async function resolveMatrixMonitorConfig(params: {
+export async function resolveMatrixMonitorConfig(params: {
   cfg: CoreConfig;
   runtime: RuntimeEnv;
   accountConfig: MatrixConfig;
@@ -214,7 +214,7 @@ async function resolveMatrixMonitorConfig(params: {
     cfg: params.cfg,
     runtime: params.runtime,
     label: "matrix dm allowlist",
-    list: params.accountConfig.dm?.allowFrom ?? [],
+    list: params.accountConfig.allowFrom ?? params.accountConfig.dm?.allowFrom ?? [],
   });
   const groupAllowFrom = await resolveMatrixUserAllowlist({
     cfg: params.cfg,


### PR DESCRIPTION
## Summary
- use `channels.matrix.allowFrom` as the primary DM allowlist for monitor auth, falling back to `channels.matrix.dm.allowFrom`
- add a regression test covering top-level allowFrom precedence

## Why
Matrix command authorization currently reads only `dm.allowFrom`, so configs that place `allowFrom` at the top level silently reject DM slash commands even though other channel integrations already honor the top-level field first.

## Testing
- corepack pnpm exec vitest run extensions/matrix/src/matrix/monitor/*.test.ts

Closes #43688
