### PR TITLE
fix(gateway): use account-scoped reload for channel account changes

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -15,6 +15,7 @@ export type GatewayReloadPlan = {
   restartHeartbeat: boolean;
   restartHealthMonitor: boolean;
   restartChannels: Set<ChannelKind>;
+  restartChannelAccounts: Map<ChannelKind, Set<string>>;
   noopPaths: string[];
 };
 
@@ -139,6 +140,24 @@ function matchRule(path: string): ReloadRule | null {
   return null;
 }
 
+function parseScopedChannelAccountPath(
+  path: string,
+): { channel: ChannelId; accountId: string } | null {
+  const parts = path.split(".");
+  if (parts.length < 4) {
+    return null;
+  }
+  if (parts[0] !== "channels" || parts[2] !== "accounts") {
+    return null;
+  }
+  const channel = parts[1];
+  const accountId = parts[3];
+  if (!channel || !accountId) {
+    return null;
+  }
+  return { channel: channel as ChannelId, accountId };
+}
+
 export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPlan {
   const plan: GatewayReloadPlan = {
     changedPaths,
@@ -152,13 +171,21 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
     restartHeartbeat: false,
     restartHealthMonitor: false,
     restartChannels: new Set(),
+    restartChannelAccounts: new Map(),
     noopPaths: [],
   };
 
-  const applyAction = (action: ReloadAction) => {
+  const applyAction = (action: ReloadAction, path: string) => {
     if (action.startsWith("restart-channel:")) {
       const channel = action.slice("restart-channel:".length) as ChannelId;
-      plan.restartChannels.add(channel);
+      const scopedAccount = parseScopedChannelAccountPath(path);
+      if (scopedAccount && scopedAccount.channel === channel) {
+        const accounts = plan.restartChannelAccounts.get(channel) ?? new Set();
+        accounts.add(scopedAccount.accountId);
+        plan.restartChannelAccounts.set(channel, accounts);
+      } else {
+        plan.restartChannels.add(channel);
+      }
       return;
     }
     switch (action) {
@@ -203,7 +230,13 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
     }
     plan.hotReasons.push(path);
     for (const action of rule.actions ?? []) {
-      applyAction(action);
+      applyAction(action, path);
+    }
+  }
+
+  if (plan.restartChannels.size > 0) {
+    for (const channel of plan.restartChannels) {
+      plan.restartChannelAccounts.delete(channel);
     }
   }
 

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -130,6 +130,36 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.reloadHooks).toBe(true);
   });
 
+  it("plans account-scoped restarts for channel account config", () => {
+    const plan = buildGatewayReloadPlan(["channels.telegram.accounts.botA.token"]);
+    expect(plan.restartChannels.has("telegram")).toBe(false);
+    expect(plan.restartChannelAccounts.get("telegram")).toEqual(new Set(["botA"]));
+  });
+
+  it("keeps full channel restarts for channel-global config", () => {
+    const plan = buildGatewayReloadPlan(["channels.telegram.replyToMode"]);
+    expect(plan.restartChannels).toContain("telegram");
+    expect(plan.restartChannelAccounts.size).toBe(0);
+  });
+
+  it("prefers full channel restarts when mixed with account-scoped changes", () => {
+    const plan = buildGatewayReloadPlan([
+      "channels.telegram.accounts.botA.token",
+      "channels.telegram.replyToMode",
+    ]);
+    expect(plan.restartChannels).toContain("telegram");
+    expect(plan.restartChannelAccounts.size).toBe(0);
+  });
+
+  it("collects multiple account restarts for a channel", () => {
+    const plan = buildGatewayReloadPlan([
+      "channels.telegram.accounts.botA.token",
+      "channels.telegram.accounts.botB.enabled",
+    ]);
+    expect(plan.restartChannels.has("telegram")).toBe(false);
+    expect(plan.restartChannelAccounts.get("telegram")).toEqual(new Set(["botA", "botB"]));
+  });
+
   it("restarts providers when provider config prefixes change", () => {
     const changedPaths = ["web.enabled", "channels.telegram.botToken"];
     const plan = buildGatewayReloadPlan(changedPaths);

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -36,8 +36,8 @@ export function createGatewayReloadHandlers(params: {
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   getState: () => GatewayHotReloadState;
   setState: (state: GatewayHotReloadState) => void;
-  startChannel: (name: ChannelKind) => Promise<void>;
-  stopChannel: (name: ChannelKind) => Promise<void>;
+  startChannel: (name: ChannelKind, accountId?: string) => Promise<void>;
+  stopChannel: (name: ChannelKind, accountId?: string) => Promise<void>;
   logHooks: {
     info: (msg: string) => void;
     warn: (msg: string) => void;
@@ -111,7 +111,7 @@ export function createGatewayReloadHandlers(params: {
       });
     }
 
-    if (plan.restartChannels.size > 0) {
+    if (plan.restartChannelAccounts.size > 0 || plan.restartChannels.size > 0) {
       if (
         isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
         isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS)
@@ -120,11 +120,21 @@ export function createGatewayReloadHandlers(params: {
           "skipping channel reload (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)",
         );
       } else {
+        const restartChannelAccount = async (name: ChannelKind, accountId: string) => {
+          params.logChannels.info(`restarting ${name} channel account ${accountId}`);
+          await params.stopChannel(name, accountId);
+          await params.startChannel(name, accountId);
+        };
         const restartChannel = async (name: ChannelKind) => {
           params.logChannels.info(`restarting ${name} channel`);
           await params.stopChannel(name);
           await params.startChannel(name);
         };
+        for (const [channel, accounts] of plan.restartChannelAccounts) {
+          for (const accountId of accounts) {
+            await restartChannelAccount(channel, accountId);
+          }
+        }
         for (const channel of plan.restartChannels) {
           await restartChannel(channel);
         }

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -506,6 +506,7 @@ describe("gateway hot reload", () => {
           restartCron: true,
           restartHeartbeat: true,
           restartChannels: new Set(["whatsapp", "telegram", "discord", "signal", "imessage"]),
+          restartChannelAccounts: new Map(),
           noopPaths: [],
         },
         nextConfig,
@@ -556,6 +557,7 @@ describe("gateway hot reload", () => {
           restartCron: false,
           restartHeartbeat: false,
           restartChannels: new Set(),
+          restartChannelAccounts: new Map(),
           noopPaths: [],
         },
         {},
@@ -563,6 +565,39 @@ describe("gateway hot reload", () => {
       await Promise.resolve(restartResult);
 
       expect(signalSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("restarts only the impacted channel account on hot reload", async () => {
+    await withGatewayServer(async () => {
+      const onHotReload = hoisted.getOnHotReload();
+      expect(onHotReload).toBeTypeOf("function");
+
+      hoisted.providerManager.stopChannel.mockClear();
+      hoisted.providerManager.startChannel.mockClear();
+
+      await onHotReload?.(
+        {
+          changedPaths: ["channels.telegram.accounts.botA.token"],
+          restartGateway: false,
+          restartReasons: [],
+          hotReasons: ["channels.telegram.accounts.botA.token"],
+          reloadHooks: false,
+          restartGmailWatcher: false,
+          restartBrowserControl: false,
+          restartCron: false,
+          restartHeartbeat: false,
+          restartChannels: new Set(),
+          restartChannelAccounts: new Map([["telegram", new Set(["botA"])]]),
+          noopPaths: [],
+        },
+        {},
+      );
+
+      expect(hoisted.providerManager.stopChannel).toHaveBeenCalledTimes(1);
+      expect(hoisted.providerManager.startChannel).toHaveBeenCalledTimes(1);
+      expect(hoisted.providerManager.stopChannel).toHaveBeenCalledWith("telegram", "botA");
+      expect(hoisted.providerManager.startChannel).toHaveBeenCalledWith("telegram", "botA");
     });
   });
 
@@ -634,6 +669,7 @@ describe("gateway hot reload", () => {
         restartCron: false,
         restartHeartbeat: false,
         restartChannels: new Set(),
+        restartChannelAccounts: new Map(),
         noopPaths: [],
       };
       const nextConfig = {
@@ -690,6 +726,7 @@ describe("gateway hot reload", () => {
         restartCron: false,
         restartHeartbeat: false,
         restartChannels: new Set(),
+        restartChannelAccounts: new Map(),
         noopPaths: [],
       };
       const nextConfig = {


### PR DESCRIPTION
## Summary

Use account-scoped hot reload for config changes under:

- `channels.<channel>.accounts.<accountId>.*`

instead of always restarting the entire channel.

## What changed

- added account-scoped restart planning to `GatewayReloadPlan`
- detect account-scoped channel config paths in `buildGatewayReloadPlan`
- route those changes through:
  - `stopChannel(channelId, accountId)`
  - `startChannel(channelId, accountId)`
- preserve full channel restart behavior for:
  - channel-global config changes
  - mixed changes where full-channel restart takes precedence

## Why

The gateway reload framework already has account-scoped channel lifecycle support, but hot reload planning previously collapsed all matching channel config changes into full channel restarts.

That makes account-only config edits broader and more disruptive than necessary.

## Tests

Added coverage for:

- account-scoped channel account config -> account-only restart
- channel-global config -> full channel restart
- mixed account-scoped + channel-global changes -> full channel restart wins
- multiple account-scoped changes in one channel -> collect all impacted accounts

Validated with:

```bash
corepack pnpm exec vitest run src/gateway/config-reload.test.ts src/gateway/server.reload.test.ts
```

## Scope / non-goals

This change is intentionally narrow.

It does not redesign active reply draining, typing lifecycle coordination, or provider-specific recovery behavior.


Closes #43935
