### PR TITLE
fix(doctor): canonicalize gateway service entrypoint paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.
 - Sandbox/write: preserve pinned mutation-helper payload stdin so sandboxed `write` no longer reports success while creating empty files. (#43876) Thanks @glitch418x.
 - Gateway/main-session routing: keep TUI and other `mode:UI` main-session sends on the internal surface when `deliver` is enabled, so replies no longer inherit the session's persisted Telegram/WhatsApp route. (#43918) Thanks @obviyus.
+- Doctor/gateway service audit: canonicalize service entrypoint paths before comparing them so symlink-vs-realpath installs no longer trigger false "entrypoint does not match the current install" repair prompts. (#43882) Thanks @realriphub.
 
 ## 2026.3.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ Docs: https://docs.openclaw.ai
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.
 - Sandbox/write: preserve pinned mutation-helper payload stdin so sandboxed `write` no longer reports success while creating empty files. (#43876) Thanks @glitch418x.
 - Gateway/main-session routing: keep TUI and other `mode:UI` main-session sends on the internal surface when `deliver` is enabled, so replies no longer inherit the session's persisted Telegram/WhatsApp route. (#43918) Thanks @obviyus.
-- Doctor/gateway service audit: canonicalize service entrypoint paths before comparing them so symlink-vs-realpath installs no longer trigger false "entrypoint does not match the current install" repair prompts. (#43882) Thanks @realriphub.
+- Doctor/gateway service audit: canonicalize service entrypoint paths before comparing them so symlink-vs-realpath installs no longer trigger false "entrypoint does not match the current install" repair prompts. (#43882) Thanks @ngutman.
+- Doctor/gateway service audit: earlier groundwork for this fix landed in the superseded #28338 branch. Thanks @realriphub.
 
 ## 2026.3.11
 

--- a/extensions/zalouser/src/channel.test.ts
+++ b/extensions/zalouser/src/channel.test.ts
@@ -1,42 +1,65 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { chunkMarkdownText } from "../../../src/auto-reply/chunk.js";
 import { zalouserPlugin } from "./channel.js";
 import { setZalouserRuntime } from "./runtime.js";
-import { sendReactionZalouser } from "./send.js";
+import { sendMessageZalouser, sendReactionZalouser } from "./send.js";
 
 vi.mock("./send.js", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
     ...actual,
+    sendMessageZalouser: vi.fn(async () => ({ ok: true, messageId: "mid-1" })),
     sendReactionZalouser: vi.fn(async () => ({ ok: true })),
   };
 });
 
+const mockSendMessage = vi.mocked(sendMessageZalouser);
 const mockSendReaction = vi.mocked(sendReactionZalouser);
 
-describe("zalouser outbound chunker", () => {
+describe("zalouser outbound", () => {
   beforeEach(() => {
+    mockSendMessage.mockClear();
     setZalouserRuntime({
       channel: {
         text: {
-          chunkMarkdownText,
+          resolveChunkMode: vi.fn(() => "newline"),
+          resolveTextChunkLimit: vi.fn(() => 10),
         },
       },
     } as never);
   });
 
-  it("chunks without empty strings and respects limit", () => {
-    const chunker = zalouserPlugin.outbound?.chunker;
-    expect(chunker).toBeTypeOf("function");
-    if (!chunker) {
+  it("passes markdown chunk settings through sendText", async () => {
+    const sendText = zalouserPlugin.outbound?.sendText;
+    expect(sendText).toBeTypeOf("function");
+    if (!sendText) {
       return;
     }
 
-    const limit = 10;
-    const chunks = chunker("hello world\nthis is a test", limit);
-    expect(chunks.length).toBeGreaterThan(1);
-    expect(chunks.every((c) => c.length > 0)).toBe(true);
-    expect(chunks.every((c) => c.length <= limit)).toBe(true);
+    const result = await sendText({
+      cfg: { channels: { zalouser: { enabled: true } } } as never,
+      to: "group:123456",
+      text: "hello world\nthis is a test",
+      accountId: "default",
+    } as never);
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      "123456",
+      "hello world\nthis is a test",
+      expect.objectContaining({
+        profile: "default",
+        isGroup: true,
+        textMode: "markdown",
+        textChunkMode: "newline",
+        textChunkLimit: 10,
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        channel: "zalouser",
+        messageId: "mid-1",
+        ok: true,
+      }),
+    );
   });
 });
 

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -2,6 +2,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
+const fsMocks = vi.hoisted(() => ({
+  realpath: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      realpath: fsMocks.realpath,
+    },
+    realpath: fsMocks.realpath,
+  };
+});
+
 const mocks = vi.hoisted(() => ({
   readCommand: vi.fn(),
   install: vi.fn(),
@@ -137,6 +153,7 @@ function setupGatewayTokenRepairScenario() {
 describe("maybeRepairGatewayServiceConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fsMocks.realpath.mockImplementation(async (value: string) => value);
     mocks.resolveGatewayAuthTokenForService.mockImplementation(async (cfg: OpenClawConfig, env) => {
       const configToken =
         typeof cfg.gateway?.auth?.token === "string" ? cfg.gateway.auth.token.trim() : undefined;
@@ -216,6 +233,50 @@ describe("maybeRepairGatewayServiceConfig", () => {
       );
       expect(mocks.install).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("does not flag entrypoint mismatch when symlink and realpath match", async () => {
+    mocks.readCommand.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/Users/test/Library/pnpm/global/5/node_modules/openclaw/dist/index.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      environment: {},
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: true,
+      issues: [],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/Users/test/Library/pnpm/global/5/node_modules/.pnpm/openclaw@2026.3.12/node_modules/openclaw/dist/index.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      environment: {},
+    });
+    fsMocks.realpath.mockImplementation(async (value: string) => {
+      if (value.includes("/global/5/node_modules/openclaw/")) {
+        return value.replace(
+          "/global/5/node_modules/openclaw/",
+          "/global/5/node_modules/.pnpm/openclaw@2026.3.12/node_modules/openclaw/",
+        );
+      }
+      return value;
+    });
+
+    await runRepair({ gateway: {} });
+
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("Gateway service entrypoint does not match the current install."),
+      "Gateway service config",
+    );
+    expect(mocks.install).not.toHaveBeenCalled();
   });
 
   it("treats SecretRef-managed gateway token as non-persisted service state", async () => {

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -279,6 +279,77 @@ describe("maybeRepairGatewayServiceConfig", () => {
     expect(mocks.install).not.toHaveBeenCalled();
   });
 
+  it("does not flag entrypoint mismatch when realpath fails but normalized absolute paths match", async () => {
+    mocks.readCommand.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/opt/openclaw/../openclaw/dist/index.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      environment: {},
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: true,
+      issues: [],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/opt/openclaw/dist/index.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      environment: {},
+    });
+    fsMocks.realpath.mockRejectedValue(new Error("no realpath"));
+
+    await runRepair({ gateway: {} });
+
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("Gateway service entrypoint does not match the current install."),
+      "Gateway service config",
+    );
+    expect(mocks.install).not.toHaveBeenCalled();
+  });
+
+  it("still flags entrypoint mismatch when canonicalized paths differ", async () => {
+    mocks.readCommand.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/Users/test/.nvm/versions/node/v22.0.0/lib/node_modules/openclaw/dist/index.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      environment: {},
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: true,
+      issues: [],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/Users/test/Library/pnpm/global/5/node_modules/openclaw/dist/index.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      environment: {},
+    });
+
+    await runRepair({ gateway: {} });
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("Gateway service entrypoint does not match the current install."),
+      "Gateway service config",
+    );
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+
   it("treats SecretRef-managed gateway token as non-persisted service state", async () => {
     mocks.readCommand.mockResolvedValue({
       programArguments: gatewayProgramArguments,

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -55,7 +55,7 @@ function findGatewayEntrypoint(programArguments?: string[]): string | null {
 }
 
 async function normalizeExecutablePath(value: string): Promise<string> {
-  const resolvedPath = path.isAbsolute(value) ? value : path.resolve(value);
+  const resolvedPath = path.resolve(value);
   try {
     return await fs.realpath(resolvedPath);
   } catch {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -54,8 +54,13 @@ function findGatewayEntrypoint(programArguments?: string[]): string | null {
   return programArguments[gatewayIndex - 1] ?? null;
 }
 
-function normalizeExecutablePath(value: string): string {
-  return path.resolve(value);
+async function normalizeExecutablePath(value: string): Promise<string> {
+  const resolvedPath = path.isAbsolute(value) ? value : path.resolve(value);
+  try {
+    return await fs.realpath(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
 }
 
 function extractDetailPath(detail: string, prefix: string): string | null {
@@ -269,10 +274,16 @@ export async function maybeRepairGatewayServiceConfig(
   });
   const expectedEntrypoint = findGatewayEntrypoint(programArguments);
   const currentEntrypoint = findGatewayEntrypoint(command.programArguments);
+  const normalizedExpectedEntrypoint = expectedEntrypoint
+    ? await normalizeExecutablePath(expectedEntrypoint)
+    : null;
+  const normalizedCurrentEntrypoint = currentEntrypoint
+    ? await normalizeExecutablePath(currentEntrypoint)
+    : null;
   if (
-    expectedEntrypoint &&
-    currentEntrypoint &&
-    normalizeExecutablePath(expectedEntrypoint) !== normalizeExecutablePath(currentEntrypoint)
+    normalizedExpectedEntrypoint &&
+    normalizedCurrentEntrypoint &&
+    normalizedExpectedEntrypoint !== normalizedCurrentEntrypoint
   ) {
     audit.issues.push({
       code: SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` can report a gateway entrypoint mismatch when the current service uses a symlinked CLI path and the expected install plan resolves the same file through a real path (for example under `.pnpm/...`).
- Why it matters: doctor can recommend or apply an unnecessary service rewrite even though the service already points at the current install.
- What changed: canonicalize expected/current gateway entrypoint paths with `fs.realpath()` before comparing them, falling back to absolute resolved paths when canonicalization fails; add a regression test for symlink-vs-realpath equivalence; add an unreleased changelog line.
- What did NOT change: no `program-args` changes, no service install path selection changes, and no update/startup entrypoint candidate order changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #28338

## User-visible / Behavior Changes

- `openclaw doctor` no longer reports a gateway service entrypoint mismatch when the current and expected entrypoint paths only differ by symlink vs realpath expansion.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local macOS dev machine
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Mock a gateway service command whose entrypoint uses a symlinked `node_modules/openclaw/dist/index.js` path.
2. Mock the current install plan to use the equivalent `.pnpm/.../node_modules/openclaw/dist/index.js` real path.
3. Run `maybeRepairGatewayServiceConfig()`.

### Expected

- No `gatewayEntrypointMismatch` issue is added when both paths canonicalize to the same file.

### Actual

- With this patch, the mismatch is suppressed and no repair is triggered.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added focused regression coverage in `src/commands/doctor-gateway-services.test.ts` for the symlink-vs-realpath case.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/commands/doctor-gateway-services.test.ts`; `pnpm vitest run src/daemon/program-args.test.ts`
- Edge cases checked: `realpath` falls back to absolute resolved paths when canonicalization fails; only the doctor comparison logic changed.
- What you did **not** verify: I did not run a live pnpm global-install reproduction. Full `pnpm check` is currently failing on unrelated existing repo-wide `tsgo` errors outside this change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or re-run `openclaw gateway install --force` to regenerate the service command from the current install plan.
- Files/config to restore: no persistent config migration; only service repair comparison behavior changes.
- Known bad symptoms reviewers should watch for: legitimate entrypoint drift no longer being reported when two different paths incorrectly canonicalize to the same target.

## Risks and Mitigations

- Risk: Canonicalization could hide a real mismatch if two compared paths unexpectedly resolve to the same file via symlinks.
  - Mitigation: that is the intended equivalence class here; true mismatches still compare different canonical targets and still raise `gatewayEntrypointMismatch`.
