### PR TITLE
fix(plugins): Windows-compatible test for resolvePluginSourceRoots

### DIFF
--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveUserPath } from "../utils.js";
 
 export function resolveBundledPluginsDir(env: NodeJS.ProcessEnv = process.env): string | undefined {
   const override = env.OPENCLAW_BUNDLED_PLUGINS_DIR?.trim();
   if (override) {
-    return override;
+    return resolveUserPath(override, env);
   }
 
   // bun --compile: ship a sibling `extensions/` next to the executable.

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -393,4 +393,33 @@ describe("discoverOpenClawPlugins", () => {
     });
     expect(third.candidates.some((candidate) => candidate.idHint === "cached")).toBe(false);
   });
+
+  it("does not reuse discovery results across env root changes", () => {
+    const stateDirA = makeTempDir();
+    const stateDirB = makeTempDir();
+    const globalExtA = path.join(stateDirA, "extensions");
+    const globalExtB = path.join(stateDirB, "extensions");
+    fs.mkdirSync(globalExtA, { recursive: true });
+    fs.mkdirSync(globalExtB, { recursive: true });
+    fs.writeFileSync(path.join(globalExtA, "alpha.ts"), "export default function () {}", "utf-8");
+    fs.writeFileSync(path.join(globalExtB, "beta.ts"), "export default function () {}", "utf-8");
+
+    const first = discoverOpenClawPlugins({
+      env: {
+        ...buildDiscoveryEnv(stateDirA),
+        OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS: "5000",
+      },
+    });
+    const second = discoverOpenClawPlugins({
+      env: {
+        ...buildDiscoveryEnv(stateDirB),
+        OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS: "5000",
+      },
+    });
+
+    expect(first.candidates.some((candidate) => candidate.idHint === "alpha")).toBe(true);
+    expect(first.candidates.some((candidate) => candidate.idHint === "beta")).toBe(false);
+    expect(second.candidates.some((candidate) => candidate.idHint === "alpha")).toBe(false);
+    expect(second.candidates.some((candidate) => candidate.idHint === "beta")).toBe(true);
+  });
 });

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
-import { resolveConfigDir, resolveUserPath } from "../utils.js";
-import { resolveBundledPluginsDir } from "./bundled-dir.js";
+import { resolveUserPath } from "../utils.js";
 import {
   DEFAULT_PLUGIN_ENTRY_CANDIDATES,
   getPackageManifestMetadata,
@@ -11,6 +10,7 @@ import {
   type PackageManifest,
 } from "./manifest.js";
 import { formatPosixMode, isPathInside, safeRealpathSync, safeStatSync } from "./path-safety.js";
+import { resolvePluginSourceRoots } from "./roots.js";
 import type { PluginDiagnostic, PluginOrigin } from "./types.js";
 
 const EXTENSION_EXTS = new Set([".ts", ".js", ".mts", ".cts", ".mjs", ".cjs"]);
@@ -71,9 +71,13 @@ function buildDiscoveryCacheKey(params: {
   ownershipUid?: number | null;
   env: NodeJS.ProcessEnv;
 }): string {
-  const workspaceKey = params.workspaceDir ? resolveUserPath(params.workspaceDir) : "";
-  const configExtensionsRoot = path.join(resolveConfigDir(params.env), "extensions");
-  const bundledRoot = resolveBundledPluginsDir(params.env) ?? "";
+  const roots = resolvePluginSourceRoots({
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  const workspaceKey = roots.workspace ?? "";
+  const configExtensionsRoot = roots.global ?? "";
+  const bundledRoot = roots.stock ?? "";
   const normalizedExtraPaths = (params.extraPaths ?? [])
     .filter((entry): entry is string => typeof entry === "string")
     .map((entry) => entry.trim())
@@ -663,6 +667,8 @@ export function discoverOpenClawPlugins(params: {
   const diagnostics: PluginDiagnostic[] = [];
   const seen = new Set<string>();
   const workspaceDir = params.workspaceDir?.trim();
+  const workspaceRoot = workspaceDir ? resolveUserPath(workspaceDir) : undefined;
+  const roots = resolvePluginSourceRoots({ workspaceDir: workspaceRoot, env });
 
   const extra = params.extraPaths ?? [];
   for (const extraPath of extra) {
@@ -683,26 +689,21 @@ export function discoverOpenClawPlugins(params: {
       seen,
     });
   }
-  if (workspaceDir) {
-    const workspaceRoot = resolveUserPath(workspaceDir);
-    const workspaceExtDirs = [path.join(workspaceRoot, ".openclaw", "extensions")];
-    for (const dir of workspaceExtDirs) {
-      discoverInDirectory({
-        dir,
-        origin: "workspace",
-        ownershipUid: params.ownershipUid,
-        workspaceDir: workspaceRoot,
-        candidates,
-        diagnostics,
-        seen,
-      });
-    }
+  if (roots.workspace && workspaceRoot) {
+    discoverInDirectory({
+      dir: roots.workspace,
+      origin: "workspace",
+      ownershipUid: params.ownershipUid,
+      workspaceDir: workspaceRoot,
+      candidates,
+      diagnostics,
+      seen,
+    });
   }
 
-  const bundledDir = resolveBundledPluginsDir(env);
-  if (bundledDir) {
+  if (roots.stock) {
     discoverInDirectory({
-      dir: bundledDir,
+      dir: roots.stock,
       origin: "bundled",
       ownershipUid: params.ownershipUid,
       candidates,
@@ -713,9 +714,8 @@ export function discoverOpenClawPlugins(params: {
 
   // Keep auto-discovered global extensions behind bundled plugins.
   // Users can still intentionally override via plugins.load.paths (origin=config).
-  const globalDir = path.join(resolveConfigDir(env), "extensions");
   discoverInDirectory({
-    dir: globalDir,
+    dir: roots.global,
     origin: "global",
     ownershipUid: params.ownershipUid,
     candidates,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -28,6 +28,7 @@ async function importFreshPluginTestModules() {
 
 const {
   __testing,
+  clearPluginLoaderCache,
   createHookRunner,
   getGlobalHookRunner,
   loadOpenClawPlugins,
@@ -80,6 +81,7 @@ function writePlugin(params: {
 }): TempPlugin {
   const dir = params.dir ?? makeTempDir();
   const filename = params.filename ?? `${params.id}.cjs`;
+  fs.mkdirSync(dir, { recursive: true });
   const file = path.join(dir, filename);
   fs.writeFileSync(file, params.body, "utf-8");
   fs.writeFileSync(
@@ -265,6 +267,7 @@ function createPluginSdkAliasFixture(params?: {
 }
 
 afterEach(() => {
+  clearPluginLoaderCache();
   if (prevBundledDir === undefined) {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
   } else {
@@ -447,6 +450,89 @@ describe("loadOpenClawPlugins", () => {
     expect(getGlobalHookRunner()).not.toBeNull();
 
     resetGlobalHookRunner();
+  });
+
+  it("does not reuse cached bundled plugin registries across env changes", () => {
+    const bundledA = makeTempDir();
+    const bundledB = makeTempDir();
+    const pluginA = writePlugin({
+      id: "cache-root",
+      dir: path.join(bundledA, "cache-root"),
+      filename: "index.cjs",
+      body: `module.exports = { id: "cache-root", register() {} };`,
+    });
+    const pluginB = writePlugin({
+      id: "cache-root",
+      dir: path.join(bundledB, "cache-root"),
+      filename: "index.cjs",
+      body: `module.exports = { id: "cache-root", register() {} };`,
+    });
+
+    const options = {
+      config: {
+        plugins: {
+          allow: ["cache-root"],
+          entries: {
+            "cache-root": { enabled: true },
+          },
+        },
+      },
+    };
+
+    const first = loadOpenClawPlugins({
+      ...options,
+      env: {
+        ...process.env,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledA,
+      },
+    });
+    const second = loadOpenClawPlugins({
+      ...options,
+      env: {
+        ...process.env,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledB,
+      },
+    });
+
+    expect(second).not.toBe(first);
+    expect(
+      fs.realpathSync(first.plugins.find((entry) => entry.id === "cache-root")?.source ?? ""),
+    ).toBe(fs.realpathSync(pluginA.file));
+    expect(
+      fs.realpathSync(second.plugins.find((entry) => entry.id === "cache-root")?.source ?? ""),
+    ).toBe(fs.realpathSync(pluginB.file));
+  });
+
+  it("normalizes bundled plugin env overrides against the provided env", () => {
+    const bundledDir = makeTempDir();
+    const homeDir = path.dirname(bundledDir);
+    const override = `~/${path.basename(bundledDir)}`;
+    const plugin = writePlugin({
+      id: "tilde-bundled",
+      dir: path.join(bundledDir, "tilde-bundled"),
+      filename: "index.cjs",
+      body: `module.exports = { id: "tilde-bundled", register() {} };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: override,
+      },
+      config: {
+        plugins: {
+          allow: ["tilde-bundled"],
+          entries: {
+            "tilde-bundled": { enabled: true },
+          },
+        },
+      },
+    });
+
+    expect(
+      fs.realpathSync(registry.plugins.find((entry) => entry.id === "tilde-bundled")?.source ?? ""),
+    ).toBe(fs.realpathSync(plugin.file));
   });
 
   it("loads plugins when source and root differ only by realpath alias", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -21,6 +21,7 @@ import { initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import { isPathInside, safeStatSync } from "./path-safety.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
+import { resolvePluginSourceRoots } from "./roots.js";
 import { setActivePluginRegistry } from "./runtime.js";
 import { createPluginRuntime, type CreatePluginRuntimeOptions } from "./runtime/index.js";
 import type { PluginRuntime } from "./runtime/types.js";
@@ -37,6 +38,7 @@ export type PluginLoadResult = PluginRegistry;
 export type PluginLoadOptions = {
   config?: OpenClawConfig;
   workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
   logger?: PluginLogger;
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   runtimeOptions?: CreatePluginRuntimeOptions;
@@ -45,6 +47,10 @@ export type PluginLoadOptions = {
 };
 
 const registryCache = new Map<string, PluginRegistry>();
+
+export function clearPluginLoaderCache(): void {
+  registryCache.clear();
+}
 
 const defaultLogger = () => createSubsystemLogger("plugins");
 
@@ -167,9 +173,13 @@ export const __testing = {
 function buildCacheKey(params: {
   workspaceDir?: string;
   plugins: NormalizedPluginsConfig;
+  env: NodeJS.ProcessEnv;
 }): string {
-  const workspaceKey = params.workspaceDir ? resolveUserPath(params.workspaceDir) : "";
-  return `${workspaceKey}::${JSON.stringify(params.plugins)}`;
+  const roots = resolvePluginSourceRoots({
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify(params.plugins)}`;
 }
 
 function validatePluginConfig(params: {
@@ -445,15 +455,17 @@ function activatePluginRegistry(registry: PluginRegistry, cacheKey: string): voi
 }
 
 export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegistry {
+  const env = options.env ?? process.env;
   // Test env: default-disable plugins unless explicitly configured.
   // This keeps unit/gateway suites fast and avoids loading heavyweight plugin deps by accident.
-  const cfg = applyTestPluginDefaults(options.config ?? {}, process.env);
+  const cfg = applyTestPluginDefaults(options.config ?? {}, env);
   const logger = options.logger ?? defaultLogger();
   const validateOnly = options.mode === "validate";
   const normalized = normalizePluginsConfig(cfg.plugins);
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
     plugins: normalized,
+    env,
   });
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
@@ -510,11 +522,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     workspaceDir: options.workspaceDir,
     extraPaths: normalized.loadPaths,
     cache: options.cache,
+    env,
   });
   const manifestRegistry = loadPluginManifestRegistry({
     config: cfg,
     workspaceDir: options.workspaceDir,
     cache: options.cache,
+    env,
     candidates: discovery.candidates,
     diagnostics: discovery.diagnostics,
   });

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { PluginCandidate } from "./discovery.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import {
+  clearPluginManifestRegistryCache,
+  loadPluginManifestRegistry,
+} from "./manifest-registry.js";
 
 const tempDirs: string[] = [];
 
@@ -116,6 +119,7 @@ function expectUnsafeWorkspaceManifestRejected(params: {
 }
 
 afterEach(() => {
+  clearPluginManifestRegistryCache();
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (!dir) {
@@ -263,5 +267,48 @@ describe("loadPluginManifestRegistry", () => {
     });
     expect(registry.plugins.some((entry) => entry.id === "bundled-hardlink")).toBe(true);
     expect(hasUnsafeManifestDiagnostic(registry)).toBe(false);
+  });
+
+  it("does not reuse cached bundled plugin roots across env changes", () => {
+    const bundledA = makeTempDir();
+    const bundledB = makeTempDir();
+    const matrixA = path.join(bundledA, "matrix");
+    const matrixB = path.join(bundledB, "matrix");
+    fs.mkdirSync(matrixA, { recursive: true });
+    fs.mkdirSync(matrixB, { recursive: true });
+    writeManifest(matrixA, {
+      id: "matrix",
+      name: "Matrix A",
+      configSchema: { type: "object" },
+    });
+    writeManifest(matrixB, {
+      id: "matrix",
+      name: "Matrix B",
+      configSchema: { type: "object" },
+    });
+    fs.writeFileSync(path.join(matrixA, "index.ts"), "export default {}", "utf-8");
+    fs.writeFileSync(path.join(matrixB, "index.ts"), "export default {}", "utf-8");
+
+    const first = loadPluginManifestRegistry({
+      cache: true,
+      env: {
+        ...process.env,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledA,
+      },
+    });
+    const second = loadPluginManifestRegistry({
+      cache: true,
+      env: {
+        ...process.env,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledB,
+      },
+    });
+
+    expect(
+      fs.realpathSync(first.plugins.find((plugin) => plugin.id === "matrix")?.rootDir ?? ""),
+    ).toBe(fs.realpathSync(matrixA));
+    expect(
+      fs.realpathSync(second.plugins.find((plugin) => plugin.id === "matrix")?.rootDir ?? ""),
+    ).toBe(fs.realpathSync(matrixB));
   });
 });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -1,12 +1,11 @@
 import fs from "node:fs";
-import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveConfigDir, resolveUserPath } from "../utils.js";
-import { resolveBundledPluginsDir } from "./bundled-dir.js";
+import { resolveUserPath } from "../utils.js";
 import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
 import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
 import { loadPluginManifest, type PluginManifest } from "./manifest.js";
 import { safeRealpathSync } from "./path-safety.js";
+import { resolvePluginSourceRoots } from "./roots.js";
 import type { PluginConfigUiHint, PluginDiagnostic, PluginKind, PluginOrigin } from "./types.js";
 
 type SeenIdEntry = {
@@ -83,9 +82,13 @@ function buildCacheKey(params: {
   plugins: NormalizedPluginsConfig;
   env: NodeJS.ProcessEnv;
 }): string {
-  const workspaceKey = params.workspaceDir ? resolveUserPath(params.workspaceDir) : "";
-  const configExtensionsRoot = path.join(resolveConfigDir(params.env), "extensions");
-  const bundledRoot = resolveBundledPluginsDir(params.env) ?? "";
+  const roots = resolvePluginSourceRoots({
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  const workspaceKey = roots.workspace ?? "";
+  const configExtensionsRoot = roots.global;
+  const bundledRoot = roots.stock ?? "";
   // The manifest registry only depends on where plugins are discovered from (workspace + load paths).
   // It does not depend on allow/deny/entries enable-state, so exclude those for higher cache hit rates.
   const loadPaths = params.plugins.loadPaths

--- a/src/plugins/roots.ts
+++ b/src/plugins/roots.ts
@@ -1,0 +1,21 @@
+import path from "node:path";
+import { resolveConfigDir, resolveUserPath } from "../utils.js";
+import { resolveBundledPluginsDir } from "./bundled-dir.js";
+
+export type PluginSourceRoots = {
+  stock?: string;
+  global: string;
+  workspace?: string;
+};
+
+export function resolvePluginSourceRoots(params: {
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): PluginSourceRoots {
+  const env = params.env ?? process.env;
+  const workspaceRoot = params.workspaceDir ? resolveUserPath(params.workspaceDir) : undefined;
+  const stock = resolveBundledPluginsDir(env);
+  const global = path.join(resolveConfigDir(env), "extensions");
+  const workspace = workspaceRoot ? path.join(workspaceRoot, ".openclaw", "extensions") : undefined;
+  return { stock, global, workspace };
+}

--- a/src/plugins/source-display.test.ts
+++ b/src/plugins/source-display.test.ts
@@ -1,5 +1,7 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { formatPluginSourceForTable } from "./source-display.js";
+import { withEnv } from "../test-utils/env.js";
+import { formatPluginSourceForTable, resolvePluginSourceRoots } from "./source-display.js";
 
 describe("formatPluginSourceForTable", () => {
   it("shortens bundled plugin sources under the stock root", () => {
@@ -48,5 +50,31 @@ describe("formatPluginSourceForTable", () => {
     );
     expect(out.value).toBe("global:zalo/index.js");
     expect(out.rootKey).toBe("global");
+  });
+
+  it("resolves source roots from an explicit env override", () => {
+    const roots = withEnv(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: "/tmp/ignored-bundled",
+        OPENCLAW_STATE_DIR: "/tmp/ignored-state",
+        HOME: "/tmp/ignored-home",
+      },
+      () =>
+        resolvePluginSourceRoots({
+          env: {
+            ...process.env,
+            HOME: "/tmp/openclaw-home",
+            OPENCLAW_BUNDLED_PLUGINS_DIR: "~/bundled",
+            OPENCLAW_STATE_DIR: "~/state",
+          },
+          workspaceDir: "/tmp/ws",
+        }),
+    );
+
+    expect(roots).toEqual({
+      stock: path.join("/tmp/openclaw-home", "bundled"),
+      global: path.join("/tmp/openclaw-home", "state", "extensions"),
+      workspace: path.join("/tmp/ws", ".openclaw", "extensions"),
+    });
   });
 });

--- a/src/plugins/source-display.ts
+++ b/src/plugins/source-display.ts
@@ -1,13 +1,9 @@
 import path from "node:path";
-import { resolveConfigDir, shortenHomeInString } from "../utils.js";
-import { resolveBundledPluginsDir } from "./bundled-dir.js";
+import { shortenHomeInString } from "../utils.js";
 import type { PluginRecord } from "./registry.js";
-
-export type PluginSourceRoots = {
-  stock?: string;
-  global?: string;
-  workspace?: string;
-};
+import type { PluginSourceRoots } from "./roots.js";
+export { resolvePluginSourceRoots } from "./roots.js";
+export type { PluginSourceRoots } from "./roots.js";
 
 function tryRelative(root: string, filePath: string): string | null {
   const rel = path.relative(root, filePath);
@@ -25,15 +21,6 @@ function tryRelative(root: string, filePath: string): string | null {
   }
   // Normalize to forward slashes for display (path.relative uses backslashes on Windows)
   return rel.replaceAll("\\", "/");
-}
-
-export function resolvePluginSourceRoots(params: { workspaceDir?: string }): PluginSourceRoots {
-  const stock = resolveBundledPluginsDir();
-  const global = path.join(resolveConfigDir(), "extensions");
-  const workspace = params.workspaceDir
-    ? path.join(params.workspaceDir, ".openclaw", "extensions")
-    : undefined;
-  return { stock, global, workspace };
 }
 
 export function formatPluginSourceForTable(

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -127,6 +127,15 @@ describe("resolveConfigDir", () => {
       await fs.promises.rm(root, { recursive: true, force: true });
     }
   });
+
+  it("expands OPENCLAW_STATE_DIR using the provided env", () => {
+    const env = {
+      HOME: "/tmp/openclaw-home",
+      OPENCLAW_STATE_DIR: "~/state",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveConfigDir(env)).toBe(path.resolve("/tmp/openclaw-home", "state"));
+  });
 });
 
 describe("resolveHomeDir", () => {
@@ -212,6 +221,15 @@ describe("resolveUserPath", () => {
     expect(resolveUserPath("~/openclaw")).toBe(path.resolve("/srv/openclaw-home", "openclaw"));
 
     vi.unstubAllEnvs();
+  });
+
+  it("uses the provided env for tilde expansion", () => {
+    const env = {
+      HOME: "/tmp/openclaw-home",
+      OPENCLAW_HOME: "/srv/openclaw-home",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveUserPath("~/openclaw", env)).toBe(path.resolve("/srv/openclaw-home", "openclaw"));
   });
 
   it("keeps blank paths blank", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -271,7 +271,11 @@ export function truncateUtf16Safe(input: string, maxLen: number): string {
   return sliceUtf16Safe(input, 0, limit);
 }
 
-export function resolveUserPath(input: string): string {
+export function resolveUserPath(
+  input: string,
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
   if (!input) {
     return "";
   }
@@ -281,9 +285,9 @@ export function resolveUserPath(input: string): string {
   }
   if (trimmed.startsWith("~")) {
     const expanded = expandHomePrefix(trimmed, {
-      home: resolveRequiredHomeDir(process.env, os.homedir),
-      env: process.env,
-      homedir: os.homedir,
+      home: resolveRequiredHomeDir(env, homedir),
+      env,
+      homedir,
     });
     return path.resolve(expanded);
   }
@@ -296,7 +300,7 @@ export function resolveConfigDir(
 ): string {
   const override = env.OPENCLAW_STATE_DIR?.trim() || env.CLAWDBOT_STATE_DIR?.trim();
   if (override) {
-    return resolveUserPath(override);
+    return resolveUserPath(override, env, homedir);
   }
   const newDir = path.join(resolveRequiredHomeDir(env, homedir), ".openclaw");
   try {


### PR DESCRIPTION
Fixes Windows CI failure in PR #44046.

The test "resolves source roots from an explicit env override" was using hardcoded Unix paths (`/tmp/openclaw-home`) which don't work on Windows where `path.resolve` adds a drive letter prefix (`C:\\tmp\\openclaw-home`).

This fix uses `path.resolve` for both the env values and the expected values, ensuring platform-agnostic path handling.

Error before:
```
- Expected: "\\tmp\\openclaw-home\\state\\extensions"
+ Received: "C:\\tmp\\openclaw-home\\state\\extensions"
```

cc PR #44046