### PR TITLE
media: reclassify audio-only mp4 containers

### DIFF
--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -68,6 +68,21 @@ describe("mime detection", () => {
     });
     expect(mime).toBe("text/javascript");
   });
+
+  it("reclassifies audio-only mp4 containers as audio/mp4", async () => {
+    const buf = Buffer.from([
+      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x52, 0x20, 0x00, 0x00, 0x00,
+      0x00, 0x4d, 0x34, 0x52, 0x20, 0x69, 0x73, 0x6f, 0x6d,
+    ]);
+
+    const mime = await detectMime({
+      buffer: buf,
+      filePath: "/tmp/voice-note.mp4",
+    });
+
+    expect(mime).toBe("audio/mp4");
+    expect(kindFromMime(mime)).toBe("audio");
+  });
 });
 
 describe("extensionForMime", () => {

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -57,6 +57,8 @@ const AUDIO_FILE_EXTENSIONS = new Set([
   ".wav",
 ]);
 
+const MP4_AUDIO_BRANDS = new Set(["m4a ", "m4b ", "m4p ", "m4r ", "f4a ", "f4b "]);
+
 export function normalizeMimeType(mime?: string | null): string | undefined {
   if (!mime) {
     return undefined;
@@ -71,10 +73,31 @@ async function sniffMime(buffer?: Buffer): Promise<string | undefined> {
   }
   try {
     const type = await fileTypeFromBuffer(buffer);
-    return type?.mime ?? undefined;
+    const sniffed = type?.mime;
+    if (sniffed === "video/mp4") {
+      const corrected = correctAudioOnlyMp4Mime(buffer);
+      if (corrected) {
+        return corrected;
+      }
+    }
+    return sniffed ?? undefined;
   } catch {
     return undefined;
   }
+}
+
+function correctAudioOnlyMp4Mime(buffer: Buffer): string | undefined {
+  const hasFtypBox =
+    buffer.length >= 12 &&
+    buffer[4] === 0x66 &&
+    buffer[5] === 0x74 &&
+    buffer[6] === 0x79 &&
+    buffer[7] === 0x70;
+  if (!hasFtypBox) {
+    return undefined;
+  }
+  const majorBrand = buffer.toString("ascii", 8, 12).toLowerCase();
+  return MP4_AUDIO_BRANDS.has(majorBrand) ? "audio/mp4" : undefined;
 }
 
 export function getFileExtension(filePath?: string | null): string | undefined {


### PR DESCRIPTION
## Summary
- correct shared MIME sniffing for audio-only mp4 container brands that file-type still reports as video/mp4
- keep the fix centralized in src/media/mime.ts so every channel benefits from the same correction
- add a regression test for an audio-only M4R-style container and assert it routes as audio

## Testing
- pnpm test src/media/mime.test.ts
- pnpm test src/media/audio.test.ts
- pnpm build
- pnpm exec oxfmt --check src/media/mime.ts src/media/mime.test.ts

Closes #43313
