### PR TITLE
fix: show user messages immediately on Dashboard when agent starts (UX improvement)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -28,7 +28,6 @@ import {
   isMarkdownCapableMessageChannel,
   resolveMessageChannel,
 } from "../../utils/message-channel.js";
-import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
@@ -122,11 +121,9 @@ export async function runAgentTurnWithFallback(params: {
     didNotifyAgentRunStart = true;
     params.opts?.onAgentRunStart?.(runId);
   };
-  const shouldSurfaceToControlUi = isInternalMessageChannel(
-    params.followupRun.run.messageProvider ??
-      params.sessionCtx.Surface ??
-      params.sessionCtx.Provider,
-  );
+  // Always surface to control UI (Dashboard) - this ensures user messages from any channel
+  // (Telegram, Discord, etc.) are visible in the Dashboard in real-time
+  const shouldSurfaceToControlUi = true;
   if (params.sessionKey) {
     registerAgentRunContext(runId, {
       sessionKey: params.sessionKey,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -10,7 +10,6 @@ import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { defaultRuntime } from "../../runtime.js";
-import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import type { OriginatingChannelType } from "../templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
@@ -132,12 +131,9 @@ export function createFollowupRunner(params: {
   return async (queued: FollowupRun) => {
     try {
       const runId = crypto.randomUUID();
-      const shouldSurfaceToControlUi = isInternalMessageChannel(
-        resolveOriginMessageProvider({
-          originatingChannel: queued.originatingChannel,
-          provider: queued.run.messageProvider,
-        }),
-      );
+      // Always surface to control UI (Dashboard) - this ensures user messages from any channel
+      // (Telegram, Discord, etc.) are visible in the Dashboard in real-time
+      const shouldSurfaceToControlUi = true;
       if (queued.run.sessionKey) {
         registerAgentRunContext(runId, {
           sessionKey: queued.run.sessionKey,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -590,6 +590,15 @@ export function createAgentEventHandler({
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
 
+    // When agent starts running, broadcast a refresh event so Dashboard can load the user message immediately
+    if (isControlUiVisible && sessionKey && lifecyclePhase === "start") {
+      nodeSendToSession(sessionKey, "chat", {
+        runId: clientRunId,
+        sessionKey,
+        state: "refresh" as const,
+      });
+    }
+
     if (isControlUiVisible && sessionKey) {
       // Send tool events to node/channel subscribers only when verbose is enabled;
       // WS clients already received the event above via broadcastToConnIds.

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -46,7 +46,7 @@ export type ChatState = {
 export type ChatEventPayload = {
   runId: string;
   sessionKey: string;
-  state: "delta" | "final" | "aborted" | "error";
+  state: "delta" | "final" | "aborted" | "error" | "refresh";
   message?: unknown;
   errorMessage?: string;
 };
@@ -264,6 +264,12 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     return null;
   }
   if (payload.sessionKey !== state.sessionKey) {
+    return null;
+  }
+
+  // Handle refresh event: when agent starts running, reload chat history to show user message immediately
+  if (payload.state === "refresh") {
+    void loadChatHistory(state);
     return null;
   }
 


### PR DESCRIPTION
## Closed - Not a Bug

After deeper analysis, I realized this is not actually a bug.

The existing heartbeat-based refresh mechanism already works correctly:
- When agent starts, lifecycle events trigger
- When agent completes, final messages are broadcast
- Dashboard displays messages correctly

The perceived issue was a misunderstanding of the original design. The current implementation is working as intended.

Thanks for reviewing!