### PR TITLE
CLI: honor OPENCLAW_GATEWAY_BIND in gateway run

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { withEnvOverride } from "../../config/test-helpers.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
 const startGatewayServer = vi.fn(async (_port: number, _opts?: unknown) => ({
@@ -191,6 +192,25 @@ describe("gateway run option collisions", () => {
       18789,
       expect.objectContaining({
         bind: "loopback",
+      }),
+    );
+  });
+
+  it("uses OPENCLAW_GATEWAY_BIND when --bind is omitted", async () => {
+    configState.cfg = {
+      gateway: {
+        bind: "loopback",
+      },
+    };
+
+    await withEnvOverride({ OPENCLAW_GATEWAY_BIND: "lan" }, async () => {
+      await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
+    });
+
+    expect(startGatewayServer).toHaveBeenCalledWith(
+      18789,
+      expect.objectContaining({
+        bind: "lan",
       }),
     );
   });

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -215,6 +215,38 @@ describe("gateway run option collisions", () => {
     );
   });
 
+  it("treats empty OPENCLAW_GATEWAY_BIND as unset and falls through", async () => {
+    configState.cfg = {
+      gateway: {
+        bind: "lan",
+      },
+    };
+
+    await withEnvOverride({ OPENCLAW_GATEWAY_BIND: "" }, async () => {
+      await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
+    });
+
+    expect(startGatewayServer).toHaveBeenCalledWith(
+      18789,
+      expect.objectContaining({
+        bind: "lan",
+      }),
+    );
+  });
+
+  it("--bind CLI flag takes precedence over OPENCLAW_GATEWAY_BIND", async () => {
+    await withEnvOverride({ OPENCLAW_GATEWAY_BIND: "lan" }, async () => {
+      await runGatewayCli(["gateway", "run", "--bind", "loopback", "--allow-unconfigured"]);
+    });
+
+    expect(startGatewayServer).toHaveBeenCalledWith(
+      18789,
+      expect.objectContaining({
+        bind: "loopback",
+      }),
+    );
+  });
+
   it("accepts --auth none override", async () => {
     await runGatewayCli(["gateway", "run", "--auth", "none", "--allow-unconfigured"]);
 

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -209,12 +209,10 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.error("Invalid port");
     defaultRuntime.exit(1);
   }
+  const envBind = process.env.OPENCLAW_GATEWAY_BIND?.trim() || undefined;
+  const legacyEnvBind = process.env.CLAWDBOT_GATEWAY_BIND?.trim() || undefined;
   const bindRaw =
-    toOptionString(opts.bind) ??
-    process.env.OPENCLAW_GATEWAY_BIND?.trim() ??
-    process.env.CLAWDBOT_GATEWAY_BIND?.trim() ??
-    cfg.gateway?.bind ??
-    "loopback";
+    toOptionString(opts.bind) ?? envBind ?? legacyEnvBind ?? cfg.gateway?.bind ?? "loopback";
   const bind =
     bindRaw === "loopback" ||
     bindRaw === "lan" ||

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -209,7 +209,12 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.error("Invalid port");
     defaultRuntime.exit(1);
   }
-  const bindRaw = toOptionString(opts.bind) ?? cfg.gateway?.bind ?? "loopback";
+  const bindRaw =
+    toOptionString(opts.bind) ??
+    process.env.OPENCLAW_GATEWAY_BIND?.trim() ??
+    process.env.CLAWDBOT_GATEWAY_BIND?.trim() ??
+    cfg.gateway?.bind ??
+    "loopback";
   const bind =
     bindRaw === "loopback" ||
     bindRaw === "lan" ||


### PR DESCRIPTION
## Summary

- Problem: Docker deployments that only set `OPENCLAW_GATEWAY_BIND=lan` could still start `openclaw gateway run` on loopback because run-time bind selection ignored the env var.
- Why it matters: This blocks external/reverse-proxy gateway access paths and causes the gateway to remain reachable only at `127.0.0.1`.
- What changed: `gateway run` now resolves bind mode in this order: `--bind` CLI option, `OPENCLAW_GATEWAY_BIND`, `CLAWDBOT_GATEWAY_BIND`, config `gateway.bind`, then default `loopback`.
- What did NOT change (scope boundary): No changes to gateway listener implementation, auth semantics, Docker compose templates, or onboarding defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43886
- Related #N/A

## User-visible / Behavior Changes

- `openclaw gateway run` now honors `OPENCLAW_GATEWAY_BIND` (and legacy `CLAWDBOT_GATEWAY_BIND`) when `--bind` is not provided.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Gateway CLI
- Relevant config (redacted): `gateway.bind=loopback` in test fixture + `OPENCLAW_GATEWAY_BIND=lan`

### Steps

1. Start gateway via CLI command path without `--bind`.
2. Set `OPENCLAW_GATEWAY_BIND=lan`.
3. Verify resolved bind passed to `startGatewayServer`.

### Expected

- Env bind value is honored when CLI `--bind` is omitted.

### Actual

- Confirmed by test: `startGatewayServer` receives `bind: "lan"`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Added focused unit test for env bind precedence in `gateway run`.
  - Ran targeted test suite for modified gateway CLI run behavior.
- Edge cases checked:
  - Config still provides fallback when env is unset.
  - Existing CLI path remains unchanged when `--bind` is explicitly set.
- What you did **not** verify:
  - Full Docker/Traefik end-to-end deployment in this local run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Explicitly pass `--bind loopback` in gateway startup command.
  - Revert this PR commit.
- Files/config to restore:
  - `src/cli/gateway-cli/run.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected bind precedence in CLI startup when both env and config are set.

## Risks and Mitigations

- Risk:
  - Environment variable could override an expected config bind in deployments that set `OPENCLAW_GATEWAY_BIND` globally.
  - Mitigation:
  - CLI `--bind` still has highest precedence, and this behavior is now covered by a focused test.

## Validation Commands

- `pnpm install` (needed because `node_modules` was missing in this worktree)
- `pnpm test -- src/cli/gateway-cli/run.option-collisions.test.ts` (pass)
