### PR TITLE
fix: keep session model overrides from silently falling back

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -205,6 +205,13 @@ describe("resolveAgentConfig", () => {
       resolveEffectiveModelFallbacks({
         cfg: cfgInheritDefaults,
         agentId: "linus",
+        hasSessionModelOverride: false,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveEffectiveModelFallbacks({
+        cfg: cfgInheritDefaults,
+        agentId: "linus",
         hasSessionModelOverride: true,
       }),
     ).toEqual([]);
@@ -286,6 +293,13 @@ describe("resolveAgentConfig", () => {
         sessionKey: "agent:main:session",
       }),
     ).toBe(true);
+    expect(
+      hasConfiguredModelFallbacks({
+        cfg: cfgDefaultsOnly,
+        sessionKey: "agent:main:session",
+        hasSessionModelOverride: true,
+      }),
+    ).toBe(false);
 
     const cfgAgentOverrideOnly: OpenClawConfig = {
       agents: {
@@ -309,6 +323,14 @@ describe("resolveAgentConfig", () => {
         cfg: cfgAgentOverrideOnly,
         agentId: "support",
         sessionKey: "agent:support:session",
+      }),
+    ).toBe(true);
+    expect(
+      hasConfiguredModelFallbacks({
+        cfg: cfgAgentOverrideOnly,
+        agentId: "support",
+        sessionKey: "agent:support:session",
+        hasSessionModelOverride: true,
       }),
     ).toBe(true);
     expect(

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -207,7 +207,7 @@ describe("resolveAgentConfig", () => {
         agentId: "linus",
         hasSessionModelOverride: true,
       }),
-    ).toEqual(["openai/gpt-4.1"]);
+    ).toEqual([]);
     expect(
       resolveEffectiveModelFallbacks({
         cfg: cfgDisable,

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -234,8 +234,12 @@ export function hasConfiguredModelFallbacks(params: {
   cfg: OpenClawConfig | undefined;
   agentId?: string | null;
   sessionKey?: string | null;
+  hasSessionModelOverride?: boolean;
 }): boolean {
   const fallbacksOverride = resolveRunModelFallbacksOverride(params);
+  if (params.hasSessionModelOverride) {
+    return (fallbacksOverride ?? []).length > 0;
+  }
   const defaultFallbacks = resolveAgentModelFallbackValues(params.cfg?.agents?.defaults?.model);
   return (fallbacksOverride ?? defaultFallbacks).length > 0;
 }

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -249,8 +249,13 @@ export function resolveEffectiveModelFallbacks(params: {
   if (!params.hasSessionModelOverride) {
     return agentFallbacksOverride;
   }
-  const defaultFallbacks = resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
-  return agentFallbacksOverride ?? defaultFallbacks;
+
+  // Session-level model overrides (for example /model, sessions.patch(model), or
+  // subagent spawn model routing) are expected to be sticky. Falling back to
+  // global defaults can silently swap to a higher-cost/incorrect model and make
+  // it look like the override was ignored. Keep session overrides strict by
+  // default; allow explicit per-agent fallback overrides when configured.
+  return agentFallbacksOverride ?? [];
 }
 
 export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -303,6 +303,7 @@ export async function runEmbeddedPiAgent(
         cfg: params.config,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
+        hasSessionModelOverride: params.hasSessionModelOverride,
       });
       await ensureOpenClawModelsJson(params.config, agentDir);
 

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -76,6 +76,8 @@ export type RunEmbeddedPiAgentParams = {
   disableTools?: boolean;
   provider?: string;
   model?: string;
+  /** True when the current session has an explicit model override (for example /model). */
+  hasSessionModelOverride?: boolean;
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
   thinkLevel?: ThinkLevel;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -320,6 +320,7 @@ async function persistAcpTurnTranscript(params: {
 function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
+  hasSessionModelOverride: boolean;
   cfg: ReturnType<typeof loadConfig>;
   sessionEntry: SessionEntry | undefined;
   sessionId: string;
@@ -482,6 +483,7 @@ function runAgentAttempt(params: {
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,
+    hasSessionModelOverride: params.hasSessionModelOverride,
     authProfileId,
     authProfileIdSource: authProfileId ? params.sessionEntry?.authProfileOverrideSource : undefined,
     thinkLevel: params.resolvedThinkLevel,
@@ -1113,6 +1115,7 @@ async function agentCommandInternal(
           return runAgentAttempt({
             providerOverride,
             modelOverride,
+            hasSessionModelOverride: Boolean(storedModelOverride),
             cfg,
             sessionEntry,
             sessionId,


### PR DESCRIPTION
## Summary
- treat session-level model overrides as strict by default in resolveEffectiveModelFallbacks
- keep per-agent fallback overrides working when explicitly configured
- update agent-scope.test.ts coverage for the session-override + default-fallback case

## Why
When a session already has an explicit model override (including subagent spawn model routing), inheriting global default fallbacks can silently swap to a different model and make it look like the override was ignored.

## Validation
- bash /Users/newdldewdl/.openclaw/workspace/skills/openclaw-autonomous-contributor/scripts/quality_gate.sh /tmp/openclaw-issue-43768-1773301093

Fixes #43768
