### PR TITLE
Feishu: prevent cross-reply merge in streaming final cards

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -315,6 +315,50 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("retries streaming close with preserved final text after initial close failure", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.onReplyStart?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    const closeMock = streamingInstances[0].close;
+    closeMock.mockImplementationOnce(async () => {
+      throw new Error("close failed");
+    });
+
+    const finalText = "```md\n最终完整回复\n```";
+    let deliverError: unknown;
+    try {
+      await options.deliver({ text: finalText }, { kind: "final" });
+    } catch (error) {
+      deliverError = error;
+    }
+
+    expect(deliverError).toBeInstanceOf(Error);
+    await options.onError?.(deliverError as Error, { kind: "final" });
+
+    expect(closeMock).toHaveBeenCalledTimes(2);
+    expect(closeMock).toHaveBeenNthCalledWith(1, finalText);
+    expect(closeMock).toHaveBeenNthCalledWith(2, finalText);
+  });
+
   it("skips exact duplicate final text after streaming close", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -304,13 +304,13 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
     await options.deliver({ text: "```md\n完整回复第一段\n```" }, { kind: "final" });
-    await options.deliver({ text: "```md\n完整回复第一段 + 第二段\n```" }, { kind: "final" });
+    await options.deliver({ text: "```md\n独立的第二条回复\n```" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(2);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n完整回复第一段\n```");
     expect(streamingInstances[1].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[1].close).toHaveBeenCalledWith("```md\n完整回复第一段 + 第二段\n```");
+    expect(streamingInstances[1].close).toHaveBeenCalledWith("```md\n独立的第二条回复\n```");
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -207,6 +207,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const closeStreaming = async (finalText?: string) => {
+    if (finalText !== undefined) {
+      // Preserve final payload for retry paths if close fails before cleanup.
+      streamText = finalText;
+    }
     if (streamingStartPromise) {
       await streamingStartPromise;
     }

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -206,13 +206,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     })();
   };
 
-  const closeStreaming = async () => {
+  const closeStreaming = async (finalText?: string) => {
     if (streamingStartPromise) {
       await streamingStartPromise;
     }
     await partialUpdateQueue;
     if (streaming?.isActive()) {
-      let text = streamText;
+      let text = finalText ?? streamText;
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
@@ -283,8 +283,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               queueStreamingUpdate(text, { mode: "delta" });
             }
             if (info?.kind === "final") {
-              streamText = mergeStreamingText(streamText, text);
-              await closeStreaming();
+              await closeStreaming(text);
               deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -330,7 +330,9 @@ export class FeishuStreamingSession {
     await this.queue;
 
     const pendingMerged = mergeStreamingText(this.state.currentText, this.pendingText ?? undefined);
-    const text = finalText ? mergeStreamingText(pendingMerged, finalText) : pendingMerged;
+    // Final reply payloads are authoritative; do not merge unrelated buffered
+    // content into a completed message.
+    const text = finalText ?? pendingMerged;
     const apiBase = resolveApiBase(this.creds.domain);
 
     // Only send final update if content differs from what's already displayed


### PR DESCRIPTION
## Summary
- treat each streaming `final` payload as authoritative when closing a Feishu card session
- stop merging buffered streaming text into `final` payloads during `FeishuStreamingSession.close`
- update Feishu reply dispatcher coverage to assert independent final replies stay isolated across cards

## Testing
- `pnpm vitest run extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/streaming-card.test.ts` ✅ passed (29 tests)

Closes #43704
