### PR TITLE
fix(mattermost): pass mediaLocalRoots through reply delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 - Doctor/gateway service audit: canonicalize service entrypoint paths before comparing them so symlink-vs-realpath installs no longer trigger false "entrypoint does not match the current install" repair prompts. (#43882) Thanks @ngutman.
 - Doctor/gateway service audit: earlier groundwork for this fix landed in the superseded #28338 branch. Thanks @realriphub.
 - Telegram/model picker: make inline model button selections persist the chosen session model correctly, clear overrides when selecting the configured default, and include effective fallback models in `/models` button validation. (#40105) Thanks @avirweb.
+- Mattermost/reply media delivery: pass agent-scoped `mediaLocalRoots` through shared reply delivery so allowed local files upload correctly from button, slash-command, and model-picker replies. (#44021) Thanks @LyleLiu666.
 
 ## 2026.3.11
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -80,6 +80,7 @@ import {
   type MattermostWebSocketFactory,
 } from "./monitor-websocket.js";
 import { runWithReconnect } from "./reconnect.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import { sendMessageMattermost } from "./send.js";
 import {
   DEFAULT_COMMAND_SPECS,
@@ -682,44 +683,21 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             ...prefixOptions,
             humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
             deliver: async (payload: ReplyPayload) => {
-              const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-              const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
-              if (mediaUrls.length === 0) {
-                const chunkMode = core.channel.text.resolveChunkMode(
-                  cfg,
-                  "mattermost",
-                  account.accountId,
-                );
-                const chunks = core.channel.text.chunkMarkdownTextWithMode(
-                  text,
-                  textLimit,
-                  chunkMode,
-                );
-                for (const chunk of chunks.length > 0 ? chunks : [text]) {
-                  if (!chunk) continue;
-                  await sendMessageMattermost(to, chunk, {
-                    accountId: account.accountId,
-                    replyToId: resolveMattermostReplyRootId({
-                      threadRootId: threadContext.effectiveReplyToId,
-                      replyToId: payload.replyToId,
-                    }),
-                  });
-                }
-              } else {
-                let first = true;
-                for (const mediaUrl of mediaUrls) {
-                  const caption = first ? text : "";
-                  first = false;
-                  await sendMessageMattermost(to, caption, {
-                    accountId: account.accountId,
-                    mediaUrl,
-                    replyToId: resolveMattermostReplyRootId({
-                      threadRootId: threadContext.effectiveReplyToId,
-                      replyToId: payload.replyToId,
-                    }),
-                  });
-                }
-              }
+              await deliverMattermostReplyPayload({
+                core,
+                cfg,
+                payload,
+                to,
+                accountId: account.accountId,
+                agentId: route.agentId,
+                replyToId: resolveMattermostReplyRootId({
+                  threadRootId: threadContext.effectiveReplyToId,
+                  replyToId: payload.replyToId,
+                }),
+                textLimit,
+                tableMode,
+                sendMessage: sendMessageMattermost,
+              });
               runtime.log?.(`delivered button-click reply to ${to}`);
             },
             onError: (err, info) => {
@@ -1000,53 +978,33 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         ...prefixOptions,
         // Picker-triggered confirmations should stay immediate.
         deliver: async (payload: ReplyPayload) => {
-          const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-          const text = core.channel.text
-            .convertMarkdownTables(payload.text ?? "", tableMode)
-            .trim();
+          const trimmedPayload = {
+            ...payload,
+            text: core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode).trim(),
+          };
 
           if (!shouldDeliverReplies) {
-            if (text) {
-              capturedTexts.push(text);
+            if (trimmedPayload.text) {
+              capturedTexts.push(trimmedPayload.text);
             }
             return;
           }
 
-          if (mediaUrls.length === 0) {
-            const chunkMode = core.channel.text.resolveChunkMode(
-              cfg,
-              "mattermost",
-              account.accountId,
-            );
-            const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
-            for (const chunk of chunks.length > 0 ? chunks : [text]) {
-              if (!chunk) {
-                continue;
-              }
-              await sendMessageMattermost(to, chunk, {
-                accountId: account.accountId,
-                replyToId: resolveMattermostReplyRootId({
-                  threadRootId: params.effectiveReplyToId,
-                  replyToId: payload.replyToId,
-                }),
-              });
-            }
-            return;
-          }
-
-          let first = true;
-          for (const mediaUrl of mediaUrls) {
-            const caption = first ? text : "";
-            first = false;
-            await sendMessageMattermost(to, caption, {
-              accountId: account.accountId,
-              mediaUrl,
-              replyToId: resolveMattermostReplyRootId({
-                threadRootId: params.effectiveReplyToId,
-                replyToId: payload.replyToId,
-              }),
-            });
-          }
+          await deliverMattermostReplyPayload({
+            core,
+            cfg,
+            payload: trimmedPayload,
+            to,
+            accountId: account.accountId,
+            agentId: params.route.agentId,
+            replyToId: resolveMattermostReplyRootId({
+              threadRootId: params.effectiveReplyToId,
+              replyToId: trimmedPayload.replyToId,
+            }),
+            textLimit,
+            tableMode: "off",
+            sendMessage: sendMessageMattermost,
+          });
         },
         onError: (err, info) => {
           runtime.error?.(`mattermost model picker ${info.kind} reply failed: ${String(err)}`);
@@ -1743,42 +1701,21 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
         typingCallbacks,
         deliver: async (payload: ReplyPayload) => {
-          const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-          const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
-          if (mediaUrls.length === 0) {
-            const chunkMode = core.channel.text.resolveChunkMode(
-              cfg,
-              "mattermost",
-              account.accountId,
-            );
-            const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
-            for (const chunk of chunks.length > 0 ? chunks : [text]) {
-              if (!chunk) {
-                continue;
-              }
-              await sendMessageMattermost(to, chunk, {
-                accountId: account.accountId,
-                replyToId: resolveMattermostReplyRootId({
-                  threadRootId: effectiveReplyToId,
-                  replyToId: payload.replyToId,
-                }),
-              });
-            }
-          } else {
-            let first = true;
-            for (const mediaUrl of mediaUrls) {
-              const caption = first ? text : "";
-              first = false;
-              await sendMessageMattermost(to, caption, {
-                accountId: account.accountId,
-                mediaUrl,
-                replyToId: resolveMattermostReplyRootId({
-                  threadRootId: effectiveReplyToId,
-                  replyToId: payload.replyToId,
-                }),
-              });
-            }
-          }
+          await deliverMattermostReplyPayload({
+            core,
+            cfg,
+            payload,
+            to,
+            accountId: account.accountId,
+            agentId: route.agentId,
+            replyToId: resolveMattermostReplyRootId({
+              threadRootId: effectiveReplyToId,
+              replyToId: payload.replyToId,
+            }),
+            textLimit,
+            tableMode,
+            sendMessage: sendMessageMattermost,
+          });
           runtime.log?.(`delivered reply to ${to}`);
         },
         onError: (err, info) => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1002,6 +1002,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               replyToId: trimmedPayload.replyToId,
             }),
             textLimit,
+            // The picker path already converts and trims text before capture/delivery.
             tableMode: "off",
             sendMessage: sendMessageMattermost,
           });

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
+import { describe, expect, it, vi } from "vitest";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
+
+describe("deliverMattermostReplyPayload", () => {
+  it("passes agent-scoped mediaLocalRoots when sending media paths", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mm-state-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      const sendMessage = vi.fn(async () => undefined);
+      const core = {
+        channel: {
+          text: {
+            convertMarkdownTables: vi.fn((text: string) => text),
+            resolveChunkMode: vi.fn(() => "length"),
+            chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+          },
+        },
+      } as any;
+
+      const agentId = "agent-1";
+      const mediaUrl = `file://${path.join(stateDir, `workspace-${agentId}`, "photo.png")}`;
+      const cfg = {} satisfies OpenClawConfig;
+
+      await deliverMattermostReplyPayload({
+        core,
+        cfg,
+        payload: { text: "caption", mediaUrl },
+        to: "channel:town-square",
+        accountId: "default",
+        agentId,
+        replyToId: "root-post",
+        textLimit: 4000,
+        tableMode: "off",
+        sendMessage,
+      });
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(sendMessage).toHaveBeenCalledWith(
+        "channel:town-square",
+        "caption",
+        expect.objectContaining({
+          accountId: "default",
+          mediaUrl,
+          replyToId: "root-post",
+          mediaLocalRoots: expect.arrayContaining([path.join(stateDir, `workspace-${agentId}`)]),
+        }),
+      );
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -60,4 +60,36 @@ describe("deliverMattermostReplyPayload", () => {
       await fs.rm(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("forwards replyToId for text-only chunked replies", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const core = {
+      channel: {
+        text: {
+          convertMarkdownTables: vi.fn((text: string) => text),
+          resolveChunkMode: vi.fn(() => "length"),
+          chunkMarkdownTextWithMode: vi.fn(() => ["hello"]),
+        },
+      },
+    } as any;
+
+    await deliverMattermostReplyPayload({
+      core,
+      cfg: {} satisfies OpenClawConfig,
+      payload: { text: "hello" },
+      to: "channel:town-square",
+      accountId: "default",
+      agentId: "agent-1",
+      replyToId: "root-post",
+      textLimit: 4000,
+      tableMode: "off",
+      sendMessage,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("channel:town-square", "hello", {
+      accountId: "default",
+      replyToId: "root-post",
+    });
+  });
 });

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -1,0 +1,71 @@
+import type { OpenClawConfig, PluginRuntime, ReplyPayload } from "openclaw/plugin-sdk/mattermost";
+import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/mattermost";
+
+type MarkdownTableMode = Parameters<PluginRuntime["channel"]["text"]["convertMarkdownTables"]>[1];
+
+type SendMattermostMessage = (
+  to: string,
+  text: string,
+  opts: {
+    accountId?: string;
+    mediaUrl?: string;
+    mediaLocalRoots?: readonly string[];
+    replyToId?: string;
+  },
+) => Promise<unknown>;
+
+export async function deliverMattermostReplyPayload(params: {
+  core: PluginRuntime;
+  cfg: OpenClawConfig;
+  payload: ReplyPayload;
+  to: string;
+  accountId: string;
+  agentId?: string;
+  replyToId?: string;
+  textLimit: number;
+  tableMode: MarkdownTableMode;
+  sendMessage: SendMattermostMessage;
+}): Promise<void> {
+  const mediaUrls =
+    params.payload.mediaUrls ?? (params.payload.mediaUrl ? [params.payload.mediaUrl] : []);
+  const text = params.core.channel.text.convertMarkdownTables(
+    params.payload.text ?? "",
+    params.tableMode,
+  );
+
+  if (mediaUrls.length === 0) {
+    const chunkMode = params.core.channel.text.resolveChunkMode(
+      params.cfg,
+      "mattermost",
+      params.accountId,
+    );
+    const chunks = params.core.channel.text.chunkMarkdownTextWithMode(
+      text,
+      params.textLimit,
+      chunkMode,
+    );
+    for (const chunk of chunks.length > 0 ? chunks : [text]) {
+      if (!chunk) {
+        continue;
+      }
+      await params.sendMessage(params.to, chunk, {
+        accountId: params.accountId,
+        replyToId: params.replyToId,
+      });
+    }
+    return;
+  }
+
+  const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.agentId);
+  let first = true;
+  for (const mediaUrl of mediaUrls) {
+    const caption = first ? text : "";
+    first = false;
+    await params.sendMessage(params.to, caption, {
+      accountId: params.accountId,
+      mediaUrl,
+      mediaLocalRoots,
+      replyToId: params.replyToId,
+    });
+  }
+}

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -35,6 +35,7 @@ import {
   authorizeMattermostCommandInvocation,
   normalizeMattermostAllowList,
 } from "./monitor-auth.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import { sendMessageMattermost } from "./send.js";
 import {
   parseSlashCommandPayload,
@@ -492,32 +493,17 @@ async function handleSlashCommandAsync(params: {
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
       deliver: async (payload: ReplyPayload) => {
-        const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-        const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
-        if (mediaUrls.length === 0) {
-          const chunkMode = core.channel.text.resolveChunkMode(
-            cfg,
-            "mattermost",
-            account.accountId,
-          );
-          const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
-          for (const chunk of chunks.length > 0 ? chunks : [text]) {
-            if (!chunk) continue;
-            await sendMessageMattermost(to, chunk, {
-              accountId: account.accountId,
-            });
-          }
-        } else {
-          let first = true;
-          for (const mediaUrl of mediaUrls) {
-            const caption = first ? text : "";
-            first = false;
-            await sendMessageMattermost(to, caption, {
-              accountId: account.accountId,
-              mediaUrl,
-            });
-          }
-        }
+        await deliverMattermostReplyPayload({
+          core,
+          cfg,
+          payload,
+          to,
+          accountId: account.accountId,
+          agentId: route.agentId,
+          textLimit,
+          tableMode,
+          sendMessage: sendMessageMattermost,
+        });
         runtime.log?.(`delivered slash reply to ${to}`);
       },
       onError: (err, info) => {

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -101,5 +101,6 @@ export {
 export { evaluateSenderGroupAccessForPolicy } from "./group-access.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
+export { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 export { loadOutboundMediaFromUrl } from "./outbound-media.js";
 export { createScopedPairingAccess } from "./pairing-access.js";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Mattermost reply delivery still uploads local media without agent-scoped `mediaLocalRoots` in inbound reply paths (normal replies, slash-command replies, model picker confirmations, and interactive button replies), even though the direct `sendMedia` path already forwards them.
- Why it matters: agent/workspace-local media paths can fail local-root checks and silently degrade to text-only replies when the reply pipeline tries to upload them.
- What changed: added a small `reply-delivery` helper that centralizes Mattermost chunked text/media reply sends, applies `getAgentScopedMediaLocalRoots(cfg, agentId)` for media replies, and reuses that helper from `monitor.ts` and `slash-http.ts`.
- What did NOT change (scope boundary): no Mattermost API contract changes, no warning/fallback copy changes, and no read-tool/image materialization changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #30830

## User-visible / Behavior Changes

- Mattermost replies that attach agent/workspace-local media now forward the same trusted local roots already used by direct `sendMedia`, so those uploads no longer depend on default local-root allowlists.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Mattermost extension
- Relevant config (redacted): default Mattermost account; reply delivery with agent-scoped workspace media roots

### Steps

1. Trigger a Mattermost reply payload with a local media path under an agent workspace root.
2. Route that payload through the Mattermost reply delivery pipeline.
3. Verify the send path receives `mediaLocalRoots` containing the agent workspace root.

### Expected

- Reply delivery should pass agent-scoped local roots into Mattermost media upload sends, matching the direct `sendMedia` path.

### Actual

- Added regression coverage and updated reply delivery to forward `mediaLocalRoots` for media replies across monitor + slash reply paths.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm exec vitest run extensions/mattermost/src/mattermost/reply-delivery.test.ts extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/mattermost/slash-http.test.ts extensions/mattermost/src/mattermost/send.test.ts`
- `pnpm exec oxfmt --check src/plugin-sdk/mattermost.ts extensions/mattermost/src/mattermost/reply-delivery.ts extensions/mattermost/src/mattermost/reply-delivery.test.ts extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/slash-http.ts`
- `pnpm lint:plugins:no-monolithic-plugin-sdk-entry-imports`

Notes about repo baseline while verifying from current `upstream/main`:

- `pnpm check` stops at a pre-existing format failure in `src/cli/daemon-cli/lifecycle.test.ts` before reaching later steps.
- `pnpm tsgo` and `pnpm lint` also report unrelated baseline failures on `upstream/main` (missing optional deps in other extensions and an existing type-aware lint error in `src/agents/openai-ws-stream.ts`).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: media reply payloads now carry agent-scoped `mediaLocalRoots`; monitor and slash reply test suites still pass after switching to the shared helper; existing Mattermost send tests still pass.
- Edge cases checked: plain text chunking path still preserves `replyToId`; media sends keep first-caption behavior; model-picker captured-text path still trims converted text before deciding whether to emit replies.
- What you did **not** verify: live Mattermost server end-to-end upload behavior in this PR cycle.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `4846e8f49`.
- Files/config to restore: `extensions/mattermost/src/mattermost/monitor.ts`, `extensions/mattermost/src/mattermost/slash-http.ts`, `src/plugin-sdk/mattermost.ts`, and remove `extensions/mattermost/src/mattermost/reply-delivery.ts` plus its test.
- Known bad symptoms reviewers should watch for: Mattermost local media replies from agent/workspace paths still degrading to text-only sends, especially in slash or button-triggered reply flows.

## Risks and Mitigations

- Risk:
  - Helper extraction could accidentally change non-media chunking behavior in one of the reply paths.
  - Mitigation:
    - The helper keeps the existing chunking/first-caption logic, and targeted monitor/slash/send tests all pass.
