### PR TITLE
Cron: prevent isolated jobs from waiting on stale descendants

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -294,6 +294,7 @@ export async function dispatchCronDelivery(
         initialReply: initialSynthesizedText,
         timeoutMs: params.timeoutMs,
         observedActiveDescendants: activeSubagentRuns > 0 || expectedSubagentFollowup,
+        runStartedAt: params.runStartedAt,
       });
       activeSubagentRuns = countActiveDescendantRuns(params.agentSessionKey);
       if (!finalReply && activeSubagentRuns === 0) {

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -285,6 +285,32 @@ describe("waitForDescendantSubagentSummary", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
+  it("ignores stale active descendants that started before the current cron run", async () => {
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([
+      {
+        runId: "stale-run",
+        childSessionKey: "child-stale",
+        requesterSessionKey: "cron-session",
+        requesterDisplayKey: "cron-session",
+        task: "stale",
+        cleanup: "keep",
+        createdAt: 1_000,
+        startedAt: 1_500,
+      },
+    ]);
+
+    const result = await waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: "on it",
+      timeoutMs: 30_000,
+      observedActiveDescendants: false,
+      runStartedAt: 5_000,
+    });
+
+    expect(result).toBe("on it");
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
   it("awaits active descendants via agent.wait and returns synthesis after grace period", async () => {
     // First call: active run; second call (after agent.wait resolves): no active runs
     vi.mocked(listDescendantRunsForRequester)

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -117,14 +117,26 @@ export async function waitForDescendantSubagentSummary(params: {
   initialReply?: string;
   timeoutMs: number;
   observedActiveDescendants?: boolean;
+  runStartedAt?: number;
 }): Promise<string | undefined> {
   const initialReply = params.initialReply?.trim();
   const deadline = Date.now() + Math.max(CRON_SUBAGENT_WAIT_MIN_MS, Math.floor(params.timeoutMs));
+  const runStartedAt =
+    typeof params.runStartedAt === "number" && Number.isFinite(params.runStartedAt)
+      ? params.runStartedAt
+      : undefined;
+  const isInRunWindow = (entry: { createdAt: number; startedAt?: number }) => {
+    if (runStartedAt === undefined) {
+      return true;
+    }
+    const startedAt = typeof entry.startedAt === "number" ? entry.startedAt : entry.createdAt;
+    return startedAt >= runStartedAt;
+  };
 
   // Snapshot the currently active descendant run IDs.
   const getActiveRuns = () =>
     listDescendantRunsForRequester(params.sessionKey).filter(
-      (entry) => typeof entry.endedAt !== "number",
+      (entry) => typeof entry.endedAt !== "number" && isInRunWindow(entry),
     );
 
   const initialActiveRuns = getActiveRuns();


### PR DESCRIPTION
## Summary

- Problem: isolated cron `agentTurn` runs could wait on stale descendant subagent runs from earlier executions, consuming the full job timeout window and ending as `cron: job execution timed out`.
- Why it matters: scheduled jobs that normally finish quickly were failing consistently when stale active descendant records existed under the same session key.
- What changed: scoped descendant wait candidates to the current cron run window (`runStartedAt`) in `waitForDescendantSubagentSummary`, and passed `runStartedAt` from delivery dispatch.
- What did NOT change (scope boundary): cron timeout policy values and normal descendant wait behavior for descendants started by the current run.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43850
- Related #29774

## User-visible / Behavior Changes

- Isolated cron runs no longer block on stale active descendant runs from previous executions; they stop waiting only for descendants started in the current run window.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local macOS dev environment
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (unit tests)
- Integration/channel (if any): cron isolated agent delivery path
- Relevant config (redacted): N/A

### Steps

1. Create an isolated cron run scenario with stale active descendant runs from an earlier execution.
2. Trigger descendant follow-up wait logic for a new cron run.
3. Verify stale descendants are ignored for wait candidates, while current-run descendants still use `agent.wait`.

### Expected

- New cron run should not spend its timeout budget waiting on stale descendants.

### Actual

- With this patch, stale descendants are ignored; follow-up wait returns immediately (or only tracks current-run descendants).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Ran focused tests after patch:
    - `pnpm test src/cron/isolated-agent/subagent-followup.test.ts` (pass)
    - `pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` (pass)
- Edge cases checked:
  - Added regression coverage for stale active descendants older than `runStartedAt`.
- What you did **not** verify:
  - Full end-to-end live cron execution against real providers/channels.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Cron: scope isolated follow-up waits to current run`.
- Files/config to restore:
  - `src/cron/isolated-agent/subagent-followup.ts`
  - `src/cron/isolated-agent/delivery-dispatch.ts`
- Known bad symptoms reviewers should watch for:
  - Current-run descendants not being awaited when `runStartedAt` handling is incorrect.

## Risks and Mitigations

- Risk: Over-filtering could skip legitimate descendants if timestamps are malformed.
  - Mitigation: fallback uses `createdAt` when `startedAt` is absent; existing descendant wait tests remain green and regression test added.
