### PR TITLE
docs(install): clarify --bind mode vs resolved 0.0.0.0 listener output

### DIFF
--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -84,7 +84,7 @@ primary_region = "iad"
 
 | Setting                        | Why                                                                         |
 | ------------------------------ | --------------------------------------------------------------------------- |
-| `--bind lan`                   | Uses bind mode `lan` (all interfaces) so Fly's proxy can reach the gateway |
+| `--bind lan`                   | Uses bind mode `lan` (all interfaces) so Fly's proxy can reach the gateway  |
 | `--allow-unconfigured`         | Starts without a config file (you'll create one after)                      |
 | `internal_port = 3000`         | Must match `--port 3000` (or `OPENCLAW_GATEWAY_PORT`) for Fly health checks |
 | `memory = "2048mb"`            | 512MB is too small; 2GB recommended                                         |

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -84,7 +84,7 @@ primary_region = "iad"
 
 | Setting                        | Why                                                                         |
 | ------------------------------ | --------------------------------------------------------------------------- |
-| `--bind lan`                   | Binds to `0.0.0.0` so Fly's proxy can reach the gateway                     |
+| `--bind lan`                   | Uses bind mode `lan` (all interfaces) so Fly's proxy can reach the gateway |
 | `--allow-unconfigured`         | Starts without a config file (you'll create one after)                      |
 | `internal_port = 3000`         | Must match `--port 3000` (or `OPENCLAW_GATEWAY_PORT`) for Fly health checks |
 | `memory = "2048mb"`            | 512MB is too small; 2GB recommended                                         |
@@ -134,6 +134,9 @@ You should see:
 [gateway] listening on ws://0.0.0.0:3000 (PID xxx)
 [discord] logged in to discord as xxx
 ```
+
+This log line shows the resolved listener host for bind mode `lan`. Keep using bind
+mode values (`--bind lan`), not host aliases like `--bind 0.0.0.0`.
 
 ## 5) Create config file
 
@@ -246,7 +249,8 @@ fly ssh console
 
 ### "App is not listening on expected address"
 
-The gateway is binding to `127.0.0.1` instead of `0.0.0.0`.
+The gateway is running in loopback mode instead of LAN mode (for example, `--bind loopback`
+instead of `--bind lan`).
 
 **Fix:** Add `--bind lan` to your process command in `fly.toml`.
 

--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -391,6 +391,10 @@ Success:
 [gateway] listening on ws://0.0.0.0:18789
 ```
 
+This output reflects the resolved listener host for bind mode `lan`. Configure the
+gateway with bind modes (for example `gateway.bind: "lan"`), not host aliases like
+`gateway.bind: "0.0.0.0"`.
+
 ---
 
 ## 13) Access from your laptop

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -302,6 +302,10 @@ Success:
 [gateway] listening on ws://0.0.0.0:18789
 ```
 
+This output reflects the resolved listener host for bind mode `lan`. Configure the
+gateway with bind modes (for example `gateway.bind: "lan"`), not host aliases like
+`gateway.bind: "0.0.0.0"`.
+
 From your laptop:
 
 ```bash


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Install docs showed listener outputs like `ws://0.0.0.0:...` without clearly distinguishing them from the supported bind-mode configuration model (`lan`/`loopback`/`tailnet`/`custom`/`auto`).
- Why it matters: Readers could misinterpret examples and try unsupported host-alias values (for example `--bind 0.0.0.0` or `gateway.bind: "0.0.0.0"`), causing confusion and setup errors.
- What changed: Updated wording in `docs/install/fly.md`, `docs/install/gcp.md`, and `docs/install/hetzner.md` to explicitly state that `0.0.0.0` in logs is resolved runtime output for bind mode `lan`, and configuration should use bind modes.
- What did NOT change (scope boundary): No runtime code, CLI parsing, auth behavior, networking behavior, defaults, or config schema was changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44101
- Related #

## User-visible / Behavior Changes

- Documentation now explicitly tells users to configure bind **modes** (for example `--bind lan`, `gateway.bind: "lan"`), not host aliases.
- Fly troubleshooting text now describes the mismatch as loopback mode vs LAN mode, not `127.0.0.1` vs `0.0.0.0`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: N/A (docs-only change)
- Model/provider: N/A
- Integration/channel (if any): Gateway install documentation (Fly, GCP, Hetzner)
- Relevant config (redacted): N/A

### Steps

1. Open the updated install docs sections for Fly, GCP, and Hetzner.
2. Verify wording around `0.0.0.0` listener examples and bind configuration guidance.
3. Confirm docs consistently recommend bind modes (`lan`/`loopback`/etc.) instead of host aliases.

### Expected

- Docs make a clear distinction between runtime listener output and supported bind configuration values.
- No instruction suggests setting `--bind 0.0.0.0` or `gateway.bind: "0.0.0.0"`.

### Actual

- Updated docs now explicitly describe `0.0.0.0` as resolved output for `lan` and direct users to bind modes.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace snippets (doc diffs):
- `docs/install/fly.md`: clarified `--bind lan` description + added runtime output note + updated troubleshooting wording.
- `docs/install/gcp.md`: added bind-mode clarification under `ws://0.0.0.0:18789` success log.
- `docs/install/hetzner.md`: added bind-mode clarification under `ws://0.0.0.0:18789` success log.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Reviewed all modified sections to ensure wording consistently points to bind modes and not host aliases.
- Edge cases checked: Confirmed examples that show `0.0.0.0` remain valid as runtime output while config guidance remains bind-mode based.
- What you did **not** verify: Full docs build/render pipeline and external deployment smoke tests (not required for this text-only update).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `docs/install/fly.md`, `docs/install/gcp.md`, `docs/install/hetzner.md`.
- Known bad symptoms reviewers should watch for: Confusing wording that still implies host aliases are valid bind config values.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Minor wording ambiguity could still remain in nearby untouched sections.
  - Mitigation: Updated the highest-impact install guides where users most often copy commands, and aligned wording with existing bind-mode guidance already documented elsewhere.