### PR TITLE
Fix OpenRouter auth header regression for marker API keys

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -230,6 +230,51 @@ describe("getApiKeyForModel", () => {
     });
   });
 
+  it("resolves marker-style OpenRouter provider apiKey from config env vars", async () => {
+    await withEnvAsync({ OPENROUTER_API_KEY: undefined }, async () => {
+      const resolved = await resolveApiKeyForProvider({
+        provider: "openrouter",
+        store: { version: 1, profiles: {} },
+        cfg: {
+          env: {
+            vars: {
+              OPENROUTER_API_KEY: "sk-or-v1-config-only", // pragma: allowlist secret
+            },
+          },
+          models: {
+            providers: {
+              openrouter: {
+                apiKey: "OPENROUTER_API_KEY",
+              },
+            },
+          },
+        },
+      });
+      expect(resolved.apiKey).toBe("sk-or-v1-config-only");
+      expect(resolved.source).toBe("models.json");
+    });
+  });
+
+  it("does not use unresolved OpenRouter env marker as a literal api key", async () => {
+    await withEnvAsync({ OPENROUTER_API_KEY: undefined }, async () => {
+      await expect(
+        resolveApiKeyForProvider({
+          provider: "openrouter",
+          store: { version: 1, profiles: {} },
+          cfg: {
+            models: {
+              providers: {
+                openrouter: {
+                  apiKey: "OPENROUTER_API_KEY",
+                },
+              },
+            },
+          },
+        }),
+      ).rejects.toThrow('No API key found for provider "openrouter".');
+    });
+  });
+
   it("resolves synthetic local auth key for configured ollama provider without apiKey", async () => {
     await withEnvAsync({ OLLAMA_API_KEY: undefined }, async () => {
       const resolved = await resolveApiKeyForProvider({

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { type Api, getEnvApiKey, type Model } from "@mariozechner/pi-ai";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { collectConfigRuntimeEnvVars } from "../config/env-vars.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import {
@@ -17,6 +18,7 @@ import {
   resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
 import { PROVIDER_ENV_API_KEY_CANDIDATES } from "./model-auth-env-vars.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { OLLAMA_LOCAL_AUTH_MARKER } from "./model-auth-markers.js";
 import { normalizeProviderId } from "./model-selection.js";
 
@@ -54,7 +56,19 @@ export function getCustomProviderApiKey(
   provider: string,
 ): string | undefined {
   const entry = resolveProviderConfig(cfg, provider);
-  return normalizeOptionalSecretInput(entry?.apiKey);
+  const configured = normalizeOptionalSecretInput(entry?.apiKey);
+  if (!configured) {
+    return undefined;
+  }
+  if (!isNonSecretApiKeyMarker(configured)) {
+    return configured;
+  }
+  const envValue = normalizeOptionalSecretInput(process.env[configured]);
+  if (envValue) {
+    return envValue;
+  }
+  const configEnvValue = normalizeOptionalSecretInput(collectConfigRuntimeEnvVars(cfg)[configured]);
+  return configEnvValue;
 }
 
 function resolveProviderAuthOverride(


### PR DESCRIPTION
## Summary

- Problem: OpenRouter requests can fail with `401 missing authentication header` when `models.providers.openrouter.apiKey` is set to a marker-like value (for example `OPENROUTER_API_KEY`) instead of a literal key.
- Why it matters: this is a regression reported in 2026.3.2 where valid configured keys are not resolved and auth headers are missing.
- What changed: `getCustomProviderApiKey` now resolves marker-style values from runtime env (`process.env`) and config env vars (`cfg.env.vars`) and returns `undefined` when unresolved.
- What did NOT change (scope boundary): provider routing/auth precedence and non-OpenRouter auth flows remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34830

## User-visible / Behavior Changes

- `models.providers.openrouter.apiKey: "OPENROUTER_API_KEY"` now resolves correctly from configured env vars (`cfg.env.vars`) and runtime env, so OpenRouter requests include auth headers again.
- Unresolved marker strings are no longer treated as literal API keys.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: resolving marker names from config/runtime env could accidentally choose an unexpected empty value.
  - Mitigation: values are normalized; unresolved/empty values return `undefined`, which triggers existing missing-key error path instead of sending bad credentials.

## Repro + Verification

### Environment

- OS: Ubuntu 25 VM (issue report)
- Runtime/container: npm install of OpenClaw 2026.3.2 (issue report), validated in repo tests
- Model/provider: OpenRouter (`stepfun/step3.5flash:free` in report)
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.providers.openrouter.apiKey: "OPENROUTER_API_KEY"`

### Steps

1. Configure provider api key as a marker-like string (`OPENROUTER_API_KEY`) rather than inline secret.
2. Ensure the key exists only in config env vars (`cfg.env.vars`) or runtime env.
3. Resolve provider API key and perform provider auth path.

### Expected

- Marker-style key resolves to actual key and auth header is sent.

### Actual

- Before fix, marker string could pass through as literal key, resulting in missing/invalid auth header behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification command (after install):

- `pnpm test src/agents/model-auth.profiles.test.ts`
- Result: `✓ src/agents/model-auth.profiles.test.ts (20 tests)`

Added regression coverage:

- resolves marker-style OpenRouter `apiKey` from config env vars
- rejects unresolved marker so it is not used as a literal API key

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Marker-based OpenRouter key resolves from `cfg.env.vars`.
  - Unresolved marker path throws missing-key error (no literal marker usage).
- Edge cases checked:
  - Runtime env missing while config env present.
  - Runtime env and config env missing.
- What you did **not** verify:
  - Live OpenRouter network call in external environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `52834245ed5c8b7c2d1ec9f236e1163d4015527e`.
- Files/config to restore:
  - `src/agents/model-auth.ts`
  - `src/agents/model-auth.profiles.test.ts`
- Known bad symptoms reviewers should watch for:
  - Provider API key resolution unexpectedly ignoring configured literal keys.

## Risks and Mitigations

- Risk:
  - Marker detection could match a value intended to be literal.
  - Mitigation:
    - Only marker-like values are resolved via env lookup; regular literal keys return unchanged.
