### PR TITLE
fix(msteams): add @microsoft/agents-hosting to root dependencies

### DIFF
--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -29,9 +29,7 @@
       "defaultChoice": "npm"
     },
     "releaseChecks": {
-      "rootDependencyMirrorAllowlist": [
-        "@microsoft/agents-hosting"
-      ]
+      "rootDependencyMirrorAllowlist": []
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -353,6 +353,7 @@
     "@mariozechner/pi-ai": "0.57.1",
     "@mariozechner/pi-coding-agent": "0.57.1",
     "@mariozechner/pi-tui": "0.57.1",
+    "@microsoft/agents-hosting": "^1.3.1",
     "@mozilla/readability": "^0.6.0",
     "@sinclair/typebox": "0.34.48",
     "@slack/bolt": "^4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@mariozechner/pi-tui':
         specifier: 0.57.1
         version: 0.57.1
+      '@microsoft/agents-hosting':
+        specifier: ^1.3.1
+        version: 1.3.1
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0


### PR DESCRIPTION
## Summary

Fixes the runtime crash `Cannot find module '@microsoft/agents-hosting'` that occurs when the bundled msteams extension is loaded in global npm or Homebrew installs, as originally reported in #15622.

## Relationship to #12849

PR #12849 addressed the *plugin installation* side of #15622 by adding a bundled-source fallback when `npm pack` returns a 404. That fix landed, but the *runtime* module resolution issue persisted: even after successful installation, the msteams extension crashes at load time because `@microsoft/agents-hosting` is not hoisted to the root `node_modules`. This PR closes the remaining gap by mirroring the dependency into the root `package.json`.

## Root Cause

First reported in [#15622](https://github.com/openclaw/openclaw/issues/15622): after updating OpenClaw, the Teams channel breaks with `Cannot find module '@microsoft/agents-hosting'`.

Bundled extensions ship inside the `openclaw` package via the `files: ["extensions/"]` entry in `package.json`, but their own `node_modules` directories are **not** included in the published tarball. When OpenClaw is installed globally (npm, Homebrew, pnpm global), Node's module resolution starts from the main `openclaw` package and cannot find `@microsoft/agents-hosting` because it was only declared in the extension's `package.json`.

The repo's `rootDependencyMirrorAllowlist` mechanism (enforced by `scripts/release-check.ts`) was explicitly marking this gap as "expected" — so the release-check gate passed, but the runtime still failed.

## What Changed

| File | Change |
|------|--------|
| `package.json` | Added `"@microsoft/agents-hosting": "^1.3.1"` to root `dependencies` |
| `extensions/msteams/package.json` | Cleared the now-stale `rootDependencyMirrorAllowlist` entry (was `["@microsoft/agents-hosting"]`, now `[]`) |
| `pnpm-lock.yaml` | Updated to include the new root dependency |

The version range `^1.3.1` matches the extension's own declaration in `extensions/msteams/package.json`.

## Validation

- ✅ `test/release-check.test.ts` — all 8 tests pass
- ✅ Root dependency mirror gap check — no drift detected across all bundled extensions
- ✅ `extensions/msteams/` test suite — 224/225 pass; the 1 failure (`probe.test.ts` credential check) is pre-existing on main and unrelated to this change
- ✅ `pnpm-lock.yaml` updated via `pnpm install --lockfile-only` on current main

## Why This Supersedes #16606

PR #16606 by @daocoding correctly identified the root cause and proposed the right fix direction. However, it:

1. **Only edited `package.json`** — missing the `pnpm-lock.yaml` update required for merge
2. **Added 3 packages** (`@microsoft/agents-hosting`, `@microsoft/agents-hosting-express`, `@microsoft/agents-hosting-extensions-teams`) — but only `@microsoft/agents-hosting` is actually imported by the extension code (the other two were sub-packages from an older SDK split)
3. **Used version `^1.2.3`** — the extension now declares `^1.3.1`
4. **Did not clean up `rootDependencyMirrorAllowlist`** — which would cause the release-check gate to flag stale entries

This PR implements the minimal correct fix against current main.

## Architectural Note

The `rootDependencyMirrorAllowlist` mechanism is a pragmatic workaround for the fundamental issue: bundled extensions declare their own dependencies but those deps aren't available in the root `node_modules` at runtime. A more robust solution would be to either:
- Include extension `node_modules` in the published tarball, or
- Pre-bundle extensions into self-contained artifacts during the build

This is out of scope for this fix but noted for future consideration.

## Scope & Caveats

This PR targets one specific failure mode: the recurring `Cannot find module '@microsoft/agents-hosting'` crash that breaks the msteams extension after updates. The underlying issue — bundled extensions whose dependencies aren't hoisted to the root `node_modules` — is not unique to Teams; the same class of problem has surfaced for other extensions and install paths (see #41431, #9357, #17089). This fix addresses the Teams instance by mirroring the dependency into the root package, but it is not a general solution to the broader bundled-extension resolution pattern.

**What this does NOT cover:**

- **Other bundled-extension module failures.** Analogous missing-module issues in non-Teams contexts (#41431, #9357) and install-path edge cases (#17089) require their own fixes and are tracked separately.
- **Non-module Teams behavior.** Other problems (e.g., `[msteams] channels unresolved` errors) may have independent root causes and could require separate follow-up even after this module loads correctly.
- **Stale dependency caches.** The fix depends on deployment/update paths properly installing refreshed dependencies. If a deployment skips `npm install` or uses a stale cache, the same class of missing-module error could recur.

## References

- Originally reported: #15622
- Related: #9357, #12849, #17089, #41431
- Supersedes: #16606

