### PR TITLE
feat(telegram): support URL inline buttons alongside callback_data

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -567,7 +567,7 @@ describe("buildAgentSystemPrompt", () => {
       },
     });
 
-    expect(prompt).toContain("buttons=[[{text,callback_data,style?}]]");
+    expect(prompt).toContain("buttons=[[{text,callback_data?,url?,style?}]]");
     expect(prompt).toContain("`style` can be `primary`, `success`, or `danger`");
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -144,7 +144,7 @@ function buildMessagingSection(params: {
           `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
           `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
           params.inlineButtonsEnabled
-            ? "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`."
+            ? "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data?,url?,style?}]]`; each button needs `text` plus either `callback_data` or `url`; `style` can be `primary`, `success`, or `danger`."
             : params.runtimeChannel
               ? `- Inline buttons not enabled for ${params.runtimeChannel}. If you need them, ask to set ${params.runtimeChannel}.capabilities.inlineButtons ("dm"|"group"|"all"|"allowlist").`
               : "",

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -206,12 +206,14 @@ function buildSendSchema(options: {
         Type.Array(
           Type.Object({
             text: Type.String(),
-            callback_data: Type.String(),
+            callback_data: Type.Optional(Type.String()),
+            url: Type.Optional(Type.String()),
             style: Type.Optional(stringEnum(["danger", "success", "primary"])),
           }),
         ),
         {
-          description: "Telegram inline keyboard buttons (array of button rows)",
+          description:
+            "Telegram inline keyboard buttons (array of button rows; each button needs text plus callback_data or url)",
         },
       ),
     ),

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -736,11 +736,18 @@ describe("handleTelegramAction", () => {
 });
 
 describe("readTelegramButtons", () => {
-  it("returns trimmed button rows for valid input", () => {
+  it("returns trimmed button rows for callback buttons", () => {
     const result = readTelegramButtons({
       buttons: [[{ text: "  Option A ", callback_data: " cmd:a " }]],
     });
     expect(result).toEqual([[{ text: "Option A", callback_data: "cmd:a" }]]);
+  });
+
+  it("returns trimmed button rows for url buttons", () => {
+    const result = readTelegramButtons({
+      buttons: [[{ text: "  Docs ", url: " https://docs.openclaw.ai " }]],
+    });
+    expect(result).toEqual([[{ text: "Docs", url: "https://docs.openclaw.ai" }]]);
   });
 
   it("normalizes optional style", () => {
@@ -764,6 +771,22 @@ describe("readTelegramButtons", () => {
         },
       ],
     ]);
+  });
+
+  it("rejects buttons without callback_data or url", () => {
+    expect(() =>
+      readTelegramButtons({
+        buttons: [[{ text: "Option A" }]],
+      }),
+    ).toThrow(/requires text and either callback_data or url/i);
+  });
+
+  it("rejects buttons that set both callback_data and url", () => {
+    expect(() =>
+      readTelegramButtons({
+        buttons: [[{ text: "Option A", callback_data: "cmd:a", url: "https://docs.openclaw.ai" }]],
+      }),
+    ).toThrow(/cannot set both callback_data and url/i);
   });
 
   it("rejects unsupported button style", () => {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -89,10 +89,16 @@ export function readTelegramButtons(
           `buttons[${rowIndex}][${buttonIndex}] style must be one of ${TELEGRAM_BUTTON_STYLES.join(", ")}`,
         );
       }
+      if (callbackData) {
+        return {
+          text,
+          callback_data: callbackData,
+          ...(style ? { style: style as TelegramButtonStyle } : {}),
+        };
+      }
       return {
         text,
-        ...(callbackData ? { callback_data: callbackData } : {}),
-        ...(url ? { url } : {}),
+        url,
         ...(style ? { style: style as TelegramButtonStyle } : {}),
       };
     });

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -60,8 +60,19 @@ export function readTelegramButtons(
         typeof (button as { callback_data?: unknown }).callback_data === "string"
           ? (button as { callback_data: string }).callback_data.trim()
           : "";
-      if (!text || !callbackData) {
-        throw new Error(`buttons[${rowIndex}][${buttonIndex}] requires text and callback_data`);
+      const url =
+        typeof (button as { url?: unknown }).url === "string"
+          ? (button as { url: string }).url.trim()
+          : "";
+      if (!text || (!callbackData && !url)) {
+        throw new Error(
+          `buttons[${rowIndex}][${buttonIndex}] requires text and either callback_data or url`,
+        );
+      }
+      if (callbackData && url) {
+        throw new Error(
+          `buttons[${rowIndex}][${buttonIndex}] cannot set both callback_data and url`,
+        );
       }
       if (callbackData.length > 64) {
         throw new Error(
@@ -80,7 +91,8 @@ export function readTelegramButtons(
       }
       return {
         text,
-        callback_data: callbackData,
+        ...(callbackData ? { callback_data: callbackData } : {}),
+        ...(url ? { url } : {}),
         ...(style ? { style: style as TelegramButtonStyle } : {}),
       };
     });

--- a/src/telegram/button-types.ts
+++ b/src/telegram/button-types.ts
@@ -1,10 +1,7 @@
 export type TelegramButtonStyle = "danger" | "success" | "primary";
 
-export type TelegramInlineButton = {
-  text: string;
-  callback_data?: string;
-  url?: string;
-  style?: TelegramButtonStyle;
-};
+export type TelegramInlineButton =
+  | { text: string; callback_data: string; url?: never; style?: TelegramButtonStyle }
+  | { text: string; url: string; callback_data?: never; style?: TelegramButtonStyle };
 
 export type TelegramInlineButtons = ReadonlyArray<ReadonlyArray<TelegramInlineButton>>;

--- a/src/telegram/button-types.ts
+++ b/src/telegram/button-types.ts
@@ -2,7 +2,8 @@ export type TelegramButtonStyle = "danger" | "success" | "primary";
 
 export type TelegramInlineButton = {
   text: string;
-  callback_data: string;
+  callback_data?: string;
+  url?: string;
   style?: TelegramButtonStyle;
 };
 

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -150,6 +150,13 @@ describe("buildInlineKeyboard", () => {
         },
       },
       {
+        name: "supports url buttons",
+        input: [[{ text: "Docs", url: "https://docs.openclaw.ai" }]],
+        expected: {
+          inline_keyboard: [[{ text: "Docs", url: "https://docs.openclaw.ai" }]],
+        },
+      },
+      {
         name: "filters invalid buttons and empty rows",
         input: [
           [

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -570,14 +570,20 @@ export function buildInlineKeyboard(
     .map((row) =>
       row
         .filter((button) => button?.text && (button?.callback_data || button?.url))
-        .map(
-          (button): InlineKeyboardButton => ({
+        .map((button): InlineKeyboardButton => {
+          if (button.callback_data) {
+            return {
+              text: button.text,
+              callback_data: button.callback_data,
+              ...(button.style ? { style: button.style } : {}),
+            };
+          }
+          return {
             text: button.text,
-            ...(button.callback_data ? { callback_data: button.callback_data } : {}),
-            ...(button.url ? { url: button.url } : {}),
+            url: button.url!,
             ...(button.style ? { style: button.style } : {}),
-          }),
-        ),
+          };
+        }),
     )
     .filter((row) => row.length > 0);
   if (rows.length === 0) {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -569,11 +569,12 @@ export function buildInlineKeyboard(
   const rows = buttons
     .map((row) =>
       row
-        .filter((button) => button?.text && button?.callback_data)
+        .filter((button) => button?.text && (button?.callback_data || button?.url))
         .map(
           (button): InlineKeyboardButton => ({
             text: button.text,
-            callback_data: button.callback_data,
+            ...(button.callback_data ? { callback_data: button.callback_data } : {}),
+            ...(button.url ? { url: button.url } : {}),
             ...(button.style ? { style: button.style } : {}),
           }),
         ),


### PR DESCRIPTION
## Summary

Add support for Telegram [`url` inline keyboard buttons](https://core.telegram.org/bots/api#inlinekeyboardbutton) alongside the existing `callback_data` buttons. This lets agents send messages with direct-link buttons (article links, docs, etc.) that open in the user's browser when tapped.

## Motivation

The message tool currently only supports `callback_data` buttons. Telegram's Bot API natively supports `url` buttons (`InlineKeyboardButton` with a `url` field), which are useful for news digests, documentation links, and any scenario where you want a tap-to-open-URL button.

## Changes

| File | Change |
|---|---|
| `src/telegram/button-types.ts` | Use a discriminated union: each button has `text` + either `callback_data` or `url` (mutually exclusive via `never`) |
| `src/telegram/send.ts` | `buildInlineKeyboard` constructs the correct `InlineKeyboardButton` variant |
| `src/agents/tools/telegram-actions.ts` | `readTelegramButtons` validates and narrows to the union at runtime |
| `src/agents/tools/message-tool.ts` | Schema accepts optional `url` field on buttons |
| `src/agents/system-prompt.ts` | Update inline button guidance to mention `url` |

## Type Design

`TelegramInlineButton` is a discriminated union using `never` markers, so TypeScript rejects invalid constructions (e.g. missing both fields, or setting both) at compile time:

```typescript
export type TelegramInlineButton =
  | { text: string; callback_data: string; url?: never; style?: TelegramButtonStyle }
  | { text: string; url: string; callback_data?: never; style?: TelegramButtonStyle };
```

## Tests

- ✅ `readTelegramButtons`: url buttons parsed and trimmed
- ✅ `readTelegramButtons`: rejects buttons missing both `callback_data` and `url`
- ✅ `readTelegramButtons`: rejects buttons with both `callback_data` and `url`
- ✅ `buildInlineKeyboard`: url buttons produce correct `inline_keyboard` output
- ✅ System prompt test updated
- ✅ All existing `callback_data` tests pass unchanged
- ✅ `pnpm check` / `pnpm build` / `pnpm protocol:check` pass locally

## Note on CI

The remaining `check` failure (`oxfmt` formatting on 3 CSS files) is a pre-existing issue on `main` — unrelated to this PR.
