### PR TITLE
fix(cron): avoid false positive legacy format detection in normalizePayloadKind

### DIFF
--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,12 +28,13 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
+  const current = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  const raw = current.toLowerCase();
+  if (raw === "agentturn" && current !== "agentTurn") {
     payload.kind = "agentTurn";
     return true;
   }
-  if (raw === "systemevent") {
+  if (raw === "systemevent" && current !== "systemEvent") {
     payload.kind = "systemEvent";
     return true;
   }


### PR DESCRIPTION
Fixes #44005

## Problem

`openclaw doctor --fix` would repeatedly report "Legacy cron job storage detected" even after the cron store had already been normalized to the correct format.

## Root Cause

The `normalizePayloadKind()` function in `src/cron/store-migration.ts` would:
1. Always set `payload.kind` to `"agentTurn"` or `"systemEvent"` 
2. Always return `true` (indicating a mutation was made)

This meant even when `payload.kind` was already in the correct format (`"agentTurn"`), the function would still:
- Reassign the same value
- Return `true` (marking the job as "mutated")

This caused the `mutated` flag to be `true` even when no actual changes were needed, leading doctor to believe the store still needed normalization.

## Fix

Now `normalizePayloadKind()` only updates `payload.kind` and returns `true` when the current value differs from the correct format:

```typescript
// Before: always mutated
if (raw === "agentturn") {
  payload.kind = "agentTurn";  // Always set
  return true;                   // Always report mutated
}

// After: only mutate when needed
if (raw === "agentturn" && current !== "agentTurn") {
  payload.kind = "agentTurn";   // Only set when different
  return true;                   // Only report mutated when changed
}
```

## Test plan

- [x] Run `pnpm test` on cron and doctor modules (all 507 tests pass)
- [ ] Verify `openclaw doctor` no longer shows false positives for normalized cron stores