### PR TITLE
Agents: prevent empty Gemini function response names

### DIFF
--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -180,6 +180,26 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.toolName).toBe("read");
   });
 
+  it("fills missing toolResult names with unknown when no fallback is available", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_missing_name",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["toolResult"]) as Array<{
+      role: string;
+      toolName?: string;
+    }>;
+    expect(messages[0]?.toolName).toBe("unknown");
+  });
+
   it("preserves ordering with multiple tool calls and partial results", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -62,10 +62,7 @@ function normalizePersistedToolResultName(
     return { ...toolResult, toolName: normalizedFallback };
   }
 
-  if (typeof rawToolName === "string") {
-    return { ...toolResult, toolName: "unknown" };
-  }
-  return toolResult;
+  return { ...toolResult, toolName: "unknown" };
 }
 
 export function installSessionToolResultGuard(

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -99,6 +99,28 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(toolResult?.toolName).toBe("read");
   });
 
+  it("fills missing tool result names with unknown when fallback is unavailable", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "   ", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    ]);
+
+    const out = sanitizeToolUseResultPairing(input);
+    const toolResult = out.find((message) => message.role === "toolResult") as {
+      toolName?: string;
+    };
+
+    expect(toolResult?.toolName).toBe("unknown");
+  });
+
   it("drops duplicate tool results for the same id within a span", () => {
     const input = castAgentMessages([
       ...buildDuplicateToolResultInput(),

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -177,10 +177,7 @@ function normalizeToolResultName(
     return { ...message, toolName: normalizedFallback };
   }
 
-  if (typeof rawToolName === "string") {
-    return { ...message, toolName: "unknown" };
-  }
-  return message;
+  return { ...message, toolName: "unknown" };
 }
 
 export { makeMissingToolResult };


### PR DESCRIPTION
## Summary

- Problem: Session transcripts could retain `toolResult` messages without a usable `toolName` after provider/model switching, which can surface as Gemini `function_response.name` empty errors.
- Why it matters: Gemini rejects requests with empty function response names (`INVALID_ARGUMENT`), blocking the session.
- What changed: Normalized tool-result names now always fall back to `"unknown"` when both direct and fallback names are missing.
- What changed: Added regression tests for session guard persistence and transcript repair paths.
- What did NOT change (scope boundary): No provider SDK/dependency changes and no tool-call routing behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43930
- Related #43930

## User-visible / Behavior Changes

- Switching back to Gemini no longer fails due to empty `function_response.name` coming from nameless historical tool results.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: unit-test coverage around agent transcript handling for Google/Gemini compatibility
- Integration/channel (if any): N/A (unit tests)
- Relevant config (redacted): N/A

### Steps

1. Build transcript entries where `toolResult.toolName` is blank or missing.
2. Run transcript sanitization/guard paths.
3. Confirm resulting tool-result messages always have non-empty names.

### Expected

- Tool-result names are non-empty, preventing Gemini function response validation failures.

### Actual

- Passing tests confirm fallback to `"read"` when available and `"unknown"` when not.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm exec vitest run src/agents/session-tool-result-guard.test.ts src/agents/session-transcript-repair.test.ts`
  - Result: 2 files passed, 48 tests passed.
- `pnpm exec vitest run src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
  - Result: 1 file passed, 28 tests passed.

## Human Verification (required)

- Verified scenarios:
  - Missing/blank tool-result names are repaired to non-empty values in guard + transcript repair.
- Edge cases checked:
  - Blank names with matching tool calls use matching tool name.
  - Missing names without fallback are forced to `"unknown"`.
- What you did **not** verify:
  - Live Discord/Gateway repro against real Gemini API.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/session-tool-result-guard.ts`
  - `src/agents/session-transcript-repair.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected tool-result naming regressions in transcript-related tests.

## Risks and Mitigations

- Risk:
  - Fallback `"unknown"` may appear in transcripts where tool name metadata is unavailable.
  - Mitigation:
    - Prefer real tool names when available; fallback applies only when both direct and inferred names are missing.
