### PR TITLE
fix(cron): make normalizePayloadKind idempotent so doctor does not re-flag fixed jobs

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -47,6 +47,45 @@ describe("normalizeStoredCronJobs", () => {
     });
   });
 
+  it("is idempotent: already-normalized payload kinds are not flagged as legacy (#44005)", () => {
+    const jobs = [
+      {
+        id: "already-fixed",
+        name: "test job",
+        schedule: { kind: "cron", expr: "*/5 * * * *" },
+        payload: { kind: "agentTurn", message: "hello" },
+        sessionTarget: "isolated",
+        enabled: true,
+        wakeMode: "now",
+        state: {},
+        delivery: { mode: "announce" },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+    expect((jobs[0]?.payload as Record<string, unknown>)?.kind).toBe("agentTurn");
+  });
+
+  it("is idempotent: running normalization twice produces no new issues", () => {
+    const jobs = [
+      {
+        jobId: "legacy-job",
+        schedule: { kind: "cron", cron: "*/5 * * * *" },
+        message: "say hi",
+        model: "openai/gpt-4.1",
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const first = normalizeStoredCronJobs(jobs);
+    expect(first.mutated).toBe(true);
+
+    const second = normalizeStoredCronJobs(jobs);
+    expect(second.issues).toEqual({});
+    expect(second.mutated).toBe(false);
+  });
+
   it("normalizes payload provider alias into channel", () => {
     const jobs = [
       {

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,12 +28,16 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
+  const raw = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  if (raw === "agentTurn" || raw === "systemEvent") {
+    return false;
+  }
+  const lowered = raw.toLowerCase();
+  if (lowered === "agentturn") {
     payload.kind = "agentTurn";
     return true;
   }
-  if (raw === "systemevent") {
+  if (lowered === "systemevent") {
     payload.kind = "systemEvent";
     return true;
   }


### PR DESCRIPTION
Fixes #44005

## Problem

Running `openclaw doctor --fix` correctly normalizes legacy cron job payload kinds (e.g. case-insensitive `agentturn` to `agentTurn`), but on subsequent runs it flags them again. The doctor keeps wanting to fix jobs that are already fixed.

## Root cause

`normalizePayloadKind()` lowercases the `kind` value before comparing it against known legacy forms. So an already-correct `"agentTurn"` becomes `"agentturn"` internally, matches the legacy check, and gets reported as needing migration. The function was not idempotent.

## Fix

Short-circuit on exact camelCase matches (`agentTurn`, `systemEvent`) before lowercasing. Only fall through to case-insensitive legacy detection for genuinely non-normalized values.

## Testing

- Two new regression tests: one verifies already-normalized kinds are not flagged, another verifies double-normalization produces zero issues on the second pass
- All 505 existing cron tests pass
- Doctor test suite (4 tests) passes