### PR TITLE
agents: validate uuid cli session ids

### DIFF
--- a/src/agents/claude-cli-runner.test.ts
+++ b/src/agents/claude-cli-runner.test.ts
@@ -79,7 +79,14 @@ describe("runClaudeCliAgent", () => {
 
   it("starts a new session with --session-id when none is provided", async () => {
     mocks.spawn.mockResolvedValueOnce(
-      createManagedRun(Promise.resolve(successExit({ message: "ok", session_id: "sid-1" }))),
+      createManagedRun(
+        Promise.resolve(
+          successExit({
+            message: "ok",
+            session_id: "550e8400-e29b-41d4-a716-446655440000",
+          }),
+        ),
+      ),
     );
 
     await runClaudeCliAgent({
@@ -102,7 +109,14 @@ describe("runClaudeCliAgent", () => {
 
   it("uses --resume when a claude session id is provided", async () => {
     mocks.spawn.mockResolvedValueOnce(
-      createManagedRun(Promise.resolve(successExit({ message: "ok", session_id: "sid-2" }))),
+      createManagedRun(
+        Promise.resolve(
+          successExit({
+            message: "ok",
+            session_id: "550e8400-e29b-41d4-a716-446655440000",
+          }),
+        ),
+      ),
     );
 
     await runClaudeCliAgent({
@@ -154,11 +168,21 @@ describe("runClaudeCliAgent", () => {
 
     await waitForCalls(mocks.spawn, 1);
 
-    firstDeferred.resolve(successExit({ message: "ok", session_id: "sid-1" }));
+    firstDeferred.resolve(
+      successExit({
+        message: "ok",
+        session_id: "550e8400-e29b-41d4-a716-446655440000",
+      }),
+    );
 
     await waitForCalls(mocks.spawn, 2);
 
-    secondDeferred.resolve(successExit({ message: "ok", session_id: "sid-2" }));
+    secondDeferred.resolve(
+      successExit({
+        message: "ok",
+        session_id: "123e4567-e89b-12d3-a456-426614174000",
+      }),
+    );
 
     await Promise.all([firstRun, secondRun]);
   });

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -56,6 +56,7 @@ const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
   sessionArg: "--session-id",
   sessionMode: "always",
   sessionIdFields: ["session_id", "sessionId", "conversation_id", "conversationId"],
+  sessionIdFormat: "uuid",
   systemPromptArg: "--append-system-prompt",
   systemPromptMode: "append",
   systemPromptWhen: "first",

--- a/src/agents/cli-runner/helpers.test.ts
+++ b/src/agents/cli-runner/helpers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { CliBackendConfig } from "../../config/types.js";
+import { parseCliJson, parseCliJsonl } from "./helpers.js";
+
+describe("cli session id parsing", () => {
+  it("ignores non-uuid session ids for uuid backends", () => {
+    const backend: CliBackendConfig = {
+      command: "claude",
+      output: "json",
+      sessionIdFormat: "uuid",
+    };
+
+    const parsed = parseCliJson(
+      JSON.stringify({
+        message: "rate limited",
+        session_id: "rate-limited",
+      }),
+      backend,
+    );
+
+    expect(parsed).toEqual({
+      text: "rate limited",
+      sessionId: undefined,
+      usage: undefined,
+    });
+  });
+
+  it("keeps valid uuid session ids for uuid backends", () => {
+    const backend: CliBackendConfig = {
+      command: "claude",
+      output: "json",
+      sessionIdFormat: "uuid",
+    };
+
+    const parsed = parseCliJson(
+      JSON.stringify({
+        message: "ok",
+        session_id: "550e8400-e29b-41d4-a716-446655440000",
+      }),
+      backend,
+    );
+
+    expect(parsed?.sessionId).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("preserves opaque thread ids for non-uuid backends", () => {
+    const backend: CliBackendConfig = {
+      command: "codex",
+      output: "jsonl",
+      sessionIdFields: ["thread_id"],
+      sessionIdFormat: "opaque",
+    };
+
+    const parsed = parseCliJsonl(
+      [
+        JSON.stringify({ thread_id: "thread_abc123" }),
+        JSON.stringify({
+          item: { type: "message", text: "hello" },
+        }),
+      ].join("\n"),
+      backend,
+    );
+
+    expect(parsed).toEqual({
+      text: "hello",
+      sessionId: "thread_abc123",
+      usage: undefined,
+    });
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -162,6 +162,7 @@ function pickSessionId(
   parsed: Record<string, unknown>,
   backend: CliBackendConfig,
 ): string | undefined {
+  const requiresUuid = backend.sessionIdFormat === "uuid";
   const fields = backend.sessionIdFields ?? [
     "session_id",
     "sessionId",
@@ -171,10 +172,18 @@ function pickSessionId(
   for (const field of fields) {
     const value = parsed[field];
     if (typeof value === "string" && value.trim()) {
-      return value.trim();
+      const candidate = value.trim();
+      if (requiresUuid && !isUuidSessionId(candidate)) {
+        continue;
+      }
+      return candidate;
     }
   }
   return undefined;
+}
+
+function isUuidSessionId(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value.trim());
 }
 
 export function parseCliJson(raw: string, backend: CliBackendConfig): CliOutput | null {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -75,6 +75,8 @@ export type CliBackendConfig = {
   sessionMode?: "always" | "existing" | "none";
   /** JSON fields to read session id from (in order). */
   sessionIdFields?: string[];
+  /** Validation mode for parsed session ids before persisting them. */
+  sessionIdFormat?: "opaque" | "uuid";
   /** Flag used to pass system prompt. */
   systemPromptArg?: string;
   /** System prompt behavior (append vs replace). */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -468,6 +468,7 @@ export const CliBackendSchema = z
       .union([z.literal("always"), z.literal("existing"), z.literal("none")])
       .optional(),
     sessionIdFields: z.array(z.string()).optional(),
+    sessionIdFormat: z.union([z.literal("opaque"), z.literal("uuid")]).optional(),
     systemPromptArg: z.string().optional(),
     systemPromptMode: z.union([z.literal("append"), z.literal("replace")]).optional(),
     systemPromptWhen: z

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -14,6 +14,7 @@ import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
+import { stripAssistantInternalScaffolding } from "../../shared/text/assistant-visible-text.js";
 import {
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
@@ -272,17 +273,28 @@ function truncateChatHistoryText(text: string): { text: string; truncated: boole
   };
 }
 
-function sanitizeChatHistoryContentBlock(block: unknown): { block: unknown; changed: boolean } {
+function sanitizeAssistantHistoryTextForDisplay(text: string): { text: string; changed: boolean } {
+  const stripped = stripAssistantInternalScaffolding(text);
+  return { text: stripped, changed: stripped !== text };
+}
+
+function sanitizeChatHistoryContentBlock(
+  block: unknown,
+  options?: { stripAssistantInternal?: boolean },
+): { block: unknown; changed: boolean } {
   if (!block || typeof block !== "object") {
     return { block, changed: false };
   }
   const entry = { ...(block as Record<string, unknown>) };
   let changed = false;
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const visible = options?.stripAssistantInternal
+      ? sanitizeAssistantHistoryTextForDisplay(entry.text)
+      : { text: entry.text, changed: false };
+    const stripped = stripInlineDirectiveTagsForDisplay(visible.text);
     const res = truncateChatHistoryText(stripped.text);
     entry.text = res.text;
-    changed ||= stripped.changed || res.truncated;
+    changed ||= visible.changed || stripped.changed || res.truncated;
   }
   if (typeof entry.partialJson === "string") {
     const res = truncateChatHistoryText(entry.partialJson);
@@ -335,12 +347,20 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
   }
 
   if (typeof entry.content === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
+    const visible =
+      entry.role === "assistant"
+        ? sanitizeAssistantHistoryTextForDisplay(entry.content)
+        : { text: entry.content, changed: false };
+    const stripped = stripInlineDirectiveTagsForDisplay(visible.text);
     const res = truncateChatHistoryText(stripped.text);
     entry.content = res.text;
-    changed ||= stripped.changed || res.truncated;
+    changed ||= visible.changed || stripped.changed || res.truncated;
   } else if (Array.isArray(entry.content)) {
-    const updated = entry.content.map((block) => sanitizeChatHistoryContentBlock(block));
+    const updated = entry.content.map((block) =>
+      sanitizeChatHistoryContentBlock(block, {
+        stripAssistantInternal: entry.role === "assistant",
+      }),
+    );
     if (updated.some((item) => item.changed)) {
       entry.content = updated.map((item) => item.block);
       changed = true;
@@ -348,10 +368,14 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
   }
 
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const visible =
+      entry.role === "assistant"
+        ? sanitizeAssistantHistoryTextForDisplay(entry.text)
+        : { text: entry.text, changed: false };
+    const stripped = stripInlineDirectiveTagsForDisplay(visible.text);
     const res = truncateChatHistoryText(stripped.text);
     entry.text = res.text;
-    changed ||= stripped.changed || res.truncated;
+    changed ||= visible.changed || stripped.changed || res.truncated;
   }
 
   return { message: changed ? entry : message, changed };

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -496,6 +496,34 @@ describe("gateway server chat", () => {
     ]);
   });
 
+  test("chat.history strips assistant relevant-memories scaffolding from user-visible history", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: [
+              "Visible intro",
+              "<relevant-memories>",
+              "private memory",
+              "</relevant-memories>",
+              "Visible outro",
+            ].join("\n"),
+          },
+        ],
+        timestamp: 1,
+      },
+    ]);
+
+    const textValues = collectHistoryTextValues(historyMessages);
+    expect(textValues).toHaveLength(1);
+    expect(textValues[0]).toContain("Visible intro");
+    expect(textValues[0]).toContain("Visible outro");
+    expect(textValues[0]).not.toContain("relevant-memories");
+    expect(textValues[0]).not.toContain("private memory");
+  });
+
   test("agent.wait resolves chat.send runs that finish without lifecycle events", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     try {

--- a/src/tui/components/assistant-message.test.ts
+++ b/src/tui/components/assistant-message.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeAssistantMessageTextForDisplay } from "./assistant-message.js";
+
+describe("sanitizeAssistantMessageTextForDisplay", () => {
+  it("strips relevant-memories scaffolding before rendering", () => {
+    const out = sanitizeAssistantMessageTextForDisplay(
+      [
+        "Visible intro",
+        "<relevant-memories>",
+        "private memory",
+        "</relevant-memories>",
+        "Visible outro",
+      ].join("\n"),
+    );
+
+    expect(out).toContain("Visible intro");
+    expect(out).toContain("Visible outro");
+    expect(out).not.toContain("relevant-memories");
+    expect(out).not.toContain("private memory");
+  });
+});

--- a/src/tui/components/assistant-message.ts
+++ b/src/tui/components/assistant-message.ts
@@ -1,22 +1,33 @@
 import { Container, Spacer } from "@mariozechner/pi-tui";
+import { stripAssistantInternalScaffolding } from "../../shared/text/assistant-visible-text.js";
 import { markdownTheme, theme } from "../theme/theme.js";
 import { HyperlinkMarkdown } from "./hyperlink-markdown.js";
+
+export function sanitizeAssistantMessageTextForDisplay(text: string): string {
+  return stripAssistantInternalScaffolding(text);
+}
 
 export class AssistantMessageComponent extends Container {
   private body: HyperlinkMarkdown;
 
   constructor(text: string) {
     super();
-    this.body = new HyperlinkMarkdown(text, 1, 0, markdownTheme, {
-      // Keep assistant body text in terminal default foreground so contrast
-      // follows the user's terminal theme (dark or light).
-      color: (line) => theme.assistantText(line),
-    });
+    this.body = new HyperlinkMarkdown(
+      sanitizeAssistantMessageTextForDisplay(text),
+      1,
+      0,
+      markdownTheme,
+      {
+        // Keep assistant body text in terminal default foreground so contrast
+        // follows the user's terminal theme (dark or light).
+        color: (line) => theme.assistantText(line),
+      },
+    );
     this.addChild(new Spacer(1));
     this.addChild(this.body);
   }
 
   setText(text: string) {
-    this.body.setText(text);
+    this.body.setText(sanitizeAssistantMessageTextForDisplay(text));
   }
 }


### PR DESCRIPTION
## Summary
- validate UUID-backed CLI session ids before persisting them for resume
- mark the built-in Claude CLI backend as UUID-based while leaving opaque thread ids untouched
- add regression coverage for rate-limit sentinel values and valid/opaque session ids

## Testing
- pnpm test src/agents/cli-runner/helpers.test.ts
- pnpm test src/agents/claude-cli-runner.test.ts
- pnpm build
- pnpm exec oxfmt --check src/config/types.agent-defaults.ts src/config/zod-schema.core.ts src/agents/cli-backends.ts src/agents/cli-runner/helpers.ts src/agents/cli-runner/helpers.test.ts src/agents/claude-cli-runner.test.ts

Closes #43288
