### PR TITLE
Gateway: allow explicit none auth on non-loopback binds

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2450,9 +2450,9 @@ See [Plugins](/tools/plugin).
 - `bind`: `auto`, `loopback` (default), `lan` (`0.0.0.0`), `tailnet` (Tailscale IP only), or `custom`.
 - **Legacy bind aliases**: use bind mode values in `gateway.bind` (`auto`, `loopback`, `lan`, `tailnet`, `custom`), not host aliases (`0.0.0.0`, `127.0.0.1`, `localhost`, `::`, `::1`).
 - **Docker note**: the default `loopback` bind listens on `127.0.0.1` inside the container. With Docker bridge networking (`-p 18789:18789`), traffic arrives on `eth0`, so the gateway is unreachable. Use `--network host`, or set `bind: "lan"` (or `bind: "custom"` with `customBindHost: "0.0.0.0"`) to listen on all interfaces.
-- **Auth**: required by default. Non-loopback binds require a shared token/password. Onboarding wizard generates a token by default.
+- **Auth**: required by default. Non-loopback binds require a shared token/password unless you explicitly set `gateway.auth.mode: "none"` or `gateway.auth.mode: "trusted-proxy"`. Onboarding wizard generates a token by default.
 - If both `gateway.auth.token` and `gateway.auth.password` are configured (including SecretRefs), set `gateway.auth.mode` explicitly to `token` or `password`. Startup and service install/repair flows fail when both are configured and mode is unset.
-- `gateway.auth.mode: "none"`: explicit no-auth mode. Use only for trusted local loopback setups; this is intentionally not offered by onboarding prompts.
+- `gateway.auth.mode: "none"`: explicit no-auth mode for trusted environments where auth is enforced externally (for example API gateway/ingress/service mesh). This is intentionally not offered by onboarding prompts.
 - `gateway.auth.mode: "trusted-proxy"`: delegate auth to an identity-aware reverse proxy and trust identity headers from `gateway.trustedProxies` (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)).
 - `gateway.auth.allowTailscale`: when `true`, Tailscale Serve identity headers can satisfy Control UI/WebSocket auth (verified via `tailscale whois`); HTTP API endpoints still require token/password auth. This tokenless flow assumes the gateway host is trusted. Defaults to `true` when `tailscale.mode = "serve"`.
 - `gateway.auth.rateLimit`: optional failed-auth limiter. Applies per client IP and per auth scope (shared-secret and device-token are tracked independently). Blocked attempts return `429` + `Retry-After`.

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -207,6 +207,26 @@ describe("gateway run option collisions", () => {
     expectAuthOverrideMode("trusted-proxy");
   });
 
+  it("allows --auth none on non-loopback bind", async () => {
+    await runGatewayCli([
+      "gateway",
+      "run",
+      "--bind",
+      "lan",
+      "--auth",
+      "none",
+      "--allow-unconfigured",
+    ]);
+
+    expect(startGatewayServer).toHaveBeenCalledWith(
+      18789,
+      expect.objectContaining({
+        bind: "lan",
+        auth: expect.objectContaining({ mode: "none" }),
+      }),
+    );
+  });
+
   it("prints all supported modes on invalid --auth value", async () => {
     await expect(
       runGatewayCli(["gateway", "run", "--auth", "bad-mode", "--allow-unconfigured"]),

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -396,7 +396,8 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     bind !== "loopback" &&
     !hasSharedSecret &&
     !canBootstrapToken &&
-    resolvedAuthMode !== "trusted-proxy"
+    resolvedAuthMode !== "trusted-proxy" &&
+    resolvedAuthMode !== "none"
   ) {
     defaultRuntime.error(
       [

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -208,19 +208,31 @@ describe("resolveGatewayRuntimeConfig", () => {
       );
     });
 
-    it("rejects non-loopback control UI when allowed origins are missing", async () => {
-      await expect(
-        resolveGatewayRuntimeConfig({
-          cfg: {
-            gateway: {
-              bind: "lan",
-              auth: TOKEN_AUTH,
+    it.each([
+      {
+        name: "token auth",
+        auth: TOKEN_AUTH,
+      },
+      {
+        name: "explicit none auth",
+        auth: { mode: "none" as const },
+      },
+    ])(
+      "rejects non-loopback control UI when allowed origins are missing ($name)",
+      async ({ auth }) => {
+        await expect(
+          resolveGatewayRuntimeConfig({
+            cfg: {
+              gateway: {
+                bind: "lan",
+                auth,
+              },
             },
-          },
-          port: 18789,
-        }),
-      ).rejects.toThrow("non-loopback Control UI requires gateway.controlUi.allowedOrigins");
-    });
+            port: 18789,
+          }),
+        ).rejects.toThrow("non-loopback Control UI requires gateway.controlUi.allowedOrigins");
+      },
+    );
 
     it("allows non-loopback control UI without allowed origins when dangerous fallback is enabled", async () => {
       const result = await resolveGatewayRuntimeConfig({

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -143,6 +143,18 @@ describe("resolveGatewayRuntimeConfig", () => {
         expectedAuthMode: "none",
         expectedBindHost: "127.0.0.1",
       },
+      {
+        name: "lan binding with explicit none auth",
+        cfg: {
+          gateway: {
+            bind: "lan" as const,
+            auth: { mode: "none" as const },
+            controlUi: { allowedOrigins: ["https://control.example.com"] },
+          },
+        },
+        expectedAuthMode: "none",
+        expectedBindHost: "0.0.0.0",
+      },
     ])("allows $name", async ({ cfg, expectedAuthMode, expectedBindHost }) => {
       const result = await resolveGatewayRuntimeConfig({ cfg, port: 18789 });
       expect(result.authMode).toBe(expectedAuthMode);
@@ -155,11 +167,6 @@ describe("resolveGatewayRuntimeConfig", () => {
         cfg: { gateway: { bind: "lan" as const, auth: { mode: "token" as const } } },
         expectedMessage:
           "gateway auth mode is token, but no token was configured (set gateway.auth.token or OPENCLAW_GATEWAY_TOKEN)",
-      },
-      {
-        name: "lan binding with explicit none auth",
-        cfg: { gateway: { bind: "lan" as const, auth: { mode: "none" as const } } },
-        expectedMessage: "refusing to bind gateway",
       },
       {
         name: "loopback binding that resolves to non-loopback host",

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -130,7 +130,12 @@ export async function resolveGatewayRuntimeConfig(params: {
   if (tailscaleMode !== "off" && !isLoopbackHost(bindHost)) {
     throw new Error("tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)");
   }
-  if (!isLoopbackHost(bindHost) && !hasSharedSecret && authMode !== "trusted-proxy") {
+  if (
+    !isLoopbackHost(bindHost) &&
+    !hasSharedSecret &&
+    authMode !== "trusted-proxy" &&
+    authMode !== "none"
+  ) {
     throw new Error(
       `refusing to bind gateway to ${bindHost}:${params.port} without auth (set gateway.auth.token/password, or set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD)`,
     );


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `gateway.auth.mode: "none"` could be set, but gateway startup still refused non-loopback binds unless token/password or trusted-proxy auth was configured.
- Why it matters: trusted internal deployments (Docker/Kubernetes + external gateway/mesh auth) had to add unnecessary proxy auth workarounds.
- What changed: runtime config validation and `openclaw gateway run` preflight now allow explicit `auth.mode=none` on non-loopback binds.
- What did NOT change (scope boundary): shared-secret and trusted-proxy validation behavior is unchanged; security audit findings for exposed unauthenticated setups remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43786
- Related #N/A

## User-visible / Behavior Changes

- Users can now run gateway with `gateway.auth.mode: "none"` on non-loopback binds (for example `bind: "lan"`) without startup rejection in CLI preflight/runtime validation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway CLI/runtime
- Relevant config (redacted): `gateway.bind=lan`, `gateway.auth.mode=none`, `gateway.controlUi.allowedOrigins=["https://control.example.com"]`

### Steps

1. Configure gateway with `bind: "lan"` and `auth.mode: "none"`.
2. Start gateway through CLI preflight path and runtime config resolution.
3. Verify startup does not reject due to non-loopback no-auth validation.

### Expected

- Explicit `auth.mode=none` should start on non-loopback binds.

### Actual

- Startup now succeeds; focused tests pass for CLI preflight + runtime config.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `src/gateway/server-runtime-config.test.ts` passes with lan + `auth.mode=none` allow case.
  - `src/cli/gateway-cli/run.option-collisions.test.ts` passes with `--bind lan --auth none`.
- Edge cases checked:
  - Existing token-missing and bind/host validation cases still enforced.
- What you did **not** verify:
  - End-to-end manual gateway startup against a live Kubernetes ingress.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Set `gateway.auth.mode` to `token` or `password` and configure matching secret.
- Files/config to restore:
  - `src/gateway/server-runtime-config.ts`
  - `src/cli/gateway-cli/run.ts`
- Known bad symptoms reviewers should watch for:
  - Non-loopback startup still rejects when `auth.mode=none` is explicitly configured.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Users may unintentionally expose unauthenticated gateway on non-loopback interfaces.
  - Mitigation:
    - `auth.mode=none` must still be explicit, warning remains in CLI, and security auditing remains unchanged.

## Validation Commands Run

- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server-runtime-config.test.ts src/cli/gateway-cli/run.option-collisions.test.ts` (initial attempt failed: `Command "vitest" not found`)
- `pnpm install` (installed workspace dependencies)
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server-runtime-config.test.ts src/cli/gateway-cli/run.option-collisions.test.ts` (passed: `src/gateway/server-runtime-config.test.ts`, 19 tests)
- `pnpm exec vitest run --config vitest.unit.config.ts src/cli/gateway-cli/run.option-collisions.test.ts` (passed: 10 tests)
