### PR TITLE
Fix Feishu route matching for legacy lark bindings

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -681,6 +681,49 @@ describe("backward compatibility: feishu channel alias lark", () => {
   });
 });
 
+describe("routing channel normalization", () => {
+  test("keeps extension channel ids distinct from built-in aliases", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "plugin-agent",
+          match: {
+            channel: "imsg",
+            accountId: "main",
+            peer: { kind: "group", id: "room-1" },
+          },
+        },
+        {
+          agentId: "builtin-agent",
+          match: {
+            channel: "imessage",
+            accountId: "main",
+            peer: { kind: "group", id: "room-1" },
+          },
+        },
+      ],
+    };
+
+    const extensionRoute = resolveAgentRoute({
+      cfg,
+      channel: "imsg",
+      accountId: "main",
+      peer: { kind: "group", id: "room-1" },
+    });
+    expect(extensionRoute.agentId).toBe("plugin-agent");
+    expect(extensionRoute.matchedBy).toBe("binding.peer");
+
+    const builtInRoute = resolveAgentRoute({
+      cfg,
+      channel: "imessage",
+      accountId: "main",
+      peer: { kind: "group", id: "room-1" },
+    });
+    expect(builtInRoute.agentId).toBe("builtin-agent");
+    expect(builtInRoute.matchedBy).toBe("binding.peer");
+  });
+});
+
 describe("role-based agent routing", () => {
   type DiscordBinding = NonNullable<OpenClawConfig["bindings"]>[number];
 

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -656,6 +656,31 @@ describe("backward compatibility: peer.kind group ↔ channel", () => {
   });
 });
 
+describe("backward compatibility: feishu channel alias lark", () => {
+  test("legacy lark binding matches feishu runtime routing inputs", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "nova",
+          match: {
+            channel: "lark",
+            accountId: "main",
+            peer: { kind: "group", id: "oc_nova_group" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: "main",
+      peer: { kind: "group", id: "oc_nova_group" },
+    });
+    expect(route.agentId).toBe("nova");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+});
+
 describe("role-based agent routing", () => {
   type DiscordBinding = NonNullable<OpenClawConfig["bindings"]>[number];
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -1,7 +1,6 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
-import { normalizeChatChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { shouldLogVerbose } from "../globals.js";
 import { logDebug } from "../logger.js";
@@ -80,15 +79,7 @@ function normalizeToken(value: string | undefined | null): string {
 }
 
 function normalizeRoutingChannelId(value: string | undefined | null): string {
-  const trimmed = (value ?? "").trim();
-  if (!trimmed) {
-    return "";
-  }
-  const normalizedBuiltIn = normalizeChatChannelId(trimmed);
-  if (normalizedBuiltIn) {
-    return normalizedBuiltIn;
-  }
-  const lowered = trimmed.toLowerCase();
+  const lowered = normalizeToken(value);
   // Feishu plugin channel id is "feishu"; keep legacy "lark" bindings routable.
   if (lowered === "lark") {
     return "feishu";

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -1,6 +1,7 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
+import { normalizeChatChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { shouldLogVerbose } from "../globals.js";
 import { logDebug } from "../logger.js";
@@ -76,6 +77,23 @@ export function resolveInboundLastRouteSessionKey(params: {
 
 function normalizeToken(value: string | undefined | null): string {
   return (value ?? "").trim().toLowerCase();
+}
+
+function normalizeRoutingChannelId(value: string | undefined | null): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) {
+    return "";
+  }
+  const normalizedBuiltIn = normalizeChatChannelId(trimmed);
+  if (normalizedBuiltIn) {
+    return normalizedBuiltIn;
+  }
+  const lowered = trimmed.toLowerCase();
+  // Feishu plugin channel id is "feishu"; keep legacy "lark" bindings routable.
+  if (lowered === "lark") {
+    return "feishu";
+  }
+  return lowered;
 }
 
 function normalizeId(value: unknown): string {
@@ -241,7 +259,7 @@ function buildEvaluatedBindingsByChannel(
     if (!binding || typeof binding !== "object") {
       continue;
     }
-    const channel = normalizeToken(binding.match?.channel);
+    const channel = normalizeRoutingChannelId(binding.match?.channel);
     if (!channel) {
       continue;
     }
@@ -612,7 +630,7 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
 }
 
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
-  const channel = normalizeToken(input.channel);
+  const channel = normalizeRoutingChannelId(input.channel);
   const accountId = normalizeAccountId(input.accountId);
   const peer = input.peer
     ? {


### PR DESCRIPTION
## Summary

- Problem: Feishu inbound routing can silently fall back to the default agent when bindings still use the legacy channel alias `lark`.
- Why it matters: `accountId` + `peer.kind=group` bindings appear valid but never match, so group/account routing breaks for existing configs.
- What changed: normalized routing channel keys in `resolveAgentRoute` and evaluated binding indexing to treat legacy `lark` as canonical `feishu`.
- What did NOT change (scope boundary): no changes to binding precedence, peer matching semantics, or Feishu message parsing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43633
- Related #16354
- Related #39382

## User-visible / Behavior Changes

- Existing bindings with `match.channel: "lark"` now match Feishu inbound routing (`channel: "feishu"`) and route to the configured agent instead of default fallback.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v22
- Model/provider: N/A (routing unit tests)
- Integration/channel (if any): Feishu
- Relevant config (redacted): route binding with `match.channel: "lark"`, `match.accountId: "main"`, `match.peer: { kind: "group", id: "oc_nova_group" }`

### Steps

1. Configure a route binding using legacy `match.channel: "lark"` for a Feishu group/account.
2. Resolve inbound route for channel `feishu`, account `main`, and matching group peer.
3. Observe route selection.

### Expected

- Binding should match and route to configured agent.

### Actual

- Before fix: route falls back to default agent.
- After fix: route matches binding (`matchedBy: "binding.peer"`).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/routing/resolve-route.test.ts` passes including new regression test.
  - Runtime probe now resolves `lark` binding with Feishu input to configured agent (`agent:nova`).
- Edge cases checked:
  - Existing `feishu` bindings still match unchanged.
  - Group/channel peer compatibility behavior remains unchanged.
- What you did **not** verify:
  - Live Feishu webhook traffic in a real tenant.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `fe3fc569a`.
- Files/config to restore:
  - `src/routing/resolve-route.ts`
  - `src/routing/resolve-route.test.ts`
- Known bad symptoms reviewers should watch for:
  - Route matches unexpectedly changing for non-Feishu alias channels.

## Risks and Mitigations

- Risk: Channel normalization path in resolver now canonicalizes legacy alias.
  - Mitigation: Added focused regression test and kept scope to channel key normalization only.
