### PR TITLE
test(onboard): add Kimi Coding config regression coverage

### DIFF
--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -131,9 +131,9 @@ async function runOnboardingAndReadConfig(
 async function expectWrittenConfigValid(configPath: string): Promise<void> {
   const cfg = await readJsonFile<Record<string, unknown>>(configPath);
   const validated = validateConfigObject(cfg);
-  const details = validated.ok
-    ? "expected config validation to succeed"
-    : validated.issues.map((issue) => `${issue.path || "<root>"}: ${issue.message}`).join("\n");
+  const details = !validated.ok
+    ? validated.issues.map((issue) => `${issue.path || "<root>"}: ${issue.message}`).join("\n")
+    : "expected config validation to succeed";
   expect(validated.ok, details).toBe(true);
 }
 

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { validateConfigObject } from "../config/config.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { MINIMAX_API_BASE_URL, MINIMAX_CN_API_BASE_URL } from "./onboard-auth.js";
@@ -127,6 +128,15 @@ async function runOnboardingAndReadConfig(
   return readJsonFile<ProviderAuthConfigSnapshot>(env.configPath);
 }
 
+async function expectWrittenConfigValid(configPath: string): Promise<void> {
+  const cfg = await readJsonFile<Record<string, unknown>>(configPath);
+  const validated = validateConfigObject(cfg);
+  const details = validated.ok
+    ? "expected config validation to succeed"
+    : validated.issues.map((issue) => `${issue.path || "<root>"}: ${issue.message}`).join("\n");
+  expect(validated.ok, details).toBe(true);
+}
+
 const CUSTOM_LOCAL_BASE_URL = "https://models.custom.local/v1";
 const CUSTOM_LOCAL_MODEL_ID = "local-large";
 const CUSTOM_LOCAL_PROVIDER_ID = "custom-models-custom-local";
@@ -230,6 +240,28 @@ describe("onboard (non-interactive): provider auth", () => {
       expect(cfg.models?.providers?.zai?.baseUrl).toBe("https://api.z.ai/api/paas/v4");
       expect(cfg.agents?.defaults?.model?.primary).toBe("zai/glm-5");
       await expectApiKeyProfile({ profileId: "zai:default", provider: "zai", key: "zai-test-key" });
+    });
+  });
+
+  it("stores Kimi Coding API key and writes a schema-valid config", async () => {
+    await withOnboardEnv("openclaw-onboard-kimi-coding-", async (env) => {
+      const cfg = await runOnboardingAndReadConfig(env, {
+        authChoice: "kimi-code-api-key",
+        kimiCodeApiKey: "kimi-coding-test-key", // pragma: allowlist secret
+      });
+
+      expect(cfg.auth?.profiles?.["kimi-coding:default"]?.provider).toBe("kimi-coding");
+      expect(cfg.auth?.profiles?.["kimi-coding:default"]?.mode).toBe("api_key");
+      expect(cfg.models?.providers?.["kimi-coding"]?.baseUrl).toBe("https://api.kimi.com/coding/");
+      expect(cfg.models?.providers?.["kimi-coding"]?.api).toBe("anthropic-messages");
+      expect(cfg.models?.providers?.["kimi-coding"]?.models?.[0]?.id).toBe("k2p5");
+      expect(cfg.agents?.defaults?.model?.primary).toBe("kimi-coding/k2p5");
+      await expectApiKeyProfile({
+        profileId: "kimi-coding:default",
+        provider: "kimi-coding",
+        key: "kimi-coding-test-key",
+      });
+      await expectWrittenConfigValid(env.configPath);
     });
   });
 


### PR DESCRIPTION
## Summary

- Problem: The original Kimi Coding onboarding/schema fix is already in `main`, but we did not have a regression test covering the `kimi-code-api-key` onboarding path.
- Why it matters: Without coverage here, a future change could silently reintroduce invalid config output for Kimi Coding onboarding.
- What changed: Added a non-interactive onboarding test for `kimi-code-api-key` and verified that the written config stores the expected auth/profile/provider values and passes `validateConfigObject`.
- What did NOT change (scope boundary): This PR does not change production onboarding logic, schema definitions, defaults, or runtime behavior. It only adds regression coverage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #43050

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node.js / pnpm
- Model/provider: Kimi Coding
- Integration/channel (if any): non-interactive onboarding
- Relevant config (redacted): temporary test workspace generated by the test harness

### Steps

1. Run non-interactive onboarding with `authChoice: "kimi-code-api-key"`.
2. Read the generated config and assert the expected Kimi Coding auth/profile/provider fields.
3. Validate the written config with `validateConfigObject`.

### Expected

- The generated config is schema-valid and contains the expected Kimi Coding auth + model wiring.

### Actual

- The added test covers this flow and verifies schema validation succeeds.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Kimi Coding non-interactive onboarding writes the expected config fields and passes schema validation.
- Edge cases checked: Confirmed the saved profile uses `kimi-coding:default`, `api_key` mode, and the expected provider/model defaults.
- What you did **not** verify: No manual end-to-end runtime validation outside the automated test.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR to remove the added regression test.
- Files/config to restore: `src/commands/onboard-non-interactive.provider-auth.test.ts`
- Known bad symptoms reviewers should watch for: Unexpected test failures in non-interactive onboarding auth coverage.

## Risks and Mitigations

- Risk: The test could become brittle if onboarding defaults or provider metadata intentionally change later.
- Mitigation: The assertions are scoped to the Kimi Coding path and validate only the contract this flow is expected to preserve.
