### PR TITLE
fix(cron): drain in-flight ops on hot reload to prevent state overwrite

### DIFF
--- a/src/cron/service.stop-graceful.test.ts
+++ b/src/cron/service.stop-graceful.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { CronService } from "./service.js";
 import { writeCronStoreSnapshot } from "./service.test-harness.js";
+import { createCronServiceState } from "./service/state.js";
+import { armTimer } from "./service/timer.js";
 import { loadCronStore } from "./store.js";
 import type { CronJob } from "./types.js";
 
@@ -124,6 +126,43 @@ describe("CronService.stopGraceful", () => {
     // Create service but do NOT call start() — store is null
     const cron = makeCronService(store.storePath);
     await expect(cron.stopGraceful()).resolves.toBeUndefined();
+
+    await store.cleanup();
+  });
+
+  it("stopping flag prevents armTimer from re-arming after stopGraceful", async () => {
+    const store = await makeStorePath();
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [makeFutureJob("rearm-guard-job")],
+    });
+
+    const state = createCronServiceState({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    const futureMs = Date.now() + 60_000;
+    const job = makeFutureJob("rearm-guard-job");
+    job.state.nextRunAtMs = futureMs;
+    state.store = { version: 1, jobs: [job] };
+
+    // Before stopping, armTimer should arm the timer
+    armTimer(state);
+    expect(state.timer).not.toBeNull();
+
+    // Set the stopping flag (as stopGraceful would)
+    state.stopping = true;
+    clearTimeout(state.timer!);
+    state.timer = null;
+
+    // armTimer should now refuse to re-arm
+    armTimer(state);
+    expect(state.timer).toBeNull();
 
     await store.cleanup();
   });

--- a/src/cron/service.stop-graceful.test.ts
+++ b/src/cron/service.stop-graceful.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import { writeCronStoreSnapshot } from "./service.test-harness.js";
+import { loadCronStore } from "./store.js";
+import type { CronJob } from "./types.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-stop-graceful-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      try {
+        await fs.rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 10 });
+      } catch {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    },
+  };
+}
+
+function makeFutureJob(id: string): CronJob {
+  const now = Date.now();
+  return {
+    id,
+    name: `job-${id}`,
+    enabled: true,
+    createdAtMs: now - 86400_000,
+    updatedAtMs: now - 86400_000,
+    schedule: { kind: "every", everyMs: 3600_000, anchorMs: now - 86400_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "test" },
+    delivery: { mode: "none" },
+    state: {},
+  };
+}
+
+function makeCronService(storePath: string) {
+  return new CronService({
+    storePath,
+    cronEnabled: true,
+    log: noopLogger,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeatNow: vi.fn(),
+    runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+  });
+}
+
+describe("CronService.stopGraceful", () => {
+  it("flushes in-memory state to disk before returning", async () => {
+    const store = await makeStorePath();
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [makeFutureJob("flush-job")],
+    });
+
+    const cron = makeCronService(store.storePath);
+    await cron.start();
+
+    // Update delivery config via API (persists immediately, but also
+    // exercises the stopGraceful flush path)
+    await cron.update("flush-job", {
+      delivery: { mode: "announce", channel: "telegram", to: "-1001234567890" },
+    });
+
+    await cron.stopGraceful();
+
+    // Re-read from disk — delivery config must be preserved
+    const diskStore = await loadCronStore(store.storePath);
+    const diskJob = diskStore.jobs.find((j: { id: string }) => j.id === "flush-job");
+    expect(diskJob).toBeDefined();
+    expect(diskJob?.delivery?.channel).toBe("telegram");
+    expect(diskJob?.delivery?.to).toBe("-1001234567890");
+    expect(diskJob?.delivery?.mode).toBe("announce");
+
+    await store.cleanup();
+  });
+
+  it("new service reads correct state after old service stopGraceful (#30098)", async () => {
+    const store = await makeStorePath();
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [makeFutureJob("replace-job")],
+    });
+
+    // Old service: start, update delivery config
+    const oldCron = makeCronService(store.storePath);
+    await oldCron.start();
+    await oldCron.update("replace-job", {
+      delivery: { mode: "announce", channel: "slack", to: "#alerts" },
+    });
+
+    // Gracefully stop (simulates hot reload cron restart)
+    await oldCron.stopGraceful();
+
+    // New replacement service loads from disk
+    const newCron = makeCronService(store.storePath);
+    await newCron.start();
+
+    const jobs = await newCron.list({ includeDisabled: true });
+    const updated = jobs.find((j) => j.id === "replace-job");
+    expect(updated?.delivery?.mode).toBe("announce");
+    expect(updated?.delivery?.channel).toBe("slack");
+    expect(updated?.delivery?.to).toBe("#alerts");
+
+    newCron.stop();
+    await store.cleanup();
+  });
+
+  it("stopGraceful is safe to call when store is not loaded", async () => {
+    const store = await makeStorePath();
+    await writeCronStoreSnapshot({ storePath: store.storePath, jobs: [] });
+
+    // Create service but do NOT call start() — store is null
+    const cron = makeCronService(store.storePath);
+    await expect(cron.stopGraceful()).resolves.toBeUndefined();
+
+    await store.cleanup();
+  });
+});

--- a/src/cron/service.stop-graceful.test.ts
+++ b/src/cron/service.stop-graceful.test.ts
@@ -2,8 +2,15 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import {
+  clearCommandLane,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
+import { CommandLane } from "../process/lanes.js";
 import { CronService } from "./service.js";
-import { writeCronStoreSnapshot } from "./service.test-harness.js";
+import { createDeferred, writeCronStoreSnapshot } from "./service.test-harness.js";
+import { locked } from "./service/locked.js";
+import { stopGraceful as stopGracefulOp } from "./service/ops.js";
 import { createCronServiceState } from "./service/state.js";
 import { armTimer } from "./service/timer.js";
 import { loadCronStore } from "./store.js";
@@ -126,6 +133,157 @@ describe("CronService.stopGraceful", () => {
     // Create service but do NOT call start() — store is null
     const cron = makeCronService(store.storePath);
     await expect(cron.stopGraceful()).resolves.toBeUndefined();
+
+    await store.cleanup();
+  });
+
+  it("waits for an in-flight locked() operation before returning", async () => {
+    const store = await makeStorePath();
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [makeFutureJob("inflight-job")],
+    });
+
+    const state = createCronServiceState({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    state.store = { version: 1, jobs: [makeFutureJob("inflight-job")] };
+
+    // Hold the locked() chain open with a deferred.  This simulates an
+    // in-flight timer tick or API mutation that hasn't finished persisting
+    // at the moment hot reload begins.
+    const release = createDeferred<void>();
+    let lockedOpResolved = false;
+    const lockedOp = locked(state, async () => {
+      await release.promise;
+      lockedOpResolved = true;
+    });
+
+    // Yield one microtask so the locked op is actually running (not just queued).
+    await Promise.resolve();
+
+    // Start stopGraceful while the lock is held.
+    let stopGracefulResolved = false;
+    const stopPromise = stopGracefulOp(state).then(() => {
+      stopGracefulResolved = true;
+    });
+
+    // Give the event loop a few turns to prove stopGraceful is blocked.
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+    expect(lockedOpResolved).toBe(false);
+    expect(stopGracefulResolved).toBe(false);
+
+    // Release the in-flight op.  stopGraceful must only resolve after.
+    release.resolve();
+    await lockedOp;
+    expect(lockedOpResolved).toBe(true);
+    await stopPromise;
+    expect(stopGracefulResolved).toBe(true);
+
+    await store.cleanup();
+  });
+
+  it("drains in-flight enqueueRun manual runs before returning", async () => {
+    // Isolate from any lane state leaked by prior tests in this process.
+    clearCommandLane(CommandLane.Cron);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+
+    const store = await makeStorePath();
+    // Seed a job with a FUTURE nextRunAtMs so startup catch-up does not
+    // pick it up; we'll trigger it manually via enqueueRun("force").
+    const seedJob = makeFutureJob("manual-run-job");
+    seedJob.state.nextRunAtMs = Date.now() + 3600_000;
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [seedJob],
+    });
+
+    // Deferred runIsolatedAgentJob — the manual run pauses here, inside
+    // executeJobCoreWithTimeout, which runs OUTSIDE the locked() queue.
+    // stopGraceful must wait for this to resolve, then for the subsequent
+    // finishPreparedManualRun persist, before returning.
+    const agentJobRelease = createDeferred<{ status: "ok" }>();
+    const runIsolatedAgentJob = vi.fn(async () => {
+      return await agentJobRelease.promise;
+    });
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: runIsolatedAgentJob as never,
+    });
+    await cron.start();
+
+    // Dispatch a manual run on CommandLane.Cron.  It will block inside
+    // executeJobCoreWithTimeout on agentJobRelease.
+    const enqueueResult = await cron.enqueueRun("manual-run-job", "force");
+    expect(enqueueResult.ok).toBe(true);
+
+    // Wait until the isolated job runner has actually been invoked — this
+    // confirms the manual run has passed the prepare-phase locked() block
+    // and is now running outside the lock, which is the scenario the
+    // original PR's drain did NOT cover.
+    for (let i = 0; i < 100 && runIsolatedAgentJob.mock.calls.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(runIsolatedAgentJob).toHaveBeenCalled();
+
+    // stopGraceful must now block until we release the manual run.
+    let stopResolved = false;
+    const stopPromise = cron.stopGraceful().then(() => {
+      stopResolved = true;
+    });
+
+    // Prove blocked: wait a short real-time window while the deferred is
+    // unresolved, stopGraceful must not have returned.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stopResolved).toBe(false);
+
+    // Release the isolated job runner — manual run completes,
+    // finishPreparedManualRun persists, stopGraceful resolves.
+    agentJobRelease.resolve({ status: "ok" });
+    await stopPromise;
+    expect(stopResolved).toBe(true);
+
+    // On-disk state must reflect the completed manual run: nextRunAtMs
+    // recomputed for the next schedule, runningAtMs cleared.
+    const diskStore = await loadCronStore(store.storePath);
+    const diskJob = diskStore.jobs.find((j) => j.id === "manual-run-job");
+    expect(diskJob).toBeDefined();
+    expect(diskJob?.state.runningAtMs).toBeUndefined();
+    expect(diskJob?.state.lastRunAtMs).toBeDefined();
+
+    await store.cleanup();
+  });
+
+  it("rejects new enqueueRun after stopGraceful begins", async () => {
+    clearCommandLane(CommandLane.Cron);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+
+    const store = await makeStorePath();
+    const seedJob = makeFutureJob("reject-after-stop");
+    seedJob.state.nextRunAtMs = Date.now() + 3600_000;
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [seedJob],
+    });
+
+    const cron = makeCronService(store.storePath);
+    await cron.start();
+    await cron.stopGraceful();
+
+    const result = await cron.enqueueRun("reject-after-stop", "force");
+    expect(result.ok).toBe(false);
 
     await store.cleanup();
   });

--- a/src/cron/service.stop-graceful.test.ts
+++ b/src/cron/service.stop-graceful.test.ts
@@ -12,7 +12,7 @@ import { createDeferred, writeCronStoreSnapshot } from "./service.test-harness.j
 import { locked } from "./service/locked.js";
 import { stopGraceful as stopGracefulOp } from "./service/ops.js";
 import { createCronServiceState } from "./service/state.js";
-import { armTimer } from "./service/timer.js";
+import { armTimer, onTimer } from "./service/timer.js";
 import { loadCronStore } from "./store.js";
 import type { CronJob } from "./types.js";
 
@@ -259,6 +259,79 @@ describe("CronService.stopGraceful", () => {
     // recomputed for the next schedule, runningAtMs cleared.
     const diskStore = await loadCronStore(store.storePath);
     const diskJob = diskStore.jobs.find((j) => j.id === "manual-run-job");
+    expect(diskJob).toBeDefined();
+    expect(diskJob?.state.runningAtMs).toBeUndefined();
+    expect(diskJob?.state.lastRunAtMs).toBeDefined();
+
+    await store.cleanup();
+  });
+
+  it("drains an in-flight timer tick's worker + phase-3 persist", async () => {
+    const store = await makeStorePath();
+    const seedJob = makeFutureJob("timer-tick-job");
+    // Set nextRunAtMs in the past so collectRunnableJobs picks it up.
+    seedJob.state.nextRunAtMs = Date.now() - 1_000;
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [seedJob],
+    });
+
+    // Deferred runner — the timer tick's worker phase (outside locked())
+    // pauses here until we resolve.  If stopGraceful were to return
+    // before the tick resolves, the tick's phase-3 persist would write
+    // to disk *after* the replacement service loaded — the exact race
+    // the reviewer flagged.
+    const agentJobRelease = createDeferred<{ status: "ok" }>();
+    const runIsolatedAgentJob = vi.fn(async () => {
+      return await agentJobRelease.promise;
+    });
+
+    const state = createCronServiceState({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: runIsolatedAgentJob as never,
+    });
+    // Load store so onTimer can observe the seeded job.
+    state.store = {
+      version: 1,
+      jobs: [{ ...seedJob, state: { ...seedJob.state } }],
+    };
+
+    // Kick the tick manually (do not await — onTimer is fire-and-forget
+    // from setTimeout in production).
+    void onTimer(state);
+
+    // Wait until the worker phase has been entered — at that point the
+    // tick is past the phase-1 locked() block and suspended outside
+    // the lock, which is the race window.
+    for (let i = 0; i < 100 && runIsolatedAgentJob.mock.calls.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(runIsolatedAgentJob).toHaveBeenCalled();
+
+    // stopGraceful must wait for the tick to finish its worker phase
+    // AND its phase-3 persist, even though the tick's locked() blocks
+    // are not currently held at this moment.
+    let stopResolved = false;
+    const stopPromise = stopGracefulOp(state).then(() => {
+      stopResolved = true;
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stopResolved).toBe(false);
+
+    // Release the worker — tick completes phase-3 persist, stopGraceful
+    // resolves only after that persist lands.
+    agentJobRelease.resolve({ status: "ok" });
+    await stopPromise;
+    expect(stopResolved).toBe(true);
+
+    // On-disk state must reflect the completed tick run.
+    const diskStore = await loadCronStore(store.storePath);
+    const diskJob = diskStore.jobs.find((j) => j.id === "timer-tick-job");
     expect(diskJob).toBeDefined();
     expect(diskJob?.state.runningAtMs).toBeUndefined();
     expect(diskJob?.state.lastRunAtMs).toBeDefined();

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -246,6 +246,7 @@ export function createMockCronStateForJobs(params: {
     storeFileMtimeMs: null,
     op: Promise.resolve(),
     warnedDisabled: false,
+    inFlightManualRuns: new Set(),
     deps: {
       storePath: "/mock/path",
       cronEnabled: true,

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -240,6 +240,7 @@ export function createMockCronStateForJobs(params: {
   return {
     store: { version: 1, jobs: params.jobs },
     running: false,
+    stopping: false,
     timer: null,
     storeLoadedAtMs: nowMs,
     storeFileMtimeMs: null,

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -246,7 +246,7 @@ export function createMockCronStateForJobs(params: {
     storeFileMtimeMs: null,
     op: Promise.resolve(),
     warnedDisabled: false,
-    inFlightManualRuns: new Set(),
+    inFlightRuns: new Set(),
     deps: {
       storePath: "/mock/path",
       cronEnabled: true,

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -30,6 +30,16 @@ export class CronService implements CronServiceContract {
     ops.stop(this.state);
   }
 
+  /**
+   * Gracefully stop: drain in-flight operations and flush state to disk.
+   * Use this instead of `stop()` when replacing the service (e.g. during
+   * hot config reload) to prevent the old instance from overwriting
+   * changes loaded by the new one.
+   */
+  async stopGraceful() {
+    await ops.stopGraceful(this.state);
+  }
+
   async status() {
     return await ops.status(this.state);
   }

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -28,6 +28,7 @@ function createMockState(jobs: CronJob[]): CronServiceState {
     store,
     timer: null,
     running: false,
+    stopping: false,
   } as unknown as CronServiceState;
 }
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -147,24 +147,40 @@ export function stop(state: CronServiceState) {
 
 /**
  * Gracefully stop the cron scheduler: cancel the timer, wait for any
- * in-flight locked operation to complete, and flush in-memory state to disk.
+ * in-flight operation to complete, and flush in-memory state to disk.
  * This prevents a write-after-read race when the service is rebuilt during
  * a hot config reload — without draining, the old service's in-flight
  * persist can overwrite changes already loaded by the replacement service.
  *
- * NOTE: Jobs dispatched via `enqueueRun` execute outside the `locked()` queue
- * (in `CommandLane.Cron`). If a manual run is in-flight when this is called,
- * its final persist may still race with the replacement service. A complete
- * fix would require draining the command lane, which is out of scope here.
+ * Drains two independent execution paths:
+ *  1. `locked()` operations (timer ticks, API mutations, status/list).
+ *  2. `enqueueRun` manual runs dispatched on `CommandLane.Cron`, which
+ *     execute outside `locked()`.  Their final persist happens inside
+ *     `finishPreparedManualRun`'s own locked block, which is covered by
+ *     the locked-queue drain below once the manual run returns.
  */
 export async function stopGraceful(state: CronServiceState) {
-  // Signal armTimer/onTimer to stop re-arming the scheduler.
+  // Signal armTimer/onTimer to stop re-arming the scheduler and reject
+  // new enqueueRun dispatches.  Snapshot pending manual runs *after* the
+  // flag is set so no new additions slip in after the snapshot.
   state.stopping = true;
   stopTimer(state);
-  // Drain the in-flight operation queue so no pending persist can fire
-  // after the caller creates a replacement CronService.  The `locked()`
-  // call waits for any active onTimer tick's locked block to finish, and
-  // the `stopping` flag prevents the tick's finally block from re-arming.
+  const pendingManualRuns = [...state.inFlightManualRuns];
+
+  // Wait for manual runs to return.  Each run's task body awaits `run()`,
+  // which awaits both `prepareManualRun` and `finishPreparedManualRun`;
+  // the latter is the one that persists job completion state.  Settling
+  // these promises guarantees that any manual-run persist has entered
+  // the locked() chain (or already landed).
+  if (pendingManualRuns.length > 0) {
+    await Promise.allSettled(pendingManualRuns);
+  }
+
+  // Drain the locked() chain.  Waits for any in-flight locked block
+  // (including a just-finished manual run's `finishPreparedManualRun`
+  // persist that may still be chained behind us) and then flushes
+  // current in-memory state to disk.  The `stopping` flag prevents a
+  // tick's finally block from re-arming the timer after this returns.
   await locked(state, async () => {
     // Final timer kill inside the lock in case an in-flight operation
     // called armTimer() between our stopTimer() above and acquiring the lock.
@@ -732,13 +748,21 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
 }
 
 export async function enqueueRun(state: CronServiceState, id: string, mode?: "due" | "force") {
+  if (state.stopping) {
+    return { ok: false } as const;
+  }
   const disposition = await inspectManualRunDisposition(state, id, mode);
   if (!disposition.ok || !("runnable" in disposition && disposition.runnable)) {
     return disposition;
   }
+  // Recheck after the disposition await so a stopGraceful that landed
+  // while we were suspended is honored before we enqueue on the lane.
+  if (state.stopping) {
+    return { ok: false } as const;
+  }
 
   const runId = `manual:${id}:${state.deps.nowMs()}:${nextManualRunId++}`;
-  void enqueueCommandInLane(
+  const runPromise = enqueueCommandInLane(
     CommandLane.Cron,
     async () => {
       const result = await run(state, id, mode);
@@ -759,7 +783,15 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
         );
       },
     },
-  ).catch((err) => {
+  );
+  // Track so stopGraceful can drain it.  Register removal before the
+  // `.catch(...)` so settle-cleanup runs regardless of outcome.
+  state.inFlightManualRuns.add(runPromise);
+  const cleanup = () => {
+    state.inFlightManualRuns.delete(runPromise);
+  };
+  runPromise.then(cleanup, cleanup);
+  runPromise.catch((err) => {
     state.deps.log.error(
       { jobId: id, runId, err: String(err) },
       "cron: queued manual run background execution failed",

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -145,6 +145,24 @@ export function stop(state: CronServiceState) {
   stopTimer(state);
 }
 
+/**
+ * Gracefully stop the cron scheduler: cancel the timer, wait for any
+ * in-flight locked operation to complete, and flush in-memory state to disk.
+ * This prevents a write-after-read race when the service is rebuilt during
+ * a hot config reload — without draining, the old service's in-flight
+ * persist can overwrite changes already loaded by the replacement service.
+ */
+export async function stopGraceful(state: CronServiceState) {
+  stopTimer(state);
+  // Drain the in-flight operation queue so no pending persist can fire
+  // after the caller creates a replacement CronService.
+  await locked(state, async () => {
+    if (state.store) {
+      await persist(state);
+    }
+  });
+}
+
 export async function status(state: CronServiceState) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -152,35 +152,38 @@ export function stop(state: CronServiceState) {
  * a hot config reload — without draining, the old service's in-flight
  * persist can overwrite changes already loaded by the replacement service.
  *
- * Drains two independent execution paths:
- *  1. `locked()` operations (timer ticks, API mutations, status/list).
- *  2. `enqueueRun` manual runs dispatched on `CommandLane.Cron`, which
- *     execute outside `locked()`.  Their final persist happens inside
- *     `finishPreparedManualRun`'s own locked block, which is covered by
- *     the locked-queue drain below once the manual run returns.
+ * Drains every execution path that can produce a post-return persist:
+ *  1. `state.inFlightRuns` — timer ticks (`onTimer`) and manual runs
+ *     (`enqueueRun` on `CommandLane.Cron`).  Both run their heavy phase
+ *     outside `locked()` and then re-enter `locked()` to persist the
+ *     outcome; awaiting these promises ensures that final persist has
+ *     entered the chain (or already landed).
+ *  2. The `locked()` chain itself — picks up any late writes queued
+ *     behind us (API mutations or the onTimer phase-3 persist) and
+ *     flushes current in-memory state to disk.
  */
 export async function stopGraceful(state: CronServiceState) {
   // Signal armTimer/onTimer to stop re-arming the scheduler and reject
-  // new enqueueRun dispatches.  Snapshot pending manual runs *after* the
-  // flag is set so no new additions slip in after the snapshot.
+  // new enqueueRun dispatches.  Snapshot pending runs *after* the flag
+  // is set so no new additions slip in after the snapshot.
   state.stopping = true;
   stopTimer(state);
-  const pendingManualRuns = [...state.inFlightManualRuns];
+  const pendingRuns = [...state.inFlightRuns];
 
-  // Wait for manual runs to return.  Each run's task body awaits `run()`,
-  // which awaits both `prepareManualRun` and `finishPreparedManualRun`;
-  // the latter is the one that persists job completion state.  Settling
-  // these promises guarantees that any manual-run persist has entered
-  // the locked() chain (or already landed).
-  if (pendingManualRuns.length > 0) {
-    await Promise.allSettled(pendingManualRuns);
+  // Wait for timer ticks and manual runs to complete.  Each tick ends
+  // with its phase-3 locked() persist before the tick promise settles;
+  // manual runs end with finishPreparedManualRun's locked() persist.
+  // Settling these promises guarantees those persists have entered the
+  // locked() chain (or already landed).
+  if (pendingRuns.length > 0) {
+    await Promise.allSettled(pendingRuns);
   }
 
   // Drain the locked() chain.  Waits for any in-flight locked block
-  // (including a just-finished manual run's `finishPreparedManualRun`
-  // persist that may still be chained behind us) and then flushes
-  // current in-memory state to disk.  The `stopping` flag prevents a
-  // tick's finally block from re-arming the timer after this returns.
+  // (a late tail from a just-finished tick/manual-run, plus any
+  // concurrent API mutation) and then flushes current in-memory state
+  // to disk.  The `stopping` flag prevents a tick's finally from
+  // re-arming the timer after this returns.
   await locked(state, async () => {
     // Final timer kill inside the lock in case an in-flight operation
     // called armTimer() between our stopTimer() above and acquiring the lock.
@@ -786,9 +789,9 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
   );
   // Track so stopGraceful can drain it.  Register removal before the
   // `.catch(...)` so settle-cleanup runs regardless of outcome.
-  state.inFlightManualRuns.add(runPromise);
+  state.inFlightRuns.add(runPromise);
   const cleanup = () => {
-    state.inFlightManualRuns.delete(runPromise);
+    state.inFlightRuns.delete(runPromise);
   };
   runPromise.then(cleanup, cleanup);
   runPromise.catch((err) => {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -151,14 +151,33 @@ export function stop(state: CronServiceState) {
  * This prevents a write-after-read race when the service is rebuilt during
  * a hot config reload — without draining, the old service's in-flight
  * persist can overwrite changes already loaded by the replacement service.
+ *
+ * NOTE: Jobs dispatched via `enqueueRun` execute outside the `locked()` queue
+ * (in `CommandLane.Cron`). If a manual run is in-flight when this is called,
+ * its final persist may still race with the replacement service. A complete
+ * fix would require draining the command lane, which is out of scope here.
  */
 export async function stopGraceful(state: CronServiceState) {
+  // Signal armTimer/onTimer to stop re-arming the scheduler.
+  state.stopping = true;
   stopTimer(state);
   // Drain the in-flight operation queue so no pending persist can fire
-  // after the caller creates a replacement CronService.
+  // after the caller creates a replacement CronService.  The `locked()`
+  // call waits for any active onTimer tick's locked block to finish, and
+  // the `stopping` flag prevents the tick's finally block from re-arming.
   await locked(state, async () => {
+    // Final timer kill inside the lock in case an in-flight operation
+    // called armTimer() between our stopTimer() above and acquiring the lock.
+    stopTimer(state);
     if (state.store) {
-      await persist(state);
+      try {
+        await persist(state);
+      } catch (err) {
+        state.deps.log.warn(
+          { err: String(err) },
+          "cron: stopGraceful persist failed, proceeding with shutdown",
+        );
+      }
     }
   });
 }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -134,12 +134,17 @@ export type CronServiceState = {
   warnedDisabled: boolean;
   storeLoadedAtMs: number | null;
   storeFileMtimeMs: number | null;
-  /** Tracks in-flight promises returned by `enqueueCommandInLane` for
-   *  manual runs (CommandLane.Cron).  Those runs execute outside the
-   *  `locked()` queue, so `stopGraceful` awaits this set to ensure
-   *  `finishPreparedManualRun`'s final persist lands before the
-   *  replacement service loads from disk — see #30098. */
-  inFlightManualRuns: Set<Promise<unknown>>;
+  /** Tracks in-flight run promises whose final persist happens outside
+   *  the `locked()` queue:
+   *    - Timer ticks (`onTimer`): the worker phase runs outside the lock
+   *      between the phase-1 running-marker persist and the phase-3
+   *      outcome persist.
+   *    - Manual runs via `enqueueRun` on `CommandLane.Cron`:
+   *      `executeJobCoreWithTimeout` runs outside the lock between
+   *      `prepareManualRun` and `finishPreparedManualRun`.
+   *  `stopGraceful` awaits this set so those deferred persists land
+   *  before the replacement service loads from disk — see #30098. */
+  inFlightRuns: Set<Promise<unknown>>;
 };
 
 export function createCronServiceState(deps: CronServiceDeps): CronServiceState {
@@ -153,7 +158,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     warnedDisabled: false,
     storeLoadedAtMs: null,
     storeFileMtimeMs: null,
-    inFlightManualRuns: new Set(),
+    inFlightRuns: new Set(),
   };
 }
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -126,6 +126,9 @@ export type CronServiceState = {
   store: CronStoreFile | null;
   timer: NodeJS.Timeout | null;
   running: boolean;
+  /** Set by `stopGraceful` to prevent `armTimer`/`onTimer` from re-arming
+   *  the scheduler after the service has begun shutting down. */
+  stopping: boolean;
   op: Promise<unknown>;
   warnedDisabled: boolean;
   storeLoadedAtMs: number | null;
@@ -138,6 +141,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     store: null,
     timer: null,
     running: false,
+    stopping: false,
     op: Promise.resolve(),
     warnedDisabled: false,
     storeLoadedAtMs: null,

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -127,12 +127,19 @@ export type CronServiceState = {
   timer: NodeJS.Timeout | null;
   running: boolean;
   /** Set by `stopGraceful` to prevent `armTimer`/`onTimer` from re-arming
-   *  the scheduler after the service has begun shutting down. */
+   *  the scheduler, and to reject new `enqueueRun` dispatches, after the
+   *  service has begun shutting down. */
   stopping: boolean;
   op: Promise<unknown>;
   warnedDisabled: boolean;
   storeLoadedAtMs: number | null;
   storeFileMtimeMs: number | null;
+  /** Tracks in-flight promises returned by `enqueueCommandInLane` for
+   *  manual runs (CommandLane.Cron).  Those runs execute outside the
+   *  `locked()` queue, so `stopGraceful` awaits this set to ensure
+   *  `finishPreparedManualRun`'s final persist lands before the
+   *  replacement service loads from disk — see #30098. */
+  inFlightManualRuns: Set<Promise<unknown>>;
 };
 
 export function createCronServiceState(deps: CronServiceDeps): CronServiceState {
@@ -146,6 +153,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     warnedDisabled: false,
     storeLoadedAtMs: null,
     storeFileMtimeMs: null,
+    inFlightManualRuns: new Set(),
   };
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -708,6 +708,22 @@ export async function onTimer(state: CronServiceState) {
     armRunningRecheckTimer(state);
     return;
   }
+  // Track the tick body so `stopGraceful` can wait for the worker phase
+  // (outside the `locked()` queue) and the post-worker phase-3 persist
+  // to complete before the replacement service loads from disk.  The
+  // add happens synchronously between `runTimerTickBody(state)` starting
+  // and the first `await` inside it, so it is visible to any later
+  // `stopGraceful` snapshot.
+  const tickPromise = runTimerTickBody(state);
+  state.inFlightRuns.add(tickPromise);
+  try {
+    await tickPromise;
+  } finally {
+    state.inFlightRuns.delete(tickPromise);
+  }
+}
+
+async function runTimerTickBody(state: CronServiceState) {
   state.running = true;
   // Keep a watchdog timer armed while a tick is executing. If execution hangs
   // (for example in a provider call), the scheduler still wakes to re-check.

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -616,6 +616,9 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
 }
 
 export function armTimer(state: CronServiceState) {
+  if (state.stopping) {
+    return;
+  }
   if (state.timer) {
     clearTimeout(state.timer);
   }
@@ -674,6 +677,9 @@ export function armTimer(state: CronServiceState) {
 }
 
 function armRunningRecheckTimer(state: CronServiceState) {
+  if (state.stopping) {
+    return;
+  }
   if (state.timer) {
     clearTimeout(state.timer);
   }
@@ -685,6 +691,9 @@ function armRunningRecheckTimer(state: CronServiceState) {
 }
 
 export async function onTimer(state: CronServiceState) {
+  if (state.stopping) {
+    return;
+  }
   if (state.running) {
     // Re-arm the timer so the scheduler keeps ticking even when a job is
     // still executing.  Without this, a long-running job (e.g. an agentTurn

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -134,7 +134,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     resetDirectoryCache();
 
     if (plan.restartCron) {
-      state.cronState.cron.stop();
+      await state.cronState.cron.stopGraceful();
       nextState.cronState = buildGatewayCronService({
         cfg: nextConfig,
         deps: params.deps,


### PR DESCRIPTION
## Summary

- Add `CronService.stopGraceful()` that drains the in-flight operation queue and flushes in-memory state to disk before returning
- Use `stopGraceful()` in the hot config reload path (`server-reload-handlers.ts`) instead of the synchronous `stop()`
- Prevents a write-after-read race where the old service's pending persist overwrites changes loaded by the replacement service

Fixes #30098

## Problem

When `config.patch` changes a `cron.*` key, the hot reload handler calls `cron.stop()` (synchronous — only clears the timer) then immediately creates a replacement `CronService` that loads `jobs.json` from disk. If the old service had an in-flight locked operation (e.g., a timer tick executing a job), that operation continues running after `stop()` returns. When it completes, it calls `persist()`, writing the old service's stale in-memory state to disk — overwriting the file that the new service already loaded.

The result: API-modified job properties (delivery config, enabled state, etc.) revert to their pre-update values after any `cron.*` config change.

## Root Cause

`stop()` in `src/cron/service/ops.ts:133` only calls `stopTimer()`:
```typescript
export function stop(state: CronServiceState) {
  stopTimer(state);
}
```

It does not wait for in-flight operations or flush state. The `locked()` queue continues executing after `stop()` returns.

## Fix

New `stopGraceful()` method:
1. Cancels the timer (same as `stop()`)
2. Enters the `locked()` queue — this waits for any in-flight operation to complete
3. Flushes in-memory state to disk via `persist()`
4. Returns only when the service is fully quiescent

The hot reload handler (`server-reload-handlers.ts:75`) now `await`s `stopGraceful()` before creating the replacement service.

The synchronous `stop()` is preserved for the process shutdown path (`server-close.ts`) where draining is unnecessary.

## Files Changed

- `src/cron/service/ops.ts` — Add `stopGraceful()` function
- `src/cron/service.ts` — Expose `stopGraceful()` on `CronService` class
- `src/gateway/server-reload-handlers.ts` — Use `await stopGraceful()` in hot reload
- `src/cron/service.stop-graceful.test.ts` — 3 regression tests

## Testing

- 3 new tests: flush-to-disk, service replacement state preservation, safe-when-unloaded
- All existing cron tests pass
- `pnpm build`, `pnpm check` clean

## AI Disclosure

This PR was authored with AI assistance (OpenCode/Claude). The changes have been reviewed and tested locally. Degree of testing: fully tested against existing + new test suite.