### PR TITLE
status: avoid misleading default model when agent defaults vary

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -316,6 +316,9 @@ export async function statusCommand(
   })();
 
   const defaults = summary.sessions.defaults;
+  const defaultModelLabel = defaults.variesByAgent
+    ? "varies by agent"
+    : (defaults.model ?? "unknown");
   const defaultCtx = defaults.contextTokens
     ? ` (${formatKTokens(defaults.contextTokens)} ctx)`
     : "";
@@ -438,7 +441,7 @@ export async function statusCommand(
     ...(lastHeartbeatValue ? [{ Item: "Last heartbeat", Value: lastHeartbeatValue }] : []),
     {
       Item: "Sessions",
-      Value: `${summary.sessions.count} active · default ${defaults.model ?? "unknown"}${defaultCtx} · ${storeLabel}`,
+      Value: `${summary.sessions.count} active · default ${defaultModelLabel}${defaultCtx} · ${storeLabel}`,
     },
   ];
 

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -15,6 +15,10 @@ vi.mock("../agents/model-selection.js", () => ({
     provider: "openai",
     model: "gpt-5.2",
   })),
+  resolveDefaultModelForAgent: vi.fn(() => ({
+    provider: "openai",
+    model: "gpt-5.2",
+  })),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -81,5 +85,57 @@ describe("getStatusSummary", () => {
     expect(summary.runtimeVersion).toBe("2026.3.8");
     expect(summary.heartbeat.defaultAgentId).toBe("main");
     expect(summary.channelSummary).toEqual(["ok"]);
+  });
+
+  it("marks session defaults as varying when agent models differ", async () => {
+    const sessionUtils = await import("../gateway/session-utils.js");
+    const modelSelection = await import("../agents/model-selection.js");
+    const { getStatusSummary } = await import("./status.summary.js");
+
+    vi.mocked(sessionUtils.listAgentsForGateway).mockReturnValue({
+      defaultId: "agentA",
+      mainKey: "agent:agenta:main",
+      scope: "per-sender",
+      agents: [{ id: "agentA" }, { id: "agentB" }],
+    });
+    vi.mocked(modelSelection.resolveDefaultModelForAgent).mockImplementation(
+      ({ agentId }: { agentId?: string }) =>
+        agentId === "agentB"
+          ? { provider: "openrouter", model: "openrouter/free" }
+          : { provider: "anthropic", model: "claude-sonnet-4-5" },
+    );
+
+    const summary = await getStatusSummary();
+
+    expect(summary.sessions.defaults).toEqual({
+      model: null,
+      contextTokens: 200_000,
+      variesByAgent: true,
+    });
+  });
+
+  it("keeps a concrete default model when all agents resolve to the same model", async () => {
+    const sessionUtils = await import("../gateway/session-utils.js");
+    const modelSelection = await import("../agents/model-selection.js");
+    const { getStatusSummary } = await import("./status.summary.js");
+
+    vi.mocked(sessionUtils.listAgentsForGateway).mockReturnValue({
+      defaultId: "agentA",
+      mainKey: "agent:agenta:main",
+      scope: "per-sender",
+      agents: [{ id: "agentA" }, { id: "agentB" }],
+    });
+    vi.mocked(modelSelection.resolveDefaultModelForAgent).mockImplementation(() => ({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+    }));
+
+    const summary = await getStatusSummary();
+
+    expect(summary.sessions.defaults).toEqual({
+      model: "claude-sonnet-4-5",
+      contextTokens: 200_000,
+      variesByAgent: false,
+    });
   });
 });

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -1,6 +1,9 @@
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import { resolveConfiguredModelRef } from "../agents/model-selection.js";
+import {
+  resolveConfiguredModelRef,
+  resolveDefaultModelForAgent,
+} from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -77,6 +80,33 @@ export function redactSensitiveStatusSummary(summary: StatusSummary): StatusSumm
   };
 }
 
+function resolveStatusSessionDefaults(cfg: OpenClawConfig, agentIds: string[]) {
+  const effectiveAgentIds = agentIds.length > 0 ? agentIds : [undefined];
+  const resolvedDefaults = effectiveAgentIds.map((agentId) =>
+    resolveDefaultModelForAgent({ cfg, agentId }),
+  );
+  const uniqueModels = new Set(
+    resolvedDefaults.map((resolved) => `${resolved.provider}/${resolved.model}`),
+  );
+  const contextTokens = resolvedDefaults.map(
+    (resolved) =>
+      resolveContextTokensForModel({
+        cfg,
+        provider: resolved.provider ?? DEFAULT_PROVIDER,
+        model: resolved.model ?? DEFAULT_MODEL,
+        contextTokensOverride: cfg.agents?.defaults?.contextTokens,
+        fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      }) ?? DEFAULT_CONTEXT_TOKENS,
+  );
+  const uniqueContextTokens = new Set(contextTokens);
+  return {
+    model: uniqueModels.size === 1 ? (resolvedDefaults[0]?.model ?? DEFAULT_MODEL) : null,
+    contextTokens:
+      uniqueContextTokens.size === 1 ? (contextTokens[0] ?? DEFAULT_CONTEXT_TOKENS) : null,
+    variesByAgent: uniqueModels.size > 1,
+  };
+}
+
 export async function getStatusSummary(
   options: {
     includeSensitive?: boolean;
@@ -119,6 +149,10 @@ export async function getStatusSummary(
       contextTokensOverride: cfg.agents?.defaults?.contextTokens,
       fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
     }) ?? DEFAULT_CONTEXT_TOKENS;
+  const sessionDefaults = resolveStatusSessionDefaults(
+    cfg,
+    agentList.agents.map((agent) => agent.id),
+  );
 
   const now = Date.now();
   const storeCache = new Map<string, Record<string, SessionEntry | undefined>>();
@@ -229,10 +263,7 @@ export async function getStatusSummary(
     sessions: {
       paths: Array.from(paths),
       count: totalSessions,
-      defaults: {
-        model: configModel ?? null,
-        contextTokens: configContextTokens ?? null,
-      },
+      defaults: sessionDefaults,
       recent,
       byAgent,
     },

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -50,7 +50,7 @@ export type StatusSummary = {
   sessions: {
     paths: string[];
     count: number;
-    defaults: { model: string | null; contextTokens: number | null };
+    defaults: { model: string | null; contextTokens: number | null; variesByAgent?: boolean };
     recent: SessionStatus[];
     byAgent: Array<{
       agentId: string;

--- a/src/tui/tui-status-summary.ts
+++ b/src/tui/tui-status-summary.ts
@@ -52,7 +52,7 @@ export function formatStatusSummary(summary: GatewayStatusSummary) {
   }
 
   const defaults = summary.sessions?.defaults;
-  const defaultModel = defaults?.model ?? "unknown";
+  const defaultModel = defaults?.variesByAgent ? "varies by agent" : (defaults?.model ?? "unknown");
   const defaultCtx =
     typeof defaults?.contextTokens === "number"
       ? ` (${formatTokenCount(defaults.contextTokens)} ctx)`

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -70,7 +70,11 @@ export type GatewayStatusSummary = {
   sessions?: {
     paths?: string[];
     count?: number;
-    defaults?: { model?: string | null; contextTokens?: number | null };
+    defaults?: {
+      model?: string | null;
+      contextTokens?: number | null;
+      variesByAgent?: boolean;
+    };
     recent?: Array<{
       agentId?: string;
       key: string;


### PR DESCRIPTION
## Summary
`openclaw status` summarized session defaults from `agents.defaults.model` only, which made explicit `agents.list[*].model` overrides look ignored in status output.

## Root cause
`getStatusSummary()` resolved `sessions.defaults.model` without agent context, so multi-agent configs collapsed to the global default model in `status`, `status --json`, and the TUI summary.

## Fix
- derive the status session-default summary from each agent’s effective default model
- keep the concrete model display when all agents resolve to the same effective default
- report `varies by agent` when agent-effective defaults differ
- carry that state through the CLI and TUI renderers

## Tests
- regression for divergent per-agent default models
- regression for the non-divergent case