### PR TITLE
Hardening: require LINE webhook signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Security/browser.request: block persistent browser profile create/delete routes from write-scoped `browser.request` so callers can no longer persist admin-only browser profile changes through the browser control surface. (`GHSA-vmhq-cqm9-6p7q`)(#43800) Thanks @tdjackey and @vincentkoc.
 - Security/agent: reject public spawned-run lineage fields and keep workspace inheritance on the internal spawned-session path so external `agent` callers can no longer override the gateway workspace boundary. (`GHSA-2rqg-gjgv-84jm`)(#43801) Thanks @tdjackey and @vincentkoc.
 - Security/exec allowlist: preserve POSIX case sensitivity and keep `?` within a single path segment so exact-looking allowlist patterns no longer overmatch executables across case or directory boundaries. (`GHSA-f8r2-vg7x-gh8m`)(#43798) Thanks @zpbrent and @vincentkoc.
+- Security/LINE webhook: require signatures for empty-event POST probes too so unsigned requests no longer confirm webhook reachability with a `200` response. (`GHSA-mhxh-9pjm-w7q5`)(#44090) Thanks @TerminalsandCoffee and @vincentkoc.
 
 ### Changes
 

--- a/src/line/webhook-node.test.ts
+++ b/src/line/webhook-node.test.ts
@@ -86,16 +86,16 @@ describe("createLineNodeWebhookHandler", () => {
     expect(res.body).toBeUndefined();
   });
 
-  it("returns 200 for verification request (empty events, no signature)", async () => {
+  it("rejects verification-shaped requests without a signature", async () => {
     const rawBody = JSON.stringify({ events: [] });
     const { bot, handler } = createPostWebhookTestHarness(rawBody);
 
     const { res, headers } = createRes();
     await handler({ method: "POST", headers: {} } as unknown as IncomingMessage, res);
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(400);
     expect(headers["content-type"]).toBe("application/json");
-    expect(res.body).toBe(JSON.stringify({ status: "ok" }));
+    expect(res.body).toBe(JSON.stringify({ error: "Missing X-Line-Signature header" }));
     expect(bot.handleWebhook).not.toHaveBeenCalled();
   });
 

--- a/src/line/webhook-node.test.ts
+++ b/src/line/webhook-node.test.ts
@@ -99,6 +99,19 @@ describe("createLineNodeWebhookHandler", () => {
     expect(bot.handleWebhook).not.toHaveBeenCalled();
   });
 
+  it("accepts signed verification-shaped requests without dispatching events", async () => {
+    const rawBody = JSON.stringify({ events: [] });
+    const { bot, handler, secret } = createPostWebhookTestHarness(rawBody);
+
+    const { res, headers } = createRes();
+    await runSignedPost({ handler, rawBody, secret, res });
+
+    expect(res.statusCode).toBe(200);
+    expect(headers["content-type"]).toBe("application/json");
+    expect(res.body).toBe(JSON.stringify({ status: "ok" }));
+    expect(bot.handleWebhook).not.toHaveBeenCalled();
+  });
+
   it("returns 405 for non-GET/HEAD/POST methods", async () => {
     const { bot, handler } = createPostWebhookTestHarness(JSON.stringify({ events: [] }));
 

--- a/src/line/webhook-node.test.ts
+++ b/src/line/webhook-node.test.ts
@@ -134,13 +134,10 @@ describe("createLineNodeWebhookHandler", () => {
     expect(bot.handleWebhook).not.toHaveBeenCalled();
   });
 
-  it("uses a tight body-read limit for unsigned POST requests", async () => {
+  it("rejects unsigned POST requests before reading the body", async () => {
     const bot = { handleWebhook: vi.fn(async () => {}) };
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-    const readBody = vi.fn(async (_req: IncomingMessage, maxBytes: number) => {
-      expect(maxBytes).toBe(4096);
-      return JSON.stringify({ events: [{ type: "message" }] });
-    });
+    const readBody = vi.fn(async () => JSON.stringify({ events: [{ type: "message" }] }));
     const handler = createLineNodeWebhookHandler({
       channelSecret: "secret",
       bot,
@@ -152,7 +149,7 @@ describe("createLineNodeWebhookHandler", () => {
     await handler({ method: "POST", headers: {} } as unknown as IncomingMessage, res);
 
     expect(res.statusCode).toBe(400);
-    expect(readBody).toHaveBeenCalledTimes(1);
+    expect(readBody).not.toHaveBeenCalled();
     expect(bot.handleWebhook).not.toHaveBeenCalled();
   });
 

--- a/src/line/webhook-node.ts
+++ b/src/line/webhook-node.ts
@@ -8,7 +8,7 @@ import {
 } from "../infra/http-body.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { validateLineSignature } from "./signature.js";
-import { isLineWebhookVerificationRequest, parseLineWebhookBody } from "./webhook-utils.js";
+import { parseLineWebhookBody } from "./webhook-utils.js";
 
 const LINE_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const LINE_WEBHOOK_PREAUTH_MAX_BODY_BYTES = 64 * 1024;
@@ -75,20 +75,10 @@ export function createLineNodeWebhookHandler(params: {
         : Math.min(maxBodyBytes, LINE_WEBHOOK_UNSIGNED_MAX_BODY_BYTES);
       const rawBody = await readBody(req, bodyLimit, LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS);
 
-      // Parse once; we may need it for verification requests and for event processing.
+      // Parse once for signature-verified event processing.
       const body = parseLineWebhookBody(rawBody);
 
-      // LINE webhook verification sends POST {"events":[]} without a
-      // signature header. Return 200 so the LINE Developers Console
-      // "Verify" button succeeds.
       if (!hasSignature) {
-        if (isLineWebhookVerificationRequest(body)) {
-          logVerbose("line: webhook verification request (empty events, no signature) - 200 OK");
-          res.statusCode = 200;
-          res.setHeader("Content-Type", "application/json");
-          res.end(JSON.stringify({ status: "ok" }));
-          return;
-        }
         logVerbose("line: webhook missing X-Line-Signature header");
         res.statusCode = 400;
         res.setHeader("Content-Type", "application/json");

--- a/src/line/webhook-node.ts
+++ b/src/line/webhook-node.ts
@@ -75,9 +75,6 @@ export function createLineNodeWebhookHandler(params: {
         : Math.min(maxBodyBytes, LINE_WEBHOOK_UNSIGNED_MAX_BODY_BYTES);
       const rawBody = await readBody(req, bodyLimit, LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS);
 
-      // Parse once for signature-verified event processing.
-      const body = parseLineWebhookBody(rawBody);
-
       if (!hasSignature) {
         logVerbose("line: webhook missing X-Line-Signature header");
         res.statusCode = 400;
@@ -93,6 +90,8 @@ export function createLineNodeWebhookHandler(params: {
         res.end(JSON.stringify({ error: "Invalid signature" }));
         return;
       }
+
+      const body = parseLineWebhookBody(rawBody);
 
       if (!body) {
         res.statusCode = 400;

--- a/src/line/webhook-node.ts
+++ b/src/line/webhook-node.ts
@@ -12,7 +12,6 @@ import { parseLineWebhookBody } from "./webhook-utils.js";
 
 const LINE_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const LINE_WEBHOOK_PREAUTH_MAX_BODY_BYTES = 64 * 1024;
-const LINE_WEBHOOK_UNSIGNED_MAX_BODY_BYTES = 4 * 1024;
 const LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS = 5_000;
 
 export async function readLineWebhookRequestBody(
@@ -65,23 +64,24 @@ export function createLineNodeWebhookHandler(params: {
       const signatureHeader = req.headers["x-line-signature"];
       const signature =
         typeof signatureHeader === "string"
-          ? signatureHeader
+          ? signatureHeader.trim()
           : Array.isArray(signatureHeader)
-            ? signatureHeader[0]
-            : undefined;
-      const hasSignature = typeof signature === "string" && signature.trim().length > 0;
-      const bodyLimit = hasSignature
-        ? Math.min(maxBodyBytes, LINE_WEBHOOK_PREAUTH_MAX_BODY_BYTES)
-        : Math.min(maxBodyBytes, LINE_WEBHOOK_UNSIGNED_MAX_BODY_BYTES);
-      const rawBody = await readBody(req, bodyLimit, LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS);
+            ? (signatureHeader[0] ?? "").trim()
+            : "";
 
-      if (!hasSignature) {
+      if (!signature) {
         logVerbose("line: webhook missing X-Line-Signature header");
         res.statusCode = 400;
         res.setHeader("Content-Type", "application/json");
         res.end(JSON.stringify({ error: "Missing X-Line-Signature header" }));
         return;
       }
+
+      const rawBody = await readBody(
+        req,
+        Math.min(maxBodyBytes, LINE_WEBHOOK_PREAUTH_MAX_BODY_BYTES),
+        LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS,
+      );
 
       if (!validateLineSignature(rawBody, signature, params.channelSecret)) {
         logVerbose("line: webhook signature validation failed");

--- a/src/line/webhook-utils.ts
+++ b/src/line/webhook-utils.ts
@@ -7,9 +7,3 @@ export function parseLineWebhookBody(rawBody: string): WebhookRequestBody | null
     return null;
   }
 }
-
-export function isLineWebhookVerificationRequest(
-  body: WebhookRequestBody | null | undefined,
-): boolean {
-  return !!body && Array.isArray(body.events) && body.events.length === 0;
-}

--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -107,6 +107,14 @@ describe("createLineWebhookMiddleware", () => {
     expect(onEvents).not.toHaveBeenCalled();
   });
 
+  it("rejects oversized signed payloads before JSON parsing", async () => {
+    const largeBody = JSON.stringify({ events: [], payload: "x".repeat(70 * 1024) });
+    const { res, onEvents } = await invokeWebhook({ body: largeBody });
+    expect(res.status).toHaveBeenCalledWith(413);
+    expect(res.json).toHaveBeenCalledWith({ error: "Payload too large" });
+    expect(onEvents).not.toHaveBeenCalled();
+  });
+
   it("rejects missing signature when events are non-empty", async () => {
     const { res, onEvents } = await invokeWebhook({
       body: JSON.stringify({ events: [{ type: "message" }] }),

--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -98,6 +98,15 @@ describe("createLineWebhookMiddleware", () => {
     expect(onEvents).not.toHaveBeenCalled();
   });
 
+  it("accepts signed verification-shaped requests without dispatching events", async () => {
+    const { res, onEvents } = await invokeWebhook({
+      body: JSON.stringify({ events: [] }),
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: "ok" });
+    expect(onEvents).not.toHaveBeenCalled();
+  });
+
   it("rejects missing signature when events are non-empty", async () => {
     const { res, onEvents } = await invokeWebhook({
       body: JSON.stringify({ events: [{ type: "message" }] }),

--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -87,14 +87,14 @@ describe("createLineWebhookMiddleware", () => {
     expect(onEvents).not.toHaveBeenCalled();
   });
 
-  it("returns 200 for verification request (empty events, no signature)", async () => {
+  it("rejects verification-shaped requests without a signature", async () => {
     const { res, onEvents } = await invokeWebhook({
       body: JSON.stringify({ events: [] }),
       headers: {},
       autoSign: false,
     });
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ status: "ok" });
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "Missing X-Line-Signature header" });
     expect(onEvents).not.toHaveBeenCalled();
   });
 

--- a/src/line/webhook.ts
+++ b/src/line/webhook.ts
@@ -5,6 +5,8 @@ import type { RuntimeEnv } from "../runtime.js";
 import { validateLineSignature } from "./signature.js";
 import { parseLineWebhookBody } from "./webhook-utils.js";
 
+const LINE_WEBHOOK_MAX_RAW_BODY_BYTES = 64 * 1024;
+
 export interface LineWebhookOptions {
   channelSecret: string;
   onEvents: (body: WebhookRequestBody) => Promise<void>;
@@ -49,6 +51,10 @@ export function createLineWebhookMiddleware(
 
       if (!rawBody) {
         res.status(400).json({ error: "Missing raw request body for signature verification" });
+        return;
+      }
+      if (Buffer.byteLength(rawBody, "utf-8") > LINE_WEBHOOK_MAX_RAW_BODY_BYTES) {
+        res.status(413).json({ error: "Payload too large" });
         return;
       }
 

--- a/src/line/webhook.ts
+++ b/src/line/webhook.ts
@@ -39,13 +39,13 @@ export function createLineWebhookMiddleware(
   return async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
     try {
       const signature = req.headers["x-line-signature"];
-      const rawBody = readRawBody(req);
-      const body = parseWebhookBody(req, rawBody);
 
       if (!signature || typeof signature !== "string") {
         res.status(400).json({ error: "Missing X-Line-Signature header" });
         return;
       }
+
+      const rawBody = readRawBody(req);
 
       if (!rawBody) {
         res.status(400).json({ error: "Missing raw request body for signature verification" });
@@ -57,6 +57,8 @@ export function createLineWebhookMiddleware(
         res.status(401).json({ error: "Invalid signature" });
         return;
       }
+
+      const body = parseWebhookBody(req, rawBody);
 
       if (!body) {
         res.status(400).json({ error: "Invalid webhook payload" });

--- a/src/line/webhook.ts
+++ b/src/line/webhook.ts
@@ -3,7 +3,7 @@ import type { Request, Response, NextFunction } from "express";
 import { logVerbose, danger } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { validateLineSignature } from "./signature.js";
-import { isLineWebhookVerificationRequest, parseLineWebhookBody } from "./webhook-utils.js";
+import { parseLineWebhookBody } from "./webhook-utils.js";
 
 export interface LineWebhookOptions {
   channelSecret: string;
@@ -42,15 +42,7 @@ export function createLineWebhookMiddleware(
       const rawBody = readRawBody(req);
       const body = parseWebhookBody(req, rawBody);
 
-      // LINE webhook verification sends POST {"events":[]} without a
-      // signature header.  Return 200 immediately so the LINE Developers
-      // Console "Verify" button succeeds.
       if (!signature || typeof signature !== "string") {
-        if (isLineWebhookVerificationRequest(body)) {
-          logVerbose("line: webhook verification request (empty events, no signature) - 200 OK");
-          res.status(200).json({ status: "ok" });
-          return;
-        }
         res.status(400).json({ error: "Missing X-Line-Signature header" });
         return;
       }


### PR DESCRIPTION
## Summary

- Problem: LINE webhook handlers returned `200 {"status":"ok"}` for unsigned `{"events":[]}` POSTs.
- Why it matters: this enables endpoint verification and fingerprinting without demonstrating signed event injection.
- What changed: require `X-Line-Signature` for all POST webhook requests in both Express and Node handlers and update tests.
- What did NOT change (scope boundary): signed LINE webhook processing and event dispatch.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #GHSA-mhxh-9pjm-w7q5

## User-visible / Behavior Changes

Unsigned LINE webhook POSTs now return signature errors even when the body contains an empty events array.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): LINE webhook handlers
- Relevant config (redacted): POST body with `{"events":[]}` and no signature header

### Steps

1. Send an unsigned POST with `{"events":[]}` to the Express webhook handler.
2. Send the same request to the Node webhook handler.
3. Compare responses before and after the change.

### Expected

- All POST webhook requests should require `X-Line-Signature`.

### Actual

- Before this change, unsigned empty-event requests were accepted with `200`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: confirmed both handlers previously accepted unsigned empty-event POSTs and now reject them; reran the targeted webhook tests.
- Edge cases checked: signed requests continue through the normal verification path.
- What you did **not** verify: live LINE platform callback behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this branch.
- Files/config to restore: LINE webhook handler signature checks.
- Known bad symptoms reviewers should watch for: test or health-check callers relying on unsigned empty-event POSTs.

## Risks and Mitigations

- Risk: unsigned probe traffic will now receive errors instead of `200`.
  - Mitigation: that traffic was never valid webhook traffic and should not be relied on.
