### PR TITLE
docs: add ademczuk to maintainers list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,9 @@ Welcome to the lobster tank! 🦞
 - **Tengji (George) Zhang** - Chinese model APIs, cloud, pi
   - GitHub: [@odysseus0](https://github.com/odysseus0) · X: [@odysseus0z](https://x.com/odysseus0z)
 
+- **Andrew (Bubbles) Demczuk** - Agents/Gateway/TTS/VTT
+  - GitHub: [@ademczuk](https://github.com/ademczuk) · X: [@ademczuk](https://x.com/ademczuk)
+
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!


### PR DESCRIPTION
Adds @ademczuk to the maintainers list in CONTRIBUTING.md.

Org invite accepted, push + triage permissions active as of 2026-03-12.

Focus areas: Agents, Gateway, TTS/VTT.