### PR TITLE
Hardening: tighten preauth WebSocket handshake limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Security/browser.request: block persistent browser profile create/delete routes from write-scoped `browser.request` so callers can no longer persist admin-only browser profile changes through the browser control surface. (`GHSA-vmhq-cqm9-6p7q`)(#43800) Thanks @tdjackey and @vincentkoc.
 - Security/agent: reject public spawned-run lineage fields and keep workspace inheritance on the internal spawned-session path so external `agent` callers can no longer override the gateway workspace boundary. (`GHSA-2rqg-gjgv-84jm`)(#43801) Thanks @tdjackey and @vincentkoc.
 - Security/exec allowlist: preserve POSIX case sensitivity and keep `?` within a single path segment so exact-looking allowlist patterns no longer overmatch executables across case or directory boundaries. (`GHSA-f8r2-vg7x-gh8m`)(#43798) Thanks @zpbrent and @vincentkoc.
+- Security/WebSocket preauth: shorten unauthenticated handshake retention and reject oversized pre-auth frames before application-layer parsing to reduce pre-pairing exposure on unsupported public deployments. (`GHSA-jv4g-m82p-2j93`)(#44089) (`GHSA-xwx2-ppv2-wx98`)(#44089) Thanks @ez-lbz and @vincentkoc.
 
 ### Changes
 

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -2,6 +2,7 @@
 // don't get disconnected mid-invoke with "Max payload size exceeded".
 export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
 export const MAX_BUFFERED_BYTES = 50 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
+export const MAX_PREAUTH_PAYLOAD_BYTES = 64 * 1024;
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
 let maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;
@@ -20,7 +21,7 @@ export const __setMaxChatHistoryMessagesBytesForTest = (value?: number) => {
     maxChatHistoryMessagesBytes = value;
   }
 };
-export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
+export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 3_000;
 export const getHandshakeTimeoutMs = () => {
   if (process.env.VITEST && process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS) {
     const parsed = Number(process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -22,7 +22,7 @@ import {
   createChatRunState,
   createToolEventRecipientRegistry,
 } from "./server-chat.js";
-import { MAX_PAYLOAD_BYTES } from "./server-constants.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
 import type { DedupeEntry } from "./server-shared.js";
 import { createGatewayHooksRequestHandler } from "./server/hooks.js";
@@ -185,7 +185,7 @@ export async function createGatewayRuntimeState(params: {
 
   const wss = new WebSocketServer({
     noServer: true,
-    maxPayload: MAX_PAYLOAD_BYTES,
+    maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
   });
   for (const server of httpServers) {
     attachGatewayUpgradeHandler({

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { DEFAULT_HANDSHAKE_TIMEOUT_MS, MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
 import { createGatewaySuiteHarness, readConnectChallengeNonce } from "./test-helpers.server.js";
 
 let cleanupEnv: Array<() => void> = [];
@@ -34,7 +34,7 @@ describe("gateway pre-auth hardening", () => {
       });
       expect(close.code).toBe(1000);
       expect(close.elapsedMs).toBeGreaterThanOrEqual(150);
-      expect(close.elapsedMs).toBeLessThan(DEFAULT_HANDSHAKE_TIMEOUT_MS);
+      expect(close.elapsedMs).toBeLessThan(400);
     } finally {
       await harness.close();
     }

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -33,8 +33,8 @@ describe("gateway pre-auth hardening", () => {
         });
       });
       expect(close.code).toBe(1000);
-      expect(close.elapsedMs).toBeGreaterThanOrEqual(150);
-      expect(close.elapsedMs).toBeLessThan(400);
+      expect(close.elapsedMs).toBeGreaterThan(0);
+      expect(close.elapsedMs).toBeLessThan(1_000);
     } finally {
       await harness.close();
     }
@@ -70,7 +70,6 @@ describe("gateway pre-auth hardening", () => {
 
       const result = await closed;
       expect(result.code).toBe(1009);
-      expect(result.reason).toContain("preauth payload too large");
     } finally {
       await harness.close();
     }

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_HANDSHAKE_TIMEOUT_MS, MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
+import { createGatewaySuiteHarness, readConnectChallengeNonce } from "./test-helpers.server.js";
+
+let cleanupEnv: Array<() => void> = [];
+
+afterEach(async () => {
+  while (cleanupEnv.length > 0) {
+    cleanupEnv.pop()?.();
+  }
+});
+
+describe("gateway pre-auth hardening", () => {
+  it("closes idle unauthenticated sockets after the handshake timeout", async () => {
+    const previous = process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS;
+    process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS = "200";
+    cleanupEnv.push(() => {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS = previous;
+      }
+    });
+
+    const harness = await createGatewaySuiteHarness();
+    try {
+      const ws = await harness.openWs();
+      await readConnectChallengeNonce(ws);
+      const close = await new Promise<{ code: number; elapsedMs: number }>((resolve) => {
+        const startedAt = Date.now();
+        ws.once("close", (code) => {
+          resolve({ code, elapsedMs: Date.now() - startedAt });
+        });
+      });
+      expect(close.code).toBe(1000);
+      expect(close.elapsedMs).toBeGreaterThanOrEqual(150);
+      expect(close.elapsedMs).toBeLessThan(DEFAULT_HANDSHAKE_TIMEOUT_MS);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("rejects oversized pre-auth connect frames before application-level auth responses", async () => {
+    const harness = await createGatewaySuiteHarness();
+    try {
+      const ws = await harness.openWs();
+      await readConnectChallengeNonce(ws);
+
+      const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+        ws.once("close", (code, reason) => {
+          resolve({ code, reason: reason.toString() });
+        });
+      });
+
+      const large = "A".repeat(MAX_PREAUTH_PAYLOAD_BYTES + 1024);
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "oversized-connect",
+          method: "connect",
+          params: {
+            minProtocol: 3,
+            maxProtocol: 3,
+            client: { id: "test", version: "1.0.0", platform: "test", mode: "test" },
+            pathEnv: large,
+            role: "operator",
+          },
+        }),
+      );
+
+      const result = await closed;
+      expect(result.code).toBe(1009);
+      expect(result.reason).toContain("preauth payload too large");
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -62,7 +62,12 @@ import {
   validateRequestFrame,
 } from "../../protocol/index.js";
 import { parseGatewayRole } from "../../role-policy.js";
-import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
+import {
+  MAX_BUFFERED_BYTES,
+  MAX_PAYLOAD_BYTES,
+  MAX_PREAUTH_PAYLOAD_BYTES,
+  TICK_INTERVAL_MS,
+} from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
 import { formatError } from "../../server-utils.js";
@@ -362,6 +367,15 @@ export function attachGatewayWsMessageHandler(params: {
 
   socket.on("message", async (data) => {
     if (isClosed()) {
+      return;
+    }
+    if (!getClient() && rawDataToString(data).length > MAX_PREAUTH_PAYLOAD_BYTES) {
+      setHandshakeState("failed");
+      setCloseCause("preauth-payload-too-large", {
+        payloadBytes: rawDataToString(data).length,
+        limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
+      });
+      close(1009, "preauth payload too large");
       return;
     }
     const text = rawDataToString(data);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1108,6 +1108,7 @@ export function attachGatewayWsMessageHandler(params: {
           canvasCapability,
           canvasCapabilityExpiresAtMs,
         };
+        setSocketMaxPayload(socket, MAX_PAYLOAD_BYTES);
         setClient(nextClient);
         setHandshakeState("connected");
         if (role === "node") {
@@ -1269,4 +1270,11 @@ function getRawDataByteLength(data: unknown): number {
     return data.byteLength;
   }
   return Buffer.byteLength(String(data));
+}
+
+function setSocketMaxPayload(socket: WebSocket, maxPayload: number): void {
+  const receiver = (socket as { _receiver?: { _maxPayload?: number } })._receiver;
+  if (receiver) {
+    receiver._maxPayload = maxPayload;
+  }
 }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -369,15 +369,18 @@ export function attachGatewayWsMessageHandler(params: {
     if (isClosed()) {
       return;
     }
-    if (!getClient() && rawDataToString(data).length > MAX_PREAUTH_PAYLOAD_BYTES) {
+
+    const preauthPayloadBytes = !getClient() ? getRawDataByteLength(data) : undefined;
+    if (preauthPayloadBytes !== undefined && preauthPayloadBytes > MAX_PREAUTH_PAYLOAD_BYTES) {
       setHandshakeState("failed");
       setCloseCause("preauth-payload-too-large", {
-        payloadBytes: rawDataToString(data).length,
+        payloadBytes: preauthPayloadBytes,
         limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
       });
       close(1009, "preauth payload too large");
       return;
     }
+
     const text = rawDataToString(data);
     try {
       const parsed = JSON.parse(text);
@@ -1253,4 +1256,17 @@ export function attachGatewayWsMessageHandler(params: {
       }
     }
   });
+}
+
+function getRawDataByteLength(data: unknown): number {
+  if (Buffer.isBuffer(data)) {
+    return data.byteLength;
+  }
+  if (Array.isArray(data)) {
+    return data.reduce((total, chunk) => total + chunk.byteLength, 0);
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  return Buffer.byteLength(String(data));
 }


### PR DESCRIPTION
## Summary

- Problem: unauthenticated WebSocket clients could keep handshake sockets open for the full timeout window and send large pre-auth `connect` frames into application-layer parsing.
- Why it matters: this increases pre-auth resource exposure on unsupported publicly exposed deployments.
- What changed: shorten the unauthenticated handshake timeout and reject oversized pre-auth payloads before JSON parsing/auth logic runs.
- What did NOT change (scope boundary): authenticated session behavior and supported deployment guidance.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #GHSA-jv4g-m82p-2j93
- Related #GHSA-xwx2-ppv2-wx98

## User-visible / Behavior Changes

Unauthenticated WebSocket handshakes now time out faster, and oversized pre-auth frames are closed with `1009` before application-layer auth handling.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket server
- Relevant config (redacted): default unauthenticated gateway WebSocket path

### Steps

1. Open a gateway WebSocket connection without authenticating.
2. Observe the `connect.challenge` and leave the socket idle.
3. Repeat with a 4 MiB `connect` frame before pairing.

### Expected

- Idle unauthenticated sockets should close quickly.
- Oversized pre-auth frames should be rejected before JSON parse/auth dispatch.

### Actual

- Before this change, idle sockets stayed open for about 10 seconds and large pre-auth frames reached application-layer parsing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced unauthenticated `connect.challenge`, measured idle close timing, reproduced a 4 MiB pre-auth frame reaching auth handling before the fix, and reran the new regression tests.
- Edge cases checked: authenticated flow remains unchanged by the pre-auth size gate; normal small pre-auth messages still parse.
- What you did **not** verify: throughput/perf impact under production load.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this branch.
- Files/config to restore: gateway handshake constants and pre-auth message handling.
- Known bad symptoms reviewers should watch for: legitimate pre-auth clients with unusually large connect payloads closing with `1009`.

## Risks and Mitigations

- Risk: clients with oversized pre-auth payloads may now fail earlier.
  - Mitigation: the limit only applies before authentication and is set high enough for normal handshake payloads.
