### PR TITLE
fix(memory): support FTS-only indexing without embedding provider

### DIFF
--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -768,12 +768,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           .run(pathname, source);
       } catch {}
     }
-    const currentModel = this.provider?.model ?? "fts-only";
     if (this.fts.enabled && this.fts.available) {
       try {
         this.db
-          .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-          .run(pathname, source, currentModel);
+          .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+          .run(pathname, source);
       } catch {}
     }
     this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(pathname, source);

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -768,11 +768,12 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           .run(pathname, source);
       } catch {}
     }
-    if (this.fts.enabled && this.fts.available && this.provider) {
+    const currentModel = this.provider?.model ?? "fts-only";
+    if (this.fts.enabled && this.fts.available) {
       try {
         this.db
           .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-          .run(pathname, source, this.provider.model);
+          .run(pathname, source, currentModel);
       } catch {}
     }
     this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(pathname, source);
@@ -805,73 +806,72 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     entry: MemoryFileEntry | SessionFileEntry,
     options: { source: MemorySource; content?: string },
   ) {
-    // FTS-only mode: skip indexing if no provider
-    if (!this.provider) {
-      log.debug("Skipping embedding indexing in FTS-only mode", {
-        path: entry.path,
-        source: options.source,
-      });
-      return;
-    }
-
+    const provider = this.provider;
+    const providerModel = provider?.model ?? "fts-only";
     let chunks: MemoryChunk[];
     let structuredInputBytes: number | undefined;
     if ("kind" in entry && entry.kind === "multimodal") {
-      const multimodalChunk = await buildMultimodalChunkForIndexing(entry);
-      if (!multimodalChunk) {
-        this.clearIndexedFileData(entry.path, options.source);
-        this.deleteFileRecord(entry.path, options.source);
-        return;
+      if (!provider) {
+        const text = entry.contentText?.trim() || entry.path;
+        chunks = [{ startLine: 1, endLine: 1, text, hash: entry.hash }];
+      } else {
+        const multimodalChunk = await buildMultimodalChunkForIndexing(entry);
+        if (!multimodalChunk) {
+          this.clearIndexedFileData(entry.path, options.source);
+          this.deleteFileRecord(entry.path, options.source);
+          return;
+        }
+        structuredInputBytes = multimodalChunk.structuredInputBytes;
+        chunks = [multimodalChunk.chunk];
       }
-      structuredInputBytes = multimodalChunk.structuredInputBytes;
-      chunks = [multimodalChunk.chunk];
     } else {
       const content = options.content ?? (await fs.readFile(entry.absPath, "utf-8"));
-      chunks = enforceEmbeddingMaxInputTokens(
-        this.provider,
-        chunkMarkdown(content, this.settings.chunking).filter(
-          (chunk) => chunk.text.trim().length > 0,
-        ),
-        EMBEDDING_BATCH_MAX_TOKENS,
+      const rawChunks = chunkMarkdown(content, this.settings.chunking).filter(
+        (chunk) => chunk.text.trim().length > 0,
       );
+      chunks = provider
+        ? enforceEmbeddingMaxInputTokens(provider, rawChunks, EMBEDDING_BATCH_MAX_TOKENS)
+        : rawChunks;
       if (options.source === "sessions" && "lineMap" in entry) {
         remapChunkLines(chunks, entry.lineMap);
       }
     }
-    let embeddings: number[][];
-    try {
-      embeddings = this.batch.enabled
-        ? await this.embedChunksWithBatch(chunks, entry, options.source)
-        : await this.embedChunksInBatches(chunks);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (
-        "kind" in entry &&
-        entry.kind === "multimodal" &&
-        this.isStructuredInputTooLargeError(message)
-      ) {
-        log.warn("memory embeddings: skipping multimodal file rejected as too large", {
-          path: entry.path,
-          bytes: structuredInputBytes,
-          provider: this.provider.id,
-          model: this.provider.model,
-          error: message,
-        });
-        this.clearIndexedFileData(entry.path, options.source);
-        this.upsertFileRecord(entry, options.source);
-        return;
+    let embeddings: number[][] = chunks.map(() => []);
+    if (provider) {
+      try {
+        embeddings = this.batch.enabled
+          ? await this.embedChunksWithBatch(chunks, entry, options.source)
+          : await this.embedChunksInBatches(chunks);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (
+          "kind" in entry &&
+          entry.kind === "multimodal" &&
+          this.isStructuredInputTooLargeError(message)
+        ) {
+          log.warn("memory embeddings: skipping multimodal file rejected as too large", {
+            path: entry.path,
+            bytes: structuredInputBytes,
+            provider: provider.id,
+            model: provider.model,
+            error: message,
+          });
+          this.clearIndexedFileData(entry.path, options.source);
+          this.upsertFileRecord(entry, options.source);
+          return;
+        }
+        throw err;
       }
-      throw err;
     }
-    const sample = embeddings.find((embedding) => embedding.length > 0);
-    const vectorReady = sample ? await this.ensureVectorReady(sample.length) : false;
+    const sample = provider ? embeddings.find((embedding) => embedding.length > 0) : undefined;
+    const vectorReady = provider && sample ? await this.ensureVectorReady(sample.length) : false;
     const now = Date.now();
     this.clearIndexedFileData(entry.path, options.source);
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
       const embedding = embeddings[i] ?? [];
       const id = hashText(
-        `${options.source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${this.provider.model}`,
+        `${options.source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${providerModel}`,
       );
       this.db
         .prepare(
@@ -891,7 +891,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           chunk.startLine,
           chunk.endLine,
           chunk.hash,
-          this.provider.model,
+          providerModel,
           chunk.text,
           JSON.stringify(embedding),
           now,
@@ -915,7 +915,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
             id,
             entry.path,
             options.source,
-            this.provider.model,
+            providerModel,
             chunk.startLine,
             chunk.endLine,
           );

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -663,6 +663,9 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
+    if (!this.provider && !this.fts.enabled) {
+      return;
+    }
     const files = await listMemoryFiles(
       this.workspaceDir,
       this.settings.extraPaths,
@@ -721,7 +724,6 @@ export abstract class MemoryManagerSyncOps {
     const staleRows = this.db
       .prepare(`SELECT path FROM files WHERE source = ?`)
       .all("memory") as Array<{ path: string }>;
-    const currentModel = this.provider?.model ?? "fts-only";
     for (const stale of staleRows) {
       if (activePaths.has(stale.path)) {
         continue;
@@ -738,8 +740,8 @@ export abstract class MemoryManagerSyncOps {
       if (this.fts.enabled && this.fts.available) {
         try {
           this.db
-            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-            .run(stale.path, "memory", currentModel);
+            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+            .run(stale.path, "memory");
         } catch {}
       }
     }
@@ -749,6 +751,9 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
+    if (!this.provider && !this.fts.enabled) {
+      return;
+    }
     const files = await listSessionFilesForAgent(this.agentId);
     const activePaths = new Set(files.map((file) => sessionPathForFile(file)));
     const indexAll = params.needsFullReindex || this.sessionsDirtyFiles.size === 0;
@@ -819,7 +824,6 @@ export abstract class MemoryManagerSyncOps {
     const staleRows = this.db
       .prepare(`SELECT path FROM files WHERE source = ?`)
       .all("sessions") as Array<{ path: string }>;
-    const currentModel = this.provider?.model ?? "fts-only";
     for (const stale of staleRows) {
       if (activePaths.has(stale.path)) {
         continue;
@@ -840,8 +844,8 @@ export abstract class MemoryManagerSyncOps {
       if (this.fts.enabled && this.fts.available) {
         try {
           this.db
-            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-            .run(stale.path, "sessions", currentModel);
+            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+            .run(stale.path, "sessions");
         } catch {}
       }
     }

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -663,12 +663,6 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    // FTS-only mode: skip embedding sync (no provider)
-    if (!this.provider) {
-      log.debug("Skipping memory file sync in FTS-only mode (no embedding provider)");
-      return;
-    }
-
     const files = await listMemoryFiles(
       this.workspaceDir,
       this.settings.extraPaths,
@@ -727,6 +721,7 @@ export abstract class MemoryManagerSyncOps {
     const staleRows = this.db
       .prepare(`SELECT path FROM files WHERE source = ?`)
       .all("memory") as Array<{ path: string }>;
+    const currentModel = this.provider?.model ?? "fts-only";
     for (const stale of staleRows) {
       if (activePaths.has(stale.path)) {
         continue;
@@ -744,7 +739,7 @@ export abstract class MemoryManagerSyncOps {
         try {
           this.db
             .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-            .run(stale.path, "memory", this.provider.model);
+            .run(stale.path, "memory", currentModel);
         } catch {}
       }
     }
@@ -754,12 +749,6 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    // FTS-only mode: skip embedding sync (no provider)
-    if (!this.provider) {
-      log.debug("Skipping session file sync in FTS-only mode (no embedding provider)");
-      return;
-    }
-
     const files = await listSessionFilesForAgent(this.agentId);
     const activePaths = new Set(files.map((file) => sessionPathForFile(file)));
     const indexAll = params.needsFullReindex || this.sessionsDirtyFiles.size === 0;
@@ -830,6 +819,7 @@ export abstract class MemoryManagerSyncOps {
     const staleRows = this.db
       .prepare(`SELECT path FROM files WHERE source = ?`)
       .all("sessions") as Array<{ path: string }>;
+    const currentModel = this.provider?.model ?? "fts-only";
     for (const stale of staleRows) {
       if (activePaths.has(stale.path)) {
         continue;
@@ -851,7 +841,7 @@ export abstract class MemoryManagerSyncOps {
         try {
           this.db
             .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-            .run(stale.path, "sessions", this.provider.model);
+            .run(stale.path, "sessions", currentModel);
         } catch {}
       }
     }

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -663,7 +663,7 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    if (!this.provider && !this.fts.enabled) {
+    if (!this.provider && (!this.fts.enabled || !this.fts.available)) {
       return;
     }
     const files = await listMemoryFiles(
@@ -751,7 +751,7 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    if (!this.provider && !this.fts.enabled) {
+    if (!this.provider && (!this.fts.enabled || !this.fts.available)) {
       return;
     }
     const files = await listSessionFilesForAgent(this.agentId);

--- a/src/memory/manager.fts-only.test.ts
+++ b/src/memory/manager.fts-only.test.ts
@@ -222,6 +222,43 @@ describe("memory manager fts-only indexing", () => {
     await expect(activeManager.search("zebra")).resolves.toEqual([]);
   });
 
+  it("removes old provider-model FTS rows when reindexing into fts-only mode", async () => {
+    mockState.mode = "mock";
+    const providerManager = await createManager(createCfg({ provider: "openai" }));
+    await providerManager.sync({ reason: "test" });
+
+    expect(
+      countRows(
+        providerManager,
+        "SELECT COUNT(*) as c FROM chunks_fts WHERE model = ?",
+        "mock-embed",
+      ),
+    ).toBeGreaterThan(0);
+
+    await providerManager.close();
+    manager = null;
+
+    mockState.mode = "none";
+    const ftsOnlyManager = await createManager(createCfg());
+    await ftsOnlyManager.sync({ reason: "test" });
+
+    expect(
+      countRows(
+        ftsOnlyManager,
+        "SELECT COUNT(*) as c FROM chunks_fts WHERE model = ?",
+        "mock-embed",
+      ),
+    ).toBe(0);
+    expect(
+      countRows(ftsOnlyManager, "SELECT COUNT(*) as c FROM chunks_fts WHERE model = ?", "fts-only"),
+    ).toBeGreaterThan(0);
+
+    const zebraResults = (await ftsOnlyManager.search("zebra")).filter(
+      (entry) => entry.path === "memory/2026-01-12.md",
+    );
+    expect(zebraResults).toHaveLength(1);
+  });
+
   it("keeps provider-backed indexing behavior unchanged", async () => {
     mockState.mode = "mock";
     const activeManager = await createManager(createCfg({ provider: "openai" }));

--- a/src/memory/manager.fts-only.test.ts
+++ b/src/memory/manager.fts-only.test.ts
@@ -1,0 +1,245 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { MemoryIndexManager } from "./index.js";
+import { getRequiredMemoryIndexManager } from "./test-manager-helpers.js";
+import "./test-runtime-mocks.js";
+
+function encodeText(text: string): number[] {
+  const lower = text.toLowerCase();
+  const alpha = lower.split("alpha").length - 1;
+  const zebra = lower.split("zebra").length - 1;
+  const session = lower.split("session").length - 1;
+  return [alpha, zebra, session];
+}
+
+const mockState = vi.hoisted(() => ({
+  mode: "none" as "none" | "mock",
+  embedBatch: vi.fn(),
+  embedQuery: vi.fn(),
+}));
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: async (options: { provider?: string; model?: string }) => {
+    if (mockState.mode === "none") {
+      return {
+        requestedProvider: options.provider ?? "auto",
+        provider: null,
+        providerUnavailableReason: 'No API key found for provider "openai"',
+      };
+    }
+    const model = options.model ?? "mock-embed";
+    return {
+      requestedProvider: options.provider ?? "openai",
+      provider: {
+        id: "mock",
+        model,
+        maxInputTokens: 8192,
+        embedQuery: mockState.embedQuery,
+        embedBatch: mockState.embedBatch,
+      },
+    };
+  },
+}));
+
+describe("memory manager fts-only indexing", () => {
+  let workspaceDir = "";
+  let indexPath = "";
+  let manager: MemoryIndexManager | null = null;
+
+  function createCfg(params?: {
+    sources?: Array<"memory" | "sessions">;
+    sessionMemory?: boolean;
+    provider?: "auto" | "openai";
+  }): OpenClawConfig {
+    return {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: params?.provider ?? "auto",
+            model: "mock-embed",
+            fallback: "none",
+            store: { path: indexPath, vector: { enabled: false } },
+            cache: { enabled: false },
+            chunking: { tokens: 4000, overlap: 0 },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+            query: {
+              minScore: 0,
+              hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+            },
+            sources: params?.sources,
+            experimental: { sessionMemory: params?.sessionMemory ?? false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+  }
+
+  function countRows(
+    managerInstance: MemoryIndexManager,
+    sql: string,
+    ...params: unknown[]
+  ): number {
+    const db = (
+      managerInstance as unknown as {
+        db: {
+          prepare: (statement: string) => {
+            get: (...statementParams: unknown[]) => { c?: number } | undefined;
+          };
+        };
+      }
+    ).db;
+    const row = db.prepare(sql).get(...params) as { c?: number } | undefined;
+    return row?.c ?? 0;
+  }
+
+  function setDirty(managerInstance: MemoryIndexManager): void {
+    (managerInstance as unknown as { dirty: boolean }).dirty = true;
+  }
+
+  async function createManager(cfg: OpenClawConfig): Promise<MemoryIndexManager> {
+    manager = await getRequiredMemoryIndexManager({ cfg, agentId: "main" });
+    return manager;
+  }
+
+  beforeEach(async () => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "1");
+    vi.unstubAllGlobals();
+    mockState.mode = "none";
+    mockState.embedBatch.mockReset();
+    mockState.embedQuery.mockReset();
+    mockState.embedBatch.mockImplementation(async (texts: string[]) => texts.map(encodeText));
+    mockState.embedQuery.mockImplementation(async (text: string) => encodeText(text));
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-fts-only-"));
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-01-12.md"),
+      "# Log\nAlpha memory line.\nZebra memory line.",
+    );
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    if (workspaceDir) {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      workspaceDir = "";
+    }
+  });
+
+  it("indexes markdown memory files in fts-only mode and searches via FTS", async () => {
+    const activeManager = await createManager(createCfg());
+    await activeManager.sync({ reason: "test" });
+
+    const status = activeManager.status();
+    expect(status.provider).toBe("none");
+    expect(status.custom?.searchMode).toBe("fts-only");
+    expect(status.files).toBe(1);
+    expect(status.chunks).toBeGreaterThan(0);
+    expect(countRows(activeManager, "SELECT COUNT(*) as c FROM chunks")).toBeGreaterThan(0);
+    expect(
+      countRows(activeManager, "SELECT COUNT(*) as c FROM chunks_fts WHERE model = ?", "fts-only"),
+    ).toBeGreaterThan(0);
+    expect(mockState.embedBatch).not.toHaveBeenCalled();
+
+    const results = await activeManager.search("zebra");
+    expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+  });
+
+  it("indexes session transcripts in fts-only mode", async () => {
+    const stateDir = path.join(workspaceDir, "state");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionDir, "session-1.jsonl"),
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "Session fallback topic" }],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Session recall detail" }],
+          },
+        }),
+      ].join("\n"),
+    );
+
+    const activeManager = await createManager(
+      createCfg({
+        sources: ["memory", "sessions"],
+        sessionMemory: true,
+      }),
+    );
+    await activeManager.sync({ reason: "test" });
+
+    const status = activeManager.status();
+    const sessionCounts = status.sourceCounts?.find((entry) => entry.source === "sessions");
+    expect(sessionCounts?.files).toBe(1);
+    expect(sessionCounts?.chunks ?? 0).toBeGreaterThan(0);
+    expect(
+      countRows(
+        activeManager,
+        "SELECT COUNT(*) as c FROM chunks_fts WHERE source = ? AND model = ?",
+        "sessions",
+        "fts-only",
+      ),
+    ).toBeGreaterThan(0);
+
+    const results = await activeManager.search("fallback");
+    expect(results.some((entry) => entry.path === "sessions/session-1.jsonl")).toBe(true);
+  });
+
+  it("cleans stale fts-only rows on resync", async () => {
+    const activeManager = await createManager(createCfg());
+    const memoryPath = path.join(workspaceDir, "memory", "2026-01-12.md");
+
+    await activeManager.sync({ reason: "test" });
+    expect(countRows(activeManager, "SELECT COUNT(*) as c FROM files")).toBe(1);
+    expect(countRows(activeManager, "SELECT COUNT(*) as c FROM chunks_fts")).toBeGreaterThan(0);
+
+    await fs.rm(memoryPath, { force: true });
+    setDirty(activeManager);
+    await activeManager.sync({ reason: "test" });
+
+    expect(countRows(activeManager, "SELECT COUNT(*) as c FROM files")).toBe(0);
+    expect(countRows(activeManager, "SELECT COUNT(*) as c FROM chunks")).toBe(0);
+    expect(countRows(activeManager, "SELECT COUNT(*) as c FROM chunks_fts")).toBe(0);
+    await expect(activeManager.search("zebra")).resolves.toEqual([]);
+  });
+
+  it("keeps provider-backed indexing behavior unchanged", async () => {
+    mockState.mode = "mock";
+    const activeManager = await createManager(createCfg({ provider: "openai" }));
+    await activeManager.sync({ reason: "test" });
+
+    const status = activeManager.status();
+    expect(status.provider).toBe("mock");
+    expect(status.custom?.searchMode).toBe("hybrid");
+    expect(mockState.embedBatch).toHaveBeenCalled();
+    expect(
+      countRows(
+        activeManager,
+        "SELECT COUNT(*) as c FROM chunks_fts WHERE model = ?",
+        "mock-embed",
+      ),
+    ).toBeGreaterThan(0);
+
+    const results = await activeManager.search("zebra");
+    expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes memory indexing when no embedding provider is configured.

Previously, the indexing pipeline bailed out early in provider-null mode, which prevented:

- memory file scanning
- session transcript scanning
- chunk persistence
- FTS row insertion

As a result, memory search could report FTS-only mode while still returning no indexed results.

This follow-up also fixes cleanup behavior when transitioning from provider-backed indexing to FTS-only mode, so old-model FTS rows do not remain behind and cause duplicate search results. It also skips provider-less sync work when FTS is disabled or unavailable.

## What changed

- removed provider-null early returns from:
  - `syncMemoryFiles()`
  - `syncSessionFiles()`
- updated `indexFile()` so text chunking and persistence always happen
- made embedding generation and vector writes conditional on provider availability
- added a stable provider-less model sentinel: `"fts-only"`
- made FTS cleanup path/source-based in:
  - `clearIndexedFileData()`
  - stale-row cleanup in `syncMemoryFiles()`
  - stale-row cleanup in `syncSessionFiles()`
- added a fast-exit for provider-less sync when FTS is disabled or unavailable, to avoid unnecessary scanning and indexing work
- added focused tests for:
  - markdown memory indexing in FTS-only mode
  - session transcript indexing in FTS-only mode
  - stale-row cleanup on resync
  - provider-backed regression sanity
  - provider-backed -> FTS-only transition cleanup, ensuring old-model FTS rows are removed and search results do not duplicate

## Scope

This patch intentionally preserves the existing configuration semantics around FTS/hybrid enablement. It fixes the broken provider-null indexing path when FTS-backed search is enabled, but does not change whether FTS should be auto-enabled when `query.hybrid.enabled` is false.

## Validation

Passed locally:

- `pnpm exec vitest run src/memory/manager.fts-only.test.ts`
- `pnpm exec vitest run src/memory/index.test.ts`
- `pnpm build`
- `pnpm check`

Closes #43957