### PR TITLE
Onboarding: add DingTalk first-install channel option

### DIFF
--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -51,6 +51,28 @@ type ExternalCatalogEntry = {
   description?: string;
 } & Partial<Record<ManifestKey, OpenClawPackageManifest>>;
 
+const BUILTIN_CATALOG_ENTRIES: ExternalCatalogEntry[] = [
+  {
+    name: "@soimy/dingtalk",
+    openclaw: {
+      channel: {
+        id: "dingtalk",
+        label: "DingTalk",
+        selectionLabel: "DingTalk (Stream Mode)",
+        docsPath: "https://github.com/soimy/openclaw-channel-dingtalk",
+        docsLabel: "openclaw-channel-dingtalk",
+        blurb: "DingTalk bot plugin for Stream mode setup.",
+        order: 70,
+        aliases: ["dd", "ding"],
+      },
+      install: {
+        npmSpec: "@soimy/dingtalk",
+        defaultChoice: "npm",
+      },
+    },
+  },
+];
+
 const DEFAULT_CATALOG_PATHS = [
   path.join(CONFIG_DIR, "mpm", "plugins.json"),
   path.join(CONFIG_DIR, "mpm", "catalog.json"),
@@ -101,8 +123,8 @@ function resolveExternalCatalogPaths(options: CatalogOptions): string[] {
 }
 
 function loadExternalCatalogEntries(options: CatalogOptions): ExternalCatalogEntry[] {
+  const entries: ExternalCatalogEntry[] = [...BUILTIN_CATALOG_ENTRIES];
   const paths = resolveExternalCatalogPaths(options);
-  const entries: ExternalCatalogEntry[] = [];
   for (const rawPath of paths) {
     const resolved = resolveUserPath(rawPath);
     if (!fs.existsSync(resolved)) {

--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -102,6 +102,12 @@ describe("channel plugin registry", () => {
 });
 
 describe("channel plugin catalog", () => {
+  it("includes DingTalk for first-install onboarding", () => {
+    const entry = getChannelPluginCatalogEntry("dingtalk");
+    expect(entry?.install.npmSpec).toBe("@soimy/dingtalk");
+    expect(entry?.meta.label).toBe("DingTalk");
+  });
+
   it("includes Microsoft Teams", () => {
     const entry = getChannelPluginCatalogEntry("msteams");
     expect(entry?.install.npmSpec).toBe("@openclaw/msteams");
@@ -110,6 +116,7 @@ describe("channel plugin catalog", () => {
 
   it("lists plugin catalog entries", () => {
     const ids = listChannelPluginCatalogEntries().map((entry) => entry.id);
+    expect(ids).toContain("dingtalk");
     expect(ids).toContain("msteams");
   });
 

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -223,6 +223,33 @@ describe("setupChannels", () => {
     expect(multiselect).not.toHaveBeenCalled();
   });
 
+  it("shows DingTalk in QuickStart channel selection for first-install setup", async () => {
+    const select = vi.fn(async ({ message, options }: { message: string; options?: unknown[] }) => {
+      if (message === "Select channel (QuickStart)") {
+        const values = (options ?? []).map((option) => (option as { value?: string }).value ?? "");
+        expect(values).toContain("dingtalk");
+        return "__skip__";
+      }
+      return "__done__";
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    await runSetupChannels({} as OpenClawConfig, prompter, {
+      quickstartDefaults: true,
+    });
+
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Select channel (QuickStart)" }),
+    );
+    expect(multiselect).not.toHaveBeenCalled();
+    expect(text).not.toHaveBeenCalled();
+  });
+
   it("continues Telegram onboarding even when plugin registry is empty (avoids 'plugin not available' block)", async () => {
     // Simulate missing registry entries (the scenario reported in #25545).
     setActivePluginRegistry(createEmptyPluginRegistry());


### PR DESCRIPTION
## Summary

- Problem: DingTalk was not surfaced in first-install onboarding channel choices unless users manually installed a plugin first.
- Why it matters: users in DingTalk-first environments could assume the channel is unsupported during initial setup.
- What changed: added a built-in channel plugin catalog entry for `dingtalk` backed by `@soimy/dingtalk`, so onboarding now shows DingTalk as an installable channel option in QuickStart/selection flows.
- What did NOT change (scope boundary): no DingTalk runtime implementation was added in core; this change only exposes first-install discovery/install through the existing plugin onboarding flow.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26534
- Related #10347

## User-visible / Behavior Changes

- DingTalk now appears in onboarding channel selection as a first-install option.
- Selecting DingTalk follows the existing plugin install flow and installs `@soimy/dingtalk` via npm.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v22.21.1 + pnpm v10.23.0
- Model/provider: N/A
- Integration/channel (if any): onboarding channel catalog + DingTalk plugin catalog entry
- Relevant config (redacted): default test config

### Steps

1. Run onboarding channel selection tests with the e2e config.
2. Run channel plugin catalog tests with the unit config.

### Expected

- DingTalk is present in QuickStart channel selection options.
- Catalog entry lookup for `dingtalk` resolves to npm spec `@soimy/dingtalk`.

### Actual

- Both behaviors verified via tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands run:

- `pnpm vitest run --config vitest.unit.config.ts src/channels/plugins/plugins-core.test.ts` -> passed (29 tests)
- `pnpm vitest run --config vitest.e2e.config.ts src/commands/onboard-channels.e2e.test.ts` -> passed (11 tests)

## Human Verification (required)

- Verified scenarios:
  - Catalog includes `dingtalk` and resolves install spec to `@soimy/dingtalk`.
  - Onboarding QuickStart select options include `dingtalk`.
- Edge cases checked:
  - Existing catalog entry behavior remains intact for `msteams`.
- What you did **not** verify:
  - Live DingTalk message send/receive after plugin installation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/channels/plugins/catalog.ts`
- Known bad symptoms reviewers should watch for:
  - DingTalk missing again from onboarding channel selection.

## Risks and Mitigations

- Risk: third-party plugin npm package metadata drift.
  - Mitigation: onboarding install remains explicit user choice; catalog test pins expected id/spec.
