### PR TITLE
Agents: clear invalidated Kimi tool arg repairs

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -560,6 +560,51 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
     expect(partialToolCall.arguments).toEqual({});
     expect(streamedToolCall.arguments).toEqual({});
   });
+
+  it("clears a cached repair when later deltas make the trailing suffix invalid", async () => {
+    const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: '{"path":"/tmp/report.txt"}',
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: "x",
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: "yzq",
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+          },
+        ],
+        resultMessage: { role: "assistant", content: [partialToolCall] },
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    for await (const _item of stream) {
+      // drain
+    }
+
+    expect(partialToolCall.arguments).toEqual({});
+    expect(streamedToolCall.arguments).toEqual({});
+  });
 });
 
 describe("isOllamaCompatProvider", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -557,6 +557,25 @@ function repairToolCallArgumentsInMessage(
   typedBlock.arguments = repairedArgs;
 }
 
+function clearToolCallArgumentsInMessage(message: unknown, contentIndex: number): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return;
+  }
+  const block = content[contentIndex];
+  if (!block || typeof block !== "object") {
+    return;
+  }
+  const typedBlock = block as { type?: unknown; arguments?: unknown };
+  if (!isToolCallBlockType(typedBlock.type)) {
+    return;
+  }
+  typedBlock.arguments = {};
+}
+
 function repairMalformedToolCallArgumentsInMessage(
   message: unknown,
   repairedArgsByIndex: Map<number, Record<string, unknown>>,
@@ -637,6 +656,10 @@ function wrapStreamRepairMalformedToolCallArguments(
                       `repairing kimi-coding tool call arguments after ${repair.trailingSuffix.length} trailing chars`,
                     );
                   }
+                } else {
+                  repairedArgsByIndex.delete(event.contentIndex);
+                  clearToolCallArgumentsInMessage(event.partial, event.contentIndex);
+                  clearToolCallArgumentsInMessage(event.message, event.contentIndex);
                 }
               }
             }


### PR DESCRIPTION
## Summary

- Problem: the Kimi tool-argument repair wrapper can cache a valid repair from an early short suffix, then keep using it even if later deltas make the final suffix invalid.
- Why it matters: `toolcall_end` could still execute with stale repaired arguments that no longer match the final streamed payload.
- What changed: clear cached repaired args and reset the mutated partial/message snapshots when a later delta re-parse fails, plus add regression coverage for the invalidation case.
- What did NOT change (scope boundary): no widening of the Kimi repair behavior and no changes to non-Kimi or non-`anthropic-messages` code paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42481
- Related #42835

## User-visible / Behavior Changes

Kimi tool-call argument repair no longer survives later streamed deltas that invalidate the trailing-suffix safety gate.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: `kimi-coding` repair wrapper regression coverage
- Integration/channel (if any): embedded runner / tool execution
- Relevant config (redacted): none

### Steps

1. Stream a valid Kimi-style repaired tool-call suffix.
2. Append later `toolcall_delta` chunks that make the total suffix invalid.
3. Observe the arguments used at `toolcall_end`.

### Expected

- The cached repair is cleared and the final tool call does not use stale repaired arguments.

### Actual

- Before this change, the early repaired args stayed cached and were still applied on `toolcall_end`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused regression for invalidated cached repairs; existing trailing-junk and incomplete-JSON regressions still pass.
- Edge cases checked: later deltas that exceed the suffix allowance now clear both cached repaired args and previously mutated snapshots.
- What you did **not** verify: live Kimi traffic against the remote endpoint.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8f3628e154`.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for: Kimi tool-call repairs failing to invalidate when later deltas exceed the trailing-suffix allowance.

## Risks and Mitigations

- Risk: clearing cached repairs could hide a previously recovered prefix if the final payload keeps changing.
- Mitigation: the fix only clears repairs after a re-parse on later deltas proves the final accumulated suffix no longer qualifies for the narrow Kimi-specific repair.
