### PR TITLE
fix(hooks): expose session context in typed message hooks

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1721,6 +1721,7 @@ describe("dispatchReplyFromConfig", () => {
       SenderUsername: "alice",
       SenderE164: "+15555550123",
       AccountId: "acc-1",
+      SessionKey: "agent:main:main",
       GroupSpace: "guild-123",
       GroupChannel: "alerts",
     });
@@ -1749,6 +1750,8 @@ describe("dispatchReplyFromConfig", () => {
         channelId: "telegram",
         accountId: "acc-1",
         conversationId: "telegram:999",
+        sessionKey: "agent:main:main",
+        agentId: "main",
       }),
     );
   });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -117,6 +117,7 @@ export async function dispatchReplyFromConfig(params: {
   const chatId = ctx.To ?? ctx.From;
   const messageId = ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
   const sessionKey = ctx.SessionKey;
+  const agentId = sessionKey ? resolveSessionAgentId({ sessionKey, config: cfg }) : undefined;
   const startTime = diagnosticsEnabled ? Date.now() : 0;
   const canTrackSession = diagnosticsEnabled && Boolean(sessionKey);
 
@@ -181,7 +182,11 @@ export async function dispatchReplyFromConfig(params: {
     typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
   const messageIdForHook =
     ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
-  const hookContext = deriveInboundMessageHookContext(ctx, { messageId: messageIdForHook });
+  const hookContext = deriveInboundMessageHookContext(ctx, {
+    messageId: messageIdForHook,
+    sessionKey,
+    agentId,
+  });
   const { isGroup, groupId } = hookContext;
 
   // Trigger plugin hooks (fire-and-forget)

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -73,6 +73,8 @@ describe("message hook mappers", () => {
       channelId: "telegram",
       accountId: "acc-1",
       conversationId: "telegram:chat:456",
+      sessionKey: undefined,
+      agentId: undefined,
     });
     expect(toPluginMessageReceivedEvent(canonical)).toEqual({
       from: "telegram:user:123",
@@ -123,6 +125,8 @@ describe("message hook mappers", () => {
       channelId: "telegram",
       accountId: "acc-1",
       messageId: "out-1",
+      sessionKey: "agent:main:telegram:chat:456",
+      agentId: "main",
       isGroup: true,
       groupId: "telegram:chat:456",
     });
@@ -131,6 +135,8 @@ describe("message hook mappers", () => {
       channelId: "telegram",
       accountId: "acc-1",
       conversationId: "telegram:chat:456",
+      sessionKey: "agent:main:telegram:chat:456",
+      agentId: "main",
     });
     expect(toPluginMessageSentEvent(canonical)).toEqual({
       to: "telegram:chat:456",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -23,6 +23,8 @@ export type CanonicalInboundMessageHookContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  sessionKey?: string;
+  agentId?: string;
   messageId?: string;
   senderId?: string;
   senderName?: string;
@@ -49,6 +51,8 @@ export type CanonicalSentMessageHookContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  sessionKey?: string;
+  agentId?: string;
   messageId?: string;
   isGroup?: boolean;
   groupId?: string;
@@ -59,6 +63,8 @@ export function deriveInboundMessageHookContext(
   overrides?: {
     content?: string;
     messageId?: string;
+    sessionKey?: string;
+    agentId?: string;
   },
 ): CanonicalInboundMessageHookContext {
   const content =
@@ -87,6 +93,8 @@ export function deriveInboundMessageHookContext(
     channelId,
     accountId: ctx.AccountId,
     conversationId,
+    sessionKey: overrides?.sessionKey ?? ctx.SessionKey,
+    agentId: overrides?.agentId,
     messageId:
       overrides?.messageId ??
       ctx.MessageSidFull ??
@@ -119,6 +127,8 @@ export function buildCanonicalSentMessageHookContext(params: {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  sessionKey?: string;
+  agentId?: string;
   messageId?: string;
   isGroup?: boolean;
   groupId?: string;
@@ -131,6 +141,8 @@ export function buildCanonicalSentMessageHookContext(params: {
     channelId: params.channelId,
     accountId: params.accountId,
     conversationId: params.conversationId ?? params.to,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
     messageId: params.messageId,
     isGroup: params.isGroup,
     groupId: params.groupId,
@@ -144,6 +156,8 @@ export function toPluginMessageContext(
     channelId: canonical.channelId,
     accountId: canonical.accountId,
     conversationId: canonical.conversationId,
+    sessionKey: canonical.sessionKey,
+    agentId: canonical.agentId,
   };
 }
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
 }));
 const hookMocks = vi.hoisted(() => ({
   runner: {
-    hasHooks: vi.fn(() => false),
+    hasHooks: vi.fn<(name: string) => boolean>((_name) => false),
     runMessageSending: vi.fn(async () => undefined),
     runMessageSent: vi.fn(async () => {}),
   },

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
 const hookMocks = vi.hoisted(() => ({
   runner: {
     hasHooks: vi.fn(() => false),
+    runMessageSending: vi.fn(async () => undefined),
     runMessageSent: vi.fn(async () => {}),
   },
 }));
@@ -191,6 +192,8 @@ describe("deliverOutboundPayloads", () => {
     setActivePluginRegistry(defaultRegistry);
     hookMocks.runner.hasHooks.mockClear();
     hookMocks.runner.hasHooks.mockReturnValue(false);
+    hookMocks.runner.runMessageSending.mockClear();
+    hookMocks.runner.runMessageSending.mockResolvedValue(undefined);
     hookMocks.runner.runMessageSent.mockClear();
     hookMocks.runner.runMessageSent.mockResolvedValue(undefined);
     internalHookMocks.createInternalHookEvent.mockClear();
@@ -891,7 +894,81 @@ describe("deliverOutboundPayloads", () => {
 
     expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
       expect.objectContaining({ to: "+1555", content: "hello", success: true }),
-      expect.objectContaining({ channelId: "whatsapp" }),
+      expect.objectContaining({
+        channelId: "whatsapp",
+        conversationId: "+1555",
+        sessionKey: undefined,
+        agentId: undefined,
+      }),
+    );
+  });
+
+  it("passes resolved session context to message_sending hooks", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "message_sending");
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+      session: {
+        key: "agent:sender:whatsapp:+1555",
+        agentId: "sender-agent",
+      },
+      mirror: {
+        sessionKey: "agent:mirror:whatsapp:+1555",
+        agentId: "mirror-agent",
+      },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "+1555",
+        content: "hello",
+      }),
+      expect.objectContaining({
+        channelId: "whatsapp",
+        conversationId: "+1555",
+        sessionKey: "agent:mirror:whatsapp:+1555",
+        agentId: "mirror-agent",
+      }),
+    );
+  });
+
+  it("passes resolved session context to message_sent hooks", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+      session: {
+        key: "agent:sender:whatsapp:+1555",
+        agentId: "sender-agent",
+      },
+      mirror: {
+        sessionKey: "agent:mirror:whatsapp:+1555",
+        agentId: "mirror-agent",
+      },
+    });
+
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "+1555",
+        content: "hello",
+        success: true,
+      }),
+      expect.objectContaining({
+        channelId: "whatsapp",
+        conversationId: "+1555",
+        sessionKey: "agent:mirror:whatsapp:+1555",
+        agentId: "mirror-agent",
+      }),
     );
   });
 
@@ -922,7 +999,12 @@ describe("deliverOutboundPayloads", () => {
 
     expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
       expect.objectContaining({ to: "!room:1", content: "payload text", success: true }),
-      expect.objectContaining({ channelId: "matrix" }),
+      expect.objectContaining({
+        channelId: "matrix",
+        conversationId: "!room:1",
+        sessionKey: undefined,
+        agentId: undefined,
+      }),
     );
   });
 
@@ -1083,7 +1165,12 @@ describe("deliverOutboundPayloads", () => {
         error:
           "Plugin outbound adapter does not implement sendMedia and no text fallback is available for media payload",
       }),
-      expect.objectContaining({ channelId: "matrix" }),
+      expect.objectContaining({
+        channelId: "matrix",
+        conversationId: "!room:1",
+        sessionKey: undefined,
+        agentId: undefined,
+      }),
     );
   });
 
@@ -1108,7 +1195,12 @@ describe("deliverOutboundPayloads", () => {
         success: false,
         error: "downstream failed",
       }),
-      expect.objectContaining({ channelId: "whatsapp" }),
+      expect.objectContaining({
+        channelId: "whatsapp",
+        conversationId: "+1555",
+        sessionKey: undefined,
+        agentId: undefined,
+      }),
     );
   });
 });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -340,6 +340,8 @@ function createMessageSentEmitter(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  sessionKey?: string;
+  agentId?: string;
   sessionKeyForInternalHooks?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
@@ -358,6 +360,8 @@ function createMessageSentEmitter(params: {
       channelId: params.channel,
       accountId: params.accountId ?? undefined,
       conversationId: params.to,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
       messageId: event.messageId,
       isGroup: params.mirrorIsGroup,
       groupId: params.mirrorGroupId,
@@ -395,6 +399,22 @@ function createMessageSentEmitter(params: {
   return { emitMessageSent, hasMessageSentHooks };
 }
 
+function resolveMessageHookContext(params: {
+  channel: Exclude<OutboundChannel, "none">;
+  to: string;
+  accountId?: string;
+  session?: OutboundSessionContext;
+  mirror?: DeliverOutboundPayloadsCoreParams["mirror"];
+}) {
+  return {
+    channelId: params.channel,
+    accountId: params.accountId ?? undefined,
+    conversationId: params.to,
+    sessionKey: params.mirror?.sessionKey ?? params.session?.key,
+    agentId: params.mirror?.agentId ?? params.session?.agentId,
+  };
+}
+
 async function applyMessageSendingHook(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   enabled: boolean;
@@ -403,6 +423,8 @@ async function applyMessageSendingHook(params: {
   to: string;
   channel: Exclude<OutboundChannel, "none">;
   accountId?: string;
+  sessionKey?: string;
+  agentId?: string;
 }): Promise<{
   cancelled: boolean;
   payload: ReplyPayload;
@@ -429,6 +451,9 @@ async function applyMessageSendingHook(params: {
       {
         channelId: params.channel,
         accountId: params.accountId ?? undefined,
+        conversationId: params.to,
+        sessionKey: params.sessionKey,
+        agentId: params.agentId,
       },
     );
     if (sendingResult?.cancel) {
@@ -676,7 +701,14 @@ async function deliverOutboundPayloadsCore(
     accountId,
   );
   const hookRunner = getGlobalHookRunner();
-  const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
+  const messageHookContext = resolveMessageHookContext({
+    channel,
+    to,
+    accountId,
+    session: params.session,
+    mirror: params.mirror,
+  });
+  const sessionKeyForInternalHooks = messageHookContext.sessionKey;
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;
   const { emitMessageSent, hasMessageSentHooks } = createMessageSentEmitter({
@@ -684,18 +716,20 @@ async function deliverOutboundPayloadsCore(
     channel,
     to,
     accountId,
+    sessionKey: messageHookContext.sessionKey,
+    agentId: messageHookContext.agentId,
     sessionKeyForInternalHooks,
     mirrorIsGroup,
     mirrorGroupId,
   });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
-  if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
+  if (hasMessageSentHooks && messageHookContext.agentId && !sessionKeyForInternalHooks) {
     log.warn(
       "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
       {
         channel,
         to,
-        agentId: params.session.agentId,
+        agentId: messageHookContext.agentId,
       },
     );
   }
@@ -713,6 +747,8 @@ async function deliverOutboundPayloadsCore(
         to,
         channel,
         accountId,
+        sessionKey: messageHookContext.sessionKey,
+        agentId: messageHookContext.agentId,
       });
       if (hookResult.cancelled) {
         continue;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -560,6 +560,8 @@ export type PluginHookMessageContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  sessionKey?: string;
+  agentId?: string;
 };
 
 // message_received hook


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: plugin typed message hooks only exposed `channelId`, `accountId`, and `conversationId` in `PluginHookMessageContext`, so hook consumers could not reliably tell which session or agent a message event belonged to.
- Why it matters: plugins that correlate inbound messages with outbound sends need stable session-scoped identity to attribute events correctly without re-deriving it from provider-specific metadata.
- What changed: added optional `sessionKey` and `agentId` to `PluginHookMessageContext`, threaded them through inbound `message_received` dispatch and outbound `message_sending` / `message_sent` delivery, and added mapper + delivery tests covering both unset and mirror/session-resolved contexts.
- What did NOT change (scope boundary): this PR does not add new message event fields or change internal hook payloads; it only extends the typed plugin hook context.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #40007

## User-visible / Behavior Changes

- Plugins using typed `message_received`, `message_sending`, or `message_sent` hooks can now read `ctx.sessionKey` and `ctx.agentId` directly.
- Existing plugins remain compatible because the new context fields are optional.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 24.2.0
- Model/provider: N/A
- Integration/channel (if any): synthetic inbound/outbound hook tests (Telegram, WhatsApp, Matrix)
- Relevant config (redacted): N/A

### Steps

1. Trigger `message_received` with a session-backed inbound context.
2. Trigger `message_sending` and `message_sent` with outbound delivery contexts both with and without mirror/session metadata.
3. Inspect typed hook context passed to plugin handlers.

### Expected

- `PluginHookMessageContext` includes `sessionKey` and `agentId` when that information is available.
- Inbound hooks derive `agentId` from the session key, and outbound hooks use the resolved mirror/session context consistently.

### Actual

- Verified by targeted Vitest coverage after the patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `src/hooks/message-hook-mappers.test.ts`
  - `src/auto-reply/reply/dispatch-from-config.test.ts`
  - `src/infra/outbound/deliver.test.ts`
  - file-format check with `node node_modules/oxfmt/bin/oxfmt --check ...`
- Edge cases checked:
  - inbound contexts without a session still expose `undefined` for the new fields
  - outbound hooks prefer mirror session identity when present and fall back to direct session identity otherwise
  - success and failure `message_sent` paths both preserve the new context shape
- What you did **not** verify:
  - full `pnpm check` / repo-wide test suite

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `2b96453fda1772f45bc677ab3d7b25366f710090`.
- Files/config to restore: `src/plugins/types.ts`, `src/hooks/message-hook-mappers.ts`, `src/auto-reply/reply/dispatch-from-config.ts`, `src/infra/outbound/deliver.ts`, and the associated tests.
- Known bad symptoms reviewers should watch for: typed message hooks missing `sessionKey` / `agentId` when a session is available, or mismatched outbound context between `message_sending` and `message_sent`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: outbound send paths could populate different session identity depending on mirror/session ordering.
  - Mitigation: added delivery tests that assert the same resolved mirror/session identity is used for both `message_sending` and `message_sent`.
- Risk: plugins may start depending on `sessionKey` semantics as a stable public contract.
  - Mitigation: the fields are optional and only mirror the already-used routing/session identity that core passes through existing internals.
