### PR TITLE
[AI-assisted] Matrix: expand auto-join allowlist matching

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -220,6 +220,7 @@ Notes:
 - The configure wizard prompts for room allowlists (room IDs, aliases, or names) and resolves names only on an exact, unique match.
 - On startup, OpenClaw resolves room/user names in allowlists to IDs and logs the mapping; unresolved entries are ignored for allowlist matching.
 - Invites are auto-joined by default; control with `channels.matrix.autoJoin` and `channels.matrix.autoJoinAllowlist`.
+- In `allowlist` mode, `channels.matrix.autoJoinAllowlist` accepts inviter user IDs, room IDs, room aliases, or `"*"`.
 - To allow **no rooms**, set `channels.matrix.groupPolicy: "disabled"` (or keep an empty allowlist).
 - Legacy key: `channels.matrix.rooms` (same shape as `groups`).
 
@@ -298,6 +299,6 @@ Provider options:
 - `channels.matrix.replyToMode`: reply-to mode for threads/tags.
 - `channels.matrix.mediaMaxMb`: inbound/outbound media cap (MB).
 - `channels.matrix.autoJoin`: invite handling (`always | allowlist | off`, default: always).
-- `channels.matrix.autoJoinAllowlist`: allowed room IDs/aliases for auto-join.
+- `channels.matrix.autoJoinAllowlist`: allowed inviter user IDs, room IDs, room aliases, or `"*"` for auto-join.
 - `channels.matrix.accounts`: multi-account configuration keyed by account ID (each account inherits top-level settings).
 - `channels.matrix.actions`: per-action tool gating (reactions/messages/pins/memberInfo/channelInfo).

--- a/docs/zh-CN/channels/matrix.md
+++ b/docs/zh-CN/channels/matrix.md
@@ -165,6 +165,7 @@ E2EE 配置（启用端到端加密）：
 - 配置向导会提示输入房间允许列表（房间 ID、别名或名称），仅在精确且唯一匹配时解析名称。
 - 启动时，OpenClaw 将允许列表中的房间/用户名称解析为 ID 并记录映射；未解析的条目不会参与允许列表匹配。
 - 默认自动加入邀请；使用 `channels.matrix.autoJoin` 和 `channels.matrix.autoJoinAllowlist` 控制。
+- 在 `allowlist` 模式下，`channels.matrix.autoJoinAllowlist` 支持邀请者用户 ID、房间 ID、房间别名以及 `"*"`。
 - 要**禁止所有房间**，设置 `channels.matrix.groupPolicy: "disabled"`（或保持空的允许列表）。
 - 旧版键名：`channels.matrix.rooms`（与 `groups` 相同的结构）。
 
@@ -217,5 +218,5 @@ E2EE 配置（启用端到端加密）：
 - `channels.matrix.replyToMode`：话题/标签的 reply-to 模式。
 - `channels.matrix.mediaMaxMb`：入站/出站媒体上限（MB）。
 - `channels.matrix.autoJoin`：邀请处理（`always | allowlist | off`，默认：always）。
-- `channels.matrix.autoJoinAllowlist`：自动加入的允许房间 ID/别名。
+- `channels.matrix.autoJoinAllowlist`：自动加入的允许邀请者用户 ID、房间 ID、房间别名或 `"*"`。
 - `channels.matrix.actions`：每个操作的工具限制（reactions/messages/pins/memberInfo/channelInfo）。

--- a/extensions/matrix/src/matrix/monitor/auto-join.test.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+const shouldLogVerboseMock = vi.hoisted(() => vi.fn(() => true));
+const setupOnClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../runtime.js", () => ({
+  getMatrixRuntime: vi.fn(() => ({
+    logging: {
+      shouldLogVerbose: shouldLogVerboseMock,
+    },
+  })),
+}));
+
+vi.mock("../sdk-runtime.js", () => ({
+  loadMatrixSdk: vi.fn(() => ({
+    AutojoinRoomsMixin: {
+      setupOnClient: setupOnClientMock,
+    },
+  })),
+}));
+
+import { registerMatrixAutoJoin } from "./auto-join.js";
+
+function createClient() {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  return {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(event, handler);
+    }),
+    getRoomStateEvent: vi.fn().mockResolvedValue(null),
+    joinRoom: vi.fn().mockResolvedValue(undefined),
+    emitInvite: async (roomId: string, event: unknown) => {
+      const handler = handlers.get("room.invite");
+      if (!handler) {
+        throw new Error("room.invite handler not registered");
+      }
+      await handler(roomId, event);
+    },
+  };
+}
+
+describe("registerMatrixAutoJoin", () => {
+  it("auto-joins allowlisted inviter user ids", async () => {
+    const client = createClient();
+    const runtime = { log: vi.fn(), error: vi.fn() };
+
+    registerMatrixAutoJoin({
+      client: client as never,
+      cfg: {
+        channels: {
+          matrix: {
+            autoJoin: "allowlist",
+            autoJoinAllowlist: ["@inviter:example.test"],
+          },
+        },
+      },
+      runtime: runtime as never,
+    });
+
+    await client.emitInvite("!room123:example.test", { sender: "@inviter:example.test" });
+
+    expect(client.joinRoom).toHaveBeenCalledWith("!room123:example.test");
+  });
+
+  it("still auto-joins allowlisted room ids", async () => {
+    const client = createClient();
+    const runtime = { log: vi.fn(), error: vi.fn() };
+
+    registerMatrixAutoJoin({
+      client: client as never,
+      cfg: {
+        channels: {
+          matrix: {
+            autoJoin: "allowlist",
+            autoJoinAllowlist: ["!room123:example.test"],
+          },
+        },
+      },
+      runtime: runtime as never,
+    });
+
+    await client.emitInvite("!room123:example.test", { sender: "@other:example.test" });
+
+    expect(client.joinRoom).toHaveBeenCalledWith("!room123:example.test");
+  });
+
+  it("does not join invites outside the allowlist", async () => {
+    const client = createClient();
+    const runtime = { log: vi.fn(), error: vi.fn() };
+
+    registerMatrixAutoJoin({
+      client: client as never,
+      cfg: {
+        channels: {
+          matrix: {
+            autoJoin: "allowlist",
+            autoJoinAllowlist: ["@inviter:example.test"],
+          },
+        },
+      },
+      runtime: runtime as never,
+    });
+
+    await client.emitInvite("!room999:example.test", { sender: "@someoneelse:example.test" });
+
+    expect(client.joinRoom).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/auto-join.test.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.test.ts
@@ -62,6 +62,29 @@ describe("registerMatrixAutoJoin", () => {
     expect(client.joinRoom).toHaveBeenCalledWith("!room123:example.test");
   });
 
+  it("still auto-joins allowlisted room aliases", async () => {
+    const client = createClient();
+    const runtime = { log: vi.fn(), error: vi.fn() };
+    client.getRoomStateEvent.mockResolvedValue({ alias: "#ops:example.test" });
+
+    registerMatrixAutoJoin({
+      client: client as never,
+      cfg: {
+        channels: {
+          matrix: {
+            autoJoin: "allowlist",
+            autoJoinAllowlist: ["#ops:example.test"],
+          },
+        },
+      },
+      runtime: runtime as never,
+    });
+
+    await client.emitInvite("!room123:example.test", { sender: "@other:example.test" });
+
+    expect(client.joinRoom).toHaveBeenCalledWith("!room123:example.test");
+  });
+
   it("still auto-joins allowlisted room ids", async () => {
     const client = createClient();
     const runtime = { log: vi.fn(), error: vi.fn() };

--- a/extensions/matrix/src/matrix/monitor/auto-join.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.ts
@@ -33,10 +33,15 @@ export function registerMatrixAutoJoin(params: {
   }
 
   // For "allowlist" mode, handle invites manually
-  client.on("room.invite", async (roomId: string, _inviteEvent: unknown) => {
+  client.on("room.invite", async (roomId: string, inviteEvent: unknown) => {
     if (autoJoin !== "allowlist") {
       return;
     }
+
+    const sender =
+      inviteEvent && typeof inviteEvent === "object" && "sender" in inviteEvent
+        ? String((inviteEvent as { sender?: unknown }).sender ?? "").trim()
+        : "";
 
     // Get room alias if available
     let alias: string | undefined;
@@ -53,6 +58,7 @@ export function registerMatrixAutoJoin(params: {
 
     const allowed =
       autoJoinAllowlist.includes("*") ||
+      (sender ? autoJoinAllowlist.includes(sender) : false) ||
       autoJoinAllowlist.includes(roomId) ||
       (alias ? autoJoinAllowlist.includes(alias) : false) ||
       altAliases.some((value) => autoJoinAllowlist.includes(value));

--- a/extensions/matrix/src/matrix/monitor/auto-join.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.ts
@@ -34,13 +34,11 @@ export function registerMatrixAutoJoin(params: {
 
   // For "allowlist" mode, handle invites manually
   client.on("room.invite", async (roomId: string, inviteEvent: unknown) => {
-    if (autoJoin !== "allowlist") {
-      return;
-    }
-
     const sender =
       inviteEvent && typeof inviteEvent === "object" && "sender" in inviteEvent
-        ? String((inviteEvent as { sender?: unknown }).sender ?? "").trim()
+        ? typeof (inviteEvent as { sender?: unknown }).sender === "string"
+          ? (inviteEvent as { sender: string }).sender.trim()
+          : ""
         : "";
 
     // Get room alias if available

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -85,7 +85,7 @@ export type MatrixConfig = {
   mediaMaxMb?: number;
   /** Auto-join invites (always|allowlist|off). Default: always. */
   autoJoin?: "always" | "allowlist" | "off";
-  /** Allowlist for auto-join invites (room IDs, aliases). */
+  /** Allowlist for auto-join invites (inviter user IDs, room IDs, aliases). */
   autoJoinAllowlist?: Array<string | number>;
   /** Direct message policy + allowlist overrides. */
   dm?: MatrixDmConfig;


### PR DESCRIPTION
## Summary

- Problem: Matrix `autoJoinAllowlist` docs only described room IDs and aliases, while operators also need to allow joins based on the inviter user ID.
- Why it matters: invite workflows that depend on trusted inviters were awkward to configure and easy to misread from the docs.
- What changed: `allowlist` auto-join mode now matches inviter user IDs in addition to room IDs and aliases, docs describe the expanded matching, and targeted tests cover inviter, alias, room ID, and miss cases.
- What did NOT change (scope boundary): `autoJoin: "always"` still uses the SDK mixin, `autoJoin: "off"` still disables auto-join, and joining still only occurs for explicit allowlist matches.
- AI-assisted: yes, with manual review and targeted verification.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- In `channels.matrix.autoJoin = "allowlist"` mode, `channels.matrix.autoJoinAllowlist` can now match inviter Matrix user IDs as well as room IDs, room aliases, and `"*"`.
- Matrix docs now describe the supported allowlist entry types accurately.

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: this expands the set of explicit allowlist keys accepted in `allowlist` mode, but joining still requires a direct exact match against operator-provided values. The negative-path test confirms non-matching invites are still ignored.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node.js checkout
- Model/provider: GPT-5.4 via Copilot, manually reviewed
- Integration/channel (if any): Matrix
- Relevant config (redacted): `channels.matrix.autoJoin = "allowlist"` with redacted inviter IDs / aliases

### Steps

1. Configure Matrix with `channels.matrix.autoJoin = "allowlist"`.
2. Set `channels.matrix.autoJoinAllowlist` to a trusted inviter ID, room alias, or room ID.
3. Emit invite events and verify joins only happen on explicit matches.

### Expected

- Allowlisted inviter IDs, aliases, and room IDs join successfully; non-matching invites are ignored.

### Actual

- Before this change, inviter IDs were documented neither in code comments nor docs and were not accepted by the runtime matcher.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the `room.invite` flow, confirmed `always` and `off` modes remain unchanged, and ran focused auto-join tests covering inviter ID, room alias, room ID, and allowlist misses.
- Edge cases checked: canonical alias lookup still participates in matching; unmatched invites still log and return without joining.
- What you did **not** verify: live Matrix invites against a real homeserver.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `channels.matrix.autoJoin` to `off`, or remove inviter IDs from `autoJoinAllowlist`, or revert this branch.
- Files/config to restore: `extensions/matrix/src/matrix/monitor/auto-join.ts`, Matrix docs.
- Known bad symptoms reviewers should watch for: joins triggered by invites that do not exactly match any configured inviter, room ID, or alias.

## Risks and Mitigations

- Risk: invite matching could become broader than intended in `allowlist` mode.
- Mitigation: the matcher still requires exact string equality, and focused tests cover both accepted and rejected invite paths.
