### PR TITLE
fix(gateway): keep main sessions visible in active session lists

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -724,6 +724,45 @@ describe("listSessionsFromStore search", () => {
     ]);
   });
 
+  test("does not keep legacy agent:main sessions pinned when a custom mainKey is configured", () => {
+    const now = Date.now();
+    const cfg = {
+      session: { mainKey: "primary" },
+      agents: { list: [{ id: "main", default: true }, { id: "heartbeat" }] },
+    } as OpenClawConfig;
+    const store: Record<string, SessionEntry> = {
+      "agent:main:primary": {
+        sessionId: "sess-main-primary",
+        updatedAt: now - 3 * 60 * 60_000,
+      } as SessionEntry,
+      "agent:heartbeat:primary": {
+        sessionId: "sess-heartbeat-primary",
+        updatedAt: now - 5 * 60_000,
+        label: "heartbeat",
+      } as SessionEntry,
+      "agent:main:main": {
+        sessionId: "sess-legacy-main",
+        updatedAt: now - 3 * 60 * 60_000,
+      } as SessionEntry,
+      "agent:main:stale-chat": {
+        sessionId: "sess-stale-chat",
+        updatedAt: now - 3 * 60 * 60_000,
+      } as SessionEntry,
+    };
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: { activeMinutes: 120 },
+    });
+
+    expect(result.sessions.map((session) => session.key)).toEqual([
+      "agent:heartbeat:primary",
+      "agent:main:primary",
+    ]);
+  });
+
   test.each([
     {
       name: "does not guess provider for legacy runtime model without modelProvider",

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -689,6 +689,41 @@ describe("listSessionsFromStore search", () => {
     expect(result.sessions.map((session) => session.key)).toEqual(["agent:main:cron:job-1"]);
   });
 
+  test("keeps top-level agent sessions visible when activeMinutes filters stale sessions", () => {
+    const now = Date.now();
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }, { id: "heartbeat" }] },
+    } as OpenClawConfig;
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess-main",
+        updatedAt: now - 3 * 60 * 60_000,
+      } as SessionEntry,
+      "agent:heartbeat:main": {
+        sessionId: "sess-heartbeat",
+        updatedAt: now - 5 * 60_000,
+        label: "heartbeat",
+      } as SessionEntry,
+      "agent:main:stale-chat": {
+        sessionId: "sess-stale-chat",
+        updatedAt: now - 3 * 60 * 60_000,
+      } as SessionEntry,
+    };
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: { activeMinutes: 120 },
+    });
+
+    expect(result.sessions.map((session) => session.key)).toEqual([
+      "agent:heartbeat:main",
+      "agent:main:main",
+    ]);
+  });
+
   test.each([
     {
       name: "does not guess provider for legacy runtime model without modelProvider",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -727,7 +727,7 @@ function isPrimaryAgentSessionKey(key: string, cfg: OpenClawConfig): boolean {
     return false;
   }
   const normalizedMainKey = normalizeMainKey(cfg.session?.mainKey);
-  return parsed.rest === normalizedMainKey || parsed.rest === "main";
+  return parsed.rest === normalizedMainKey;
 }
 
 export function listSessionsFromStore(params: {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -715,6 +715,21 @@ export function resolveSessionModelIdentityRef(
   return { provider: resolved.provider, model: resolved.model };
 }
 
+function isPrimaryAgentSessionKey(key: string, cfg: OpenClawConfig): boolean {
+  if (key === "global") {
+    return resolveMainSessionKey(cfg) === "global";
+  }
+  if (key === "main") {
+    return true;
+  }
+  const parsed = parseAgentSessionKey(key);
+  if (!parsed) {
+    return false;
+  }
+  const normalizedMainKey = normalizeMainKey(cfg.session?.mainKey);
+  return parsed.rest === normalizedMainKey || parsed.rest === "main";
+}
+
 export function listSessionsFromStore(params: {
   cfg: OpenClawConfig;
   storePath: string;
@@ -855,7 +870,9 @@ export function listSessionsFromStore(params: {
 
   if (activeMinutes !== undefined) {
     const cutoff = now - activeMinutes * 60_000;
-    sessions = sessions.filter((s) => (s.updatedAt ?? 0) >= cutoff);
+    sessions = sessions.filter(
+      (s) => isPrimaryAgentSessionKey(s.key, cfg) || (s.updatedAt ?? 0) >= cutoff,
+    );
   }
 
   if (typeof opts.limit === "number" && Number.isFinite(opts.limit)) {


### PR DESCRIPTION
## Summary
- keep top-level agent main sessions in `sessions.list` even when `activeMinutes` hides stale conversations
- preserve the recent-session filter for other stale sessions so the chat dropdown stays compact
- add a regression test covering a stale `main` session alongside an active `heartbeat` session

Fixes #43737.
