### PR TITLE
Gateway: parse Compose-style gateway port env values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - Slack/runtime defaults: trim Slack DM reply overhead, restore Codex auto transport, and tighten Slack/web-search runtime defaults around DM preview threading, cache scoping, warning dedupe, and explicit web-search opt-in. (#53957) Thanks @vincentkoc.
 - Discord/timeouts: send a visible timeout reply when the inbound Discord worker times out before a final reply starts, including created auto-thread targets and queued-run ordering. (#53823) Thanks @Kimbo7870.
 - Models/google: normalize bare Google Generative AI API roots for custom provider names, and keep built-in Google model-id rewrites working when `api` is declared only on individual models, so custom Google lanes and older configs stop missing `/v1beta` or preview-id normalization. (#44969) Thanks @Kathie-yu.
+- Gateway/ports: parse Docker Compose-style `OPENCLAW_GATEWAY_PORT` host publish values correctly without reviving the legacy `CLAWDBOT_GATEWAY_PORT` override. (#44083) Thanks @bebule.
 
 ## 2026.3.23
 

--- a/extensions/device-pair/api.ts
+++ b/extensions/device-pair/api.ts
@@ -8,7 +8,11 @@ export {
   type DeviceBootstrapProfile,
 } from "openclaw/plugin-sdk/device-bootstrap";
 export { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-export { resolveGatewayBindUrl, resolveTailnetHostWithRunner } from "openclaw/plugin-sdk/core";
+export {
+  resolveGatewayBindUrl,
+  resolveGatewayPort,
+  resolveTailnetHostWithRunner,
+} from "openclaw/plugin-sdk/core";
 export {
   resolvePreferredOpenClawTmpDir,
   runPluginCommandWithTimeout,

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -11,9 +11,10 @@ import {
   renderQrPngBase64,
   revokeDeviceBootstrapToken,
   resolveGatewayBindUrl,
+  resolveGatewayPort,
   resolvePreferredOpenClawTmpDir,
-  resolveTailnetHostWithRunner,
   runPluginCommandWithTimeout,
+  resolveTailnetHostWithRunner,
   type OpenClawPluginApi,
 } from "./api.js";
 import {
@@ -42,8 +43,6 @@ function formatDurationMinutes(expiresAtMs: number): string {
   const minutes = Math.max(1, Math.ceil(msRemaining / 60_000));
   return `${minutes} minute${minutes === 1 ? "" : "s"}`;
 }
-
-const DEFAULT_GATEWAY_PORT = 18789;
 
 type DevicePairPluginConfig = {
   publicUrl?: string;
@@ -173,26 +172,6 @@ function parseNormalizedGatewayUrl(raw: string): string | null {
   } catch {
     return null;
   }
-}
-
-function parsePositiveInteger(raw: string | undefined): number | null {
-  if (!raw) {
-    return null;
-  }
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
-
-function resolveGatewayPort(cfg: OpenClawPluginApi["config"]): number {
-  const envPort = parsePositiveInteger(process.env.OPENCLAW_GATEWAY_PORT?.trim());
-  if (envPort) {
-    return envPort;
-  }
-  const configPort = cfg.gateway?.port;
-  if (typeof configPort === "number" && Number.isFinite(configPort) && configPort > 0) {
-    return configPort;
-  }
-  return DEFAULT_GATEWAY_PORT;
 }
 
 function resolveScheme(

--- a/scripts/test-force.ts
+++ b/scripts/test-force.ts
@@ -3,8 +3,7 @@ import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { forceFreePort, type PortProcess } from "../src/cli/ports.js";
-
-const DEFAULT_PORT = 18789;
+import { resolveGatewayPort } from "../src/config/config.js";
 
 function killGatewayListeners(port: number): PortProcess[] {
   try {
@@ -44,7 +43,7 @@ function runTests() {
 }
 
 function main() {
-  const port = Number.parseInt(process.env.OPENCLAW_GATEWAY_PORT ?? `${DEFAULT_PORT}`, 10);
+  const port = resolveGatewayPort(undefined, process.env);
 
   console.log(`🧹 test:force - clearing gateway on port ${port}`);
   const killed = killGatewayListeners(port);

--- a/src/config/config.nix-integration-u3-u5-u9.test.ts
+++ b/src/config/config.nix-integration-u3-u5-u9.test.ts
@@ -218,11 +218,35 @@ describe("Nix integration (U3, U5, U9)", () => {
       ).toBe(19001);
     });
 
+    it("accepts Compose-style host publish values from env", () => {
+      expect(
+        resolveGatewayPort(
+          { gateway: { port: 19002 } },
+          envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:18789" }),
+        ),
+      ).toBe(18789);
+      expect(
+        resolveGatewayPort(
+          { gateway: { port: 19002 } },
+          envWith({ OPENCLAW_GATEWAY_PORT: "[::1]:28789" }),
+        ),
+      ).toBe(28789);
+    });
+
     it("falls back to config when env is invalid", () => {
       expect(
         resolveGatewayPort(
           { gateway: { port: 19003 } },
           envWith({ OPENCLAW_GATEWAY_PORT: "nope" }),
+        ),
+      ).toBe(19003);
+    });
+
+    it("falls back to config when Compose-style env suffix is invalid", () => {
+      expect(
+        resolveGatewayPort(
+          { gateway: { port: 19003 } },
+          envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:not-a-port" }),
         ),
       ).toBe(19003);
     });

--- a/src/config/config.nix-integration-u3-u5-u9.test.ts
+++ b/src/config/config.nix-integration-u3-u5-u9.test.ts
@@ -218,35 +218,11 @@ describe("Nix integration (U3, U5, U9)", () => {
       ).toBe(19001);
     });
 
-    it("accepts Compose-style host publish values from env", () => {
-      expect(
-        resolveGatewayPort(
-          { gateway: { port: 19002 } },
-          envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:18789" }),
-        ),
-      ).toBe(18789);
-      expect(
-        resolveGatewayPort(
-          { gateway: { port: 19002 } },
-          envWith({ OPENCLAW_GATEWAY_PORT: "[::1]:28789" }),
-        ),
-      ).toBe(28789);
-    });
-
     it("falls back to config when env is invalid", () => {
       expect(
         resolveGatewayPort(
           { gateway: { port: 19003 } },
           envWith({ OPENCLAW_GATEWAY_PORT: "nope" }),
-        ),
-      ).toBe(19003);
-    });
-
-    it("falls back to config when Compose-style env suffix is invalid", () => {
-      expect(
-        resolveGatewayPort(
-          { gateway: { port: 19003 } },
-          envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:not-a-port" }),
         ),
       ).toBe(19003);
     });

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -67,13 +67,13 @@ describe("gateway port resolution", () => {
     ).toBe(28789);
   });
 
-  it("accepts Compose-style values from the legacy env name", () => {
+  it("ignores the legacy env name and falls back to config", () => {
     expect(
       resolveGatewayPort(
         { gateway: { port: 19002 } },
         envWith({ CLAWDBOT_GATEWAY_PORT: "127.0.0.1:18789" }),
       ),
-    ).toBe(18789);
+    ).toBe(19002);
   });
 
   it("falls back to config when the Compose-style suffix is invalid", () => {

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -3,13 +3,19 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
+  DEFAULT_GATEWAY_PORT,
   resolveDefaultConfigCandidates,
   resolveConfigPathCandidate,
   resolveConfigPath,
+  resolveGatewayPort,
   resolveOAuthDir,
   resolveOAuthPath,
   resolveStateDir,
 } from "./paths.js";
+
+function envWith(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return { ...overrides };
+}
 
 describe("oauth paths", () => {
   it("prefers OPENCLAW_OAUTH_DIR over OPENCLAW_STATE_DIR", () => {
@@ -32,6 +38,65 @@ describe("oauth paths", () => {
     expect(resolveOAuthDir(env, "/custom/state")).toBe(path.join("/custom/state", "credentials"));
     expect(resolveOAuthPath(env, "/custom/state")).toBe(
       path.join("/custom/state", "credentials", "oauth.json"),
+    );
+  });
+});
+
+describe("gateway port resolution", () => {
+  it("prefers numeric env values over config", () => {
+    expect(
+      resolveGatewayPort({ gateway: { port: 19002 } }, envWith({ OPENCLAW_GATEWAY_PORT: "19001" })),
+    ).toBe(19001);
+  });
+
+  it("accepts Compose-style IPv4 host publish values from env", () => {
+    expect(
+      resolveGatewayPort(
+        { gateway: { port: 19002 } },
+        envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:18789" }),
+      ),
+    ).toBe(18789);
+  });
+
+  it("accepts Compose-style IPv6 host publish values from env", () => {
+    expect(
+      resolveGatewayPort(
+        { gateway: { port: 19002 } },
+        envWith({ OPENCLAW_GATEWAY_PORT: "[::1]:28789" }),
+      ),
+    ).toBe(28789);
+  });
+
+  it("accepts Compose-style values from the legacy env name", () => {
+    expect(
+      resolveGatewayPort(
+        { gateway: { port: 19002 } },
+        envWith({ CLAWDBOT_GATEWAY_PORT: "127.0.0.1:18789" }),
+      ),
+    ).toBe(18789);
+  });
+
+  it("falls back to config when the Compose-style suffix is invalid", () => {
+    expect(
+      resolveGatewayPort(
+        { gateway: { port: 19003 } },
+        envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:not-a-port" }),
+      ),
+    ).toBe(19003);
+  });
+
+  it("falls back when malformed IPv6 inputs do not provide an explicit port", () => {
+    expect(
+      resolveGatewayPort({ gateway: { port: 19003 } }, envWith({ OPENCLAW_GATEWAY_PORT: "::1" })),
+    ).toBe(19003);
+    expect(resolveGatewayPort({}, envWith({ OPENCLAW_GATEWAY_PORT: "2001:db8::1" }))).toBe(
+      DEFAULT_GATEWAY_PORT,
+    );
+  });
+
+  it("falls back to the default port when env is invalid and config is unset", () => {
+    expect(resolveGatewayPort({}, envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:not-a-port" }))).toBe(
+      DEFAULT_GATEWAY_PORT,
     );
   });
 });

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -251,16 +251,45 @@ export function resolveOAuthPath(
   return path.join(resolveOAuthDir(env, stateDir), OAUTH_FILENAME);
 }
 
+function parseGatewayPortEnvValue(raw: string | undefined): number | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    const parsed = Number.parseInt(trimmed, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  // Docker Compose publish strings can leak into host CLI env loading via repo `.env`,
+  // for example `127.0.0.1:18789` or `[::1]:18789`. Accept only explicit host:port forms.
+  const bracketedIpv6Match = trimmed.match(/^\[[^\]]+\]:(\d+)$/);
+  if (bracketedIpv6Match?.[1]) {
+    const parsed = Number.parseInt(bracketedIpv6Match[1], 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  const firstColon = trimmed.indexOf(":");
+  const lastColon = trimmed.lastIndexOf(":");
+  if (firstColon <= 0 || firstColon !== lastColon) {
+    return null;
+  }
+  const suffix = trimmed.slice(firstColon + 1);
+  if (!/^\d+$/.test(suffix)) {
+    return null;
+  }
+  const parsed = Number.parseInt(suffix, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
 export function resolveGatewayPort(
   cfg?: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): number {
   const envRaw = env.OPENCLAW_GATEWAY_PORT?.trim();
-  if (envRaw) {
-    const parsed = Number.parseInt(envRaw, 10);
-    if (Number.isFinite(parsed) && parsed > 0) {
-      return parsed;
-    }
+  const envPort = parseGatewayPortEnvValue(envRaw);
+  if (envPort !== null) {
+    return envPort;
   }
   const configPort = cfg?.gateway?.port;
   if (typeof configPort === "number" && Number.isFinite(configPort)) {

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -120,6 +120,7 @@ export type { SecretFileReadOptions, SecretFileReadResult } from "../infra/secre
 
 export { resolveGatewayBindUrl } from "../shared/gateway-bind-url.js";
 export type { GatewayBindUrlResult } from "../shared/gateway-bind-url.js";
+export { resolveGatewayPort } from "../config/paths.js";
 export { normalizeAtHashSlug, normalizeHyphenSlug } from "../shared/string-normalization.js";
 
 export { resolveTailnetHostWithRunner } from "../shared/tailscale-status.js";


### PR DESCRIPTION
## Summary

- Problem: repo root host CLI could misread `OPENCLAW_GATEWAY_PORT=127.0.0.1:18789` as port `127`, which made `gateway probe --json` and other local callers target the wrong loopback URL.
- Why it matters: Compose-style publish strings from `.env` can leak into host-side CLI env resolution, leading to failed local gateway probes and related local tooling breakage.
- What changed: `resolveGatewayPort()` now accepts plain numeric ports plus explicit Compose-style `host:port` and `[ipv6]:port` env values, `scripts/test-force.ts` now uses the shared resolver, and the bundled `device-pair` plugin now shares the same parsing logic through `plugin-sdk`.
- What did NOT change (scope boundary): gateway auth, pairing policy, Docker networking behavior, and probe auth/fallback behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #22307

## User-visible / Behavior Changes

- Host-side CLI now resolves `OPENCLAW_GATEWAY_PORT=127.0.0.1:18789` to `18789` instead of `127`.
- Host-side CLI now resolves bracketed IPv6 publish values like `[::1]:28789` to `28789`.
- Malformed values like `127.0.0.1:not-a-port` or `::1` now fall back to config/default instead of producing an unintended loopback port.
- `pnpm test:force` and the bundled `device-pair` plugin now use the same shared gateway port resolver.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: host CLI from repo root + Docker Compose gateway
- Model/provider: N/A
- Integration/channel (if any): bundled `device-pair` plugin
- Relevant config (redacted): repo `.env` with `OPENCLAW_GATEWAY_PORT=127.0.0.1:18789`

### Steps

1. Set `OPENCLAW_GATEWAY_PORT` to a Compose-style publish value like `127.0.0.1:18789`.
2. Run host-side CLI from repo root, or any code path that resolves the local gateway port from env.
3. Observe the resolved port before/after the fix.

### Expected

- Plain numeric ports remain unchanged.
- Explicit `host:port` / `[ipv6]:port` env values resolve to the published host port.
- Malformed inputs fall back to config/default.

### Actual

- Before this change, `Number.parseInt("127.0.0.1:18789", 10)` could resolve to `127`.
- Before this change, malformed IPv6-like values such as `::1` could resolve to `1` via suffix parsing.
- The bundled `device-pair` plugin and `test:force` also had duplicate parsing paths.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: numeric env port, Compose-style IPv4 host publish, bracketed IPv6 host publish, malformed suffix fallback, malformed IPv6 fallback, bundled `device-pair` using the shared resolver, `test:force` using the shared resolver.
- Edge cases checked: legacy `CLAWDBOT_GATEWAY_PORT` Compose-style env values; invalid inputs now fall back instead of producing unintended suffix ports.
- What you did **not** verify: full end-to-end `gateway probe --json` against every runtime mode; broader repo `pnpm check` remains affected by unrelated worktree changes outside this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `fb654e3d7` and `bdd75e2c8`
- Files/config to restore: `src/config/paths.ts`, `src/config/paths.test.ts`, `src/config/config.nix-integration-u3-u5-u9.test.ts`, `src/plugin-sdk/device-pair.ts`, `extensions/device-pair/index.ts`, `scripts/test-force.ts`
- Known bad symptoms reviewers should watch for: valid `host:port` env values no longer resolving to the published host port, or bundled plugin subpath import regressions.

## Risks and Mitigations

- Risk: restricting accepted env shapes too aggressively could reject a valid Compose-style value that callers previously relied on.
  - Mitigation: support remains for numeric, `host:port`, and bracketed `[ipv6]:port`, which are the intended forms for this env var.
- Risk: bundled plugin subpath reuse could introduce an import/type regression.
  - Mitigation: `src/plugin-sdk/subpaths.test.ts` was run after exporting the shared resolver.

## AI Assistance

- Built with Codex.
