### PR TITLE
fix(memory): include archived session transcripts in QMD export

### DIFF
--- a/src/memory/session-files.test.ts
+++ b/src/memory/session-files.test.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildSessionEntry } from "./session-files.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildSessionEntry, listSessionFilesForAgent } from "./session-files.js";
 
-describe("buildSessionEntry", () => {
+describe("session files", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
@@ -12,7 +12,31 @@ describe("buildSessionEntry", () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("lists live and archived session transcripts from the agent sessions root", async () => {
+    vi.stubEnv("OPENCLAW_HOME", tmpDir);
+    const sessionsDir = path.join(tmpDir, ".openclaw", "agents", "coder", "sessions");
+    await fs.mkdir(path.join(sessionsDir, "archive"), { recursive: true });
+
+    await fs.writeFile(path.join(sessionsDir, "live.jsonl"), "");
+    await fs.writeFile(path.join(sessionsDir, "archived.jsonl.reset.2026-03-12T08-50-29.182Z"), "");
+    await fs.writeFile(
+      path.join(sessionsDir, "deleted.jsonl.deleted.2026-03-11T22-41-34.394Z"),
+      "",
+    );
+    await fs.writeFile(path.join(sessionsDir, "ignore.jsonl.lock"), "");
+    await fs.writeFile(path.join(sessionsDir, "archive", "nested.jsonl"), "");
+
+    const files = await listSessionFilesForAgent("coder");
+
+    expect(files.map((file) => path.basename(file)).toSorted()).toEqual([
+      "archived.jsonl.reset.2026-03-12T08-50-29.182Z",
+      "deleted.jsonl.deleted.2026-03-11T22-41-34.394Z",
+      "live.jsonl",
+    ]);
   });
 
   it("returns lineMap tracking original JSONL line numbers", async () => {

--- a/src/memory/session-files.test.ts
+++ b/src/memory/session-files.test.ts
@@ -18,6 +18,7 @@ describe("session files", () => {
 
   it("lists live and archived session transcripts from the agent sessions root", async () => {
     vi.stubEnv("OPENCLAW_HOME", tmpDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tmpDir, ".openclaw"));
     const sessionsDir = path.join(tmpDir, ".openclaw", "agents", "coder", "sessions");
     await fs.mkdir(path.join(sessionsDir, "archive"), { recursive: true });
 

--- a/src/memory/session-files.ts
+++ b/src/memory/session-files.ts
@@ -6,6 +6,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { hashText } from "./internal.js";
 
 const log = createSubsystemLogger("memory");
+const SESSION_EXPORT_FILE_RE = /\.jsonl(?:\.(?:reset|deleted)\..+)?$/;
 
 export type SessionFileEntry = {
   path: string;
@@ -25,7 +26,7 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
     return entries
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name)
-      .filter((name) => name.endsWith(".jsonl"))
+      .filter((name) => SESSION_EXPORT_FILE_RE.test(name))
       .map((name) => path.join(dir, name));
   } catch {
     return [];


### PR DESCRIPTION
## Summary
- include archived session transcript files in `listSessionFilesForAgent()`
- keep the scope intentionally small by handling `.jsonl.reset.*` and `.jsonl.deleted.*` in the agent sessions root
- add a unit test covering live files, archived files, and ignored nested/archive entries

## Problem
The QMD session export currently only picks up live `*.jsonl` transcript files.

When a session is reset, OpenClaw renames the transcript to something like:
- `session-id.jsonl.reset.<timestamp>`
- `session-id.jsonl.deleted.<timestamp>`

After that rename, the transcript disappears from the QMD session export because `listSessionFilesForAgent()` filters strictly on `name.endsWith(".jsonl")`.

In practice this means older sessions can silently drop out of `qmd/sessions/*.md` even though the transcript still exists locally.

## Why this change
This is the smallest safe fix for the observed data-loss path:
- live sessions still work as before
- archived reset/deleted transcripts in the sessions root are exported again
- nested `sessions/archive/...` files are still out of scope for this PR on purpose

That broader archive behavior likely deserves a separate product decision around retention/deduplication.

## Test
- `pnpm exec vitest run --config vitest.unit.config.ts src/memory/session-files.test.ts`
