### PR TITLE
fix: stop main-session UI replies inheriting channel routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles/self-chat echo dedupe: drop reflected duplicate webhook copies only when a matching `fromMe` event was just seen for the same chat, body, and timestamp, preventing self-chat loops without broad webhook suppression. Related to #32166. (#38442) Thanks @vincentkoc.
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.
 - Sandbox/write: preserve pinned mutation-helper payload stdin so sandboxed `write` no longer reports success while creating empty files. (#43876) Thanks @glitch418x.
+- Gateway/main-session routing: keep TUI and other `mode:UI` main-session sends on the internal surface when `deliver` is enabled, so replies no longer inherit the session's persisted Telegram/WhatsApp route. (#43918) Thanks @obviyus.
 
 ## 2026.3.11
 

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -656,6 +656,49 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
+  it("chat.send does not inherit external delivery context for UI clients on main sessions when deliver is enabled", async () => {
+    createTranscriptFixture("openclaw-chat-send-main-ui-deliver-no-route-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:200482621",
+        accountId: "default",
+      },
+      lastChannel: "telegram",
+      lastTo: "telegram:200482621",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-main-ui-deliver-no-route",
+      client: {
+        connect: {
+          client: {
+            mode: GATEWAY_CLIENT_MODES.UI,
+            id: "openclaw-tui",
+          },
+        },
+      } as unknown,
+      sessionKey: "agent:main:main",
+      deliver: true,
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        ExplicitDeliverRoute: false,
+        AccountId: undefined,
+      }),
+    );
+  });
+
   it("chat.send inherits external delivery context for CLI clients on configured main sessions", async () => {
     createTranscriptFixture("openclaw-chat-send-config-main-cli-routes-");
     mockState.mainSessionKey = "work";

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -20,6 +20,7 @@ import {
 } from "../../utils/directive-tags.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
+  isGatewayCliClient,
   isWebchatClient,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
@@ -181,21 +182,27 @@ function resolveChatSendOriginatingRoute(params: {
     typeof sessionScopeParts[1] === "string" &&
     sessionChannelHint === routeChannelCandidate;
   const isFromWebchatClient = isWebchatClient(params.client);
+  const isFromGatewayCliClient = isGatewayCliClient(params.client);
+  const hasClientMetadata =
+    (typeof params.client?.mode === "string" && params.client.mode.trim().length > 0) ||
+    (typeof params.client?.id === "string" && params.client.id.trim().length > 0);
   const configuredMainKey = (params.mainKey ?? "main").trim().toLowerCase();
   const isConfiguredMainSessionScope =
     normalizedSessionScopeHead.length > 0 && normalizedSessionScopeHead === configuredMainKey;
+  const canInheritConfiguredMainRoute =
+    isConfiguredMainSessionScope &&
+    params.hasConnectedClient &&
+    (isFromGatewayCliClient || !hasClientMetadata);
 
-  // Webchat/Control UI clients never inherit external delivery routes, even when
-  // accessing channel-scoped sessions. External routes are only for non-webchat
-  // clients where the session key explicitly encodes an external target.
-  // Preserve the old configured-main contract: any connected non-webchat client
-  // may inherit the last external route even when client metadata is absent.
+  // Webchat clients never inherit external delivery routes. Configured-main
+  // sessions are stricter than channel-scoped sessions: only CLI callers, or
+  // legacy callers with no client metadata, may inherit the last external route.
   const canInheritDeliverableRoute = Boolean(
     !isFromWebchatClient &&
     sessionChannelHint &&
     sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
     ((!isChannelAgnosticSessionScope && (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
-      (isConfiguredMainSessionScope && params.hasConnectedClient)),
+      canInheritConfiguredMainRoute),
   );
   const hasDeliverableRoute =
     canInheritDeliverableRoute &&


### PR DESCRIPTION
## Summary

- Problem: `chat.send` on configured main sessions let `mode:UI` callers inherit the session's persisted external delivery route.
- Why it matters: TUI / `gateway-client` replies could be delivered to Telegram or another channel instead of staying on the originating UI surface.
- What changed: tightened configured-main route inheritance to CLI callers, or legacy callers with no client metadata; added a regression test for `deliver:true` on `agent:main:main`.
- What did NOT change (scope boundary): channel-scoped UI delivery stays intact; pure WebChat handling is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #33201
- Fixes #35789
- Fixes #37243
- Related #33996
- Related #34324
- Related #34377
- Related #34582
- Related #34971
- Related #39855
- Related #43341

## User-visible / Behavior Changes

- Replies from TUI / gateway UI clients using the shared main session no longer inherit the last external route when `deliver` is enabled.
- CLI callers keep the existing configured-main delivery inheritance behavior.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.3.1 local dev host
- Runtime/container: Node 24.11.1, local launchd gateway
- Model/provider: `openai-codex/gpt-5.2`
- Integration/channel (if any): Telegram + TUI-style gateway client
- Relevant config (redacted): shared `agent:main:main`, Telegram delivery context already pinned on the main session

### Steps

1. Seed `agent:main:main` with persisted Telegram delivery context.
2. Connect a TUI-style gateway client (`gateway-client`, `mode:UI`).
3. Call `chat.send` with `deliver:true` on the main session.

### Expected

- Reply stays on the internal UI surface.
- No inherited Telegram/WhatsApp route for the TUI caller.

### Actual

- Before fix: main-session UI callers inherited the persisted external route in `resolveChatSendOriginatingRoute()`.
- After fix: configured-main inheritance is limited to CLI or legacy no-metadata callers.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the seam with a new unit regression; rebuilt `dist`; restarted `ai.openclaw.gateway`; connected a real TUI-style WS client; ran `chat.send` + `agent.wait`; confirmed the assistant reply landed in the main-session transcript and did not emit a new `telegram sendMessage ok chat=200482621` log line.
- Edge cases checked: channel-scoped UI inheritance still covered by the existing passing test; configured-main CLI inheritance still covered by the existing passing test.
- What you did **not** verify: pure WebChat/control-ui-only regressions in the wider cluster; TUI live subscription/update issues unrelated to wrong-channel routing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/gateway/server-methods/chat.ts`
- Known bad symptoms reviewers should watch for: configured-main CLI callers unexpectedly losing inherited external delivery.

## Risks and Mitigations

- Risk: configured-main inheritance behavior changes for non-CLI UI callers.
- Mitigation: scoped the change to configured-main sessions only; preserved the legacy no-client-metadata path; added a targeted regression test.
