### PR TITLE
Fix malformed assistant replay content in session sanitization

### DIFF
--- a/src/agents/pi-embedded-helpers.images.log.test.ts
+++ b/src/agents/pi-embedded-helpers.images.log.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
+
+const warnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../logging/subsystem.js", () => {
+  const makeLogger = () => ({
+    subsystem: "agent/embedded",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: () => makeLogger(),
+  });
+  return { createSubsystemLogger: () => makeLogger() };
+});
+
+import { sanitizeSessionMessagesImages } from "./pi-embedded-helpers.js";
+
+describe("sanitizeSessionMessagesImages logging", () => {
+  beforeEach(() => {
+    warnMock.mockClear();
+  });
+
+  it("warns when dropping unrecognized assistant replay object content", async () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: { type: 42, payload: "unexpected-shape" },
+        stopReason: "error",
+        timestamp: 1,
+      },
+    ]);
+
+    await sanitizeSessionMessagesImages(input, "test-replay");
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0]?.[0]).toContain(
+      "dropping unrecognized assistant replay content object during session sanitization",
+    );
+    expect(warnMock.mock.calls[0]?.[1]).toMatchObject({
+      label: "test-replay",
+      contentKeys: ["type", "payload"],
+      typeType: "number",
+      textType: "undefined",
+    });
+  });
+});

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -268,6 +268,44 @@ describe("sanitizeSessionMessagesImages", () => {
     expect(out[1]?.role).toBe("assistant");
     expect(out[2]?.role).toBe("assistant");
   });
+  it("normalizes malformed assistant error content to an empty array", async () => {
+    const input = castAgentMessages([
+      { role: "user", content: "hello", timestamp: nextTimestamp() } satisfies UserMessage,
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "upstream failed",
+        timestamp: nextTimestamp(),
+      },
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test");
+
+    expect(out).toHaveLength(2);
+    expect(out[1]?.role).toBe("assistant");
+    if (out[1]?.role === "assistant") {
+      expect(Array.isArray(out[1].content)).toBe(true);
+      expect(out[1].content).toEqual([]);
+    }
+  });
+  it("normalizes malformed assistant string content into a text block", async () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: "legacy assistant text",
+        stopReason: "stop",
+        timestamp: nextTimestamp(),
+      },
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test");
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("assistant");
+    if (out[0]?.role === "assistant") {
+      expect(out[0].content).toEqual([{ type: "text", text: "legacy assistant text" }]);
+    }
+  });
   it("leaves non-assistant messages unchanged", async () => {
     const input = [
       { role: "user", content: "hello", timestamp: nextTimestamp() } satisfies UserMessage,

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -306,6 +306,42 @@ describe("sanitizeSessionMessagesImages", () => {
       expect(out[0].content).toEqual([{ type: "text", text: "legacy assistant text" }]);
     }
   });
+  it("normalizes a single assistant object block into an array", async () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: { type: "text", text: "legacy assistant block" },
+        stopReason: "stop",
+        timestamp: nextTimestamp(),
+      },
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test");
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("assistant");
+    if (out[0]?.role === "assistant") {
+      expect(out[0].content).toEqual([{ type: "text", text: "legacy assistant block" }]);
+    }
+  });
+  it("normalizes unrecognized assistant object content to an empty array", async () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: { type: 42, payload: "unexpected" },
+        stopReason: "error",
+        timestamp: nextTimestamp(),
+      },
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test");
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("assistant");
+    if (out[0]?.role === "assistant") {
+      expect(out[0].content).toEqual([]);
+    }
+  });
   it("leaves non-assistant messages unchanged", async () => {
     const input = [
       { role: "user", content: "hello", timestamp: nextTimestamp() } satisfies UserMessage,

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -6,6 +6,7 @@ import { sanitizeContentBlocksImages } from "../tool-images.js";
 import { stripThoughtSignatures } from "./bootstrap.js";
 
 type ContentBlock = AgentToolResult<unknown>["content"][number];
+type AssistantMessage = Extract<AgentMessage, { role: "assistant" }>;
 
 export function isEmptyAssistantMessageContent(
   message: Extract<AgentMessage, { role: "assistant" }>,
@@ -27,6 +28,28 @@ export function isEmptyAssistantMessageContent(
     }
     return typeof rec.text !== "string" || rec.text.trim().length === 0;
   });
+}
+
+function normalizeAssistantReplayContent(content: unknown): AssistantMessage["content"] {
+  if (Array.isArray(content)) {
+    return content as AssistantMessage["content"];
+  }
+  if (typeof content === "string") {
+    if (!content.trim()) {
+      return [] as AssistantMessage["content"];
+    }
+    return [{ type: "text", text: content }] as AssistantMessage["content"];
+  }
+  if (content && typeof content === "object") {
+    const record = content as { type?: unknown; text?: unknown };
+    if (typeof record.type === "string") {
+      return [content as AssistantMessage["content"][number]] as AssistantMessage["content"];
+    }
+    if (typeof record.text === "string") {
+      return [{ type: "text", text: record.text }] as AssistantMessage["content"];
+    }
+  }
+  return [] as AssistantMessage["content"];
 }
 
 export async function sanitizeSessionMessagesImages(
@@ -96,21 +119,21 @@ export async function sanitizeSessionMessagesImages(
 
     if (role === "assistant") {
       const assistantMsg = msg as Extract<AgentMessage, { role: "assistant" }>;
+      const normalizedContent = normalizeAssistantReplayContent(assistantMsg.content);
+      const normalizedAssistantMsg =
+        normalizedContent === assistantMsg.content
+          ? assistantMsg
+          : ({ ...assistantMsg, content: normalizedContent } as typeof assistantMsg);
       if (assistantMsg.stopReason === "error") {
-        const content = assistantMsg.content;
-        if (Array.isArray(content)) {
-          const nextContent = (await sanitizeContentBlocksImages(
-            content as unknown as ContentBlock[],
-            label,
-            imageSanitization,
-          )) as unknown as typeof assistantMsg.content;
-          out.push({ ...assistantMsg, content: nextContent });
-        } else {
-          out.push(assistantMsg);
-        }
+        const nextContent = (await sanitizeContentBlocksImages(
+          normalizedContent as unknown as ContentBlock[],
+          label,
+          imageSanitization,
+        )) as unknown as typeof assistantMsg.content;
+        out.push({ ...normalizedAssistantMsg, content: nextContent });
         continue;
       }
-      const content = assistantMsg.content;
+      const content = normalizedContent;
       if (Array.isArray(content)) {
         if (!allowNonImageSanitization) {
           const nextContent = (await sanitizeContentBlocksImages(
@@ -118,7 +141,7 @@ export async function sanitizeSessionMessagesImages(
             label,
             imageSanitization,
           )) as unknown as typeof assistantMsg.content;
-          out.push({ ...assistantMsg, content: nextContent });
+          out.push({ ...normalizedAssistantMsg, content: nextContent });
           continue;
         }
         const strippedContent = options?.preserveSignatures
@@ -143,7 +166,7 @@ export async function sanitizeSessionMessagesImages(
         if (finalContent.length === 0) {
           continue;
         }
-        out.push({ ...assistantMsg, content: finalContent });
+        out.push({ ...normalizedAssistantMsg, content: finalContent });
         continue;
       }
     }

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { ImageSanitizationLimits } from "../image-sanitization.js";
 import type { ToolCallIdMode } from "../tool-call-id.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
@@ -7,6 +8,7 @@ import { stripThoughtSignatures } from "./bootstrap.js";
 
 type ContentBlock = AgentToolResult<unknown>["content"][number];
 type AssistantMessage = Extract<AgentMessage, { role: "assistant" }>;
+const log = createSubsystemLogger("agent/embedded");
 
 export function isEmptyAssistantMessageContent(
   message: Extract<AgentMessage, { role: "assistant" }>,
@@ -30,7 +32,10 @@ export function isEmptyAssistantMessageContent(
   });
 }
 
-function normalizeAssistantReplayContent(content: unknown): AssistantMessage["content"] {
+function normalizeAssistantReplayContent(
+  content: unknown,
+  context?: { label?: string },
+): AssistantMessage["content"] {
   if (Array.isArray(content)) {
     return content as AssistantMessage["content"];
   }
@@ -48,6 +53,12 @@ function normalizeAssistantReplayContent(content: unknown): AssistantMessage["co
     if (typeof record.text === "string") {
       return [{ type: "text", text: record.text }] as AssistantMessage["content"];
     }
+    log.warn("dropping unrecognized assistant replay content object during session sanitization", {
+      label: context?.label,
+      contentKeys: Object.keys(record).slice(0, 8),
+      typeType: typeof record.type,
+      textType: typeof record.text,
+    });
   }
   return [] as AssistantMessage["content"];
 }
@@ -119,7 +130,7 @@ export async function sanitizeSessionMessagesImages(
 
     if (role === "assistant") {
       const assistantMsg = msg as Extract<AgentMessage, { role: "assistant" }>;
-      const normalizedContent = normalizeAssistantReplayContent(assistantMsg.content);
+      const normalizedContent = normalizeAssistantReplayContent(assistantMsg.content, { label });
       const normalizedAssistantMsg =
         normalizedContent === assistantMsg.content
           ? assistantMsg


### PR DESCRIPTION
## Summary
- normalize malformed assistant replay content in `sanitizeSessionMessagesImages` before transcript replay
- coerce malformed assistant content into provider-safe arrays:
  - string -> text block
  - single block-like object -> one-item array
  - invalid/missing content -> empty array
- apply this normalization to both error and non-error assistant turns so replay never forwards non-iterable `content`
- add regression tests for malformed assistant history entries

## Validation
- `pnpm vitest run src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts src/agents/pi-embedded-runner/sanitize-session-history.tool-result-details.test.ts`
  - failed: existing test `does not synthesize tool call input when missing` in the first file
- `pnpm vitest run src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts -t "normalizes malformed assistant"`
  - passed (2 passed, 13 skipped)
- `pnpm vitest run src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts -t "keeps empty assistant error messages|normalizes malformed assistant"`
  - passed (3 passed, 12 skipped)
- `pnpm vitest run src/agents/pi-embedded-runner/sanitize-session-history.tool-result-details.test.ts`
  - passed (1 passed)

Closes #43795
