### PR TITLE
fix(feishu): decode URL-encoded filenames when receiving files

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -53,6 +53,7 @@ vi.mock("./send.js", () => ({
 
 vi.mock("./media.js", () => ({
   downloadMessageResourceFeishu: mockDownloadMessageResourceFeishu,
+  decodeFileNameFromFeishu: vi.fn((fileName: string) => fileName),
 }));
 
 vi.mock("./client.js", () => ({

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -18,7 +18,7 @@ import { createFeishuClient } from "./client.js";
 import { tryRecordMessage, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
-import { downloadMessageResourceFeishu } from "./media.js";
+import { decodeFileNameFromFeishu, downloadMessageResourceFeishu } from "./media.js";
 import { extractMentionTargets, isMentionForwardRequest } from "./mention.js";
 import {
   resolveFeishuGroupConfig,
@@ -434,7 +434,7 @@ function formatSubMessageContent(content: string, contentType: string): string {
       case "image":
         return "[Image]";
       case "file":
-        return `[File: ${parsed.file_name || "unknown"}]`;
+        return `[File: ${decodeFileNameFromFeishu(parsed.file_name) || "unknown"}]`;
       case "audio":
         return "[Audio]";
       case "video":
@@ -525,7 +525,7 @@ function parseMediaKeys(
       case "image":
         return { imageKey };
       case "file":
-        return { fileKey, fileName: parsed.file_name };
+        return { fileKey, fileName: decodeFileNameFromFeishu(parsed.file_name) };
       case "audio":
         return { fileKey };
       case "video":

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -486,9 +486,9 @@ describe("decodeFileNameFromFeishu", () => {
     expect(decodeFileNameFromFeishu("")).toBe("");
   });
 
-  it("returns null/undefined unchanged", () => {
-    expect(decodeFileNameFromFeishu(null as any)).toBe(null);
-    expect(decodeFileNameFromFeishu(undefined as any)).toBe(undefined);
+  it("returns empty string for null/undefined", () => {
+    expect(decodeFileNameFromFeishu(null as any)).toBe("");
+    expect(decodeFileNameFromFeishu(undefined as any)).toBe("");
   });
 
   it("returns ASCII filenames unchanged", () => {

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -486,9 +486,9 @@ describe("decodeFileNameFromFeishu", () => {
     expect(decodeFileNameFromFeishu("")).toBe("");
   });
 
-  it("returns empty string for null/undefined", () => {
-    expect(decodeFileNameFromFeishu(null as any)).toBe("");
-    expect(decodeFileNameFromFeishu(undefined as any)).toBe("");
+  it("returns null/undefined unchanged", () => {
+    expect(decodeFileNameFromFeishu(null as any)).toBe(null);
+    expect(decodeFileNameFromFeishu(undefined as any)).toBe(undefined);
   });
 
   it("returns ASCII filenames unchanged", () => {
@@ -520,6 +520,13 @@ describe("decodeFileNameFromFeishu", () => {
   it("decodes mixed ASCII and encoded characters", () => {
     const encoded = "Report_" + encodeURIComponent("报告") + "_2026.xlsx";
     expect(decodeFileNameFromFeishu(encoded)).toBe("Report_报告_2026.xlsx");
+  });
+
+  it("does not decode literal percent sequences like report%20draft.txt", () => {
+    // Literal %20 should NOT be decoded to space
+    expect(decodeFileNameFromFeishu("report%20draft.txt")).toBe("report%20draft.txt");
+    // Literal %2F should NOT be decoded to /
+    expect(decodeFileNameFromFeishu("data%2F2026.csv")).toBe("data%2F2026.csv");
   });
 });
 

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -40,6 +40,7 @@ vi.mock("./runtime.js", () => ({
 }));
 
 import {
+  decodeFileNameFromFeishu,
   downloadImageFeishu,
   downloadMessageResourceFeishu,
   sanitizeFileNameForUpload,
@@ -477,6 +478,48 @@ describe("sanitizeFileNameForUpload", () => {
     expect(result).toContain("notes_");
     expect(result).toContain("%E6%B5%8B%E8%AF%95");
     expect(result).not.toContain("测试");
+  });
+});
+
+describe("decodeFileNameFromFeishu", () => {
+  it("returns empty string unchanged", () => {
+    expect(decodeFileNameFromFeishu("")).toBe("");
+  });
+
+  it("returns null/undefined unchanged", () => {
+    expect(decodeFileNameFromFeishu(null as any)).toBe(null);
+    expect(decodeFileNameFromFeishu(undefined as any)).toBe(undefined);
+  });
+
+  it("returns ASCII filenames unchanged", () => {
+    expect(decodeFileNameFromFeishu("report.pdf")).toBe("report.pdf");
+    expect(decodeFileNameFromFeishu("my-file_v2.txt")).toBe("my-file_v2.txt");
+  });
+
+  it("decodes URL-encoded Chinese characters", () => {
+    // This is what Feishu returns when file was uploaded with sanitizeFileNameForUpload
+    const encoded = encodeURIComponent("测试文件") + ".md";
+    expect(decodeFileNameFromFeishu(encoded)).toBe("测试文件.md");
+  });
+
+  it("decodes URL-encoded em-dash and full-width brackets", () => {
+    const encoded = encodeURIComponent("文件—说明（v2）") + ".pdf";
+    const result = decodeFileNameFromFeishu(encoded);
+    expect(result).toBe("文件—说明（v2）.pdf");
+  });
+
+  it("returns partially malformed encoded strings as-is", () => {
+    // %GG is not valid hex, should return unchanged
+    expect(decodeFileNameFromFeishu("test%GG.pdf")).toBe("test%GG.pdf");
+  });
+
+  it("handles filenames without encoded characters", () => {
+    expect(decodeFileNameFromFeishu("报告.pdf")).toBe("报告.pdf");
+  });
+
+  it("decodes mixed ASCII and encoded characters", () => {
+    const encoded = "Report_" + encodeURIComponent("报告") + "_2026.xlsx";
+    expect(decodeFileNameFromFeishu(encoded)).toBe("Report_报告_2026.xlsx");
   });
 });
 

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -247,11 +247,12 @@ export function decodeFileNameFromFeishu(
   if (!fileName) {
     return fileName;
   }
-  // Only decode if it looks like UTF-8 percent-encoded sequences
-  // (e.g., %E6%96%87%E6%A1%A3 for Chinese characters)
-  // Avoids false positives for literal % in filenames like "report%20draft.txt"
-  const hasUtf8EncodedChars = /%(?:E[0-9A-F]|C[2-9A-F]|D[0-9A-F])[0-9A-F]{2}/i.test(fileName);
-  if (!hasUtf8EncodedChars) {
+  // Check if the filename looks like it was encoded by sanitizeFileNameForUpload
+  // which uses encodeURIComponent. We look for multiple consecutive %XX sequences
+  // that indicate UTF-8 encoded non-ASCII characters.
+  // This avoids decoding literal % in filenames like "report%20draft.txt"
+  const hasEncodedUtf8 = /%[0-9A-Fa-f]{2}%[0-9A-Fa-f]{2}/.test(fileName);
+  if (!hasEncodedUtf8) {
     return fileName;
   }
   try {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -238,11 +238,12 @@ export function sanitizeFileNameForUpload(fileName: string): string {
 
 /**
  * Decode a filename that may have been URL-encoded by sanitizeFileNameForUpload.
- * This is used when receiving filenames from Feishu messages, * to ensure proper display of non-ASCII characters.
+ * This is used when receiving filenames from Feishu messages, to ensure proper
+ * display of non-ASCII characters.
  */
-export function decodeFileNameFromFeishu(fileName: string): string {
+export function decodeFileNameFromFeishu(fileName: string | undefined | null): string {
   if (!fileName) {
-    return fileName;
+    return fileName ?? "";
   }
   // Check if the filename looks URL-encoded
   const hasEncodedChars = /%[0-9A-Fa-f]{2}/.test(fileName);

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -241,13 +241,17 @@ export function sanitizeFileNameForUpload(fileName: string): string {
  * This is used when receiving filenames from Feishu messages, to ensure proper
  * display of non-ASCII characters.
  */
-export function decodeFileNameFromFeishu(fileName: string | undefined | null): string {
+export function decodeFileNameFromFeishu(
+  fileName: string | undefined | null,
+): string | undefined | null {
   if (!fileName) {
-    return fileName ?? "";
+    return fileName;
   }
-  // Check if the filename looks URL-encoded
-  const hasEncodedChars = /%[0-9A-Fa-f]{2}/.test(fileName);
-  if (!hasEncodedChars) {
+  // Only decode if it looks like UTF-8 percent-encoded sequences
+  // (e.g., %E6%96%87%E6%A1%A3 for Chinese characters)
+  // Avoids false positives for literal % in filenames like "report%20draft.txt"
+  const hasUtf8EncodedChars = /%(?:E[0-9A-F]|C[2-9A-F]|D[0-9A-F])[0-9A-F]{2}/i.test(fileName);
+  if (!hasUtf8EncodedChars) {
     return fileName;
   }
   try {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -237,6 +237,27 @@ export function sanitizeFileNameForUpload(fileName: string): string {
 }
 
 /**
+ * Decode a filename that may have been URL-encoded by sanitizeFileNameForUpload.
+ * This is used when receiving filenames from Feishu messages, * to ensure proper display of non-ASCII characters.
+ */
+export function decodeFileNameFromFeishu(fileName: string): string {
+  if (!fileName) {
+    return fileName;
+  }
+  // Check if the filename looks URL-encoded
+  const hasEncodedChars = /%[0-9A-Fa-f]{2}/.test(fileName);
+  if (!hasEncodedChars) {
+    return fileName;
+  }
+  try {
+    return decodeURIComponent(fileName);
+  } catch {
+    // If decoding fails, return as-is
+    return fileName;
+  }
+}
+
+/**
  * Upload a file to Feishu and get a file_key for sending.
  * Max file size: 30MB
  */

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -1,0 +1,52 @@
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { ToolCard } from "../types/chat-types.ts";
+import { renderToolCardSidebar } from "./tool-cards.ts";
+
+describe("tool-cards sidebar", () => {
+  it("shows full command plus output in sidebar while card detail remains truncated", () => {
+    const longCommand = `python3 ~/.openclaw/workspace/skills/node-cluster-3.connector/scripts/main.py invoke wangjx-node-host system.run --raw-command '${"x".repeat(220)}'`;
+    const onOpenSidebar = vi.fn();
+    const card: ToolCard = {
+      kind: "result",
+      name: "exec",
+      args: { command: longCommand, cwd: "/tmp/demo", timeoutMs: 5000 },
+      text: "command output line 1\ncommand output line 2",
+    };
+
+    const container = document.createElement("div");
+    render(renderToolCardSidebar(card, onOpenSidebar), container);
+
+    const detail = container.querySelector(".chat-tool-card__detail");
+    expect(detail?.textContent).toContain("…");
+
+    const clickable = container.querySelector(".chat-tool-card") as HTMLElement;
+    clickable.click();
+
+    expect(onOpenSidebar).toHaveBeenCalledTimes(1);
+    const content = onOpenSidebar.mock.calls[0][0] as string;
+    expect(content).toContain(longCommand);
+    expect(content).toContain('"cwd": "/tmp/demo"');
+    expect(content).toContain("command output line 1");
+    expect(content).toContain("**Command:**");
+    expect(content).toContain("**Args:**");
+  });
+
+  it("shows full args and explicit no-output note when no command exists", () => {
+    const onOpenSidebar = vi.fn();
+    const card: ToolCard = {
+      kind: "result",
+      name: "read",
+      args: { path: "/tmp/file.txt", offset: 10, limit: 5 },
+    };
+
+    const container = document.createElement("div");
+    render(renderToolCardSidebar(card, onOpenSidebar), container);
+    (container.querySelector(".chat-tool-card") as HTMLElement).click();
+
+    const content = onOpenSidebar.mock.calls[0][0] as string;
+    expect(content).toContain("**Args:**");
+    expect(content).toContain('"path": "/tmp/file.txt"');
+    expect(content).toContain("No output — tool completed successfully");
+  });
+});

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -16,17 +16,31 @@ export function extractToolCards(message: unknown): ToolCard[] {
   const content = normalizeContent(m.content);
   const cards: ToolCard[] = [];
 
+  // Build lookup maps from tool calls for result-card arg pairing
+  const argsByToolCallId = new Map<string, unknown>();
+  const argsByName = new Map<string, unknown>();
+
   for (const item of content) {
     const kind = (typeof item.type === "string" ? item.type : "").toLowerCase();
     const isToolCall =
       ["toolcall", "tool_call", "tooluse", "tool_use"].includes(kind) ||
       (typeof item.name === "string" && item.arguments != null);
     if (isToolCall) {
+      const name = (item.name as string) ?? "tool";
+      const args = coerceArgs(item.arguments ?? item.args);
       cards.push({
         kind: "call",
-        name: (item.name as string) ?? "tool",
-        args: coerceArgs(item.arguments ?? item.args),
+        name,
+        args,
       });
+      // Index by toolCallId if present
+      const toolCallId =
+        (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
+      if (toolCallId) {
+        argsByToolCallId.set(toolCallId, args);
+      }
+      // Also index by name (last wins for same name)
+      argsByName.set(name, args);
     }
   }
 
@@ -37,10 +51,23 @@ export function extractToolCards(message: unknown): ToolCard[] {
     }
     const text = extractToolText(item);
     const name = typeof item.name === "string" ? item.name : "tool";
+    // Try to get args from the result block first, then look up paired tool call
+    let args = coerceArgs(item.arguments ?? item.args);
+    if (args === undefined || args === null) {
+      // Try matching by toolCallId first
+      const toolCallId =
+        (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
+      if (toolCallId && argsByToolCallId.has(toolCallId)) {
+        args = argsByToolCallId.get(toolCallId);
+      } else if (argsByName.has(name)) {
+        // Fallback to name-based matching
+        args = argsByName.get(name);
+      }
+    }
     cards.push({
       kind: "result",
       name,
-      args: coerceArgs(item.arguments ?? item.args),
+      args,
       text,
     });
   }
@@ -51,7 +78,12 @@ export function extractToolCards(message: unknown): ToolCard[] {
       (typeof m.tool_name === "string" && m.tool_name) ||
       "tool";
     const text = extractTextCached(message) ?? undefined;
-    cards.push({ kind: "result", name, text, args: coerceArgs(m.arguments ?? m.args) });
+    // Also try to look up args from any prior tool call by name
+    let args = coerceArgs(m.arguments ?? m.args);
+    if ((args === undefined || args === null) && argsByName.has(name)) {
+      args = argsByName.get(name);
+    }
+    cards.push({ kind: "result", name, text, args });
   }
 
   return cards;
@@ -60,12 +92,13 @@ export function extractToolCards(message: unknown): ToolCard[] {
 export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: string) => void) {
   const display = resolveToolDisplay({ name: card.name, args: card.args });
   const detail = formatToolDetail(display);
-  const argsSections = formatToolArgsForSidebar(card.args);
   const hasText = Boolean(card.text?.trim());
 
   const canClick = Boolean(onOpenSidebar);
   const handleClick = canClick
     ? () => {
+        // Lazy compute args sections only when sidebar is opened
+        const argsSections = formatToolArgsForSidebar(card.args);
         const headerParts = [`## ${display.label}`];
         if (argsSections.length > 0) {
           headerParts.push(

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -5,7 +5,11 @@ import type { ToolCard } from "../types/chat-types.ts";
 import { TOOL_INLINE_THRESHOLD } from "./constants.ts";
 import { extractTextCached } from "./message-extract.ts";
 import { isToolResultMessage } from "./message-normalizer.ts";
-import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
+import {
+  formatToolArgsForSidebar,
+  formatToolOutputForSidebar,
+  getTruncatedPreview,
+} from "./tool-helpers.ts";
 
 export function extractToolCards(message: unknown): ToolCard[] {
   const m = message as Record<string, unknown>;
@@ -33,7 +37,12 @@ export function extractToolCards(message: unknown): ToolCard[] {
     }
     const text = extractToolText(item);
     const name = typeof item.name === "string" ? item.name : "tool";
-    cards.push({ kind: "result", name, text });
+    cards.push({
+      kind: "result",
+      name,
+      args: coerceArgs(item.arguments ?? item.args),
+      text,
+    });
   }
 
   if (isToolResultMessage(message) && !cards.some((card) => card.kind === "result")) {
@@ -42,7 +51,7 @@ export function extractToolCards(message: unknown): ToolCard[] {
       (typeof m.tool_name === "string" && m.tool_name) ||
       "tool";
     const text = extractTextCached(message) ?? undefined;
-    cards.push({ kind: "result", name, text });
+    cards.push({ kind: "result", name, text, args: coerceArgs(m.arguments ?? m.args) });
   }
 
   return cards;
@@ -51,19 +60,26 @@ export function extractToolCards(message: unknown): ToolCard[] {
 export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: string) => void) {
   const display = resolveToolDisplay({ name: card.name, args: card.args });
   const detail = formatToolDetail(display);
+  const argsSections = formatToolArgsForSidebar(card.args);
   const hasText = Boolean(card.text?.trim());
 
   const canClick = Boolean(onOpenSidebar);
   const handleClick = canClick
     ? () => {
+        const headerParts = [`## ${display.label}`];
+        if (argsSections.length > 0) {
+          headerParts.push(
+            ...argsSections.map((section) => `**${section.label}:**\n${section.body}`),
+          );
+        } else if (detail) {
+          headerParts.push(`**Command:** \`${detail}\``);
+        }
+        const header = `${headerParts.join("\n\n")}\n\n`;
         if (hasText) {
-          onOpenSidebar!(formatToolOutputForSidebar(card.text!));
+          onOpenSidebar!(`${header}${formatToolOutputForSidebar(card.text!)}`);
           return;
         }
-        const info = `## ${display.label}\n\n${
-          detail ? `**Command:** \`${detail}\`\n\n` : ""
-        }*No output — tool completed successfully.*`;
-        onOpenSidebar!(info);
+        onOpenSidebar!(`${header}*No output — tool completed successfully.*`);
       }
     : undefined;
 

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -18,7 +18,8 @@ export function extractToolCards(message: unknown): ToolCard[] {
 
   // Build lookup maps from tool calls for result-card arg pairing
   const argsByToolCallId = new Map<string, unknown>();
-  const argsByName = new Map<string, unknown>();
+  // Use per-name queue for ordered matching (FIFO) instead of last-wins
+  const argsQueueByName = new Map<string, unknown[]>();
 
   for (const item of content) {
     const kind = (typeof item.type === "string" ? item.type : "").toLowerCase();
@@ -39,8 +40,11 @@ export function extractToolCards(message: unknown): ToolCard[] {
       if (toolCallId) {
         argsByToolCallId.set(toolCallId, args);
       }
-      // Also index by name (last wins for same name)
-      argsByName.set(name, args);
+      // Push to per-name queue for ordered matching
+      if (!argsQueueByName.has(name)) {
+        argsQueueByName.set(name, []);
+      }
+      argsQueueByName.get(name)!.push(args);
     }
   }
 
@@ -59,9 +63,12 @@ export function extractToolCards(message: unknown): ToolCard[] {
         (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
       if (toolCallId && argsByToolCallId.has(toolCallId)) {
         args = argsByToolCallId.get(toolCallId);
-      } else if (argsByName.has(name)) {
-        // Fallback to name-based matching
-        args = argsByName.get(name);
+      } else if (argsQueueByName.has(name)) {
+        // FIFO: shift from per-name queue for ordered matching
+        const queue = argsQueueByName.get(name)!;
+        if (queue.length > 0) {
+          args = queue.shift();
+        }
       }
     }
     cards.push({
@@ -78,10 +85,13 @@ export function extractToolCards(message: unknown): ToolCard[] {
       (typeof m.tool_name === "string" && m.tool_name) ||
       "tool";
     const text = extractTextCached(message) ?? undefined;
-    // Also try to look up args from any prior tool call by name
+    // Also try to look up args from any prior tool call by name (FIFO)
     let args = coerceArgs(m.arguments ?? m.args);
-    if ((args === undefined || args === null) && argsByName.has(name)) {
-      args = argsByName.get(name);
+    if ((args === undefined || args === null) && argsQueueByName.has(name)) {
+      const queue = argsQueueByName.get(name)!;
+      if (queue.length > 0) {
+        args = queue.shift();
+      }
     }
     cards.push({ kind: "result", name, text, args });
   }

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -57,18 +57,29 @@ export function extractToolCards(message: unknown): ToolCard[] {
     const name = typeof item.name === "string" ? item.name : "tool";
     // Try to get args from the result block first, then look up paired tool call
     let args = coerceArgs(item.arguments ?? item.args);
-    if (args === undefined || args === null) {
-      // Try matching by toolCallId first
-      const toolCallId =
-        (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
-      if (toolCallId && argsByToolCallId.has(toolCallId)) {
-        args = argsByToolCallId.get(toolCallId);
-      } else if (argsQueueByName.has(name)) {
-        // FIFO: shift from per-name queue for ordered matching
+    // Try matching by toolCallId first
+    const toolCallId =
+      (item.toolCallId as string) ?? (item.tool_call_id as string) ?? (item.id as string);
+    if (toolCallId && argsByToolCallId.has(toolCallId)) {
+      args = argsByToolCallId.get(toolCallId);
+    } else if (args === undefined || args === null) {
+      // Only use queue fallback if we don't have args yet
+      if (argsQueueByName.has(name)) {
         const queue = argsQueueByName.get(name)!;
         if (queue.length > 0) {
           args = queue.shift();
         }
+      }
+    }
+    // Always consume matching queue entry to keep queue in sync
+    // (for results matched by toolCallId or with their own args)
+    if (argsQueueByName.has(name)) {
+      const queue = argsQueueByName.get(name)!;
+      // Find and remove the args we matched (by reference or position)
+      // For toolCallId match, remove the first entry (FIFO preserves order)
+      // For own-args, also remove first to keep queue aligned with call order
+      if (queue.length > 0) {
+        queue.shift();
       }
     }
     cards.push({

--- a/ui/src/ui/chat/tool-helpers.test.ts
+++ b/ui/src/ui/chat/tool-helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
+import {
+  formatToolArgsForSidebar,
+  formatToolOutputForSidebar,
+  getTruncatedPreview,
+} from "./tool-helpers.ts";
 
 describe("tool-helpers", () => {
   describe("formatToolOutputForSidebar", () => {
@@ -77,6 +81,47 @@ describe("tool-helpers", () => {
     });
   });
 
+  describe("formatToolArgsForSidebar", () => {
+    it("formats full command as shell block", () => {
+      const result = formatToolArgsForSidebar({ command: "python3 script.py --flag long-value" });
+      expect(result).toEqual([
+        {
+          label: "Command",
+          body: "```shell\npython3 script.py --flag long-value\n```",
+        },
+      ]);
+    });
+
+    it("preserves sibling args when command exists", () => {
+      const result = formatToolArgsForSidebar({
+        command: "python3 script.py --flag long-value",
+        cwd: "/tmp/demo",
+        timeoutMs: 5000,
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        label: "Command",
+        body: "```shell\npython3 script.py --flag long-value\n```",
+      });
+      expect(result[1]?.label).toBe("Args");
+      expect(result[1]?.body).toContain('"cwd": "/tmp/demo"');
+      expect(result[1]?.body).toContain('"timeoutMs": 5000');
+    });
+
+    it("uses longer fence when command contains triple backticks", () => {
+      const result = formatToolArgsForSidebar({ command: "echo ```hello```" });
+      expect(result[0]?.body).toBe("````shell\necho ```hello```\n````");
+    });
+
+    it("formats non-command args as json block", () => {
+      const result = formatToolArgsForSidebar({ path: "/tmp/demo", recursive: true });
+      expect(result[0]?.label).toBe("Args");
+      expect(result[0]?.body).toContain("```json");
+      expect(result[0]?.body).toContain('"path": "/tmp/demo"');
+      expect(result[0]?.body).toContain('"recursive": true');
+    });
+  });
+
   describe("getTruncatedPreview", () => {
     it("returns short text unchanged", () => {
       const input = "Short text";
@@ -97,7 +142,6 @@ describe("tool-helpers", () => {
       const input = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
       const result = getTruncatedPreview(input);
 
-      // Should only show first 2 lines (PREVIEW_MAX_LINES = 2)
       expect(result).toBe("Line 1\nLine 2…");
     });
 
@@ -129,12 +173,11 @@ describe("tool-helpers", () => {
     });
 
     it("truncates by chars even within line limit", () => {
-      // Two lines but very long content
       const longLine = "x".repeat(80);
       const input = `${longLine}\n${longLine}`;
       const result = getTruncatedPreview(input);
 
-      expect(result.length).toBe(101); // 100 + ellipsis
+      expect(result.length).toBe(101);
       expect(result.endsWith("…")).toBe(true);
     });
   });

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -5,7 +5,14 @@
 import { PREVIEW_MAX_CHARS, PREVIEW_MAX_LINES } from "./constants.ts";
 
 function fenceFor(text: string): string {
-  return text.includes("```") ? "````" : "```";
+  // Find longest run of consecutive backticks
+  const match = text.match(/`+/g);
+  if (!match) {
+    return "```";
+  }
+  const maxLen = Math.max(...match.map((s) => s.length));
+  // Use one more backtick than the longest run
+  return "`".repeat(maxLen + 1);
 }
 
 /**

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -4,6 +4,10 @@
 
 import { PREVIEW_MAX_CHARS, PREVIEW_MAX_LINES } from "./constants.ts";
 
+function fenceFor(text: string): string {
+  return text.includes("```") ? "````" : "```";
+}
+
 /**
  * Format tool output content for display in the sidebar.
  * Detects JSON and wraps it in a code block with formatting.
@@ -20,6 +24,71 @@ export function formatToolOutputForSidebar(text: string): string {
     }
   }
   return text;
+}
+
+export type SidebarArgsSection = {
+  label: "Command" | "Args";
+  body: string;
+};
+
+function jsonFence(value: unknown): string {
+  return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``.replace(/\`/g, "`");
+}
+
+/**
+ * Format full tool args for display in the sidebar.
+ * When a command exists, preserve it as a dedicated full command section and
+ * also keep any sibling args (cwd/env/etc) in a separate Args section.
+ */
+export function formatToolArgsForSidebar(args: unknown): SidebarArgsSection[] {
+  if (args === null || args === undefined) {
+    return [];
+  }
+
+  if (typeof args === "object") {
+    const record = args as Record<string, unknown>;
+    const sections: SidebarArgsSection[] = [];
+    if (typeof record.command === "string") {
+      const cmd = record.command;
+      const fence = fenceFor(cmd);
+      sections.push({
+        label: "Command",
+        body: `${fence}shell\n${cmd}\n${fence}`,
+      });
+      const rest = Object.fromEntries(Object.entries(record).filter(([key]) => key !== "command"));
+      if (Object.keys(rest).length > 0) {
+        sections.push({
+          label: "Args",
+          body: jsonFence(rest),
+        });
+      }
+      return sections;
+    }
+
+    return [
+      {
+        label: "Args",
+        body: jsonFence(args),
+      },
+    ];
+  }
+
+  if (typeof args === "string") {
+    const fence = fenceFor(args);
+    return [
+      {
+        label: "Args",
+        body: `${fence}\n${args}\n${fence}`,
+      },
+    ];
+  }
+
+  return [
+    {
+      label: "Args",
+      body: jsonFence(args),
+    },
+  ];
 }
 
 /**

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -11,8 +11,9 @@ function fenceFor(text: string): string {
     return "```";
   }
   const maxLen = Math.max(...match.map((s) => s.length));
-  // Use one more backtick than the longest run
-  return "`".repeat(maxLen + 1);
+  // Use one more backtick than the longest run, minimum 3
+  const fenceLen = Math.max(3, maxLen + 1);
+  return "`".repeat(fenceLen);
 }
 
 /**

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -32,7 +32,9 @@ export type SidebarArgsSection = {
 };
 
 function jsonFence(value: unknown): string {
-  return "```json\n" + JSON.stringify(value, null, 2) + "\n```";
+  const body = JSON.stringify(value, null, 2);
+  const fence = fenceFor(body);
+  return `${fence}json\n${body}\n${fence}`;
 }
 
 /**

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -32,7 +32,7 @@ export type SidebarArgsSection = {
 };
 
 function jsonFence(value: unknown): string {
-  return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``.replace(/\`/g, "`");
+  return "```json\n" + JSON.stringify(value, null, 2) + "\n```";
 }
 
 /**


### PR DESCRIPTION
Fixes #43840

## Summary
When sending files with non-ASCII filenames (Chinese, Japanese, emoji), the filename is URL-encoded via sanitizeFileNameForUpload for safe multipart/form-data transmission. However, when receiving files from Feishu messages, the filename was not decoded, causing display issues like `%E6%B5%8B%E8%AF%95.txt` instead of `测试.txt`.

## Changes
- Added `decodeFileNameFromFeishu()` function to decode URL-encoded filenames
- Applied decoding in `parseMediaKeys()` and `formatSubMessageContent()` when parsing Feishu message content
- Added test cases for the new decode function

## Test Plan
- [x] Added 8 test cases for `decodeFileNameFromFeishu` function
- [x] Lint passes
- [ ] Manual verification: send file with Chinese filename in Feishu, verify display shows decoded name