### PR TITLE
fix(cron): normalizePayloadKind returns false for already-canonical payload kinds

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -47,6 +47,71 @@ describe("normalizeStoredCronJobs", () => {
     });
   });
 
+  it("does not flag canonical payload kinds as needing normalization", () => {
+    const jobs = [
+      {
+        id: "canonical-agent",
+        name: "agent job",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "agentTurn", message: "ping" },
+        sessionTarget: "isolated",
+        enabled: true,
+        wakeMode: "now",
+        state: {},
+      },
+      {
+        id: "canonical-system",
+        name: "system job",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "systemEvent", text: "heartbeat" },
+        sessionTarget: "main",
+        enabled: true,
+        wakeMode: "now",
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    // legacyPayloadKind must not be incremented for already-canonical kinds.
+    expect(result.issues.legacyPayloadKind ?? 0).toBe(0);
+    // Payload kinds must remain unchanged.
+    expect((jobs[0]?.payload as Record<string, unknown>)?.kind).toBe("agentTurn");
+    expect((jobs[1]?.payload as Record<string, unknown>)?.kind).toBe("systemEvent");
+  });
+
+  it("normalizes non-canonical payload kind casing to the canonical form", () => {
+    const jobs = [
+      {
+        id: "uppercase-kind",
+        name: "uppercase job",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "AGENTTURN", message: "ping" },
+        sessionTarget: "isolated",
+        enabled: true,
+        wakeMode: "now",
+        state: {},
+      },
+      {
+        id: "mixed-kind",
+        name: "mixed job",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "SystemEvent", text: "heartbeat" },
+        sessionTarget: "main",
+        enabled: true,
+        wakeMode: "now",
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.legacyPayloadKind).toBe(2);
+    expect((jobs[0]?.payload as Record<string, unknown>)?.kind).toBe("agentTurn");
+    expect((jobs[1]?.payload as Record<string, unknown>)?.kind).toBe("systemEvent");
+  });
+
   it("normalizes payload provider alias into channel", () => {
     const jobs = [
       {

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,6 +28,10 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
+  // Already in canonical form — no mutation needed.
+  if (payload.kind === "agentTurn" || payload.kind === "systemEvent") {
+    return false;
+  }
   const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
   if (raw === "agentturn") {
     payload.kind = "agentTurn";


### PR DESCRIPTION
## Problem

`openclaw doctor --fix` permanently reports every cron job as needing payload-kind normalization, even after repair. The warning never clears.

Fixes #43855

## Root Cause

`normalizePayloadKind` in `src/cron/store-migration.ts` lowercases the `payload.kind` string before comparing:

```ts
// Before (buggy)
function normalizePayloadKind(payload: Record<string, unknown>) {
  const raw = typeof payload.kind === 'string' ? payload.kind.trim().toLowerCase() : '';
  if (raw === 'agentturn') {
    payload.kind = 'agentTurn'; // no-op — already canonical
    return true;                // always signals "mutated"
  }
  // ...
}
```

A job with `payload.kind = "agentTurn"` (canonical form) hits the `raw === "agentturn"` branch, writes the same value back, and returns `true` — treating a no-op as a mutation. On the next `doctor` run the same false positive fires again, so the warning never resolves.

## Fix

Add an early-return guard for the two canonical strings before the `toLowerCase()` comparison:

```ts
// After (fixed)
function normalizePayloadKind(payload: Record<string, unknown>) {
  // Already in canonical form — no mutation needed.
  if (payload.kind === 'agentTurn' || payload.kind === 'systemEvent') {
    return false;
  }
  const raw = typeof payload.kind === 'string' ? payload.kind.trim().toLowerCase() : '';
  if (raw === 'agentturn') {
    payload.kind = 'agentTurn';
    return true;
  }
  if (raw === 'systemevent') {
    payload.kind = 'systemEvent';
    return true;
  }
  return false;
}
```

Non-canonical casing (e.g. `"AGENTTURN"`, `"SystemEvent"`) is still normalised correctly — only the exact canonical strings short-circuit early.

## Tests

- **New**: `does not flag canonical payload kinds as needing normalization` — verifies `legacyPayloadKind` is 0 for jobs already using `"agentTurn"` / `"systemEvent"`
- **New**: `normalizes non-canonical payload kind casing to the canonical form` — verifies genuinely non-canonical casing is still fixed and counted

```
pnpm vitest run src/cron/store-migration.test.ts
✓ src/cron/store-migration.test.ts (4 tests) 4ms
```