### PR TITLE
feat(tui): show reconnect hint and auto-probe gateway when disconnected

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -600,28 +600,27 @@ final class AppState {
     private func syncGatewayConfigIfNeeded() {
         guard !self.isPreview, !self.isInitializing else { return }
 
-        let connectionMode = self.connectionMode
-        let remoteTarget = self.remoteTarget
-        let remoteIdentity = self.remoteIdentity
-        let remoteTransport = self.remoteTransport
-        let remoteUrl = self.remoteUrl
-        let remoteToken = self.remoteToken
-        let remoteTokenDirty = self.remoteTokenDirty
-
         Task { @MainActor in
-            // Keep app-only connection settings local to avoid overwriting remote gateway config.
-            let synced = Self.syncedGatewayRoot(
-                currentRoot: OpenClawConfigFile.loadDict(),
-                connectionMode: connectionMode,
-                remoteTransport: remoteTransport,
-                remoteTarget: remoteTarget,
-                remoteIdentity: remoteIdentity,
-                remoteUrl: remoteUrl,
-                remoteToken: remoteToken,
-                remoteTokenDirty: remoteTokenDirty)
-            guard synced.changed else { return }
-            OpenClawConfigFile.saveDict(synced.root)
+            self.syncGatewayConfigNow()
         }
+    }
+
+    @MainActor
+    func syncGatewayConfigNow() {
+        guard !self.isPreview, !self.isInitializing else { return }
+
+        // Keep app-only connection settings local to avoid overwriting remote gateway config.
+        let synced = Self.syncedGatewayRoot(
+            currentRoot: OpenClawConfigFile.loadDict(),
+            connectionMode: self.connectionMode,
+            remoteTransport: self.remoteTransport,
+            remoteTarget: self.remoteTarget,
+            remoteIdentity: self.remoteIdentity,
+            remoteUrl: self.remoteUrl,
+            remoteToken: self.remoteToken,
+            remoteTokenDirty: self.remoteTokenDirty)
+        guard synced.changed else { return }
+        OpenClawConfigFile.saveDict(synced.root)
     }
 
     func triggerVoiceEars(ttl: TimeInterval? = 5) {
@@ -784,7 +783,7 @@ extension AppState {
         remoteToken: String,
         remoteTokenDirty: Bool) -> [String: Any]
     {
-        Self.updatedRemoteGatewayConfig(
+        self.updatedRemoteGatewayConfig(
             current: current,
             transport: transport,
             remoteUrl: remoteUrl,
@@ -805,7 +804,7 @@ extension AppState {
         remoteToken: String,
         remoteTokenDirty: Bool) -> [String: Any]
     {
-        Self.syncedGatewayRoot(
+        self.syncedGatewayRoot(
             currentRoot: currentRoot,
             connectionMode: connectionMode,
             remoteTransport: remoteTransport,

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -172,6 +172,10 @@ final class AppState {
         }
     }
 
+    /// Set to `true` while a remote-probe diagnostic is temporarily flipping `connectionMode`
+    /// so that `MenuBar` can skip triggering `ConnectionModeCoordinator.apply` for that transient flip.
+    var suppressRemoteProbeReset: Bool = false
+
     var remoteTransport: RemoteTransport {
         didSet { self.syncGatewayConfigIfNeeded() }
     }

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -348,10 +348,18 @@ struct GeneralSettings: View {
             Text("Testing…")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-        case .ok:
-            Label("Ready", systemImage: "checkmark.circle.fill")
-                .font(.caption)
-                .foregroundStyle(.green)
+        case let .ok(success):
+            VStack(alignment: .leading, spacing: 2) {
+                Label(success.title, systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                if let detail = success.detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         case let .failed(message):
             Text(message)
                 .font(.caption)
@@ -518,7 +526,7 @@ struct GeneralSettings: View {
 private enum RemoteStatus: Equatable {
     case idle
     case checking
-    case ok
+    case ok(RemoteGatewayProbeSuccess)
     case failed(String)
 }
 
@@ -558,114 +566,14 @@ extension GeneralSettings {
     @MainActor
     func testRemote() async {
         self.remoteStatus = .checking
-        let settings = CommandResolver.connectionSettings()
-        if self.state.remoteTransport == .direct {
-            let trimmedUrl = self.state.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedUrl.isEmpty else {
-                self.remoteStatus = .failed("Set a gateway URL first")
-                return
-            }
-            guard Self.isValidWsUrl(trimmedUrl) else {
-                self.remoteStatus = .failed(
-                    "Gateway URL must use wss:// for remote hosts (ws:// only for localhost)")
-                return
-            }
-        } else {
-            guard !settings.target.isEmpty else {
-                self.remoteStatus = .failed("Set an SSH target first")
-                return
-            }
-
-            // Step 1: basic SSH reachability check
-            guard let sshCommand = Self.sshCheckCommand(
-                target: settings.target,
-                identity: settings.identity)
-            else {
-                self.remoteStatus = .failed("SSH target is invalid")
-                return
-            }
-            let sshResult = await ShellExecutor.run(
-                command: sshCommand,
-                cwd: nil,
-                env: nil,
-                timeout: 8)
-
-            guard sshResult.ok else {
-                self.remoteStatus = .failed(self.formatSSHFailure(sshResult, target: settings.target))
-                return
-            }
+        switch await RemoteGatewayProbe.run() {
+        case let .ready(success):
+            self.remoteStatus = .ok(success)
+        case let .authIssue(issue):
+            self.remoteStatus = .failed(issue.statusMessage)
+        case let .failed(message):
+            self.remoteStatus = .failed(message)
         }
-
-        // Step 2: control channel health check
-        let originalMode = AppStateStore.shared.connectionMode
-        do {
-            try await ControlChannel.shared.configure(mode: .remote(
-                target: settings.target,
-                identity: settings.identity))
-            let data = try await ControlChannel.shared.health(timeout: 10)
-            if decodeHealthSnapshot(from: data) != nil {
-                self.remoteStatus = .ok
-            } else {
-                self.remoteStatus = .failed("Control channel returned invalid health JSON")
-            }
-        } catch {
-            self.remoteStatus = .failed(error.localizedDescription)
-        }
-
-        // Restore original mode if we temporarily switched
-        switch originalMode {
-        case .remote:
-            break
-        case .local:
-            try? await ControlChannel.shared.configure(mode: .local)
-        case .unconfigured:
-            await ControlChannel.shared.disconnect()
-        }
-    }
-
-    private static func isValidWsUrl(_ raw: String) -> Bool {
-        GatewayRemoteConfig.normalizeGatewayUrl(raw) != nil
-    }
-
-    private static func sshCheckCommand(target: String, identity: String) -> [String]? {
-        guard let parsed = CommandResolver.parseSSHTarget(target) else { return nil }
-        let options = [
-            "-o", "BatchMode=yes",
-            "-o", "ConnectTimeout=5",
-            "-o", "StrictHostKeyChecking=accept-new",
-            "-o", "UpdateHostKeys=yes",
-        ]
-        let args = CommandResolver.sshArguments(
-            target: parsed,
-            identity: identity,
-            options: options,
-            remoteCommand: ["echo", "ok"])
-        return ["/usr/bin/ssh"] + args
-    }
-
-    private func formatSSHFailure(_ response: Response, target: String) -> String {
-        let payload = response.payload.flatMap { String(data: $0, encoding: .utf8) }
-        let trimmed = payload?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .split(whereSeparator: \.isNewline)
-            .joined(separator: " ")
-        if let trimmed,
-           trimmed.localizedCaseInsensitiveContains("host key verification failed")
-        {
-            let host = CommandResolver.parseSSHTarget(target)?.host ?? target
-            return "SSH check failed: Host key verification failed. Remove the old key with " +
-                "`ssh-keygen -R \(host)` and try again."
-        }
-        if let trimmed, !trimmed.isEmpty {
-            if let message = response.message, message.hasPrefix("exit ") {
-                return "SSH check failed: \(trimmed) (\(message))"
-            }
-            return "SSH check failed: \(trimmed)"
-        }
-        if let message = response.message {
-            return "SSH check failed (\(message))"
-        }
-        return "SSH check failed"
     }
 
     private func revealLogs() {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -74,6 +74,8 @@ struct OpenClawApp: App {
             self.applyStatusItemAppearance(paused: self.state.isPaused, sleeping: self.isGatewaySleeping)
         }
         .onChange(of: self.state.connectionMode) { _, mode in
+            // Skip coordinator apply during a transient probe flip so we don't disrupt the active local session.
+            guard !self.state.suppressRemoteProbeReset else { return }
             Task { await ConnectionModeCoordinator.shared.apply(mode: mode, paused: self.state.isPaused) }
             CLIInstallPrompter.shared.checkAndPromptIfNeeded(reason: "connection-mode")
         }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
@@ -147,7 +147,9 @@ actor MacNodeBrowserProxy {
         }
 
         if method != "GET", let body = params.body {
-            request.httpBody = try JSONSerialization.data(withJSONObject: body.foundationValue, options: [.fragmentsAllowed])
+            request.httpBody = try JSONSerialization.data(
+                withJSONObject: body.foundationValue,
+                options: [.fragmentsAllowed])
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
 

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -78,6 +78,9 @@ struct OnboardingView: View {
     @State var onboardingWizard = OnboardingWizardModel()
     @State var didLoadOnboardingSkills = false
     @State var localGatewayProbe: LocalGatewayProbe?
+    @State var remoteProbeState: RemoteProbeState = .idle
+    @State var remoteAuthIssue: RemoteGatewayAuthIssue? = nil
+    @State var suppressRemoteProbeReset: Bool = false
     @Bindable var state: AppState
     var permissionMonitor: PermissionMonitor
 

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -80,7 +80,7 @@ struct OnboardingView: View {
     @State var localGatewayProbe: LocalGatewayProbe?
     @State var remoteProbeState: RemoteProbeState = .idle
     @State var remoteAuthIssue: RemoteGatewayAuthIssue? = nil
-    @State var suppressRemoteProbeReset: Bool = false
+
     @Bindable var state: AppState
     var permissionMonitor: PermissionMonitor
 

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -80,6 +80,7 @@ struct OnboardingView: View {
     @State var localGatewayProbe: LocalGatewayProbe?
     @State var remoteProbeState: RemoteProbeState = .idle
     @State var remoteAuthIssue: RemoteGatewayAuthIssue? = nil
+    @State var suppressRemoteProbeReset: Bool = false
 
     @Bindable var state: AppState
     var permissionMonitor: PermissionMonitor

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -2,6 +2,7 @@ import AppKit
 import OpenClawChatUI
 import OpenClawDiscovery
 import OpenClawIPC
+import OpenClawKit
 import SwiftUI
 
 extension OnboardingView {
@@ -97,6 +98,11 @@ extension OnboardingView {
 
                     self.gatewayDiscoverySection()
 
+                    if self.shouldShowRemoteConnectionSection {
+                        Divider().padding(.vertical, 4)
+                        self.remoteConnectionSection()
+                    }
+
                     self.connectionChoiceButton(
                         title: "Configure later",
                         subtitle: "Don’t start the Gateway yet.",
@@ -108,6 +114,22 @@ extension OnboardingView {
                     self.advancedConnectionSection()
                 }
             }
+        }
+        .onChange(of: self.state.connectionMode) { _, newValue in
+            guard Self.shouldResetRemoteProbeFeedback(
+                for: newValue,
+                suppressReset: self.suppressRemoteProbeReset)
+            else { return }
+            self.resetRemoteProbeFeedback()
+        }
+        .onChange(of: self.state.remoteTransport) { _, _ in
+            self.resetRemoteProbeFeedback()
+        }
+        .onChange(of: self.state.remoteTarget) { _, _ in
+            self.resetRemoteProbeFeedback()
+        }
+        .onChange(of: self.state.remoteUrl) { _, _ in
+            self.resetRemoteProbeFeedback()
         }
     }
 
@@ -199,25 +221,6 @@ extension OnboardingView {
                         .pickerStyle(.segmented)
                         .frame(width: fieldWidth)
                     }
-                    GridRow {
-                        Text("Gateway token")
-                            .font(.callout.weight(.semibold))
-                            .frame(width: labelWidth, alignment: .leading)
-                        SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: fieldWidth)
-                    }
-                    if self.state.remoteTokenUnsupported {
-                        GridRow {
-                            Text("")
-                                .frame(width: labelWidth, alignment: .leading)
-                            Text(
-                                "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.")
-                                .font(.caption)
-                                .foregroundStyle(.orange)
-                                .frame(width: fieldWidth, alignment: .leading)
-                        }
-                    }
                     if self.state.remoteTransport == .direct {
                         GridRow {
                             Text("Gateway URL")
@@ -287,6 +290,249 @@ extension OnboardingView {
             }
             .transition(.opacity.combined(with: .move(edge: .top)))
         }
+    }
+
+    private var shouldShowRemoteConnectionSection: Bool {
+        self.state.connectionMode == .remote ||
+            self.showAdvancedConnection ||
+            self.remoteProbeState != .idle ||
+            self.remoteAuthIssue != nil ||
+            Self.shouldShowRemoteTokenField(
+                showAdvancedConnection: self.showAdvancedConnection,
+                remoteToken: self.state.remoteToken,
+                remoteTokenUnsupported: self.state.remoteTokenUnsupported,
+                authIssue: self.remoteAuthIssue)
+    }
+
+    private var shouldShowRemoteTokenField: Bool {
+        guard self.shouldShowRemoteConnectionSection else { return false }
+        return Self.shouldShowRemoteTokenField(
+            showAdvancedConnection: self.showAdvancedConnection,
+            remoteToken: self.state.remoteToken,
+            remoteTokenUnsupported: self.state.remoteTokenUnsupported,
+            authIssue: self.remoteAuthIssue)
+    }
+
+    private var remoteProbePreflightMessage: String? {
+        switch self.state.remoteTransport {
+        case .direct:
+            let trimmedUrl = self.state.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedUrl.isEmpty {
+                return "Select a nearby gateway or open Advanced to enter a gateway URL."
+            }
+            if GatewayRemoteConfig.normalizeGatewayUrl(trimmedUrl) == nil {
+                return "Gateway URL must use wss:// for remote hosts (ws:// only for localhost)."
+            }
+            return nil
+        case .ssh:
+            let trimmedTarget = self.state.remoteTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedTarget.isEmpty {
+                return "Select a nearby gateway or open Advanced to enter an SSH target."
+            }
+            return CommandResolver.sshTargetValidationMessage(trimmedTarget)
+        }
+    }
+
+    private var canProbeRemoteConnection: Bool {
+        self.remoteProbePreflightMessage == nil && self.remoteProbeState != .checking
+    }
+
+    private func remoteConnectionSection() -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Remote connection")
+                        .font(.callout.weight(.semibold))
+                    Text("Checks the real remote websocket and auth handshake.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                Button {
+                    Task { await self.probeRemoteConnection() }
+                } label: {
+                    if self.remoteProbeState == .checking {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(minWidth: 120)
+                    } else {
+                        Text("Check connection")
+                            .frame(minWidth: 120)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!self.canProbeRemoteConnection)
+            }
+
+            if self.shouldShowRemoteTokenField {
+                self.remoteTokenField()
+            }
+
+            if let message = self.remoteProbePreflightMessage, self.remoteProbeState != .checking {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            self.remoteProbeStatusView()
+
+            if let issue = self.remoteAuthIssue {
+                self.remoteAuthPromptView(issue: issue)
+            }
+        }
+    }
+
+    private func remoteTokenField() -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 12) {
+                Text("Gateway token")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: 110, alignment: .leading)
+                SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 320)
+            }
+            Text("Used when the remote gateway requires token auth.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if self.state.remoteTokenUnsupported {
+                Text(
+                    "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func remoteProbeStatusView() -> some View {
+        switch self.remoteProbeState {
+        case .idle:
+            EmptyView()
+        case .checking:
+            Text("Checking remote gateway…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case let .ok(success):
+            VStack(alignment: .leading, spacing: 2) {
+                Label(success.title, systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                if let detail = success.detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        case let .failed(message):
+            if self.remoteAuthIssue == nil {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func remoteAuthPromptView(issue: RemoteGatewayAuthIssue) -> some View {
+        let promptStyle = Self.remoteAuthPromptStyle(for: issue)
+        return HStack(alignment: .top, spacing: 10) {
+            Image(systemName: promptStyle.systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(promptStyle.tint)
+                .frame(width: 16, alignment: .center)
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(issue.title)
+                    .font(.caption.weight(.semibold))
+                Text(.init(issue.body))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let footnote = issue.footnote {
+                    Text(.init(footnote))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func probeRemoteConnection() async {
+        let originalMode = self.state.connectionMode
+        let shouldRestoreMode = originalMode != .remote
+        if shouldRestoreMode {
+            // Reuse the shared remote endpoint stack for probing without committing the user's mode choice.
+            self.state.connectionMode = .remote
+        }
+        self.remoteProbeState = .checking
+        self.remoteAuthIssue = nil
+        defer {
+            if shouldRestoreMode {
+                self.suppressRemoteProbeReset = true
+                self.state.connectionMode = originalMode
+                self.suppressRemoteProbeReset = false
+            }
+        }
+
+        switch await RemoteGatewayProbe.run() {
+        case let .ready(success):
+            self.remoteProbeState = .ok(success)
+        case let .authIssue(issue):
+            self.remoteAuthIssue = issue
+            self.remoteProbeState = .failed(issue.statusMessage)
+        case let .failed(message):
+            self.remoteProbeState = .failed(message)
+        }
+    }
+
+    private func resetRemoteProbeFeedback() {
+        self.remoteProbeState = .idle
+        self.remoteAuthIssue = nil
+    }
+
+    static func remoteAuthPromptStyle(
+        for issue: RemoteGatewayAuthIssue)
+        -> (systemImage: String, tint: Color)
+    {
+        switch issue {
+        case .tokenRequired:
+            ("key.fill", .orange)
+        case .tokenMismatch:
+            ("exclamationmark.triangle.fill", .orange)
+        case .gatewayTokenNotConfigured:
+            ("wrench.and.screwdriver.fill", .orange)
+        case .setupCodeExpired:
+            ("qrcode.viewfinder", .orange)
+        case .passwordRequired:
+            ("lock.slash.fill", .orange)
+        case .pairingRequired:
+            ("link.badge.plus", .orange)
+        }
+    }
+
+    static func shouldShowRemoteTokenField(
+        showAdvancedConnection: Bool,
+        remoteToken: String,
+        remoteTokenUnsupported: Bool,
+        authIssue: RemoteGatewayAuthIssue?) -> Bool
+    {
+        showAdvancedConnection ||
+            remoteTokenUnsupported ||
+            !remoteToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            authIssue?.showsTokenField == true
+    }
+
+    static func shouldResetRemoteProbeFeedback(
+        for connectionMode: AppState.ConnectionMode,
+        suppressReset: Bool) -> Bool
+    {
+        !suppressReset && connectionMode != .remote
     }
 
     func gatewaySubtitle(for gateway: GatewayDiscoveryModel.DiscoveredGateway) -> String? {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -467,7 +467,13 @@ extension OnboardingView {
         let originalMode = self.state.connectionMode
         let shouldRestoreMode = originalMode != .remote
         if shouldRestoreMode {
-            // Reuse the shared remote endpoint stack for probing without committing the user's mode choice.
+            // Raise the suppress flag before switching mode so the MenuBar .onChange handler
+            // (MenuBar.swift:76-78) does not invoke ConnectionModeCoordinator.apply for this
+            // transient probe flip, preventing the active local gateway from being torn down.
+            // The flag is kept true for the duration of the probe and cleared in the defer block
+            // after the mode is restored, so neither the forward nor the backward flip triggers
+            // ConnectionModeCoordinator.apply (which would otherwise tear down the local gateway).
+            self.state.suppressRemoteProbeReset = true
             self.state.connectionMode = .remote
         }
         self.remoteProbeState = .checking

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -118,7 +118,7 @@ extension OnboardingView {
         .onChange(of: self.state.connectionMode) { _, newValue in
             guard Self.shouldResetRemoteProbeFeedback(
                 for: newValue,
-                suppressReset: self.suppressRemoteProbeReset)
+                suppressReset: self.state.suppressRemoteProbeReset)
             else { return }
             self.resetRemoteProbeFeedback()
         }
@@ -474,9 +474,9 @@ extension OnboardingView {
         self.remoteAuthIssue = nil
         defer {
             if shouldRestoreMode {
-                self.suppressRemoteProbeReset = true
+                self.state.suppressRemoteProbeReset = true
                 self.state.connectionMode = originalMode
-                self.suppressRemoteProbeReset = false
+                self.state.suppressRemoteProbeReset = false
             }
         }
 

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -104,6 +104,13 @@ enum RemoteGatewayAuthIssue: Equatable {
     }
 }
 
+enum RemoteProbeState: Equatable {
+    case idle
+    case checking
+    case ok(RemoteGatewayProbeSuccess)
+    case failed(String)
+}
+
 enum RemoteGatewayProbeResult: Equatable {
     case ready(RemoteGatewayProbeSuccess)
     case authIssue(RemoteGatewayAuthIssue)

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -1,0 +1,237 @@
+import Foundation
+import OpenClawIPC
+import OpenClawKit
+
+enum RemoteGatewayAuthIssue: Equatable {
+    case tokenRequired
+    case tokenMismatch
+    case gatewayTokenNotConfigured
+    case setupCodeExpired
+    case passwordRequired
+    case pairingRequired
+
+    init?(error: Error) {
+        guard let authError = error as? GatewayConnectAuthError else {
+            return nil
+        }
+        switch authError.detail {
+        case .authTokenMissing:
+            self = .tokenRequired
+        case .authTokenMismatch:
+            self = .tokenMismatch
+        case .authTokenNotConfigured:
+            self = .gatewayTokenNotConfigured
+        case .authBootstrapTokenInvalid:
+            self = .setupCodeExpired
+        case .authPasswordMissing, .authPasswordMismatch, .authPasswordNotConfigured:
+            self = .passwordRequired
+        case .pairingRequired:
+            self = .pairingRequired
+        default:
+            return nil
+        }
+    }
+
+    var showsTokenField: Bool {
+        switch self {
+        case .tokenRequired, .tokenMismatch:
+            true
+        case .gatewayTokenNotConfigured, .setupCodeExpired, .passwordRequired, .pairingRequired:
+            false
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .tokenRequired:
+            "This gateway requires an auth token"
+        case .tokenMismatch:
+            "That token did not match the gateway"
+        case .gatewayTokenNotConfigured:
+            "This gateway host needs token setup"
+        case .setupCodeExpired:
+            "This setup code is no longer valid"
+        case .passwordRequired:
+            "This gateway is using unsupported auth"
+        case .pairingRequired:
+            "This device needs pairing approval"
+        }
+    }
+
+    var body: String {
+        switch self {
+        case .tokenRequired:
+            "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
+        case .tokenMismatch:
+            "Check `gateway.auth.token` or `OPENCLAW_GATEWAY_TOKEN` on the gateway host and try again."
+        case .gatewayTokenNotConfigured:
+            "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
+        case .setupCodeExpired:
+            "Scan or paste a fresh setup code from an already-paired OpenClaw client, then try again."
+        case .passwordRequired:
+            "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
+        case .pairingRequired:
+            "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
+        }
+    }
+
+    var footnote: String? {
+        switch self {
+        case .tokenRequired, .gatewayTokenNotConfigured:
+            "No token yet? Generate one on the gateway host with `openclaw doctor --generate-gateway-token`, then set it as `gateway.auth.token`."
+        case .setupCodeExpired:
+            nil
+        case .pairingRequired:
+            "If you do not have another paired OpenClaw client yet, approve the pending request on the gateway host with `openclaw devices approve`."
+        case .tokenMismatch, .passwordRequired:
+            nil
+        }
+    }
+
+    var statusMessage: String {
+        switch self {
+        case .tokenRequired:
+            "This gateway requires an auth token from the gateway host."
+        case .tokenMismatch:
+            "Gateway token mismatch. Check gateway.auth.token or OPENCLAW_GATEWAY_TOKEN on the gateway host."
+        case .gatewayTokenNotConfigured:
+            "This gateway has token auth enabled, but no gateway.auth.token is configured on the host."
+        case .setupCodeExpired:
+            "Setup code expired or already used. Scan a fresh setup code, then try again."
+        case .passwordRequired:
+            "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet."
+        case .pairingRequired:
+            "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
+        }
+    }
+}
+
+enum RemoteGatewayProbeResult: Equatable {
+    case ready(RemoteGatewayProbeSuccess)
+    case authIssue(RemoteGatewayAuthIssue)
+    case failed(String)
+}
+
+struct RemoteGatewayProbeSuccess: Equatable {
+    let authSource: GatewayAuthSource?
+
+    var title: String {
+        switch self.authSource {
+        case .some(.deviceToken):
+            "Connected via paired device"
+        case .some(.bootstrapToken):
+            "Connected with setup code"
+        case .some(.sharedToken):
+            "Connected with gateway token"
+        case .some(.password):
+            "Connected with password"
+        case .some(GatewayAuthSource.none), nil:
+            "Remote gateway ready"
+        }
+    }
+
+    var detail: String? {
+        switch self.authSource {
+        case .some(.deviceToken):
+            "This Mac used a stored device token. New or unpaired devices may still need the gateway token."
+        case .some(.bootstrapToken):
+            "This Mac is still using the temporary setup code. Approve pairing to finish provisioning device-scoped auth."
+        case .some(.sharedToken), .some(.password), .some(GatewayAuthSource.none), nil:
+            nil
+        }
+    }
+}
+
+enum RemoteGatewayProbe {
+    @MainActor
+    static func run() async -> RemoteGatewayProbeResult {
+        AppStateStore.shared.syncGatewayConfigNow()
+        let settings = CommandResolver.connectionSettings()
+        let transport = AppStateStore.shared.remoteTransport
+
+        if transport == .direct {
+            let trimmedUrl = AppStateStore.shared.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedUrl.isEmpty else {
+                return .failed("Set a gateway URL first")
+            }
+            guard self.isValidWsUrl(trimmedUrl) else {
+                return .failed("Gateway URL must use wss:// for remote hosts (ws:// only for localhost)")
+            }
+        } else {
+            let trimmedTarget = settings.target.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedTarget.isEmpty else {
+                return .failed("Set an SSH target first")
+            }
+            if let validationMessage = CommandResolver.sshTargetValidationMessage(trimmedTarget) {
+                return .failed(validationMessage)
+            }
+            guard let sshCommand = self.sshCheckCommand(target: settings.target, identity: settings.identity) else {
+                return .failed("SSH target is invalid")
+            }
+
+            let sshResult = await ShellExecutor.run(
+                command: sshCommand,
+                cwd: nil,
+                env: nil,
+                timeout: 8)
+            guard sshResult.ok else {
+                return .failed(self.formatSSHFailure(sshResult, target: settings.target))
+            }
+        }
+
+        do {
+            _ = try await GatewayConnection.shared.healthSnapshot(timeoutMs: 10000)
+            let authSource = await GatewayConnection.shared.authSource()
+            return .ready(RemoteGatewayProbeSuccess(authSource: authSource))
+        } catch {
+            if let authIssue = RemoteGatewayAuthIssue(error: error) {
+                return .authIssue(authIssue)
+            }
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    private static func isValidWsUrl(_ raw: String) -> Bool {
+        GatewayRemoteConfig.normalizeGatewayUrl(raw) != nil
+    }
+
+    private static func sshCheckCommand(target: String, identity: String) -> [String]? {
+        guard let parsed = CommandResolver.parseSSHTarget(target) else { return nil }
+        let options = [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=5",
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "UpdateHostKeys=yes",
+        ]
+        let args = CommandResolver.sshArguments(
+            target: parsed,
+            identity: identity,
+            options: options,
+            remoteCommand: ["echo", "ok"])
+        return ["/usr/bin/ssh"] + args
+    }
+
+    private static func formatSSHFailure(_ response: Response, target: String) -> String {
+        let payload = response.payload.flatMap { String(data: $0, encoding: .utf8) }
+        let trimmed = payload?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isNewline)
+            .joined(separator: " ")
+        if let trimmed,
+           trimmed.localizedCaseInsensitiveContains("host key verification failed")
+        {
+            let host = CommandResolver.parseSSHTarget(target)?.host ?? target
+            return "SSH check failed: Host key verification failed. Remove the old key with ssh-keygen -R \(host) and try again."
+        }
+        if let trimmed, !trimmed.isEmpty {
+            if let message = response.message, message.hasPrefix("exit ") {
+                return "SSH check failed: \(trimmed) (\(message))"
+            }
+            return "SSH check failed: \(trimmed)"
+        }
+        if let message = response.message {
+            return "SSH check failed (\(message))"
+        }
+        return "SSH check failed"
+    }
+}

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -14,18 +14,16 @@ enum RemoteGatewayAuthIssue: Equatable {
         guard let authError = error as? GatewayConnectAuthError else {
             return nil
         }
-        switch authError.detail {
-        case .authTokenMissing:
+        switch authError.detailCode {
+        case "AUTH_TOKEN_MISSING":
             self = .tokenRequired
-        case .authTokenMismatch:
+        case "AUTH_TOKEN_MISMATCH":
             self = .tokenMismatch
-        case .authTokenNotConfigured:
+        case "AUTH_TOKEN_NOT_CONFIGURED":
             self = .gatewayTokenNotConfigured
-        case .authBootstrapTokenInvalid:
-            self = .setupCodeExpired
-        case .authPasswordMissing, .authPasswordMismatch, .authPasswordNotConfigured:
+        case "AUTH_PASSWORD_MISSING", "AUTH_PASSWORD_MISMATCH", "AUTH_PASSWORD_NOT_CONFIGURED":
             self = .passwordRequired
-        case .pairingRequired:
+        case "PAIRING_REQUIRED":
             self = .pairingRequired
         default:
             return nil

--- a/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
@@ -23,8 +23,8 @@ enum TalkModeGatewayConfigParser {
         defaultSilenceTimeoutMs: Int,
         envVoice: String?,
         sagVoice: String?,
-        envApiKey: String?
-    ) -> TalkModeGatewayConfigState {
+        envApiKey: String?) -> TalkModeGatewayConfigState
+    {
         let talk = snapshot.config?["talk"]?.dictionaryValue
         let selection = TalkConfigParsing.selectProviderConfig(talk, defaultProvider: defaultProvider)
         let activeProvider = selection?.provider ?? defaultProvider
@@ -81,8 +81,8 @@ enum TalkModeGatewayConfigParser {
         defaultSilenceTimeoutMs: Int,
         envVoice: String?,
         sagVoice: String?,
-        envApiKey: String?
-    ) -> TalkModeGatewayConfigState {
+        envApiKey: String?) -> TalkModeGatewayConfigState
+    {
         let resolvedVoice =
             (envVoice?.isEmpty == false ? envVoice : nil) ??
             (sagVoice?.isEmpty == false ? sagVoice : nil)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -143,12 +143,12 @@ private enum GatewayConnectErrorCodes {
     static let deviceIdentityRequired = "DEVICE_IDENTITY_REQUIRED"
 }
 
-private struct GatewayConnectAuthError: LocalizedError {
-    let message: String
-    let detailCode: String?
-    let canRetryWithDeviceToken: Bool
+public struct GatewayConnectAuthError: LocalizedError {
+    public let message: String
+    public let detailCode: String?
+    public let canRetryWithDeviceToken: Bool
 
-    var errorDescription: String? { self.message }
+    public var errorDescription: String? { self.message }
 
     var isNonRecoverable: Bool {
         switch self.detailCode {

--- a/extensions/diffs/src/store.test.ts
+++ b/extensions/diffs/src/store.test.ts
@@ -104,18 +104,26 @@ describe("DiffArtifactStore", () => {
   });
 
   it("expires standalone file artifacts using ttl metadata", async () => {
+    // Use a dedicated store with no automatic cleanup (cleanupIntervalMs: Infinity)
+    // so scheduleCleanup() never fires a background sweep. This makes the test
+    // fully deterministic with fake timers: only the explicit cleanupExpired()
+    // call below is responsible for deletion, with no concurrent background sweep
+    // that could race against vi.setSystemTime() and produce non-deterministic
+    // results (fake Date.now() vs real stat.mtimeMs in the fallback path).
+    const testStore = new DiffArtifactStore({ rootDir, cleanupIntervalMs: Infinity });
+
     vi.useFakeTimers();
     const now = new Date("2026-02-27T16:00:00Z");
     vi.setSystemTime(now);
 
-    const standalone = await store.createStandaloneFileArtifact({
+    const standalone = await testStore.createStandaloneFileArtifact({
       format: "png",
       ttlMs: 1_000,
     });
     await fs.writeFile(standalone.filePath, Buffer.from("png"));
 
     vi.setSystemTime(new Date(now.getTime() + 2_000));
-    await store.cleanupExpired();
+    await testStore.cleanupExpired();
 
     await expect(fs.stat(path.dirname(standalone.filePath))).rejects.toMatchObject({
       code: "ENOENT",

--- a/extensions/diffs/src/store.ts
+++ b/extensions/diffs/src/store.ts
@@ -38,7 +38,7 @@ export class DiffArtifactStore {
   private readonly logger?: PluginLogger;
   private readonly cleanupIntervalMs: number;
   private cleanupInFlight: Promise<void> | null = null;
-  private nextCleanupAt = 0;
+  private nextCleanupAt: number;
 
   constructor(params: { rootDir: string; logger?: PluginLogger; cleanupIntervalMs?: number }) {
     this.rootDir = path.resolve(params.rootDir);
@@ -47,6 +47,10 @@ export class DiffArtifactStore {
       params.cleanupIntervalMs === undefined
         ? DEFAULT_CLEANUP_INTERVAL_MS
         : Math.max(0, Math.floor(params.cleanupIntervalMs));
+    // When cleanupIntervalMs is Infinity (disabled), start at MAX_SAFE_INTEGER so
+    // scheduleCleanup() never fires automatically. Otherwise start at 0 so the
+    // first createArtifact/createStandaloneFileArtifact eagerly triggers a sweep.
+    this.nextCleanupAt = Number.isFinite(this.cleanupIntervalMs) ? 0 : Number.MAX_SAFE_INTEGER;
   }
 
   async createArtifact(params: CreateArtifactParams): Promise<DiffArtifactMeta> {

--- a/src/gateway/client-callsites.guard.test.ts
+++ b/src/gateway/client-callsites.guard.test.ts
@@ -6,7 +6,7 @@ const GATEWAY_CLIENT_CONSTRUCTOR_PATTERN = /new\s+GatewayClient\s*\(/;
 
 const ALLOWED_GATEWAY_CLIENT_CALLSITES = new Set([
   "src/acp/server.ts",
-  "src/discord/monitor/exec-approvals.ts",
+  "src/gateway/operator-approvals-client.ts",
   "src/gateway/call.ts",
   "src/gateway/probe.ts",
   "src/node-host/runner.ts",

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -23,6 +23,11 @@ class MockWebSocket {
   private closeHandlers: WsEventHandlers["close"][] = [];
   private errorHandlers: WsEventHandlers["error"][] = [];
   readonly sent: string[] = [];
+  readyState: number = 0; // 0=CONNECTING, 1=OPEN, 2=CLOSING, 3=CLOSED
+  static readonly OPEN = 1;
+  static readonly CONNECTING = 0;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
 
   constructor(_url: string, _options?: unknown) {
     wsInstances.push(this);
@@ -52,6 +57,7 @@ class MockWebSocket {
   }
 
   close(code?: number, reason?: string): void {
+    this.readyState = 2;
     this.emitClose(code ?? 1000, reason ?? "");
   }
 
@@ -60,6 +66,7 @@ class MockWebSocket {
   }
 
   emitOpen(): void {
+    this.readyState = 1;
     for (const handler of this.openHandlers) {
       handler();
     }
@@ -72,6 +79,7 @@ class MockWebSocket {
   }
 
   emitClose(code: number, reason: string): void {
+    this.readyState = 3;
     for (const handler of this.closeHandlers) {
       handler(code, Buffer.from(reason));
     }
@@ -577,6 +585,53 @@ describe("GatewayClient connect auth payload", () => {
 
     await vi.advanceTimersByTimeAsync(30_000);
     expect(wsInstances).toHaveLength(1);
+    client.stop();
+    vi.useRealTimers();
+  });
+});
+
+describe("GatewayClient reconnect() timer cleanup", () => {
+  beforeEach(() => {
+    wsInstances.length = 0;
+    loadDeviceAuthTokenMock.mockReset();
+    clearDeviceAuthTokenMock.mockReset();
+    storeDeviceAuthTokenMock.mockReset();
+  });
+
+  it("clears the handshake connectTimer so it cannot spuriously close the next socket", async () => {
+    vi.useFakeTimers();
+    const connectErrors: Error[] = [];
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      token: "tok",
+      onConnectError: (err) => connectErrors.push(err),
+    });
+
+    // Start and let the WebSocket open — this arms the connect-challenge timeout.
+    client.start();
+    const ws1 = getLatestWs();
+    ws1.emitOpen(); // readyState → 1 (OPEN); queueConnect() arms connectTimer (~2000ms)
+
+    // Simulate ctrl+r mid-handshake (before connect.challenge arrives).
+    // Without the fix, the old connectTimer would still be running.
+    client.reconnect(); // should clear connectTimer AND close ws1
+
+    // Advance past the original 2 s handshake window.
+    // The reconnect backoff fires at 1000 ms, so the second socket will be created.
+    await vi.advanceTimersByTimeAsync(1_100);
+    const ws2 = getLatestWs();
+    expect(wsInstances).toHaveLength(2); // new socket was opened
+    ws2.emitOpen(); // second socket enters OPEN state
+
+    // Advance another 1500 ms — if the stale connectTimer were still alive it
+    // would fire here (total ~2600 ms from ws1.emitOpen) and close ws2 with a
+    // false "connect challenge timeout".
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    // The new socket should still be alive (not closed by a stale timer).
+    expect(ws2.readyState).toBe(1); // still OPEN
+    expect(connectErrors.map((e) => e.message)).not.toContain("gateway connect challenge timeout");
+
     client.stop();
     vi.useRealTimers();
   });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -237,7 +237,14 @@ export class GatewayClient {
       }
       this.flushPendingErrors(new Error(`gateway closed (${code}): ${reasonText}`));
       if (this.shouldPauseReconnectAfterAuthFailure(connectErrorDetailCode)) {
-        this.opts.onClose?.(code, reasonText);
+        // Enrich the close reason with the auth detail code so the TUI can
+        // suppress the misleading "Auto-reconnecting" hint for paused auth
+        // failures (e.g. "connect failed" from sendConnect() errors).
+        const enrichedReason =
+          connectErrorDetailCode && reasonText === "connect failed"
+            ? `connect failed: ${connectErrorDetailCode}`
+            : reasonText;
+        this.opts.onClose?.(code, enrichedReason);
         return;
       }
       this.scheduleReconnect();

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -612,6 +612,12 @@ export class GatewayClient {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+    // Cancel any in-flight handshake timeout so a stale timer cannot close the
+    // next socket attempt with a false "connect challenge timeout".
+    if (this.connectTimer) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
     // Reset backoff so the next auto-reconnect after this also starts fast.
     this.backoffMs = 1000;
     if (this.ws) {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -112,6 +112,7 @@ export class GatewayClient {
   private pending = new Map<string, Pending>();
   private backoffMs = 1000;
   private closed = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private lastSeq: number | null = null;
   private connectNonce: string | null = null;
   private connectSent = false;
@@ -258,6 +259,10 @@ export class GatewayClient {
     if (this.tickTimer) {
       clearInterval(this.tickTimer);
       this.tickTimer = null;
+    }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
     }
     this.ws?.close();
     this.ws = null;
@@ -581,9 +586,41 @@ export class GatewayClient {
       clearInterval(this.tickTimer);
       this.tickTimer = null;
     }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+    }
     const delay = this.backoffMs;
     this.backoffMs = Math.min(this.backoffMs * 2, 30_000);
-    setTimeout(() => this.start(), delay).unref();
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.start();
+    }, delay);
+    this.reconnectTimer.unref?.();
+  }
+
+  /**
+   * Force an immediate reconnect attempt, resetting the exponential backoff.
+   * Safe to call while disconnected or while a reconnect attempt is in progress.
+   * Has no effect if the client has been stopped.
+   */
+  reconnect() {
+    if (this.closed) {
+      return;
+    }
+    // Cancel any pending scheduled reconnect so we don't get a double-connect.
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    // Reset backoff so the next auto-reconnect after this also starts fast.
+    this.backoffMs = 1000;
+    if (this.ws) {
+      // Currently connected or mid-handshake: close to trigger scheduleReconnect.
+      this.ws.close(1000, "manual reconnect");
+    } else {
+      // Already disconnected: attempt immediately.
+      this.start();
+    }
   }
 
   private flushPendingErrors(err: Error) {

--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -8,6 +8,7 @@ export class CustomEditor extends Editor {
   onCtrlL?: () => void;
   onCtrlO?: () => void;
   onCtrlP?: () => void;
+  onCtrlR?: () => void;
   onCtrlT?: () => void;
   onShiftTab?: () => void;
   onAltEnter?: () => void;
@@ -27,6 +28,10 @@ export class CustomEditor extends Editor {
     }
     if (matchesKey(data, Key.ctrl("p")) && this.onCtrlP) {
       this.onCtrlP();
+      return;
+    }
+    if (matchesKey(data, Key.ctrl("r")) && this.onCtrlR) {
+      this.onCtrlR();
       return;
     }
     if (matchesKey(data, Key.ctrl("g")) && this.onCtrlG) {

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -197,6 +197,11 @@ export class GatewayChatClient {
     this.client.stop();
   }
 
+  /** Force an immediate reconnect, resetting the exponential backoff. */
+  reconnect() {
+    this.client.reconnect();
+  }
+
   async waitForReady() {
     await this.readyPromise;
   }

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -166,6 +166,23 @@ describe("resolveGatewayDisconnectState", () => {
     expect(state.connectionStatus).toBe("gateway disconnected: network timeout");
     expect(state.activityStatus).toBe("reconnecting… ctrl+r to retry now");
     expect(state.pairingHint).toBeUndefined();
+    expect(state.suppressReconnectHint).toBeUndefined();
+  });
+
+  it("suppresses auto-reconnect hint for auth failures that pause reconnect", () => {
+    const authReasons = [
+      "unauthorized: gateway token missing (set gateway.remote.token to match gateway.auth.token)",
+      "unauthorized: gateway password mismatch (set gateway.remote.password to match gateway.auth.password)",
+      "unauthorized: too many failed authentication attempts (retry later)",
+      "unauthorized: device token mismatch (rotate/reissue device token)",
+    ];
+    for (const reason of authReasons) {
+      const state = resolveGatewayDisconnectState(reason);
+      expect(state.connectionStatus).toContain("unauthorized");
+      expect(state.activityStatus).toBe("check credentials — ctrl+r to retry");
+      expect(state.pairingHint).toBeUndefined();
+      expect(state.suppressReconnectHint).toBe(true);
+    }
   });
 });
 

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -161,10 +161,10 @@ describe("resolveGatewayDisconnectState", () => {
     expect(state.pairingHint).toContain("openclaw devices list");
   });
 
-  it("falls back to idle for generic disconnect reasons", () => {
+  it("falls back to reconnecting hint for generic disconnect reasons", () => {
     const state = resolveGatewayDisconnectState("network timeout");
     expect(state.connectionStatus).toBe("gateway disconnected: network timeout");
-    expect(state.activityStatus).toBe("idle");
+    expect(state.activityStatus).toBe("reconnecting… ctrl+r to retry now");
     expect(state.pairingHint).toBeUndefined();
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -252,6 +252,27 @@ export function resolveGatewayDisconnectState(reason?: string): {
       suppressReconnectHint: true,
     };
   }
+  // sendConnect() auth failures close with "connect failed: <DETAIL_CODE>"; the
+  // gateway client pauses reconnection in these cases, so suppress the hint.
+  if (/^connect failed:\s*PAIRING_REQUIRED/i.test(reasonLabel)) {
+    return {
+      connectionStatus: `gateway disconnected: ${reasonLabel}`,
+      activityStatus: "pairing required: run openclaw devices list",
+      pairingHint:
+        "Pairing required. Run `openclaw devices list`, approve your request ID, then reconnect.",
+    };
+  }
+  if (
+    /^connect failed:\s*(AUTH_TOKEN_MISSING|AUTH_TOKEN_MISMATCH|AUTH_TOKEN_NOT_CONFIGURED|AUTH_PASSWORD_MISSING|AUTH_PASSWORD_MISMATCH|AUTH_PASSWORD_NOT_CONFIGURED|AUTH_RATE_LIMITED|CONTROL_UI_DEVICE_IDENTITY_REQUIRED|DEVICE_IDENTITY_REQUIRED)/i.test(
+      reasonLabel,
+    )
+  ) {
+    return {
+      connectionStatus: `gateway disconnected: ${reasonLabel}`,
+      activityStatus: "check credentials — ctrl+r to retry",
+      suppressReconnectHint: true,
+    };
+  }
   return {
     connectionStatus: `gateway disconnected: ${reasonLabel}`,
     activityStatus: "reconnecting… ctrl+r to retry now",

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -940,6 +940,7 @@ export async function runTui(opts: TuiOptions) {
     const reconnected = wasDisconnected;
     wasDisconnected = false;
     setConnectionStatus("connected");
+    setActivityStatus("idle");
     void (async () => {
       await refreshAgents();
       updateHeader();
@@ -965,7 +966,7 @@ export async function runTui(opts: TuiOptions) {
     if (disconnectState.pairingHint && !pairingHintShown) {
       pairingHintShown = true;
       chatLog.addSystem(disconnectState.pairingHint);
-    } else if (!disconnectHintShown) {
+    } else if (!disconnectHintShown && !disconnectState.pairingHint) {
       disconnectHintShown = true;
       chatLog.addSystem(
         "Gateway disconnected. Auto-reconnecting… press ctrl+r to retry immediately.\n" +

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -246,7 +246,7 @@ export function resolveGatewayDisconnectState(reason?: string): {
   }
   return {
     connectionStatus: `gateway disconnected: ${reasonLabel}`,
-    activityStatus: "idle",
+    activityStatus: "reconnecting… ctrl+r to retry now",
   };
 }
 
@@ -343,6 +343,7 @@ export async function runTui(opts: TuiOptions) {
   let toolsExpanded = false;
   let showThinking = false;
   let pairingHintShown = false;
+  let disconnectHintShown = false;
   const localRunIds = new Set<string>();
 
   const deliverDefault = opts.deliver ?? false;
@@ -911,6 +912,13 @@ export async function runTui(opts: TuiOptions) {
   editor.onCtrlP = () => {
     void openSessionSelector();
   };
+  editor.onCtrlR = () => {
+    if (!isConnected) {
+      setActivityStatus("reconnecting…");
+      client.reconnect();
+      tui.requestRender();
+    }
+  };
   editor.onCtrlT = () => {
     showThinking = !showThinking;
     void loadHistory();
@@ -928,6 +936,7 @@ export async function runTui(opts: TuiOptions) {
   client.onConnected = () => {
     isConnected = true;
     pairingHintShown = false;
+    disconnectHintShown = false;
     const reconnected = wasDisconnected;
     wasDisconnected = false;
     setConnectionStatus("connected");
@@ -956,6 +965,12 @@ export async function runTui(opts: TuiOptions) {
     if (disconnectState.pairingHint && !pairingHintShown) {
       pairingHintShown = true;
       chatLog.addSystem(disconnectState.pairingHint);
+    } else if (!disconnectHintShown) {
+      disconnectHintShown = true;
+      chatLog.addSystem(
+        "Gateway disconnected. Auto-reconnecting… press ctrl+r to retry immediately.\n" +
+          "If the problem persists, restart the TUI with: openclaw tui",
+      );
     }
     updateFooter();
     tui.requestRender();

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -234,6 +234,7 @@ export function resolveGatewayDisconnectState(reason?: string): {
   connectionStatus: string;
   activityStatus: string;
   pairingHint?: string;
+  suppressReconnectHint?: boolean;
 } {
   const reasonLabel = reason?.trim() ? reason.trim() : "closed";
   if (/pairing required/i.test(reasonLabel)) {
@@ -242,6 +243,13 @@ export function resolveGatewayDisconnectState(reason?: string): {
       activityStatus: "pairing required: run openclaw devices list",
       pairingHint:
         "Pairing required. Run `openclaw devices list`, approve your request ID, then reconnect.",
+    };
+  }
+  if (/^unauthorized/i.test(reasonLabel)) {
+    return {
+      connectionStatus: `gateway disconnected: ${reasonLabel}`,
+      activityStatus: "check credentials — ctrl+r to retry",
+      suppressReconnectHint: true,
     };
   }
   return {
@@ -966,7 +974,11 @@ export async function runTui(opts: TuiOptions) {
     if (disconnectState.pairingHint && !pairingHintShown) {
       pairingHintShown = true;
       chatLog.addSystem(disconnectState.pairingHint);
-    } else if (!disconnectHintShown && !disconnectState.pairingHint) {
+    } else if (
+      !disconnectHintShown &&
+      !disconnectState.pairingHint &&
+      !disconnectState.suppressReconnectHint
+    ) {
       disconnectHintShown = true;
       chatLog.addSystem(
         "Gateway disconnected. Auto-reconnecting… press ctrl+r to retry immediately.\n" +


### PR DESCRIPTION
## Problem

Fixes #43778.

When the gateway restarts (e.g. after `openclaw gateway restart`), the TUI shows `not connected to gateway — message not sent` with no guidance on what to do. Users had no way to know they could manually reconnect or how to restart the TUI.

## Changes

### 1. `GatewayClient` — trackable reconnect timer + `reconnect()` method
- Store the pending reconnect `setTimeout` handle so it can be cancelled before a forced reconnect (prevents double-connect race)
- New public `reconnect()` method: resets exponential backoff to 1 s and immediately retries. If a WebSocket is open/mid-handshake it closes it cleanly; if already disconnected it calls `start()` directly
- `stop()` now clears the tracked timer

### 2. `GatewayChatClient` — expose `reconnect()`
Delegates to `GatewayClient.reconnect()`.

### 3. `CustomEditor` — `onCtrlR` hook
Adds ctrl+r key binding alongside the existing ctrl+l / ctrl+g / ctrl+p family.

### 4. `tui.ts` — UX improvements on disconnect
- **ctrl+r wired**: `editor.onCtrlR` calls `client.reconnect()` when disconnected
- **Status hint updated**: `activityStatus` now reads `reconnecting… ctrl+r to retry now` instead of the silent `idle`
- **One-shot system message**: first disconnect in a session surfaces:
  ```
  Gateway disconnected. Auto-reconnecting… press ctrl+r to retry immediately.
  If the problem persists, restart the TUI with: openclaw tui
  ```
  (resets on reconnect so it fires again if the gateway goes away a second time)

## Behaviour summary

| Scenario | Before | After |
|----------|--------|-------|
| Gateway restarts | Silent `not connected` | System message + `ctrl+r to retry now` in status |
| User wants to retry immediately | No shortcut | ctrl+r forces immediate reconnect |
| Gateway takes >30 s to come back | Backoff maxes at 30 s silently | ctrl+r resets backoff at any time |
| Gateway stays down | No guidance | Chat log shows `openclaw tui` restart command |

## Testing
- All existing tests pass (57 tests across tui, gateway-chat, tui-event-handlers)
- Updated `tui.test.ts` to reflect new `activityStatus` text