### PR TITLE
feat: add myaider plugin in community plugin doc

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **MyAider** - Connect OpenClaw to MyAider.ai Skillful MCP Hub. Bring MCP servers back without token consumption issue, by using custom skills calling dehydrated MCP tools.
+  npm: `myaider`
+  repo: `https://github.com/hurungang/myaider`
+  install: `openclaw plugins install myaider`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -50,7 +50,7 @@ Use this format when adding entries:
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
 
-- **MyAider** - Connect OpenClaw to MyAider.ai Skillful MCP Hub. Bring MCP servers back without token consumption issue, by using custom skills calling dehydrated MCP tools.
+- **MyAider** — Connect OpenClaw to MyAider.ai Skillful MCP Hub. Bring MCP servers back without token consumption issue, by using custom skills calling dehydrated MCP tools.
   npm: `myaider`
   repo: `https://github.com/hurungang/myaider`
   install: `openclaw plugins install myaider`


### PR DESCRIPTION
## Summary

Add MyAider Skillful MCP Hub to enpower openclaw with MCP server(http) support without token concerns.

- **MyAider** - Connect OpenClaw to MyAider.ai Skillful MCP Hub. Bring MCP servers back without token consumption issue, by using custom skills calling dehydrated MCP tools.
  npm: `myaider`
  repo: `https://github.com/hurungang/myaider`
  install: `openclaw plugins install myaider`

## Change Type (select all)

- [X] Docs

## Checklist

 - [X] Plugin published on npm
 - [X] Source code on GitHub (public repo)
 - [X] README with setup/usage docs
 - [X] Issue tracker enabled


