### PR TITLE
Add personal assistant product tools plugin

### DIFF
--- a/extensions/personal-assistant-channel/index.ts
+++ b/extensions/personal-assistant-channel/index.ts
@@ -1,0 +1,8 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
+import { createChannelTool } from "./src/create-channel-tool.js";
+import { getWeatherTool } from "./src/get-weather-tool.js";
+
+export default function register(api: OpenClawPluginApi) {
+  api.registerTool((ctx) => createChannelTool(api, ctx), { optional: false });
+  api.registerTool((ctx) => getWeatherTool(api, ctx), { optional: false });
+}

--- a/extensions/personal-assistant-channel/openclaw.plugin.json
+++ b/extensions/personal-assistant-channel/openclaw.plugin.json
@@ -1,0 +1,25 @@
+{
+  "id": "personal-assistant-channel",
+  "name": "Personal Assistant Product",
+  "description": "Product tools and skills for the personal assistant app.",
+  "skills": ["./skills"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "assistantApiBaseUrl": {
+        "type": "string",
+        "minLength": 1
+      },
+      "assistantApiToken": {
+        "type": "string",
+        "minLength": 1
+      },
+      "requestTimeoutMs": {
+        "type": "integer",
+        "minimum": 1000
+      }
+    },
+    "required": ["assistantApiBaseUrl", "assistantApiToken"]
+  }
+}

--- a/extensions/personal-assistant-channel/skills/personal-assistant-product/SKILL.md
+++ b/extensions/personal-assistant-channel/skills/personal-assistant-product/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: personal-assistant-product
+description: "Use the personal assistant product tools for topic channels and short-term weather. Use when: the user asks to create a topic/channel, or asks for today's/tomorrow's weather. NOT for: historical climate analysis or severe weather alerts."
+metadata: { "openclaw": { "always": true } }
+---
+
+# Personal Assistant Product Tools
+
+Use these tools when the user is asking for product-native actions.
+
+## `create_channel`
+
+- Use this when the user explicitly asks to create a new topic or channel.
+- Keep the channel name short and literal.
+- If the tool reports that the channel already exists, tell the user you switched to it.
+- Do not claim success unless the tool succeeds.
+
+## `get_weather`
+
+- Use this for today's or tomorrow's weather.
+- If the user already gave a city, pass it as `location`.
+- If the user did not give a city, omit `location` so the tool can try the app's current location.
+- If the tool says location is unavailable, ask the user to allow location permission or tell you which city to check.
+- Do not use this tool for severe weather alerts, historical data, or climate analysis.

--- a/extensions/personal-assistant-channel/src/create-channel-tool.test.ts
+++ b/extensions/personal-assistant-channel/src/create-channel-tool.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChannelTool } from "./create-channel-tool.js";
+
+function fakeApi(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "personal-assistant-channel",
+    name: "personal-assistant-channel",
+    source: "test",
+    config: {},
+    pluginConfig: {
+      assistantApiBaseUrl: "http://127.0.0.1:4000",
+      assistantApiToken: "test-token",
+      ...overrides.pluginConfig,
+    },
+    runtime: { version: "test" },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    registerTool() {},
+    ...overrides,
+  };
+}
+
+describe("create_channel tool", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a channel through the assistant api", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        created: true,
+        mode: "created",
+        channel: { id: "channel-1", name: "旅行", primary_thread_id: "thread-1" },
+      }),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createChannelTool(fakeApi(), { sessionKey: "agent:test:session-1" });
+    const result = await tool.execute("tool-1", { name: "旅行" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:4000/api/internal/openclaw/channels",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        }),
+      }),
+    );
+    expect(result.content[0]?.text).toContain("旅行");
+    expect(result.details).toMatchObject({
+      created: true,
+      mode: "created",
+      channel: { id: "channel-1", name: "旅行" },
+    });
+  });
+
+  it("requires an active session key", async () => {
+    const tool = createChannelTool(fakeApi(), {});
+    await expect(tool.execute("tool-1", { name: "旅行" })).rejects.toThrow(/active session/i);
+  });
+
+  it("surfaces assistant api errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: "not_found" }),
+      }),
+    );
+
+    const tool = createChannelTool(fakeApi(), { sessionKey: "agent:test:session-1" });
+    await expect(tool.execute("tool-1", { name: "旅行" })).rejects.toThrow(/not_found/i);
+  });
+});

--- a/extensions/personal-assistant-channel/src/create-channel-tool.ts
+++ b/extensions/personal-assistant-channel/src/create-channel-tool.ts
@@ -1,0 +1,137 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
+import {
+  normalizeText,
+  readPluginConfig,
+  resolveTimeoutSignal,
+  trimTrailingSlash,
+} from "./plugin-config.js";
+
+type ChannelResponse = {
+  channel?: {
+    id?: string;
+    kind?: string;
+    name?: string;
+    primary_thread_id?: string;
+  };
+  created?: boolean;
+  mode?: "created" | "existing" | "current";
+};
+
+type CreateChannelToolContext = {
+  sessionKey?: string;
+};
+
+export function createChannelTool(api: OpenClawPluginApi, ctx: CreateChannelToolContext) {
+  return {
+    name: "create_channel",
+    label: "Create Channel",
+    description:
+      "Create or reuse a named topic channel for the current user and switch the app to it.",
+    parameters: Type.Object({
+      name: Type.String({
+        description: "Short topic name for the new channel.",
+        minLength: 1,
+        maxLength: 40,
+      }),
+      icon: Type.Optional(
+        Type.String({
+          description: "Optional icon or emoji for the topic channel.",
+          minLength: 1,
+          maxLength: 8,
+        }),
+      ),
+    }),
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const sessionKey = normalizeText(ctx.sessionKey);
+
+      if (!sessionKey) {
+        throw new Error("create_channel requires an active session");
+      }
+
+      const name = normalizeText(params.name);
+
+      if (!name) {
+        throw new Error("name required");
+      }
+
+      const icon = normalizeText(params.icon);
+      const pluginConfig = readPluginConfig(api);
+
+      if (!pluginConfig.assistantApiBaseUrl) {
+        throw new Error("personal-assistant-channel missing assistantApiBaseUrl");
+      }
+
+      if (!pluginConfig.assistantApiToken) {
+        throw new Error("personal-assistant-channel missing assistantApiToken");
+      }
+
+      const timeoutMs = pluginConfig.requestTimeoutMs ?? 10_000;
+      const response = await requestCreateChannel({
+        assistantApiBaseUrl: pluginConfig.assistantApiBaseUrl,
+        assistantApiToken: pluginConfig.assistantApiToken,
+        sessionKey,
+        name,
+        icon,
+        timeoutMs,
+      });
+
+      const channelName = response.channel?.name ?? name;
+      const text =
+        response.mode === "existing" || response.mode === "current"
+          ? `已切换到主题「${channelName}」。`
+          : `已创建主题「${channelName}」，并切换过去。`;
+
+      return {
+        content: [{ type: "text", text }],
+        details: {
+          channel: response.channel,
+          created: response.created ?? false,
+          mode: response.mode ?? (response.created ? "created" : "existing"),
+        },
+      };
+    },
+  };
+}
+
+async function requestCreateChannel(params: {
+  assistantApiBaseUrl: string;
+  assistantApiToken: string;
+  sessionKey: string;
+  name: string;
+  icon?: string;
+  timeoutMs: number;
+}): Promise<ChannelResponse> {
+  const response = await fetch(
+    `${trimTrailingSlash(params.assistantApiBaseUrl)}/api/internal/openclaw/channels`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${params.assistantApiToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        session_key: params.sessionKey,
+        name: params.name,
+        icon: params.icon,
+      }),
+      signal: resolveTimeoutSignal(params.timeoutMs),
+    },
+  );
+
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+
+  if (!response.ok) {
+    const message =
+      typeof payload.details === "string"
+        ? payload.details
+        : typeof payload.error === "string"
+          ? payload.error
+          : `assistant api responded ${response.status}`;
+
+    throw new Error(message);
+  }
+
+  return payload as ChannelResponse;
+}

--- a/extensions/personal-assistant-channel/src/get-weather-tool.test.ts
+++ b/extensions/personal-assistant-channel/src/get-weather-tool.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { getWeatherTool } from "./get-weather-tool.js";
+
+describe("get_weather tool", () => {
+  const sessionKey = "agent:user-1:web:direct:session-1";
+
+  it("returns weather summary when the assistant API succeeds", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        summary: "明天上海晴间多云，16.1°C 到 24.3°C，降水概率 5%。",
+        location: { name: "上海" },
+        forecast: { day: "tomorrow", weather_text: "晴间多云" },
+      }),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getWeatherTool(
+      {
+        pluginConfig: {
+          assistantApiBaseUrl: "http://127.0.0.1:4000",
+          assistantApiToken: "internal-token",
+        },
+        registerTool() {},
+      } as never,
+      { sessionKey },
+    );
+
+    const result = await tool.execute("tool-1", { day: "tomorrow", location: "上海" });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(result.content).toEqual([
+      { type: "text", text: "明天上海晴间多云，16.1°C 到 24.3°C，降水概率 5%。" },
+    ]);
+  });
+
+  it("returns a follow-up instruction when location is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          error: "location_unavailable",
+          reason: "permission_denied",
+        }),
+      }),
+    );
+
+    const tool = getWeatherTool(
+      {
+        pluginConfig: {
+          assistantApiBaseUrl: "http://127.0.0.1:4000",
+          assistantApiToken: "internal-token",
+        },
+        registerTool() {},
+      } as never,
+      { sessionKey },
+    );
+
+    const result = await tool.execute("tool-1", { day: "today" });
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "当前没有可用位置信息。请让用户授权当前位置，或直接告诉你想查哪个城市。",
+      },
+    ]);
+    expect(result.details).toEqual({
+      needsUserLocation: true,
+      reason: "permission_denied",
+    });
+  });
+});

--- a/extensions/personal-assistant-channel/src/get-weather-tool.ts
+++ b/extensions/personal-assistant-channel/src/get-weather-tool.ts
@@ -1,0 +1,186 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
+import {
+  normalizeText,
+  readPluginConfig,
+  resolveTimeoutSignal,
+  trimTrailingSlash,
+} from "./plugin-config.js";
+
+type GetWeatherToolContext = {
+  sessionKey?: string;
+};
+
+type WeatherResponse = {
+  error?: "location_not_found" | "location_unavailable";
+  reason?: string;
+  summary?: string;
+  location?: {
+    latitude?: number;
+    longitude?: number;
+    name?: string;
+    timezone?: string;
+  };
+  forecast?: {
+    date?: string;
+    day?: "today" | "tomorrow";
+    precipitation_probability_max?: number;
+    temperature_max_c?: number;
+    temperature_min_c?: number;
+    weather_code?: number;
+    weather_text?: string;
+  };
+};
+
+export function getWeatherTool(api: OpenClawPluginApi, ctx: GetWeatherToolContext) {
+  return {
+    name: "get_weather",
+    label: "Get Weather",
+    description:
+      "Get today's or tomorrow's weather for the current user, using the provided city or the app's current location when available.",
+    parameters: Type.Object({
+      day: Type.Optional(
+        Type.Union([Type.Literal("today"), Type.Literal("tomorrow")], {
+          description: "Which day to check. Defaults to today.",
+        }),
+      ),
+      location: Type.Optional(
+        Type.String({
+          description: "Optional city or location name. Omit it to use the app's current location.",
+          minLength: 1,
+          maxLength: 80,
+        }),
+      ),
+    }),
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const sessionKey = normalizeText(ctx.sessionKey);
+
+      if (!sessionKey) {
+        throw new Error("get_weather requires an active session");
+      }
+
+      const day = normalizeDay(params.day) ?? "today";
+      const location = normalizeText(params.location);
+      const pluginConfig = readPluginConfig(api);
+
+      if (!pluginConfig.assistantApiBaseUrl) {
+        throw new Error("personal-assistant-channel missing assistantApiBaseUrl");
+      }
+
+      if (!pluginConfig.assistantApiToken) {
+        throw new Error("personal-assistant-channel missing assistantApiToken");
+      }
+
+      const timeoutMs = pluginConfig.requestTimeoutMs ?? 30_000;
+      const response = await requestWeather({
+        assistantApiBaseUrl: pluginConfig.assistantApiBaseUrl,
+        assistantApiToken: pluginConfig.assistantApiToken,
+        day,
+        location,
+        sessionKey,
+        timeoutMs,
+      });
+
+      if (response.error === "location_unavailable") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "当前没有可用位置信息。请让用户授权当前位置，或直接告诉你想查哪个城市。",
+            },
+          ],
+          details: {
+            needsUserLocation: true,
+            reason: response.reason ?? null,
+          },
+        };
+      }
+
+      if (response.error === "location_not_found") {
+        const locationHint = location ? `「${location}」` : "这个地点";
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `没有找到${locationHint}。请让用户换一个更明确的城市或地区名称。`,
+            },
+          ],
+          details: {
+            locationNotFound: true,
+          },
+        };
+      }
+
+      if (!response.summary) {
+        throw new Error("weather response missing summary");
+      }
+
+      return {
+        content: [{ type: "text", text: response.summary }],
+        details: response,
+      };
+    },
+  };
+}
+
+async function requestWeather(params: {
+  assistantApiBaseUrl: string;
+  assistantApiToken: string;
+  day: "today" | "tomorrow";
+  location?: string;
+  sessionKey: string;
+  timeoutMs: number;
+}): Promise<WeatherResponse> {
+  const response = await fetch(
+    `${trimTrailingSlash(params.assistantApiBaseUrl)}/api/internal/openclaw/weather`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${params.assistantApiToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        session_key: params.sessionKey,
+        day: params.day,
+        location: params.location,
+      }),
+      signal: resolveTimeoutSignal(params.timeoutMs),
+    },
+  );
+
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+
+  if (response.status === 404 && payload.error === "location_not_found") {
+    return { error: "location_not_found" };
+  }
+
+  if (response.status === 409 && payload.error === "location_unavailable") {
+    return {
+      error: "location_unavailable",
+      reason: typeof payload.reason === "string" ? payload.reason : undefined,
+    };
+  }
+
+  if (!response.ok) {
+    const message =
+      typeof payload.details === "string"
+        ? payload.details
+        : typeof payload.error === "string"
+          ? payload.error
+          : `assistant api responded ${response.status}`;
+
+    throw new Error(message);
+  }
+
+  return payload as WeatherResponse;
+}
+
+function normalizeDay(value: unknown): "today" | "tomorrow" | undefined {
+  if (value === "today" || value === "tomorrow") {
+    return value;
+  }
+
+  return undefined;
+}

--- a/extensions/personal-assistant-channel/src/plugin-config.ts
+++ b/extensions/personal-assistant-channel/src/plugin-config.ts
@@ -1,0 +1,41 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
+
+export type PersonalAssistantPluginConfig = {
+  assistantApiBaseUrl?: string;
+  assistantApiToken?: string;
+  requestTimeoutMs?: number;
+};
+
+export function readPluginConfig(api: OpenClawPluginApi): PersonalAssistantPluginConfig {
+  const config = (api.pluginConfig ?? {}) as PersonalAssistantPluginConfig;
+
+  return {
+    assistantApiBaseUrl: normalizeText(config.assistantApiBaseUrl),
+    assistantApiToken: normalizeText(config.assistantApiToken),
+    requestTimeoutMs:
+      typeof config.requestTimeoutMs === "number" && config.requestTimeoutMs >= 1_000
+        ? config.requestTimeoutMs
+        : undefined,
+  };
+}
+
+export function normalizeText(value: unknown) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+export function trimTrailingSlash(value: string) {
+  return value.replace(/\/+$/u, "");
+}
+
+export function resolveTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
+  if (typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function") {
+    return AbortSignal.timeout(timeoutMs);
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- add a personal assistant plugin with create_channel and get_weather tools
- include a companion skill pack that teaches OpenClaw when to use the product tools
- cover both tools with focused Vitest cases

## Verification
- pnpm exec vitest run extensions/personal-assistant-channel/src/create-channel-tool.test.ts extensions/personal-assistant-channel/src/get-weather-tool.test.ts