### PR TITLE
fix: preserve Telegram forum topic delivery for sessions_send

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -32,6 +32,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
 
 import "./test-helpers/fast-core-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
+import { runSessionsSendA2AFlow } from "./tools/sessions-send-tool.a2a.js";
 
 const waitForCalls = async (getCount: () => number, count: number, timeoutMs = 2000) => {
   await vi.waitFor(
@@ -815,6 +816,349 @@ describe("sessions tools", () => {
       channel: "discord",
       message: "announce now",
     });
+  });
+
+  it("sessions_send suppresses ping-pong for Telegram topic room moves and preserves thread delivery", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    let agentCallCount = 0;
+    let lastWaitedRunId: string | undefined;
+    const replyByRunId = new Map<string, string>();
+    let sendParams:
+      | {
+          to?: string;
+          channel?: string;
+          message?: string;
+          threadId?: string;
+        }
+      | undefined;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        const runId = `run-${agentCallCount}`;
+        const params = request.params as
+          | {
+              extraSystemPrompt?: string;
+            }
+          | undefined;
+        const reply = params?.extraSystemPrompt?.includes("Agent-to-agent announce step")
+          ? "ANNOUNCE_SKIP"
+          : "Hello from topic 3";
+        replyByRunId.set(runId, reply);
+        return {
+          runId,
+          status: "accepted",
+          acceptedAt: 2000 + agentCallCount,
+        };
+      }
+      if (request.method === "agent.wait") {
+        const params = request.params as { runId?: string } | undefined;
+        lastWaitedRunId = params?.runId;
+        return { runId: params?.runId ?? "run-1", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: "agent:main:telegram:group:-1001234567890:topic:3",
+              deliveryContext: {
+                channel: "telegram",
+                to: "-1001234567890",
+                accountId: "default",
+              },
+              lastThreadId: 3,
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        sendParams = request.params as {
+          to?: string;
+          channel?: string;
+          message?: string;
+          threadId?: string;
+        };
+        return { messageId: "m-announce" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:telegram:group:-1001234567890:topic:47",
+      agentChannel: "telegram",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const waited = await tool.execute("call-telegram-room-move", {
+      sessionKey: "agent:main:telegram:group:-1001234567890:topic:3",
+      message: "Move to the topic and post a visible hello.",
+      timeoutSeconds: 1,
+    });
+    expect(waited.details).toMatchObject({
+      status: "ok",
+      reply: "Hello from topic 3",
+    });
+    await waitForCalls(() => calls.filter((call) => call.method === "agent").length, 2);
+
+    const replySteps = calls.filter(
+      (call) =>
+        call.method === "agent" &&
+        typeof (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt === "string" &&
+        (call.params as { extraSystemPrompt?: string }).extraSystemPrompt?.includes(
+          "Agent-to-agent reply step",
+        ),
+    );
+    expect(replySteps).toHaveLength(0);
+    expect(sendParams).toMatchObject({
+      to: "-1001234567890",
+      channel: "telegram",
+      message: "Hello from topic 3",
+      threadId: "3",
+    });
+  });
+
+  it("reuses the target reply for visible Telegram topic handoffs when announce skips", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    let lastWaitedRunId: string | undefined;
+    const replyByRunId = new Map<string, string>();
+    let sendParams:
+      | {
+          to?: string;
+          channel?: string;
+          message?: string;
+          threadId?: string;
+        }
+      | undefined;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        const runId = "run-announce";
+        replyByRunId.set(runId, "ANNOUNCE_SKIP");
+        return {
+          runId,
+          status: "accepted",
+          acceptedAt: 3000,
+        };
+      }
+      if (request.method === "agent.wait") {
+        const params = request.params as { runId?: string } | undefined;
+        lastWaitedRunId = params?.runId;
+        return { runId: params?.runId ?? "run-announce", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: "agent:worker:telegram:group:-1001234567890:topic:3",
+              deliveryContext: {
+                channel: "telegram",
+                to: "-1001234567890",
+                accountId: "default",
+              },
+              lastThreadId: 3,
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        sendParams = request.params as {
+          to?: string;
+          channel?: string;
+          message?: string;
+          threadId?: string;
+        };
+        return { messageId: "m-visible" };
+      }
+      return {};
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:worker:telegram:group:-1001234567890:topic:3",
+      displayKey: "agent:worker:telegram:group:-1001234567890:topic:3",
+      message: "Join the Telegram topic visibly and acknowledge the handoff.",
+      announceTimeoutMs: 1_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:telegram:group:-1001234567890:topic:47",
+      requesterChannel: "telegram",
+      roundOneReply: "Engineering hello from topic 3",
+    });
+
+    const replySteps = calls.filter(
+      (call) =>
+        call.method === "agent" &&
+        typeof (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt === "string" &&
+        (call.params as { extraSystemPrompt?: string }).extraSystemPrompt?.includes(
+          "Agent-to-agent reply step",
+        ),
+    );
+    expect(replySteps).toHaveLength(0);
+    expect(sendParams).toMatchObject({
+      to: "-1001234567890",
+      channel: "telegram",
+      message: "Engineering hello from topic 3",
+      threadId: "3",
+    });
+  });
+
+  it("does not post the raw original instruction when a same-agent Telegram room move has no reusable reply", async () => {
+    let sendCount = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      if (request.method === "agent") {
+        const params = request.params as
+          | {
+              extraSystemPrompt?: string;
+            }
+          | undefined;
+        return {
+          runId: params?.extraSystemPrompt?.includes("Agent-to-agent announce step")
+            ? "run-announce"
+            : "run-initial",
+          status: "accepted",
+          acceptedAt: 3000,
+        };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "ANNOUNCE_SKIP" }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: "agent:main:telegram:group:-1001234567890:topic:3",
+              deliveryContext: {
+                channel: "telegram",
+                to: "-1001234567890",
+                accountId: "default",
+              },
+              lastThreadId: 3,
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        sendCount += 1;
+        return { messageId: "unexpected-send" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:telegram:group:-1001234567890:topic:47",
+      agentChannel: "telegram",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    await tool.execute("call-telegram-no-raw-fallback", {
+      sessionKey: "agent:main:telegram:group:-1001234567890:topic:3",
+      message: "Move to the topic and tell them hello.",
+      timeoutSeconds: 1,
+    });
+    expect(sendCount).toBe(0);
+  });
+
+  it("keeps Telegram topic handoffs silent when visible delivery was not requested and announce skips", async () => {
+    let sendCount = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      if (request.method === "agent") {
+        return {
+          runId: "run-announce",
+          status: "accepted",
+          acceptedAt: 3000,
+        };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "ANNOUNCE_SKIP" }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: "agent:worker:telegram:group:-1001234567890:topic:3",
+              deliveryContext: {
+                channel: "telegram",
+                to: "-1001234567890",
+                accountId: "default",
+              },
+              lastThreadId: 3,
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        sendCount += 1;
+        return { messageId: "unexpected-visible-send" };
+      }
+      return {};
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:worker:telegram:group:-1001234567890:topic:3",
+      displayKey: "agent:worker:telegram:group:-1001234567890:topic:3",
+      message: "Join the Telegram topic and acknowledge the handoff.",
+      announceTimeoutMs: 1_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:telegram:group:-1001234567890:topic:47",
+      requesterChannel: "telegram",
+      roundOneReply: "Engineering hello from topic 3",
+    });
+
+    expect(sendCount).toBe(0);
   });
 
   it("subagents lists active and recent runs", async () => {

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -13,9 +13,11 @@ export async function resolveAnnounceTarget(params: {
   const fallback = parsed ?? parsedDisplay ?? null;
 
   if (fallback) {
-    const normalized = normalizeChannelId(fallback.channel);
+    const normalized = normalizeChannelId(fallback.channel) ?? fallback.channel.toLowerCase();
     const plugin = normalized ? getChannelPlugin(normalized) : null;
-    if (!plugin?.meta?.preferSessionLookupForAnnounceTarget) {
+    const shouldPreferSessionLookup =
+      normalized === "telegram" || plugin?.meta?.preferSessionLookupForAnnounceTarget;
+    if (!shouldPreferSessionLookup) {
       return fallback;
     }
   }
@@ -47,8 +49,12 @@ export async function resolveAnnounceTarget(params: {
     const accountId =
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined);
+    const threadId =
+      (typeof match?.lastThreadId === "string" || typeof match?.lastThreadId === "number"
+        ? String(match.lastThreadId)
+        : fallback?.threadId) ?? fallback?.threadId;
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -64,6 +64,7 @@ export type SessionListRow = {
   lastChannel?: string;
   lastTo?: string;
   lastAccountId?: string;
+  lastThreadId?: string | number;
   transcriptPath?: string;
   messages?: unknown[];
 };

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -1,9 +1,11 @@
+import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
 import {
   getChannelPlugin,
   normalizeChannelId as normalizeAnyChannelId,
 } from "../../channels/plugins/index.js";
 import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 
 const ANNOUNCE_SKIP_TOKEN = "ANNOUNCE_SKIP";
 const REPLY_SKIP_TOKEN = "REPLY_SKIP";
@@ -125,6 +127,10 @@ export function buildAgentToAgentAnnounceContext(params: {
   roundOneReply?: string;
   latestReply?: string;
 }) {
+  const sameAgentRoomMove = isSameAgentRoomMove({
+    requesterSessionKey: params.requesterSessionKey,
+    targetSessionKey: params.targetSessionKey,
+  });
   const lines = [
     "Agent-to-agent announce step:",
     params.requesterSessionKey
@@ -140,6 +146,9 @@ export function buildAgentToAgentAnnounceContext(params: {
       ? `Round 1 reply: ${params.roundOneReply}`
       : "Round 1 reply: (not available).",
     params.latestReply ? `Latest reply: ${params.latestReply}` : "Latest reply: (not available).",
+    sameAgentRoomMove
+      ? `Same-agent room move: if the original request asked you to say or post something in the target session, output the visible text to post there. Do not reply exactly "${ANNOUNCE_SKIP_TOKEN}" unless the request is purely meta or diagnostic.`
+      : undefined,
     `If you want to remain silent, reply exactly "${ANNOUNCE_SKIP_TOKEN}".`,
     "Any other reply will be posted to the target channel.",
     "After this reply, the agent-to-agent conversation is over.",
@@ -153,6 +162,82 @@ export function isAnnounceSkip(text?: string) {
 
 export function isReplySkip(text?: string) {
   return (text ?? "").trim() === REPLY_SKIP_TOKEN;
+}
+
+function isTelegramTopicSessionKey(sessionKey?: string): boolean {
+  return Boolean(
+    sessionKey && sessionKey.includes(":telegram:group:") && sessionKey.includes(":topic:"),
+  );
+}
+
+function isSameAgentRoomMove(params: {
+  requesterSessionKey?: string;
+  targetSessionKey: string;
+}): boolean {
+  if (
+    !parseAgentSessionKey(params.requesterSessionKey) ||
+    !parseAgentSessionKey(params.targetSessionKey)
+  ) {
+    return false;
+  }
+  const requesterAgentId = params.requesterSessionKey
+    ? resolveAgentIdFromSessionKey(params.requesterSessionKey)
+    : undefined;
+  const targetAgentId = resolveAgentIdFromSessionKey(params.targetSessionKey);
+  return Boolean(
+    requesterAgentId &&
+    targetAgentId &&
+    requesterAgentId === targetAgentId &&
+    params.requesterSessionKey &&
+    params.requesterSessionKey !== params.targetSessionKey,
+  );
+}
+
+function cleanAgentToAgentVisibleText(text?: string): string {
+  const parsedReply = parseReplyDirectives(text ?? "");
+  return typeof parsedReply.text === "string" ? parsedReply.text.trim() : "";
+}
+
+export function shouldSuppressAgentToAgentPingPong(params: {
+  requesterSessionKey?: string;
+  targetSessionKey: string;
+}): boolean {
+  return (
+    isSameAgentRoomMove(params) ||
+    (isTelegramTopicSessionKey(params.requesterSessionKey) &&
+      isTelegramTopicSessionKey(params.targetSessionKey))
+  );
+}
+
+export function resolveAgentToAgentAnnounceFallback(params: {
+  requesterSessionKey?: string;
+  targetSessionKey: string;
+  roundOneReply?: string;
+  latestReply?: string;
+  originalMessage: string;
+}): string | undefined {
+  const sameAgentRoomMove = isSameAgentRoomMove(params);
+  const visibleTelegramTopicHandoff =
+    isTelegramTopicSessionKey(params.requesterSessionKey) &&
+    isTelegramTopicSessionKey(params.targetSessionKey) &&
+    /\bvisib(?:le|ly)\b/i.test(params.originalMessage);
+  if (!sameAgentRoomMove && !visibleTelegramTopicHandoff) {
+    return undefined;
+  }
+
+  const replyCandidates = sameAgentRoomMove
+    ? [params.roundOneReply, params.latestReply]
+    : [params.latestReply, params.roundOneReply];
+  for (const candidateReply of replyCandidates) {
+    if (!candidateReply || isReplySkip(candidateReply) || isAnnounceSkip(candidateReply)) {
+      continue;
+    }
+    const cleanedText = cleanAgentToAgentVisibleText(candidateReply);
+    if (cleanedText) {
+      return cleanedText;
+    }
+  }
+  return undefined;
 }
 
 export function resolvePingPongTurns(cfg?: OpenClawConfig) {

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -11,6 +11,8 @@ import {
   buildAgentToAgentReplyContext,
   isAnnounceSkip,
   isReplySkip,
+  resolveAgentToAgentAnnounceFallback,
+  shouldSuppressAgentToAgentPingPong,
 } from "./sessions-send-helpers.js";
 
 const log = createSubsystemLogger("agents/sessions-send");
@@ -60,7 +62,11 @@ export async function runSessionsSendA2AFlow(params: {
     if (
       params.maxPingPongTurns > 0 &&
       params.requesterSessionKey &&
-      params.requesterSessionKey !== params.targetSessionKey
+      params.requesterSessionKey !== params.targetSessionKey &&
+      !shouldSuppressAgentToAgentPingPong({
+        requesterSessionKey: params.requesterSessionKey,
+        targetSessionKey: params.targetSessionKey,
+      })
     ) {
       let currentSessionKey = params.requesterSessionKey;
       let nextSessionKey = params.targetSessionKey;
@@ -118,15 +124,26 @@ export async function runSessionsSendA2AFlow(params: {
       sourceChannel: params.requesterChannel,
       sourceTool: "sessions_send",
     });
-    if (announceTarget && announceReply && announceReply.trim() && !isAnnounceSkip(announceReply)) {
+    const announceDeliveryText =
+      announceReply && announceReply.trim() && !isAnnounceSkip(announceReply)
+        ? announceReply.trim()
+        : resolveAgentToAgentAnnounceFallback({
+            requesterSessionKey: params.requesterSessionKey,
+            targetSessionKey: params.targetSessionKey,
+            roundOneReply: primaryReply,
+            latestReply,
+            originalMessage: params.message,
+          });
+    if (announceTarget && announceDeliveryText) {
       try {
         await callGateway({
           method: "send",
           params: {
             to: announceTarget.to,
-            message: announceReply.trim(),
+            message: announceDeliveryText,
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
+            threadId: announceTarget.threadId,
             idempotencyKey: crypto.randomUUID(),
           },
           timeoutMs: 10_000,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -254,6 +254,36 @@ describe("resolveAnnounceTarget", () => {
     expect(first).toBeDefined();
     expect(first?.method).toBe("sessions.list");
   });
+
+  it("hydrates Telegram threadId from sessions.list for forum topics", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:telegram:group:-1001234567890:topic:42",
+          deliveryContext: {
+            channel: "telegram",
+            to: "-1001234567890",
+            accountId: "default",
+          },
+          lastThreadId: 42,
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
+      displayKey: "agent:main:telegram:group:-1001234567890:topic:42",
+    });
+    expect(target).toEqual({
+      channel: "telegram",
+      to: "-1001234567890",
+      accountId: "default",
+      threadId: "42",
+    });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const first = callGatewayMock.mock.calls[0]?.[0] as { method?: string } | undefined;
+    expect(first?.method).toBe("sessions.list");
+  });
 });
 
 describe("sessions_list gating", () => {


### PR DESCRIPTION
## Summary

- Problem: `sessions_send` can lose Telegram forum topic delivery, suppress visible topic handoffs when announce returns `ANNOUNCE_SKIP`, and echo topic-to-topic handoff text back into the requester transcript.
- Why it matters: Telegram supergroup forum users can miss visible replies, get messages in the wrong place, and carry polluted requester context into later turns.
- What changed: preserve Telegram `threadId` during announce target resolution and final send, reuse the target reply for visible Telegram topic handoffs when announce skips, and suppress ping-pong for same-agent room moves plus Telegram topic-to-topic handoffs.
- What did NOT change (scope boundary): no company-specific workflow logic, no bootstrap/session-seeding changes, and no channel behavior changes outside the `sessions_send` announce path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43848
- Related #4911

## User-visible / Behavior Changes

- Telegram forum-topic announce delivery now preserves the target topic thread when `sessions_send` posts back visibly.
- Visible Telegram topic handoffs no longer disappear just because the announce step returns `ANNOUNCE_SKIP` after the target already produced the intended reply.
- Telegram topic-to-topic handoffs no longer run reply-back ping-pong into the requester transcript.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.4 LTS
- Runtime/container: npm global install, local source checkout for validation
- Model/provider: openai-responses / gpt-5.4 for local repro; bug is transport-side and model-independent
- Integration/channel (if any): Telegram supergroup forum topics
- Relevant config (redacted): Telegram topic sessions bound under `channels.telegram.groups.<chatId>.topics.<topicId>`

### Steps

1. Bind persistent OpenClaw sessions to Telegram supergroup forum topics.
2. Trigger `sessions_send` from one Telegram topic session to another with a prompt that should post visibly in the target topic.
3. Observe the target reply/announce flow, including cases where the target already produced a real reply but the announce step returns `ANNOUNCE_SKIP`.

### Expected

- Visible delivery stays in the target Telegram topic.
- The visible post survives the announce step when the target already produced the intended reply.
- Topic-to-topic traffic does not echo new `inter_session` requester turns back into the source transcript.

### Actual

- Topic delivery can fall back to chat-level routing without the forum thread.
- Visible handoffs can disappear when announce returns `ANNOUNCE_SKIP`.
- Topic-to-topic ping-pong can contaminate the requester transcript.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Vitest coverage for announce target hydration, same-agent Telegram topic room moves, and visible Telegram topic handoffs that hit `ANNOUNCE_SKIP`; full `pnpm build`; full `pnpm check`.
- Edge cases checked: legacy non-agent session keys do not get treated as same-agent room moves; Telegram lookup still hydrates the final thread even when plugin metadata is not the deciding factor.
- What you did **not** verify: live Telegram delivery from this upstream checkout against a real bot token.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or install the prior package version.
- Files/config to restore: `src/agents/tools/sessions-announce-target.ts`, `src/agents/tools/sessions-send-helpers.ts`, `src/agents/tools/sessions-send-tool.a2a.ts`
- Known bad symptoms reviewers should watch for: non-Telegram `sessions_send` announce routing unexpectedly changing, or Telegram topic sends losing visible delivery.

## Risks and Mitigations

- Risk: suppressing ping-pong for Telegram topic-to-topic handoffs could change workflows that relied on hidden refinement loops.
  - Mitigation: the suppression is limited to topic-to-topic handoffs and covered by targeted regression tests for visible delivery plus existing non-Telegram ping-pong tests.
