### PR TITLE
fix(hooks): use session creation date for memory filename

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -572,4 +572,130 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("user: Only message 1");
     expect(memoryContent).toContain("assistant: Only message 2");
   });
+
+  describe("session creation date for memory filename", () => {
+    it("uses session file timestamp for date when session header is present", async () => {
+      // Session created on 2026-03-10 but /new triggered on 2026-03-12
+      const sessionHeader = JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "test-session-id",
+        timestamp: "2026-03-10T15:30:00.000Z",
+        cwd: "/test",
+      });
+      const sessionContent = createMockSessionContent([
+        { role: "user", content: "Hello on March 10" },
+        { role: "assistant", content: "Hi there" },
+      ]);
+      const fullContent = sessionHeader + "\n" + sessionContent;
+
+      const { files } = await runNewWithPreviousSession({ sessionContent: fullContent });
+
+      // Filename should use the session creation date (2026-03-10), not /new date
+      expect(files.length).toBe(1);
+      expect(files[0]).toMatch(/^2026-03-10-/);
+    });
+
+    it("falls back to event timestamp when session file has no session header", async () => {
+      // No session header, just messages
+      const sessionContent = createMockSessionContent([
+        { role: "user", content: "Hello without header" },
+        { role: "assistant", content: "Hi there" },
+      ]);
+
+      const { files } = await runNewWithPreviousSession({ sessionContent });
+
+      // Filename should use today's date (event timestamp) as fallback
+      expect(files.length).toBe(1);
+      // The date will be whatever "now" is when the test runs
+      expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}-/);
+    });
+
+    it("falls back to event timestamp when no session file is available", async () => {
+      const tempDir = await createCaseWorkspace("workspace");
+
+      const event = createHookEvent("command", "new", "agent:main:main", {
+        cfg: {
+          agents: { defaults: { workspace: tempDir } },
+        } satisfies OpenClawConfig,
+        // No previousSessionEntry, no sessionFile
+        previousSessionEntry: {
+          sessionId: "test-123",
+        },
+      });
+
+      await handler(event);
+
+      const memoryDir = path.join(tempDir, "memory");
+      const files = await fs.readdir(memoryDir);
+
+      // Should still create a memory file using event timestamp
+      expect(files.length).toBe(1);
+      expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}-\d{4}\.md$/);
+    });
+
+    it("uses session timestamp even when /new is triggered days later", async () => {
+      // Simulate: session created on March 1, /new triggered on March 12
+      const sessionHeader = JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "old-session-id",
+        timestamp: "2026-03-01T08:00:00.000Z",
+        cwd: "/test",
+      });
+      const sessionContent = createMockSessionContent([
+        { role: "user", content: "Session from March 1" },
+        { role: "assistant", content: "Recorded" },
+      ]);
+      const fullContent = sessionHeader + "\n" + sessionContent;
+
+      const { files, memoryContent } = await runNewWithPreviousSession({
+        sessionContent: fullContent,
+      });
+
+      // Filename should be dated March 1, not the current date
+      expect(files.length).toBe(1);
+      expect(files[0]).toMatch(/^2026-03-01-/);
+      // The header in the memory file should also show March 1
+      expect(memoryContent).toContain("# Session: 2026-03-01");
+    });
+
+    it("ignores malformed session header and falls back to event timestamp", async () => {
+      // Invalid JSON as first line
+      const malformedHeader = "this is not valid json";
+      const sessionContent = createMockSessionContent([
+        { role: "user", content: "Hello with malformed header" },
+        { role: "assistant", content: "Hi there" },
+      ]);
+      const fullContent = malformedHeader + "\n" + sessionContent;
+
+      const { files } = await runNewWithPreviousSession({ sessionContent: fullContent });
+
+      // Should fallback to event timestamp
+      expect(files.length).toBe(1);
+      expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}-/);
+    });
+
+    it("ignores session header without timestamp field", async () => {
+      // Session header exists but missing timestamp
+      const sessionHeader = JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "no-timestamp-session",
+        // No timestamp field
+        cwd: "/test",
+      });
+      const sessionContent = createMockSessionContent([
+        { role: "user", content: "Hello without timestamp" },
+        { role: "assistant", content: "Hi there" },
+      ]);
+      const fullContent = sessionHeader + "\n" + sessionContent;
+
+      const { files } = await runNewWithPreviousSession({ sessionContent: fullContent });
+
+      // Should fallback to event timestamp
+      expect(files.length).toBe(1);
+      expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}-/);
+    });
+  });
 });

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -139,6 +139,27 @@ function stripResetSuffix(fileName: string): string {
   return resetIndex === -1 ? fileName : fileName.slice(0, resetIndex);
 }
 
+/**
+ * Extract session creation timestamp from the first line of a session file.
+ * Returns null if the file cannot be read or parsed.
+ */
+async function getSessionCreatedAt(sessionFilePath: string): Promise<string | null> {
+  try {
+    const content = await fs.readFile(sessionFilePath, "utf-8");
+    const firstLine = content.split("\n")[0];
+    if (!firstLine) {
+      return null;
+    }
+    const entry = JSON.parse(firstLine);
+    if (entry.type === "session" && typeof entry.timestamp === "string") {
+      return entry.timestamp;
+    }
+  } catch {
+    // Ignore read/parse errors
+  }
+  return null;
+}
+
 async function findPreviousSessionFile(params: {
   sessionsDir: string;
   currentSessionFile?: string;
@@ -226,10 +247,6 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
-    // Get today's date for filename
-    const now = new Date(event.timestamp);
-    const dateStr = now.toISOString().split("T")[0]; // YYYY-MM-DD
-
     // Generate descriptive slug from session using LLM
     // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
     const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {}) as Record<
@@ -269,6 +286,20 @@ const saveSessionToMemory: HookHandler = async (event) => {
     });
 
     const sessionFile = currentSessionFile || undefined;
+
+    // Determine the date for the memory filename:
+    // Prefer the session's creation timestamp from the session file header,
+    // fallback to the event timestamp if no session file is available.
+    const now = new Date(event.timestamp);
+    let dateStr: string;
+    if (sessionFile) {
+      const sessionCreatedAt = await getSessionCreatedAt(sessionFile);
+      dateStr = sessionCreatedAt
+        ? new Date(sessionCreatedAt).toISOString().split("T")[0]
+        : now.toISOString().split("T")[0];
+    } else {
+      dateStr = now.toISOString().split("T")[0];
+    }
 
     // Read message count from hook config (default: 15)
     const hookConfig = resolveHookConfig(cfg, "session-memory");


### PR DESCRIPTION
## Problem
Memory files were dated using the `/new` command timestamp instead of the session's actual creation date. If a session was created on March 10 but `/new` was run on March 12, the memory file would be named `2026-03-12-*.md` instead of `2026-03-10-*.md`.

## Solution
- Added `getSessionCreatedAt()` to read the session creation timestamp from the first line of the session file (type="session" entry)
- Date calculation now prefers session creation timestamp, falling back to event timestamp when no session file is available
- HHMM slug still uses event timestamp to avoid filename collisions when `/new` is called multiple times in the same session

## Testing
Added 6 new test cases covering:
- Session with valid header → uses session timestamp
- Session without header → falls back to event timestamp
- No session file → falls back to event timestamp
- Session date differs from /new date by days → correct behavior
- Malformed header → falls back gracefully
- Session header without timestamp field → falls back gracefully

---

- [x] AI-assisted: Claude Code + GLM-5
- [x] Testing: Fully tested (23 tests pass)
- [x] Ran `pnpm build && pnpm check && pnpm test`
- [x] I understand what the code does