### PR TITLE
Fix assistant tool-call replay content null regression

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -491,6 +491,57 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("parallel_tool_calls");
   });
 
+  it("rewrites assistant content null to empty string when tool_calls are present", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "deepseek",
+      applyModelId: "deepseek-chat",
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "read", arguments: '{"path":"SOUL.md"}' },
+              },
+            ],
+          },
+        ],
+      },
+      model: {
+        api: "openai-completions",
+        provider: "deepseek",
+        id: "deepseek-chat",
+      } as Model<"openai-completions">,
+    });
+
+    expect((payload.messages as Array<{ content: unknown }>)[0]?.content).toBe("");
+  });
+
+  it("does not rewrite assistant content null without tool calls", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "deepseek",
+      applyModelId: "deepseek-chat",
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+          },
+        ],
+      },
+      model: {
+        api: "openai-completions",
+        provider: "deepseek",
+        id: "deepseek-chat",
+      } as Model<"openai-completions">,
+    });
+
+    expect((payload.messages as Array<{ content: unknown }>)[0]?.content).toBeNull();
+  });
+
   it("lets runtime override win across alias styles for parallel_tool_calls", () => {
     const payload = runParallelToolCallsPayloadMutationCase({
       applyProvider: "nvidia-nim",

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -520,6 +520,32 @@ describe("applyExtraParamsToAgent", () => {
     expect((payload.messages as Array<{ content: unknown }>)[0]?.content).toBe("");
   });
 
+  it("rewrites assistant content null to empty string when legacy function_call is present", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "deepseek",
+      applyModelId: "deepseek-chat",
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+            function_call: {
+              name: "read",
+              arguments: '{"path":"SOUL.md"}',
+            },
+          },
+        ],
+      },
+      model: {
+        api: "openai-completions",
+        provider: "deepseek",
+        id: "deepseek-chat",
+      } as Model<"openai-completions">,
+    });
+
+    expect((payload.messages as Array<{ content: unknown }>)[0]?.content).toBe("");
+  });
+
   it("does not rewrite assistant content null without tool calls", () => {
     const payload = runParallelToolCallsPayloadMutationCase({
       applyProvider: "deepseek",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -592,7 +592,54 @@ function isOpenRouterAnthropicModel(provider: string, modelId: string): boolean 
 type PayloadMessage = {
   role?: string;
   content?: unknown;
+  tool_calls?: unknown;
+  function_call?: unknown;
 };
+
+function hasOpenAIToolCall(message: PayloadMessage): boolean {
+  if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+    return true;
+  }
+  return Boolean(
+    message.function_call &&
+    typeof message.function_call === "object" &&
+    !Array.isArray(message.function_call),
+  );
+}
+
+/**
+ * Some OpenAI-compatible providers reject assistant tool-call messages when
+ * `content` is null. Preserve empty assistant text as "" for replay.
+ */
+function createOpenAIEmptyAssistantContentWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.api !== "openai-completions") {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const messages = (payload as Record<string, unknown>).messages;
+          if (Array.isArray(messages)) {
+            for (const message of messages as PayloadMessage[]) {
+              if (message.role !== "assistant" || message.content !== null) {
+                continue;
+              }
+              if (!hasOpenAIToolCall(message)) {
+                continue;
+              }
+              message.content = "";
+            }
+          }
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
 
 /**
  * Inject cache_control into the system message for OpenRouter Anthropic models.
@@ -1345,4 +1392,8 @@ export function applyExtraParamsToAgent(
       log.warn(`ignoring invalid parallel_tool_calls param: ${summary}`);
     }
   }
+
+  // Preserve empty assistant content across tool-call turns for providers
+  // that reject `assistant.content = null` in openai-completions payloads.
+  agent.streamFn = createOpenAIEmptyAssistantContentWrapper(agent.streamFn);
 }


### PR DESCRIPTION
## Summary
- add an `openai-completions` payload wrapper that rewrites assistant `content: null` to `""` when the assistant message contains tool calls
- keep behavior scoped so only assistant tool-call replay turns are normalized
- add regression tests covering both rewrite and no-rewrite cases

## Validation
- `pnpm test src/agents/pi-embedded-runner-extraparams.test.ts` (pass, 70 tests)

Closes #43716
