### PR TITLE
fix(media): classify audio-only MP4/M4A containers as audio, not video

### DIFF
--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { messagingApi } from "@line/bot-sdk";
 import { logVerbose } from "../globals.js";
+import { reclassifyMp4 } from "../media/mime.js";
 import { buildRandomTempFilePath } from "../plugin-sdk/temp-path.js";
 
 interface DownloadResult {
@@ -8,8 +9,6 @@ interface DownloadResult {
   contentType?: string;
   size: number;
 }
-
-const AUDIO_BRANDS = new Set(["m4a ", "m4b ", "m4p ", "m4r ", "f4a ", "f4b "]);
 
 export async function downloadLineMedia(
   messageId: string,
@@ -55,13 +54,6 @@ export async function downloadLineMedia(
 }
 
 function detectContentType(buffer: Buffer): string {
-  const hasFtypBox =
-    buffer.length >= 12 &&
-    buffer[4] === 0x66 &&
-    buffer[5] === 0x74 &&
-    buffer[6] === 0x79 &&
-    buffer[7] === 0x70;
-
   // Check magic bytes
   if (buffer.length >= 2) {
     // JPEG
@@ -89,14 +81,15 @@ function detectContentType(buffer: Buffer): string {
     ) {
       return "image/webp";
     }
-    if (hasFtypBox) {
-      // ISO BMFF containers share `ftyp`; use major brand to separate common
-      // M4A audio payloads from video mp4 containers.
-      const majorBrand = buffer.toString("ascii", 8, 12).toLowerCase();
-      if (AUDIO_BRANDS.has(majorBrand)) {
-        return "audio/mp4";
-      }
-      return "video/mp4";
+    // ISO BMFF (ftyp) – delegate audio/video classification to shared helper
+    if (
+      buffer.length >= 12 &&
+      buffer[4] === 0x66 &&
+      buffer[5] === 0x74 &&
+      buffer[6] === 0x79 &&
+      buffer[7] === 0x70
+    ) {
+      return reclassifyMp4("video/mp4", buffer);
     }
   }
 

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -8,6 +8,7 @@ import {
   isAudioFileName,
   kindFromMime,
   normalizeMimeType,
+  reclassifyMp4,
 } from "./mime.js";
 
 async function makeOoxmlZip(opts: { mainMime: string; partPath: string }): Promise<Buffer> {
@@ -120,6 +121,49 @@ describe("normalizeMimeType", () => {
     { input: undefined, expected: undefined },
   ] as const)("normalizes $input", ({ input, expected }) => {
     expect(normalizeMimeType(input)).toBe(expected);
+  });
+});
+
+/** Build a minimal ftyp box with the given 4-char major brand. */
+function makeFtypBuffer(brand: string): Buffer {
+  // ftyp box: [size(4)] [ftyp(4)] [major_brand(4)] [minor_version(4)] ...
+  const buf = Buffer.alloc(16);
+  buf.writeUInt32BE(16, 0); // box size
+  buf.write("ftyp", 4, 4, "ascii"); // box type
+  buf.write(brand, 8, 4, "ascii"); // major brand
+  buf.writeUInt32BE(0, 12); // minor version
+  return buf;
+}
+
+describe("reclassifyMp4", () => {
+  it.each([
+    { brand: "M4A ", expected: "audio/mp4" },
+    { brand: "M4B ", expected: "audio/mp4" },
+    { brand: "m4a ", expected: "audio/mp4" },
+    { brand: "f4a ", expected: "audio/mp4" },
+  ])("reclassifies ftyp major brand $brand as audio/mp4", ({ brand, expected }) => {
+    const buf = makeFtypBuffer(brand);
+    expect(reclassifyMp4("video/mp4", buf)).toBe(expected);
+  });
+
+  it("keeps video/mp4 for isom brand", () => {
+    const buf = makeFtypBuffer("isom");
+    expect(reclassifyMp4("video/mp4", buf)).toBe("video/mp4");
+  });
+
+  it("keeps video/mp4 for mp42 brand", () => {
+    const buf = makeFtypBuffer("mp42");
+    expect(reclassifyMp4("video/mp4", buf)).toBe("video/mp4");
+  });
+
+  it("does not reclassify non-video/mp4 mimes", () => {
+    const buf = makeFtypBuffer("M4A ");
+    expect(reclassifyMp4("audio/mpeg", buf)).toBe("audio/mpeg");
+  });
+
+  it("returns original mime when buffer is too short", () => {
+    const buf = Buffer.alloc(8);
+    expect(reclassifyMp4("video/mp4", buf)).toBe("video/mp4");
   });
 });
 

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -2,6 +2,13 @@ import path from "node:path";
 import { fileTypeFromBuffer } from "file-type";
 import { type MediaKind, mediaKindFromMime } from "./constants.js";
 
+/**
+ * ISO BMFF ftyp major brands that indicate an audio-only MPEG-4 container.
+ * `file-type` returns `video/mp4` for all ftyp containers; we check the major
+ * brand at bytes 8-11 to reclassify audio-only variants.
+ */
+const AUDIO_FTYP_BRANDS = new Set(["m4a ", "m4b ", "m4p ", "m4r ", "f4a ", "f4b "]);
+
 // Map common mimes to preferred file extensions.
 const EXT_BY_MIME: Record<string, string> = {
   "image/heic": ".heic",
@@ -65,13 +72,40 @@ export function normalizeMimeType(mime?: string | null): string | undefined {
   return cleaned || undefined;
 }
 
+/**
+ * When `file-type` reports `video/mp4`, check the ftyp major brand to see if
+ * the container is actually audio-only (M4A, M4B, etc.).
+ */
+export function reclassifyMp4(mime: string, buffer: Buffer): string {
+  if (mime !== "video/mp4" || buffer.length < 12) {
+    return mime;
+  }
+  // bytes 4-7 must be "ftyp"
+  if (
+    buffer[4] !== 0x66 || // f
+    buffer[5] !== 0x74 || // t
+    buffer[6] !== 0x79 || // y
+    buffer[7] !== 0x70 // p
+  ) {
+    return mime;
+  }
+  const majorBrand = buffer.toString("ascii", 8, 12).toLowerCase();
+  if (AUDIO_FTYP_BRANDS.has(majorBrand)) {
+    return "audio/mp4";
+  }
+  return mime;
+}
+
 async function sniffMime(buffer?: Buffer): Promise<string | undefined> {
   if (!buffer) {
     return undefined;
   }
   try {
     const type = await fileTypeFromBuffer(buffer);
-    return type?.mime ?? undefined;
+    if (!type) {
+      return undefined;
+    }
+    return reclassifyMp4(type.mime, buffer);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

- Added ftyp major brand detection to reclassify audio-only MPEG-4 containers (M4A, M4B, M4P, M4R, F4A, F4B) as `audio/mp4` instead of `video/mp4`
- Integrated reclassification into the shared `sniffMime()` pipeline so all channels benefit
- Deduplicated the LINE-specific fix from #29751 into the shared `src/media/mime.ts` module

Fixes #43313

## Changes

- `src/media/mime.ts`: Added `AUDIO_FTYP_BRANDS` set and exported `reclassifyMp4()` function; updated `sniffMime()` to call it
- `src/line/download.ts`: Replaced local `AUDIO_BRANDS` set and inline ftyp detection with shared `reclassifyMp4()` import
- `src/media/mime.test.ts`: Added 7 test cases for `reclassifyMp4` covering audio brands, video brands, non-MP4 mimes, and short buffers

## Test plan

- [x] Unit tests pass (`pnpm vitest run src/media/mime.test.ts` — 52 tests)
- [x] Format check passes (`pnpm format:check`)
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm tsgo`)

This contribution was developed with AI assistance (Claude Code).