### PR TITLE
Fix duplicated acp server args in ACP client

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -152,6 +152,23 @@ describe("resolveAcpClientSpawnInvocation", () => {
     expect(resolved.windowsHide).toBe(true);
   });
 
+  it("dedupes a leading acp server arg from callers", () => {
+    const resolved = resolveAcpClientSpawnInvocation(
+      { serverCommand: "openclaw", serverArgs: ["acp", "--verbose"] },
+      {
+        platform: "darwin",
+        env: {},
+        execPath: "/usr/bin/node",
+      },
+    );
+    expect(resolved).toEqual({
+      command: "openclaw",
+      args: ["acp", "--verbose"],
+      shell: undefined,
+      windowsHide: undefined,
+    });
+  });
+
   it("falls back to shell mode for unresolved wrappers on windows", async () => {
     const dir = await createTempDir();
     const shimPath = path.join(dir, "openclaw.cmd");

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -339,7 +339,9 @@ function toArgs(value: string[] | string | undefined): string[] {
 }
 
 function buildServerArgs(opts: AcpClientOptions): string[] {
-  const args = ["acp", ...toArgs(opts.serverArgs)];
+  const extraArgs = toArgs(opts.serverArgs);
+  const normalizedExtraArgs = extraArgs[0] === "acp" ? extraArgs.slice(1) : extraArgs;
+  const args = ["acp", ...normalizedExtraArgs];
   if (opts.serverVerbose && !args.includes("--verbose") && !args.includes("-v")) {
     args.push("--verbose");
   }


### PR DESCRIPTION
## Summary
- dedupe a leading `acp` from ACP client server args before spawning the server
- keep `--server-verbose` behavior unchanged after normalization
- add a regression test covering callers that already pass `acp` in `serverArgs`

## Problem
`openclaw acp client` always prefixes the spawned server command with `acp`.
If an upstream caller also passes `serverArgs=["acp", ...]`, the effective command becomes:

```bash
openclaw acp acp ...
```

That fails with:

```text
error: too many arguments for 'acp'
```

## Fix
Normalize `serverArgs` in the ACP client by dropping one leading `acp` when present, then prepend the canonical `acp` subcommand exactly once.

## Testing
- reproduced the failure locally with `openclaw acp client --server openclaw --server-args acp --server-verbose`
- verified the command now spawns as `openclaw acp --verbose` and reaches session creation
- `npx vitest run src/acp/client.test.ts`
