### PR TITLE
fix(zalouser): update chunker test to use runtime chunkMarkdownText

### DIFF
--- a/extensions/zalouser/src/channel.test.ts
+++ b/extensions/zalouser/src/channel.test.ts
@@ -26,14 +26,9 @@ describe("zalouser outbound chunker", () => {
   });
 
   it("chunks without empty strings and respects limit", () => {
-    const chunker = zalouserPlugin.outbound?.chunker;
-    expect(chunker).toBeTypeOf("function");
-    if (!chunker) {
-      return;
-    }
-
+    // chunking is now delegated to the runtime's chunkMarkdownText
     const limit = 10;
-    const chunks = chunker("hello world\nthis is a test", limit);
+    const chunks = chunkMarkdownText("hello world\nthis is a test", limit);
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.every((c) => c.length > 0)).toBe(true);
     expect(chunks.every((c) => c.length <= limit)).toBe(true);


### PR DESCRIPTION
Commit `a6711afdc` (feat(zalouser): add markdown-to-Zalo text style parsing) removed `chunker` from `zalouserPlugin.outbound`:

```diff
-    chunker: chunkTextForOutbound,
-    chunkerMode: "text",
-    textChunkLimit: 2000,
```

Chunking is now delegated to the runtime via `textChunkMode`/`textChunkLimit` parameters passed to `sendMessageZalouser`, using `chunkMarkdownText` from the runtime.

However, the `channel.test.ts` `it("chunks without empty strings and respects limit")` body was not updated — it still accessed the now-removed `zalouserPlugin.outbound?.chunker`, causing the CI check `checks (node, extensions, pnpm test:extensions)` to fail on every PR with:

```
AssertionError: expected undefined to be type of 'function'
```

This PR updates the test to call `chunkMarkdownText` directly (already imported and set up in `beforeEach` via `setZalouserRuntime`), which is the function now responsible for chunking in the zalouser extension.

The test logic is unchanged — it verifies that chunking produces multiple non-empty chunks that each respect the limit.
