### PR TITLE
Gateway: refresh daemon service env after update.run

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { confirm, isCancel } from "@clack/prompts";
 import {
   checkShellCompletionStatus,
@@ -29,8 +28,8 @@ import {
   resolveGlobalPackageRoot,
 } from "../../infra/update-global.js";
 import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runner.js";
+import { refreshGatewayServiceEnvFromUpdatedInstall } from "../../infra/update-service-refresh.js";
 import { syncPluginsForUpdateChannel, updateNpmInstalledPlugins } from "../../plugins/update.js";
-import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { stylePromptMessage } from "../../terminal/prompt-style.js";
 import { theme } from "../../terminal/theme.js";
@@ -66,8 +65,6 @@ import {
 import { suppressDeprecations } from "./suppress-deprecations.js";
 
 const CLI_NAME = resolveCliName();
-const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
-
 const UPDATE_QUIPS = [
   "Leveled up! New skills unlocked. You're welcome.",
   "Fresh code, same lobster. Miss me?",
@@ -93,26 +90,6 @@ const UPDATE_QUIPS = [
 
 function pickUpdateQuip(): string {
   return UPDATE_QUIPS[Math.floor(Math.random() * UPDATE_QUIPS.length)] ?? "Update complete.";
-}
-
-function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
-  if (!root) {
-    return [];
-  }
-  return [
-    path.join(root, "dist", "entry.js"),
-    path.join(root, "dist", "entry.mjs"),
-    path.join(root, "dist", "index.js"),
-    path.join(root, "dist", "index.mjs"),
-  ];
-}
-
-function formatCommandFailure(stdout: string, stderr: string): string {
-  const detail = (stderr || stdout).trim();
-  if (!detail) {
-    return "command returned a non-zero exit code";
-  }
-  return detail.split("\n").slice(-3).join("\n");
 }
 
 type UpdateDryRunPreview = {
@@ -178,27 +155,13 @@ async function refreshGatewayServiceEnv(params: {
   result: UpdateRunResult;
   jsonMode: boolean;
 }): Promise<void> {
-  const args = ["gateway", "install", "--force"];
-  if (params.jsonMode) {
-    args.push("--json");
-  }
-
-  for (const candidate of resolveGatewayInstallEntrypointCandidates(params.result.root)) {
-    if (!(await pathExists(candidate))) {
-      continue;
-    }
-    const res = await runCommandWithTimeout([resolveNodeRunner(), candidate, ...args], {
-      timeoutMs: SERVICE_REFRESH_TIMEOUT_MS,
-    });
-    if (res.code === 0) {
-      return;
-    }
-    throw new Error(
-      `updated install refresh failed (${candidate}): ${formatCommandFailure(res.stdout, res.stderr)}`,
-    );
-  }
-
-  await runDaemonInstall({ force: true, json: params.jsonMode || undefined });
+  await refreshGatewayServiceEnvFromUpdatedInstall({
+    root: params.result.root,
+    json: params.jsonMode,
+    fallback: async () => {
+      await runDaemonInstall({ force: true, json: params.jsonMode || undefined });
+    },
+  });
 }
 
 async function tryInstallShellCompletion(opts: {

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -6,6 +6,7 @@ import type { UpdateRunResult } from "../../infra/update-runner.js";
 let capturedPayload: RestartSentinelPayload | undefined;
 
 const runGatewayUpdateMock = vi.fn<() => Promise<UpdateRunResult>>();
+const refreshGatewayServiceEnvFromUpdatedInstallMock = vi.fn<() => Promise<void>>();
 
 const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
 
@@ -59,6 +60,10 @@ vi.mock("../../infra/update-runner.js", () => ({
   runGatewayUpdate: runGatewayUpdateMock,
 }));
 
+vi.mock("../../infra/update-service-refresh.js", () => ({
+  refreshGatewayServiceEnvFromUpdatedInstall: refreshGatewayServiceEnvFromUpdatedInstallMock,
+}));
+
 vi.mock("../protocol/index.js", () => ({
   validateUpdateRunParams: () => true,
 }));
@@ -81,9 +86,12 @@ beforeEach(() => {
   runGatewayUpdateMock.mockResolvedValue({
     status: "ok",
     mode: "npm",
+    root: "/tmp/openclaw",
     steps: [],
     durationMs: 100,
   });
+  refreshGatewayServiceEnvFromUpdatedInstallMock.mockClear();
+  refreshGatewayServiceEnvFromUpdatedInstallMock.mockResolvedValue();
   scheduleGatewaySigusr1RestartMock.mockClear();
   scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
 });
@@ -164,6 +172,9 @@ describe("update.run restart scheduling", () => {
       payload = typed;
     });
 
+    expect(refreshGatewayServiceEnvFromUpdatedInstallMock).toHaveBeenCalledWith({
+      root: "/tmp/openclaw",
+    });
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
     expect(payload?.ok).toBe(true);
     expect(payload?.restart).toEqual({ scheduled: true });
@@ -185,6 +196,7 @@ describe("update.run restart scheduling", () => {
       payload = typed;
     });
 
+    expect(refreshGatewayServiceEnvFromUpdatedInstallMock).not.toHaveBeenCalled();
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
     expect(payload?.ok).toBe(false);
     expect(payload?.restart).toBeNull();

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -9,6 +9,7 @@ import {
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { runGatewayUpdate } from "../../infra/update-runner.js";
+import { refreshGatewayServiceEnvFromUpdatedInstall } from "../../infra/update-service-refresh.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "../control-plane-audit.js";
 import { validateUpdateRunParams } from "../protocol/index.js";
 import { parseRestartRequestParams } from "./restart-request.js";
@@ -90,6 +91,14 @@ export const updateHandlers: GatewayRequestHandlers = {
       sentinelPath = await writeRestartSentinel(payload);
     } catch {
       sentinelPath = null;
+    }
+
+    if (result.status === "ok") {
+      try {
+        await refreshGatewayServiceEnvFromUpdatedInstall({ root: result.root });
+      } catch (err) {
+        context?.logGateway?.warn(`update.run service refresh skipped: ${String(err)}`);
+      }
     }
 
     // Only restart the gateway when the update actually succeeded.

--- a/src/infra/update-service-refresh.ts
+++ b/src/infra/update-service-refresh.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { pathExists } from "../utils.js";
+import { resolveStableNodePath } from "./stable-node-path.js";
+
+const DEFAULT_SERVICE_REFRESH_TIMEOUT_MS = 60_000;
+
+export function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
+  if (!root) {
+    return [];
+  }
+  return [
+    path.join(root, "openclaw.mjs"),
+    path.join(root, "dist", "entry.js"),
+    path.join(root, "dist", "entry.mjs"),
+    path.join(root, "dist", "index.js"),
+    path.join(root, "dist", "index.mjs"),
+  ];
+}
+
+function formatCommandFailure(stdout: string, stderr: string): string {
+  const detail = (stderr || stdout).trim();
+  if (!detail) {
+    return "command returned a non-zero exit code";
+  }
+  return detail.split("\n").slice(-3).join("\n");
+}
+
+export async function refreshGatewayServiceEnvFromUpdatedInstall(params: {
+  root?: string;
+  json?: boolean;
+  timeoutMs?: number;
+  fallback?: () => Promise<void>;
+}): Promise<void> {
+  const args = ["gateway", "install", "--force"];
+  if (params.json) {
+    args.push("--json");
+  }
+
+  for (const candidate of resolveGatewayInstallEntrypointCandidates(params.root)) {
+    if (!(await pathExists(candidate))) {
+      continue;
+    }
+    const nodePath = await resolveStableNodePath(process.execPath);
+    const res = await runCommandWithTimeout([nodePath, candidate, ...args], {
+      timeoutMs: params.timeoutMs ?? DEFAULT_SERVICE_REFRESH_TIMEOUT_MS,
+    });
+    if (res.code === 0) {
+      return;
+    }
+    throw new Error(
+      `updated install refresh failed (${candidate}): ${formatCommandFailure(res.stdout, res.stderr)}`,
+    );
+  }
+
+  if (params.fallback) {
+    await params.fallback();
+    return;
+  }
+
+  throw new Error("no updated gateway install entrypoint found");
+}


### PR DESCRIPTION
## Summary
- refresh gateway service env from the updated install after a successful self-update
- reuse the same refresh helper from both CLI update and gateway update paths
- keep update success non-fatal if the post-update service refresh fails

## Testing
- pnpm test src/gateway/server-methods/update.test.ts
- pnpm test src/cli/update-cli.test.ts
- pnpm build

Closes #7710
