### PR TITLE
fix: restore final response delivery when Telegram reasoning mode is "on"

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -433,10 +433,11 @@ export async function dispatchReplyFromConfig(params: {
         },
         onBlockReply: (payload: ReplyPayload, context) => {
           const run = async () => {
-            // Suppress reasoning payloads — channels using this generic dispatch
-            // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
-            // Telegram has its own dispatch path that handles reasoning splitting.
-            if (shouldSuppressReasoningPayload(payload)) {
+            // Suppress reasoning payloads for channels without a dedicated reasoning
+            // lane (WhatsApp, web, etc.). Channels that set allowReasoningPayloads=true
+            // (e.g. Telegram with reasoning="on") handle reasoning splitting themselves
+            // and must receive these payloads to display them in the reasoning lane.
+            if (!params.replyOptions?.allowReasoningPayloads && shouldSuppressReasoningPayload(payload)) {
               return;
             }
             // Accumulate block text for TTS generation after streaming

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -364,7 +364,9 @@ export async function resolveReplyDirectives(params: {
           ? "on"
           : "off";
   const resolvedBlockStreamingBreak: "text_end" | "message_end" =
-    agentCfg?.blockStreamingBreak === "message_end" ? "message_end" : "text_end";
+    agentCfg?.blockStreamingBreak === "message_end" || resolvedReasoningLevel === "on"
+      ? "message_end"
+      : "text_end";
   const blockStreamingEnabled =
     resolvedBlockStreaming === "on" && opts?.disableBlockStreaming !== true;
   const blockReplyChunking = blockStreamingEnabled

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -58,6 +58,10 @@ export type GetReplyOptions = {
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;
   disableBlockStreaming?: boolean;
+  /** Allow reasoning payloads (isReasoning: true) to be forwarded to the dispatcher
+   *  instead of being suppressed. Set by channels that have a dedicated reasoning lane
+   *  and handle reasoning splitting themselves (e.g. Telegram with reasoning="on"). */
+  allowReasoningPayloads?: boolean;
   /** Timeout for block reply delivery (ms). */
   blockReplyTimeoutMs?: number;
   /** If provided, only load these skills for this session (empty = no skills). */

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -320,6 +320,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({
         replyOptions: expect.objectContaining({
           disableBlockStreaming: false,
+          allowReasoningPayloads: true,
         }),
       }),
     );
@@ -327,6 +328,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [expect.objectContaining({ text: "Reasoning:\n_step_" })],
+      }),
+    );
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: "Hello" })],
       }),
     );
   });

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -661,6 +661,7 @@ export const dispatchTelegramMessage = async ({
       replyOptions: {
         skillFilter,
         disableBlockStreaming,
+        allowReasoningPayloads: forceBlockStreamingForReasoning,
         onPartialReply:
           answerLane.stream || reasoningLane.stream
             ? (payload) =>


### PR DESCRIPTION
## Summary

Fixes #43807

When using `/reasoning on` in Telegram, users only received the thinking
content — the final response was silently dropped and never delivered.
`/reasoning off` and `/reasoning stream` both worked correctly.

Root cause: two separate bugs in the reply pipeline:

1. **Reasoning payloads suppressed on the wrong path.** The generic
   `onBlockReply` handler in `dispatch-from-config.ts` unconditionally
   dropped all payloads where `isReasoning: true`. A comment in that file
   claimed Telegram had its own dispatch path, but in `reasoning="on"` mode
   Telegram was actually going through this generic path. The reasoning
   payload was swallowed before it could reach the Telegram lane coordinator,
   which meant the pipeline registered a "did stream" state but never
   forwarded the final answer, leaving the user with no response at all.

2. **Answer fragmented across multiple messages.** `blockReplyBreak`
   defaulted to `"text_end"`, so in `reasoning="on"` mode the answer was
   split into many small Telegram messages rather than one coherent reply.

## Behavior Changes

- **`/reasoning on`**: now delivers both the reasoning block (as a separate
  Telegram message) **and** the final answer (as a single consolidated
  message). Previously only the reasoning block appeared.
- **`/reasoning off` / `/reasoning stream`**: behavior unchanged.
- **Other channels** (WhatsApp, web, etc.): unaffected — reasoning payloads
  are still suppressed on those paths.

## Existing Functionality Check

- [x] Searched for all call sites of `shouldSuppressReasoningPayload` and
  `onBlockReply` to confirm no other channel is affected.
- [x] Verified `forceBlockStreamingForReasoning` is only `true` when
  `reasoningLevel === "on"`, so `allowReasoningPayloads` is never set for
  other reasoning levels or other channels.
- [x] Confirmed `blockReplyBreak = "message_end"` override is scoped to
  `resolvedReasoningLevel === "on"` only.

## What Changed

- **`src/auto-reply/types.ts`**
  - Added `allowReasoningPayloads?: boolean` to `GetReplyOptions`.
    Channels with a dedicated reasoning lane (Telegram `reasoning="on"`)
    set this to `true` to bypass generic reasoning suppression.

- **`src/auto-reply/reply/dispatch-from-config.ts`**
  - The `shouldSuppressReasoningPayload` guard is now conditional:
    suppression is skipped when `params.replyOptions?.allowReasoningPayloads`
    is `true`.

- **`src/auto-reply/reply/get-reply-directives.ts`**
  - `resolvedBlockStreamingBreak` is forced to `"message_end"` when
    `resolvedReasoningLevel === "on"`, ensuring the answer is delivered as
    one complete message instead of many fragments.

- **`src/telegram/bot-message-dispatch.ts`**
  - Passes `allowReasoningPayloads: forceBlockStreamingForReasoning` in
    `replyOptions` so the new guard in `dispatch-from-config.ts` is
    activated for Telegram `reasoning="on"` sessions.

- **`src/telegram/bot-message-dispatch.test.ts`**
  - Extended the `"keeps block streaming enabled when session reasoning level
    is on"` test to assert:
    - `replyOptions` includes `allowReasoningPayloads: true`
    - `deliverReplies` is called with the reasoning block (`"Reasoning:\n_step_"`)
    - `deliverReplies` is also called with the final answer (`"Hello"`)

## Tests

- `src/telegram/bot-message-dispatch.test.ts` — **66 tests passed**
- `src/auto-reply/reply/dispatch-from-config.test.ts` — **44 tests passed**

## Files Changed

- `src/auto-reply/types.ts` (+4 lines)
- `src/auto-reply/reply/dispatch-from-config.ts` (+5 lines, -4 lines)
- `src/auto-reply/reply/get-reply-directives.ts` (+3 lines, -1 line)
- `src/telegram/bot-message-dispatch.ts` (+1 line)
- `src/telegram/bot-message-dispatch.test.ts` (+6 lines)

## Checklist

- [x] Test locally with your OpenClaw instance
- [x] Run tests: `node_modules/.bin/vitest.CMD run src/telegram/bot-message-dispatch.test.ts` ✅
- [x] Run tests: `node_modules/.bin/vitest.CMD run src/auto-reply/reply/dispatch-from-config.test.ts` ✅
- [x] Keep PRs focused (one thing per PR) ✅
- [x] Describe what & why ✅

**Sign-Off**

- Models used: Claude
- Submitter effort: AI-assisted with manual code review
- Agent notes: Fix is minimal and surgical — 19 lines changed across 5 files.
  No new abstractions introduced; the `allowReasoningPayloads` flag follows
  the same opt-in pattern already used by `disableBlockStreaming` and
  `onPartialReply` in `GetReplyOptions`.