### PR TITLE
Infra: tighten exec allowlist glob matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Security/host env: block inherited `GIT_EXEC_PATH` from sanitized host exec environments so Git helper resolution cannot be steered by host environment state. (`GHSA-jf5v-pqgw-gm5m`)(#43685) Thanks @zpbrent and @vincentkoc.
 - Security/session_status: enforce sandbox session-tree visibility and shared agent-to-agent access guards before reading or mutating target session state, so sandboxed subagents can no longer inspect parent session metadata or write parent model overrides via `session_status`. (`GHSA-wcxr-59v9-rxr8`)(#43754) Thanks @tdjackey and @vincentkoc.
 - Models/secrets: enforce source-managed SecretRef markers in generated `models.json` so runtime-resolved provider secrets are not persisted when runtime projection is skipped. (#43759) Thanks @joshavant.
+- Security/exec allowlist: preserve POSIX case sensitivity and keep `?` within a single path segment so exact-looking allowlist patterns no longer overmatch executables across case or directory boundaries. (`GHSA-f8r2-vg7x-gh8m`)(#43798) Thanks @zpbrent and @vincentkoc.
 
 ### Changes
 

--- a/src/infra/exec-allowlist-pattern.test.ts
+++ b/src/infra/exec-allowlist-pattern.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { matchesExecAllowlistPattern } from "./exec-allowlist-pattern.js";
+
+describe("matchesExecAllowlistPattern", () => {
+  it("does not let ? cross path separators", () => {
+    expect(matchesExecAllowlistPattern("/tmp/a?b", "/tmp/a/b")).toBe(false);
+    expect(matchesExecAllowlistPattern("/tmp/a?b", "/tmp/acb")).toBe(true);
+  });
+
+  it.runIf(process.platform !== "win32")("preserves case sensitivity on POSIX", () => {
+    expect(matchesExecAllowlistPattern("/tmp/Allowed-Tool", "/tmp/allowed-tool")).toBe(false);
+    expect(matchesExecAllowlistPattern("/tmp/Allowed-Tool", "/tmp/Allowed-Tool")).toBe(true);
+  });
+});

--- a/src/infra/exec-allowlist-pattern.ts
+++ b/src/infra/exec-allowlist-pattern.ts
@@ -9,7 +9,7 @@ function normalizeMatchTarget(value: string): string {
     const stripped = value.replace(/^\\\\[?.]\\/, "");
     return stripped.replace(/\\/g, "/").toLowerCase();
   }
-  return value.replace(/\\\\/g, "/").toLowerCase();
+  return value.replace(/\\\\/g, "/");
 }
 
 function tryRealpath(value: string): string | null {
@@ -46,7 +46,7 @@ function compileGlobRegex(pattern: string): RegExp {
       continue;
     }
     if (ch === "?") {
-      regex += ".";
+      regex += "[^/]";
       i += 1;
       continue;
     }
@@ -55,7 +55,7 @@ function compileGlobRegex(pattern: string): RegExp {
   }
   regex += "$";
 
-  const compiled = new RegExp(regex, "i");
+  const compiled = new RegExp(regex, process.platform === "win32" ? "i" : "");
   if (globRegexCache.size >= GLOB_REGEX_CACHE_LIMIT) {
     globRegexCache.clear();
   }


### PR DESCRIPTION
## Summary

- Problem: `matchesExecAllowlistPattern()` lowercased POSIX targets and let `?` match `/`, so exact-looking allowlist entries could overmatch.
- Why it matters: that weakens the exec approval boundary for `security=allowlist` and makes path patterns broader than reviewers expect.
- What changed: preserve case-sensitive matching on POSIX, keep Windows case-folding, and compile `?` to a single non-separator character.
- What did NOT change (scope boundary): this does not expand the allowlist surface or change Windows realpath handling for exact patterns.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related GHSA-f8r2-vg7x-gh8m

## User-visible / Behavior Changes

Users on POSIX now get case-sensitive exec allowlist matching, and `?` no longer crosses directory separators.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: exec allowlist matching is stricter, with regression coverage for the two overmatch cases.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): exec allowlist patterns

### Steps

1. Match `/tmp/Allowed-Tool` against `/tmp/allowed-tool` on POSIX.
2. Match `/tmp/a?b` against `/tmp/a/b`.
3. Run the new regression tests.

### Expected

- POSIX matching stays case-sensitive, and `?` only matches within a single path segment.

### Actual

- Before this patch both cases returned `true`; after the patch both return `false`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced both overmatches with a direct `tsx` probe, then reran `pnpm test -- src/infra/exec-allowlist-pattern.test.ts` after the fix.
- Edge cases checked: positive `?` matching within a segment still works.
- What you did **not** verify: Windows runtime behavior on a live Windows host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/infra/exec-allowlist-pattern.ts`
- Known bad symptoms reviewers should watch for: previously tolerated mixed-case POSIX allowlist matches will stop matching.

## Risks and Mitigations

- Risk: a workflow may have relied on permissive POSIX case folding or slash-crossing `?` matches.
- Mitigation: behavior now matches standard path-glob expectations and is covered by focused regression tests.
