### PR TITLE
fix(hooks): use session creation date for memory filename

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -572,4 +572,146 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("user: Only message 1");
     expect(memoryContent).toContain("assistant: Only message 2");
   });
+
+  describe("session creation date for memory filename", () => {
+    it("uses session creation timestamp for date when session header has valid timestamp", async () => {
+      // Session created on 2026-03-10, but /new runs on 2026-03-12
+      const sessionCreatedAt = "2026-03-10T08:30:00.000Z";
+      const sessionContent = [
+        JSON.stringify({ type: "session", timestamp: sessionCreatedAt }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "Hello" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "World" } }),
+      ].join("\n");
+
+      const tempDir = await createCaseWorkspace("workspace");
+      const sessionsDir = path.join(tempDir, "sessions");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const sessionFile = await writeWorkspaceFile({
+        dir: sessionsDir,
+        name: "test-session.jsonl",
+        content: sessionContent,
+      });
+
+      const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+        tempDir,
+        previousSessionEntry: { sessionId: "test-123", sessionFile },
+      });
+
+      // File should be named with session creation date
+      expect(files[0]).toMatch(/^2026-03-10-/);
+      // Header should show session creation time
+      expect(memoryContent).toContain("# Session: 2026-03-10 08:30:00 UTC");
+    });
+
+    it("falls back to event timestamp when session header has no timestamp field", async () => {
+      const sessionContent = [
+        JSON.stringify({ type: "session" }), // no timestamp field
+        JSON.stringify({ type: "message", message: { role: "user", content: "Hello" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "World" } }),
+      ].join("\n");
+
+      const { files } = await runNewWithPreviousSession({ sessionContent });
+
+      // File should be named with today's date (event timestamp)
+      const today = new Date().toISOString().split("T")[0];
+      expect(files[0]).toMatch(new RegExp(`^${today}-`));
+    });
+
+    it("falls back to event timestamp when session file has no session header", async () => {
+      // No type="session" entry at all
+      const sessionContent = createMockSessionContent([
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "World" },
+      ]);
+
+      const { files } = await runNewWithPreviousSession({ sessionContent });
+
+      const today = new Date().toISOString().split("T")[0];
+      expect(files[0]).toMatch(new RegExp(`^${today}-`));
+    });
+
+    it("falls back to event timestamp when session header has invalid date string", async () => {
+      const sessionContent = [
+        JSON.stringify({ type: "session", timestamp: "not-a-valid-date" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "Hello" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "World" } }),
+      ].join("\n");
+
+      const tempDir = await createCaseWorkspace("workspace");
+      const sessionsDir = path.join(tempDir, "sessions");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const sessionFile = await writeWorkspaceFile({
+        dir: sessionsDir,
+        name: "test-session.jsonl",
+        content: sessionContent,
+      });
+
+      const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+        tempDir,
+        previousSessionEntry: { sessionId: "test-123", sessionFile },
+      });
+
+      // Should still create a memory file (no silent failure)
+      expect(files.length).toBe(1);
+      // Should use today's date (fallback)
+      const today = new Date().toISOString().split("T")[0];
+      expect(files[0]).toMatch(new RegExp(`^${today}-`));
+      // Memory content should still have the messages
+      expect(memoryContent).toContain("user: Hello");
+      expect(memoryContent).toContain("assistant: World");
+    });
+
+    it("uses event timestamp for HHMM slug even when session has creation timestamp", async () => {
+      // This tests that the HHMM slug (for uniqueness) uses event.timestamp
+      // while date uses session creation timestamp
+      const sessionCreatedAt = "2026-03-10T08:30:00.000Z";
+      const sessionContent = [
+        JSON.stringify({ type: "session", timestamp: sessionCreatedAt }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "Test" } }),
+      ].join("\n");
+
+      const tempDir = await createCaseWorkspace("workspace");
+      const sessionsDir = path.join(tempDir, "sessions");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const sessionFile = await writeWorkspaceFile({
+        dir: sessionsDir,
+        name: "test-session.jsonl",
+        content: sessionContent,
+      });
+
+      // Disable LLM slug to force HHMM fallback
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { workspace: tempDir } },
+        hooks: { internal: { entries: { "session-memory": { enabled: true, llmSlug: false } } } },
+      } as OpenClawConfig;
+
+      const { files } = await runNewWithPreviousSessionEntry({
+        tempDir,
+        cfg,
+        previousSessionEntry: { sessionId: "test-123", sessionFile },
+      });
+
+      // File should be named with session creation date, but HHMM from event
+      expect(files[0]).toMatch(/^2026-03-10-\d{4}\.md$/);
+      // The HHMM should NOT be 0830 (session creation time) but rather current time
+      const hhmm = files[0].match(/2026-03-10-(\d{4})\.md$/)?.[1];
+      // HHMM should be from current time, not from sessionCreatedAt
+      const nowHHMM = new Date().toISOString().split("T")[1].split(":").slice(0, 2).join("");
+      expect(hhmm).toBe(nowHHMM);
+    });
+
+    it("uses event timestamp when no session file is available", async () => {
+      const tempDir = await createCaseWorkspace("workspace");
+
+      const { files } = await runNewWithPreviousSessionEntry({
+        tempDir,
+        previousSessionEntry: { sessionId: "test-123" }, // no sessionFile
+      });
+
+      // Should still create a memory file
+      expect(files.length).toBe(1);
+      const today = new Date().toISOString().split("T")[0];
+      expect(files[0]).toMatch(new RegExp(`^${today}-`));
+    });
+  });
 });

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -685,6 +685,8 @@ describe("session-memory hook", () => {
         hooks: { internal: { entries: { "session-memory": { enabled: true, llmSlug: false } } } },
       } as OpenClawConfig;
 
+      // Capture time before calling the handler to avoid minute-boundary flakiness
+      const preRunTime = new Date();
       const { files } = await runNewWithPreviousSessionEntry({
         tempDir,
         cfg,
@@ -696,7 +698,7 @@ describe("session-memory hook", () => {
       // The HHMM should NOT be 0830 (session creation time) but rather current time
       const hhmm = files[0].match(/2026-03-10-(\d{4})\.md$/)?.[1];
       // HHMM should be from current time, not from sessionCreatedAt
-      const nowHHMM = new Date().toISOString().split("T")[1].split(":").slice(0, 2).join("");
+      const nowHHMM = preRunTime.toISOString().split("T")[1].split(":").slice(0, 2).join("");
       expect(hhmm).toBe(nowHHMM);
     });
 

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -139,6 +139,31 @@ function stripResetSuffix(fileName: string): string {
   return resetIndex === -1 ? fileName : fileName.slice(0, resetIndex);
 }
 
+/**
+ * Extract session creation timestamp from the first line of a session file.
+ * Returns null if the file cannot be read, parsed, or the timestamp is invalid.
+ */
+async function getSessionCreatedAt(sessionFilePath: string): Promise<string | null> {
+  try {
+    const content = await fs.readFile(sessionFilePath, "utf-8");
+    const firstLine = content.split("\n")[0];
+    if (!firstLine) {
+      return null;
+    }
+    const entry = JSON.parse(firstLine);
+    if (entry.type === "session" && typeof entry.timestamp === "string") {
+      // Validate the timestamp is a parseable date
+      const parsed = new Date(entry.timestamp);
+      if (!isNaN(parsed.getTime())) {
+        return entry.timestamp;
+      }
+    }
+  } catch {
+    // Ignore read/parse errors
+  }
+  return null;
+}
+
 async function findPreviousSessionFile(params: {
   sessionsDir: string;
   currentSessionFile?: string;
@@ -226,10 +251,6 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
-    // Get today's date for filename
-    const now = new Date(event.timestamp);
-    const dateStr = now.toISOString().split("T")[0]; // YYYY-MM-DD
-
     // Generate descriptive slug from session using LLM
     // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
     const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {}) as Record<
@@ -269,6 +290,28 @@ const saveSessionToMemory: HookHandler = async (event) => {
     });
 
     const sessionFile = currentSessionFile || undefined;
+
+    // Determine the date and time for the memory file:
+    // Prefer the session's creation timestamp from the session file header,
+    // fallback to the event timestamp if no session file is available.
+    // The HHMM slug (for filename uniqueness) always uses event.timestamp to avoid collisions.
+    const now = new Date(event.timestamp);
+    let dateStr: string;
+    let timeStr: string;
+    let sessionCreatedAt: string | null = null;
+
+    if (sessionFile) {
+      sessionCreatedAt = await getSessionCreatedAt(sessionFile);
+    }
+
+    if (sessionCreatedAt) {
+      const sessionDate = new Date(sessionCreatedAt);
+      dateStr = sessionDate.toISOString().split("T")[0];
+      timeStr = sessionDate.toISOString().split("T")[1].split(".")[0];
+    } else {
+      dateStr = now.toISOString().split("T")[0];
+      timeStr = now.toISOString().split("T")[1].split(".")[0];
+    }
 
     // Read message count from hook config (default: 15)
     const hookConfig = resolveHookConfig(cfg, "session-memory");
@@ -318,9 +361,6 @@ const saveSessionToMemory: HookHandler = async (event) => {
       filename,
       path: memoryFilePath.replace(os.homedir(), "~"),
     });
-
-    // Format time as HH:MM:SS UTC
-    const timeStr = now.toISOString().split("T")[1].split(".")[0];
 
     // Extract context details
     const sessionId = (sessionEntry.sessionId as string) || "unknown";


### PR DESCRIPTION
## Problem
Memory files were dated using the `/new` command timestamp instead of the session's actual creation date. If a session was created on March 10 but `/new` was run on March 12, the memory file would be named `2026-03-12-*.md` instead of `2026-03-10-*.md`.

## Solution
- Added `getSessionCreatedAt()` to read the session creation timestamp from the first line of the session file (type="session" entry)
- Date and time in header now prefer session creation timestamp, falling back to event timestamp when no session file is available
- HHMM slug still uses event timestamp to avoid filename collisions when `/new` is called multiple times in the same session
- Added date validation in `getSessionCreatedAt()` to prevent silent failures from invalid date strings

## Testing
Added 6 new test cases covering:
- Session with valid header → uses session timestamp for date and header time
- Session without timestamp field → falls back to event timestamp
- No session header → falls back to event timestamp
- Invalid date string in header → falls back gracefully, no silent failure
- HHMM slug uses event timestamp even when session has creation timestamp
- No session file available → uses event timestamp

Fixes comment feedback from PR #44081:
- Unvalidated date string could cause silent failure
- Mixed-source timestamp in header was confusing

---

- [x] AI-assisted: Claude Code + GLM-5
- [x] Testing: Fully tested (23 tests pass)
- [x] Ran `pnpm build && pnpm check && pnpm test`
- [x] I understand what the code does