### PR TITLE
fix(cron): avoid false-positive legacyPayloadKind in normalizePayloadKind

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -75,4 +75,57 @@ describe("normalizeStoredCronJobs", () => {
       channel: "slack",
     });
   });
+
+  it("does not report legacyPayloadKind when payload kind is already normalized (#44005)", () => {
+    const jobs = [
+      {
+        id: "already-normalized",
+        name: "test job",
+        schedule: { kind: "every", everyMs: 60_000 },
+        enabled: true,
+        wakeMode: "now",
+        state: {},
+        sessionTarget: "isolated",
+        delivery: { mode: "announce" },
+        payload: { kind: "agentTurn", message: "hello" },
+      },
+      {
+        id: "already-normalized-system",
+        name: "test system job",
+        schedule: { kind: "every", everyMs: 60_000 },
+        enabled: true,
+        wakeMode: "now",
+        state: {},
+        sessionTarget: "main",
+        payload: { kind: "systemEvent", text: "ping" },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    // The key assertion: payload kind normalization should NOT be reported
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+  });
+
+  it("normalizes lowercase payload kind variants", () => {
+    const jobs = [
+      {
+        id: "needs-normalization",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "agentturn", message: "hello" },
+      },
+      {
+        id: "needs-normalization-system",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "SYSTEMEVENT", text: "ping" },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.legacyPayloadKind).toBe(2);
+    expect((jobs[0]?.payload as Record<string, unknown>)?.kind).toBe("agentTurn");
+    expect((jobs[1]?.payload as Record<string, unknown>)?.kind).toBe("systemEvent");
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,12 +28,19 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
+  const original = typeof payload.kind === "string" ? payload.kind : "";
+  const raw = original.trim().toLowerCase();
   if (raw === "agentturn") {
+    if (original === "agentTurn") {
+      return false;
+    }
     payload.kind = "agentTurn";
     return true;
   }
   if (raw === "systemevent") {
+    if (original === "systemEvent") {
+      return false;
+    }
     payload.kind = "systemEvent";
     return true;
   }


### PR DESCRIPTION
$## Summary\n\n`normalizePayloadKind()` lowercases the value before comparing to canonical forms, so an already-correct `\"agentTurn\"` becomes `\"agentturn\"`, matches the canonical lookup, and returns `mutated=true` — triggering a false-positive `legacyPayloadKind` issue in `openclaw doctor`.\n\n## Fix\n\nCompare the **original** (pre-lowercase) value against the canonical form before returning `true`. If the original already matches, skip the mutation flag.\n\n## Tests\n\n- Added regression test: fully-normalized job must not report `legacyPayloadKind`\n- Added test: lowercase variants (e.g. `\"agentturn\"`) are still correctly normalized\n\nFixes #44047\nFixes #44005