### PR TITLE
feat(feishu): pass through form_value, input_value, option(s) from card actions

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -13,6 +13,13 @@ vi.mock("./bot.js", () => ({
 
 import { handleFeishuMessage } from "./bot.js";
 
+function getLastMessageText(): string {
+  const mock = handleFeishuMessage as ReturnType<typeof vi.fn>;
+  const lastCall = mock.mock.calls.at(-1);
+  if (!lastCall) throw new Error("handleFeishuMessage was not called");
+  return JSON.parse(lastCall[0].event.message.content).text;
+}
+
 describe("Feishu Card Action Handler", () => {
   const cfg = {} as any; // Minimal mock
   const runtime = { log: vi.fn(), error: vi.fn() } as any;
@@ -47,12 +54,7 @@ describe("Feishu Card Action Handler", () => {
       context: { open_id: "u1", user_id: "uid1", chat_id: "chat1" },
     };
     await handleFeishuCardAction({ cfg, event, runtime });
-    const parsed = JSON.parse(
-      JSON.parse(
-        (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message
-          .content,
-      ).text,
-    );
+    const parsed = JSON.parse(getLastMessageText());
     expect(parsed).toMatchObject({ action: "input", input_value: "hello", name: "q1" });
   });
 
@@ -69,12 +71,7 @@ describe("Feishu Card Action Handler", () => {
       context: { open_id: "u1", user_id: "uid1", chat_id: "chat1" },
     };
     await handleFeishuCardAction({ cfg, event, runtime });
-    const parsed = JSON.parse(
-      JSON.parse(
-        (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message
-          .content,
-      ).text,
-    );
+    const parsed = JSON.parse(getLastMessageText());
     expect(parsed).toMatchObject({
       action: "form",
       form_value: { field1: "val1", field2: "val2" },
@@ -90,12 +87,7 @@ describe("Feishu Card Action Handler", () => {
       context: { open_id: "u1", user_id: "uid1", chat_id: "chat1" },
     };
     await handleFeishuCardAction({ cfg, event, runtime });
-    const parsed = JSON.parse(
-      JSON.parse(
-        (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message
-          .content,
-      ).text,
-    );
+    const parsed = JSON.parse(getLastMessageText());
     expect(parsed).toMatchObject({ action: "select_static", option: "opt_a", name: "dropdown1" });
   });
 
@@ -107,11 +99,8 @@ describe("Feishu Card Action Handler", () => {
       context: { open_id: "u1", user_id: "uid1", chat_id: "chat1" },
     };
     await handleFeishuCardAction({ cfg, event, runtime });
-    const text = JSON.parse(
-      (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message.content,
-    ).text;
     // name-only should NOT trigger structured payload — preserves plain command extraction
-    expect(text).toBe("/help");
+    expect(getLastMessageText()).toBe("/help");
   });
 
   it("handles card action with JSON object payload", async () => {

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -39,6 +39,83 @@ describe("Feishu Card Action Handler", () => {
     );
   });
 
+  it("handles card action with input_value", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u1", user_id: "uid1", union_id: "un1" },
+      token: "tok3",
+      action: { value: {}, tag: "input", input_value: "hello", name: "q1" },
+      context: { open_id: "u1", user_id: "uid1", chat_id: "chat1" },
+    };
+    await handleFeishuCardAction({ cfg, event, runtime });
+    const parsed = JSON.parse(
+      JSON.parse(
+        (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message
+          .content,
+      ).text,
+    );
+    expect(parsed).toMatchObject({ action: "input", input_value: "hello", name: "q1" });
+  });
+
+  it("handles card action with form_value", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u1", user_id: "uid1", union_id: "un1" },
+      token: "tok4",
+      action: {
+        value: {},
+        tag: "form",
+        form_value: { field1: "val1", field2: "val2" },
+        name: "myform",
+      },
+      context: { open_id: "u1", user_id: "uid1", chat_id: "chat1" },
+    };
+    await handleFeishuCardAction({ cfg, event, runtime });
+    const parsed = JSON.parse(
+      JSON.parse(
+        (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message
+          .content,
+      ).text,
+    );
+    expect(parsed).toMatchObject({
+      action: "form",
+      form_value: { field1: "val1", field2: "val2" },
+      name: "myform",
+    });
+  });
+
+  it("handles card action with option (select)", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u1", user_id: "uid1", union_id: "un1" },
+      token: "tok5",
+      action: { value: {}, tag: "select_static", option: "opt_a", name: "dropdown1" },
+      context: { open_id: "u1", user_id: "uid1", chat_id: "chat1" },
+    };
+    await handleFeishuCardAction({ cfg, event, runtime });
+    const parsed = JSON.parse(
+      JSON.parse(
+        (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message
+          .content,
+      ).text,
+    );
+    expect(parsed).toMatchObject({ action: "select_static", option: "opt_a", name: "dropdown1" });
+  });
+
+  it("handles card action with name-only (triggers form branch)", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u1", user_id: "uid1", union_id: "un1" },
+      token: "tok6",
+      action: { value: { key: "val" }, tag: "button", name: "btn1" },
+      context: { open_id: "u1", user_id: "uid1", chat_id: "chat1" },
+    };
+    await handleFeishuCardAction({ cfg, event, runtime });
+    const parsed = JSON.parse(
+      JSON.parse(
+        (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message
+          .content,
+      ).text,
+    );
+    expect(parsed).toMatchObject({ action: "button", name: "btn1", value: { key: "val" } });
+  });
+
   it("handles card action with JSON object payload", async () => {
     const event: FeishuCardActionEvent = {
       operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -99,21 +99,19 @@ describe("Feishu Card Action Handler", () => {
     expect(parsed).toMatchObject({ action: "select_static", option: "opt_a", name: "dropdown1" });
   });
 
-  it("handles card action with name-only (triggers form branch)", async () => {
+  it("handles card action with name-only as plain button (preserves command extraction)", async () => {
     const event: FeishuCardActionEvent = {
       operator: { open_id: "u1", user_id: "uid1", union_id: "un1" },
       token: "tok6",
-      action: { value: { key: "val" }, tag: "button", name: "btn1" },
+      action: { value: { command: "/help" }, tag: "button", name: "btn1" },
       context: { open_id: "u1", user_id: "uid1", chat_id: "chat1" },
     };
     await handleFeishuCardAction({ cfg, event, runtime });
-    const parsed = JSON.parse(
-      JSON.parse(
-        (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message
-          .content,
-      ).text,
-    );
-    expect(parsed).toMatchObject({ action: "button", name: "btn1", value: { key: "val" } });
+    const text = JSON.parse(
+      (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)[0].event.message.content,
+    ).text;
+    // name-only should NOT trigger structured payload — preserves plain command extraction
+    expect(text).toBe("/help");
   });
 
   it("handles card action with JSON object payload", async () => {

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -38,8 +38,10 @@ export async function handleFeishuCardAction(params: {
 
   const action = event.action;
   const actionValue = action.value;
-  const hasFormData = action.form_value !== undefined ||
+  const hasFormData =
+    action.form_value !== undefined ||
     action.input_value !== undefined ||
+    action.name !== undefined ||
     action.option !== undefined ||
     action.options !== undefined;
 

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -41,7 +41,6 @@ export async function handleFeishuCardAction(params: {
   const hasFormData =
     action.form_value !== undefined ||
     action.input_value !== undefined ||
-    action.name !== undefined ||
     action.option !== undefined ||
     action.options !== undefined;
 

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -12,6 +12,11 @@ export type FeishuCardActionEvent = {
   action: {
     value: Record<string, unknown>;
     tag: string;
+    input_value?: string;
+    name?: string;
+    form_value?: Record<string, unknown>;
+    option?: string;
+    options?: string[];
   };
   context: {
     open_id: string;
@@ -31,19 +36,40 @@ export async function handleFeishuCardAction(params: {
   const account = resolveFeishuAccount({ cfg, accountId });
   const log = runtime?.log ?? console.log;
 
-  // Extract action value
-  const actionValue = event.action.value;
+  const action = event.action;
+  const actionValue = action.value;
+  const hasFormData = action.form_value !== undefined ||
+    action.input_value !== undefined ||
+    action.option !== undefined ||
+    action.options !== undefined;
+
   let content = "";
-  if (typeof actionValue === "object" && actionValue !== null) {
-    if ("text" in actionValue && typeof actionValue.text === "string") {
-      content = actionValue.text;
-    } else if ("command" in actionValue && typeof actionValue.command === "string") {
-      content = actionValue.command;
-    } else {
-      content = JSON.stringify(actionValue);
-    }
+
+  if (hasFormData) {
+    // Form submission or input component — build structured payload
+    const payload: Record<string, unknown> = {
+      action: action.tag,
+      value: actionValue,
+    };
+    if (action.form_value !== undefined) payload.form_value = action.form_value;
+    if (action.input_value !== undefined) payload.input_value = action.input_value;
+    if (action.name !== undefined) payload.name = action.name;
+    if (action.option !== undefined) payload.option = action.option;
+    if (action.options !== undefined) payload.options = action.options;
+    content = JSON.stringify(payload);
   } else {
-    content = String(actionValue);
+    // Simple button click — preserve existing behavior
+    if (typeof actionValue === "object" && actionValue !== null) {
+      if ("text" in actionValue && typeof actionValue.text === "string") {
+        content = actionValue.text;
+      } else if ("command" in actionValue && typeof actionValue.command === "string") {
+        content = actionValue.command;
+      } else {
+        content = JSON.stringify(actionValue);
+      }
+    } else {
+      content = String(actionValue);
+    }
   }
 
   // Construct a synthetic message event


### PR DESCRIPTION
## Problem

Feishu card action callbacks include more than just `action.value` (button values). They also carry `form_value`, `input_value`, `name`, `option`, and `options` fields for form submissions, input components, and select menus.

Currently, `handleFeishuCardAction` only extracts `action.value`, silently dropping all form data. This makes it impossible for agents to process interactive card form submissions.

Closes #43202

## Changes

1. **Extended `FeishuCardActionEvent` type** — added `input_value`, `name`, `form_value`, `option`, and `options` fields to the `action` object
2. **Form-aware payload construction** in `handleFeishuCardAction`:
   - When form data is present → builds a structured JSON payload including all form fields
   - When no form data (simple button click) → preserves existing behavior exactly

## Backward Compatibility

- Simple button clicks (the only previously supported interaction) behave identically
- No changes to any other files
- The structured JSON payload for form submissions is a new code path that only triggers when form fields are present