### PR TITLE
Android: fix HttpURLConnection leak in TalkModeVoiceResolver

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeVoiceResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeVoiceResolver.kt
@@ -101,9 +101,8 @@ internal object TalkModeVoiceResolver {
           val name = obj["name"].asStringOrNull()
           ElevenLabsVoice(voiceId, name)
         }
-      } catch (e: Exception) {
+      } finally {
         conn.disconnect()
-        throw e
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeVoiceResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeVoiceResolver.kt
@@ -87,7 +87,7 @@ internal object TalkModeVoiceResolver {
 
         val code = conn.responseCode
         val stream = if (code >= 400) conn.errorStream else conn.inputStream
-        val data = stream.use { it.readBytes() }
+        val data = stream?.use { it.readBytes() } ?: byteArrayOf()
         if (code >= 400) {
           val message = data.toString(Charsets.UTF_8)
           throw IllegalStateException("ElevenLabs voices failed: $code $message")
@@ -101,8 +101,9 @@ internal object TalkModeVoiceResolver {
           val name = obj["name"].asStringOrNull()
           ElevenLabsVoice(voiceId, name)
         }
-      } finally {
+      } catch (e: Exception) {
         conn.disconnect()
+        throw e
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeVoiceResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeVoiceResolver.kt
@@ -79,26 +79,30 @@ internal object TalkModeVoiceResolver {
     return withContext(Dispatchers.IO) {
       val url = URL("https://api.elevenlabs.io/v1/voices")
       val conn = url.openConnection() as HttpURLConnection
-      conn.requestMethod = "GET"
-      conn.connectTimeout = 15_000
-      conn.readTimeout = 15_000
-      conn.setRequestProperty("xi-api-key", apiKey)
+      try {
+        conn.requestMethod = "GET"
+        conn.connectTimeout = 15_000
+        conn.readTimeout = 15_000
+        conn.setRequestProperty("xi-api-key", apiKey)
 
-      val code = conn.responseCode
-      val stream = if (code >= 400) conn.errorStream else conn.inputStream
-      val data = stream.readBytes()
-      if (code >= 400) {
-        val message = data.toString(Charsets.UTF_8)
-        throw IllegalStateException("ElevenLabs voices failed: $code $message")
-      }
+        val code = conn.responseCode
+        val stream = if (code >= 400) conn.errorStream else conn.inputStream
+        val data = stream.use { it.readBytes() }
+        if (code >= 400) {
+          val message = data.toString(Charsets.UTF_8)
+          throw IllegalStateException("ElevenLabs voices failed: $code $message")
+        }
 
-      val root = json.parseToJsonElement(data.toString(Charsets.UTF_8)).asObjectOrNull()
-      val voices = (root?.get("voices") as? JsonArray) ?: JsonArray(emptyList())
-      voices.mapNotNull { entry ->
-        val obj = entry.asObjectOrNull() ?: return@mapNotNull null
-        val voiceId = obj["voice_id"].asStringOrNull() ?: return@mapNotNull null
-        val name = obj["name"].asStringOrNull()
-        ElevenLabsVoice(voiceId, name)
+        val root = json.parseToJsonElement(data.toString(Charsets.UTF_8)).asObjectOrNull()
+        val voices = (root?.get("voices") as? JsonArray) ?: JsonArray(emptyList())
+        voices.mapNotNull { entry ->
+          val obj = entry.asObjectOrNull() ?: return@mapNotNull null
+          val voiceId = obj["voice_id"].asStringOrNull() ?: return@mapNotNull null
+          val name = obj["name"].asStringOrNull()
+          ElevenLabsVoice(voiceId, name)
+        }
+      } finally {
+        conn.disconnect()
       }
     }
   }


### PR DESCRIPTION
## Summary

`TalkModeVoiceResolver.listVoices()` opens an `HttpURLConnection` to the ElevenLabs API but never calls `conn.disconnect()`, and the response `InputStream` is never closed. Each call leaks a connection, which accumulates over repeated voice list fetches and can exhaust the connection pool.

### Fix

- Wrap the connection usage in `try/finally { conn.disconnect() }` to ensure the connection is released on all paths (success, HTTP error, parse error, exception).
- Use `stream.use { it.readBytes() }` to close the InputStream after reading.

## Test plan

- [x] Code review: verified `conn.disconnect()` runs on all exit paths (normal return, HTTP 4xx/5xx throw, JSON parse exception).
- [x] Verified `stream.use {}` closes both `inputStream` and `errorStream` paths.
- [ ] Manual test: call voice list multiple times and confirm no connection leak in network profiler.

> This PR was authored with AI assistance.

@steipete @obviyus Would appreciate a review when you have a chance.

Made with [Cursor](https://cursor.com)