### PR TITLE
Improve ACP spawn and timeout diagnostics

### DIFF
--- a/src/acp/runtime/errors.test.ts
+++ b/src/acp/runtime/errors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { AcpRuntimeError, withAcpRuntimeErrorBoundary } from "./errors.js";
+import {
+  AcpRuntimeError,
+  describeAcpErrorForLog,
+  normalizeAcpDiagnosticText,
+  withAcpRuntimeErrorBoundary,
+} from "./errors.js";
 
 describe("withAcpRuntimeErrorBoundary", () => {
   it("wraps generic errors with fallback code and source message", async () => {
@@ -29,5 +34,35 @@ describe("withAcpRuntimeErrorBoundary", () => {
         fallbackMessage: "fallback",
       }),
     ).rejects.toBe(existing);
+  });
+
+  it("normalizes diagnostic text and truncates long values", () => {
+    expect(normalizeAcpDiagnosticText("  hello  ")).toBe("hello");
+    expect(normalizeAcpDiagnosticText("")).toBeUndefined();
+    expect(normalizeAcpDiagnosticText("abcdef", 4)).toBe("abcd...");
+  });
+
+  it("extracts nested stderr/stdout diagnostics for logs", () => {
+    const cause = new Error("child failure") as Error & {
+      code?: string;
+      stderr?: string;
+      stdout?: string;
+      details?: { stderr?: string };
+    };
+    cause.code = "ACP_CHILD_FAILED";
+    cause.stderr = "stderr details";
+    cause.stdout = "stdout details";
+    cause.details = { stderr: "deep stderr" };
+
+    const top = new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "top level", { cause });
+    const text = describeAcpErrorForLog(top);
+
+    expect(text).toContain("error.name=AcpRuntimeError");
+    expect(text).toContain("error.code=ACP_SESSION_INIT_FAILED");
+    expect(text).toContain('error.message="top level"');
+    expect(text).toContain("cause1.code=ACP_CHILD_FAILED");
+    expect(text).toContain('cause1.stderr="stderr details"');
+    expect(text).toContain('cause1.stdout="stdout details"');
+    expect(text).toContain('cause1.details.stderr="deep stderr"');
   });
 });

--- a/src/acp/runtime/errors.test.ts
+++ b/src/acp/runtime/errors.test.ts
@@ -35,13 +35,17 @@ describe("withAcpRuntimeErrorBoundary", () => {
       }),
     ).rejects.toBe(existing);
   });
+});
 
+describe("normalizeAcpDiagnosticText", () => {
   it("normalizes diagnostic text and truncates long values", () => {
     expect(normalizeAcpDiagnosticText("  hello  ")).toBe("hello");
     expect(normalizeAcpDiagnosticText("")).toBeUndefined();
     expect(normalizeAcpDiagnosticText("abcdef", 4)).toBe("abcd...");
   });
+});
 
+describe("describeAcpErrorForLog", () => {
   it("extracts nested stderr/stdout diagnostics for logs", () => {
     const cause = new Error("child failure") as Error & {
       code?: string;

--- a/src/acp/runtime/errors.ts
+++ b/src/acp/runtime/errors.ts
@@ -65,13 +65,16 @@ export function describeAcpErrorForLog(error: unknown): string {
     seen.add(current);
     const prefix = depth === 0 ? "error" : `cause${depth}`;
     if (current instanceof Error) {
+      const currentRecord = current as unknown as {
+        code?: unknown;
+        stderr?: unknown;
+        stdout?: unknown;
+        details?: unknown;
+      };
       if (typeof current.name === "string" && current.name !== "Error") {
         parts.push(`${prefix}.name=${current.name}`);
       }
-      const code =
-        typeof (current as { code?: unknown }).code === "string"
-          ? (current as { code: string }).code.trim()
-          : "";
+      const code = typeof currentRecord.code === "string" ? currentRecord.code.trim() : "";
       if (code) {
         parts.push(`${prefix}.code=${code}`);
       }
@@ -79,18 +82,17 @@ export function describeAcpErrorForLog(error: unknown): string {
       if (message) {
         parts.push(`${prefix}.message=${JSON.stringify(message)}`);
       }
-      const stderr = normalizeAcpDiagnosticText((current as { stderr?: unknown }).stderr, 500);
+      const stderr = normalizeAcpDiagnosticText(currentRecord.stderr, 500);
       if (stderr) {
         parts.push(`${prefix}.stderr=${JSON.stringify(stderr)}`);
       }
-      const stdout = normalizeAcpDiagnosticText((current as { stdout?: unknown }).stdout, 500);
+      const stdout = normalizeAcpDiagnosticText(currentRecord.stdout, 500);
       if (stdout) {
         parts.push(`${prefix}.stdout=${JSON.stringify(stdout)}`);
       }
       const details =
-        typeof (current as { details?: unknown }).details === "object" &&
-        (current as { details?: unknown }).details !== null
-          ? (current as { details: Record<string, unknown> }).details
+        typeof currentRecord.details === "object" && currentRecord.details !== null
+          ? (currentRecord.details as Record<string, unknown>)
           : undefined;
       const detailsStderr = normalizeAcpDiagnosticText(details?.stderr, 500);
       if (detailsStderr) {
@@ -120,12 +122,11 @@ export function describeAcpErrorForLog(error: unknown): string {
       current = (current as { cause?: unknown }).cause;
     } else {
       const text = normalizeAcpDiagnosticText(
-        typeof current === "number" ||
-          typeof current === "boolean" ||
-          typeof current === "bigint" ||
-          typeof current === "symbol"
+        typeof current === "number" || typeof current === "boolean"
           ? JSON.stringify(current)
-          : typeof current,
+          : typeof current === "bigint" || typeof current === "symbol"
+            ? String(current)
+            : typeof current,
         500,
       );
       if (text) {

--- a/src/acp/runtime/errors.ts
+++ b/src/acp/runtime/errors.ts
@@ -44,6 +44,101 @@ export function toAcpRuntimeError(params: {
   });
 }
 
+export function normalizeAcpDiagnosticText(value: unknown, maxLength = 400): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength)}...` : trimmed;
+}
+
+export function describeAcpErrorForLog(error: unknown): string {
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  let depth = 0;
+
+  while (current && depth < 4 && !seen.has(current)) {
+    seen.add(current);
+    const prefix = depth === 0 ? "error" : `cause${depth}`;
+    if (current instanceof Error) {
+      if (typeof current.name === "string" && current.name !== "Error") {
+        parts.push(`${prefix}.name=${current.name}`);
+      }
+      const code =
+        typeof (current as { code?: unknown }).code === "string"
+          ? (current as { code: string }).code.trim()
+          : "";
+      if (code) {
+        parts.push(`${prefix}.code=${code}`);
+      }
+      const message = normalizeAcpDiagnosticText(current.message, 500);
+      if (message) {
+        parts.push(`${prefix}.message=${JSON.stringify(message)}`);
+      }
+      const stderr = normalizeAcpDiagnosticText((current as { stderr?: unknown }).stderr, 500);
+      if (stderr) {
+        parts.push(`${prefix}.stderr=${JSON.stringify(stderr)}`);
+      }
+      const stdout = normalizeAcpDiagnosticText((current as { stdout?: unknown }).stdout, 500);
+      if (stdout) {
+        parts.push(`${prefix}.stdout=${JSON.stringify(stdout)}`);
+      }
+      const details =
+        typeof (current as { details?: unknown }).details === "object" &&
+        (current as { details?: unknown }).details !== null
+          ? (current as { details: Record<string, unknown> }).details
+          : undefined;
+      const detailsStderr = normalizeAcpDiagnosticText(details?.stderr, 500);
+      if (detailsStderr) {
+        parts.push(`${prefix}.details.stderr=${JSON.stringify(detailsStderr)}`);
+      }
+      const detailsStdout = normalizeAcpDiagnosticText(details?.stdout, 500);
+      if (detailsStdout) {
+        parts.push(`${prefix}.details.stdout=${JSON.stringify(detailsStdout)}`);
+      }
+      current = current.cause;
+    } else if (typeof current === "object") {
+      const code =
+        typeof (current as { code?: unknown }).code === "string"
+          ? (current as { code: string }).code.trim()
+          : "";
+      if (code) {
+        parts.push(`${prefix}.code=${code}`);
+      }
+      const stderr = normalizeAcpDiagnosticText((current as { stderr?: unknown }).stderr, 500);
+      if (stderr) {
+        parts.push(`${prefix}.stderr=${JSON.stringify(stderr)}`);
+      }
+      const stdout = normalizeAcpDiagnosticText((current as { stdout?: unknown }).stdout, 500);
+      if (stdout) {
+        parts.push(`${prefix}.stdout=${JSON.stringify(stdout)}`);
+      }
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      const text = normalizeAcpDiagnosticText(
+        typeof current === "number" ||
+          typeof current === "boolean" ||
+          typeof current === "bigint" ||
+          typeof current === "symbol"
+          ? JSON.stringify(current)
+          : typeof current,
+        500,
+      );
+      if (text) {
+        parts.push(`${prefix}=${JSON.stringify(text)}`);
+      }
+      break;
+    }
+    depth += 1;
+  }
+
+  return parts.join(" ");
+}
+
 export async function withAcpRuntimeErrorBoundary<T>(params: {
   run: () => Promise<T>;
   fallbackCode: AcpRuntimeErrorCode;

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -5,6 +5,7 @@ import {
   type AcpSpawnRuntimeCloseHandle,
 } from "../acp/control-plane/spawn.js";
 import { isAcpEnabledByPolicy, resolveAcpAgentPolicyError } from "../acp/policy.js";
+import { describeAcpErrorForLog } from "../acp/runtime/errors.js";
 import {
   resolveAcpSessionCwd,
   resolveAcpThreadSessionDetailLines,
@@ -640,6 +641,10 @@ export async function spawnAcpDirect(
       }
     }
   } catch (err) {
+    const diagnostic = describeAcpErrorForLog(err);
+    log.warn(
+      `ACP spawn failed: agent=${targetAgentId} mode=${runtimeMode} requester=${parentSessionKey || "<none>"} channel=${ctx.agentChannel || "<none>"} thread=${requestThreadBinding} cwd=${params.cwd || "<default>"} sessionKey=${sessionKey}${diagnostic ? ` ${diagnostic}` : ""}`,
+    );
     await cleanupFailedAcpSpawn({
       cfg,
       sessionKey,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -7,6 +7,7 @@ import {
   DefaultResourceLoader,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
+import { normalizeAcpDiagnosticText } from "../../../acp/runtime/errors.js";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
@@ -1854,8 +1855,26 @@ export async function runEmbeddedAttempt(
       const abortTimer = setTimeout(
         () => {
           if (!isProbeSession) {
+            const timeoutDetails: string[] = [];
+            const lastToolError = getLastToolError();
+            if (lastToolError) {
+              timeoutDetails.push(
+                `lastToolError=${JSON.stringify(normalizeAcpDiagnosticText(describeUnknownError(lastToolError), 400))}`,
+              );
+            }
+            const messageTargets = getMessagingToolSentTargets()
+              .map((target) =>
+                normalizeAcpDiagnosticText(
+                  typeof target === "string" ? target : JSON.stringify(target),
+                  120,
+                ),
+              )
+              .filter((target): target is string => Boolean(target));
+            if (messageTargets.length > 0) {
+              timeoutDetails.push(`messageTargets=${JSON.stringify(messageTargets.join(","))}`);
+            }
             log.warn(
-              `embedded run timeout: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${params.timeoutMs}`,
+              `embedded run timeout: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${params.timeoutMs}${timeoutDetails.length > 0 ? ` ${timeoutDetails.join(" ")}` : ""}`,
             );
           }
           if (

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1858,9 +1858,13 @@ export async function runEmbeddedAttempt(
             const timeoutDetails: string[] = [];
             const lastToolError = getLastToolError();
             if (lastToolError) {
-              timeoutDetails.push(
-                `lastToolError=${JSON.stringify(normalizeAcpDiagnosticText(describeUnknownError(lastToolError), 400))}`,
+              const normalizedLastToolError = normalizeAcpDiagnosticText(
+                describeUnknownError(lastToolError),
+                400,
               );
+              if (normalizedLastToolError) {
+                timeoutDetails.push(`lastToolError=${JSON.stringify(normalizedLastToolError)}`);
+              }
             }
             const messageTargets = getMessagingToolSentTargets()
               .map((target) =>


### PR DESCRIPTION
## Summary
- add a reusable ACP diagnostic formatter that preserves nested stderr/stdout/cause details
- log richer context when `sessions_spawn(runtime=\"acp\")` fails during ACP session initialization
- include last tool error and recent message targets in embedded run timeout logs

## Why
Several current ACP/session issues are hard to debug from gateway logs because failures collapse down to generic strings like `ACP_SESSION_INIT_FAILED`, `acpx exited with code 1`, or a bare embedded timeout line.

This does not change runtime behavior or routing. It makes the failure path observable enough to diagnose workspace/cwd mismatches, backend stderr, and timeout context without reproducing everything interactively.

## Related
- #43667
- #43661

## Testing
- `corepack pnpm vitest run src/acp/runtime/errors.test.ts src/agents/acp-spawn.test.ts`

## AI assistance
AI-assisted. I reviewed and tested the patch locally.
