### PR TITLE
fix(cron): stop false legacy payload-kind warnings in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: skip the post-compaction `cache-ttl` marker write when a compaction completed in the same attempt, preventing the next turn from immediately triggering a second tiny compaction. (#28548) thanks @MoerAI.
 - Native chat/macOS: add `/new`, `/reset`, and `/clear` reset triggers, keep shared main-session aliases aligned, and ignore stale model-selection completions so native chat state stays in sync across reset and fast model changes. (#10898) Thanks @Nachx639.
 - Agents/compaction safeguard: route missing-model and missing-API-key cancellation warnings through the shared subsystem logger so they land in structured and file logs. (#9974) Thanks @dinakars777.
+- Cron/doctor: stop flagging canonical `agentTurn` and `systemEvent` payload kinds as legacy cron storage, while still normalizing whitespace-padded and non-canonical variants. (#44012) Thanks @shuicici.
 
 ## 2026.3.11
 

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -96,4 +96,38 @@ describe("normalizeStoredCronJobs", () => {
     expect(result.mutated).toBe(false);
     expect(result.issues.legacyPayloadKind).toBeUndefined();
   });
+
+  it("normalizes whitespace-padded and non-canonical payload kinds", () => {
+    const jobs = [
+      {
+        id: "spaced-agent-turn",
+        name: "normalized",
+        enabled: true,
+        wakeMode: "now",
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
+        payload: { kind: " agentTurn ", message: "ping" },
+        sessionTarget: "isolated",
+        delivery: { mode: "announce" },
+        state: {},
+      },
+      {
+        id: "upper-system-event",
+        name: "normalized",
+        enabled: true,
+        wakeMode: "now",
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
+        payload: { kind: "SYSTEMEVENT", text: "pong" },
+        sessionTarget: "main",
+        delivery: { mode: "announce" },
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.legacyPayloadKind).toBe(2);
+    expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn", message: "ping" });
+    expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent", text: "pong" });
+  });
 });

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -75,4 +75,25 @@ describe("normalizeStoredCronJobs", () => {
       channel: "slack",
     });
   });
+
+  it("does not report legacyPayloadKind for already-normalized payload kinds", () => {
+    const jobs = [
+      {
+        id: "normalized-agent-turn",
+        name: "normalized",
+        enabled: true,
+        wakeMode: "now",
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
+        payload: { kind: "agentTurn", message: "ping" },
+        sessionTarget: "isolated",
+        delivery: { mode: "announce" },
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(false);
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,14 +28,21 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
-    payload.kind = "agentTurn";
-    return true;
+  const original = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  const lowered = original.toLowerCase();
+  if (lowered === "agentturn") {
+    if (original !== "agentTurn") {
+      payload.kind = "agentTurn";
+      return true;
+    }
+    return false;
   }
-  if (raw === "systemevent") {
-    payload.kind = "systemEvent";
-    return true;
+  if (lowered === "systemevent") {
+    if (original !== "systemEvent") {
+      payload.kind = "systemEvent";
+      return true;
+    }
+    return false;
   }
   return false;
 }

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,17 +28,16 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const original = typeof payload.kind === "string" ? payload.kind.trim() : "";
-  const lowered = original.toLowerCase();
-  if (lowered === "agentturn") {
-    if (original !== "agentTurn") {
+  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
+  if (raw === "agentturn") {
+    if (payload.kind !== "agentTurn") {
       payload.kind = "agentTurn";
       return true;
     }
     return false;
   }
-  if (lowered === "systemevent") {
-    if (original !== "systemEvent") {
+  if (raw === "systemevent") {
+    if (payload.kind !== "systemEvent") {
       payload.kind = "systemEvent";
       return true;
     }


### PR DESCRIPTION
## Summary
- make payload kind normalization idempotent for already-normalized `agentTurn`/`systemEvent` values
- avoid reporting `legacyPayloadKind` when no actual migration is needed
- add a regression test to ensure normalized jobs do not trigger repeated doctor warnings

## Repro
1. Create a cron job with payload kind `agentTurn` in `~/.openclaw/cron/jobs.json`
2. Run `openclaw doctor --fix`
3. Before this patch, doctor can keep reporting legacy cron storage on repeated runs even when payload kinds are already normalized

## Verification
- `pnpm vitest run src/cron/store-migration.test.ts`

Closes #44005
