### PR TITLE
fix(feishu): preserve non-ASCII filenames for file uploads

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -39,12 +39,7 @@ vi.mock("./runtime.js", () => ({
   }),
 }));
 
-import {
-  downloadImageFeishu,
-  downloadMessageResourceFeishu,
-  sanitizeFileNameForUpload,
-  sendMediaFeishu,
-} from "./media.js";
+import { downloadImageFeishu, downloadMessageResourceFeishu, sendMediaFeishu } from "./media.js";
 
 function expectPathIsolatedToTmpRoot(pathValue: string, key: string): void {
   expect(pathValue).not.toContain(key);
@@ -381,7 +376,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageResourceGetMock).not.toHaveBeenCalled();
   });
 
-  it("encodes Chinese filenames for file uploads", async () => {
+  it("preserves Chinese filenames for file uploads", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -390,8 +385,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     const createCall = fileCreateMock.mock.calls[0][0];
-    expect(createCall.data.file_name).not.toBe("测试文档.pdf");
-    expect(createCall.data.file_name).toBe(encodeURIComponent("测试文档") + ".pdf");
+    expect(createCall.data.file_name).toBe("测试文档.pdf");
   });
 
   it("preserves ASCII filenames unchanged for file uploads", async () => {
@@ -406,7 +400,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(createCall.data.file_name).toBe("report-2026.pdf");
   });
 
-  it("encodes special characters (em-dash, full-width brackets) in filenames", async () => {
+  it("preserves special characters (em-dash, full-width brackets) in filenames", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -415,68 +409,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     const createCall = fileCreateMock.mock.calls[0][0];
-    expect(createCall.data.file_name).toMatch(/\.md$/);
-    expect(createCall.data.file_name).not.toContain("—");
-    expect(createCall.data.file_name).not.toContain("（");
-  });
-});
-
-describe("sanitizeFileNameForUpload", () => {
-  it("returns ASCII filenames unchanged", () => {
-    expect(sanitizeFileNameForUpload("report.pdf")).toBe("report.pdf");
-    expect(sanitizeFileNameForUpload("my-file_v2.txt")).toBe("my-file_v2.txt");
-  });
-
-  it("encodes Chinese characters in basename, preserves extension", () => {
-    const result = sanitizeFileNameForUpload("测试文件.md");
-    expect(result).toBe(encodeURIComponent("测试文件") + ".md");
-    expect(result).toMatch(/\.md$/);
-  });
-
-  it("encodes em-dash and full-width brackets", () => {
-    const result = sanitizeFileNameForUpload("文件—说明（v2）.pdf");
-    expect(result).toMatch(/\.pdf$/);
-    expect(result).not.toContain("—");
-    expect(result).not.toContain("（");
-    expect(result).not.toContain("）");
-  });
-
-  it("encodes single quotes and parentheses per RFC 5987", () => {
-    const result = sanitizeFileNameForUpload("文件'(test).txt");
-    expect(result).toContain("%27");
-    expect(result).toContain("%28");
-    expect(result).toContain("%29");
-    expect(result).toMatch(/\.txt$/);
-  });
-
-  it("handles filenames without extension", () => {
-    const result = sanitizeFileNameForUpload("测试文件");
-    expect(result).toBe(encodeURIComponent("测试文件"));
-  });
-
-  it("handles mixed ASCII and non-ASCII", () => {
-    const result = sanitizeFileNameForUpload("Report_报告_2026.xlsx");
-    expect(result).toMatch(/\.xlsx$/);
-    expect(result).not.toContain("报告");
-  });
-
-  it("encodes non-ASCII extensions", () => {
-    const result = sanitizeFileNameForUpload("报告.文档");
-    expect(result).toContain("%E6%96%87%E6%A1%A3");
-    expect(result).not.toContain("文档");
-  });
-
-  it("encodes emoji filenames", () => {
-    const result = sanitizeFileNameForUpload("report_😀.txt");
-    expect(result).toContain("%F0%9F%98%80");
-    expect(result).toMatch(/\.txt$/);
-  });
-
-  it("encodes mixed ASCII and non-ASCII extensions", () => {
-    const result = sanitizeFileNameForUpload("notes_总结.v测试");
-    expect(result).toContain("notes_");
-    expect(result).toContain("%E6%B5%8B%E8%AF%95");
-    expect(result).not.toContain("测试");
+    expect(createCall.data.file_name).toBe("报告—详情（2026）.md");
   });
 });
 

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -219,24 +219,6 @@ export async function uploadImageFeishu(params: {
 }
 
 /**
- * Encode a filename for safe use in Feishu multipart/form-data uploads.
- * Non-ASCII characters (Chinese, em-dash, full-width brackets, etc.) cause
- * the upload to silently fail when passed raw through the SDK's form-data
- * serialization.  RFC 5987 percent-encoding keeps headers 7-bit clean while
- * Feishu's server decodes and preserves the original display name.
- */
-export function sanitizeFileNameForUpload(fileName: string): string {
-  const ASCII_ONLY = /^[\x20-\x7E]+$/;
-  if (ASCII_ONLY.test(fileName)) {
-    return fileName;
-  }
-  return encodeURIComponent(fileName)
-    .replace(/'/g, "%27")
-    .replace(/\(/g, "%28")
-    .replace(/\)/g, "%29");
-}
-
-/**
  * Upload a file to Feishu and get a file_key for sending.
  * Max file size: 30MB
  */
@@ -264,12 +246,10 @@ export async function uploadFileFeishu(params: {
   // See: https://github.com/larksuite/node-sdk/issues/121
   const fileData = typeof file === "string" ? fs.createReadStream(file) : file;
 
-  const safeFileName = sanitizeFileNameForUpload(fileName);
-
   const response = await client.im.file.create({
     data: {
       file_type: fileType,
-      file_name: safeFileName,
+      file_name: fileName,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       file: fileData as any,
       ...(duration !== undefined && { duration }),


### PR DESCRIPTION
## Summary

- Problem: Feishu file uploads percent-encoded non-ASCII `file_name` values before upload.
- Why it matters: recipients saw URL-encoded filenames like `%E7%A4%BA%E4%BE%8B.pdf` instead of human-readable names.
- What changed: removed non-ASCII filename percent-encoding in Feishu upload path and preserved original `file_name` values.
- What did NOT change (scope boundary): no changes to media type routing, upload transport, or non-Feishu channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43840
- Related #31328

## User-visible / Behavior Changes

- Feishu/Lark file messages now keep original non-ASCII filenames (Chinese/special characters) instead of showing URL-encoded names.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): default mocked Feishu account in test

### Steps

1. Send a file via Feishu path with non-ASCII filename (e.g. `测试文档.pdf`).
2. Inspect upload payload `im.file.create` `data.file_name`.
3. Verify filename passed to Feishu remains human-readable.

### Expected

- Non-ASCII filenames are preserved as-is.

### Actual

- Verified in tests: `data.file_name` equals original non-ASCII filename.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/feishu/src/media.test.ts`
  - Result: `1 passed`, `18 passed` tests.
  - Assertions now verify preserved Chinese and special-character filenames in Feishu upload call payload.
- Edge cases checked:
  - ASCII filenames remain unchanged.
  - Special characters (em-dash/full-width brackets) remain unchanged.
- What you did **not** verify:
  - Live Feishu API run in a real tenant.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `extensions/feishu/src/media.ts`, `extensions/feishu/src/media.test.ts`.
- Known bad symptoms reviewers should watch for: Feishu upload failures for some non-ASCII filenames.

## Risks and Mitigations

- Risk: Some environments may still require encoded multipart filename handling.
  - Mitigation: behavior is covered by focused Feishu media tests and rollback is one commit.
