### PR TITLE
Fix Telegram sessions_send announce delivery

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -31,6 +31,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 import "./test-helpers/fast-core-tools.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 
 const waitForCalls = async (getCount: () => number, count: number, timeoutMs = 2000) => {
@@ -628,7 +629,7 @@ describe("sessions tools", () => {
     );
     expect(messageContextCalls).toHaveLength(2);
     for (const call of messageContextCalls) {
-      expect((call.params as { channel?: string }).channel).toBe("discord");
+      expect((call.params as { channel?: string }).channel).toBe(INTERNAL_MESSAGE_CHANNEL);
     }
     expect(
       agentCalls.some(
@@ -818,7 +819,7 @@ describe("sessions tools", () => {
     );
     expect(messageContextCalls).toHaveLength(1);
     expect((messageContextCalls[0]?.params as { channel?: string } | undefined)?.channel).toBe(
-      "discord",
+      INTERNAL_MESSAGE_CHANNEL,
     );
 
     const replySteps = calls.filter(
@@ -837,7 +838,7 @@ describe("sessions tools", () => {
     });
   });
 
-  it("sessions_send falls back to round-one reply and preserves Telegram threadId on announce skip", async () => {
+  it("sessions_send falls back to round-one reply and preserves Telegram threadId when announce reply is empty", async () => {
     const requesterKey = "agent:main:telegram:group:-1001879711349";
     const targetKey = "agent:main:telegram:direct:3718260:thread:3718260:1147978";
     let agentCallCount = 0;
@@ -866,7 +867,7 @@ describe("sessions tools", () => {
         };
         let reply = "round-one reply";
         if (params.extraSystemPrompt?.includes("Agent-to-agent announce step")) {
-          reply = "ANNOUNCE_SKIP";
+          reply = "";
         }
         replyByRunId.set(runId, reply);
         return { runId, status: "accepted", acceptedAt: 3000 + agentCallCount };
@@ -944,6 +945,99 @@ describe("sessions tools", () => {
       threadId: "3718260:1147978",
       message: "round-one reply",
     });
+  });
+
+  it("sessions_send suppresses announce delivery for explicit ANNOUNCE_SKIP", async () => {
+    const requesterKey = "agent:main:telegram:group:-1001879711349";
+    const targetKey = "agent:main:telegram:direct:3718260:thread:3718260:1147978";
+    let agentCallCount = 0;
+    let lastWaitedRunId: string | undefined;
+    const replyByRunId = new Map<string, string>();
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        const runId = `run-${agentCallCount}`;
+        const params = request.params as { extraSystemPrompt?: string };
+        const reply = params.extraSystemPrompt?.includes("Agent-to-agent announce step")
+          ? "ANNOUNCE_SKIP"
+          : "round-one reply";
+        replyByRunId.set(runId, reply);
+        return { runId, status: "accepted", acceptedAt: 4000 + agentCallCount };
+      }
+      if (request.method === "agent.wait") {
+        const params = request.params as { runId?: string } | undefined;
+        lastWaitedRunId = params?.runId;
+        return { runId: params?.runId ?? "run-1", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: targetKey,
+              deliveryContext: {
+                channel: "telegram",
+                to: "telegram:3718260",
+                accountId: "default",
+              },
+              lastThreadId: "3718260:1147978",
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        throw new Error("send should not be called for ANNOUNCE_SKIP");
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      agentChannel: "telegram",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const waited = await tool.execute("call-telegram-sessions-send-skip", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+    expect(waited.details).toMatchObject({
+      status: "ok",
+      reply: "round-one reply",
+      delivery: { status: "pending", mode: "announce" },
+    });
+
+    await vi.waitFor(
+      () => {
+        const agentCalls = callGatewayMock.mock.calls.filter(
+          (call) => (call[0] as { method?: string }).method === "agent",
+        );
+        expect(agentCalls.length).toBeGreaterThanOrEqual(2);
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+
+    const sendCalls = callGatewayMock.mock.calls.filter(
+      (call) => (call[0] as { method?: string }).method === "send",
+    );
+    expect(sendCalls).toHaveLength(0);
   });
 
   it("subagents lists active and recent runs", async () => {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -616,9 +616,19 @@ describe("sessions tools", () => {
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",
-        channel: "webchat",
         inputProvenance: { kind: "inter_session" },
       });
+    }
+    const messageContextCalls = agentCalls.filter(
+      (call) =>
+        typeof (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt === "string" &&
+        (call.params as { extraSystemPrompt?: string }).extraSystemPrompt?.includes(
+          "Agent-to-agent message context",
+        ),
+    );
+    expect(messageContextCalls).toHaveLength(2);
+    for (const call of messageContextCalls) {
+      expect((call.params as { channel?: string }).channel).toBe("discord");
     }
     expect(
       agentCalls.some(
@@ -796,10 +806,20 @@ describe("sessions tools", () => {
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",
-        channel: "webchat",
         inputProvenance: { kind: "inter_session" },
       });
     }
+    const messageContextCalls = agentCalls.filter(
+      (call) =>
+        typeof (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt === "string" &&
+        (call.params as { extraSystemPrompt?: string }).extraSystemPrompt?.includes(
+          "Agent-to-agent message context",
+        ),
+    );
+    expect(messageContextCalls).toHaveLength(1);
+    expect((messageContextCalls[0]?.params as { channel?: string } | undefined)?.channel).toBe(
+      "discord",
+    );
 
     const replySteps = calls.filter(
       (call) =>
@@ -814,6 +834,115 @@ describe("sessions tools", () => {
       to: "channel:target",
       channel: "discord",
       message: "announce now",
+    });
+  });
+
+  it("sessions_send falls back to round-one reply and preserves Telegram threadId on announce skip", async () => {
+    const requesterKey = "agent:main:telegram:group:-1001879711349";
+    const targetKey = "agent:main:telegram:direct:3718260:thread:3718260:1147978";
+    let agentCallCount = 0;
+    let lastWaitedRunId: string | undefined;
+    const replyByRunId = new Map<string, string>();
+    let sendParams:
+      | {
+          to?: string;
+          channel?: string;
+          message?: string;
+          accountId?: string;
+          threadId?: string;
+        }
+      | undefined;
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        const runId = `run-${agentCallCount}`;
+        const params = request.params as {
+          message?: string;
+          extraSystemPrompt?: string;
+          sessionKey?: string;
+          channel?: string;
+        };
+        let reply = "round-one reply";
+        if (params.extraSystemPrompt?.includes("Agent-to-agent announce step")) {
+          reply = "ANNOUNCE_SKIP";
+        }
+        replyByRunId.set(runId, reply);
+        return { runId, status: "accepted", acceptedAt: 3000 + agentCallCount };
+      }
+      if (request.method === "agent.wait") {
+        const params = request.params as { runId?: string } | undefined;
+        lastWaitedRunId = params?.runId;
+        return { runId: params?.runId ?? "run-1", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: targetKey,
+              deliveryContext: {
+                channel: "telegram",
+                to: "telegram:3718260",
+                accountId: "default",
+              },
+              lastThreadId: "3718260:1147978",
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        sendParams = request.params as typeof sendParams;
+        return { messageId: "m-telegram" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      agentChannel: "telegram",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const waited = await tool.execute("call-telegram-sessions-send", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+    expect(waited.details).toMatchObject({
+      status: "ok",
+      reply: "round-one reply",
+      delivery: { status: "pending", mode: "announce" },
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(sendParams).toBeDefined();
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+
+    expect(sendParams).toMatchObject({
+      to: "telegram:3718260",
+      channel: "telegram",
+      accountId: "default",
+      threadId: "3718260:1147978",
+      message: "round-one reply",
     });
   });
 

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -1,4 +1,5 @@
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import { extractDeliveryInfo } from "../../config/sessions/delivery-info.js";
 import { callGateway } from "../../gateway/call.js";
 import { SessionListRow } from "./sessions-helpers.js";
 import type { AnnounceTarget } from "./sessions-send-helpers.js";
@@ -38,17 +39,25 @@ export async function resolveAnnounceTarget(params: {
       match?.deliveryContext && typeof match.deliveryContext === "object"
         ? (match.deliveryContext as Record<string, unknown>)
         : undefined;
+    const extracted = extractDeliveryInfo(params.sessionKey);
     const channel =
       (typeof deliveryContext?.channel === "string" ? deliveryContext.channel : undefined) ??
-      (typeof match?.lastChannel === "string" ? match.lastChannel : undefined);
+      (typeof match?.lastChannel === "string" ? match.lastChannel : undefined) ??
+      extracted.deliveryContext?.channel;
     const to =
       (typeof deliveryContext?.to === "string" ? deliveryContext.to : undefined) ??
-      (typeof match?.lastTo === "string" ? match.lastTo : undefined);
+      (typeof match?.lastTo === "string" ? match.lastTo : undefined) ??
+      extracted.deliveryContext?.to;
     const accountId =
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
-      (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined);
+      (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined) ??
+      extracted.deliveryContext?.accountId;
+    const threadId =
+      (typeof deliveryContext?.threadId === "string" ? deliveryContext.threadId : undefined) ??
+      (typeof match?.lastThreadId === "string" ? match.lastThreadId : undefined) ??
+      extracted.threadId;
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -120,15 +120,18 @@ export async function runSessionsSendA2AFlow(params: {
     });
     const effectiveAnnounceReply = (() => {
       const trimmed = announceReply?.trim() ?? "";
-      if (trimmed && !isAnnounceSkip(trimmed)) {
+      if (!trimmed) {
+        const roundOne = primaryReply?.trim() ?? "";
+        if (roundOne) {
+          return roundOne;
+        }
+        const latest = latestReply?.trim() ?? "";
+        return latest;
+      }
+      if (!isAnnounceSkip(trimmed)) {
         return trimmed;
       }
-      const roundOne = primaryReply?.trim() ?? "";
-      if (roundOne) {
-        return roundOne;
-      }
-      const latest = latestReply?.trim() ?? "";
-      return latest;
+      return "";
     })();
     if (announceTarget && effectiveAnnounceReply) {
       try {

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -118,15 +118,28 @@ export async function runSessionsSendA2AFlow(params: {
       sourceChannel: params.requesterChannel,
       sourceTool: "sessions_send",
     });
-    if (announceTarget && announceReply && announceReply.trim() && !isAnnounceSkip(announceReply)) {
+    const effectiveAnnounceReply = (() => {
+      const trimmed = announceReply?.trim() ?? "";
+      if (trimmed && !isAnnounceSkip(trimmed)) {
+        return trimmed;
+      }
+      const roundOne = primaryReply?.trim() ?? "";
+      if (roundOne) {
+        return roundOne;
+      }
+      const latest = latestReply?.trim() ?? "";
+      return latest;
+    })();
+    if (announceTarget && effectiveAnnounceReply) {
       try {
         await callGateway({
           method: "send",
           params: {
             to: announceTarget.to,
-            message: announceReply.trim(),
+            message: effectiveAnnounceReply,
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
+            threadId: announceTarget.threadId,
             idempotencyKey: crypto.randomUUID(),
           },
           timeoutMs: 10_000,
@@ -136,6 +149,8 @@ export async function runSessionsSendA2AFlow(params: {
           runId: runContextId,
           channel: announceTarget.channel,
           to: announceTarget.to,
+          accountId: announceTarget.accountId,
+          threadId: announceTarget.threadId,
           error: formatErrorMessage(err),
         });
       }

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -222,7 +222,7 @@ export function createSessionsSendTool(opts?: {
         sessionKey: resolvedKey,
         idempotencyKey,
         deliver: false,
-        channel: opts?.agentChannel ?? INTERNAL_MESSAGE_CHANNEL,
+        channel: INTERNAL_MESSAGE_CHANNEL,
         lane: AGENT_LANE_NESTED,
         extraSystemPrompt: agentMessageContext,
         inputProvenance: {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -222,7 +222,7 @@ export function createSessionsSendTool(opts?: {
         sessionKey: resolvedKey,
         idempotencyKey,
         deliver: false,
-        channel: INTERNAL_MESSAGE_CHANNEL,
+        channel: opts?.agentChannel ?? INTERNAL_MESSAGE_CHANNEL,
         lane: AGENT_LANE_NESTED,
         extraSystemPrompt: agentMessageContext,
         inputProvenance: {

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -254,6 +254,33 @@ describe("resolveAnnounceTarget", () => {
     expect(first).toBeDefined();
     expect(first?.method).toBe("sessions.list");
   });
+
+  it("preserves Telegram direct threadId from session lookup", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:telegram:direct:3718260:thread:3718260:1147978",
+          deliveryContext: {
+            channel: "telegram",
+            to: "telegram:3718260",
+            accountId: "default",
+          },
+          lastThreadId: "3718260:1147978",
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:telegram:direct:3718260:thread:3718260:1147978",
+      displayKey: "agent:main:telegram:direct:3718260:thread:3718260:1147978",
+    });
+    expect(target).toEqual({
+      channel: "telegram",
+      to: "telegram:3718260",
+      accountId: "default",
+      threadId: "3718260:1147978",
+    });
+  });
 });
 
 describe("sessions_list gating", () => {


### PR DESCRIPTION
## Summary

Fix `sessions_send` Telegram announce delivery regressions for direct/threaded targets.

This PR addresses a cluster of issues in the same delivery chain:

- preserve Telegram `threadId` during announce-target resolution
- pass `threadId` through to the final gateway `send`
- stop forcing Telegram-originated `sessions_send` turns onto `webchat`
- when the nested announce step returns `ANNOUNCE_SKIP`, fall back to the target session's actual reply for the visible external delivery

## Why

In a real repro (`Telegram group session -> sessions_send -> Telegram DM General topic`), the delivery path could fail in multiple ways:

1. target resolution kept `channel/to/accountId` but lost the DM topic `threadId`
2. the initial injected nested turn was always stamped with `INTERNAL_MESSAGE_CHANNEL` (`webchat`), which caused routing confusion in Telegram-bound sessions
3. the nested announce step often returned `ANNOUNCE_SKIP`, which suppressed the visible external send entirely even though the target session had already produced the real reply text

These failures could combine into "reply exists in history but nothing visible is delivered" behavior.

## Changes

- `src/agents/tools/sessions-send-tool.ts`
  - use `opts?.agentChannel ?? INTERNAL_MESSAGE_CHANNEL` for the injected nested turn
- `src/agents/tools/sessions-announce-target.ts`
  - hydrate `threadId` alongside `channel/to/accountId` from session lookup / extracted delivery info
- `src/agents/tools/sessions-send-tool.a2a.ts`
  - include `threadId` in final `send`
  - if announce reply is skipped, fall back to `primaryReply` / `latestReply` for visible external delivery
- tests
  - cover Telegram direct-thread announce target resolution
  - cover `ANNOUNCE_SKIP` fallback sending the round-one reply to a Telegram threaded target
  - adjust `sessions_send` expectations so the initial message-context turn preserves the originating external channel

## Repro covered

- Telegram group session triggers `sessions_send` into a Telegram DM topic session
- target session replies normally
- announce step returns `ANNOUNCE_SKIP`
- visible Telegram delivery now uses the target reply with preserved `threadId`

## Tests

```bash
corepack pnpm -s vitest run src/agents/tools/sessions.test.ts src/agents/openclaw-tools.sessions.test.ts
```

## Related issues

- Closes #43848
- Related: #43318
- Related: #34308