### PR TITLE
feat(web-search): add baseUrl config support for proxy-compatible endpoints

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -309,7 +309,7 @@ const LOCAL_PROVIDER_HINTS: Record<string, string> = {
     "See: https://docs.openclaw.ai/providers/vllm",
 };
 
-function buildUnknownModelError(provider: string, modelId: string): string {
+export function buildUnknownModelError(provider: string, modelId: string): string {
   const suppressed = buildSuppressedBuiltInModelError({ provider, id: modelId });
   if (suppressed) {
     return suppressed;

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -1,6 +1,7 @@
 import { type Api, type Model } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getDefaultLocalRoots } from "../../web/media.js";
+import { buildUnknownModelError } from "../pi-embedded-runner/model.js";
 import type { ImageModelConfig } from "./image-tool.helpers.js";
 import { getApiKeyForModel, normalizeWorkspaceDir, requireApiKey } from "./tool-runtime.helpers.js";
 
@@ -89,7 +90,7 @@ export function resolveModelFromRegistry(params: {
 }): Model<Api> {
   const model = params.modelRegistry.find(params.provider, params.modelId) as Model<Api> | null;
   if (!model) {
-    throw new Error(`Unknown model: ${params.provider}/${params.modelId}`);
+    throw new Error(buildUnknownModelError(params.provider, params.modelId));
   }
   return model;
 }

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -16,8 +16,10 @@ const {
   isoToPerplexityDate,
   resolveGrokApiKey,
   resolveGrokModel,
+  resolveGrokBaseUrl,
   resolveGrokInlineCitations,
   extractGrokContent,
+  resolveGeminiBaseUrl,
   resolveKimiApiKey,
   resolveKimiModel,
   resolveKimiBaseUrl,
@@ -228,6 +230,42 @@ describe("web_search grok config resolution", () => {
   it("respects inlineCitations config", () => {
     expect(resolveGrokInlineCitations({ inlineCitations: true })).toBe(true);
     expect(resolveGrokInlineCitations({ inlineCitations: false })).toBe(false);
+  });
+
+  describe("resolveGrokBaseUrl", () => {
+    it("returns default when not configured", () => {
+      expect(resolveGrokBaseUrl({})).toBe("https://api.x.ai/v1");
+      expect(resolveGrokBaseUrl(undefined)).toBe("https://api.x.ai/v1");
+    });
+    it("returns configured baseUrl", () => {
+      expect(resolveGrokBaseUrl({ baseUrl: "https://proxy.example.com/v1" })).toBe(
+        "https://proxy.example.com/v1",
+      );
+    });
+    it("trims whitespace", () => {
+      expect(resolveGrokBaseUrl({ baseUrl: "  https://proxy.example.com/v1  " })).toBe(
+        "https://proxy.example.com/v1",
+      );
+    });
+  });
+});
+
+describe("web_search gemini config resolution", () => {
+  it("returns default baseUrl when not configured", () => {
+    expect(resolveGeminiBaseUrl({})).toBe("https://generativelanguage.googleapis.com/v1beta");
+    expect(resolveGeminiBaseUrl(undefined)).toBe(
+      "https://generativelanguage.googleapis.com/v1beta",
+    );
+  });
+  it("returns configured baseUrl", () => {
+    expect(resolveGeminiBaseUrl({ baseUrl: "https://proxy.example.com/gemini" })).toBe(
+      "https://proxy.example.com/gemini",
+    );
+  });
+  it("trims whitespace", () => {
+    expect(resolveGeminiBaseUrl({ baseUrl: "  https://proxy.example.com/gemini  " })).toBe(
+      "https://proxy.example.com/gemini",
+    );
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -35,7 +35,7 @@ const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
 const PERPLEXITY_KEY_PREFIXES = ["pplx-"];
 const OPENROUTER_KEY_PREFIXES = ["sk-or-"];
 
-const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
+const DEFAULT_GROK_BASE_URL = "https://api.x.ai/v1";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
 const DEFAULT_KIMI_BASE_URL = "https://api.moonshot.ai/v1";
 const DEFAULT_KIMI_MODEL = "moonshot-v1-128k";
@@ -323,6 +323,7 @@ type PerplexityBaseUrlHint = "direct" | "openrouter";
 
 type GrokConfig = {
   apiKey?: string;
+  baseUrl?: string;
   model?: string;
   inlineCitations?: boolean;
 };
@@ -497,6 +498,7 @@ function extractGrokContent(data: GrokSearchResponse): {
 
 type GeminiConfig = {
   apiKey?: string;
+  baseUrl?: string;
   model?: string;
 };
 
@@ -853,6 +855,12 @@ function resolveGrokInlineCitations(grok?: GrokConfig): boolean {
   return grok?.inlineCitations === true;
 }
 
+function resolveGrokBaseUrl(grok?: GrokConfig): string {
+  const fromConfig =
+    grok && "baseUrl" in grok && typeof grok.baseUrl === "string" ? grok.baseUrl.trim() : "";
+  return fromConfig || DEFAULT_GROK_BASE_URL;
+}
+
 function resolveKimiConfig(search?: WebSearchConfig): KimiConfig {
   if (!search || typeof search !== "object") {
     return {};
@@ -909,6 +917,14 @@ function resolveGeminiApiKey(gemini?: GeminiConfig): string | undefined {
   return fromEnv || undefined;
 }
 
+function resolveGeminiBaseUrl(gemini?: GeminiConfig): string {
+  const fromConfig =
+    gemini && "baseUrl" in gemini && typeof gemini.baseUrl === "string"
+      ? gemini.baseUrl.trim()
+      : "";
+  return fromConfig || GEMINI_API_BASE;
+}
+
 function resolveGeminiModel(gemini?: GeminiConfig): string {
   const fromConfig =
     gemini && "model" in gemini && typeof gemini.model === "string" ? gemini.model.trim() : "";
@@ -936,10 +952,12 @@ async function withTrustedWebSearchEndpoint<T>(
 async function runGeminiSearch(params: {
   query: string;
   apiKey: string;
+  baseUrl: string;
   model: string;
   timeoutSeconds: number;
 }): Promise<{ content: string; citations: Array<{ url: string; title?: string }> }> {
-  const endpoint = `${GEMINI_API_BASE}/models/${params.model}:generateContent`;
+  const base = params.baseUrl.trim().replace(/\/$/, "");
+  const endpoint = `${base}/models/${params.model}:generateContent`;
 
   return withTrustedWebSearchEndpoint(
     {
@@ -1305,6 +1323,7 @@ async function runPerplexitySearch(params: {
 async function runGrokSearch(params: {
   query: string;
   apiKey: string;
+  baseUrl: string;
   model: string;
   timeoutSeconds: number;
   inlineCitations: boolean;
@@ -1329,9 +1348,10 @@ async function runGrokSearch(params: {
   // citations are returned automatically when available — we just parse
   // them from the response without requesting them explicitly (#12910).
 
+  const endpoint = `${params.baseUrl.trim().replace(/\/$/, "")}/responses`;
   return withTrustedWebSearchEndpoint(
     {
-      url: XAI_API_ENDPOINT,
+      url: endpoint,
       timeoutSeconds: params.timeoutSeconds,
       init: {
         method: "POST",
@@ -1597,8 +1617,10 @@ async function runWebSearch(params: {
   perplexityBaseUrl?: string;
   perplexityModel?: string;
   perplexityTransport?: PerplexityTransport;
+  grokBaseUrl?: string;
   grokModel?: string;
   grokInlineCitations?: boolean;
+  geminiBaseUrl?: string;
   geminiModel?: string;
   kimiBaseUrl?: string;
   kimiModel?: string;
@@ -1609,9 +1631,9 @@ async function runWebSearch(params: {
     params.provider === "perplexity"
       ? `${params.perplexityTransport ?? "search_api"}:${params.perplexityBaseUrl ?? PERPLEXITY_DIRECT_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
       : params.provider === "grok"
-        ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
+        ? `${params.grokBaseUrl ?? DEFAULT_GROK_BASE_URL}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
         : params.provider === "gemini"
-          ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
+          ? `${params.geminiBaseUrl ?? GEMINI_API_BASE}:${params.geminiModel ?? DEFAULT_GEMINI_MODEL}`
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
             : "";
@@ -1692,6 +1714,7 @@ async function runWebSearch(params: {
     const { content, citations, inlineCitations } = await runGrokSearch({
       query: params.query,
       apiKey: params.apiKey,
+      baseUrl: params.grokBaseUrl ?? DEFAULT_GROK_BASE_URL,
       model: params.grokModel ?? DEFAULT_GROK_MODEL,
       timeoutSeconds: params.timeoutSeconds,
       inlineCitations: params.grokInlineCitations ?? false,
@@ -1747,6 +1770,7 @@ async function runWebSearch(params: {
     const geminiResult = await runGeminiSearch({
       query: params.query,
       apiKey: params.apiKey,
+      baseUrl: params.geminiBaseUrl ?? GEMINI_API_BASE,
       model: params.geminiModel ?? DEFAULT_GEMINI_MODEL,
       timeoutSeconds: params.timeoutSeconds,
     });
@@ -2180,8 +2204,10 @@ export function createWebSearchTool(options?: {
         perplexityBaseUrl: perplexityRuntime?.baseUrl,
         perplexityModel: perplexityRuntime?.model,
         perplexityTransport: perplexityRuntime?.transport,
+        grokBaseUrl: resolveGrokBaseUrl(grokConfig),
         grokModel: resolveGrokModel(grokConfig),
         grokInlineCitations: resolveGrokInlineCitations(grokConfig),
+        geminiBaseUrl: resolveGeminiBaseUrl(geminiConfig),
         geminiModel: resolveGeminiModel(geminiConfig),
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
@@ -2209,9 +2235,11 @@ export const __testing = {
   FRESHNESS_TO_RECENCY,
   RECENCY_TO_FRESHNESS,
   resolveGrokApiKey,
+  resolveGrokBaseUrl,
   resolveGrokModel,
   resolveGrokInlineCitations,
   extractGrokContent,
+  resolveGeminiBaseUrl,
   resolveKimiApiKey,
   resolveKimiModel,
   resolveKimiBaseUrl,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -668,8 +668,12 @@ export const FIELD_HELP: Record<string, string> = {
     'Brave Search mode: "web" (URL results) or "llm-context" (pre-extracted page content for LLM grounding).',
   "tools.web.search.gemini.apiKey":
     "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY env var).",
+  "tools.web.search.gemini.baseUrl":
+    'Gemini base URL override (default: "https://generativelanguage.googleapis.com/v1beta"). Useful for compatible proxies.',
   "tools.web.search.gemini.model": 'Gemini model override (default: "gemini-2.5-flash").',
   "tools.web.search.grok.apiKey": "Grok (xAI) API key (fallback: XAI_API_KEY env var).", // pragma: allowlist secret
+  "tools.web.search.grok.baseUrl":
+    'Grok base URL override (default: "https://api.x.ai/v1"). Useful for compatible proxies.',
   "tools.web.search.grok.model": 'Grok model override (default: "grok-4-1-fast").',
   "tools.web.search.kimi.apiKey":
     "Moonshot/Kimi API key (fallback: KIMI_API_KEY or MOONSHOT_API_KEY env var).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -220,8 +220,10 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.search.cacheTtlMinutes": "Web Search Cache TTL (min)",
   "tools.web.search.brave.mode": "Brave Search Mode",
   "tools.web.search.gemini.apiKey": "Gemini Search API Key", // pragma: allowlist secret
+  "tools.web.search.gemini.baseUrl": "Gemini Search Base URL",
   "tools.web.search.gemini.model": "Gemini Search Model",
   "tools.web.search.grok.apiKey": "Grok Search API Key", // pragma: allowlist secret
+  "tools.web.search.grok.baseUrl": "Grok Search Base URL",
   "tools.web.search.grok.model": "Grok Search Model",
   "tools.web.search.kimi.apiKey": "Kimi Search API Key", // pragma: allowlist secret
   "tools.web.search.kimi.baseUrl": "Kimi Search Base URL",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -476,6 +476,8 @@ export type ToolsConfig = {
       gemini?: {
         /** Gemini API key (defaults to GEMINI_API_KEY env var). */
         apiKey?: SecretInput;
+        /** Base URL override (defaults to "https://generativelanguage.googleapis.com/v1beta"). */
+        baseUrl?: string;
         /** Model to use for grounded search (defaults to "gemini-2.5-flash"). */
         model?: string;
       };
@@ -483,6 +485,8 @@ export type ToolsConfig = {
       grok?: {
         /** API key for xAI (defaults to XAI_API_KEY env var). */
         apiKey?: SecretInput;
+        /** Base URL for API requests (defaults to "https://api.x.ai/v1"). */
+        baseUrl?: string;
         /** Model to use (defaults to "grok-4-1-fast"). */
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -288,6 +288,7 @@ export const ToolsWebSearchSchema = z
     grok: z
       .object({
         apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
         model: z.string().optional(),
         inlineCitations: z.boolean().optional(),
       })
@@ -296,6 +297,7 @@ export const ToolsWebSearchSchema = z
     gemini: z
       .object({
         apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
         model: z.string().optional(),
       })
       .strict()


### PR DESCRIPTION
## Summary

- Add `tools.web.search.grok.baseUrl` and `tools.web.search.gemini.baseUrl` config fields, allowing users to point either provider at a compatible proxy or alternative endpoint
- Grok defaults to `https://api.x.ai/v1`; Gemini defaults to `https://generativelanguage.googleapis.com/v1beta`
- Also fixes a silent config rejection bug: both providers' Zod schemas used `.strict()` but were missing the `baseUrl` field, causing `safeParse` to fail → config load to throw `INVALID_CONFIG` → gateway falling back to empty config → baseUrl override having no effect

## Changes

- `src/agents/tools/web-search.ts` — `GrokConfig`/`GeminiConfig` types, `resolveGrokBaseUrl`/`resolveGeminiBaseUrl` functions, thread baseUrl through `runGrokSearch`/`runGeminiSearch` and cache keys; export via `__testing`
- `src/config/types.tools.ts` — `baseUrl?: string` on both `gemini` and `grok` config shapes
- `src/config/zod-schema.agent-runtime.ts` — add `baseUrl` to both `.strict()` schemas
- `src/config/schema.help.ts` / `schema.labels.ts` — UI metadata for both new fields

## Test plan

- [x] `pnpm test -- src/agents/tools/web-search.test.ts` — 53 tests pass (6 new: default / configured / trims-whitespace for each provider)
- [x] Set `tools.web.search.grok.baseUrl` to a proxy URL and verify requests route there
- [x] Set `tools.web.search.gemini.baseUrl` to a proxy URL and verify requests route there
- [x] Omit `baseUrl` entirely — confirm fallback to default endpoints
