### PR TITLE
fix(compaction): strip thinking/redacted_thinking blocks to prevent Anthropic API rejection

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -808,6 +808,9 @@ export async function compactEmbeddedPiSessionDirect(
         // assistant message to be byte-identical — but the serialization pipeline
         // can corrupt them. Since compaction is summarizing (not continuing), strip
         // ALL thinking blocks so the compaction LLM call won't be rejected.
+        // Note: this mutates session state before the compaction call. If compaction
+        // fails, thinking blocks remain stripped — this is intentional because absent
+        // blocks are API-compatible whereas corrupted blocks cause permanent rejection.
         if (transcriptPolicy.preserveSignatures) {
           const withoutThinking = dropThinkingBlocks(session.messages);
           if (withoutThinking !== session.messages) {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -90,6 +90,7 @@ import {
   buildEmbeddedSystemPrompt,
   createSystemPromptOverride,
 } from "./system-prompt.js";
+import { dropThinkingBlocks } from "./thinking.js";
 import { collectAllowedToolNames } from "./tool-name-allowlist.js";
 import { splitSdkTools } from "./tool-split.js";
 import type { EmbeddedPiCompactResult } from "./types.js";
@@ -800,6 +801,18 @@ export async function compactEmbeddedPiSessionDirect(
             compacted: false,
             reason: "no real conversation messages",
           };
+        }
+
+        // Compaction makes its own LLM call to summarize the conversation.
+        // Anthropic requires thinking/redacted_thinking blocks in the latest
+        // assistant message to be byte-identical — but the serialization pipeline
+        // can corrupt them. Since compaction is summarizing (not continuing), strip
+        // ALL thinking blocks so the compaction LLM call won't be rejected.
+        if (transcriptPolicy.preserveSignatures) {
+          const withoutThinking = dropThinkingBlocks(session.messages);
+          if (withoutThinking !== session.messages) {
+            session.agent.replaceMessages(withoutThinking);
+          }
         }
 
         const compactStartedAt = Date.now();

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -32,7 +32,7 @@ import {
   type UsageLike,
 } from "../usage.js";
 import { log } from "./logger.js";
-import { dropThinkingBlocks } from "./thinking.js";
+import { dropThinkingBlocks, stripThinkingFromNonLatestAssistant } from "./thinking.js";
 import { describeUnknownError } from "./utils.js";
 
 const GOOGLE_TURN_ORDERING_CUSTOM_TYPE = "google-turn-ordering-bootstrap";
@@ -549,9 +549,17 @@ export async function sanitizeSessionHistory(params: {
       ...resolveImageSanitizationLimits(params.config),
     },
   );
-  const droppedThinking = policy.dropThinkingBlocks
-    ? dropThinkingBlocks(sanitizedImages)
+  // Anthropic requires thinking/redacted_thinking blocks in the latest assistant
+  // message to be byte-identical. The serialization pipeline (sanitizeSurrogates,
+  // compaction, etc.) can corrupt them. Strip from non-latest messages (Anthropic
+  // allows omission there) to prevent corruption; the latest message's blocks are
+  // preserved for the API call.
+  const strippedNonLatest = policy.preserveSignatures
+    ? stripThinkingFromNonLatestAssistant(sanitizedImages)
     : sanitizedImages;
+  const droppedThinking = policy.dropThinkingBlocks
+    ? dropThinkingBlocks(strippedNonLatest)
+    : strippedNonLatest;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,
   });

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -1,7 +1,11 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
-import { dropThinkingBlocks, isAssistantMessageWithContent } from "./thinking.js";
+import {
+  dropThinkingBlocks,
+  isAssistantMessageWithContent,
+  stripThinkingFromNonLatestAssistant,
+} from "./thinking.js";
 
 describe("isAssistantMessageWithContent", () => {
   it("accepts assistant messages with array content and rejects others", () => {
@@ -57,5 +61,192 @@ describe("dropThinkingBlocks", () => {
     const result = dropThinkingBlocks(messages);
     const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
     expect(assistant.content).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("drops redacted_thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "opaque" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = dropThinkingBlocks(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(result).not.toBe(messages);
+    expect(assistant.content).toEqual([{ type: "text", text: "answer" }]);
+  });
+
+  it("drops both thinking and redacted_thinking blocks from the same message", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning" },
+          { type: "redacted_thinking", data: "secret" },
+          { type: "text", text: "result" },
+        ],
+      }),
+    ];
+
+    const result = dropThinkingBlocks(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "result" }]);
+  });
+});
+
+describe("stripThinkingFromNonLatestAssistant", () => {
+  it("returns original reference when no thinking blocks exist", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "hello" }),
+      castAgentMessage({ role: "assistant", content: [{ type: "text", text: "hi" }] }),
+    ];
+
+    const result = stripThinkingFromNonLatestAssistant(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("preserves thinking blocks in the latest assistant message", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "hello" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripThinkingFromNonLatestAssistant(messages);
+    // Latest assistant is the only assistant — nothing should change.
+    expect(result).toBe(messages);
+  });
+
+  it("strips thinking from non-latest assistant messages", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "old reasoning" },
+          { type: "text", text: "old answer" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "follow-up" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "new reasoning" },
+          { type: "text", text: "new answer" },
+        ],
+      }),
+    ];
+
+    const result = stripThinkingFromNonLatestAssistant(messages);
+    const first = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const last = result[2] as Extract<AgentMessage, { role: "assistant" }>;
+
+    // Non-latest: thinking stripped
+    expect(first.content).toEqual([{ type: "text", text: "old answer" }]);
+    // Latest: thinking preserved
+    expect(last.content).toEqual([
+      { type: "thinking", thinking: "new reasoning" },
+      { type: "text", text: "new answer" },
+    ]);
+  });
+
+  it("strips redacted_thinking from non-latest assistant messages", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "opaque" },
+          { type: "text", text: "old answer" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "next" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "latest" }],
+      }),
+    ];
+
+    const result = stripThinkingFromNonLatestAssistant(messages);
+    const first = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(first.content).toEqual([{ type: "text", text: "old answer" }]);
+  });
+
+  it("handles interleaved user/toolResult messages correctly", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "step 1" },
+          { type: "text", text: "use tool" },
+        ],
+      }),
+      castAgentMessage({ role: "toolResult", content: "tool output" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "step 2" },
+          { type: "text", text: "final" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "thanks" }),
+    ];
+
+    const result = stripThinkingFromNonLatestAssistant(messages);
+    const first = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const second = result[2] as Extract<AgentMessage, { role: "assistant" }>;
+
+    // First assistant: non-latest → stripped
+    expect(first.content).toEqual([{ type: "text", text: "use tool" }]);
+    // Second assistant: latest → preserved
+    expect(second.content).toEqual([
+      { type: "thinking", thinking: "step 2" },
+      { type: "text", text: "final" },
+    ]);
+  });
+
+  it("replaces with empty text block when all content was thinking", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "only thinking" }],
+      }),
+      castAgentMessage({ role: "user", content: "hi" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "latest" }],
+      }),
+    ];
+
+    const result = stripThinkingFromNonLatestAssistant(messages);
+    const first = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(first.content).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("returns original reference when no changes needed", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "no thinking here" }],
+      }),
+      castAgentMessage({ role: "user", content: "ok" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "only latest has thinking" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripThinkingFromNonLatestAssistant(messages);
+    expect(result).toBe(messages);
   });
 });

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -12,8 +12,17 @@ export function isAssistantMessageWithContent(message: AgentMessage): message is
   );
 }
 
+function isThinkingBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return type === "thinking" || type === "redacted_thinking";
+}
+
 /**
- * Strip all `type: "thinking"` content blocks from assistant messages.
+ * Strip all `type: "thinking"` and `type: "redacted_thinking"` content blocks
+ * from assistant messages.
  *
  * If an assistant message becomes empty after stripping, it is replaced with
  * a synthetic `{ type: "text", text: "" }` block to preserve turn structure
@@ -33,7 +42,7 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
     const nextContent: AssistantContentBlock[] = [];
     let changed = false;
     for (const block of msg.content) {
-      if (block && typeof block === "object" && (block as { type?: unknown }).type === "thinking") {
+      if (isThinkingBlock(block)) {
         touched = true;
         changed = true;
         continue;
@@ -45,6 +54,57 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
       continue;
     }
     // Preserve the assistant turn even if all blocks were thinking-only.
+    const content =
+      nextContent.length > 0 ? nextContent : [{ type: "text", text: "" } as AssistantContentBlock];
+    out.push({ ...msg, content });
+  }
+  return touched ? out : messages;
+}
+
+/**
+ * Strip `thinking` and `redacted_thinking` blocks from all assistant messages
+ * **except** the latest one. Anthropic allows omitting these blocks from
+ * non-latest messages but requires the latest assistant message's thinking
+ * blocks to be byte-identical to the original API response.
+ *
+ * Returns the original array reference when nothing was changed.
+ */
+export function stripThinkingFromNonLatestAssistant(messages: AgentMessage[]): AgentMessage[] {
+  // Find the index of the last assistant message.
+  let lastAssistantIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (isAssistantMessageWithContent(messages[i])) {
+      lastAssistantIdx = i;
+      break;
+    }
+  }
+  if (lastAssistantIdx < 0) {
+    return messages;
+  }
+
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    // Skip the latest assistant message — preserve its thinking blocks.
+    if (i === lastAssistantIdx || !isAssistantMessageWithContent(msg)) {
+      out.push(msg);
+      continue;
+    }
+    const nextContent: AssistantContentBlock[] = [];
+    let changed = false;
+    for (const block of msg.content) {
+      if (isThinkingBlock(block)) {
+        touched = true;
+        changed = true;
+        continue;
+      }
+      nextContent.push(block);
+    }
+    if (!changed) {
+      out.push(msg);
+      continue;
+    }
     const content =
       nextContent.length > 0 ? nextContent : [{ type: "text", text: "" } as AssistantContentBlock];
     out.push({ ...msg, content });


### PR DESCRIPTION
## Summary

- **Problem:** Compaction corrupts `thinking`/`redacted_thinking` blocks through the serialization pipeline (`sanitizeSurrogates`, field reordering, empty-text dropping). Anthropic then rejects all subsequent API calls with "thinking or redacted_thinking blocks in the latest assistant message cannot be modified", permanently breaking the session.
- **Why it matters:** Any user with an Anthropic model + extended thinking + safeguard compaction hits this after enough messages. The session becomes unrecoverable.
- **What changed:** (1) `dropThinkingBlocks` now handles `redacted_thinking`, (2) new `stripThinkingFromNonLatestAssistant` strips thinking from historical messages during sanitization, (3) compaction path strips all thinking blocks before its summary LLM call.
- **What did NOT change:** The regular API call path still preserves thinking blocks in the latest assistant message (Anthropic requires them). No changes to compaction logic itself, session serialization, or provider capabilities.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39887
- Related #39919
- Related #39940

## User-visible / Behavior Changes

Sessions using Anthropic models with extended thinking (e.g. `claude-opus-4-6`, `claude-sonnet-4-6`) and safeguard compaction will no longer break after compaction triggers. Previously, compaction would corrupt thinking blocks and permanently break the session.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.5 (Darwin 24.6.0)
- Runtime/container: Node.js, OpenClaw 2026.3.9
- Model/provider: anthropic/claude-sonnet-4-6
- Integration/channel: Telegram
- Relevant config: `compaction.mode: "safeguard"`, `thinking: adaptive`

### Steps

1. Configure agent with `anthropic/claude-sonnet-4-6` and `compaction.mode: "safeguard"`
2. Chat via Telegram until context window triggers compaction
3. Before fix: session breaks with "thinking blocks cannot be modified" error
4. After fix: compaction completes, conversation continues normally

### Expected

- Compaction succeeds without corrupting thinking blocks
- Session continues normally after compaction

### Actual (before fix)

- Compaction LLM call rejected by Anthropic API
- Error leaks to Telegram chat
- Session becomes permanently unresponsive

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

13 tests covering `dropThinkingBlocks` (including `redacted_thinking`) and `stripThinkingFromNonLatestAssistant` (latest preservation, non-latest stripping, interleaved messages, empty content fallback).

## Human Verification (required)

- Verified scenarios: Reproduced on Telegram with `anthropic/claude-sonnet-4-6` and safeguard compaction. After fix, compaction triggers successfully and conversation continues.
- Edge cases checked: `redacted_thinking` blocks, messages with only thinking content (empty text fallback), interleaved user/toolResult messages, conversations where only the latest assistant has thinking blocks.
- What you did **not** verify: Bedrock provider path (no Bedrock credentials available), GitHub Copilot Claude path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit. The `stripThinkingFromNonLatestAssistant` call is gated behind `policy.preserveSignatures` and the compaction stripping is gated behind the same flag, so only Anthropic providers are affected.
- Files/config to restore: `thinking.ts`, `google.ts`, `compact.ts`
- Known bad symptoms reviewers should watch for: If thinking blocks are being stripped when they shouldn't be, you'd see Anthropic responses without extended thinking in sessions that have it enabled.

## Risks and Mitigations

- Risk: Stripping thinking blocks from non-latest messages means compaction summaries won't include reasoning content from earlier messages.
  - Mitigation: Thinking blocks are internal reasoning, not user-facing content. Compaction summaries are based on text/tool_use blocks which contain the actual conversation substance. Anthropic explicitly allows omitting thinking blocks from non-latest messages.

### Files Changed

- `src/agents/pi-embedded-runner/thinking.ts` — Fixed `dropThinkingBlocks` to handle `redacted_thinking` + added `stripThinkingFromNonLatestAssistant`
- `src/agents/pi-embedded-runner/thinking.test.ts` — 13 tests covering both functions
- `src/agents/pi-embedded-runner/google.ts` — Apply `stripThinkingFromNonLatestAssistant` in `sanitizeSessionHistory` for Anthropic providers
- `src/agents/pi-embedded-runner/compact.ts` — Strip all thinking blocks before compaction LLM call