### PR TITLE
fix(failover): classify ZenMux quota-refresh 402 as rate_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@ Docs: https://docs.openclaw.ai
 - Status/context windows: normalize provider-qualified override cache keys so `/status` resolves the active provider's configured context window even when `models.providers` keys use mixed case or surrounding whitespace. (#36389) Thanks @haoruilee.
 - ACP/main session aliases: canonicalize `main` before ACP session lookup so restarted ACP main sessions rehydrate instead of failing closed with `Session is not ACP-enabled: main`. (#43285, fixes #25692)
 - Agents/embedded runner: recover canonical allowlisted tool names from malformed `toolCallId` and malformed non-blank tool-name variants before dispatch, while failing closed on ambiguous matches. (#34485) thanks @yuweuii.
+- Agents/failover: classify ZenMux quota-refresh `402` responses as `rate_limit` so model fallback retries continue instead of stopping on a temporary subscription window. (#43917) thanks @bwjoke.
 
 ## 2026.3.8
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -207,6 +207,13 @@ describe("failover-error", () => {
     expect(
       resolveFailoverReasonFromError({
         status: 402,
+        message:
+          "You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access. Learn more: https://zenmux.ai/docs/guide/subscription.html",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
         message: `${"x".repeat(520)} insufficient credits. Monthly spend limit reached.`,
       }),
     ).toBe("billing");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -300,7 +300,6 @@ function hasRetryable402TransientSignal(text: string): boolean {
   const hasSpendLimit = text.includes("spend limit") || text.includes("spending limit");
   const hasScopedHint = includesAnyHint(text, RETRYABLE_402_SCOPED_HINTS);
   return (
-    hasQuotaRefreshWindowSignal(text) ||
     (includesAnyHint(text, RETRYABLE_402_RETRY_HINTS) &&
       includesAnyHint(text, RETRYABLE_402_LIMIT_HINTS)) ||
     (hasPeriodicHint && (text.includes("usage limit") || hasSpendLimit)) ||

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -288,11 +288,19 @@ function hasExplicit402BillingSignal(text: string): boolean {
   );
 }
 
+function hasQuotaRefreshWindowSignal(text: string): boolean {
+  return (
+    text.includes("subscription quota limit") &&
+    (text.includes("automatic quota refresh") || text.includes("rolling time window"))
+  );
+}
+
 function hasRetryable402TransientSignal(text: string): boolean {
   const hasPeriodicHint = includesAnyHint(text, PERIODIC_402_HINTS);
   const hasSpendLimit = text.includes("spend limit") || text.includes("spending limit");
   const hasScopedHint = includesAnyHint(text, RETRYABLE_402_SCOPED_HINTS);
   return (
+    hasQuotaRefreshWindowSignal(text) ||
     (includesAnyHint(text, RETRYABLE_402_RETRY_HINTS) &&
       includesAnyHint(text, RETRYABLE_402_LIMIT_HINTS)) ||
     (hasPeriodicHint && (text.includes("usage limit") || hasSpendLimit)) ||
@@ -311,6 +319,10 @@ function classify402Message(message: string): PaymentRequiredFailoverReason {
   const normalized = normalize402Message(message);
   if (!normalized) {
     return "billing";
+  }
+
+  if (hasQuotaRefreshWindowSignal(normalized)) {
+    return "rate_limit";
   }
 
   if (hasExplicit402BillingSignal(normalized)) {


### PR DESCRIPTION
## Summary

Classify ZenMux subscription-quota `402` responses with an explicit quota refresh window as `rate_limit` instead of `billing`, so fallback can continue.

Fixes #43915.

## What changed

- detect the ZenMux pattern:
  - `subscription quota limit`
  - `automatic quota refresh`
  - `rolling time window`
- classify that 402 shape as `rate_limit`
- add a regression test using the exact production payload
- remove the redundant retry-helper guard now that the classifier short-circuits on the ZenMux-specific predicate

## Why

This payload represents temporary quota exhaustion within a refresh window, not a hard insufficient-credits condition. Treating it as billing stops fallback too early.

Observed payload:

```text
402 You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access. Learn more: https://zenmux.ai/docs/guide/subscription.html
```

## Validation

```bash
bunx vitest run src/agents/failover-error.test.ts
pnpm check
bun -e 'import { resolveFailoverReasonFromError } from "./src/agents/failover-error.ts"; const payload = "You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access. Learn more: https://zenmux.ai/docs/guide/subscription.html"; console.log(resolveFailoverReasonFromError({ status: 402, message: payload }));'
```
