### PR TITLE
fix(failover): classify HTTP 422 as format and OpenRouter credits as billing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ Docs: https://docs.openclaw.ai
 - ACP/main session aliases: canonicalize `main` before ACP session lookup so restarted ACP main sessions rehydrate instead of failing closed with `Session is not ACP-enabled: main`. (#43285, fixes #25692)
 - Agents/embedded runner: recover canonical allowlisted tool names from malformed `toolCallId` and malformed non-blank tool-name variants before dispatch, while failing closed on ambiguous matches. (#34485) thanks @yuweuii.
 - Agents/failover: classify ZenMux quota-refresh `402` responses as `rate_limit` so model fallback retries continue instead of stopping on a temporary subscription window. (#43917) thanks @bwjoke.
+- Agents/failover: classify HTTP 422 malformed-request responses as `format` and recognize OpenRouter "requires more credits" billing errors so provider fallback triggers instead of surfacing raw errors. (#43823) thanks @jnMetaCode.
 
 ## 2026.3.8
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -69,6 +69,7 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 499 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
+    expect(resolveFailoverReasonFromError({ status: 422 })).toBe("format");
     // Keep the status-only path behavior-preserving and conservative.
     expect(resolveFailoverReasonFromError({ status: 500 })).toBeNull();
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
@@ -158,6 +159,44 @@ describe("failover-error", () => {
       resolveFailoverReasonFromError({
         status: 400,
         message: INSUFFICIENT_QUOTA_PAYLOAD,
+      }),
+    ).toBe("billing");
+  });
+
+  it("treats HTTP 422 as format error", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "check open ai req parameter error",
+      }),
+    ).toBe("format");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "Unprocessable Entity",
+      }),
+    ).toBe("format");
+  });
+
+  it("treats 422 with billing message as billing instead of format", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "insufficient credits",
+      }),
+    ).toBe("billing");
+  });
+
+  it("classifies OpenRouter 'requires more credits' text as billing", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: "This model requires more credits to use",
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "This model require more credits",
       }),
     ).toBe("billing");
   });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -110,6 +110,9 @@ describe("isBillingErrorMessage", () => {
       // Venice returns "Insufficient USD or Diem balance" which has extra words
       // between "insufficient" and "balance"
       "Insufficient USD or Diem balance to complete request. Visit https://venice.ai/settings/api to add credits.",
+      // OpenRouter returns "requires more credits" for underfunded accounts
+      "This model requires more credits to use",
+      "This endpoint require more credits",
     ];
     for (const sample of samples) {
       expect(isBillingErrorMessage(sample)).toBe(true);
@@ -503,6 +506,18 @@ describe("isTransientHttpError", () => {
 });
 
 describe("classifyFailoverReasonFromHttpStatus", () => {
+  it("treats HTTP 422 as format error", () => {
+    expect(classifyFailoverReasonFromHttpStatus(422)).toBe("format");
+    expect(classifyFailoverReasonFromHttpStatus(422, "check open ai req parameter error")).toBe(
+      "format",
+    );
+    expect(classifyFailoverReasonFromHttpStatus(422, "Unprocessable Entity")).toBe("format");
+  });
+
+  it("treats 422 with billing message as billing instead of format", () => {
+    expect(classifyFailoverReasonFromHttpStatus(422, "insufficient credits")).toBe("billing");
+  });
+
   it("treats HTTP 499 as transient for structured errors", () => {
     expect(classifyFailoverReasonFromHttpStatus(499)).toBe("timeout");
     expect(classifyFailoverReasonFromHttpStatus(499, "499 Client Closed Request")).toBe("timeout");
@@ -718,6 +733,8 @@ describe("classifyFailoverReason", () => {
         "Insufficient USD or Diem balance to complete request. Visit https://venice.ai/settings/api to add credits.",
       ),
     ).toBe("billing");
+    // OpenRouter "requires more credits" billing text
+    expect(classifyFailoverReason("This model requires more credits to use")).toBe("billing");
   });
 
   it("classifies internal and compatibility error messages", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -431,7 +431,7 @@ export function classifyFailoverReasonFromHttpStatus(
   if (status === 529) {
     return "overloaded";
   }
-  if (status === 400) {
+  if (status === 400 || status === 422) {
     // Some providers return quota/balance errors under HTTP 400, so do not
     // let the generic format fallback mask an explicit billing signal.
     if (message && isBillingErrorMessage(message)) {

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -60,6 +60,7 @@ const ERROR_PATTERNS = {
     "plans & billing",
     "insufficient balance",
     "insufficient usd or diem balance",
+    /requires?\s+more\s+credits/i,
   ],
   authPermanent: [
     /api[_ ]?key[_ ]?(?:revoked|invalid|deactivated|deleted)/i,


### PR DESCRIPTION
## Summary
- Map HTTP 422 (Unprocessable Entity) to `format` in `classifyFailoverReasonFromHttpStatus`, matching the existing HTTP 400 path. VLLM/Qwen and other Chinese proxy providers return 422 for malformed requests, but this status was previously unhandled — leaving errors unclassified and preventing failover.
- Add `/requires?\s+more\s+credits/i` to billing text patterns so OpenRouter's "requires more credits" billing responses are correctly classified.
- Both paths preserve the billing-signal override: if the 422 body contains explicit billing text (e.g. "insufficient credits"), it classifies as `billing` instead of `format`.

## Test plan
- [x] Added `classifyFailoverReasonFromHttpStatus(422)` → `format` tests
- [x] Added `classifyFailoverReasonFromHttpStatus(422, "insufficient credits")` → `billing` override test
- [x] Added `resolveFailoverReasonFromError({ status: 422 })` → `format` tests
- [x] Added OpenRouter "requires more credits" billing pattern tests in both test files
- [x] All 93 existing + new tests pass