### PR TITLE
fix(docs): zh-CN homepage links should point to zh-CN pages

### DIFF
--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -37,13 +37,13 @@ x-i18n:
 </p>
 
 <Columns>
-  <Card title="入门指南" href="/start/getting-started" icon="rocket">
+  <Card title="入门指南" href="/zh-CN/start/getting-started" icon="rocket">
     安装 OpenClaw 并在几分钟内启动 Gateway 网关。
   </Card>
-  <Card title="运行向导" href="/start/wizard" icon="sparkles">
+  <Card title="运行向导" href="/zh-CN/start/wizard" icon="sparkles">
     通过 `openclaw onboard` 和配对流程进行引导式设置。
   </Card>
-  <Card title="打开控制界面" href="/web/control-ui" icon="layout-dashboard">
+  <Card title="打开控制界面" href="/zh-CN/web/control-ui" icon="layout-dashboard">
     启动浏览器仪表板，管理聊天、配置和会话。
   </Card>
 </Columns>
@@ -108,14 +108,14 @@ Gateway 网关是会话、路由和渠道连接的唯一事实来源。
   </Step>
 </Steps>
 
-需要完整的安装和开发环境设置？请参阅[快速开始](/start/quickstart)。
+需要完整的安装和开发环境设置？请参阅[快速开始](/zh-CN/start/quickstart)。
 
 ## 仪表板
 
 Gateway 网关启动后，打开浏览器控制界面。
 
 - 本地默认地址：http://127.0.0.1:18789/
-- 远程访问：[Web 界面](/web)和 [Tailscale](/gateway/tailscale)
+- 远程访问：[Web 界面](/zh-CN/web)和 [Tailscale](/zh-CN/gateway/tailscale)
 
 <p align="center">
   <img src="/whatsapp-openclaw.jpg" alt="OpenClaw" width="420" />
@@ -145,16 +145,16 @@ Gateway 网关启动后，打开浏览器控制界面。
 ## 从这里开始
 
 <Columns>
-  <Card title="文档中心" href="/start/hubs" icon="book-open">
+  <Card title="文档中心" href="/zh-CN/start/hubs" icon="book-open">
     所有文档和指南，按用例分类。
   </Card>
-  <Card title="配置" href="/gateway/configuration" icon="settings">
+  <Card title="配置" href="/zh-CN/gateway/configuration" icon="settings">
     核心 Gateway 网关设置、令牌和提供商配置。
   </Card>
-  <Card title="远程访问" href="/gateway/remote" icon="globe">
+  <Card title="远程访问" href="/zh-CN/gateway/remote" icon="globe">
     SSH 和 tailnet 访问模式。
   </Card>
-  <Card title="渠道" href="/channels/telegram" icon="message-square">
+  <Card title="渠道" href="/zh-CN/channels/telegram" icon="message-square">
     WhatsApp、Telegram、Discord 等渠道的具体设置。
   </Card>
   <Card title="节点" href="/nodes" icon="smartphone">
@@ -168,19 +168,19 @@ Gateway 网关启动后，打开浏览器控制界面。
 ## 了解更多
 
 <Columns>
-  <Card title="完整功能列表" href="/concepts/features" icon="list">
+  <Card title="完整功能列表" href="/zh-CN/concepts/features" icon="list">
     全部渠道、路由和媒体功能。
   </Card>
-  <Card title="多智能体路由" href="/concepts/multi-agent" icon="route">
+  <Card title="多智能体路由" href="/zh-CN/concepts/multi-agent" icon="route">
     工作区隔离和按智能体的会话管理。
   </Card>
-  <Card title="安全" href="/gateway/security" icon="shield">
+  <Card title="安全" href="/zh-CN/gateway/security" icon="shield">
     令牌、白名单和安全控制。
   </Card>
-  <Card title="故障排除" href="/gateway/troubleshooting" icon="wrench">
+  <Card title="故障排除" href="/zh-CN/gateway/troubleshooting" icon="wrench">
     Gateway 网关诊断和常见错误。
   </Card>
-  <Card title="关于与致谢" href="/reference/credits" icon="info">
+  <Card title="关于与致谢" href="/zh-CN/reference/credits" icon="info">
     项目起源、贡献者和许可证。
   </Card>
 </Columns>


### PR DESCRIPTION
## Summary

Fix #41731 - Links on zh-CN homepage were redirecting to English pages because they used absolute paths without locale prefix.

## Changes

Updated links in `docs/zh-CN/index.md` to include `/zh-CN/` prefix:
- `/start/getting-started` → `/zh-CN/start/getting-started`
- `/start/wizard` → `/zh-CN/start/wizard`
- `/web/control-ui` → `/zh-CN/web/control-ui`
- `/start/hubs` → `/zh-CN/start/hubs`
- `/gateway/configuration` → `/zh-CN/gateway/configuration`
- `/gateway/remote` → `/zh-CN/gateway/remote`
- `/channels/telegram` → `/zh-CN/channels/telegram`
- `/concepts/features` → `/zh-CN/concepts/features`
- `/concepts/multi-agent` → `/zh-CN/concepts/multi-agent`
- `/gateway/troubleshooting` → `/zh-CN/gateway/troubleshooting`
- `/reference/credits` → `/zh-CN/reference/credits`

Links to pages without zh-CN translations (`/nodes`, `/help`, `/gateway/security`) were left unchanged.

## Testing

Verified that linked zh-CN pages exist before adding the locale prefix.