### PR TITLE
feishu: fall back to text when card send fails

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -224,6 +224,43 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("falls back to plain text when card send fails", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn() } as never;
+    sendMarkdownCardFeishuMock.mockRejectedValueOnce(
+      new Error("Create card request failed with HTTP 400"),
+    );
+
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: false,
+      },
+    });
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime,
+      chatId: "oc_chat",
+    });
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "```md\nfallback please\n```" }, { kind: "final" });
+
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "```md\nfallback please\n```",
+      }),
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("feishu: card send failed, falling back to plain text"),
+    );
+  });
+
   it("suppresses internal block payload delivery", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -148,6 +148,23 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamingStartPromise: Promise<void> | null = null;
   type StreamTextUpdateMode = "snapshot" | "delta";
 
+  const sendPlainTextChunks = async (text: string) => {
+    const converted = core.channel.text.convertMarkdownTables(text, tableMode);
+    let first = true;
+    for (const chunk of core.channel.text.chunkTextWithMode(converted, textChunkLimit, chunkMode)) {
+      await sendMessageFeishu({
+        cfg,
+        to: chatId,
+        text: chunk,
+        replyToMessageId: sendReplyToMessageId,
+        replyInThread: effectiveReplyInThread,
+        mentions: first ? mentionTargets : undefined,
+        accountId,
+      });
+      first = false;
+    }
+  };
+
   const queueStreamingUpdate = (
     nextText: string,
     options?: {
@@ -305,43 +322,34 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
           let first = true;
           if (useCard) {
-            for (const chunk of core.channel.text.chunkTextWithMode(
-              text,
-              textChunkLimit,
-              chunkMode,
-            )) {
-              await sendMarkdownCardFeishu({
-                cfg,
-                to: chatId,
-                text: chunk,
-                replyToMessageId: sendReplyToMessageId,
-                replyInThread: effectiveReplyInThread,
-                mentions: first ? mentionTargets : undefined,
-                accountId,
-              });
-              first = false;
+            try {
+              for (const chunk of core.channel.text.chunkTextWithMode(
+                text,
+                textChunkLimit,
+                chunkMode,
+              )) {
+                await sendMarkdownCardFeishu({
+                  cfg,
+                  to: chatId,
+                  text: chunk,
+                  replyToMessageId: sendReplyToMessageId,
+                  replyInThread: effectiveReplyInThread,
+                  mentions: first ? mentionTargets : undefined,
+                  accountId,
+                });
+                first = false;
+              }
+            } catch (error) {
+              params.runtime.error?.(
+                `feishu: card send failed, falling back to plain text: ${String(error)}`,
+              );
+              await sendPlainTextChunks(text);
             }
             if (info?.kind === "final") {
               deliveredFinalTexts.add(text);
             }
           } else {
-            const converted = core.channel.text.convertMarkdownTables(text, tableMode);
-            for (const chunk of core.channel.text.chunkTextWithMode(
-              converted,
-              textChunkLimit,
-              chunkMode,
-            )) {
-              await sendMessageFeishu({
-                cfg,
-                to: chatId,
-                text: chunk,
-                replyToMessageId: sendReplyToMessageId,
-                replyInThread: effectiveReplyInThread,
-                mentions: first ? mentionTargets : undefined,
-                accountId,
-              });
-              first = false;
-            }
+            await sendPlainTextChunks(text);
             if (info?.kind === "final") {
               deliveredFinalTexts.add(text);
             }


### PR DESCRIPTION
## Summary
- fall back to plain text when Feishu markdown card delivery fails
- keep the fallback inside the Feishu reply dispatcher so card 400s no longer drop the whole user-visible reply
- add regression coverage for card-send failures on the non-streaming markdown path

## Testing
- pnpm test extensions/feishu/src/reply-dispatcher.test.ts
- pnpm test extensions/feishu/src/bot.test.ts
- pnpm build
- pnpm exec oxfmt --check extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts

Closes #43322
