### PR TITLE
fix(agents): assistant message content null instead of empty string breaks OpenAI-compatible providers

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -22,6 +22,7 @@ import {
   shouldApplySiliconFlowThinkingOffCompat,
 } from "./moonshot-stream-wrappers.js";
 import {
+  createAssistantNullContentFixWrapper,
   createCodexDefaultTransportWrapper,
   createOpenAIDefaultTransportWrapper,
   createOpenAIFastModeWrapper,
@@ -463,6 +464,10 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI Responses models and auto-enable
   // server-side compaction for compatible OpenAI Responses payloads.
   agent.streamFn = createOpenAIResponsesContextManagementWrapper(agent.streamFn, merged);
+
+  // Normalize assistant messages with tool_calls but null content to empty string.
+  // Some OpenAI-compatible providers (e.g. DeepSeek) reject null content.
+  agent.streamFn = createAssistantNullContentFixWrapper(agent.streamFn);
 
   const rawParallelToolCalls = resolveAliasedParamValue(
     [resolvedExtraParams, override],

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.assistant-null-content.test.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.assistant-null-content.test.ts
@@ -1,0 +1,148 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { createAssistantNullContentFixWrapper } from "./openai-stream-wrappers.js";
+
+describe("createAssistantNullContentFixWrapper", () => {
+  it("normalizes null content to empty string for assistant messages with tool_calls", () => {
+    let capturedPayload: unknown;
+    const baseFn: StreamFn = (_model, _context, options) => {
+      const payload = {
+        messages: [
+          { role: "system", content: "You are helpful" },
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "read", arguments: "{}" } },
+            ],
+          },
+          { role: "tool", content: "result", tool_call_id: "call_1" },
+        ],
+      };
+      capturedPayload = payload;
+      options?.onPayload?.(payload, _model);
+      return (async function* () {
+        /* empty */
+      })() as unknown as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createAssistantNullContentFixWrapper(baseFn);
+    const model = {
+      api: "openai-completions",
+      provider: "custom",
+      id: "test",
+      baseUrl: "http://localhost:1234",
+    } as Parameters<StreamFn>[0];
+    void wrapped(model, { messages: [] }, {});
+
+    const messages = (capturedPayload as Record<string, unknown>).messages as Array<
+      Record<string, unknown>
+    >;
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg?.content).toBe("");
+  });
+
+  it("does not modify assistant messages without tool_calls", () => {
+    let capturedPayload: unknown;
+    const baseFn: StreamFn = (_model, _context, options) => {
+      const payload = {
+        messages: [{ role: "assistant", content: null }],
+      };
+      capturedPayload = payload;
+      options?.onPayload?.(payload, _model);
+      return (async function* () {
+        /* empty */
+      })() as unknown as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createAssistantNullContentFixWrapper(baseFn);
+    const model = {
+      api: "openai-completions",
+      provider: "custom",
+      id: "test",
+      baseUrl: "http://localhost:1234",
+    } as Parameters<StreamFn>[0];
+    void wrapped(model, { messages: [] }, {});
+
+    const messages = (capturedPayload as Record<string, unknown>).messages as Array<
+      Record<string, unknown>
+    >;
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg?.content).toBeNull();
+  });
+
+  it("does not modify non-openai-completions APIs", () => {
+    let capturedPayload: unknown;
+    const baseFn: StreamFn = (_model, _context, options) => {
+      const payload = {
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "read", arguments: "{}" } },
+            ],
+          },
+        ],
+      };
+      capturedPayload = payload;
+      options?.onPayload?.(payload, _model);
+      return (async function* () {
+        /* empty */
+      })() as unknown as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createAssistantNullContentFixWrapper(baseFn);
+    const model = {
+      api: "openai-responses",
+      provider: "openai",
+      id: "test",
+      baseUrl: "https://api.openai.com",
+    } as Parameters<StreamFn>[0];
+    void wrapped(model, { messages: [] }, {});
+
+    const messages = (capturedPayload as Record<string, unknown>).messages as Array<
+      Record<string, unknown>
+    >;
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg?.content).toBeNull();
+  });
+
+  it("preserves existing string content on assistant messages with tool_calls", () => {
+    let capturedPayload: unknown;
+    const baseFn: StreamFn = (_model, _context, options) => {
+      const payload = {
+        messages: [
+          {
+            role: "assistant",
+            content: "I will help you.",
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "read", arguments: "{}" } },
+            ],
+          },
+        ],
+      };
+      capturedPayload = payload;
+      options?.onPayload?.(payload, _model);
+      return (async function* () {
+        /* empty */
+      })() as unknown as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createAssistantNullContentFixWrapper(baseFn);
+    const model = {
+      api: "openai-completions",
+      provider: "custom",
+      id: "test",
+      baseUrl: "http://localhost:1234",
+    } as Parameters<StreamFn>[0];
+    void wrapped(model, { messages: [] }, {});
+
+    const messages = (capturedPayload as Record<string, unknown>).messages as Array<
+      Record<string, unknown>
+    >;
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg?.content).toBe("I will help you.");
+  });
+});

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -341,6 +341,50 @@ export function createOpenAIServiceTierWrapper(
   };
 }
 
+/**
+ * Normalize assistant messages that have tool_calls but null content.
+ *
+ * Some OpenAI-compatible providers (e.g. DeepSeek) return assistant messages
+ * with `content: ""` and `tool_calls`. pi-ai's `convertMessages` filters out
+ * empty text blocks and defaults content to `null`, which these providers then
+ * reject ("Messages token length must be in (0, 1048576], but got 0").
+ *
+ * This wrapper ensures assistant messages with tool_calls always have a string
+ * content (`""`) instead of `null`.
+ */
+export function createAssistantNullContentFixWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.api !== "openai-completions") {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        const messages = (payload as Record<string, unknown>)?.messages;
+        if (Array.isArray(messages)) {
+          for (const msg of messages as Array<{
+            role?: string;
+            content?: unknown;
+            tool_calls?: unknown[];
+          }>) {
+            if (
+              msg.role === "assistant" &&
+              msg.content == null &&
+              Array.isArray(msg.tool_calls) &&
+              msg.tool_calls.length > 0
+            ) {
+              msg.content = "";
+            }
+          }
+        }
+        return originalOnPayload?.(payload, model);
+      },
+    });
+  };
+}
+
 export function createCodexDefaultTransportWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) =>


### PR DESCRIPTION
## Problem

When an OpenAI-compatible provider (e.g. DeepSeek v3.1) returns an assistant message with `content: ""` and `tool_calls`, the empty text block is filtered out during message conversion in `convertMessages`, causing the content to default to `null`. Providers that require string content then reject the request with:

```
Messages token length must be in (0, 1048576], but got 0
```

This happens because `convertMessages` initializes assistant content as `null` (for providers without `requiresAssistantAfterToolResult`), then filters text blocks with `b.text && b.text.trim().length > 0`, which removes empty strings. The assistant message is kept (it has `tool_calls`), but with `content: null`.

## Solution

Add an `onPayload` wrapper (`createAssistantNullContentFixWrapper`) that normalizes `content: null` to `""` on assistant messages carrying `tool_calls` for `openai-completions` API payloads. This is safe because:

- OpenAI and most providers accept both `null` and `""` for assistant content
- Providers like DeepSeek require string content, not null
- The wrapper only activates for `openai-completions` API (not Responses API)
- Existing string content is never modified

## Test plan

4 test cases covering:
- Null content normalized to empty string when tool_calls present
- Null content preserved when no tool_calls (no unnecessary modification)
- Non-openai-completions APIs unaffected
- Existing string content preserved

Fixes #43716