### PR TITLE
fix(agents): preserve agent.wait results for subagent announces

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -332,6 +332,26 @@ export async function captureSubagentCompletionReply(
   });
 }
 
+export function extractAgentWaitResultText(wait: unknown): string | undefined {
+  if (!wait || typeof wait !== "object") {
+    return undefined;
+  }
+  const payload = wait as {
+    result?: unknown;
+    output?: unknown;
+    content?: unknown;
+    summary?: unknown;
+  };
+  const candidates = [payload.result, payload.output, payload.content, payload.summary];
+  for (const candidate of candidates) {
+    const text = extractToolResultText(candidate)?.trim();
+    if (text) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
 function describeSubagentOutcome(outcome?: SubagentRunOutcome): string {
   if (!outcome) {
     return "unknown";
@@ -1191,6 +1211,10 @@ export async function runSubagentAnnounceFlow(params: {
         startedAt?: number;
         endedAt?: number;
         error?: string;
+        result?: unknown;
+        output?: unknown;
+        content?: unknown;
+        summary?: unknown;
       }>({
         method: "agent.wait",
         params: {
@@ -1200,12 +1224,16 @@ export async function runSubagentAnnounceFlow(params: {
         timeoutMs: waitMs + 2000,
       });
       const waitError = typeof wait?.error === "string" ? wait.error : undefined;
+      const waitResultText = extractAgentWaitResultText(wait);
       if (wait?.status === "timeout") {
         outcome = { status: "timeout" };
       } else if (wait?.status === "error") {
         outcome = { status: "error", error: waitError };
       } else if (wait?.status === "ok") {
         outcome = { status: "ok" };
+      }
+      if (!reply && waitResultText) {
+        reply = waitResultText;
       }
       if (typeof wait?.startedAt === "number" && !params.startedAt) {
         params.startedAt = wait.startedAt;

--- a/src/agents/subagent-registry.agent-wait-result.e2e.test.ts
+++ b/src/agents/subagent-registry.agent-wait-result.e2e.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const noop = () => {};
+const MAIN_REQUESTER_SESSION_KEY = "agent:main:main";
+
+const callGatewayMock = vi.fn(async (request: unknown) => {
+  const method = (request as { method?: string }).method;
+  if (method === "agent.wait") {
+    return {
+      status: "ok",
+      startedAt: 100,
+      endedAt: 200,
+      result: "final answer from agent.wait",
+    };
+  }
+  return {};
+});
+const onAgentEventMock = vi.fn((_handler: unknown) => noop);
+const loadConfigMock = vi.fn(() => ({
+  agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+}));
+const loadRegistryMock = vi.fn(() => new Map());
+const saveRegistryMock = vi.fn(() => {});
+const announceSpy = vi.fn(async (_params?: Record<string, unknown>) => true);
+const captureCompletionReplySpy = vi.fn(
+  async (_sessionKey?: string) => undefined as string | undefined,
+);
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: callGatewayMock,
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: onAgentEventMock,
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: loadConfigMock,
+  };
+});
+
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: announceSpy,
+  captureSubagentCompletionReply: captureCompletionReplySpy,
+  extractAgentWaitResultText: (wait: { result?: unknown }) =>
+    typeof wait?.result === "string" ? wait.result : undefined,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+vi.mock("./subagent-registry.store.js", () => ({
+  loadSubagentRegistryFromDisk: loadRegistryMock,
+  saveSubagentRegistryToDisk: saveRegistryMock,
+}));
+
+describe("subagent registry agent.wait result fallback", () => {
+  let mod: typeof import("./subagent-registry.js");
+
+  beforeAll(async () => {
+    mod = await import("./subagent-registry.js");
+  });
+
+  beforeEach(() => {
+    announceSpy.mockReset().mockResolvedValue(true);
+    captureCompletionReplySpy.mockReset().mockResolvedValue(undefined);
+    callGatewayMock.mockClear();
+  });
+
+  afterEach(() => {
+    mod.resetSubagentRegistryForTests({ persist: false });
+  });
+
+  async function waitForAnnounce() {
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      if (announceSpy.mock.calls.length > 0) {
+        return;
+      }
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    throw new Error("announce did not fire in time");
+  }
+
+  it("uses agent.wait result when completion history is still empty", async () => {
+    mod.registerSubagentRun({
+      runId: "run-wait-result",
+      childSessionKey: "agent:main:subagent:child-wait-result",
+      requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+      requesterDisplayKey: "main",
+      task: "wait result fallback",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    await waitForAnnounce();
+
+    expect(captureCompletionReplySpy.mock.calls.length).toBeLessThanOrEqual(1);
+    const run = mod
+      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+      .find((candidate) => candidate.runId === "run-wait-result");
+    expect(run?.frozenResultText).toBe("final answer from agent.wait");
+
+    const firstCall = announceSpy.mock.calls[0]?.[0] as { roundOneReply?: string } | undefined;
+    expect(firstCall?.roundOneReply).toBe("final answer from agent.wait");
+  });
+});

--- a/src/agents/subagent-registry.agent-wait-result.e2e.test.ts
+++ b/src/agents/subagent-registry.agent-wait-result.e2e.test.ts
@@ -108,4 +108,49 @@ describe("subagent registry agent.wait result fallback", () => {
     const firstCall = announceSpy.mock.calls[0]?.[0] as { roundOneReply?: string } | undefined;
     expect(firstCall?.roundOneReply).toBe("final answer from agent.wait");
   });
+
+  it("does not overwrite an existing frozen completion reply with agent.wait fallback text", async () => {
+    let releaseWait: (() => void) | undefined;
+    callGatewayMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseWait = () =>
+            resolve({
+              status: "ok",
+              startedAt: 100,
+              endedAt: 200,
+              result: "fallback text from agent.wait",
+            });
+        }),
+    );
+
+    mod.registerSubagentRun({
+      runId: "run-existing-frozen-result",
+      childSessionKey: "agent:main:subagent:child-existing-frozen-result",
+      requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+      requesterDisplayKey: "main",
+      task: "preserve richer frozen result",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const run = mod
+      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+      .find((candidate) => candidate.runId === "run-existing-frozen-result");
+    expect(run).toBeDefined();
+    run!.frozenResultText = "richer reply captured from chat history";
+    run!.frozenResultCapturedAt = 123456;
+
+    releaseWait?.();
+    await waitForAnnounce();
+
+    expect(run?.frozenResultText).toBe("richer reply captured from chat history");
+    expect(run?.frozenResultCapturedAt).toBe(123456);
+
+    const firstCall = announceSpy.mock.calls[0]?.[0] as { roundOneReply?: string } | undefined;
+    expect(firstCall?.roundOneReply).toBe("richer reply captured from chat history");
+  });
 });

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1261,7 +1261,7 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
     }
     if (waitResultText) {
       const nextFrozenResultText = capFrozenResultText(waitResultText);
-      if (entry.frozenResultText !== nextFrozenResultText) {
+      if (entry.frozenResultText == null && nextFrozenResultText) {
         entry.frozenResultText = nextFrozenResultText;
         entry.frozenResultCapturedAt = Date.now();
         mutated = true;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -20,6 +20,7 @@ import { ensureRuntimePluginsLoaded } from "./runtime-plugins.js";
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import {
   captureSubagentCompletionReply,
+  extractAgentWaitResultText,
   runSubagentAnnounceFlow,
   type SubagentRunOutcome,
 } from "./subagent-announce.js";
@@ -1214,6 +1215,10 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       startedAt?: number;
       endedAt?: number;
       error?: string;
+      result?: unknown;
+      output?: unknown;
+      content?: unknown;
+      summary?: unknown;
     }>({
       method: "agent.wait",
       params: {
@@ -1243,6 +1248,7 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       mutated = true;
     }
     const waitError = typeof wait.error === "string" ? wait.error : undefined;
+    const waitResultText = extractAgentWaitResultText(wait);
     const outcome: SubagentRunOutcome =
       wait.status === "error"
         ? { status: "error", error: waitError }
@@ -1252,6 +1258,14 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
     if (!runOutcomesEqual(entry.outcome, outcome)) {
       entry.outcome = outcome;
       mutated = true;
+    }
+    if (waitResultText) {
+      const nextFrozenResultText = capFrozenResultText(waitResultText);
+      if (entry.frozenResultText !== nextFrozenResultText) {
+        entry.frozenResultText = nextFrozenResultText;
+        entry.frozenResultCapturedAt = Date.now();
+        mutated = true;
+      }
     }
     if (mutated) {
       persistSubagentRuns();

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -49,8 +49,42 @@ describe("agent wait dedupe helper", () => {
       startedAt: 100,
       endedAt: 200,
       error: undefined,
+      result: undefined,
     });
     expect(__testing.getWaiterCount(runId)).toBe(0);
+  });
+
+  it("preserves terminal agent result payloads from dedupe snapshots", () => {
+    const dedupe = new Map();
+    const runId = "run-agent-result";
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `agent:${runId}`,
+      entry: {
+        ts: 123,
+        ok: true,
+        payload: {
+          runId,
+          status: "ok",
+          startedAt: 10,
+          endedAt: 20,
+          result: "final answer",
+        },
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "ok",
+      startedAt: 10,
+      endedAt: 20,
+      error: undefined,
+      result: "final answer",
+    });
   });
 
   it("keeps stale chat dedupe blocked while agent dedupe is in-flight", async () => {
@@ -137,6 +171,7 @@ describe("agent wait dedupe helper", () => {
       startedAt: 1,
       endedAt: 2,
       error: undefined,
+      result: undefined,
     });
   });
 
@@ -193,6 +228,7 @@ describe("agent wait dedupe helper", () => {
       startedAt: 123,
       endedAt: 456,
       error: undefined,
+      result: undefined,
     });
   });
 
@@ -261,6 +297,7 @@ describe("agent wait dedupe helper", () => {
       startedAt: 3,
       endedAt: 4,
       error: "still running",
+      result: undefined,
     });
   });
 

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -5,6 +5,7 @@ export type AgentWaitTerminalSnapshot = {
   startedAt?: number;
   endedAt?: number;
   error?: string;
+  result?: unknown;
 };
 
 const AGENT_WAITERS_BY_RUN_ID = new Map<string, Set<() => void>>();
@@ -79,6 +80,7 @@ export function readTerminalSnapshotFromDedupeEntry(
         endedAt?: unknown;
         error?: unknown;
         summary?: unknown;
+        result?: unknown;
       }
     | undefined;
   const status = typeof payload?.status === "string" ? payload.status : undefined;
@@ -94,6 +96,7 @@ export function readTerminalSnapshotFromDedupeEntry(
       : typeof payload?.summary === "string"
         ? payload.summary
         : entry.error?.message;
+  const result = payload?.result;
 
   if (status === "ok" || status === "timeout") {
     return {
@@ -101,6 +104,7 @@ export function readTerminalSnapshotFromDedupeEntry(
       startedAt,
       endedAt,
       error: status === "timeout" ? errorMessage : undefined,
+      result,
     };
   }
   if (status === "error" || !entry.ok) {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -717,6 +717,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         startedAt: cachedGatewaySnapshot.startedAt,
         endedAt: cachedGatewaySnapshot.endedAt,
         error: cachedGatewaySnapshot.error,
+        result: cachedGatewaySnapshot.result,
       });
       return;
     }
@@ -771,6 +772,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       startedAt: snapshot.startedAt,
       endedAt: snapshot.endedAt,
       error: snapshot.error,
+      result: "result" in snapshot ? snapshot.result : undefined,
     });
   },
 };

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -554,6 +554,34 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("agent.wait preserves structured result payload arrays from deduped agent runs", async () => {
+    const structuredResult = [
+      { type: "text", text: "gateway final answer" },
+      { type: "text", text: "with extra context" },
+    ];
+    const agentSpy = vi.mocked(agentCommand);
+    agentSpy.mockResolvedValueOnce(structuredResult as never);
+
+    await withMainSessionStore(async () => {
+      const runId = "idem-wait-agent-result-array";
+      const agentRes = await rpcReq(ws, "agent", {
+        sessionKey: "main",
+        message: "return structured result blocks",
+        idempotencyKey: runId,
+      });
+      expect(agentRes.ok).toBe(true);
+      expect(agentRes.payload?.status).toBe("accepted");
+
+      const waitRes = await rpcReq(ws, "agent.wait", {
+        runId,
+        timeoutMs: 1_000,
+      });
+      expect(waitRes.ok).toBe(true);
+      expect(waitRes.payload?.status).toBe("ok");
+      expect(waitRes.payload?.result).toEqual(structuredResult);
+    });
+  });
+
   test("agent.wait ignores stale chat dedupe when an agent run with the same runId is in flight", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     let resolveAgentRun: (() => void) | undefined;

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -530,6 +530,30 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("agent.wait returns the deduped agent result payload when the run finishes without lifecycle history", async () => {
+    const agentSpy = vi.mocked(agentCommand);
+    agentSpy.mockResolvedValueOnce("gateway final answer");
+
+    await withMainSessionStore(async () => {
+      const runId = "idem-wait-agent-result";
+      const agentRes = await rpcReq(ws, "agent", {
+        sessionKey: "main",
+        message: "return the final answer",
+        idempotencyKey: runId,
+      });
+      expect(agentRes.ok).toBe(true);
+      expect(agentRes.payload?.status).toBe("accepted");
+
+      const waitRes = await rpcReq(ws, "agent.wait", {
+        runId,
+        timeoutMs: 1_000,
+      });
+      expect(waitRes.ok).toBe(true);
+      expect(waitRes.payload?.status).toBe("ok");
+      expect(waitRes.payload?.result).toBe("gateway final answer");
+    });
+  });
+
   test("agent.wait ignores stale chat dedupe when an agent run with the same runId is in flight", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     let resolveAgentRun: (() => void) | undefined;

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -532,7 +532,7 @@ describe("gateway server chat", () => {
 
   test("agent.wait returns the deduped agent result payload when the run finishes without lifecycle history", async () => {
     const agentSpy = vi.mocked(agentCommand);
-    agentSpy.mockResolvedValueOnce("gateway final answer");
+    agentSpy.mockResolvedValueOnce("gateway final answer" as never);
 
     await withMainSessionStore(async () => {
       const runId = "idem-wait-agent-result";


### PR DESCRIPTION
## Summary
- preserve terminal `agent.wait` result payloads in gateway dedupe snapshots and responses
- reuse `agent.wait` result text in subagent announce/registry flows when chat history has not caught up yet
- add regressions for gateway result propagation and subagent completion delivery

## Testing
- pnpm exec vitest run src/gateway/server-methods/agent-wait-dedupe.test.ts src/gateway/server.chat.gateway-server-chat.test.ts
- pnpm exec vitest run --config vitest.e2e.config.ts src/agents/subagent-registry.agent-wait-result.e2e.test.ts src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts src/agents/subagent-announce.format.e2e.test.ts