### PR TITLE
fix(gateway): strip inline image payloads from chat history

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -320,7 +320,7 @@ function sanitizeChatHistoryContentBlock(block: unknown): { block: unknown; chan
 
   const markImagePayloadOmitted = (bytes: number) => {
     entry.omitted = true;
-    entry.bytes = bytes;
+    entry.bytes = (toFiniteNumber(entry.bytes) ?? 0) + bytes;
     changed = true;
   };
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -93,6 +93,7 @@ type ChatAbortRequester = {
 const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+const INLINE_IMAGE_DATA_URL_RE = /^data:image\//i;
 let chatHistoryPlaceholderEmitCount = 0;
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
   "main",
@@ -316,13 +317,54 @@ function sanitizeChatHistoryContentBlock(block: unknown): { block: unknown; chan
     delete entry.thinkingSignature;
     changed = true;
   }
+
+  const markImagePayloadOmitted = (bytes: number) => {
+    entry.omitted = true;
+    entry.bytes = bytes;
+    changed = true;
+  };
+
   const type = typeof entry.type === "string" ? entry.type : "";
   if (type === "image" && typeof entry.data === "string") {
     const bytes = Buffer.byteLength(entry.data, "utf8");
     delete entry.data;
-    entry.omitted = true;
-    entry.bytes = bytes;
-    changed = true;
+    markImagePayloadOmitted(bytes);
+  }
+  if (
+    type === "image" &&
+    typeof entry.url === "string" &&
+    INLINE_IMAGE_DATA_URL_RE.test(entry.url)
+  ) {
+    const bytes = Buffer.byteLength(entry.url, "utf8");
+    delete entry.url;
+    markImagePayloadOmitted(bytes);
+  }
+  const source = entry.source;
+  if (
+    type === "image" &&
+    source &&
+    typeof source === "object" &&
+    typeof (source as { data?: unknown }).data === "string"
+  ) {
+    const sourceEntry = { ...(source as Record<string, unknown>) };
+    const bytes = Buffer.byteLength(String(sourceEntry.data), "utf8");
+    delete sourceEntry.data;
+    entry.source = sourceEntry;
+    markImagePayloadOmitted(bytes);
+  }
+  const imageUrl = entry.image_url;
+  if (
+    type === "image_url" &&
+    imageUrl &&
+    typeof imageUrl === "object" &&
+    typeof (imageUrl as { url?: unknown }).url === "string" &&
+    INLINE_IMAGE_DATA_URL_RE.test(String((imageUrl as { url: string }).url))
+  ) {
+    const imageUrlEntry = { ...(imageUrl as Record<string, unknown>) };
+    const bytes = Buffer.byteLength(String(imageUrlEntry.url), "utf8");
+    delete imageUrlEntry.url;
+    entry.image_url = imageUrlEntry;
+    markImagePayloadOmitted(bytes);
   }
   return { block: changed ? entry : block, changed };
 }

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -528,6 +528,51 @@ describe("gateway server chat", () => {
     expect(JSON.stringify(historyMessages)).not.toContain(inlineImage.slice(0, 256));
   });
 
+  test("chat.history accumulates bytes when multiple inline image payload fields are stripped", async () => {
+    const inlineData = `data:image/png;base64,${"A".repeat(30_000)}`;
+    const inlineUrl = `data:image/png;base64,${"B".repeat(20_000)}`;
+    const inlineSource = `data:image/png;base64,${"C".repeat(10_000)}`;
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            data: inlineData,
+            url: inlineUrl,
+            source: { type: "base64", media_type: "image/png", data: inlineSource },
+          },
+        ],
+        timestamp: 8,
+      },
+    ]);
+
+    expect(historyMessages).toHaveLength(1);
+    const message = historyMessages[0] as { content?: Array<Record<string, unknown>> };
+    expect(Array.isArray(message.content)).toBe(true);
+    const imageBlock = message.content?.[0] as
+      | {
+          data?: unknown;
+          url?: unknown;
+          bytes?: unknown;
+          source?: { data?: unknown; type?: unknown; media_type?: unknown };
+        }
+      | undefined;
+    expect(imageBlock).toMatchObject({
+      type: "image",
+      omitted: true,
+      bytes: inlineData.length + inlineUrl.length + inlineSource.length,
+      source: { type: "base64", media_type: "image/png" },
+    });
+    expect(imageBlock?.data).toBeUndefined();
+    expect(imageBlock?.url).toBeUndefined();
+    expect(imageBlock?.source?.data).toBeUndefined();
+    const serialized = JSON.stringify(historyMessages);
+    expect(serialized).not.toContain(inlineData.slice(0, 256));
+    expect(serialized).not.toContain(inlineUrl.slice(0, 256));
+    expect(serialized).not.toContain(inlineSource.slice(0, 256));
+  });
+
   test("agent.wait resolves chat.send runs that finish without lifecycle events", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     try {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -496,6 +496,38 @@ describe("gateway server chat", () => {
     ]);
   });
 
+  test("chat.history strips inline image source payloads from content blocks", async () => {
+    const inlineImage = `data:image/png;base64,${"A".repeat(90_000)}`;
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "image upload" },
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: inlineImage },
+          },
+        ],
+        timestamp: 7,
+      },
+    ]);
+
+    expect(historyMessages).toHaveLength(1);
+    const message = historyMessages[0] as { content?: Array<Record<string, unknown>> };
+    expect(Array.isArray(message.content)).toBe(true);
+    const imageBlock = message.content?.[1];
+    expect(imageBlock).toMatchObject({
+      type: "image",
+      omitted: true,
+      bytes: inlineImage.length,
+      source: { type: "base64", media_type: "image/png" },
+    });
+    const sanitizedSource = imageBlock?.source as { data?: unknown } | undefined;
+    expect(sanitizedSource).toBeDefined();
+    expect(sanitizedSource?.data).toBeUndefined();
+    expect(JSON.stringify(historyMessages)).not.toContain(inlineImage.slice(0, 256));
+  });
+
   test("agent.wait resolves chat.send runs that finish without lifecycle events", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     try {


### PR DESCRIPTION
## Summary
- strip inline data:image payloads from chat.history content blocks before returning transcript entries
- cover the dashboard image-upload shape (`content[].source.data`) plus other inline data-url variants
- add a regression test so history no longer returns massive base64 image blobs to the chat UI

## Testing
- pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server.chat.gateway-server-chat.test.ts