### PR TITLE
fix(compaction): stabilize toolResult trim/prune flow in safeguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Anthropic replay: drop replayed assistant thinking blocks for native Anthropic and Bedrock Claude providers so persisted follow-up turns no longer fail on stored thinking blocks. (#44843) Thanks @jmcte.
 - Docs/Brave pricing: escape literal dollar signs in Brave Search cost text so the docs render the free credit and per-request pricing correctly. (#44989) Thanks @keelanfh.
 - Feishu/file uploads: preserve literal UTF-8 filenames in `im.file.create` so Chinese and other non-ASCII filenames no longer appear percent-encoded in chat. (#34262) Thanks @fabiaodemianyang and @KangShuaiFu.
+- Agents/compaction safeguard: trim large kept `toolResult` payloads consistently for budgeting, pruning, and identifier seeding, then restore preserved payloads after prune so oversized safeguard summaries stay stable. (#44133) thanks @SayrWolfridge.
 
 ## 2026.3.11
 

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -28,6 +28,8 @@ const mockSummarizeInStages = vi.mocked(compactionModule.summarizeInStages);
 const {
   collectToolFailures,
   formatToolFailuresSection,
+  trimToolResultsForSummarization,
+  restoreOriginalToolResultsForKeptMessages,
   splitPreservedRecentTurns,
   formatPreservedTurnsSection,
   buildCompactionStructureInstructions,
@@ -44,6 +46,26 @@ const {
   MIN_CHUNK_RATIO,
   SAFETY_MARGIN,
 } = __testing;
+
+function readTextBlocks(message: AgentMessage): string {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((block) => {
+      if (!block || typeof block !== "object") {
+        return "";
+      }
+      const text = (block as { text?: unknown }).text;
+      return typeof text === "string" ? text : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
 
 function stubSessionManager(): ExtensionContext["sessionManager"] {
   const stub: ExtensionContext["sessionManager"] = {
@@ -231,6 +253,114 @@ describe("compaction-safeguard tool failures", () => {
     const failures = collectToolFailures(messages);
     const section = formatToolFailuresSection(failures);
     expect(section).toBe("");
+  });
+});
+
+describe("compaction-safeguard toolResult trimming", () => {
+  it("truncates oversized tool results and compacts older entries to stay within budget", () => {
+    const messages: AgentMessage[] = Array.from({ length: 7 }, (_unused, index) => ({
+      role: "toolResult",
+      toolCallId: `call-${index}`,
+      toolName: "read",
+      content: [
+        {
+          type: "text",
+          text: `head-${index}\n${"x".repeat(25_000)}\ntail-${index}`,
+        },
+      ],
+      timestamp: index + 1,
+    })) as AgentMessage[];
+
+    const trimmed = trimToolResultsForSummarization(messages);
+
+    expect(trimmed.stats.truncatedCount).toBe(7);
+    expect(trimmed.stats.compactedCount).toBe(1);
+    expect(readTextBlocks(trimmed.messages[0])).toBe("");
+    expect(trimmed.stats.afterChars).toBeLessThan(trimmed.stats.beforeChars);
+    expect(readTextBlocks(trimmed.messages[6])).toContain("head-6");
+    expect(readTextBlocks(trimmed.messages[6])).toContain("[truncated for compaction stability]");
+    expect(readTextBlocks(trimmed.messages[6])).toContain("tail-6");
+  });
+
+  it("restores kept tool results after prune for both toolCallId and toolUseId", () => {
+    const originalMessages: AgentMessage[] = [
+      { role: "user", content: "keep these tool results", timestamp: 1 },
+      {
+        role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "read",
+        content: [{ type: "text", text: "original call payload" }],
+        timestamp: 2,
+      } as AgentMessage,
+      {
+        role: "toolResult",
+        toolUseId: "use-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "original use payload" }],
+        timestamp: 3,
+      } as AgentMessage,
+    ];
+    const prunedMessages: AgentMessage[] = [
+      originalMessages[0],
+      {
+        role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "read",
+        content: [{ type: "text", text: "trimmed call payload" }],
+        timestamp: 2,
+      } as AgentMessage,
+      {
+        role: "toolResult",
+        toolUseId: "use-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "trimmed use payload" }],
+        timestamp: 3,
+      } as AgentMessage,
+    ];
+
+    const restored = restoreOriginalToolResultsForKeptMessages({
+      prunedMessages,
+      originalMessages,
+    });
+
+    expect(readTextBlocks(restored[1])).toBe("original call payload");
+    expect(readTextBlocks(restored[2])).toBe("original use payload");
+  });
+
+  it("extracts identifiers from the trimmed kept payloads after prune restore", () => {
+    const hiddenIdentifier = "DEADBEEF12345678";
+    const restored = restoreOriginalToolResultsForKeptMessages({
+      prunedMessages: [
+        { role: "user", content: "recent ask", timestamp: 1 },
+        {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "placeholder" }],
+          timestamp: 2,
+        } as AgentMessage,
+      ],
+      originalMessages: [
+        { role: "user", content: "recent ask", timestamp: 1 },
+        {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [
+            {
+              type: "text",
+              text: `visible head ${"a".repeat(16_000)}${hiddenIdentifier}${"b".repeat(16_000)} visible tail`,
+            },
+          ],
+          timestamp: 2,
+        } as AgentMessage,
+      ],
+    });
+
+    const trimmed = trimToolResultsForSummarization(restored).messages;
+    const identifierSeedText = trimmed.map((message) => readTextBlocks(message)).join("\n");
+
+    expect(extractOpaqueIdentifiers(identifierSeedText)).not.toContain(hiddenIdentifier);
   });
 });
 

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -298,7 +298,7 @@ describe("compaction-safeguard toolResult trimming", () => {
         toolName: "exec",
         content: [{ type: "text", text: "original use payload" }],
         timestamp: 3,
-      } as AgentMessage,
+      } as unknown as AgentMessage,
     ];
     const prunedMessages: AgentMessage[] = [
       originalMessages[0],
@@ -315,7 +315,7 @@ describe("compaction-safeguard toolResult trimming", () => {
         toolName: "exec",
         content: [{ type: "text", text: "trimmed use payload" }],
         timestamp: 3,
-      } as AgentMessage,
+      } as unknown as AgentMessage,
     ];
 
     const restored = restoreOriginalToolResultsForKeptMessages({

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -258,7 +258,7 @@ describe("compaction-safeguard tool failures", () => {
 
 describe("compaction-safeguard toolResult trimming", () => {
   it("truncates oversized tool results and compacts older entries to stay within budget", () => {
-    const messages: AgentMessage[] = Array.from({ length: 7 }, (_unused, index) => ({
+    const messages: AgentMessage[] = Array.from({ length: 9 }, (_unused, index) => ({
       role: "toolResult",
       toolCallId: `call-${index}`,
       toolName: "read",
@@ -273,13 +273,15 @@ describe("compaction-safeguard toolResult trimming", () => {
 
     const trimmed = trimToolResultsForSummarization(messages);
 
-    expect(trimmed.stats.truncatedCount).toBe(7);
+    expect(trimmed.stats.truncatedCount).toBe(9);
     expect(trimmed.stats.compactedCount).toBe(1);
     expect(readTextBlocks(trimmed.messages[0])).toBe("");
     expect(trimmed.stats.afterChars).toBeLessThan(trimmed.stats.beforeChars);
-    expect(readTextBlocks(trimmed.messages[6])).toContain("head-6");
-    expect(readTextBlocks(trimmed.messages[6])).toContain("[truncated for compaction stability]");
-    expect(readTextBlocks(trimmed.messages[6])).toContain("tail-6");
+    expect(readTextBlocks(trimmed.messages[8])).toContain("head-8");
+    expect(readTextBlocks(trimmed.messages[8])).toContain(
+      "[...tool result truncated for compaction budget...]",
+    );
+    expect(readTextBlocks(trimmed.messages[8])).toContain("tail-8");
   });
 
   it("restores kept tool results after prune for both toolCallId and toolUseId", () => {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -407,6 +407,135 @@ function formatPreservedTurnsSection(messages: AgentMessage[]): string {
   return `\n\n## Recent turns preserved verbatim\n${lines.join("\n")}`;
 }
 
+type ToolResultSummaryTrimStats = {
+  truncatedCount: number;
+  compactedCount: number;
+  beforeChars: number;
+  afterChars: number;
+};
+
+const COMPACTION_SUMMARY_TOOL_RESULT_MAX_CHARS = 2_500;
+const COMPACTION_SUMMARY_TOOL_RESULT_TOTAL_CHARS_BUDGET = 20_000;
+const COMPACTION_SUMMARY_TOOL_RESULT_TRUNCATION_NOTICE =
+  "[...tool result truncated for compaction budget...]";
+const COMPACTION_SUMMARY_TOOL_RESULT_COMPACTED_NOTICE =
+  "[tool result compacted due to global compaction budget]";
+const COMPACTION_SUMMARY_TOOL_RESULT_NON_TEXT_NOTICE = "[non-text tool result content omitted]";
+
+function getToolResultTextFromContent(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const text = (block as { text?: unknown }).text;
+    if (typeof text === "string" && text.length > 0) {
+      parts.push(text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function hasNonTextToolResultContent(content: unknown): boolean {
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const t = (block as { type?: unknown }).type;
+    return t !== "text";
+  });
+}
+
+function replaceToolResultContentForSummary(msg: AgentMessage, text: string): AgentMessage {
+  return {
+    ...(msg as unknown as Record<string, unknown>),
+    content: [{ type: "text", text }],
+  } as AgentMessage;
+}
+
+function trimToolResultsForSummarization(messages: AgentMessage[]): {
+  messages: AgentMessage[];
+  stats: ToolResultSummaryTrimStats;
+} {
+  const next = [...messages];
+  let truncatedCount = 0;
+  let compactedCount = 0;
+  let beforeChars = 0;
+
+  for (let i = 0; i < next.length; i += 1) {
+    const msg = next[i];
+    if ((msg as { role?: unknown }).role !== "toolResult") {
+      continue;
+    }
+    const content = (msg as { content?: unknown }).content;
+    const text = getToolResultTextFromContent(content);
+    const hasNonText = hasNonTextToolResultContent(content);
+    beforeChars += text.length;
+
+    let normalized = text;
+    if (normalized.length === 0 && hasNonText) {
+      normalized = COMPACTION_SUMMARY_TOOL_RESULT_NON_TEXT_NOTICE;
+    }
+
+    if (normalized.length > COMPACTION_SUMMARY_TOOL_RESULT_MAX_CHARS) {
+      const separator = `\n\n${COMPACTION_SUMMARY_TOOL_RESULT_TRUNCATION_NOTICE}\n\n`;
+      const available = Math.max(0, COMPACTION_SUMMARY_TOOL_RESULT_MAX_CHARS - separator.length);
+      const tailBudget = Math.floor(available * 0.35);
+      const headBudget = Math.max(0, available - tailBudget);
+      const head = normalized.slice(0, headBudget);
+      const tail = tailBudget > 0 ? normalized.slice(-tailBudget) : "";
+      normalized = `${head}${separator}${tail}`;
+      truncatedCount += 1;
+    }
+
+    if (hasNonText || normalized !== text) {
+      next[i] = replaceToolResultContentForSummary(msg, normalized);
+    }
+  }
+
+  let runningChars = 0;
+  for (let i = next.length - 1; i >= 0; i -= 1) {
+    const msg = next[i];
+    if ((msg as { role?: unknown }).role !== "toolResult") {
+      continue;
+    }
+    const text = getToolResultTextFromContent((msg as { content?: unknown }).content);
+    if (runningChars + text.length <= COMPACTION_SUMMARY_TOOL_RESULT_TOTAL_CHARS_BUDGET) {
+      runningChars += text.length;
+      continue;
+    }
+    const placeholderLen = COMPACTION_SUMMARY_TOOL_RESULT_COMPACTED_NOTICE.length;
+    const remainingBudget = Math.max(
+      0,
+      COMPACTION_SUMMARY_TOOL_RESULT_TOTAL_CHARS_BUDGET - runningChars,
+    );
+    const replacementText =
+      remainingBudget >= placeholderLen ? COMPACTION_SUMMARY_TOOL_RESULT_COMPACTED_NOTICE : "";
+    next[i] = replaceToolResultContentForSummary(msg, replacementText);
+    runningChars += replacementText.length;
+    compactedCount += 1;
+  }
+
+  let afterChars = 0;
+  for (const msg of next) {
+    if ((msg as { role?: unknown }).role !== "toolResult") {
+      continue;
+    }
+    afterChars += getToolResultTextFromContent((msg as { content?: unknown }).content).length;
+  }
+
+  return {
+    messages: next,
+    stats: { truncatedCount, compactedCount, beforeChars, afterChars },
+  };
+}
+
 function wrapUntrustedInstructionBlock(label: string, text: string): string {
   return wrapUntrustedPromptDataBlock({
     label,
@@ -755,6 +884,18 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const modelContextWindow = resolveContextWindowTokens(model);
       const contextWindowTokens = runtime?.contextWindowTokens ?? modelContextWindow;
       const turnPrefixMessages = preparation.turnPrefixMessages ?? [];
+      const prefixTrimmedForBudget = trimToolResultsForSummarization(turnPrefixMessages);
+      if (
+        prefixTrimmedForBudget.stats.truncatedCount > 0 ||
+        prefixTrimmedForBudget.stats.compactedCount > 0
+      ) {
+        log.warn(
+          `Compaction safeguard: pre-trimmed prefix toolResult payloads for budgeting ` +
+            `(truncated=${prefixTrimmedForBudget.stats.truncatedCount}, compacted=${prefixTrimmedForBudget.stats.compactedCount}, ` +
+            `chars=${prefixTrimmedForBudget.stats.beforeChars}->${prefixTrimmedForBudget.stats.afterChars})`,
+        );
+      }
+      const prefixMessagesForSummary = prefixTrimmedForBudget.messages;
       let messagesToSummarize = preparation.messagesToSummarize;
       const recentTurnsPreserve = resolveRecentTurnsPreserve(runtime?.recentTurnsPreserve);
       const qualityGuardEnabled = runtime?.qualityGuardEnabled ?? false;
@@ -842,8 +983,21 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       });
       messagesToSummarize = summaryTargetMessages;
       const preservedTurnsSection = formatPreservedTurnsSection(preservedRecentMessages);
-      const latestUserAsk = extractLatestUserAsk([...messagesToSummarize, ...turnPrefixMessages]);
-      const identifierSeedText = [...messagesToSummarize, ...turnPrefixMessages]
+      const latestUserAsk = extractLatestUserAsk([
+        ...messagesToSummarize,
+        ...prefixMessagesForSummary,
+      ]);
+      const summaryTrimmed = trimToolResultsForSummarization(messagesToSummarize);
+      if (summaryTrimmed.stats.truncatedCount > 0 || summaryTrimmed.stats.compactedCount > 0) {
+        log.warn(
+          `Compaction safeguard: trimmed toolResult payloads before summarize ` +
+            `(truncated=${summaryTrimmed.stats.truncatedCount}, compacted=${summaryTrimmed.stats.compactedCount}, ` +
+            `chars=${summaryTrimmed.stats.beforeChars}->${summaryTrimmed.stats.afterChars})`,
+        );
+      }
+
+      const identifierSourceMessages = [...summaryTrimmed.messages, ...prefixMessagesForSummary];
+      const identifierSeedText = identifierSourceMessages
         .slice(-10)
         .map((message) => extractMessageText(message))
         .filter(Boolean)
@@ -853,7 +1007,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       // Use adaptive chunk ratio based on message sizes, reserving headroom for
       // the summarization prompt, system prompt, previous summary, and reasoning budget
       // that generateSummary adds on top of the serialized conversation chunk.
-      const allMessages = [...messagesToSummarize, ...turnPrefixMessages];
+      const allMessages = [...summaryTrimmed.messages, ...prefixMessagesForSummary];
       const adaptiveRatio = computeAdaptiveChunkRatio(allMessages, contextWindowTokens);
       const maxChunkTokens = Math.max(
         1,
@@ -875,9 +1029,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         let summaryWithPreservedTurns = "";
         try {
           const historySummary =
-            messagesToSummarize.length > 0
+            summaryTrimmed.messages.length > 0
               ? await summarizeInStages({
-                  messages: messagesToSummarize,
+                  messages: summaryTrimmed.messages,
                   model,
                   apiKey,
                   signal,
@@ -891,9 +1045,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               : buildStructuredFallbackSummary(effectivePreviousSummary, summarizationInstructions);
 
           summaryWithoutPreservedTurns = historySummary;
-          if (preparation.isSplitTurn && turnPrefixMessages.length > 0) {
+          if (preparation.isSplitTurn && prefixMessagesForSummary.length > 0) {
             const prefixSummary = await summarizeInStages({
-              messages: turnPrefixMessages,
+              messages: prefixMessagesForSummary,
               model,
               apiKey,
               signal,

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -915,8 +915,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       let droppedSummary: string | undefined;
 
       if (tokensBefore !== undefined) {
+        const budgetTrimmedForSummary = trimToolResultsForSummarization(messagesToSummarize);
         const summarizableTokens =
-          estimateMessagesTokens(messagesToSummarize) + estimateMessagesTokens(turnPrefixMessages);
+          estimateMessagesTokens(budgetTrimmedForSummary.messages) +
+          estimateMessagesTokens(prefixMessagesForSummary);
         const newContentTokens = Math.max(0, Math.floor(tokensBefore - summarizableTokens));
         // Apply SAFETY_MARGIN so token underestimates don't trigger unnecessary pruning
         const maxHistoryTokens = Math.floor(contextWindowTokens * maxHistoryShare * SAFETY_MARGIN);

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -536,6 +536,50 @@ function trimToolResultsForSummarization(messages: AgentMessage[]): {
   };
 }
 
+function getToolResultStableId(message: AgentMessage): string | null {
+  if ((message as { role?: unknown }).role !== "toolResult") {
+    return null;
+  }
+  const toolCallId = (message as { toolCallId?: unknown }).toolCallId;
+  if (typeof toolCallId === "string" && toolCallId.length > 0) {
+    return `call:${toolCallId}`;
+  }
+  const toolUseId = (message as { toolUseId?: unknown }).toolUseId;
+  if (typeof toolUseId === "string" && toolUseId.length > 0) {
+    return `use:${toolUseId}`;
+  }
+  return null;
+}
+
+function restoreOriginalToolResultsForKeptMessages(params: {
+  prunedMessages: AgentMessage[];
+  originalMessages: AgentMessage[];
+}): AgentMessage[] {
+  const originalByStableId = new Map<string, AgentMessage[]>();
+  for (const message of params.originalMessages) {
+    const stableId = getToolResultStableId(message);
+    if (!stableId) {
+      continue;
+    }
+    const bucket = originalByStableId.get(stableId) ?? [];
+    bucket.push(message);
+    originalByStableId.set(stableId, bucket);
+  }
+
+  return params.prunedMessages.map((message) => {
+    const stableId = getToolResultStableId(message);
+    if (!stableId) {
+      return message;
+    }
+    const bucket = originalByStableId.get(stableId);
+    if (!bucket || bucket.length === 0) {
+      return message;
+    }
+    const restored = bucket.shift();
+    return restored ?? message;
+  });
+}
+
 function wrapUntrustedInstructionBlock(label: string, text: string): string {
   return wrapUntrustedPromptDataBlock({
     label,
@@ -916,6 +960,16 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
 
       if (tokensBefore !== undefined) {
         const budgetTrimmedForSummary = trimToolResultsForSummarization(messagesToSummarize);
+        if (
+          budgetTrimmedForSummary.stats.truncatedCount > 0 ||
+          budgetTrimmedForSummary.stats.compactedCount > 0
+        ) {
+          log.warn(
+            `Compaction safeguard: pre-trimmed toolResult payloads for budgeting ` +
+              `(truncated=${budgetTrimmedForSummary.stats.truncatedCount}, compacted=${budgetTrimmedForSummary.stats.compactedCount}, ` +
+              `chars=${budgetTrimmedForSummary.stats.beforeChars}->${budgetTrimmedForSummary.stats.afterChars})`,
+          );
+        }
         const summarizableTokens =
           estimateMessagesTokens(budgetTrimmedForSummary.messages) +
           estimateMessagesTokens(prefixMessagesForSummary);
@@ -924,21 +978,25 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         const maxHistoryTokens = Math.floor(contextWindowTokens * maxHistoryShare * SAFETY_MARGIN);
 
         if (newContentTokens > maxHistoryTokens) {
+          const originalMessagesBeforePrune = messagesToSummarize;
           const pruned = pruneHistoryForContextShare({
-            messages: messagesToSummarize,
+            messages: budgetTrimmedForSummary.messages,
             maxContextTokens: contextWindowTokens,
             maxHistoryShare,
             parts: 2,
           });
           if (pruned.droppedChunks > 0) {
-            const newContentRatio = (newContentTokens / contextWindowTokens) * 100;
+            const historyRatio = (summarizableTokens / contextWindowTokens) * 100;
             log.warn(
-              `Compaction safeguard: new content uses ${newContentRatio.toFixed(
+              `Compaction safeguard: summarizable history uses ${historyRatio.toFixed(
                 1,
               )}% of context; dropped ${pruned.droppedChunks} older chunk(s) ` +
                 `(${pruned.droppedMessages} messages) to fit history budget.`,
             );
-            messagesToSummarize = pruned.messages;
+            messagesToSummarize = restoreOriginalToolResultsForKeptMessages({
+              prunedMessages: pruned.messages,
+              originalMessages: originalMessagesBeforePrune,
+            });
 
             // Summarize dropped messages so context isn't lost
             if (pruned.droppedMessagesList.length > 0) {
@@ -952,8 +1010,19 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   Math.floor(contextWindowTokens * droppedChunkRatio) -
                     SUMMARIZATION_OVERHEAD_TOKENS,
                 );
+                const droppedTrimmed = trimToolResultsForSummarization(pruned.droppedMessagesList);
+                if (
+                  droppedTrimmed.stats.truncatedCount > 0 ||
+                  droppedTrimmed.stats.compactedCount > 0
+                ) {
+                  log.warn(
+                    `Compaction safeguard: trimmed dropped toolResult payloads before summarize ` +
+                      `(truncated=${droppedTrimmed.stats.truncatedCount}, compacted=${droppedTrimmed.stats.compactedCount}, ` +
+                      `chars=${droppedTrimmed.stats.beforeChars}->${droppedTrimmed.stats.afterChars})`,
+                  );
+                }
                 droppedSummary = await summarizeInStages({
-                  messages: pruned.droppedMessagesList,
+                  messages: droppedTrimmed.messages,
                   model,
                   apiKey,
                   signal,

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -1218,6 +1218,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
 export const __testing = {
   collectToolFailures,
   formatToolFailuresSection,
+  trimToolResultsForSummarization,
+  restoreOriginalToolResultsForKeptMessages,
   splitPreservedRecentTurns,
   formatPreservedTurnsSection,
   buildCompactionStructureInstructions,


### PR DESCRIPTION
## Summary

- Problem: compaction summary flow could over-trim/over-prune `toolResult` history in large sessions, causing unnecessary context loss
- Why it matters: this degrades summary quality and can break strict identifier expectations in heavy tool-output transcripts
- What changed:
- added bounded `toolResult` trimming for summarization (`max per result`, `total budget`, non-text placeholder handling)
- aligned prune/budget flow to use the same trimmed input for budgeting decisions
- restored original kept `toolResult` payloads after prune (supports both `toolCallId` and `toolUseId`)
- synced strict identifier extraction with the actual trimmed summarization input
- What did NOT change (scope boundary): no live transcript mutation logic, no gateway/config changes, no new integrations or permissions

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Compaction is more stable for histories with large/many `toolResult` payloads and less likely to drop useful context unnecessarily.
No user-facing command or config-default changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (Debian-based)
- Runtime/container: local OpenClaw dev environment
- Model/provider: local Codex review flow + repository checks
- Integration/channel (if any): N/A (compaction code path)
- Relevant config (redacted): default local dev settings

### Steps

1. Reproduce compaction with oversized/many `toolResult` payloads
2. Run compaction safeguard flow and inspect prune/summary behavior
3. Run final review/check gates

### Expected

- No over-pruning caused by budget/prune mismatch
- Strict identifier checks aligned with summarization input
- Stable summary generation in oversized tool-result scenarios

### Actual

- `codex review --base origin/main` returned no blocking findings on final diff
- `pnpm check` completed successfully (`code 0`)
- Compaction behavior remained stable in validation runs

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
- oversized `toolResult` trimming path
- prune/budget alignment behavior
- restoration of kept tool results (`toolCallId` and `toolUseId`)
- strict identifier extraction against trimmed summarization input
- Edge cases checked:
- non-text tool result content placeholders
- global trim budget interactions with prune flow
- What you did **not** verify:
- extended multi-day production traffic behavior post-merge

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## AI Assistance Disclosure

- AI-assisted: Yes (Codex-assisted review/iteration)
- Testing level: Fully tested (`codex review --base origin/main` + `pnpm check` green)
- I reviewed and understand all code changes in this PR
- Addressed bot review conversations were replied to/resolved where applicable

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- revert this PR commit
- Files/config to restore:
- `src/agents/pi-extensions/compaction-safeguard.ts`
- Known bad symptoms reviewers should watch for:
- unexpectedly over-compressed summaries
- missing relevant tool-output context in compaction output
- repeated strict-quality retries due to identifier mismatch

## Risks and Mitigations

- Risk: trimming can still reduce detail in extreme high-volume tool-output sessions
- Mitigation: bounded trim + kept-message restoration + prune alignment + final review/check gates
