### PR TITLE
telegram: add configurable reply quote context

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -110,6 +110,21 @@ describe("web search provider config", () => {
   });
 });
 
+describe("telegram reply context config", () => {
+  it("accepts replyContextLength", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          botToken: "fake",
+          replyContextLength: 2048,
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});
+
 describe("talk.voiceAliases", () => {
   it("accepts a string map of voice aliases", () => {
     const res = validateConfigObject({

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1468,6 +1468,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
   "channels.telegram.streaming":
     'Unified Telegram stream preview mode: "off" | "partial" | "block" | "progress" (default: "partial"). "progress" maps to "partial" on Telegram. Legacy boolean/streamMode keys are auto-mapped.',
+  "channels.telegram.replyContextLength":
+    "Max chars of original Telegram message text to include in reply_parameters.quote when replies target the current or quoted message. Leave unset to use Telegram's default short quote snippet.",
   "channels.discord.streaming":
     'Unified Discord stream preview mode: "off" | "partial" | "block" | "progress". "progress" maps to "partial" on Discord. Legacy boolean/streamMode keys are auto-mapped.',
   "channels.discord.streamMode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -713,6 +713,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.telegram.commands.native": "Telegram Native Commands",
   "channels.telegram.commands.nativeSkills": "Telegram Native Skill Commands",
   "channels.telegram.streaming": "Telegram Streaming Mode",
+  "channels.telegram.replyContextLength": "Telegram Reply Context Length",
   "channels.telegram.retry.attempts": "Telegram Retry Attempts",
   "channels.telegram.retry.minDelayMs": "Telegram Retry Min Delay (ms)",
   "channels.telegram.retry.maxDelayMs": "Telegram Retry Max Delay (ms)",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -121,6 +121,11 @@ export type TelegramAccountConfig = {
   dms?: Record<string, DmConfig>;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
+  /**
+   * Max chars of Telegram quote context to include in reply_parameters.quote.
+   * When unset, Telegram falls back to its native auto-generated quote snippet.
+   */
+  replyContextLength?: number;
   /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */
   chunkMode?: "length" | "newline";
   /**

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -183,6 +183,7 @@ export const TelegramAccountSchemaBase = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     direct: z.record(z.string(), TelegramDirectSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
+    replyContextLength: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     streaming: z.union([z.boolean(), z.enum(["off", "partial", "block", "progress"])]).optional(),
     blockStreaming: z.boolean().optional(),

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -212,6 +212,38 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("builds reply quote text by target message id when replyContextLength is configured", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Reply", replyToId: "456" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    const context = createContext({
+      ctxPayload: {
+        BodyForAgent: "Current message body",
+        ReplyToId: "123",
+        ReplyToBody: "Quoted upstream body",
+      } as unknown as TelegramMessageContext["ctxPayload"],
+    });
+
+    await dispatchWithContext({
+      context,
+      telegramCfg: { replyContextLength: 12 },
+    });
+
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyQuoteTextByMessageId: {
+          "123": "Quoted upstr",
+          "456": "Current mess",
+        },
+      }),
+    );
+  });
+
   it("does not inject approval buttons in local dispatch once the monitor owns approvals", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -24,6 +24,7 @@ import type { OpenClawConfig, ReplyToMode, TelegramAccountConfig } from "../conf
 import { danger, logVerbose } from "../globals.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { truncateUtf16Safe } from "../utils.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
 import { deliverReplies } from "./bot/delivery.js";
@@ -51,6 +52,47 @@ const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
+
+function normalizeReplyQuoteText(text: string | undefined, maxChars?: number): string | undefined {
+  const trimmed = text?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (!(typeof maxChars === "number") || !Number.isFinite(maxChars) || maxChars <= 0) {
+    return trimmed;
+  }
+  return truncateUtf16Safe(trimmed, maxChars).trim();
+}
+
+function buildReplyQuoteTextByMessageId(params: {
+  currentMessageId?: number;
+  currentBody?: string;
+  replyTargetId?: string;
+  replyTargetBody?: string;
+  maxChars?: number;
+}): Record<string, string> | undefined {
+  if (
+    !(typeof params.maxChars === "number") ||
+    !Number.isFinite(params.maxChars) ||
+    params.maxChars <= 0
+  ) {
+    return undefined;
+  }
+  const entries = new Map<string, string>();
+  if (typeof params.currentMessageId === "number") {
+    const quote = normalizeReplyQuoteText(params.currentBody, params.maxChars);
+    if (quote) {
+      entries.set(String(params.currentMessageId), quote);
+    }
+  }
+  if (params.replyTargetId) {
+    const quote = normalizeReplyQuoteText(params.replyTargetBody, params.maxChars);
+    if (quote) {
+      entries.set(params.replyTargetId, quote);
+    }
+  }
+  return entries.size > 0 ? Object.fromEntries(entries) : undefined;
+}
 
 async function resolveStickerVisionSupport(cfg: OpenClawConfig, agentId: string) {
   try {
@@ -433,10 +475,14 @@ export const dispatchTelegramMessage = async ({
     }
   }
 
-  const replyQuoteText =
-    ctxPayload.ReplyToIsQuote && ctxPayload.ReplyToBody
-      ? ctxPayload.ReplyToBody.trim() || undefined
-      : undefined;
+  const replyQuoteTextByMessageId = buildReplyQuoteTextByMessageId({
+    currentMessageId: typeof msg.message_id === "number" ? msg.message_id : undefined,
+    currentBody: typeof ctxPayload.BodyForAgent === "string" ? ctxPayload.BodyForAgent : undefined,
+    replyTargetId: typeof ctxPayload.ReplyToId === "string" ? ctxPayload.ReplyToId : undefined,
+    replyTargetBody:
+      typeof ctxPayload.ReplyToBody === "string" ? ctxPayload.ReplyToBody : undefined,
+    maxChars: telegramCfg.replyContextLength,
+  });
   const deliveryState = createLaneDeliveryStateTracker();
   const clearGroupHistory = () => {
     if (isGroup && historyKey) {
@@ -459,7 +505,7 @@ export const dispatchTelegramMessage = async ({
     tableMode,
     chunkMode,
     linkPreview: telegramCfg.linkPreview,
-    replyQuoteText,
+    replyQuoteTextByMessageId,
   };
   const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload => {
     if (payload.text === text) {

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -576,8 +576,10 @@ export async function deliverReplies(params: {
   onVoiceRecording?: () => Promise<void> | void;
   /** Controls whether link previews are shown. Default: true (previews enabled). */
   linkPreview?: boolean;
-  /** Optional quote text for Telegram reply_parameters. */
+  /** Optional fallback quote text for Telegram reply_parameters. */
   replyQuoteText?: string;
+  /** Optional quote text keyed by reply target message id. */
+  replyQuoteTextByMessageId?: Record<string, string>;
 }): Promise<{ delivered: boolean }> {
   const progress: DeliveryProgress = {
     hasReplied: false,
@@ -641,6 +643,10 @@ export async function deliverReplies(params: {
       const deliveredCountBeforeReply = progress.deliveredCount;
       const replyToId =
         params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
+      const replyQuoteText =
+        replyToId != null
+          ? (params.replyQuoteTextByMessageId?.[String(replyToId)] ?? params.replyQuoteText)
+          : params.replyQuoteText;
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const shouldPinFirstMessage = telegramData?.pin === true;
       const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
@@ -654,7 +660,7 @@ export async function deliverReplies(params: {
           chunkText,
           replyText: reply.text || "",
           replyMarkup,
-          replyQuoteText: params.replyQuoteText,
+          replyQuoteText,
           linkPreview: params.linkPreview,
           replyToId,
           replyToMode: params.replyToMode,
@@ -673,7 +679,7 @@ export async function deliverReplies(params: {
           chunkText,
           onVoiceRecording: params.onVoiceRecording,
           linkPreview: params.linkPreview,
-          replyQuoteText: params.replyQuoteText,
+          replyQuoteText,
           replyMarkup,
           replyToId,
           replyToMode: params.replyToMode,

--- a/src/telegram/bot/delivery.send.ts
+++ b/src/telegram/bot/delivery.send.ts
@@ -75,12 +75,21 @@ export async function sendTelegramWithThreadFallback<T>(params: {
 
 export function buildTelegramSendParams(opts?: {
   replyToMessageId?: number;
+  replyQuoteText?: string;
   thread?: TelegramThreadSpec | null;
 }): Record<string, unknown> {
   const threadParams = buildTelegramThreadParams(opts?.thread);
   const params: Record<string, unknown> = {};
   if (opts?.replyToMessageId) {
-    params.reply_to_message_id = opts.replyToMessageId;
+    const replyQuoteText = opts.replyQuoteText?.trim();
+    if (replyQuoteText) {
+      params.reply_parameters = {
+        message_id: opts.replyToMessageId,
+        quote: replyQuoteText,
+      };
+    } else {
+      params.reply_to_message_id = opts.replyToMessageId;
+    }
   }
   if (threadParams) {
     params.message_thread_id = threadParams.message_thread_id;
@@ -105,6 +114,7 @@ export async function sendTelegramText(
 ): Promise<number> {
   const baseParams = buildTelegramSendParams({
     replyToMessageId: opts?.replyToMessageId,
+    replyQuoteText: opts?.replyQuoteText,
     thread: opts?.thread,
   });
   // Add link_preview_options when link preview is disabled.

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -583,7 +583,7 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("uses reply_to_message_id when quote text is provided", async () => {
+  it("uses reply_parameters.quote when quote text is provided", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 10,
@@ -603,14 +603,17 @@ describe("deliverReplies", () => {
       "123",
       expect.any(String),
       expect.objectContaining({
-        reply_to_message_id: 500,
+        reply_parameters: {
+          message_id: 500,
+          quote: "quoted text",
+        },
       }),
     );
     expect(sendMessage).toHaveBeenCalledWith(
       "123",
       expect.any(String),
       expect.not.objectContaining({
-        reply_parameters: expect.anything(),
+        reply_to_message_id: 500,
       }),
     );
   });
@@ -681,7 +684,10 @@ describe("deliverReplies", () => {
     expect(sendMessage.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(sendMessage.mock.calls[0][2]).toEqual(
       expect.objectContaining({
-        reply_to_message_id: 77,
+        reply_parameters: {
+          message_id: 77,
+          quote: "quoted context",
+        },
         reply_markup: {
           inline_keyboard: [[{ text: "Ack", callback_data: "ack" }]],
         },


### PR DESCRIPTION
## Summary
- add optional Telegram `replyContextLength` config for `reply_parameters.quote`
- build quote text per target message id so current-message replies and upstream quoted replies use the right snippet
- cover the new config and reply delivery behavior with Telegram regression tests

## Testing
- pnpm test src/telegram/bot-message-dispatch.test.ts
- pnpm test src/telegram/bot/delivery.test.ts
- pnpm test src/config/config-misc.test.ts
- pnpm build

Closes #6975
