### PR TITLE
UI: keep main session visible in chat session dropdown

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -354,6 +354,17 @@ describe("resolveMainSessionKey", () => {
     expect(resolveMainSessionKey(null, sessions)).toBe("main");
   });
 
+  it("falls back to main alias when only a non-default agent main key is visible", () => {
+    const sessions = {
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: { model: null, contextTokens: null },
+      sessions: [row({ key: "agent:ops:main", updatedAt: Date.now() })],
+    } satisfies SessionsListResult;
+    expect(resolveMainSessionKey(null, sessions)).toBe("main");
+  });
+
   it("falls back to main when snapshot and inferred keys are unavailable", () => {
     const sessions = {
       ts: Date.now(),

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isCronSessionKey,
   parseSessionKey,
+  resolveMainSessionKey,
   resolveSessionDisplayName,
 } from "./app-render.helpers.ts";
 import type { SessionsListResult } from "./types.ts";
@@ -282,5 +283,39 @@ describe("isCronSessionKey", () => {
     expect(isCronSessionKey("main")).toBe(false);
     expect(isCronSessionKey("discord:group:eng")).toBe(false);
     expect(isCronSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
+  });
+});
+
+describe("resolveMainSessionKey", () => {
+  it("returns mainSessionKey from snapshot when present", () => {
+    const hello = {
+      snapshot: { sessionDefaults: { mainSessionKey: "agent:main:main" } },
+    } as const;
+    expect(resolveMainSessionKey(hello as never, null)).toBe("agent:main:main");
+  });
+
+  it("falls back to inferred canonical main key from sessions", () => {
+    const sessions = {
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 2,
+      defaults: { model: null, contextTokens: null },
+      sessions: [
+        row({ key: "agent:main:heartbeat", updatedAt: Date.now() }),
+        row({ key: "agent:main:main", updatedAt: Date.now() }),
+      ],
+    } satisfies SessionsListResult;
+    expect(resolveMainSessionKey(null, sessions)).toBe("agent:main:main");
+  });
+
+  it("falls back to main when snapshot and inferred keys are unavailable", () => {
+    const sessions = {
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: { model: null, contextTokens: null },
+      sessions: [row({ key: "agent:main:heartbeat", updatedAt: Date.now() })],
+    } satisfies SessionsListResult;
+    expect(resolveMainSessionKey(null, sessions)).toBe("main");
   });
 });

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -294,6 +294,27 @@ describe("resolveMainSessionKey", () => {
     expect(resolveMainSessionKey(hello as never, null)).toBe("agent:main:main");
   });
 
+  it("falls back to snapshot mainKey when mainSessionKey is unavailable", () => {
+    const hello = {
+      snapshot: { sessionDefaults: { mainKey: "agent:main:main" } },
+    } as const;
+    expect(resolveMainSessionKey(hello as never, null)).toBe("agent:main:main");
+  });
+
+  it("returns explicit main when sessions list includes it", () => {
+    const sessions = {
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 2,
+      defaults: { model: null, contextTokens: null },
+      sessions: [
+        row({ key: "agent:main:heartbeat", updatedAt: Date.now() }),
+        row({ key: "main", updatedAt: Date.now() }),
+      ],
+    } satisfies SessionsListResult;
+    expect(resolveMainSessionKey(null, sessions)).toBe("main");
+  });
+
   it("falls back to inferred canonical main key from sessions", () => {
     const sessions = {
       ts: Date.now(),
@@ -306,6 +327,31 @@ describe("resolveMainSessionKey", () => {
       ],
     } satisfies SessionsListResult;
     expect(resolveMainSessionKey(null, sessions)).toBe("agent:main:main");
+  });
+
+  it("returns trimmed inferred key from sessions", () => {
+    const sessions = {
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: { model: null, contextTokens: null },
+      sessions: [row({ key: "  agent:main:main  ", updatedAt: Date.now() })],
+    } satisfies SessionsListResult;
+    expect(resolveMainSessionKey(null, sessions)).toBe("agent:main:main");
+  });
+
+  it("does not infer another agent main key when multiple are present", () => {
+    const sessions = {
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 2,
+      defaults: { model: null, contextTokens: null },
+      sessions: [
+        row({ key: "agent:ops:main", updatedAt: Date.now() }),
+        row({ key: "agent:release:main", updatedAt: Date.now() }),
+      ],
+    } satisfies SessionsListResult;
+    expect(resolveMainSessionKey(null, sessions)).toBe("main");
   });
 
   it("falls back to main when snapshot and inferred keys are unavailable", () => {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -321,9 +321,6 @@ export function resolveMainSessionKey(
   if (agentMainDefault) {
     return agentMainDefault;
   }
-  if (inferredAgentMainKeys.length === 1) {
-    return inferredAgentMainKeys[0];
-  }
   // Keep "main" visible even when sessions.list is narrowed to active sessions.
   return "main";
 }

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -307,12 +307,22 @@ export function resolveMainSessionKey(
   if (sessions?.sessions?.some((row) => row.key === "main")) {
     return "main";
   }
-  const inferredMainKey = sessions?.sessions?.find((row) => {
-    const key = row.key.trim();
-    return key === "global" || /^agent:[^:]+:main$/i.test(key);
-  })?.key;
-  if (inferredMainKey) {
-    return inferredMainKey;
+  const globalKey = sessions?.sessions?.find((row) => row.key.trim() === "global")?.key.trim();
+  if (globalKey) {
+    return globalKey;
+  }
+  const inferredAgentMainKeys =
+    sessions?.sessions
+      ?.map((row) => row.key.trim())
+      ?.filter((key) => /^agent:[^:]+:main$/i.test(key)) ?? [];
+  const agentMainDefault = inferredAgentMainKeys.find(
+    (key) => key.toLowerCase() === "agent:main:main",
+  );
+  if (agentMainDefault) {
+    return agentMainDefault;
+  }
+  if (inferredAgentMainKeys.length === 1) {
+    return inferredAgentMainKeys[0];
   }
   // Keep "main" visible even when sessions.list is narrowed to active sessions.
   return "main";

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -291,7 +291,7 @@ export function renderChatControls(state: AppViewState) {
   `;
 }
 
-function resolveMainSessionKey(
+export function resolveMainSessionKey(
   hello: AppViewState["hello"],
   sessions: SessionsListResult | null,
 ): string | null {
@@ -307,7 +307,15 @@ function resolveMainSessionKey(
   if (sessions?.sessions?.some((row) => row.key === "main")) {
     return "main";
   }
-  return null;
+  const inferredMainKey = sessions?.sessions?.find((row) => {
+    const key = row.key.trim();
+    return key === "global" || /^agent:[^:]+:main$/i.test(key);
+  })?.key;
+  if (inferredMainKey) {
+    return inferredMainKey;
+  }
+  // Keep "main" visible even when sessions.list is narrowed to active sessions.
+  return "main";
 }
 
 /* ── Channel display labels ────────────────────────────── */


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: chat session dropdown could omit the main session when `hello.snapshot.sessionDefaults` was unavailable and `sessions.list` only contained heartbeat/active sessions.
- Why it matters: users can get stuck with only heartbeat visible and cannot switch back to the main session from the web UI.
- What changed: made `resolveMainSessionKey` resilient by inferring canonical main keys (`global` or `agent:<id>:main`) and falling back to `main` instead of `null`.
- What did NOT change (scope boundary): no gateway/session-store protocol changes; fix is UI dropdown key resolution only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43737
- Related #

## User-visible / Behavior Changes

- Chat session dropdown always includes a main-session option even when active-session filtering only returns heartbeat.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: pnpm workspace
- Model/provider: N/A (UI logic)
- Integration/channel (if any): Control UI chat session selector
- Relevant config (redacted): default session config

### Steps

1. Open Control UI chat page with active-session list containing heartbeat but no explicit main row.
2. Open the session dropdown.
3. Verify main session option is still shown.

### Expected

- Main session remains selectable alongside heartbeat.

### Actual

- Before fix, main could be missing when fallback resolution returned `null`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused checks run:

- `pnpm --dir ui exec oxfmt --check src/ui/app-render.helpers.ts src/ui/app-render.helpers.node.test.ts` ✅
- `pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/app-render.helpers.node.test.ts` ✅ (39 passed)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added regression coverage for snapshot-provided main key, inferred canonical main key, and fallback-to-`main` path.
- Edge cases checked: sessions list containing only heartbeat now still resolves a main option.
- What you did **not** verify: full browser/manual UI click-through against a live gateway instance.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `ui/src/ui/app-render.helpers.ts`.
- Known bad symptoms reviewers should watch for: duplicated/incorrect main option labels in unusual custom main-key configs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: fallback to `main` could show an alias label instead of canonical key in edge configs without snapshot data.
  - Mitigation: prefer snapshot value first, then inferred canonical session keys from `sessions.list`; fallback only as last resort.
