### PR TITLE
fix(gateway): avoid self-counting backend requester in exec approvals

### DIFF
--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -7,6 +7,7 @@ import {
 import { buildSystemRunApprovalBinding } from "../../infra/system-run-approval-binding.js";
 import { resolveSystemRunApprovalRequestContext } from "../../infra/system-run-approval-context.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import { GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -20,6 +21,18 @@ export function createExecApprovalHandlers(
   manager: ExecApprovalManager,
   opts?: { forwarder?: ExecApprovalForwarder },
 ): GatewayRequestHandlers {
+  const hasApprovalClients = (
+    context: {
+      hasExecApprovalClients?: (params?: { excludeConnIds?: ReadonlySet<string> }) => boolean;
+    },
+    probeOpts?: { excludeConnIds?: ReadonlySet<string> },
+  ) => {
+    if (typeof context.hasExecApprovalClients === "function") {
+      return context.hasExecApprovalClients(probeOpts);
+    }
+    // Fail closed when no operator-scope probe is available.
+    return false;
+  };
   return {
     "exec.approval.request": async ({ params, respond, context, client }) => {
       if (!validateExecApprovalRequestParams(params)) {
@@ -194,7 +207,15 @@ export function createExecApprovalHandlers(
         }
       }
 
-      if (!hasExecApprovalClients && !forwarded) {
+      const requesterConnId =
+        client?.connect?.client?.mode === GATEWAY_CLIENT_MODES.BACKEND &&
+        typeof client?.connId === "string"
+          ? client.connId
+          : null;
+      const approverClientsAvailable = hasApprovalClients(context, {
+        excludeConnIds: requesterConnId ? new Set([requesterConnId]) : undefined,
+      });
+      if (!approverClientsAvailable && !forwarded) {
         manager.expire(record.id, "no-approval-route");
         respond(
           true,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -9,6 +9,7 @@ import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js
 import { buildSystemRunApprovalBinding } from "../../infra/system-run-approval-binding.js";
 import { resetLogger, setLoggerOverride } from "../../logging.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
+import { GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
 import { validateExecApprovalRequestParams } from "../protocol/index.js";
 import { waitForAgentJob } from "./agent-job.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
@@ -317,7 +318,7 @@ describe("exec approval handlers", () => {
 
   function toExecApprovalRequestContext(context: {
     broadcast: (event: string, payload: unknown) => void;
-    hasExecApprovalClients?: () => boolean;
+    hasExecApprovalClients?: (params?: { excludeConnIds?: ReadonlySet<string> }) => boolean;
   }): ExecApprovalRequestArgs["context"] {
     return context as unknown as ExecApprovalRequestArgs["context"];
   }
@@ -333,6 +334,7 @@ describe("exec approval handlers", () => {
     respond: ReturnType<typeof vi.fn>;
     context: { broadcast: (event: string, payload: unknown) => void };
     params?: Record<string, unknown>;
+    client?: ExecApprovalRequestArgs["client"];
   }) {
     const requestParams = {
       ...defaultExecApprovalRequestParams,
@@ -376,7 +378,7 @@ describe("exec approval handlers", () => {
         hasExecApprovalClients: () => true,
         ...params.context,
       }),
-      client: null,
+      client: params.client ?? null,
       req: { id: "req-1", type: "req", method: "exec.approval.request" },
       isWebchatConnect: execApprovalNoop,
     });
@@ -957,6 +959,58 @@ describe("exec approval handlers", () => {
       expect.objectContaining({ id: "approval-forwarded", decision: "allow-once" }),
       undefined,
     );
+  });
+
+  it("excludes backend requester connections from approver probes", async () => {
+    vi.useFakeTimers();
+    try {
+      const manager = new ExecApprovalManager();
+      const handlers = createExecApprovalHandlers(manager);
+      const respond = vi.fn();
+      const hasExecApprovalClients = vi.fn(
+        (params?: { excludeConnIds?: ReadonlySet<string> }) =>
+          !params?.excludeConnIds?.has("req-conn"),
+      );
+      const context = {
+        broadcast: (_event: string, _payload: unknown) => {},
+        hasExecApprovalClients,
+      };
+
+      const requestPromise = requestExecApproval({
+        handlers,
+        respond,
+        context,
+        client: {
+          connId: "req-conn",
+          connect: {
+            role: "operator",
+            client: {
+              id: "gateway-client",
+              version: "test",
+              platform: "test",
+              mode: GATEWAY_CLIENT_MODES.BACKEND,
+            },
+            scopes: ["operator.approvals"],
+          },
+        } as ExecApprovalRequestArgs["client"],
+        params: { timeoutMs: 60_000 },
+      });
+      await drainApprovalRequestTicks();
+
+      expect(hasExecApprovalClients).toHaveBeenCalledWith({
+        excludeConnIds: new Set(["req-conn"]),
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      await requestPromise;
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ decision: null }),
+        undefined,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -50,7 +50,7 @@ export type GatewayRequestContext = {
   nodeUnsubscribe: (nodeId: string, sessionKey: string) => void;
   nodeUnsubscribeAll: (nodeId: string) => void;
   hasConnectedMobileNode: () => boolean;
-  hasExecApprovalClients?: () => boolean;
+  hasExecApprovalClients?: (params?: { excludeConnIds?: ReadonlySet<string> }) => boolean;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -834,8 +834,16 @@ export async function startGatewayServer(
     nodeUnsubscribe,
     nodeUnsubscribeAll,
     hasConnectedMobileNode: hasMobileNodeConnected,
-    hasExecApprovalClients: () => {
+    hasExecApprovalClients: (params) => {
+      const excludedConnIds = params?.excludeConnIds;
       for (const gatewayClient of clients) {
+        if (excludedConnIds?.has(gatewayClient.connId)) {
+          continue;
+        }
+        const role = gatewayClient.connect.role ?? "operator";
+        if (role !== "operator") {
+          continue;
+        }
         const scopes = Array.isArray(gatewayClient.connect.scopes)
           ? gatewayClient.connect.scopes
           : [];

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -837,7 +837,8 @@ export async function startGatewayServer(
     hasExecApprovalClients: (params) => {
       const excludedConnIds = params?.excludeConnIds;
       for (const gatewayClient of clients) {
-        if (excludedConnIds?.has(gatewayClient.connId)) {
+        const connId = gatewayClient.connId;
+        if (excludedConnIds && typeof connId === "string" && excludedConnIds.has(connId)) {
           continue;
         }
         const role = gatewayClient.connect.role ?? "operator";


### PR DESCRIPTION
## Summary

- Problem: `exec.approval.request` could treat the requesting backend connection as an available approver client.
- Why it matters: when no real approver client is reachable, approval requests stayed pending instead of fast-failing, which made exec flows appear hung.
- What changed:
  - Added optional requester-connection exclusion support to `hasExecApprovalClients` gateway request context.
  - Updated gateway runtime approver probe to honor excluded connection IDs and operator role.
  - Updated exec approval handler to exclude backend requester connections from the approver availability probe.
  - Added a regression test covering backend requester exclusion behavior.
- What did NOT change (scope boundary): approval transport/protocol and socket config format were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43989
- Related #N/A

## User-visible / Behavior Changes

- Exec approvals now auto-expire as expected when only the backend requester connection is present and no real approver client/forwarding target is reachable.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local dev (macOS)
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): gateway exec approval handlers
- Relevant config (redacted): N/A

### Steps

1. Trigger `exec.approval.request` from a backend-mode requester connection.
2. Ensure no other approver clients/forwarding targets are available.
3. Observe decision resolution path.

### Expected

- Request should auto-expire quickly (decision `null`) instead of waiting as if an approver were reachable.

### Actual

- With this patch, backend requester connection is excluded from approver probe, and request auto-expires as expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/gateway/server-methods/server-methods.test.ts` passes, including new regression case.
- Edge cases checked:
  - Existing exec approval handler tests still pass with new context signature.
- What you did **not** verify:
  - Full end-to-end UI flow on Linux host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `243f7543c`.
- Files/config to restore:
  - `src/gateway/server-methods/exec-approval.ts`
  - `src/gateway/server-methods/types.ts`
  - `src/gateway/server.impl.ts`
- Known bad symptoms reviewers should watch for:
  - Exec approvals expiring too aggressively when a valid approver client is connected.

## Risks and Mitigations

- Risk:
  - Excluding backend requester connections could expire approvals when only backend clients are connected.
  - Mitigation:
    - Exclusion is limited to the requesting backend connection; other approver-capable clients and forwarding targets still prevent auto-expiry.
