### PR TITLE
Gateway: block profile mutations via browser.request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Security/host env: block inherited `GIT_EXEC_PATH` from sanitized host exec environments so Git helper resolution cannot be steered by host environment state. (`GHSA-jf5v-pqgw-gm5m`)(#43685) Thanks @zpbrent and @vincentkoc.
 - Security/session_status: enforce sandbox session-tree visibility and shared agent-to-agent access guards before reading or mutating target session state, so sandboxed subagents can no longer inspect parent session metadata or write parent model overrides via `session_status`. (`GHSA-wcxr-59v9-rxr8`)(#43754) Thanks @tdjackey and @vincentkoc.
 - Models/secrets: enforce source-managed SecretRef markers in generated `models.json` so runtime-resolved provider secrets are not persisted when runtime projection is skipped. (#43759) Thanks @joshavant.
+- Security/browser.request: block persistent browser profile create/delete routes from write-scoped `browser.request` so callers can no longer persist admin-only browser profile changes through the browser control surface. (`GHSA-vmhq-cqm9-6p7q`)(#43800) Thanks @tdjackey and @vincentkoc.
 
 ### Changes
 

--- a/src/gateway/server-methods/browser.profile-from-body.test.ts
+++ b/src/gateway/server-methods/browser.profile-from-body.test.ts
@@ -100,4 +100,32 @@ describe("browser.request profile selection", () => {
       }),
     );
   });
+
+  it.each([
+    {
+      method: "POST",
+      path: "/profiles/create",
+      body: { name: "poc", cdpUrl: "http://10.0.0.42:9222" },
+    },
+    {
+      method: "DELETE",
+      path: "/profiles/poc",
+      body: undefined,
+    },
+  ])("blocks persistent profile mutations for %s %s", async ({ method, path, body }) => {
+    const { respond, nodeRegistry } = await runBrowserRequest({
+      method,
+      path,
+      body,
+    });
+
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: "browser.request cannot create or delete persistent browser profiles",
+      }),
+    );
+  });
 });

--- a/src/gateway/server-methods/browser.profile-from-body.test.ts
+++ b/src/gateway/server-methods/browser.profile-from-body.test.ts
@@ -112,7 +112,17 @@ describe("browser.request profile selection", () => {
       path: "/profiles/poc",
       body: undefined,
     },
-  ])("blocks persistent profile mutations for %s %s", async ({ method, path, body }) => {
+    {
+      method: "POST",
+      path: "profiles/create",
+      body: { name: "poc", cdpUrl: "http://10.0.0.42:9222" },
+    },
+    {
+      method: "DELETE",
+      path: "profiles/poc",
+      body: undefined,
+    },
+  ])("blocks persistent profile mutations for $method $path", async ({ method, path, body }) => {
     const { respond, nodeRegistry } = await runBrowserRequest({
       method,
       path,

--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -20,6 +20,22 @@ type BrowserRequestParams = {
   timeoutMs?: number;
 };
 
+function normalizeBrowserRequestPath(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 1) {
+    return trimmed;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+function isPersistentBrowserProfileMutation(method: string, path: string): boolean {
+  const normalizedPath = normalizeBrowserRequestPath(path);
+  if (method === "POST" && normalizedPath === "/profiles/create") {
+    return true;
+  }
+  return method === "DELETE" && /^\/profiles\/[^/]+$/.test(normalizedPath);
+}
+
 function resolveRequestedProfile(params: {
   query?: Record<string, unknown>;
   body?: unknown;
@@ -164,6 +180,17 @@ export const browserHandlers: GatewayRequestHandlers = {
         false,
         undefined,
         errorShape(ErrorCodes.INVALID_REQUEST, "method must be GET, POST, or DELETE"),
+      );
+      return;
+    }
+    if (isPersistentBrowserProfileMutation(methodRaw, path)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "browser.request cannot create or delete persistent browser profiles",
+        ),
       );
       return;
     }

--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -22,10 +22,14 @@ type BrowserRequestParams = {
 
 function normalizeBrowserRequestPath(value: string): string {
   const trimmed = value.trim();
-  if (trimmed.length <= 1) {
+  if (!trimmed) {
     return trimmed;
   }
-  return trimmed.replace(/\/+$/, "");
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  if (withLeadingSlash.length <= 1) {
+    return withLeadingSlash;
+  }
+  return withLeadingSlash.replace(/\/+$/, "");
 }
 
 function isPersistentBrowserProfileMutation(method: string, path: string): boolean {


### PR DESCRIPTION
## Summary

- Problem: `browser.request` is write-scoped but could still hit persistent browser profile routes like `/profiles/create` and `/profiles/:name`.
- Why it matters: that let a write-scoped caller persist admin-only browser profile changes through the browser control surface.
- What changed: reject persistent profile create/delete routes in the gateway handler before local dispatch or node proxying.
- What did NOT change (scope boundary): non-persistent browser control routes and read-only profile listing stay available through `browser.request`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related GHSA-vmhq-cqm9-6p7q

## User-visible / Behavior Changes

`browser.request` now rejects profile creation and deletion paths instead of forwarding them.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes`
- If any `Yes`, explain risk + mitigation: write-scoped callers lose access to persistent browser profile mutations; the new handler regression asserts those requests are denied before any proxy invoke occurs.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway browser RPC
- Relevant config (redacted): browser control enabled / browser node proxy allowed

### Steps

1. Send `browser.request` with `method=POST`, `path=/profiles/create`, and a body that sets `cdpUrl`.
2. Send `browser.request` with `method=DELETE`, `path=/profiles/poc`.
3. Run the gateway handler regression test.

### Expected

- The gateway rejects persistent profile mutations before any browser proxy dispatch.

### Actual

- Before this patch the request could be forwarded; after the patch both routes return an invalid-request error and skip proxy invocation.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: checked the gateway route guard, then ran `pnpm test -- src/gateway/server-methods/browser.profile-from-body.test.ts`.
- Edge cases checked: normal `browser.request` profile selection through `/act` still passes.
- What you did **not** verify: full end-to-end browser node proxying against a live connected node.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/gateway/server-methods/browser.ts`
- Known bad symptoms reviewers should watch for: callers using `browser.request` for profile creation/deletion will now receive an invalid-request error.

## Risks and Mitigations

- Risk: an internal workflow may have been relying on `browser.request` for persistent profile management.
- Mitigation: the restriction is narrow and still leaves dedicated admin config flows available for persistent browser changes.
