### PR TITLE
fix(security): add default pidsLimit for sandbox containers

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SANDBOX_IDLE_HOURS,
   DEFAULT_SANDBOX_IMAGE,
   DEFAULT_SANDBOX_MAX_AGE_DAYS,
+  DEFAULT_SANDBOX_PIDS_LIMIT,
   DEFAULT_SANDBOX_WORKDIR,
   DEFAULT_SANDBOX_WORKSPACE_ROOT,
 } from "./constants.js";
@@ -105,7 +106,7 @@ export function resolveSandboxDockerConfig(params: {
     capDrop: agentDocker?.capDrop ?? globalDocker?.capDrop ?? ["ALL"],
     env,
     setupCommand: agentDocker?.setupCommand ?? globalDocker?.setupCommand,
-    pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit,
+    pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit ?? DEFAULT_SANDBOX_PIDS_LIMIT,
     memory: agentDocker?.memory ?? globalDocker?.memory,
     memorySwap: agentDocker?.memorySwap ?? globalDocker?.memorySwap,
     cpus: agentDocker?.cpus ?? globalDocker?.cpus,

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -10,6 +10,13 @@ export const DEFAULT_SANDBOX_WORKDIR = "/workspace";
 export const DEFAULT_SANDBOX_IDLE_HOURS = 24;
 export const DEFAULT_SANDBOX_MAX_AGE_DAYS = 7;
 
+/**
+ * Default PID limit for sandbox containers to prevent fork bomb attacks.
+ * A value of 1024 is reasonable for most agent workloads while preventing
+ * resource exhaustion attacks on the host system.
+ */
+export const DEFAULT_SANDBOX_PIDS_LIMIT = 1024;
+
 export const DEFAULT_TOOL_ALLOW = [
   "exec",
   "process",


### PR DESCRIPTION
## Summary

Sandbox containers were created without a default pidsLimit, making them vulnerable to fork bomb attacks that could exhaust host resources.

## Security Impact

- **Prevents fork bomb attacks**: Malicious or compromised agents cannot execute `:(){ :|:& };:` style attacks
- **Limits container processes**: Containers can create at most 1024 processes
- **Protects host system**: Prevents PID/memory exhaustion

## Changes

1. Added `DEFAULT_SANDBOX_PIDS_LIMIT = 1024` constant in `src/agents/sandbox/constants.ts`
2. Applied default value in `src/agents/sandbox/config.ts` when no explicit limit is configured

## Before

```typescript
pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit,  // NO DEFAULT!
```

## After

```typescript
pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit ?? DEFAULT_SANDBOX_PIDS_LIMIT,
```

Fixes #38604