### PR TITLE
fix(gateway): avoid token mismatch between openclaw-tui and control-ui

### DIFF
--- a/src/gateway/protocol/client-info.ts
+++ b/src/gateway/protocol/client-info.ts
@@ -1,6 +1,7 @@
 export const GATEWAY_CLIENT_IDS = {
   WEBCHAT_UI: "webchat-ui",
   CONTROL_UI: "openclaw-control-ui",
+  TUI: "openclaw-tui",
   WEBCHAT: "webchat",
   CLI: "cli",
   GATEWAY_CLIENT: "gateway-client",

--- a/src/gateway/server.ios-client-id.test.ts
+++ b/src/gateway/server.ios-client-id.test.ts
@@ -21,7 +21,7 @@ function makeConnectParams(clientId: string) {
 }
 
 describe("connect params client id validation", () => {
-  test.each([GATEWAY_CLIENT_IDS.IOS_APP, GATEWAY_CLIENT_IDS.ANDROID_APP])(
+  test.each([GATEWAY_CLIENT_IDS.IOS_APP, GATEWAY_CLIENT_IDS.ANDROID_APP, GATEWAY_CLIENT_IDS.TUI])(
     "accepts %s as a valid gateway client id",
     (clientId) => {
       const ok = validateConnectParams(makeConnectParams(clientId));

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   loadConfigMock as loadConfig,
   pickPrimaryLanIPv4Mock as pickPrimaryLanIPv4,
@@ -9,8 +9,29 @@ import {
   resolveGatewayPortMock as resolveGatewayPort,
 } from "../gateway/gateway-connection.test-mocks.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
+import { GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 
-const { resolveGatewayConnection } = await import("./gateway-chat.js");
+const gatewayClientCtor = vi.fn();
+
+class MockGatewayClient {
+  constructor(opts: unknown) {
+    gatewayClientCtor(opts);
+  }
+
+  start(): void {}
+
+  stop(): void {}
+
+  async request<T = unknown>(): Promise<T> {
+    return {} as T;
+  }
+}
+
+vi.mock("../gateway/client.js", () => ({
+  GatewayClient: MockGatewayClient,
+}));
+
+const { GatewayChatClient, resolveGatewayConnection } = await import("./gateway-chat.js");
 
 async function fileExists(filePath: string): Promise<boolean> {
   try {
@@ -373,5 +394,24 @@ describe("resolveGatewayConnection", () => {
         expect(await fileExists(passwordMarker)).toBe(true);
       },
     );
+  });
+});
+
+describe("GatewayChatClient", () => {
+  it("uses a dedicated TUI gateway client id", () => {
+    gatewayClientCtor.mockClear();
+
+    const client = new GatewayChatClient({ url: "ws://127.0.0.1:18789" });
+    const options = gatewayClientCtor.mock.calls[0]?.[0] as
+      | {
+          clientName?: string;
+          clientDisplayName?: string;
+        }
+      | undefined;
+
+    expect(options?.clientName).toBe(GATEWAY_CLIENT_NAMES.TUI);
+    expect(options?.clientDisplayName).toBe("openclaw-tui");
+
+    client.stop();
   });
 });

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -150,7 +150,7 @@ export class GatewayChatClient {
       url: connection.url,
       token: connection.token,
       password: connection.password,
-      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientName: GATEWAY_CLIENT_NAMES.TUI,
       clientDisplayName: "openclaw-tui",
       clientVersion: VERSION,
       platform: process.platform,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw-tui` connected to Gateway with the generic client ID `gateway-client`, which could collide with other clients (notably Control UI) and trigger `token_mismatch` failures.
- Why it matters: Users could not reliably run TUI and Control UI at the same time against one Gateway instance.
- What changed: Added a dedicated client ID `openclaw-tui` in `src/gateway/protocol/client-info.ts`, switched TUI handshake identity to that ID in `src/tui/gateway-chat.ts`, and added/updated tests in `src/tui/gateway-chat.test.ts` and `src/gateway/server.ios-client-id.test.ts`.
- What did NOT change (scope boundary): No auth mode logic, token validation rules, pairing flow, transport protocol versioning, or config schema behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44065
- Related #

## User-visible / Behavior Changes

- `openclaw-tui` now identifies itself as `openclaw-tui` (dedicated client ID) instead of `gateway-client`.
- TUI and Control UI can coexist on the same Gateway without the previous client-identity collision path.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Windows (local dev machine)
- Runtime/container: Node.js v24.14.0, Vitest v4.0.18
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket handshake (`openclaw-tui`, Control UI path)
- Relevant config (redacted): Default local Gateway test config

### Steps

1. Connect TUI client to Gateway and inspect its handshake client identity.
2. Validate Gateway connect schema accepts the TUI client ID.
3. Run targeted tests:
   - `npx vitest run src/tui/gateway-chat.test.ts src/gateway/server.ios-client-id.test.ts`

### Expected

- TUI uses a dedicated ID (`openclaw-tui`) and does not share `gateway-client` identity with other clients.
- Connect schema accepts the new TUI client ID.

### Actual

- TUI now sends `clientName: openclaw-tui`.
- Gateway connect param validation accepts `openclaw-tui`.
- Targeted test run passed: 2 files, 20 tests passed, 1 skipped.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace snippet:
- `npx vitest run src/tui/gateway-chat.test.ts src/gateway/server.ios-client-id.test.ts`
- Result: `Test Files 2 passed`, `Tests 20 passed | 1 skipped`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed code path now uses dedicated TUI client ID; confirmed protocol-level validation includes the TUI ID; executed targeted tests successfully.
- Edge cases checked: Existing accepted mobile client IDs remain valid; TUI display name behavior remains unchanged.
- What you did **not** verify: Full manual end-to-end runtime session with both Control UI and TUI connected simultaneously on one live Gateway instance.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/gateway/protocol/client-info.ts`, `src/tui/gateway-chat.ts`, and related tests.
- Known bad symptoms reviewers should watch for: TUI connection rejected at handshake with invalid client ID, or reappearance of `token_mismatch` when multiple UI clients connect.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: External tooling that implicitly expected TUI to identify as `gateway-client` may rely on old identity.
  - Mitigation: Change is limited to TUI identity only, display name remains `openclaw-tui`, and tests cover the new handshake/client-ID validation path.