### PR TITLE
fix(cron): prevent false positive in normalizePayloadKind for already-normalized jobs

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -75,4 +75,42 @@ describe("normalizeStoredCronJobs", () => {
       channel: "slack",
     });
   });
+
+  it("does not report payloadKind issue for already-normalized payload kinds (#44054)", () => {
+    const jobs = [
+      {
+        id: "already-ok",
+        name: "Already Normalized",
+        enabled: true,
+        schedule: { kind: "cron", expr: "0 * * * *", staggerMs: 300000 },
+        wakeMode: "next-heartbeat",
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: { mode: "announce" },
+        state: {},
+      },
+      {
+        id: "also-ok",
+        name: "Also Normalized",
+        enabled: true,
+        schedule: { kind: "at", at: new Date().toISOString() },
+        wakeMode: "next-heartbeat",
+        sessionTarget: "main",
+        payload: { kind: "systemEvent", text: "tick" },
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    // payload.kind values are already correct — should NOT be flagged
+    expect(result.issues.payloadKind).toBeUndefined();
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+
+    // Verify payload kinds weren't changed
+    const p0 = (jobs[0].payload as { kind: string }).kind;
+    const p1 = (jobs[1].payload as { kind: string }).kind;
+    expect(p0).toBe("agentTurn");
+    expect(p1).toBe("systemEvent");
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -30,10 +30,16 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 function normalizePayloadKind(payload: Record<string, unknown>) {
   const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
   if (raw === "agentturn") {
+    if (payload.kind === "agentTurn") {
+      return false;
+    } // already normalized
     payload.kind = "agentTurn";
     return true;
   }
   if (raw === "systemevent") {
+    if (payload.kind === "systemEvent") {
+      return false;
+    } // already normalized
     payload.kind = "systemEvent";
     return true;
   }


### PR DESCRIPTION
## Problem

`openclaw doctor` reports that cron jobs need payload kind normalization even when `payload.kind` is already the correct camelCase value (`"agentTurn"` / `"systemEvent"`).

This creates false urgency after upgrading to 2026.3.11 — the warning implies scheduled tasks may silently break, but the cron store is already normalized.

## Root Cause

`normalizePayloadKind()` in `src/cron/store-migration.ts`:

```ts
const raw = payload.kind.trim().toLowerCase();
if (raw === "agentturn") {
  payload.kind = "agentTurn";
  return true;  // BUG: returns true even if already "agentTurn"
}
```

Because `"agentTurn".toLowerCase() === "agentturn"`, the function always returns `true` (mutated) for correctly-cased values, causing the detection code to flag every normalized job.

## Fix

Check if the value is already the target casing before returning `true`:

```ts
if (raw === "agentturn") {
  if (payload.kind === "agentTurn") return false; // already normalized
  payload.kind = "agentTurn";
  return true;
}
```

Same pattern for `systemEvent`.

## Test

Added a test verifying that fully-normalized jobs don't trigger `payloadKind` / `legacyPayloadKind` issues.

Fixes #44054