### PR TITLE
fix(feishu): decode RFC 5987 filename for file downloads

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -434,7 +434,7 @@ function formatSubMessageContent(content: string, contentType: string): string {
       case "image":
         return "[Image]";
       case "file":
-        return `[File: ${parsed.file_name || "unknown"}]`;
+        return `[File: ${decodeRfc5987Filename(parsed.file_name) || "unknown"}]`;
       case "audio":
         return "[Audio]";
       case "video":
@@ -507,6 +507,17 @@ function normalizeFeishuCommandProbeBody(text: string): string {
 }
 
 /**
+ * Decode RFC 5987 encoded filename (e.g., filename*=UTF-8''%E7%A4%BA%E4%BE%8B.pdf -> 测试.pdf)
+ */
+function decodeRfc5987Filename(filename: string | undefined): string {
+  if (!filename) return "";
+  if (filename.startsWith("filename*=UTF-8''")) {
+    return decodeURIComponent(filename.replace("filename*=UTF-8''", ""));
+  }
+  return filename;
+}
+
+/**
  * Parse media keys from message content based on message type.
  */
 function parseMediaKeys(
@@ -525,7 +536,7 @@ function parseMediaKeys(
       case "image":
         return { imageKey };
       case "file":
-        return { fileKey, fileName: parsed.file_name };
+        return { fileKey, fileName: decodeRfc5987Filename(parsed.file_name) };
       case "audio":
         return { fileKey };
       case "video":


### PR DESCRIPTION
## Summary
Fixes #43840

### Problem
When sending files with non-ASCII filenames (Chinese, Japanese, emoji) in Lark/Feishu, the filename appears URL-encoded (e.g., %E6%B5%8B%E8%AF%95.txt instead of 测试.txt).

### Root Cause
The backend receives the Content-Disposition header with RFC 5987 encoded filename (filename*=UTF-8...) but fails to decode it using decodeURIComponent before storing/displaying.

### Changes
- Add decodeRfc5987Filename() helper function to decode percent-encoded filenames
- Apply to file message display (line 437)
- Apply to file download metadata (line 539)

### Test
1. Prepare a file with non-ASCII filename (e.g., 测试.pdf)
2. Send the file via Lark/Feishu client
3. Verify the filename displays correctly as 测试.pdf instead of URL-encoded string