### PR TITLE
[AI-assisted] fix(matrix): stop typing after replies

### DIFF
--- a/changelog/fragments/pr-matrix-typing-stop.md
+++ b/changelog/fragments/pr-matrix-typing-stop.md
@@ -1,1 +1,1 @@
-- Fix Matrix typing indicator so it clears after final replies instead of lingering until user input (#0) (thanks @kevin)
+- Fix Matrix typing indicator so it clears after final replies instead of lingering until user input.

--- a/changelog/fragments/pr-matrix-typing-stop.md
+++ b/changelog/fragments/pr-matrix-typing-stop.md
@@ -1,0 +1,1 @@
+- Fix Matrix typing indicator so it clears after final replies instead of lingering until user input (#0) (thanks @kevin)

--- a/extensions/matrix/src/matrix/monitor/handler.typing.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.typing.test.ts
@@ -1,0 +1,194 @@
+import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
+import type { PluginRuntime, RuntimeEnv, RuntimeLogger } from "openclaw/plugin-sdk/matrix";
+import { describe, expect, it, vi } from "vitest";
+import { createMatrixRoomMessageHandler } from "./handler.js";
+import { EventType, type MatrixRawEvent } from "./types.js";
+
+const sendTypingMatrixMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../send.js", () => ({
+  reactMatrixMessage: vi.fn().mockResolvedValue(undefined),
+  sendMessageMatrix: vi.fn().mockResolvedValue({ messageId: "$unused" }),
+  sendTypingMatrix: (...args: unknown[]) => sendTypingMatrixMock(...args),
+}));
+
+describe("createMatrixRoomMessageHandler typing flow", () => {
+  it("wires Matrix typing start and stop callbacks into the reply dispatcher", async () => {
+    const callOrder: string[] = [];
+    let capturedTypingCallbacks:
+      | {
+          onReplyStart: () => Promise<void>;
+          onIdle?: () => void;
+        }
+      | undefined;
+
+    sendTypingMatrixMock.mockImplementation(async (_roomId, typing) => {
+      callOrder.push(typing ? "typing-start" : "typing-stop");
+      return undefined;
+    });
+
+    const createReplyDispatcherWithTypingStub = vi.fn().mockImplementation((options: unknown) => {
+      const typed = options as {
+        typingCallbacks?: {
+          onReplyStart: () => Promise<void>;
+          onIdle?: () => void;
+        };
+      };
+      capturedTypingCallbacks = typed.typingCallbacks;
+      throw new Error("capture-typing-callbacks");
+    });
+
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn().mockResolvedValue([]),
+          upsertPairingRequest: vi.fn().mockResolvedValue(undefined),
+        },
+        routing: {
+          buildAgentSessionKey: vi
+            .fn()
+            .mockImplementation(
+              (params: { agentId: string; channel: string; peer?: { kind: string; id: string } }) =>
+                `agent:${params.agentId}:${params.channel}:${params.peer?.kind ?? "direct"}:${params.peer?.id ?? "unknown"}`,
+            ),
+          resolveAgentRoute: vi.fn().mockReturnValue({
+            agentId: "main",
+            accountId: undefined,
+            sessionKey: "agent:main:matrix:channel:!room:example.org",
+            mainSessionKey: "agent:main:main",
+          }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(123),
+          recordInboundSession: vi.fn().mockResolvedValue(undefined),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatInboundEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          formatAgentEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+          resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingStub,
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+        },
+        text: {
+          hasControlCommand: vi.fn().mockReturnValue(false),
+          resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+        },
+        mentions: {
+          buildMentionRegexes: vi.fn().mockReturnValue([]),
+          detectDirectMentionFromRegexes: vi.fn().mockReturnValue(false),
+          detectBotMentionFromRegexes: vi.fn().mockReturnValue(false),
+          matchesMentionPatterns: vi.fn().mockReturnValue(false),
+        },
+        reactions: {
+          shouldAckReaction: vi.fn().mockReturnValue(false),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+      logging: {
+        shouldLogVerbose: vi.fn().mockReturnValue(false),
+      },
+      config: {
+        loadConfig: vi.fn().mockReturnValue({}),
+      },
+    } as unknown as PluginRuntime;
+
+    const runtimeError = vi.fn();
+    const runtime = {
+      error: runtimeError,
+      log: vi.fn(),
+    } as unknown as RuntimeEnv;
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as RuntimeLogger;
+    const client = {
+      getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+    } as unknown as MatrixClient;
+
+    const handler = createMatrixRoomMessageHandler({
+      client,
+      core,
+      cfg: {},
+      runtime,
+      logger,
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      mentionRegexes: [],
+      groupPolicy: "open",
+      replyToMode: "first",
+      threadReplies: "inbound",
+      dmEnabled: true,
+      dmPolicy: "open",
+      textLimit: 4000,
+      mediaMaxBytes: 5 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(false),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "Dev Room",
+        canonicalAlias: "#dev:matrix.example.org",
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Bu"),
+      accountId: undefined,
+    });
+
+    const event = {
+      type: EventType.RoomMessage,
+      event_id: "$inbound-1",
+      sender: "@bu:matrix.example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "show me my commits",
+        "m.mentions": { user_ids: ["@bot:matrix.example.org"] },
+        "m.relates_to": {
+          rel_type: "m.thread",
+          event_id: "$thread-root",
+        },
+      },
+    } as unknown as MatrixRawEvent;
+
+    await handler("!room:example", event);
+
+    expect(createReplyDispatcherWithTypingStub).toHaveBeenCalledTimes(1);
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("matrix handler failed: Error: capture-typing-callbacks"),
+    );
+    expect(capturedTypingCallbacks).toBeDefined();
+
+    await capturedTypingCallbacks?.onReplyStart();
+    capturedTypingCallbacks?.onIdle?.();
+
+    expect(sendTypingMatrixMock).toHaveBeenCalledTimes(2);
+    expect(sendTypingMatrixMock).toHaveBeenNthCalledWith(
+      1,
+      "!room:example",
+      true,
+      undefined,
+      client,
+    );
+    expect(sendTypingMatrixMock).toHaveBeenNthCalledWith(
+      2,
+      "!room:example",
+      false,
+      undefined,
+      client,
+    );
+    expect(callOrder).toEqual(["typing-start", "typing-stop"]);
+  });
+});

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -2,6 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { setMatrixRuntime } from "../runtime.js";
 
+const resolveMatrixClientMock = vi.hoisted(() => vi.fn());
+
 vi.mock("music-metadata", () => ({
   // `resolveMediaDurationMs` lazily imports `music-metadata`; in tests we don't
   // need real duration parsing and the real module is expensive to load.
@@ -27,6 +29,15 @@ vi.mock("@vector-im/matrix-bot-sdk", () => ({
 vi.mock("./send-queue.js", () => ({
   enqueueSend: async <T>(_roomId: string, fn: () => Promise<T>) => await fn(),
 }));
+
+vi.mock("./send/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./send/client.js")>();
+  return {
+    ...actual,
+    resolveMatrixClient: (...args: Parameters<typeof actual.resolveMatrixClient>) =>
+      resolveMatrixClientMock(...args),
+  };
+});
 
 const loadWebMediaMock = vi.fn().mockResolvedValue({
   buffer: Buffer.from("media"),
@@ -90,6 +101,12 @@ beforeAll(async () => {
 describe("sendMessageMatrix media", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resolveMatrixClientMock.mockImplementation(async (opts) => {
+      if (!opts.client) {
+        throw new Error("test expected a Matrix client");
+      }
+      return { client: opts.client, stopOnDone: false };
+    });
     runtimeLoadConfigMock.mockReset();
     runtimeLoadConfigMock.mockReturnValue({});
     mediaKindFromMimeMock.mockReturnValue("image");
@@ -330,6 +347,12 @@ describe("resolveMediaMaxBytes cfg threading", () => {
 describe("sendTypingMatrix", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resolveMatrixClientMock.mockImplementation(async (opts) => {
+      if (!opts.client) {
+        throw new Error("test expected a Matrix client");
+      }
+      return { client: opts.client, stopOnDone: false };
+    });
     setMatrixRuntime(runtimeStub);
   });
 
@@ -367,6 +390,25 @@ describe("sendTypingMatrix", () => {
     } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
 
     await sendTypingMatrix("!room:example.org", true, 5_000, client);
+
+    expect(setTyping).toHaveBeenCalledTimes(1);
+    expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 5_000);
+  });
+
+  it("preserves legacy numeric timeout semantics when resolving the client internally", async () => {
+    const setTyping = vi.fn().mockResolvedValue(undefined);
+    resolveMatrixClientMock.mockImplementationOnce(async (opts) => {
+      expect(opts.client).toBeUndefined();
+      expect(opts.timeoutMs).toBe(5_000);
+      return {
+        client: {
+          setTyping,
+        } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient,
+        stopOnDone: false,
+      };
+    });
+
+    await sendTypingMatrix("!room:example.org", true, 5_000);
 
     expect(setTyping).toHaveBeenCalledTimes(1);
     expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 5_000);

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -395,6 +395,19 @@ describe("sendTypingMatrix", () => {
     expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 5_000);
   });
 
+  it("accepts a Matrix client as the third argument", async () => {
+    const setTyping = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      setTyping,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    await sendTypingMatrix("!room:example.org", true, client);
+
+    expect(setTyping).toHaveBeenCalledTimes(1);
+    expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 30_000);
+  });
+
   it("preserves legacy numeric timeout semantics when resolving the client internally", async () => {
     const setTyping = vi.fn().mockResolvedValue(undefined);
     resolveMatrixClientMock.mockImplementationOnce(async (opts) => {

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -359,6 +359,19 @@ describe("sendTypingMatrix", () => {
     expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 5_000);
   });
 
+  it("preserves backward compatibility for legacy numeric timeouts", async () => {
+    const setTyping = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      setTyping,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    await sendTypingMatrix("!room:example.org", true, 5_000, client);
+
+    expect(setTyping).toHaveBeenCalledTimes(1);
+    expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 5_000);
+  });
+
   it("uses sdk typing stop semantics", async () => {
     const setTyping = vi.fn().mockResolvedValue(undefined);
     const client = {

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -346,6 +346,19 @@ describe("sendTypingMatrix", () => {
     expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 30_000);
   });
 
+  it("supports a custom typing timeout without changing the API meaning", async () => {
+    const setTyping = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      setTyping,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    await sendTypingMatrix("!room:example.org", true, { typingTimeoutMs: 5_000 }, client);
+
+    expect(setTyping).toHaveBeenCalledTimes(1);
+    expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 5_000);
+  });
+
   it("uses sdk typing stop semantics", async () => {
     const setTyping = vi.fn().mockResolvedValue(undefined);
     const client = {

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -67,6 +67,7 @@ const runtimeStub = {
 
 let sendMessageMatrix: typeof import("./send.js").sendMessageMatrix;
 let resolveMediaMaxBytes: typeof import("./send/client.js").resolveMediaMaxBytes;
+let sendTypingMatrix: typeof import("./send.js").sendTypingMatrix;
 
 const makeClient = () => {
   const sendMessage = vi.fn().mockResolvedValue("evt1");
@@ -83,6 +84,7 @@ beforeAll(async () => {
   setMatrixRuntime(runtimeStub);
   ({ sendMessageMatrix } = await import("./send.js"));
   ({ resolveMediaMaxBytes } = await import("./send/client.js"));
+  ({ sendTypingMatrix } = await import("./send.js"));
 });
 
 describe("sendMessageMatrix media", () => {
@@ -322,5 +324,46 @@ describe("resolveMediaMaxBytes cfg threading", () => {
 
     expect(maxBytes).toBe(9 * 1024 * 1024);
     expect(runtimeLoadConfigMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sendTypingMatrix", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMatrixRuntime(runtimeStub);
+  });
+
+  it("sends default timeout for typing start", async () => {
+    const setTyping = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      setTyping,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    await sendTypingMatrix("!room:example.org", true, undefined, client);
+
+    expect(setTyping).toHaveBeenCalledTimes(1);
+    expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 30_000);
+  });
+
+  it("omits timeout for typing stop", async () => {
+    const setTyping = vi.fn().mockResolvedValue(undefined);
+    const doRequest = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      setTyping,
+      doRequest,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    await sendTypingMatrix("!room:example.org", false, undefined, client);
+
+    expect(setTyping).not.toHaveBeenCalled();
+    expect(doRequest).toHaveBeenCalledTimes(1);
+    expect(doRequest).toHaveBeenCalledWith(
+      "PUT",
+      "/_matrix/client/v3/rooms/!room%3Aexample.org/typing/%40bot%3Aexample.org",
+      null,
+      { typing: false },
+    );
   });
 });

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -346,24 +346,16 @@ describe("sendTypingMatrix", () => {
     expect(setTyping).toHaveBeenCalledWith("!room:example.org", true, 30_000);
   });
 
-  it("omits timeout for typing stop", async () => {
+  it("uses sdk typing stop semantics", async () => {
     const setTyping = vi.fn().mockResolvedValue(undefined);
-    const doRequest = vi.fn().mockResolvedValue(undefined);
     const client = {
       setTyping,
-      doRequest,
       getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
     } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
 
     await sendTypingMatrix("!room:example.org", false, undefined, client);
 
-    expect(setTyping).not.toHaveBeenCalled();
-    expect(doRequest).toHaveBeenCalledTimes(1);
-    expect(doRequest).toHaveBeenCalledWith(
-      "PUT",
-      "/_matrix/client/v3/rooms/!room%3Aexample.org/typing/%40bot%3Aexample.org",
-      null,
-      { typing: false },
-    );
+    expect(setTyping).toHaveBeenCalledTimes(1);
+    expect(setTyping).toHaveBeenCalledWith("!room:example.org", false, 30_000);
   });
 });

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -203,7 +203,7 @@ export async function sendTypingMatrix(
   client?: MatrixClient,
 ): Promise<void> {
   const resolvedOpts =
-    typeof opts === "number" ? { typingTimeoutMs: opts, clientTimeoutMs: undefined } : opts;
+    typeof opts === "number" ? { typingTimeoutMs: opts, clientTimeoutMs: opts } : opts;
   const { client: resolved, stopOnDone } = await resolveMatrixClient({
     client,
     timeoutMs: resolvedOpts?.clientTimeoutMs,

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -199,16 +199,18 @@ export async function sendPollMatrix(
 export async function sendTypingMatrix(
   roomId: string,
   typing: boolean,
-  opts?: { typingTimeoutMs?: number; clientTimeoutMs?: number },
+  opts?: number | { typingTimeoutMs?: number; clientTimeoutMs?: number },
   client?: MatrixClient,
 ): Promise<void> {
+  const resolvedOpts =
+    typeof opts === "number" ? { typingTimeoutMs: opts, clientTimeoutMs: undefined } : opts;
   const { client: resolved, stopOnDone } = await resolveMatrixClient({
     client,
-    timeoutMs: opts?.clientTimeoutMs,
+    timeoutMs: resolvedOpts?.clientTimeoutMs,
   });
   try {
     const resolvedTimeoutMs =
-      typeof opts?.typingTimeoutMs === "number" ? opts.typingTimeoutMs : 30_000;
+      typeof resolvedOpts?.typingTimeoutMs === "number" ? resolvedOpts.typingTimeoutMs : 30_000;
     await resolved.setTyping(roomId, typing, resolvedTimeoutMs);
   } finally {
     if (stopOnDone) {

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -34,6 +34,14 @@ const getCore = () => getMatrixRuntime();
 export type { MatrixSendOpts, MatrixSendResult } from "./send/types.js";
 export { resolveMatrixRoomId } from "./send/targets.js";
 
+function isMatrixClientLike(value: unknown): value is MatrixClient {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    typeof (value as { setTyping?: unknown }).setTyping === "function",
+  );
+}
+
 export async function sendMessageMatrix(
   to: string,
   message: string,
@@ -199,13 +207,18 @@ export async function sendPollMatrix(
 export async function sendTypingMatrix(
   roomId: string,
   typing: boolean,
-  opts?: number | { typingTimeoutMs?: number; clientTimeoutMs?: number },
+  opts?: number | { typingTimeoutMs?: number; clientTimeoutMs?: number } | MatrixClient,
   client?: MatrixClient,
 ): Promise<void> {
+  const resolvedClient = client ?? (isMatrixClientLike(opts) ? opts : undefined);
   const resolvedOpts =
-    typeof opts === "number" ? { typingTimeoutMs: opts, clientTimeoutMs: opts } : opts;
+    typeof opts === "number"
+      ? { typingTimeoutMs: opts, clientTimeoutMs: opts }
+      : isMatrixClientLike(opts)
+        ? undefined
+        : opts;
   const { client: resolved, stopOnDone } = await resolveMatrixClient({
-    client,
+    client: resolvedClient,
     timeoutMs: resolvedOpts?.clientTimeoutMs,
   });
   try {

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -199,15 +199,16 @@ export async function sendPollMatrix(
 export async function sendTypingMatrix(
   roomId: string,
   typing: boolean,
-  timeoutMs?: number,
+  opts?: { typingTimeoutMs?: number; clientTimeoutMs?: number },
   client?: MatrixClient,
 ): Promise<void> {
   const { client: resolved, stopOnDone } = await resolveMatrixClient({
     client,
-    timeoutMs,
+    timeoutMs: opts?.clientTimeoutMs,
   });
   try {
-    const resolvedTimeoutMs = typeof timeoutMs === "number" ? timeoutMs : 30_000;
+    const resolvedTimeoutMs =
+      typeof opts?.typingTimeoutMs === "number" ? opts.typingTimeoutMs : 30_000;
     await resolved.setTyping(roomId, typing, resolvedTimeoutMs);
   } finally {
     if (stopOnDone) {

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -207,14 +207,8 @@ export async function sendTypingMatrix(
     timeoutMs,
   });
   try {
-    if (typing) {
-      const resolvedTimeoutMs = typeof timeoutMs === "number" ? timeoutMs : 30_000;
-      await resolved.setTyping(roomId, true, resolvedTimeoutMs);
-      return;
-    }
-    const userId = await resolved.getUserId();
-    const endpoint = `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/typing/${encodeURIComponent(userId)}`;
-    await resolved.doRequest("PUT", endpoint, null, { typing: false });
+    const resolvedTimeoutMs = typeof timeoutMs === "number" ? timeoutMs : 30_000;
+    await resolved.setTyping(roomId, typing, resolvedTimeoutMs);
   } finally {
     if (stopOnDone) {
       resolved.stop();

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -207,8 +207,14 @@ export async function sendTypingMatrix(
     timeoutMs,
   });
   try {
-    const resolvedTimeoutMs = typeof timeoutMs === "number" ? timeoutMs : 30_000;
-    await resolved.setTyping(roomId, typing, resolvedTimeoutMs);
+    if (typing) {
+      const resolvedTimeoutMs = typeof timeoutMs === "number" ? timeoutMs : 30_000;
+      await resolved.setTyping(roomId, true, resolvedTimeoutMs);
+      return;
+    }
+    const userId = await resolved.getUserId();
+    const endpoint = `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/typing/${encodeURIComponent(userId)}`;
+    await resolved.doRequest("PUT", endpoint, null, { typing: false });
   } finally {
     if (stopOnDone) {
       resolved.stop();

--- a/src/auto-reply/reply/typing-persistence.test.ts
+++ b/src/auto-reply/reply/typing-persistence.test.ts
@@ -80,4 +80,28 @@ describe("typing persistence bug fix", () => {
     controller.markDispatchIdle();
     expect(onCleanupSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("should not start the typing loop after cleanup wins during an in-flight start", async () => {
+    let resolveStart: (() => void) | undefined;
+    onReplyStartSpy.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+
+    const startPromise = controller.startTypingLoop();
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    controller.markRunComplete();
+    controller.markDispatchIdle();
+    expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+
+    resolveStart?.();
+    await startPromise;
+
+    vi.advanceTimersByTime(12_000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+    expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -162,6 +162,9 @@ export function createTypingController(params: {
       return;
     }
     await ensureStart();
+    if (sealed || runComplete || !active) {
+      return;
+    }
     typingLoop.start();
   };
 

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -215,6 +215,34 @@ describe("createTypingCallbacks", () => {
     });
   });
 
+  it("does not restart keepalive when stop wins during an in-flight start", async () => {
+    await withFakeTimers(async () => {
+      let resolveStart: (() => void) | undefined;
+      const { start, stop, callbacks } = createTypingHarness({
+        start: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              resolveStart = resolve;
+            }),
+        ),
+      });
+
+      const inFlightStart = callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+
+      callbacks.onIdle?.();
+      await flushMicrotasks();
+      expect(stop).toHaveBeenCalledTimes(1);
+
+      resolveStart?.();
+      await inFlightStart;
+
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // ========== TTL Safety Tests ==========
   describe("TTL safety", () => {
     it("auto-stops typing after maxDurationMs", async () => {

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -61,6 +61,29 @@ describe("createTypingCallbacks", () => {
     expect(onStartError).not.toHaveBeenCalled();
   });
 
+  it("deduplicates concurrent reply starts", async () => {
+    let resolveStart: (() => void) | undefined;
+    const start = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+    const onStartError = vi.fn();
+    const callbacks = createTypingCallbacks({ start, onStartError });
+
+    const firstStart = callbacks.onReplyStart();
+    const secondStart = callbacks.onReplyStart();
+
+    expect(start).toHaveBeenCalledTimes(1);
+
+    resolveStart?.();
+    await Promise.all([firstStart, secondStart]);
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(onStartError).not.toHaveBeenCalled();
+  });
+
   it("reports start errors", async () => {
     const { onStartError, callbacks } = createTypingHarness({
       start: vi.fn().mockRejectedValue(new Error("fail")),

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -87,7 +87,7 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
       keepaliveLoop.stop();
       clearTtlTimer();
       await fireStart();
-      if (startGuard.isTripped()) {
+      if (closed || startGuard.isTripped()) {
         return;
       }
       keepaliveLoop.start();

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -28,6 +28,7 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
   let stopSent = false;
   let closed = false;
   let ttlTimer: ReturnType<typeof setTimeout> | undefined;
+  let startInFlight: Promise<void> | undefined;
 
   const startGuard = createTypingStartGuard({
     isSealed: () => closed,
@@ -72,16 +73,29 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
     if (closed) {
       return;
     }
-    stopSent = false;
-    startGuard.reset();
-    keepaliveLoop.stop();
-    clearTtlTimer();
-    await fireStart();
-    if (startGuard.isTripped()) {
+    if (startInFlight) {
+      await startInFlight;
       return;
     }
-    keepaliveLoop.start();
-    startTtlTimer(); // Start TTL safety timer
+    if (keepaliveLoop.isRunning()) {
+      startTtlTimer();
+      return;
+    }
+    startInFlight = (async () => {
+      stopSent = false;
+      startGuard.reset();
+      keepaliveLoop.stop();
+      clearTtlTimer();
+      await fireStart();
+      if (startGuard.isTripped()) {
+        return;
+      }
+      keepaliveLoop.start();
+      startTtlTimer(); // Start TTL safety timer
+    })().finally(() => {
+      startInFlight = undefined;
+    });
+    await startInFlight;
   };
 
   const fireStop = () => {


### PR DESCRIPTION
## Summary

- Problem: Matrix typing indicators could stay stuck after replies, and the shared typing lifecycle could restart keepalive if an async start resolved after idle or cleanup had already won.
- Why it matters: stuck typing is user-visible noise, and the late-start restart path is exactly the kind of race that makes channel behavior flaky under load.
- What changed: the Matrix handler coverage stays in place, concurrent typing starts are deduplicated, both shared typing controllers now block keepalive restart after stop/cleanup wins, and Matrix typing stop uses the SDK `setTyping()` path again.
- What did NOT change (scope boundary): this PR does not change reply content, Matrix send queue behavior, or non-Matrix channel semantics beyond the shared typing race hardening.
- AI-assisted: yes, with manual review and targeted verification.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Matrix typing indicators stop cleanly after reply completion instead of lingering.
- Shared typing lifecycle helpers no longer restart keepalive after idle/cleanup when a late async start resolves afterward.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node.js checkout
- Model/provider: GPT-5.4 via Copilot, manually reviewed
- Integration/channel (if any): Matrix
- Relevant config (redacted): default Matrix typing flow with shared worktree `node_modules` symlinked to the main checkout

### Steps

1. Trigger a Matrix reply flow that starts typing.
2. Exercise completion and cleanup paths, including late-resolving async start behavior.
3. Verify typing does not linger and does not restart after idle/cleanup.

### Expected

- Typing starts once per reply lifecycle, refreshes while active, and stops permanently once idle/cleanup wins.

### Actual

- Before this change, a late-resolving start could re-arm keepalive after the stop path had already closed the controller, and the branch-specific Matrix stop path had diverged from the SDK behavior without being clearly required.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: traced the Matrix handler -> typing callbacks -> reply dispatcher -> reply typing controller path, confirmed the shared late-start race at both controller layers, patched both, and reran focused Matrix and reply typing suites.
- Edge cases checked: concurrent `onReplyStart()` calls, idle winning while start is in flight, reply cleanup after run completion, and Matrix stop typing semantics through the SDK path.
- What you did **not** verify: live Matrix typing behavior against a real homeserver.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert `eeea6d743` and `17247ffac`, or disable Matrix reply handling while investigating typing behavior.
- Files/config to restore: `extensions/matrix/src/matrix/send.ts`, `src/channels/typing.ts`, `src/auto-reply/reply/typing.ts`.
- Known bad symptoms reviewers should watch for: typing indicators that restart after a reply is already done, or typing that never clears after cleanup.

## Risks and Mitigations

- Risk: hardening the shared typing lifecycle could accidentally suppress legitimate typing refreshes.
- Mitigation: focused regressions cover normal start/keepalive, concurrent starts, stop-during-start, and reply-controller cleanup ordering.