### PR TITLE
fix: enable OpenAI-compatible anthropic tool payloads for kimi-coding

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -840,8 +840,7 @@ describe("applyExtraParamsToAgent", () => {
       function: { name: "read" },
     });
   });
-
-  it("does not rewrite tool schema for kimi-coding (native Anthropic format)", () => {
+  it("rewrites tool schema for kimi-coding using OpenAI-compatible anthropic payloads", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {
@@ -878,16 +877,22 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.tools).toEqual([
       {
-        name: "read",
-        description: "Read file",
-        input_schema: {
-          type: "object",
-          properties: { path: { type: "string" } },
-          required: ["path"],
+        type: "function",
+        function: {
+          name: "read",
+          description: "Read file",
+          parameters: {
+            type: "object",
+            properties: { path: { type: "string" } },
+            required: ["path"],
+          },
         },
       },
     ]);
-    expect(payloads[0]?.tool_choice).toEqual({ type: "tool", name: "read" });
+    expect(payloads[0]?.tool_choice).toEqual({
+      type: "function",
+      function: { name: "read" },
+    });
   });
 
   it("does not rewrite anthropic tool schema for non-kimi endpoints", () => {

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -31,8 +31,8 @@ describe("resolveProviderCapabilities", () => {
       resolveProviderCapabilities("kimi-code"),
     );
     expect(resolveProviderCapabilities("kimi-code")).toEqual({
-      anthropicToolSchemaMode: "native",
-      anthropicToolChoiceMode: "native",
+      anthropicToolSchemaMode: "openai-functions",
+      anthropicToolChoiceMode: "openai-string-modes",
       providerFamily: "default",
       preserveAnthropicThinkingSignatures: false,
       openAiCompatTurnValidation: true,
@@ -73,9 +73,9 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
   });
 
-  it("treats kimi aliases as native anthropic tool payload providers", () => {
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(false);
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);
+  it("treats kimi aliases as OpenAI-compatible anthropic tool payload providers", () => {
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(true);
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(true);
     expect(requiresOpenAiCompatibleAnthropicToolPayload("anthropic")).toBe(false);
   });
 

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -33,9 +33,9 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
   "amazon-bedrock": {
     providerFamily: "anthropic",
   },
-  // kimi-coding natively supports Anthropic tool framing (input_schema);
-  // converting to OpenAI format causes XML text fallback instead of tool_use blocks.
   "kimi-coding": {
+    anthropicToolSchemaMode: "openai-functions",
+    anthropicToolChoiceMode: "openai-string-modes",
     preserveAnthropicThinkingSignatures: false,
   },
   mistral: {


### PR DESCRIPTION
## Summary

This fixes tool-call compatibility for `kimi-coding` providers using the `anthropic-messages` API, especially with `k2p5`.

## Problem

With `provider = kimi-coding` and `model = k2p5`, OpenClaw currently treats the provider as using native Anthropic tool payloads.

In practice, this leads to invalid tool-call payloads and runtime failures such as:

- `missing 'type' or 'anyOf' key in parameter type`
- `tool_calls[].function.arguments for function 'session_status' must decode to a JSON object, got NoneType`

## Root cause

`kimi-coding` is configured with `anthropic-messages`, but its provider capabilities still use native Anthropic tool modes.

For this provider/model path, OpenAI-compatible Anthropic tool payload formatting is required.

## Fix

Enable the compatibility modes for `kimi-coding`:

- `anthropicToolSchemaMode: "openai-functions"`
- `anthropicToolChoiceMode: "openai-string-modes"`

Also updates tests to reflect the expected OpenAI-compatible payload shape.

## Validation

Passed targeted tests:

- `src/agents/provider-capabilities.test.ts`
- `src/agents/pi-embedded-runner-extraparams.test.ts`

AI-assisted.