### PR TITLE
fix(cron): make doctor cron normalization idempotent

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -47,6 +47,52 @@ describe("normalizeStoredCronJobs", () => {
     });
   });
 
+  it("is idempotent on already-normalized jobs", () => {
+    const jobs = [
+      {
+        id: "already-normalized",
+        name: "test job",
+        enabled: true,
+        wakeMode: "now",
+        sessionTarget: "isolated",
+        schedule: { kind: "cron", expr: "*/5 * * * *" },
+        payload: {
+          kind: "agentTurn",
+          message: "hello",
+        },
+        delivery: { mode: "announce" },
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const _first = normalizeStoredCronJobs(jobs);
+    // First pass may touch stagger or minor fields
+    const snapshot = JSON.parse(JSON.stringify(jobs));
+
+    const second = normalizeStoredCronJobs(snapshot);
+    expect(second.issues).toEqual({});
+    expect(second.mutated).toBe(false);
+  });
+
+  it("does not flag agentTurn/systemEvent as legacy payload kind", () => {
+    const jobs = [
+      {
+        id: "correct-kind",
+        name: "already correct",
+        enabled: true,
+        wakeMode: "now",
+        sessionTarget: "isolated",
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 0 },
+        payload: { kind: "agentTurn", message: "hi" },
+        delivery: { mode: "announce" },
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+  });
+
   it("normalizes payload provider alias into channel", () => {
     const jobs = [
       {

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,12 +28,16 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
+  const raw = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  if (raw === "agentTurn" || raw === "systemEvent") {
+    return false;
+  }
+  const lowered = raw.toLowerCase();
+  if (lowered === "agentturn") {
     payload.kind = "agentTurn";
     return true;
   }
-  if (raw === "systemevent") {
+  if (lowered === "systemevent") {
     payload.kind = "systemEvent";
     return true;
   }


### PR DESCRIPTION
Running `openclaw doctor --fix` normalizes legacy cron jobs but on the next run it detects the same issues and offers to fix them again. This happens because `normalizePayloadKind()` lowercases the kind value before comparing, so `"agentTurn"` becomes `"agentturn"` which matches the legacy condition every time, even when the value is already correct.

The fix checks for the canonical forms (`"agentTurn"`, `"systemEvent"`) before lowercasing and returns false immediately when the value needs no change.

Two new tests verify the fix: one runs normalization twice and checks the second pass finds zero issues and zero mutations, the other confirms correctly-cased kinds are not flagged as legacy.

All 8 tests pass (4 store-migration + 4 doctor-cron).

Closes #44005