### PR TITLE
fix(exec): prevent self-termination during gateway restart flows

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -148,6 +148,19 @@ async function validateScriptFileForShellBleed(params: {
   }
 }
 
+function isGatewaySelfTerminationCommand(command: string): boolean {
+  const normalized = command.toLowerCase();
+  if (!normalized.includes("openclaw-gateway")) {
+    return false;
+  }
+  const directKill = /\bpkill\b|\bkillall\b/.test(normalized);
+  if (directKill) {
+    return true;
+  }
+  // Covers patterns like: kill $(pgrep -f openclaw-gateway)
+  return /\bkill\b/.test(normalized) && /\bpgrep\b/.test(normalized);
+}
+
 export function createExecTool(
   defaults?: ExecToolDefaults,
   // oxlint-disable-next-line typescript/no-explicit-any
@@ -359,6 +372,16 @@ export function createExecTool(
         containerWorkdir = resolved.containerWorkdir;
       } else {
         workdir = resolveWorkdir(rawWorkdir, warnings);
+      }
+
+      if (!sandbox && isGatewaySelfTerminationCommand(params.command)) {
+        throw new Error(
+          [
+            "Unsafe gateway self-termination command detected.",
+            "Do not kill openclaw-gateway directly from exec.",
+            "Use `gateway` tool action=`restart` or run `openclaw gateway restart` instead.",
+          ].join("\n"),
+        );
       }
 
       const inheritedBaseEnv = coerceEnv(process.env);

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -447,6 +447,13 @@ describe("exec tool backgrounding", () => {
     isWin ? 15_000 : 5_000,
   );
 
+  it("rejects gateway self-termination command chains", async () => {
+    const cmd = "pkill -f openclaw-gateway && sleep 2 && openclaw gateway run";
+    await expect(executeExecCommand(execTool, cmd)).rejects.toThrow(
+      /Do not kill openclaw-gateway directly from exec/i,
+    );
+  });
+
   it("supports explicit background and derives session name from the command", async () => {
     const sessionId = await startBackgroundCommand(execTool, COMMAND_ECHO_HELLO);
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -200,6 +200,7 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("## OpenClaw CLI Quick Reference");
     expect(prompt).toContain("openclaw gateway restart");
+    expect(prompt).toContain("Do not run `pkill`/`killall` against `openclaw-gateway` from exec");
     expect(prompt).toContain("Do not invent commands");
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -476,6 +476,8 @@ export function buildAgentSystemPrompt(params: {
     "- openclaw gateway start",
     "- openclaw gateway stop",
     "- openclaw gateway restart",
+    "Do not run `pkill`/`killall` against `openclaw-gateway` from exec; that can terminate your own runtime before restart logic runs.",
+    "Prefer the `gateway` tool restart action (or `openclaw gateway restart`) so restart survives safely.",
     "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
     "",
     ...skillsSection,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Agents could execute restart command chains like `pkill -f openclaw-gateway && ...`, which can kill the current gateway/agent runtime before restart logic completes.
- Why it matters: This causes service downtime (gateway stays offline) and breaks automated config-update/restart workflows.
- What changed: Added an `exec` safety guard that blocks gateway self-termination command patterns targeting `openclaw-gateway`, and added explicit system-prompt guidance to use safe restart paths (`gateway` tool restart action or `openclaw gateway restart`).
- What did NOT change (scope boundary): No restart daemon internals, no gateway RPC contract changes, no approval model changes, and no config schema/runtime behavior changes outside this targeted guardrail.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44000
- Related #

## User-visible / Behavior Changes

- `exec` now rejects command chains that attempt to kill `openclaw-gateway` directly (for example via `pkill` / `killall`, or `kill` + `pgrep` patterns) and returns a clear remediation message.
- Agent system prompt now explicitly warns against killing `openclaw-gateway` from `exec` and points to safe restart methods.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `Yes`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation:
  - Risk: Some previously accepted shell restart patterns are now blocked.
  - Mitigation: Error text provides supported alternatives (`gateway` tool restart action or `openclaw gateway restart`) and behavior is covered by new tests.

## Repro + Verification

### Environment

- OS: Windows (local development host)
- Runtime/container: Node.js + Vitest
- Model/provider: N/A (tool-layer and prompt tests)
- Integration/channel (if any): N/A
- Relevant config (redacted): default test config

### Steps

1. Run `exec` with a command chain that kills `openclaw-gateway` directly (for example `pkill -f openclaw-gateway && sleep 2 && openclaw gateway run`).
2. Observe `exec` result/error.
3. Build system prompt and inspect CLI quick-reference guidance.

### Expected

- `exec` blocks unsafe self-termination command chains and instructs safe restart alternatives.
- System prompt includes explicit warning not to kill `openclaw-gateway` from `exec`.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added and passed `bash-tools` test covering rejection of gateway self-termination command chains.
  - Added and passed `system-prompt` test asserting explicit anti-`pkill` guidance.
  - Ran targeted test suite: `src/agents/bash-tools.test.ts` and `src/agents/system-prompt.test.ts`.
- Edge cases checked:
  - Detection covers direct `pkill`/`killall` and `kill` + `pgrep` patterns when command targets `openclaw-gateway`.
  - Message points to safe restart paths.
- What you did **not** verify:
  - Full end-to-end restart behavior on a live Ubuntu Docker deployment with real agent traffic.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit to remove the command guard and prompt guidance.
- Files/config to restore:
  - `src/agents/bash-tools.exec.ts`
  - `src/agents/bash-tools.test.ts`
  - `src/agents/system-prompt.ts`
  - `src/agents/system-prompt.test.ts`
- Known bad symptoms reviewers should watch for:
  - Legitimate non-gateway commands being incorrectly blocked.
  - Missing guidance in system prompt regarding safe restart mechanism.

## Risks and Mitigations

- Risk: False positives could block uncommon but valid commands mentioning `openclaw-gateway`.
  - Mitigation: Guard is narrowly scoped to kill-pattern + target-name detection; tests enforce intended patterns only.
- Risk: Users accustomed to shell-kill restart flows may be surprised.
  - Mitigation: Error message and prompt text provide explicit supported restart alternatives.
