### PR TITLE
fix(session-memory): use session createdAt for memory filename date

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -226,16 +226,19 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
-    // Get today's date for filename
-    const now = new Date(event.timestamp);
-    const dateStr = now.toISOString().split("T")[0]; // YYYY-MM-DD
-
     // Generate descriptive slug from session using LLM
     // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
     const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {}) as Record<
       string,
       unknown
     >;
+
+    // Use session's createdAt for the filename date, not the /new command timestamp.
+    // This ensures the memory file reflects when the session actually started,
+    // not when the user triggered /new (which could be on a different day).
+    const sessionCreatedAt = sessionEntry.createdAt as number | undefined;
+    const now = sessionCreatedAt ? new Date(sessionCreatedAt) : new Date(event.timestamp);
+    const dateStr = now.toISOString().split("T")[0]; // YYYY-MM-DD
     const currentSessionId = sessionEntry.sessionId as string;
     let currentSessionFile = (sessionEntry.sessionFile as string) || undefined;
 


### PR DESCRIPTION
## Problem

The session-memory hook was using `event.timestamp` (when `/new` or `/reset` was triggered) for the memory file's date. This caused files to be named after the command date rather than the session's actual creation date.

For example, if a session started on March 11th and the user ran `/new` on March 12th, the memory file would be named `2026-03-12-*.md` instead of `2026-03-11-*.md`.

## Solution

Now uses `sessionEntry.createdAt` when available, falling back to `event.timestamp` only if `createdAt` is not present.

## Changes

- Moved the date calculation to after `sessionEntry` is resolved
- Added logic to prefer `sessionEntry.createdAt` over `event.timestamp`
- Added clear comment explaining the rationale

## Testing

Manually verified that `previousSessionEntry` contains `createdAt` field in the session entry structure (confirmed via code analysis in `compact-D3emcZgv.js` line 21295-21296).