### PR TITLE
gateway: enforce 512 KB max length for chat.send message

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -182,6 +182,11 @@ The Gateway treats these as **claims** and enforces server-side allowlists.
   - `pluginId`: plugin owner when `source="plugin"`
   - `optional`: whether a plugin tool is optional
 
+### Chat methods
+
+- `chat.send`: the message body is limited to **512 KB** (UTF-8 byte length). Requests with a
+  larger body are rejected; clients should shorten or split the message.
+
 ## Exec approvals
 
 - When an exec request needs approval, the gateway broadcasts `exec.approval.requested`.

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -32,10 +32,13 @@ export const ChatHistoryParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+/** Max character length for chat.send message (aligns with CHAT_SEND_MESSAGE_MAX_BYTES for ASCII). */
+const CHAT_SEND_MESSAGE_MAX_LENGTH = 512 * 1024;
+
 export const ChatSendParamsSchema = Type.Object(
   {
     sessionKey: ChatSendSessionKeyString,
-    message: Type.String(),
+    message: Type.String({ maxLength: CHAT_SEND_MESSAGE_MAX_LENGTH }),
     thinking: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -85,6 +85,9 @@ type AbortedPartialSnapshot = {
 
 const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
+
+/** Max UTF-8 byte length for a single chat.send message. Prevents DoS and keeps sessions stable. */
+export const CHAT_SEND_MESSAGE_MAX_BYTES = 512 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 let chatHistoryPlaceholderEmitCount = 0;
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
@@ -231,6 +234,14 @@ export function sanitizeChatSendMessageInput(
   const normalized = message.normalize("NFC");
   if (normalized.includes("\u0000")) {
     return { ok: false, error: "message must not contain null bytes" };
+  }
+  const byteLength = Buffer.byteLength(normalized, "utf8");
+  if (byteLength > CHAT_SEND_MESSAGE_MAX_BYTES) {
+    const maxKb = Math.floor(CHAT_SEND_MESSAGE_MAX_BYTES / 1024);
+    return {
+      ok: false,
+      error: `message exceeds maximum length (max ${maxKb} KB). Shorten or split your message.`,
+    };
   }
   return { ok: true, message: stripDisallowedChatControlChars(normalized) };
 }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -13,7 +13,7 @@ import { validateExecApprovalRequestParams } from "../protocol/index.js";
 import { waitForAgentJob } from "./agent-job.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
-import { sanitizeChatSendMessageInput } from "./chat.js";
+import { CHAT_SEND_MESSAGE_MAX_BYTES, sanitizeChatSendMessageInput } from "./chat.js";
 import { createExecApprovalHandlers } from "./exec-approval.js";
 import { logsHandlers } from "./logs.js";
 
@@ -274,6 +274,33 @@ describe("sanitizeChatSendMessageInput", () => {
 
   it("normalizes unicode to NFC", () => {
     expect(sanitizeChatSendMessageInput("Cafe\u0301")).toEqual({ ok: true, message: "Café" });
+  });
+
+  it("accepts message at exactly max byte length (ASCII)", () => {
+    const msg = "a".repeat(CHAT_SEND_MESSAGE_MAX_BYTES);
+    const result = sanitizeChatSendMessageInput(msg);
+    expect(result).toEqual({ ok: true, message: msg });
+  });
+
+  it("rejects message over max byte length", () => {
+    const msg = "a".repeat(CHAT_SEND_MESSAGE_MAX_BYTES + 1);
+    const result = sanitizeChatSendMessageInput(msg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("512");
+      expect(result.error).toContain("maximum length");
+      expect(result.error).toContain("Shorten or split");
+    }
+  });
+
+  it("rejects by UTF-8 byte length not character count (multi-byte)", () => {
+    // 3 bytes per char in UTF-8; 200k chars = 600k bytes > 512k limit
+    const msg = "中文".repeat(200_000);
+    const result = sanitizeChatSendMessageInput(msg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("maximum length");
+    }
   });
 });
 


### PR DESCRIPTION
### Summary

Add a **512 KB** (UTF-8 byte length) maximum for the `chat.send` message body in the gateway.  
This makes chat behavior predictable for clients, prevents extremely large messages from putting unnecessary memory and CPU pressure on the gateway, and aligns chat payload limits with other content-safety and size-guard rails in the system.

### Changes

- **Implementation** (`src/gateway/server-methods/chat.ts`)
  - Define and export `CHAT_SEND_MESSAGE_MAX_BYTES = 512 * 1024` (512 KB).
  - In `sanitizeChatSendMessageInput`, enforce a UTF-8 byte length check via `Buffer.byteLength(normalized, "utf8")` after NFC normalization and null-byte checks.
  - If the message exceeds 512 KB, return:
    - `{ ok: false, error: "message exceeds maximum length (max 512 KB). Shorten or split your message." }`
  - Otherwise, keep the existing control-character stripping and return `{ ok: true, message }`.

- **Protocol schema** (`src/gateway/protocol/schema/logs-chat.ts`)
  - Add `CHAT_SEND_MESSAGE_MAX_LENGTH = 512 * 1024`.
  - Change `ChatSendParamsSchema.message` from `Type.String()` to:
    - `Type.String({ maxLength: CHAT_SEND_MESSAGE_MAX_LENGTH })`.

- **Tests** (`src/gateway/server-methods/server-methods.test.ts`)
  - Import `CHAT_SEND_MESSAGE_MAX_BYTES` alongside `sanitizeChatSendMessageInput`.
  - Add tests that:
    - Accept a message at exactly 512 KB (ASCII).
    - Reject a message over 512 KB and assert the error includes `"512"`, `"maximum length"`, and `"Shorten or split"`.
    - Verify enforcement based on UTF-8 byte length using multi-byte characters.

- **Docs** (`docs/gateway/protocol.md`)
  - Add a **Chat methods** subsection stating:
    - `chat.send` message body is limited to **512 KB** (UTF-8 byte length).
    - Oversized messages are rejected and clients should shorten or split them.

### Rationale

- Prevents unbounded `chat.send` payloads from causing excessive memory usage or slow processing on the gateway.
- Gives clients a clear and documented upper bound so they can split or truncate messages proactively.
- Keeps chat behavior consistent with other gateway size and safety limits, reducing surprise for operators and users.

### Testing

- `pnpm test -- src/gateway/server-methods/server-methods.test.ts --run`
- Lint/format checks via `scripts/committer` (includes `pnpm check`).

### Checklist

- [x] Chat message size limit enforced at both schema and server sanitization layers.
- [x] Limit is based on UTF-8 byte length (multi-byte characters handled correctly).
- [x] Documentation updated to reflect the new limit and its rationale.
- [x] No version bump or release flow changes; commit only (no push).