### PR TITLE
CLI: block gateway restart on invalid config

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -105,13 +105,22 @@ describe("ensureConfigReady", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
-  it("does not exit for invalid config on allowlisted commands", async () => {
+  it("does not exit for invalid config on allowlisted read-only commands", async () => {
     setInvalidSnapshot();
     const statusRuntime = await runEnsureConfigReady(["status"]);
     expect(statusRuntime.exit).not.toHaveBeenCalled();
 
     const gatewayRuntime = await runEnsureConfigReady(["gateway", "health"]);
     expect(gatewayRuntime.exit).not.toHaveBeenCalled();
+  });
+
+  it("exits for invalid config on gateway restart", async () => {
+    setInvalidSnapshot();
+    const runtime = await runEnsureConfigReady(["gateway", "restart"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Config invalid"));
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("doctor --fix"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
   it("runs doctor migration flow only once per module instance", async () => {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -18,7 +18,6 @@ const ALLOWED_INVALID_GATEWAY_SUBCOMMANDS = new Set([
   "uninstall",
   "start",
   "stop",
-  "restart",
 ]);
 let didRunDoctorConfigFlow = false;
 let configSnapshotPromise: Promise<Awaited<ReturnType<typeof readConfigFileSnapshot>>> | null =


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw gateway restart` could proceed even when config validation failed, which could stop a healthy gateway and fail to come back up.
- Why it matters: restart on invalid config creates avoidable downtime and pushes users into manual recovery.
- What changed: removed `gateway restart` from the invalid-config allowlist in CLI preaction guard, so restart now runs doctor preflight checks and aborts early on invalid config with the existing detailed issue report and `doctor --fix` guidance.
- What did NOT change (scope boundary): no auto-fix, no config backup/restore flow changes, and no changes to other allowlisted gateway read-only commands.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #19992
- Related #

## User-visible / Behavior Changes

- `openclaw gateway restart` now exits before restart when config is invalid, prints invalid key details, and suggests `openclaw doctor --fix`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): invalid config snapshot mocked in unit test

### Steps

1. Set config snapshot to `exists=true`, `valid=false`.
2. Run `ensureConfigReady` with command path `["gateway", "restart"]`.
3. Assert error output includes `Config invalid` and `doctor --fix`, then exits with code 1.

### Expected

- Restart preflight blocks invalid config before restart logic runs.

### Actual

- Restart now blocks as expected; read-only allowlisted commands still do not exit.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: updated `config-guard` allowlist and confirmed `gateway restart` exits on invalid config in unit test.
- Edge cases checked: `status` and `gateway health` remain allowlisted for invalid-config read-only inspection.
- What you did **not** verify: full end-to-end service restart against a live daemon process.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f3cf8659f`.
- Files/config to restore: `src/cli/program/config-guard.ts`.
- Known bad symptoms reviewers should watch for: if restart is unexpectedly blocked for valid config, check config snapshot validation path.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Restart command now fails fast in cases where users previously relied on forcing restart with invalid config.
  - Mitigation: error output already includes detailed invalid keys and explicit `openclaw doctor --fix` recovery guidance.
