### PR TITLE
[AI-assisted] Fix duplicated acp server args in ACP client

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -152,6 +152,23 @@ describe("resolveAcpClientSpawnInvocation", () => {
     expect(resolved.windowsHide).toBe(true);
   });
 
+  it("dedupes a leading acp server arg from callers", () => {
+    const resolved = resolveAcpClientSpawnInvocation(
+      { serverCommand: "openclaw", serverArgs: ["acp", "--verbose"] },
+      {
+        platform: "darwin",
+        env: {},
+        execPath: "/usr/bin/node",
+      },
+    );
+    expect(resolved).toEqual({
+      command: "openclaw",
+      args: ["acp", "--verbose"],
+      shell: undefined,
+      windowsHide: undefined,
+    });
+  });
+
   it("falls back to shell mode for unresolved wrappers on windows", async () => {
     const dir = await createTempDir();
     const shimPath = path.join(dir, "openclaw.cmd");

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -270,6 +270,16 @@ describe("buildServerArgs", () => {
   });
 });
 
+describe("buildServerArgs", () => {
+  it("prepends acp when callers pass only extra server args", () => {
+    expect(buildServerArgs({ serverArgs: ["--verbose"] })).toEqual(["acp", "--verbose"]);
+  });
+
+  it("dedupes a leading acp server arg from callers", () => {
+    expect(buildServerArgs({ serverArgs: ["acp", "--verbose"] })).toEqual(["acp", "--verbose"]);
+  });
+});
+
 describe("resolveAcpClientSpawnInvocation", () => {
   it("keeps non-windows invocation unchanged", () => {
     const resolved = resolveAcpClientSpawnInvocation(

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -34,6 +34,7 @@ import {
   resolvePermissionRequest,
   shouldStripProviderAuthEnvVarsForAcpServer,
 } from "./client-helpers.js";
+import { buildServerArgs } from "./client.js";
 import {
   extractAttachmentsFromPrompt,
   extractTextFromPrompt,
@@ -253,6 +254,19 @@ describe("buildAcpClientStripKeys", () => {
     expect(stripKeys.has("GITHUB_TOKEN")).toBe(true);
     expect(stripKeys.has("HF_TOKEN")).toBe(true);
     expect(stripKeys.has("OPENCLAW_API_KEY")).toBe(false);
+  });
+});
+
+describe("buildServerArgs", () => {
+  it("prepends acp when callers pass only extra server args", () => {
+    expect(buildServerArgs({ serverArgs: ["--verbose"] })).toEqual(["acp", "--verbose"]);
+  });
+
+  it("dedupes a leading acp server arg from callers", () => {
+    expect(buildServerArgs({ serverArgs: ["acp", "--verbose"] })).toEqual([
+      "acp",
+      "--verbose",
+    ]);
   });
 });
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -339,7 +339,9 @@ function toArgs(value: string[] | string | undefined): string[] {
 }
 
 function buildServerArgs(opts: AcpClientOptions): string[] {
-  const args = ["acp", ...toArgs(opts.serverArgs)];
+  const extraArgs = toArgs(opts.serverArgs);
+  const normalizedExtraArgs = extraArgs[0] === "acp" ? extraArgs.slice(1) : extraArgs;
+  const args = ["acp", ...normalizedExtraArgs];
   if (opts.serverVerbose && !args.includes("--verbose") && !args.includes("-v")) {
     args.push("--verbose");
   }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -42,8 +42,10 @@ function toArgs(value: string[] | string | undefined): string[] {
   return Array.isArray(value) ? value : [value];
 }
 
-function buildServerArgs(opts: AcpClientOptions): string[] {
-  const args = ["acp", ...toArgs(opts.serverArgs)];
+export function buildServerArgs(opts: AcpClientOptions): string[] {
+  const extraArgs = toArgs(opts.serverArgs);
+  const normalizedExtraArgs = extraArgs[0] === "acp" ? extraArgs.slice(1) : extraArgs;
+  const args = ["acp", ...normalizedExtraArgs];
   if (opts.serverVerbose && !args.includes("--verbose") && !args.includes("-v")) {
     args.push("--verbose");
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw acp client` always prefixes the spawned server command with `acp`, so if an upstream caller also passes `serverArgs=["acp", ...]`, the effective command becomes `openclaw acp acp ...` and fails.
- Why it matters: this makes ACP client startup brittle and causes session creation to fail for callers that already include the subcommand in forwarded args.
- What changed: normalize `serverArgs` in the ACP client by dropping one leading `acp` when present, then prepend the canonical `acp` subcommand exactly once; added a regression test for this case.
- What did NOT change (scope boundary): no changes to ACP server behavior, permissions, routing, session semantics, or any non-ACP CLI paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

ACP client startup is now tolerant of callers that redundantly include `acp` in forwarded `serverArgs`.
Before: `openclaw acp client --server openclaw --server-args acp --server-verbose` could spawn `openclaw acp acp --verbose` and fail.
After: the same invocation normalizes to `openclaw acp --verbose` and proceeds to session creation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

This changes ACP client command construction only by deduping a redundant leading `acp` token in forwarded server args.
Risk is low because the change narrows an invalid invocation into the canonical one instead of expanding execution surface.
Mitigation: added a regression test covering the duplicated-`acp` case.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local host runtime
- Model/provider: openai-codex/gpt-5.4
- Integration/channel (if any): ACP CLI
- Relevant config (redacted): default local OpenClaw CLI setup; no special ACP config required for repro

### Steps

1. Run `openclaw acp client --server openclaw --server-args acp --server-verbose`
2. Observe the spawned server command
3. Attempt session creation

### Expected

- The ACP client should spawn the canonical server command once as `openclaw acp --verbose`
- Session creation should proceed successfully

### Actual

- Before the fix, this could spawn `openclaw acp acp --verbose`
- That failed with `error: too many arguments for 'acp'`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before:

```text
[acp-client] spawning: openclaw acp acp --verbose
error: too many arguments for 'acp'
```

After:

```text
[acp-client] spawning: openclaw acp --verbose
[acp-client] creating session
```

Targeted test:

```text
npx vitest run src/acp/client.test.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
    - Reproduced the failing duplicated-acp invocation locally
    - Verified the same invocation now spawns openclaw acp --verbose
    - Verified it reaches session creation successfully
- Ran npx vitest run src/acp/client.test.ts
- Edge cases checked:
    - callers that already pass leading acp in serverArgs
    - existing --server-verbose behavior remains intact after normalization
- What you did **not** verify:
    - full repository green on pnpm build && pnpm check && pnpm test
    - broader ACP server behavior outside this argument-normalization path

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / commit
- Files/config to restore: src/acp/client.ts, src/acp/client.test.ts
- Known bad symptoms reviewers should watch for:
    - ACP client spawning malformed commands
    - regression where valid serverArgs are incorrectly altered

## Risks and Mitigations

- Risk: overly broad normalization could accidentally rewrite intended server args
    - Mitigation: normalization only removes a single leading acp; all other args are preserved verbatim
- Risk: reviewers may assume the full repository test/build matrix is green
    - Mitigation: this PR explicitly reports targeted verification only; local pnpm build and pnpm test currently fail due to unrelated existing repository issues outside this change

