### PR TITLE
fix(acpx): update ACPX_PINNED_VERSION to match bundled acpx 0.2.0

### DIFF
--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -8,7 +8,7 @@ export type AcpxPermissionMode = (typeof ACPX_PERMISSION_MODES)[number];
 export const ACPX_NON_INTERACTIVE_POLICIES = ["deny", "fail"] as const;
 export type AcpxNonInteractivePermissionPolicy = (typeof ACPX_NON_INTERACTIVE_POLICIES)[number];
 
-export const ACPX_PINNED_VERSION = "0.1.16";
+export const ACPX_PINNED_VERSION = "0.2.0";
 export const ACPX_VERSION_ANY = "any";
 const ACPX_BIN_NAME = process.platform === "win32" ? "acpx.cmd" : "acpx";
 export const ACPX_PLUGIN_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");


### PR DESCRIPTION
## Summary

Fixes #43997

The 2026.3.11 release ships with acpx `0.2.0` bundled in the plugin's `node_modules`, but `ACPX_PINNED_VERSION` in `extensions/acpx/src/config.ts` was not updated from `0.1.16`. The plugin startup version check fails because `0.2.0 !== 0.1.16`, causing the ACP runtime backend to be marked unavailable for all users after upgrading to 2026.3.11.

## Change

```diff
- export const ACPX_PINNED_VERSION = "0.1.16";
+ export const ACPX_PINNED_VERSION = "0.2.0";
```

## Workaround (for users already affected)
```
openclaw config set plugins.entries.acpx.config.expectedVersion any
```