### PR TITLE
fix(agents): validate UUID format in pickSessionId

### DIFF
--- a/src/agents/cli-runner/helpers.test.ts
+++ b/src/agents/cli-runner/helpers.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { CliBackendConfig } from "../../config/types.js";
+import { parseCliJson, parseCliJsonl } from "./helpers.js";
+
+describe("parseCliJson – pickSessionId UUID validation", () => {
+  const backend: CliBackendConfig = { command: "test-cli" };
+
+  it("accepts a valid UUID session_id", () => {
+    const raw = JSON.stringify({
+      session_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      content: "hello",
+    });
+    const result = parseCliJson(raw, backend);
+    expect(result?.sessionId).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+  });
+
+  it("rejects non-UUID string like 'rate-limited'", () => {
+    const raw = JSON.stringify({
+      session_id: "rate-limited",
+      content: "hello",
+    });
+    const result = parseCliJson(raw, backend);
+    expect(result?.sessionId).toBeUndefined();
+  });
+
+  it("rejects an empty string", () => {
+    const raw = JSON.stringify({
+      session_id: "",
+      content: "hello",
+    });
+    const result = parseCliJson(raw, backend);
+    expect(result?.sessionId).toBeUndefined();
+  });
+
+  it("returns undefined when session_id field is missing", () => {
+    const raw = JSON.stringify({ content: "hello" });
+    const result = parseCliJson(raw, backend);
+    expect(result?.sessionId).toBeUndefined();
+  });
+
+  it("accepts uppercase UUID", () => {
+    const raw = JSON.stringify({
+      session_id: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+      content: "hello",
+    });
+    const result = parseCliJson(raw, backend);
+    expect(result?.sessionId).toBe("A1B2C3D4-E5F6-7890-ABCD-EF1234567890");
+  });
+
+  it("rejects a numeric string", () => {
+    const raw = JSON.stringify({
+      session_id: "12345",
+      content: "hello",
+    });
+    const result = parseCliJson(raw, backend);
+    expect(result?.sessionId).toBeUndefined();
+  });
+});
+
+describe("parseCliJsonl – thread_id UUID validation", () => {
+  const backend: CliBackendConfig = { command: "test-cli" };
+
+  it("accepts a valid UUID thread_id", () => {
+    const lines = [
+      JSON.stringify({
+        thread_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        item: { text: "hello", type: "message" },
+      }),
+    ].join("\n");
+    const result = parseCliJsonl(lines, backend);
+    expect(result?.sessionId).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+  });
+
+  it("rejects non-UUID thread_id", () => {
+    const lines = [
+      JSON.stringify({
+        thread_id: "rate-limited",
+        item: { text: "hello", type: "message" },
+      }),
+    ].join("\n");
+    const result = parseCliJsonl(lines, backend);
+    expect(result?.sessionId).toBeUndefined();
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -158,6 +158,8 @@ function collectText(value: unknown): string {
   return "";
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function pickSessionId(
   parsed: Record<string, unknown>,
   backend: CliBackendConfig,
@@ -170,7 +172,7 @@ function pickSessionId(
   ];
   for (const field of fields) {
     const value = parsed[field];
-    if (typeof value === "string" && value.trim()) {
+    if (typeof value === "string" && value.trim() && UUID_RE.test(value.trim())) {
       return value.trim();
     }
   }
@@ -225,7 +227,11 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
     if (!sessionId) {
       sessionId = pickSessionId(parsed, backend);
     }
-    if (!sessionId && typeof parsed.thread_id === "string") {
+    if (
+      !sessionId &&
+      typeof parsed.thread_id === "string" &&
+      UUID_RE.test(parsed.thread_id.trim())
+    ) {
       sessionId = parsed.thread_id.trim();
     }
     if (isRecord(parsed.usage)) {


### PR DESCRIPTION
## Summary

- `pickSessionId()` now validates that candidate session IDs match UUID format before persisting them
- Prevents non-UUID strings like `"rate-limited"` from being stored and causing crashes on `--resume`
- Also applies UUID validation to the `thread_id` fallback path in `parseCliJsonl()`

Fixes #43288

## Changes

- Added `UUID_RE` regex constant for UUID format validation
- Updated `pickSessionId()` to check UUID format before returning a candidate
- Updated `parseCliJsonl()` thread_id fallback with the same validation
- Added 8 test cases covering valid UUIDs, non-UUID strings, empty strings, and edge cases

## Test plan

- [x] Unit tests pass (`pnpm vitest run src/agents/cli-runner/helpers.test.ts`)
- [x] Format check passes (`pnpm format:check`)
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm tsgo`)

This contribution was developed with AI assistance (Claude Code).