### PR TITLE
fix(doctor): clarify lightweight security warning output

### DIFF
--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -86,11 +86,13 @@ describe("noteSecurityWarnings gateway exposure", () => {
     expect(message).toContain("CRITICAL");
   });
 
-  it("skips warning for loopback bind", async () => {
+  it("uses a non-authoritative success message for the lightweight doctor pass", async () => {
     const cfg = { gateway: { bind: "loopback" } } as OpenClawConfig;
     await noteSecurityWarnings(cfg);
     const message = lastMessage();
-    expect(message).toContain("No channel security warnings detected");
+    expect(message).toContain("doctor's lightweight pass");
+    expect(message).toContain("not a full security audit");
+    expect(message).toContain("openclaw security audit --deep");
     expect(message).not.toContain("Gateway bound");
   });
 

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -227,7 +227,13 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
     }
   }
 
-  const lines = warnings.length > 0 ? warnings : ["- No channel security warnings detected."];
+  const lines =
+    warnings.length > 0
+      ? warnings
+      : [
+          "- No channel security warnings detected in the doctor's lightweight pass.",
+          "  This is not a full security audit and may miss deeper findings.",
+        ];
   lines.push(auditHint);
   note(lines.join("\n"), "Security");
 }


### PR DESCRIPTION
## Summary

Fixes #43804 by clarifying that the doctor's clean security message only reflects the lightweight doctor pass, not a full security audit.

## What changed

- Replace the authoritative-sounding clean message in `noteSecurityWarnings()` with wording that explicitly says it is a lightweight pass
- Keep the existing `openclaw security audit --deep` follow-up hint
- Update the focused unit test to assert the new wording

## What did not change

- No changes to the underlying security audit logic
- No new warnings or policy changes
- No broader doctor/status refactor

## Validation

- `git diff --check`
- `node node_modules/.pnpm/vitest@4.0.18_@opentelemetry+api@1.9.0_@types+node@25.4.0_@vitest+browser-playwright@4._03dc94a9d8d699ba7ae9c07d7ca01662/node_modules/vitest/vitest.mjs run src/commands/doctor-security.test.ts`

AI-assisted with Codex.