### PR TITLE
fix(macos): add logging to diagnose menu bar token resolution

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -171,7 +171,8 @@ actor GatewayEndpointStore {
         if let configToken = self.resolveConfigToken(isRemote: isRemote, root: root),
            !configToken.isEmpty
         {
-            Self.staticLogger.debug("resolveGatewayToken: using config gateway.auth.token")
+            let configKey = isRemote ? "gateway.remote.token" : "gateway.auth.token"
+            Self.staticLogger.debug("resolveGatewayToken: using config \(configKey, privacy: .public)")
             return configToken
         }
 

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -164,25 +164,30 @@ actor GatewayEndpointStore {
                     envVar: "OPENCLAW_GATEWAY_TOKEN",
                     configKey: isRemote ? "gateway.remote.token" : "gateway.auth.token")
             }
+            Self.staticLogger.debug("resolveGatewayToken: using env OPENCLAW_GATEWAY_TOKEN")
             return trimmed
         }
 
         if let configToken = self.resolveConfigToken(isRemote: isRemote, root: root),
            !configToken.isEmpty
         {
+            Self.staticLogger.debug("resolveGatewayToken: using config gateway.auth.token")
             return configToken
         }
 
         if isRemote {
+            Self.staticLogger.debug("resolveGatewayToken: remote mode, no token found")
             return nil
         }
 
         if let token = launchdSnapshot?.token?.trimmingCharacters(in: .whitespacesAndNewlines),
            !token.isEmpty
         {
+            Self.staticLogger.debug("resolveGatewayToken: using launchd plist token")
             return token
         }
 
+        Self.staticLogger.warning("resolveGatewayToken: no token found in any source")
         return nil
     }
 
@@ -195,8 +200,14 @@ actor GatewayEndpointStore {
            let auth = gateway["auth"] as? [String: Any],
            let token = auth["token"] as? String
         {
-            return token.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                Self.staticLogger.debug(
+                    "resolveConfigToken: found gateway.auth.token (length=\(trimmed.count))")
+                return trimmed
+            }
         }
+        Self.staticLogger.debug("resolveConfigToken: no gateway.auth.token in config")
         return nil
     }
 


### PR DESCRIPTION
## Summary

- Problem: Menu bar widget shows "Idle" status when gateway runs as LaunchAgent
- Why it matters: Users cannot see gateway activity even though gateway is running
- What changed: Added debug logging to token resolution path in `GatewayEndpointStore`

## Change Type

- [x] Bug fix (diagnostic)

## Scope

- [x] macOS app

## Linked Issue

- Helps diagnose #43593

## User-visible Changes

- No user-visible changes (debug logs only, visible in Console.app)

## Security Impact

- No security impact (logging only token presence/absence, not token values)

## Evidence

- [x] Logs added to key token resolution paths

## Review Conversations

- [x] I will resolve all bot review conversations

## Compatibility

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks

None. This is a diagnostic change to help identify the root cause of #43593.