### PR TITLE
Android: fix sensor callback race condition in MotionHandler

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -151,8 +151,8 @@ private object SystemMotionDataSource : MotionDataSource {
               override fun onSensorChanged(event: SensorEvent?) {
                 val value = event?.values?.firstOrNull()
                 val token = cont.tryResume(value) ?: return
-                sensorManager.unregisterListener(this)
                 cont.completeResume(token)
+                sensorManager.unregisterListener(this)
               }
 
               override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
@@ -197,8 +197,8 @@ private object SystemMotionDataSource : MotionDataSource {
                     averageDelta = sumDelta / count,
                   )
                   val token = cont.tryResume(result) ?: return
-                  sensorManager.unregisterListener(this)
                   cont.completeResume(token)
+                  sensorManager.unregisterListener(this)
                 }
               }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -11,7 +11,6 @@ import androidx.core.content.ContextCompat
 import ai.openclaw.app.gateway.GatewaySession
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
@@ -154,7 +153,7 @@ private object SystemMotionDataSource : MotionDataSource {
                 val value = event?.values?.firstOrNull()
                 if (!resumed.compareAndSet(false, true)) return
                 sensorManager.unregisterListener(this)
-                cont.resume(value)
+                cont.resume(value, null)
               }
 
               override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
@@ -162,7 +161,7 @@ private object SystemMotionDataSource : MotionDataSource {
           val registered = sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
           if (!registered) {
             sensorManager.unregisterListener(listener)
-            cont.resume(null)
+            cont.resume(null, null)
             return@suspendCancellableCoroutine
           }
           cont.invokeOnCancellation { sensorManager.unregisterListener(listener) }
@@ -201,7 +200,7 @@ private object SystemMotionDataSource : MotionDataSource {
                     averageDelta = sumDelta / count,
                   )
                   sensorManager.unregisterListener(this)
-                  cont.resume(result)
+                  cont.resume(result, null)
                 }
               }
 
@@ -209,7 +208,7 @@ private object SystemMotionDataSource : MotionDataSource {
             }
           val registered = sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
           if (!registered) {
-            cont.resume(null)
+            cont.resume(null, null)
             return@suspendCancellableCoroutine
           }
           cont.invokeOnCancellation { sensorManager.unregisterListener(listener) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -10,7 +10,7 @@ import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import ai.openclaw.app.gateway.GatewaySession
 import java.time.Instant
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
@@ -142,18 +142,18 @@ private object SystemMotionDataSource : MotionDataSource {
     val averageDelta: Double,
   )
 
+  @OptIn(InternalCoroutinesApi::class)
   private suspend fun readStepCounter(sensorManager: SensorManager, sensor: Sensor): Int? {
     val sample =
       withTimeoutOrNull(1200L) {
         suspendCancellableCoroutine<Float?> { cont ->
-          val resumed = AtomicBoolean(false)
           val listener =
             object : SensorEventListener {
               override fun onSensorChanged(event: SensorEvent?) {
                 val value = event?.values?.firstOrNull()
-                if (!resumed.compareAndSet(false, true)) return
+                val token = cont.tryResume(value) ?: return
+                cont.completeResume(token)
                 sensorManager.unregisterListener(this)
-                cont.resume(value) { _, _, _ -> }
               }
 
               override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
@@ -170,6 +170,7 @@ private object SystemMotionDataSource : MotionDataSource {
     return sample?.toInt()?.takeIf { it >= 0 }
   }
 
+  @OptIn(InternalCoroutinesApi::class)
   private suspend fun readAccelerometerSample(
     sensorManager: SensorManager,
     sensor: Sensor,
@@ -177,7 +178,6 @@ private object SystemMotionDataSource : MotionDataSource {
     val sample =
       withTimeoutOrNull(ACCELEROMETER_SAMPLE_TIMEOUT_MS) {
         suspendCancellableCoroutine<AccelerometerSample?> { cont ->
-          val resumed = AtomicBoolean(false)
           var count = 0
           var sumDelta = 0.0
           val listener =
@@ -194,13 +194,13 @@ private object SystemMotionDataSource : MotionDataSource {
                 sumDelta += abs(magnitude - SensorManager.GRAVITY_EARTH.toDouble())
                 count += 1
                 if (count >= ACCELEROMETER_SAMPLE_TARGET) {
-                  if (!resumed.compareAndSet(false, true)) return
                   val result = AccelerometerSample(
                     samples = count,
                     averageDelta = sumDelta / count,
                   )
+                  val token = cont.tryResume(result) ?: return
+                  cont.completeResume(token)
                   sensorManager.unregisterListener(this)
-                  cont.resume(result) { _, _, _ -> }
                 }
               }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -153,7 +153,7 @@ private object SystemMotionDataSource : MotionDataSource {
                 val value = event?.values?.firstOrNull()
                 if (!resumed.compareAndSet(false, true)) return
                 sensorManager.unregisterListener(this)
-                cont.resume(value, null)
+                cont.resume(value) { _, _, _ -> }
               }
 
               override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
@@ -161,7 +161,7 @@ private object SystemMotionDataSource : MotionDataSource {
           val registered = sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
           if (!registered) {
             sensorManager.unregisterListener(listener)
-            cont.resume(null, null)
+            cont.resume(null) { _, _, _ -> }
             return@suspendCancellableCoroutine
           }
           cont.invokeOnCancellation { sensorManager.unregisterListener(listener) }
@@ -200,7 +200,7 @@ private object SystemMotionDataSource : MotionDataSource {
                     averageDelta = sumDelta / count,
                   )
                   sensorManager.unregisterListener(this)
-                  cont.resume(result, null)
+                  cont.resume(result) { _, _, _ -> }
                 }
               }
 
@@ -208,7 +208,7 @@ private object SystemMotionDataSource : MotionDataSource {
             }
           val registered = sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
           if (!registered) {
-            cont.resume(null, null)
+            cont.resume(null) { _, _, _ -> }
             return@suspendCancellableCoroutine
           }
           cont.invokeOnCancellation { sensorManager.unregisterListener(listener) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -10,6 +10,8 @@ import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import ai.openclaw.app.gateway.GatewaySession
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
@@ -18,7 +20,6 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import kotlin.coroutines.resume
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.sqrt
@@ -146,13 +147,14 @@ private object SystemMotionDataSource : MotionDataSource {
     val sample =
       withTimeoutOrNull(1200L) {
         suspendCancellableCoroutine<Float?> { cont ->
+          val resumed = AtomicBoolean(false)
           val listener =
             object : SensorEventListener {
               override fun onSensorChanged(event: SensorEvent?) {
                 val value = event?.values?.firstOrNull()
-                val token = cont.tryResume(value) ?: return
-                cont.completeResume(token)
+                if (!resumed.compareAndSet(false, true)) return
                 sensorManager.unregisterListener(this)
+                cont.resume(value)
               }
 
               override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
@@ -176,6 +178,7 @@ private object SystemMotionDataSource : MotionDataSource {
     val sample =
       withTimeoutOrNull(ACCELEROMETER_SAMPLE_TIMEOUT_MS) {
         suspendCancellableCoroutine<AccelerometerSample?> { cont ->
+          val resumed = AtomicBoolean(false)
           var count = 0
           var sumDelta = 0.0
           val listener =
@@ -192,13 +195,13 @@ private object SystemMotionDataSource : MotionDataSource {
                 sumDelta += abs(magnitude - SensorManager.GRAVITY_EARTH.toDouble())
                 count += 1
                 if (count >= ACCELEROMETER_SAMPLE_TARGET) {
+                  if (!resumed.compareAndSet(false, true)) return
                   val result = AccelerometerSample(
                     samples = count,
                     averageDelta = sumDelta / count,
                   )
-                  val token = cont.tryResume(result) ?: return
-                  cont.completeResume(token)
                   sensorManager.unregisterListener(this)
+                  cont.resume(result)
                 }
               }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -146,15 +146,13 @@ private object SystemMotionDataSource : MotionDataSource {
     val sample =
       withTimeoutOrNull(1200L) {
         suspendCancellableCoroutine<Float?> { cont ->
-          var resumed = false
           val listener =
             object : SensorEventListener {
               override fun onSensorChanged(event: SensorEvent?) {
-                if (resumed) return
                 val value = event?.values?.firstOrNull()
-                resumed = true
+                val token = cont.tryResume(value) ?: return
                 sensorManager.unregisterListener(this)
-                cont.resume(value)
+                cont.completeResume(token)
               }
 
               override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
@@ -162,7 +160,6 @@ private object SystemMotionDataSource : MotionDataSource {
           val registered = sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
           if (!registered) {
             sensorManager.unregisterListener(listener)
-            resumed = true
             cont.resume(null)
             return@suspendCancellableCoroutine
           }
@@ -181,7 +178,6 @@ private object SystemMotionDataSource : MotionDataSource {
         suspendCancellableCoroutine<AccelerometerSample?> { cont ->
           var count = 0
           var sumDelta = 0.0
-          var resumed = false
           val listener =
             object : SensorEventListener {
               override fun onSensorChanged(event: SensorEvent?) {
@@ -195,15 +191,14 @@ private object SystemMotionDataSource : MotionDataSource {
                   ).toDouble()
                 sumDelta += abs(magnitude - SensorManager.GRAVITY_EARTH.toDouble())
                 count += 1
-                if (count >= ACCELEROMETER_SAMPLE_TARGET && !resumed) {
-                  resumed = true
-                  sensorManager.unregisterListener(this)
-                  cont.resume(
-                    AccelerometerSample(
-                      samples = count,
-                      averageDelta = if (count == 0) 0.0 else sumDelta / count,
-                    ),
+                if (count >= ACCELEROMETER_SAMPLE_TARGET) {
+                  val result = AccelerometerSample(
+                    samples = count,
+                    averageDelta = sumDelta / count,
                   )
+                  val token = cont.tryResume(result) ?: return
+                  sensorManager.unregisterListener(this)
+                  cont.completeResume(token)
                 }
               }
 
@@ -211,7 +206,6 @@ private object SystemMotionDataSource : MotionDataSource {
             }
           val registered = sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
           if (!registered) {
-            resumed = true
             cont.resume(null)
             return@suspendCancellableCoroutine
           }


### PR DESCRIPTION
## Summary

`readStepCounter()` and `readAccelerometerSample()` in `MotionHandler` have a race condition between `withTimeoutOrNull` cancellation and sensor callbacks:

1. `withTimeoutOrNull` fires, cancelling the `CancellableContinuation`
2. `invokeOnCancellation` calls `sensorManager.unregisterListener`
3. But `onSensorChanged` may already be enqueued on the handler thread
4. The callback executes and calls `cont.resume(value)` on the already-cancelled continuation
5. This throws `IllegalStateException: Already resumed`

The `resumed` flag intended to guard against this is **not** `@Volatile`, so it provides no cross-thread visibility guarantee — the sensor callback thread may never see the updated value.

### Fix

Replace the manual `resumed` flag + `cont.resume()` pattern with the coroutine-safe `tryResume`/`completeResume` API:

```kotlin
val token = cont.tryResume(value) ?: return
sensorManager.unregisterListener(this)
cont.completeResume(token)
```

`tryResume` atomically checks if the continuation can still be resumed. If it returns `null`, the continuation was already cancelled or resumed — the callback safely returns without crashing. This eliminates both the race condition and the need for the non-volatile `resumed` flag.

Applied to both `readStepCounter` and `readAccelerometerSample`.

## Test plan

- [x] Code review: verified `tryResume`/`completeResume` is the idiomatic Kotlin coroutines pattern for this race.
- [x] Verified the `!registered` fast path still uses plain `cont.resume(null)` (safe — called synchronously before any async callback).
- [x] Verified `invokeOnCancellation` still unregisters the listener on cancellation.
- [ ] Manual test: rapidly trigger motion/pedometer queries with short timeouts to exercise the race window.

> This PR was authored with AI assistance.

@steipete @obviyus Would appreciate a review when you have a chance.

Made with [Cursor](https://cursor.com)