### PR TITLE
[AI-assisted] Matrix: honor SSRF policy for password login

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -72,6 +72,9 @@ Details: [Plugins](/tools/plugin)
    - If both are set, config takes precedence.
    - With access token: user ID is fetched automatically via `/whoami`.
    - When set, `channels.matrix.userId` should be the full Matrix ID (example: `@bot:example.org`).
+
+- If your homeserver resolves to a private or internal address and you run strict SSRF policy (`browser.ssrfPolicy.dangerouslyAllowPrivateNetwork: false`), add the exact homeserver hostname to `browser.ssrfPolicy.allowedHostnames` so password login can reach `/_matrix/client/v3/login`.
+
 5. Restart the gateway (or finish onboarding).
 6. Start a DM with the bot or invite it to a room from any Matrix client
    (Element, Beeper, etc.; see [https://matrix.org/ecosystem/clients/](https://matrix.org/ecosystem/clients/)). Beeper requires E2EE,
@@ -102,6 +105,28 @@ E2EE config (end to end encryption enabled):
       homeserver: "https://matrix.example.org",
       accessToken: "syt_***",
       encryption: true,
+      dm: { policy: "pairing" },
+    },
+  },
+}
+```
+
+Password login on a private/internal homeserver with strict SSRF policy:
+
+```json5
+{
+  browser: {
+    ssrfPolicy: {
+      dangerouslyAllowPrivateNetwork: false,
+      allowedHostnames: ["matrix.example.test"],
+    },
+  },
+  channels: {
+    matrix: {
+      enabled: true,
+      homeserver: "https://matrix.example.test",
+      userId: "@assistant:example.test",
+      password: "<matrix-password>",
       dm: { policy: "pairing" },
     },
   },
@@ -285,6 +310,7 @@ Provider options:
 - `channels.matrix.deviceName`: device display name.
 - `channels.matrix.encryption`: enable E2EE (default: false).
 - `channels.matrix.initialSyncLimit`: initial sync limit.
+- `browser.ssrfPolicy.allowedHostnames`: exact hostname exceptions for strict SSRF mode. Add your Matrix homeserver hostname here if password login needs to reach a private/internal server while `dangerouslyAllowPrivateNetwork` is disabled.
 - `channels.matrix.threadReplies`: `off | inbound | always` (default: inbound).
 - `channels.matrix.textChunkLimit`: outbound text chunk size (chars).
 - `channels.matrix.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.

--- a/docs/zh-CN/channels/matrix.md
+++ b/docs/zh-CN/channels/matrix.md
@@ -72,6 +72,9 @@ openclaw plugins install ./extensions/matrix
    - 如果两者都设置，配置优先。
    - 使用访问令牌时：用户 ID 通过 `/whoami` 自动获取。
    - 设置时，`channels.matrix.userId` 应为完整的 Matrix ID（示例：`@bot:example.org`）。
+
+- 如果你的 homeserver 解析到私有/内网地址，并且启用了严格 SSRF 策略（`browser.ssrfPolicy.dangerouslyAllowPrivateNetwork: false`），请把该 homeserver 的精确主机名加入 `browser.ssrfPolicy.allowedHostnames`，这样密码登录才能访问 `/_matrix/client/v3/login`。
+
 5. 重启 Gateway 网关（或完成新手引导）。
 6. 从任何 Matrix 客户端（Element、Beeper 等；参见 https://matrix.org/ecosystem/clients/）与机器人开始私信或邀请它加入房间。Beeper 需要 E2EE，因此请设置 `channels.matrix.encryption: true` 并验证设备。
 
@@ -100,6 +103,28 @@ E2EE 配置（启用端到端加密）：
       homeserver: "https://matrix.example.org",
       accessToken: "syt_***",
       encryption: true,
+      dm: { policy: "pairing" },
+    },
+  },
+}
+```
+
+在严格 SSRF 策略下连接私有/内网 homeserver 的密码登录示例：
+
+```json5
+{
+  browser: {
+    ssrfPolicy: {
+      dangerouslyAllowPrivateNetwork: false,
+      allowedHostnames: ["matrix.example.test"],
+    },
+  },
+  channels: {
+    matrix: {
+      enabled: true,
+      homeserver: "https://matrix.example.test",
+      userId: "@assistant:example.test",
+      password: "<matrix-password>",
       dm: { policy: "pairing" },
     },
   },
@@ -204,6 +229,7 @@ E2EE 配置（启用端到端加密）：
 - `channels.matrix.deviceName`：设备显示名称。
 - `channels.matrix.encryption`：启用 E2EE（默认：false）。
 - `channels.matrix.initialSyncLimit`：初始同步限制。
+- `browser.ssrfPolicy.allowedHostnames`：严格 SSRF 模式下的精确主机名例外列表。如果在禁用 `dangerouslyAllowPrivateNetwork` 时需要对私有/内网 Matrix 服务器执行密码登录，请把 homeserver 主机名加入这里。
 - `channels.matrix.threadReplies`：`off | inbound | always`（默认：inbound）。
 - `channels.matrix.textChunkLimit`：出站文本分块大小（字符）。
 - `channels.matrix.chunkMode`：`length`（默认）或 `newline` 在长度分块前按空行（段落边界）分割。

--- a/extensions/matrix/src/matrix/client/config.test.ts
+++ b/extensions/matrix/src/matrix/client/config.test.ts
@@ -25,7 +25,7 @@ vi.mock("../credentials.js", () => ({
 
 import { resolveMatrixAuth, resolveMatrixLoginSsrFPolicy } from "./config.js";
 
-describe("resolveMatrixLoginSsrFPolicy", () => {
+describe("Matrix login SSRF policy", () => {
   beforeEach(() => {
     fetchWithSsrFGuardMock.mockReset();
     loadMatrixCredentialsMock.mockClear();

--- a/extensions/matrix/src/matrix/client/config.test.ts
+++ b/extensions/matrix/src/matrix/client/config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveMatrixLoginSsrFPolicy } from "./config.js";
+
+describe("resolveMatrixLoginSsrFPolicy", () => {
+  it("returns browser SSRF hostname exceptions for Matrix login", () => {
+    expect(
+      resolveMatrixLoginSsrFPolicy({
+        browser: {
+          ssrfPolicy: {
+            allowedHostnames: ["matrix.example.test"],
+          },
+        },
+      } as never),
+    ).toEqual({
+      allowedHostnames: ["matrix.example.test"],
+    });
+  });
+
+  it("returns undefined when no browser SSRF policy is configured", () => {
+    expect(resolveMatrixLoginSsrFPolicy({} as never)).toBeUndefined();
+  });
+});

--- a/extensions/matrix/src/matrix/client/config.test.ts
+++ b/extensions/matrix/src/matrix/client/config.test.ts
@@ -1,7 +1,39 @@
-import { describe, expect, it } from "vitest";
-import { resolveMatrixLoginSsrFPolicy } from "./config.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const loadMatrixCredentialsMock = vi.hoisted(() => vi.fn(() => null));
+const saveMatrixCredentialsMock = vi.hoisted(() => vi.fn());
+const credentialsMatchConfigMock = vi.hoisted(() => vi.fn(() => false));
+const touchMatrixCredentialsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/matrix", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/matrix")>(
+    "openclaw/plugin-sdk/matrix",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  };
+});
+
+vi.mock("../credentials.js", () => ({
+  loadMatrixCredentials: loadMatrixCredentialsMock,
+  saveMatrixCredentials: saveMatrixCredentialsMock,
+  credentialsMatchConfig: credentialsMatchConfigMock,
+  touchMatrixCredentials: touchMatrixCredentialsMock,
+}));
+
+import { resolveMatrixAuth, resolveMatrixLoginSsrFPolicy } from "./config.js";
 
 describe("resolveMatrixLoginSsrFPolicy", () => {
+  beforeEach(() => {
+    fetchWithSsrFGuardMock.mockReset();
+    loadMatrixCredentialsMock.mockClear();
+    saveMatrixCredentialsMock.mockClear();
+    credentialsMatchConfigMock.mockClear();
+    touchMatrixCredentialsMock.mockClear();
+  });
+
   it("returns browser SSRF hostname exceptions for Matrix login", () => {
     expect(
       resolveMatrixLoginSsrFPolicy({
@@ -18,5 +50,63 @@ describe("resolveMatrixLoginSsrFPolicy", () => {
 
   it("returns undefined when no browser SSRF policy is configured", () => {
     expect(resolveMatrixLoginSsrFPolicy({} as never)).toBeUndefined();
+  });
+
+  it("passes the browser SSRF policy into password login requests", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: {
+        ok: true,
+        json: async () => ({
+          access_token: "token-123",
+          user_id: "@assistant:example.test",
+        }),
+      },
+      release: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await expect(
+      resolveMatrixAuth({
+        cfg: {
+          browser: {
+            ssrfPolicy: {
+              dangerouslyAllowPrivateNetwork: false,
+              allowedHostnames: ["matrix.example.test"],
+            },
+          },
+          channels: {
+            matrix: {
+              homeserver: "https://matrix.example.test",
+              userId: "@assistant:example.test",
+              password: "hunter2",
+            },
+          },
+        } as never,
+        env: {} as NodeJS.ProcessEnv,
+      }),
+    ).resolves.toMatchObject({
+      homeserver: "https://matrix.example.test",
+      userId: "@assistant:example.test",
+      accessToken: "token-123",
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://matrix.example.test/_matrix/client/v3/login",
+        policy: {
+          dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["matrix.example.test"],
+        },
+        auditContext: "matrix.login",
+      }),
+    );
+    expect(saveMatrixCredentialsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        homeserver: "https://matrix.example.test",
+        userId: "@assistant:example.test",
+        accessToken: "token-123",
+      }),
+      expect.any(Object),
+      undefined,
+    );
   });
 });

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -1,3 +1,4 @@
+import type { SsrFPolicy } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/matrix";
 import { getMatrixRuntime } from "../../runtime.js";
@@ -9,6 +10,18 @@ import type { CoreConfig } from "../../types.js";
 import { loadMatrixSdk } from "../sdk-runtime.js";
 import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 import type { MatrixAuth, MatrixResolvedConfig } from "./types.js";
+
+export function resolveMatrixLoginSsrFPolicy(cfg?: CoreConfig): SsrFPolicy | undefined {
+  const browser = cfg?.browser;
+  if (!browser || typeof browser !== "object") {
+    return undefined;
+  }
+  const ssrfPolicy = (browser as { ssrfPolicy?: SsrFPolicy }).ssrfPolicy;
+  if (!ssrfPolicy || typeof ssrfPolicy !== "object") {
+    return undefined;
+  }
+  return ssrfPolicy;
+}
 
 function clean(value: unknown, path: string): string {
   return normalizeResolvedSecretInputString({ value, path }) ?? "";
@@ -108,6 +121,7 @@ export async function resolveMatrixAuth(params?: {
   const cfg = params?.cfg ?? (getMatrixRuntime().config.loadConfig() as CoreConfig);
   const env = params?.env ?? process.env;
   const resolved = resolveMatrixConfigForAccount(cfg, params?.accountId, env);
+  const loginSsrFPolicy = resolveMatrixLoginSsrFPolicy(cfg);
   if (!resolved.homeserver) {
     throw new Error("Matrix homeserver is required (matrix.homeserver)");
   }
@@ -198,6 +212,7 @@ export async function resolveMatrixAuth(params?: {
         initial_device_display_name: resolved.deviceName ?? "OpenClaw Gateway",
       }),
     },
+    policy: loginSsrFPolicy,
     auditContext: "matrix.login",
   });
   const login = await (async () => {


### PR DESCRIPTION
## Summary

- Problem: Matrix password login could be blocked under strict SSRF policy even when the operator had intentionally configured browser SSRF exceptions.
- Why it matters: private or internal homeservers become impossible to use with password-based Matrix setup, and the docs did not explain the required hostname allowlist.
- What changed: password login now passes the configured `browser.ssrfPolicy` into the guarded Matrix login request, docs explain the strict-SSRF setup, and targeted tests cover the policy handoff.
- What did NOT change (scope boundary): access-token auth, cached credential reuse, and Matrix message handling are unchanged.
- AI-assisted: yes, with manual review and targeted verification.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Matrix password login now honors configured SSRF hostname exceptions during the `/_matrix/client/v3/login` call.
- Matrix docs now explain how to allow password login to a private/internal homeserver while keeping strict SSRF mode enabled.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node.js checkout
- Model/provider: GPT-5.4 via Copilot, manually reviewed
- Integration/channel (if any): Matrix
- Relevant config (redacted): Matrix homeserver hostname exception under `browser.ssrfPolicy.allowedHostnames`

### Steps

1. Configure Matrix with `channels.matrix.userId` and `channels.matrix.password`.
2. Enable strict SSRF mode and allow the Matrix homeserver hostname in `browser.ssrfPolicy.allowedHostnames`.
3. Start Matrix auth resolution and verify the guarded login request receives the SSRF policy.

### Expected

- Password login succeeds when the operator explicitly allows the homeserver hostname under strict SSRF policy.

### Actual

- Before this change, the password login path did not forward that policy to the guarded request.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the password-login path end to end, confirmed only the password flow uses `fetchWithSsrFGuard`, and added a test that asserts the SSRF policy reaches the guarded login call.
- Edge cases checked: no configured SSRF policy still returns `undefined`; access-token-based auth remains on its existing path.
- What you did **not** verify: live login against a real Matrix homeserver.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: use an access token instead of password login, or revert this branch.
- Files/config to restore: `extensions/matrix/src/matrix/client/config.ts`, Matrix docs.
- Known bad symptoms reviewers should watch for: password login unexpectedly failing despite an explicit hostname allowlist.

## Risks and Mitigations

- Risk: forwarding the wrong SSRF policy object could affect password-login requests.
- Mitigation: the new test asserts the exact policy handoff, and the change does not alter access-token auth.
