### PR TITLE
fix(installer): clarify Node >=22.12 requirement and Node 24 support

### DIFF
--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -213,16 +213,16 @@ Designed for environments where you want everything under a local prefix (defaul
 <AccordionGroup>
   <Accordion title="Flags reference">
 
-| Flag                   | Description                                                                     |
-| ---------------------- | ------------------------------------------------------------------------------- |
-| `--prefix <path>`      | Install prefix (default: `~/.openclaw`)                                         |
-| `--version <ver>`      | OpenClaw version or dist-tag (default: `latest`)                                |
-| `--node-version <ver>` | Node version (default: `22.22.0`)                                               |
-| `--json`               | Emit NDJSON events                                                              |
-| `--onboard`            | Run `openclaw onboard` after install                                            |
-| `--no-onboard`         | Skip onboarding (default)                                                       |
-| `--set-npm-prefix`     | On Linux, force npm prefix to `~/.npm-global` if current prefix is not writable |
-| `--help`               | Show usage (`-h`)                                                               |
+| Flag                   | Description                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------- |
+| `--prefix <path>`      | Install prefix (default: `~/.openclaw`)                                                           |
+| `--version <ver>`      | OpenClaw version or dist-tag (default: `latest`)                                                  |
+| `--node-version <ver>` | Preferred Node bootstrap version (default: `22.22.0`; Node `>=22.12` required, Node 24 supported) |
+| `--json`               | Emit NDJSON events                                                                                |
+| `--onboard`            | Run `openclaw onboard` after install                                                              |
+| `--no-onboard`         | Skip onboarding (default)                                                                         |
+| `--set-npm-prefix`     | On Linux, force npm prefix to `~/.npm-global` if current prefix is not writable                   |
+| `--help`               | Show usage (`-h`)                                                                                 |
 
   </Accordion>
 
@@ -251,8 +251,8 @@ Designed for environments where you want everything under a local prefix (defaul
   <Step title="Ensure PowerShell + Windows environment">
     Requires PowerShell 5+.
   </Step>
-  <Step title="Ensure Node.js 22+">
-    If missing, attempts install via winget, then Chocolatey, then Scoop.
+  <Step title="Ensure Node.js 22.12+">
+    If missing, attempts install via winget, then Chocolatey, then Scoop. Node 22 LTS is recommended and Node 24 is supported.
   </Step>
   <Step title="Install OpenClaw">
     - `npm` method (default): global npm install using selected `-Tag`

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -9,7 +9,7 @@ read_when:
 
 # Node.js
 
-OpenClaw requires **Node 22 or newer**. The [installer script](/install#install-methods) will detect and install Node automatically — this page is for when you want to set up Node yourself and make sure everything is wired up correctly (versions, PATH, global installs).
+OpenClaw requires **Node 22.12+**. Node 22 LTS is recommended, and newer majors (including Node 24) are supported. The [installer script](/install#install-methods) will detect and install Node automatically — this page is for when you want to set up Node yourself and make sure everything is wired up correctly (versions, PATH, global installs).
 
 ## Check your version
 
@@ -17,7 +17,7 @@ OpenClaw requires **Node 22 or newer**. The [installer script](/install#install-
 node -v
 ```
 
-If this prints `v22.x.x` or higher, you're good. If Node isn't installed or the version is too old, pick an install method below.
+If this prints `v22.12.0` or higher, you're good. If Node isn't installed or the version is too old, pick an install method below.
 
 ## Install Node
 
@@ -77,8 +77,8 @@ If this prints `v22.x.x` or higher, you're good. If Node isn't installed or the 
 Example with fnm:
 
 ```bash
-fnm install 22
-fnm use 22
+fnm install --lts
+fnm use --lts
 ```
 
   <Warning>

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -25,10 +25,11 @@ const ensureSupportedNodeVersion = () => {
 
   process.stderr.write(
     `openclaw: Node.js v${MIN_NODE_VERSION}+ is required (current: v${process.versions.node}).\n` +
+      "Node 22 LTS is recommended; newer majors (including Node 24) are supported.\n" +
       "If you use nvm, run:\n" +
-      `  nvm install ${MIN_NODE_MAJOR}\n` +
-      `  nvm use ${MIN_NODE_MAJOR}\n` +
-      `  nvm alias default ${MIN_NODE_MAJOR}\n`,
+      "  nvm install --lts\n" +
+      "  nvm use --lts\n" +
+      "  nvm alias default lts/*\n",
   );
   process.exit(1);
 };

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -13,6 +13,10 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+$NodeMinMajor = 22
+$NodeMinMinor = 12
+$NodeMinVersion = "$NodeMinMajor.$NodeMinMinor"
+
 # Colors
 $ACCENT = "`e[38;2;255;77;77m"    # coral-bright
 $SUCCESS = "`e[38;2;0;229;204m"    # cyan-bright
@@ -89,6 +93,37 @@ function Get-NodeVersion {
     return $null
 }
 
+function Test-NodeVersionSupported {
+    param([string]$Version)
+
+    if (-not $Version) {
+        return $false
+    }
+
+    $parts = $Version -split '\.'
+    if ($parts.Count -lt 2) {
+        return $false
+    }
+
+    $major = 0
+    $minor = 0
+    if (-not [int]::TryParse($parts[0], [ref]$major)) {
+        return $false
+    }
+    if (-not [int]::TryParse($parts[1], [ref]$minor)) {
+        return $false
+    }
+
+    if ($major -gt $NodeMinMajor) {
+        return $true
+    }
+    if ($major -eq $NodeMinMajor -and $minor -ge $NodeMinMinor) {
+        return $true
+    }
+
+    return $false
+}
+
 function Get-NpmVersion {
     try {
         $version = npm --version 2>$null
@@ -144,19 +179,18 @@ function Install-Node {
     }
     
     Write-Host "Could not install Node.js automatically" -Level error
-    Write-Host "Please install Node.js 22+ manually from: https://nodejs.org" -Level info
+    Write-Host "Please install Node.js v$NodeMinVersion+ manually (22 LTS recommended; Node 24 supported): https://nodejs.org" -Level info
     return $false
 }
 
 function Ensure-Node {
     $nodeVersion = Get-NodeVersion
     if ($nodeVersion) {
-        $major = [int]($nodeVersion -split '\.')[0]
-        if ($major -ge 22) {
+        if (Test-NodeVersionSupported -Version $nodeVersion) {
             Write-Host "Node.js v$nodeVersion found" -Level success
             return $true
         }
-        Write-Host "Node.js v$nodeVersion found, but need v22+" -Level warn
+        Write-Host "Node.js v$nodeVersion found, but need v$NodeMinVersion+" -Level warn
     }
     return Install-Node
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1316,7 +1316,7 @@ print_active_node_paths() {
     return 0
 }
 
-ensure_macos_node22_active() {
+ensure_macos_node_active() {
     if [[ "$OS" != "macos" ]]; then
         return 0
     fi
@@ -1340,17 +1340,17 @@ ensure_macos_node22_active() {
     active_path="$(command -v node 2>/dev/null || echo "not found")"
     active_version="$(node -v 2>/dev/null || echo "missing")"
 
-    ui_error "Node.js v22 was installed but this shell is using ${active_version} (${active_path})"
+    ui_error "Node.js v${NODE_MIN_VERSION}+ is required but this shell is using ${active_version} (${active_path})"
     if [[ -n "$brew_node_prefix" ]]; then
         echo "Add this to your shell profile and restart shell:"
         echo "  export PATH=\"${brew_node_prefix}/bin:\$PATH\""
     else
-        echo "Ensure Homebrew node@22 is first on PATH, then rerun installer."
+        echo "Ensure a supported Node (22 LTS recommended; Node 24 supported) is first on PATH, then rerun installer."
     fi
     return 1
 }
 
-ensure_node22_active_shell() {
+ensure_node_active_shell() {
     if node_is_at_least_required; then
         return 0
     fi
@@ -1373,13 +1373,13 @@ ensure_node22_active_shell() {
     if [[ "$nvm_detected" -eq 1 ]]; then
         echo "nvm appears to be managing Node for this shell."
         echo "Run:"
-        echo "  nvm install 22"
-        echo "  nvm use 22"
-        echo "  nvm alias default 22"
+        echo "  nvm install --lts"
+        echo "  nvm use --lts"
+        echo "  nvm alias default lts/*"
         echo "Then open a new shell and rerun:"
         echo "  curl -fsSL https://openclaw.ai/install.sh | bash"
     else
-        echo "Install/select Node.js 22+ and ensure it is first on PATH, then rerun installer."
+        echo "Install/select Node.js ${NODE_MIN_VERSION}+ (22 LTS recommended; Node 24 supported) and ensure it is first on PATH, then rerun installer."
     fi
 
     return 1
@@ -1412,7 +1412,7 @@ install_node() {
         ui_info "Installing Node.js via Homebrew"
         run_quiet_step "Installing node@22" brew install node@22
         brew link node@22 --overwrite --force 2>/dev/null || true
-        if ! ensure_macos_node22_active; then
+        if ! ensure_macos_node_active; then
             exit 1
         fi
         ui_success "Node.js installed"
@@ -1435,7 +1435,7 @@ install_node() {
             else
                 run_quiet_step "Installing Node.js" sudo pacman -Sy --noconfirm nodejs npm
             fi
-            ui_success "Node.js v22 installed"
+            ui_success "Node.js v${NODE_MIN_VERSION}+ installed"
             print_active_node_paths || true
             return 0
         fi
@@ -1476,11 +1476,11 @@ install_node() {
             fi
         else
             ui_error "Could not detect package manager"
-            echo "Please install Node.js 22+ manually: https://nodejs.org"
+            echo "Please install Node.js ${NODE_MIN_VERSION}+ manually (22 LTS recommended; Node 24 supported): https://nodejs.org"
             exit 1
         fi
 
-        ui_success "Node.js v22 installed"
+        ui_success "Node.js v${NODE_MIN_VERSION}+ installed"
         print_active_node_paths || true
     fi
 }
@@ -2267,7 +2267,7 @@ main() {
     if ! check_node; then
         install_node
     fi
-    if ! ensure_node22_active_shell; then
+    if ! ensure_node_active_shell; then
         exit 1
     fi
 

--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -251,7 +251,7 @@ describe("resolveSystemNodeInfo", () => {
       "/Users/me/.fnm/node-22/bin/node",
     );
 
-    expect(warning).toContain("below the required Node 22+");
+    expect(warning).toContain("below the required Node 22.12+");
     expect(warning).toContain(darwinNode);
   });
 });

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -151,7 +151,7 @@ export function renderSystemNodeWarning(
   }
   const versionLabel = systemNode.version ?? "unknown";
   const selectedLabel = selectedNodePath ? ` Using ${selectedNodePath} for the daemon.` : "";
-  return `System Node ${versionLabel} at ${systemNode.path} is below the required Node 22+.${selectedLabel} Install Node 22+ from nodejs.org or Homebrew.`;
+  return `System Node ${versionLabel} at ${systemNode.path} is below the required Node 22.12+.${selectedLabel} Install Node 22.12+ (Node 24 is also supported) from nodejs.org or Homebrew.`;
 }
 export { resolveStableNodePath };
 


### PR DESCRIPTION
## Summary
- clarify runtime/installer messaging to state the actual requirement: Node >=22.12.0
- explicitly note that Node 22 LTS is recommended and Node 24 is supported
- update nvm guidance in `openclaw.mjs` and `scripts/install.sh` to use LTS aliases instead of hardcoded `22`
- improve daemon warning text to avoid implying Node 24 is unsupported
- harden `scripts/install.ps1` version check to enforce >=22.12 (instead of only checking major >=22)
- update install docs to reflect the same compatibility messaging

## Validation
- `pnpm vitest src/daemon/runtime-paths.test.ts`

## Why
We got user feedback that install flow/messaging looked like it required exactly Node 22 and rejected Node 24. This keeps behavior aligned with actual support policy and reduces install confusion.
