### PR TITLE
fix(feishu): bypass mention gate for slash commands in group chats

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -358,6 +358,7 @@ export async function handleFeishuMessage(params: {
     : null;
 
   let requireMention = false; // DMs never require mention; groups may override below
+  let hasCommandInGroup = false;
   if (isGroup) {
     if (groupConfig?.enabled === false) {
       log(`feishu[${account.accountId}]: group ${ctx.chatId} is disabled`);
@@ -418,7 +419,19 @@ export async function handleFeishuMessage(params: {
       groupConfig,
     }));
 
+    // Detect slash commands before enforcing mention gate — commands like
+    // /reset, /new, /status should be processed even without a bot mention,
+    // matching the behavior of Discord and Telegram channels.
     if (requireMention && !ctx.mentionedBot) {
+      const core = getFeishuRuntime();
+      const commandProbeBody = normalizeFeishuCommandProbeBody(ctx.content);
+      hasCommandInGroup = core.channel.commands.shouldComputeCommandAuthorized(
+        commandProbeBody,
+        cfg,
+      );
+    }
+
+    if (requireMention && !ctx.mentionedBot && !hasCommandInGroup) {
       log(`feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot`);
       // Record to pending history for non-broadcast groups only. For broadcast groups,
       // the mentioned handler's broadcast dispatch writes the turn directly into all
@@ -968,7 +981,9 @@ export async function handleFeishuMessage(params: {
         ((cfg as Record<string, unknown>).broadcast as Record<string, unknown> | undefined)
           ?.strategy || "parallel";
       const activeAgentId =
-        ctx.mentionedBot || !requireMention ? normalizeAgentId(route.agentId) : null;
+        ctx.mentionedBot || !requireMention || hasCommandInGroup
+          ? normalizeAgentId(route.agentId)
+          : null;
       const agentIds = (cfg.agents?.list ?? []).map((a: { id: string }) => normalizeAgentId(a.id));
       const hasKnownAgents = agentIds.length > 0;
 


### PR DESCRIPTION
$## Summary\n\nIn Feishu group chats with `requireMention` enabled, the mention gate at line ~1053 returns early **before** command detection, so slash commands like `/reset` or `/help` are silently ignored unless the bot is @-mentioned.\n\nDiscord and Telegram already handle this via `resolveMentionGatingWithBypass`.\n\n## Fix\n\nDetect control commands via `core.channel.commands.shouldComputeCommandAuthorized()` **before** the mention gate check. If the message is a recognized command, bypass the mention requirement.\n\nUses `normalizeFeishuCommandProbeBody()` to strip `<at>` tags before probing.\n\n## Tests\n\nAll 348 existing Feishu tests pass (including 52 bot tests).\n\nFixes #42228