### PR TITLE
Security: preserve Feishu reaction chat type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Security/browser.request: block persistent browser profile create/delete routes from write-scoped `browser.request` so callers can no longer persist admin-only browser profile changes through the browser control surface. (`GHSA-vmhq-cqm9-6p7q`)(#43800) Thanks @tdjackey and @vincentkoc.
 - Security/agent: reject public spawned-run lineage fields and keep workspace inheritance on the internal spawned-session path so external `agent` callers can no longer override the gateway workspace boundary. (`GHSA-2rqg-gjgv-84jm`)(#43801) Thanks @tdjackey and @vincentkoc.
 - Security/exec allowlist: preserve POSIX case sensitivity and keep `?` within a single path segment so exact-looking allowlist patterns no longer overmatch executables across case or directory boundaries. (`GHSA-f8r2-vg7x-gh8m`)(#43798) Thanks @zpbrent and @vincentkoc.
+- Security/Feishu reactions: preserve looked-up group chat typing and fail closed on ambiguous reaction context so group authorization and mention gating cannot be bypassed through synthetic `p2p` reactions. (`GHSA-m69h-jm2f-2pv8`)(#44088) Thanks @zpbrent and @vincentkoc.
 
 ### Changes
 

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -24,14 +24,14 @@ import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
-import type { ResolvedFeishuAccount } from "./types.js";
+import type { FeishuChatType, ResolvedFeishuAccount } from "./types.js";
 
 const FEISHU_REACTION_VERIFY_TIMEOUT_MS = 1_500;
 
 export type FeishuReactionCreatedEvent = {
   message_id: string;
   chat_id?: string;
-  chat_type?: "p2p" | "group" | "private";
+  chat_type?: string;
   reaction_type?: { emoji_type?: string };
   operator_type?: string;
   user_id?: { open_id?: string };
@@ -106,7 +106,8 @@ export async function resolveReactionSyntheticEvent(
   }
 
   const fallbackChatType = reactedMsg.chatType;
-  const resolvedChatType = event.chat_type ?? fallbackChatType;
+  const normalizedEventChatType = normalizeFeishuChatType(event.chat_type);
+  const resolvedChatType = normalizedEventChatType ?? fallbackChatType;
   if (!resolvedChatType) {
     logger?.(
       `feishu[${accountId}]: skipping reaction ${emoji} on ${messageId} without chat type context`,
@@ -116,7 +117,7 @@ export async function resolveReactionSyntheticEvent(
 
   const syntheticChatIdRaw = event.chat_id ?? reactedMsg.chatId;
   const syntheticChatId = syntheticChatIdRaw?.trim() ? syntheticChatIdRaw : `p2p:${senderId}`;
-  const syntheticChatType: "p2p" | "group" | "private" = resolvedChatType;
+  const syntheticChatType: FeishuChatType = resolvedChatType;
   return {
     sender: {
       sender_id: { open_id: senderId },
@@ -132,6 +133,10 @@ export async function resolveReactionSyntheticEvent(
       }),
     },
   };
+}
+
+function normalizeFeishuChatType(value: unknown): FeishuChatType | undefined {
+  return value === "group" || value === "private" || value === "p2p" ? value : undefined;
 }
 
 type RegisterEventHandlersContext = {

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -106,7 +106,8 @@ export async function resolveReactionSyntheticEvent(
   }
 
   const fallbackChatType = reactedMsg.chatType;
-  if (!event.chat_type && !event.chat_id && !fallbackChatType) {
+  const resolvedChatType = event.chat_type ?? fallbackChatType;
+  if (!resolvedChatType) {
     logger?.(
       `feishu[${accountId}]: skipping reaction ${emoji} on ${messageId} without chat type context`,
     );
@@ -115,8 +116,7 @@ export async function resolveReactionSyntheticEvent(
 
   const syntheticChatIdRaw = event.chat_id ?? reactedMsg.chatId;
   const syntheticChatId = syntheticChatIdRaw?.trim() ? syntheticChatIdRaw : `p2p:${senderId}`;
-  const syntheticChatType: "p2p" | "group" | "private" =
-    event.chat_type ?? fallbackChatType ?? "p2p";
+  const syntheticChatType: "p2p" | "group" | "private" = resolvedChatType;
   return {
     sender: {
       sender_id: { open_id: senderId },

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -105,10 +105,18 @@ export async function resolveReactionSyntheticEvent(
     return null;
   }
 
+  const fallbackChatType = reactedMsg.chatType;
+  if (!event.chat_type && !event.chat_id && !fallbackChatType) {
+    logger?.(
+      `feishu[${accountId}]: skipping reaction ${emoji} on ${messageId} without chat type context`,
+    );
+    return null;
+  }
+
   const syntheticChatIdRaw = event.chat_id ?? reactedMsg.chatId;
   const syntheticChatId = syntheticChatIdRaw?.trim() ? syntheticChatIdRaw : `p2p:${senderId}`;
   const syntheticChatType: "p2p" | "group" | "private" =
-    event.chat_type === "group" ? "group" : "p2p";
+    event.chat_type ?? fallbackChatType ?? "p2p";
   return {
     sender: {
       sender_id: { open_id: senderId },

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -51,10 +51,11 @@ function makeReactionEvent(
   };
 }
 
-function createFetchedReactionMessage(chatId: string) {
+function createFetchedReactionMessage(chatId: string, chatType?: "p2p" | "group" | "private") {
   return {
     messageId: "om_msg1",
     chatId,
+    chatType,
     senderOpenId: "ou_bot",
     content: "hello",
     contentType: "text",
@@ -64,13 +65,15 @@ function createFetchedReactionMessage(chatId: string) {
 async function resolveReactionWithLookup(params: {
   event?: FeishuReactionCreatedEvent;
   lookupChatId: string;
+  lookupChatType?: "p2p" | "group" | "private";
 }) {
   return await resolveReactionSyntheticEvent({
     cfg,
     accountId: "default",
     event: params.event ?? makeReactionEvent(),
     botOpenId: "ou_bot",
-    fetchMessage: async () => createFetchedReactionMessage(params.lookupChatId),
+    fetchMessage: async () =>
+      createFetchedReactionMessage(params.lookupChatId, params.lookupChatType),
     uuid: () => "fixed-uuid",
   });
 }
@@ -268,6 +271,7 @@ describe("resolveReactionSyntheticEvent", () => {
       fetchMessage: async () => ({
         messageId: "om_msg1",
         chatId: "oc_group",
+        chatType: "group",
         senderOpenId: "ou_other",
         senderType: "user",
         content: "hello",
@@ -293,6 +297,7 @@ describe("resolveReactionSyntheticEvent", () => {
       fetchMessage: async () => ({
         messageId: "om_msg1",
         chatId: "oc_group",
+        chatType: "group",
         senderOpenId: "ou_other",
         senderType: "user",
         content: "hello",
@@ -348,19 +353,29 @@ describe("resolveReactionSyntheticEvent", () => {
   it("falls back to reacted message chat_id when event chat_id is absent", async () => {
     const result = await resolveReactionWithLookup({
       lookupChatId: "oc_group_from_lookup",
+      lookupChatType: "group",
     });
 
     expect(result?.message.chat_id).toBe("oc_group_from_lookup");
-    expect(result?.message.chat_type).toBe("p2p");
+    expect(result?.message.chat_type).toBe("group");
   });
 
   it("falls back to sender p2p chat when lookup returns empty chat_id", async () => {
     const result = await resolveReactionWithLookup({
       lookupChatId: "",
+      lookupChatType: "p2p",
     });
 
     expect(result?.message.chat_id).toBe("p2p:ou_user1");
     expect(result?.message.chat_type).toBe("p2p");
+  });
+
+  it("drops reactions without chat context when lookup does not provide chat_type", async () => {
+    const result = await resolveReactionWithLookup({
+      lookupChatId: "oc_group_from_lookup",
+    });
+
+    expect(result).toBeNull();
   });
 
   it("logs and drops reactions when lookup throws", async () => {

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -378,6 +378,18 @@ describe("resolveReactionSyntheticEvent", () => {
     expect(result).toBeNull();
   });
 
+  it("drops reactions when event chat_type is invalid and lookup cannot recover it", async () => {
+    const result = await resolveReactionWithLookup({
+      event: makeReactionEvent({
+        chat_id: "oc_group_from_event",
+        chat_type: "bogus" as "group",
+      }),
+      lookupChatId: "oc_group_from_lookup",
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("logs and drops reactions when lookup throws", async () => {
     const log = vi.fn();
     const event = makeReactionEvent();

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -7,7 +7,7 @@ import { parsePostContent } from "./post.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
-import type { FeishuSendResult } from "./types.js";
+import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./types.js";
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
 
@@ -73,17 +73,6 @@ async function sendFallbackDirect(
   assertFeishuMessageApiSuccess(response, errorPrefix);
   return toFeishuSendResult(response, params.receiveId);
 }
-
-export type FeishuMessageInfo = {
-  messageId: string;
-  chatId: string;
-  senderId?: string;
-  senderOpenId?: string;
-  senderType?: string;
-  content: string;
-  contentType: string;
-  createTime?: number;
-};
 
 function parseInteractiveCardContent(parsed: unknown): string {
   if (!parsed || typeof parsed !== "object") {
@@ -184,6 +173,7 @@ export async function getMessageFeishu(params: {
         items?: Array<{
           message_id?: string;
           chat_id?: string;
+          chat_type?: FeishuChatType;
           msg_type?: string;
           body?: { content?: string };
           sender?: {
@@ -195,6 +185,7 @@ export async function getMessageFeishu(params: {
         }>;
         message_id?: string;
         chat_id?: string;
+        chat_type?: FeishuChatType;
         msg_type?: string;
         body?: { content?: string };
         sender?: {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -228,6 +228,10 @@ export async function getMessageFeishu(params: {
     return {
       messageId: item.message_id ?? messageId,
       chatId: item.chat_id ?? "",
+      chatType:
+        item.chat_type === "group" || item.chat_type === "private" || item.chat_type === "p2p"
+          ? item.chat_type
+          : undefined,
       senderId: item.sender?.id,
       senderOpenId: item.sender?.id_type === "open_id" ? item.sender?.id : undefined,
       senderType: item.sender?.sender_type,

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -60,6 +60,20 @@ export type FeishuSendResult = {
   chatId: string;
 };
 
+export type FeishuChatType = "p2p" | "group" | "private";
+
+export type FeishuMessageInfo = {
+  messageId: string;
+  chatId: string;
+  chatType?: FeishuChatType;
+  senderId?: string;
+  senderOpenId?: string;
+  senderType?: string;
+  content: string;
+  contentType: string;
+  createTime?: number;
+};
+
 export type FeishuProbeResult = BaseProbeResult<string> & {
   appId?: string;
   botName?: string;


### PR DESCRIPTION
## Summary

- Problem: Feishu reaction synthesis could pair a looked-up group `chat_id` with a synthetic `p2p` `chat_type`.
- Why it matters: that shape bypasses group authorization and mention gating by routing group reactions down the DM path.
- What changed: preserve looked-up `chatType` from fetched messages and fail closed when reaction events do not provide enough chat context.
- What did NOT change (scope boundary): normal Feishu message delivery and non-reaction event routing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #GHSA-m69h-jm2f-2pv8

## User-visible / Behavior Changes

Ambiguous Feishu reaction events now drop instead of being synthesized as DM events, and fetched group reactions retain group chat typing.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Feishu extension
- Relevant config (redacted): reaction event lookup path with fetched group messages

### Steps

1. Deliver a Feishu reaction event without `chat_type`.
2. Let the account monitor look up the original message in a group chat.
3. Observe the synthesized event shape used by downstream gating.

### Expected

- Group reactions should preserve group typing, and events with insufficient chat context should not be routed as DMs.

### Actual

- Before this change, looked-up group `chat_id` values could still be synthesized as `p2p` reactions.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the mismatched reaction shape in tests, confirmed looked-up `chatType` now propagates, confirmed ambiguous events return `null`.
- Edge cases checked: explicit `chat_type` from the event still wins, missing lookup context fails closed.
- What you did **not** verify: live Feishu reaction flow against a production tenant.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this branch.
- Files/config to restore: Feishu reaction lookup path.
- Known bad symptoms reviewers should watch for: missing reaction handling where Feishu omits chat metadata and the lookup cannot recover it.

## Risks and Mitigations

- Risk: some malformed reaction events that previously flowed through will now be dropped.
  - Mitigation: the drop only happens when neither the event nor the lookup provides enough chat context to classify the conversation safely.
