### PR TITLE
fix: stop false-positive built-in extension skill root warnings

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -1,7 +1,8 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { writeSkill } from "./skills.e2e-test-helpers.js";
 import { loadWorkspaceSkillEntries } from "./skills.js";
 import { writePluginWithSkill } from "./test-helpers/skill-plugin-fixtures.js";
@@ -15,6 +16,7 @@ async function createTempWorkspaceDir() {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(
     tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
   );
@@ -128,6 +130,84 @@ describe("loadWorkspaceSkillEntries", () => {
     });
 
     expect(entries.map((entry) => entry.skill.name)).not.toContain("diffs");
+  });
+
+  it("keeps plugin skills when realpath ancestry aliases the configured root", async () => {
+    const { workspaceDir, managedDir, bundledDir } = await setupWorkspaceWithProsePlugin();
+    const pluginSkillsRoot = path.join(
+      workspaceDir,
+      ".openclaw",
+      "extensions",
+      "open-prose",
+      "skills",
+    );
+    const skillDir = path.join(pluginSkillsRoot, "prose");
+    const skillFile = path.join(skillDir, "SKILL.md");
+    const skillFileSize = (await fs.stat(skillFile)).size;
+
+    const aliasRoot = "/virtual/open-prose/skills";
+    const aliasSkillDir = "/mnt/plugins/open-prose/skills/prose";
+    const aliasSkillFile = path.join(aliasSkillDir, "SKILL.md");
+    const aliasStats = new Map<string, fsSync.Stats>([
+      [
+        aliasRoot,
+        { dev: 1, ino: 101, size: 0, isDirectory: () => true, isFile: () => false } as fsSync.Stats,
+      ],
+      [
+        aliasSkillDir,
+        { dev: 1, ino: 202, size: 0, isDirectory: () => true, isFile: () => false } as fsSync.Stats,
+      ],
+      [
+        aliasSkillFile,
+        {
+          dev: 1,
+          ino: 303,
+          size: skillFileSize,
+          isDirectory: () => false,
+          isFile: () => true,
+        } as fsSync.Stats,
+      ],
+      [
+        path.dirname(aliasSkillDir),
+        { dev: 1, ino: 101, size: 0, isDirectory: () => true, isFile: () => false } as fsSync.Stats,
+      ],
+    ]);
+
+    const originalRealpathSync = fsSync.realpathSync.bind(fsSync);
+    vi.spyOn(fsSync, "realpathSync").mockImplementation((input) => {
+      const resolved = path.resolve(String(input));
+      if (resolved === pluginSkillsRoot) {
+        return aliasRoot;
+      }
+      if (resolved === skillDir) {
+        return aliasSkillDir;
+      }
+      if (resolved === skillFile) {
+        return aliasSkillFile;
+      }
+      return originalRealpathSync(input);
+    });
+
+    const originalStatSync = fsSync.statSync.bind(fsSync);
+    vi.spyOn(fsSync, "statSync").mockImplementation((input, options) => {
+      const stat = aliasStats.get(path.resolve(String(input)));
+      if (stat) {
+        return stat;
+      }
+      return originalStatSync(input, options as never);
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: {
+        plugins: {
+          entries: { "open-prose": { enabled: true } },
+        },
+      },
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("prose");
   });
 
   it.runIf(process.platform !== "win32")(

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -198,6 +198,49 @@ function warnEscapedSkillPath(params: {
   });
 }
 
+function tryPathIdentity(filePath: string): { dev: number; ino: number } | null {
+  try {
+    const stat = fs.statSync(filePath);
+    if (typeof stat.dev !== "number" || typeof stat.ino !== "number") {
+      return null;
+    }
+    return { dev: stat.dev, ino: stat.ino };
+  } catch {
+    return null;
+  }
+}
+
+function isPathInsideRealRoot(rootRealPath: string, candidateRealPath: string): boolean {
+  if (isPathInside(rootRealPath, candidateRealPath)) {
+    return true;
+  }
+
+  // Some package-manager / mount layouts can expose the same directory through
+  // multiple canonical-looking path strings. Fall back to device+inode ancestry
+  // before warning so bundled/plugin skills do not spam false positives.
+  const rootIdentity = tryPathIdentity(rootRealPath);
+  if (!rootIdentity) {
+    return false;
+  }
+
+  let current = candidateRealPath;
+  while (true) {
+    const currentIdentity = tryPathIdentity(current);
+    if (
+      currentIdentity &&
+      currentIdentity.dev === rootIdentity.dev &&
+      currentIdentity.ino === rootIdentity.ino
+    ) {
+      return true;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return false;
+    }
+    current = parent;
+  }
+}
+
 function resolveContainedSkillPath(params: {
   source: string;
   rootDir: string;
@@ -208,7 +251,7 @@ function resolveContainedSkillPath(params: {
   if (!candidateRealPath) {
     return null;
   }
-  if (isPathInside(params.rootRealPath, candidateRealPath)) {
+  if (isPathInsideRealRoot(params.rootRealPath, candidateRealPath)) {
     return candidateRealPath;
   }
   warnEscapedSkillPath({


### PR DESCRIPTION
## Summary
- make skill root containment fall back to device/inode ancestry when realpath strings diverge
- keep the existing path escape rejection for true escapes
- add a regression test for plugin skills loaded through aliased realpath ancestry

## Testing
- pnpm exec vitest run src/agents/skills.loadworkspaceskillentries.test.ts src/agents/skills/plugin-skills.test.ts

Closes #43745