### PR TITLE
fix(telegram): prefer active preview for matching tool-call finals

### DIFF
--- a/src/telegram/lane-delivery-text-deliverer.ts
+++ b/src/telegram/lane-delivery-text-deliverer.ts
@@ -104,6 +104,13 @@ type PreviewTargetResolution = {
   stopCreatesFirstPreview: boolean;
 };
 
+function textLikelyMatchesPreviewSnapshot(snapshot: string | undefined, text: string): boolean {
+  if (!snapshot) {
+    return false;
+  }
+  return snapshot === text || snapshot.startsWith(text) || text.startsWith(snapshot);
+}
+
 function shouldSkipRegressivePreviewUpdate(args: {
   currentPreviewText: string | undefined;
   text: string;
@@ -312,10 +319,22 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     previewButtons,
     canEditViaPreview,
   }: ConsumeArchivedAnswerPreviewParams): Promise<LaneDeliveryResult | undefined> => {
-    const archivedPreview = params.archivedAnswerPreviews.shift();
+    const archivedPreview = params.archivedAnswerPreviews[0];
     if (!archivedPreview) {
       return undefined;
     }
+    const activePreviewMessageId = lane.stream?.messageId();
+    const hasActivePreviewMessage = typeof activePreviewMessageId === "number";
+    const activeSnapshot = getLanePreviewText(lane);
+    const archivedSnapshot = archivedPreview.textSnapshot;
+    const preferActivePreviewForFinal =
+      hasActivePreviewMessage &&
+      textLikelyMatchesPreviewSnapshot(activeSnapshot, text) &&
+      !textLikelyMatchesPreviewSnapshot(archivedSnapshot, text);
+    if (preferActivePreviewForFinal) {
+      return undefined;
+    }
+    params.archivedAnswerPreviews.shift();
     if (canEditViaPreview) {
       const finalized = await tryUpdatePreviewForLane({
         lane,

--- a/src/telegram/lane-delivery-text-deliverer.ts
+++ b/src/telegram/lane-delivery-text-deliverer.ts
@@ -105,6 +105,8 @@ type PreviewTargetResolution = {
 };
 
 function textLikelyMatchesPreviewSnapshot(snapshot: string | undefined, text: string): boolean {
+  // Empty snapshots are not meaningful matches. Without this guard,
+  // text.startsWith("") would treat every final as a match.
   if (!snapshot) {
     return false;
   }

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -362,6 +362,44 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.markDelivered).not.toHaveBeenCalled();
   });
 
+  it("prefers active preview over boundary archive when final matches the active stream text", async () => {
+    const harness = createHarness({
+      answerMessageId: 1002,
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "After tool call",
+    });
+    harness.archivedAnswerPreviews.push({
+      messageId: 1001,
+      textSnapshot: "Before tool boundary",
+      deleteIfUnused: false,
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "After tool call",
+      payload: { text: "After tool call" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.editPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        laneName: "answer",
+        messageId: 1002,
+        text: "After tool call",
+        context: "final",
+      }),
+    );
+    expect(harness.archivedAnswerPreviews).toEqual([
+      {
+        messageId: 1001,
+        textSnapshot: "Before tool boundary",
+        deleteIfUnused: false,
+      },
+    ]);
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+  });
+
   it("deletes consumed boundary previews after fallback final send", async () => {
     const harness = createHarness();
     harness.archivedAnswerPreviews.push({

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -400,6 +400,38 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).not.toHaveBeenCalled();
   });
 
+  it("falls back to archived boundary preview when both snapshots match the final text", async () => {
+    const harness = createHarness({
+      answerMessageId: 1002,
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "After tool",
+    });
+    harness.archivedAnswerPreviews.push({
+      messageId: 1001,
+      textSnapshot: "After",
+      deleteIfUnused: false,
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "After tool call",
+      payload: { text: "After tool call" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.editPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        laneName: "answer",
+        messageId: 1001,
+        text: "After tool call",
+        context: "final",
+      }),
+    );
+    expect(harness.archivedAnswerPreviews).toEqual([]);
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+  });
+
   it("deletes consumed boundary previews after fallback final send", async () => {
     const harness = createHarness();
     harness.archivedAnswerPreviews.push({


### PR DESCRIPTION
## Summary

- Problem: Telegram DM streaming could apply a final answer to an older archived boundary preview instead of the current active preview after tool/skill boundaries.
- Why it matters: users can see stale/truncated latest bubbles, or think the latest response disappeared when the final lands on an older message.
- What changed: final-lane mapping now prefers the active preview when final text matches the active snapshot and does not match the archived snapshot; archived FIFO behavior is kept for true multi-final boundary mapping.
- What did NOT change (scope boundary): no change to provider dispatching, send chunking, or non-Telegram channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43771
- Related #d4ab73174

## User-visible / Behavior Changes

- In Telegram DM streaming flows with tool-call boundaries, finals now resolve to the currently streamed preview when that preview text matches the final.
- This avoids leaving a stale/truncated latest preview bubble while updating an older boundary message.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22+, pnpm
- Model/provider: n/a (unit tests)
- Integration/channel (if any): Telegram
- Relevant config (redacted): n/a

### Steps

1. Simulate a streamed Telegram answer that crosses a tool boundary (archived boundary preview + active preview).
2. Deliver a final that matches the active preview text.
3. Verify the final edit target is the active preview ID, not the archived boundary ID.

### Expected

- Final is applied to the active preview bubble for the current assistant segment.

### Actual

- ✅ With this patch, active preview is finalized and the boundary archive remains untouched.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands run locally:

- `pnpm vitest src/telegram/lane-delivery.test.ts src/telegram/bot-message-dispatch.test.ts`
  - Result: `2 passed`, `74 passed` tests total.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression unit test in `src/telegram/lane-delivery.test.ts` to cover boundary archive + active preview final selection.
  - Confirmed existing Telegram dispatch tests still pass.
- Edge cases checked:
  - Active snapshot/final prefix-match logic only bypasses archive when archive snapshot does not also match.
- What you did **not** verify:
  - Live Telegram Bot API run against a real chat.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `cab7d92dd`.
- Files/config to restore:
  - `src/telegram/lane-delivery-text-deliverer.ts`
  - `src/telegram/lane-delivery.test.ts`
- Known bad symptoms reviewers should watch for:
  - Finals mapping to the wrong preview ID in DM tool-boundary flows.

## Risks and Mitigations

- Risk:
  - Snapshot matching could choose active preview in ambiguous text-overlap cases.
- Mitigation:
  - Preference only activates when active snapshot matches and archived snapshot does not; existing archived FIFO behavior remains otherwise.
