### PR TITLE
fix: deliver inter-session replies to bound channels

### DIFF
--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -1,6 +1,63 @@
 import { describe, expect, it } from "vitest";
 import { resolveLastChannelRaw, resolveLastToRaw } from "./session-delivery.js";
 
+describe("session delivery bound channel routing", () => {
+  it("delivers to bound external channel when persistedLastTo is set", () => {
+    // Session has deliveryContext bound to Telegram channel
+    const sessionKey = "agent:main:telegram:default:channel:C123456";
+
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: "INTERNAL_MESSAGE_CHANNEL",
+        persistedLastChannel: "telegram",
+        sessionKey,
+      }),
+    ).toBe("telegram");
+
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: "INTERNAL_MESSAGE_CHANNEL",
+        originatingToRaw: "session:inter-session-123",
+        persistedLastChannel: "telegram",
+        persistedLastTo: "C123456",
+        sessionKey,
+      }),
+    ).toBe("C123456");
+  });
+
+  it("falls back to originatingToRaw when persistedLastTo is not set", () => {
+    // Session bound to external channel but lastTo not yet persisted
+    const sessionKey = "agent:main:telegram:default:channel:C123456";
+
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: "INTERNAL_MESSAGE_CHANNEL",
+        originatingToRaw: "session:inter-session-123",
+        persistedLastChannel: "telegram",
+        persistedLastTo: undefined,
+        sessionKey,
+      }),
+    ).toBe("session:inter-session-123");
+  });
+
+  it("does not drop delivery when persistedLastTo is falsy", () => {
+    // Regression test: ensure we don't silently drop messages
+    const sessionKey = "agent:main:telegram:default:channel:C123456";
+
+    const result = resolveLastToRaw({
+      originatingChannelRaw: "INTERNAL_MESSAGE_CHANNEL",
+      originatingToRaw: "session:inter-session-123",
+      persistedLastChannel: "telegram",
+      persistedLastTo: undefined,
+      sessionKey,
+    });
+
+    // Should NOT return undefined (which would drop the message)
+    expect(result).not.toBeUndefined();
+    expect(result).toBe("session:inter-session-123");
+  });
+});
+
 describe("session delivery direct-session routing overrides", () => {
   it.each([
     "agent:main:direct:user-1",

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -117,14 +117,6 @@ export function resolveLastChannelRaw(params: {
       resolved = sessionKeyChannelHint;
     }
   }
-  // Fix #34308: When channel is INTERNAL but session has a persisted external channel
-  // (deliveryContext), use the persisted channel for reply delivery.
-  if (
-    originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
-    isExternalRoutingChannel(persistedChannel)
-  ) {
-    resolved = persistedChannel;
-  }
   return resolved;
 }
 
@@ -160,10 +152,11 @@ export function resolveLastToRaw(params: {
   }
 
   // Fix #34308: When channel is INTERNAL but session has a persisted external channel
-  // (deliveryContext), use the persisted to address for reply delivery.
+  // (deliveryContext) AND a persisted lastTo address, use the persisted to address for reply delivery.
   if (
     originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
-    isExternalRoutingChannel(persistedChannel)
+    isExternalRoutingChannel(persistedChannel) &&
+    params.persistedLastTo
   ) {
     return params.persistedLastTo;
   }

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -117,6 +117,14 @@ export function resolveLastChannelRaw(params: {
       resolved = sessionKeyChannelHint;
     }
   }
+  // Fix #34308: When channel is INTERNAL but session has a persisted external channel
+  // (deliveryContext), use the persisted channel for reply delivery.
+  if (
+    originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
+    isExternalRoutingChannel(persistedChannel)
+  ) {
+    resolved = persistedChannel;
+  }
   return resolved;
 }
 
@@ -149,6 +157,15 @@ export function resolveLastToRaw(params: {
     if (hasExternalFallback && params.persistedLastTo) {
       return params.persistedLastTo;
     }
+  }
+
+  // Fix #34308: When channel is INTERNAL but session has a persisted external channel
+  // (deliveryContext), use the persisted to address for reply delivery.
+  if (
+    originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
+    isExternalRoutingChannel(persistedChannel)
+  ) {
+    return params.persistedLastTo;
   }
 
   return params.originatingToRaw || params.toRaw || params.persistedLastTo;

--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -23,22 +23,27 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     return true;
   } catch {
     // Fallback for non-secure contexts (HTTP on Windows/localhost)
-    try {
-      // Use textarea element fallback for insecure contexts
-      const textarea = document.createElement("textarea");
-      textarea.value = text;
-      textarea.style.position = "fixed";
-      textarea.style.left = "-9999px";
-      textarea.style.top = "-9999px";
-      document.body.appendChild(textarea);
-      textarea.focus();
-      textarea.select();
-      const success = document.execCommand("copy");
-      document.body.removeChild(textarea);
-      return success;
-    } catch {
-      return false;
-    }
+    return copyViaExecCommand(text);
+  }
+}
+
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "-9999px";
+  document.body.appendChild(textarea);
+
+  try {
+    textarea.focus();
+    textarea.select();
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    // Always clean up the textarea element to prevent DOM leak
+    document.body.removeChild(textarea);
   }
 }
 

--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -17,11 +17,28 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     return false;
   }
 
+  // Try Clipboard API first (works in secure contexts/HTTPS)
   try {
     await navigator.clipboard.writeText(text);
     return true;
   } catch {
-    return false;
+    // Fallback for non-secure contexts (HTTP on Windows/localhost)
+    try {
+      // Use textarea element fallback for insecure contexts
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      textarea.style.top = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      const success = document.execCommand("copy");
+      document.body.removeChild(textarea);
+      return success;
+    } catch {
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

This PR combines two related fixes from #34366 and #34231 into a single PR for easier review and merge.

---

## Fix 1: Inter-session Reply Delivery (from #34366)

**Fixes**: #34308

**Problem**: When a session is bound to a Telegram channel (has a valid `deliveryContext`), replies to inter-session messages (via `sessions_send`) were stored in session history but never delivered to the bound Telegram channel.

**Root Cause**: When `sessions_send` sends a message, it uses `channel: INTERNAL_MESSAGE_CHANNEL`. The reply routing logic in `resolveLastChannelRaw` and `resolveLastToRaw` was not using the session's persisted deliveryContext when the incoming channel was internal.

**Fix**: Added logic to both `resolveLastChannelRaw` and `resolveLastToRaw` to use the persisted deliveryContext when available.

---

## Fix 2: Windows Clipboard Fallback (from #34231)

**Fixes**: #34092

**Problem**: Chat copy button not working on Windows with HTTP (non-secure context)

**Root Cause**: `navigator.clipboard.writeText()` requires secure context (HTTPS)

**Fix**: Add textarea element fallback using `document.execCommand('copy')` for non-secure contexts (HTTP on Windows)

**Additional**: Added try/finally to guarantee textarea cleanup (addresses Greptile feedback)

---

## Changes

- `src/auto-reply/reply/session-delivery.ts` - Add deliveryContext fallback for inter-session replies
- `ui/src/ui/chat/copy-as-markdown.ts` - Add clipboard API fallback for insecure contexts

## Testing

- Existing tests pass
- Works in secure contexts (HTTPS)
- Fallback works in insecure contexts (HTTP/localhost on Windows)

---

## Supersedes

This PR replaces:
- #34366 (fix: deliver inter-session replies to bound channel)
- #34231 (fix(web): add clipboard fallback for insecure contexts)

Those PRs will be closed in favor of this combined PR.

---

**Author**: @Linux2010
**Original Commits**: 3 commits from March 4, 2026