### PR TITLE
feat(slack): per-agent Slack display names via chat:write.customize

### DIFF
--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -52,6 +52,8 @@ export type SlackActionContext = {
   hasRepliedRef?: { value: boolean };
   /** Allowed local media directories for file uploads. */
   mediaLocalRoots?: readonly string[];
+  /** Agent identity for chat:write.customize (custom display name/emoji). */
+  identity?: import("../../slack/send.js").SlackSendIdentity;
 };
 
 /**
@@ -214,6 +216,7 @@ export async function handleSlackAction(
           mediaLocalRoots: context?.mediaLocalRoots,
           threadTs: threadTs ?? undefined,
           blocks,
+          ...(context?.identity ? { identity: context.identity } : {}),
         });
 
         if (threadTs && result.channelId && account.accountId) {

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -1,6 +1,7 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveSlackAccount } from "../../slack/accounts.js";
+import type { SlackSendIdentity } from "../../slack/send.js";
 import {
   deleteSlackMessage,
   downloadSlackFile,
@@ -53,7 +54,7 @@ export type SlackActionContext = {
   /** Allowed local media directories for file uploads. */
   mediaLocalRoots?: readonly string[];
   /** Agent identity for chat:write.customize (custom display name/emoji). */
-  identity?: import("../../slack/send.js").SlackSendIdentity;
+  identity?: SlackSendIdentity;
 };
 
 /**

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -1,14 +1,33 @@
 import { handleSlackAction, type SlackActionContext } from "../../agents/tools/slack-actions.js";
+import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
 import { handleSlackMessageAction } from "../../plugin-sdk/slack-message-actions.js";
 import { extractSlackToolSend, listSlackMessageActions } from "../../slack/message-actions.js";
+import type { SlackSendIdentity } from "../../slack/send.js";
 import { resolveSlackChannelId } from "../../slack/targets.js";
 import type { ChannelMessageActionAdapter } from "./types.js";
+
+function resolveSlackIdentityFromAgent(
+  cfg: Parameters<typeof resolveAgentOutboundIdentity>[0],
+  agentId: string | undefined,
+): SlackSendIdentity | undefined {
+  if (!agentId) return undefined;
+  const outbound = resolveAgentOutboundIdentity(cfg, agentId);
+  if (!outbound) return undefined;
+  return {
+    username: outbound.name,
+    iconUrl: outbound.avatarUrl,
+    iconEmoji: outbound.emoji,
+  };
+}
 
 export function createSlackActions(providerId: string): ChannelMessageActionAdapter {
   return {
     listActions: ({ cfg }) => listSlackMessageActions(cfg),
     extractToolSend: ({ args }) => extractSlackToolSend(args),
     handleAction: async (ctx) => {
+      const agentId =
+        typeof ctx.params.__agentId === "string" ? ctx.params.__agentId : undefined;
+      const identity = resolveSlackIdentityFromAgent(ctx.cfg, agentId);
       return await handleSlackMessageAction({
         providerId,
         ctx,
@@ -18,6 +37,7 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
           await handleSlackAction(action, cfg, {
             ...(toolContext as SlackActionContext | undefined),
             mediaLocalRoots: ctx.mediaLocalRoots,
+            ...(identity ? { identity } : {}),
           }),
       });
     },

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -7,7 +7,7 @@ import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient } from "./client.js";
 import { resolveSlackMedia } from "./monitor/media.js";
 import type { SlackMediaResult } from "./monitor/media.js";
-import { sendMessageSlack } from "./send.js";
+import { sendMessageSlack, type SlackSendIdentity } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
 export type SlackActionClientOpts = {
@@ -162,6 +162,7 @@ export async function sendSlackMessage(
     mediaLocalRoots?: readonly string[];
     threadTs?: string;
     blocks?: (Block | KnownBlock)[];
+    identity?: SlackSendIdentity;
   } = {},
 ) {
   return await sendMessageSlack(to, content, {
@@ -172,6 +173,7 @@ export async function sendSlackMessage(
     client: opts.client,
     threadTs: opts.threadTs,
     blocks: opts.blocks,
+    ...(opts.identity ? { identity: opts.identity } : {}),
   });
 }
 

--- a/src/slack/draft-stream.test.ts
+++ b/src/slack/draft-stream.test.ts
@@ -122,6 +122,34 @@ describe("createSlackDraftStream", () => {
     expect(remove).not.toHaveBeenCalled();
   });
 
+  it("passes identity to send when configured", async () => {
+    const send = vi.fn<DraftSendFn>(async () => ({
+      channelId: "C123",
+      messageId: "111.222",
+    }));
+    const identity = { username: "TestBot", iconEmoji: ":robot_face:" };
+    const stream = createSlackDraftStream({
+      target: "channel:C123",
+      token: "xoxb-test",
+      throttleMs: 250,
+      send,
+      edit: vi.fn<DraftEditFn>(async () => {}),
+      remove: vi.fn<DraftRemoveFn>(async () => {}),
+      identity,
+    });
+
+    stream.update("hello");
+    await stream.flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith("channel:C123", "hello", {
+      token: "xoxb-test",
+      accountId: undefined,
+      threadTs: undefined,
+      identity,
+    });
+  });
+
   it("clear warns when cleanup fails", async () => {
     const remove = vi.fn<DraftRemoveFn>(async () => {
       throw new Error("cleanup failed");

--- a/src/slack/draft-stream.ts
+++ b/src/slack/draft-stream.ts
@@ -1,6 +1,6 @@
 import { createDraftStreamLoop } from "../channels/draft-stream-loop.js";
 import { deleteSlackMessage, editSlackMessage } from "./actions.js";
-import { sendMessageSlack } from "./send.js";
+import { sendMessageSlack, type SlackSendIdentity } from "./send.js";
 
 const SLACK_STREAM_MAX_CHARS = 4000;
 const DEFAULT_THROTTLE_MS = 1000;
@@ -28,6 +28,7 @@ export function createSlackDraftStream(params: {
   send?: typeof sendMessageSlack;
   edit?: typeof editSlackMessage;
   remove?: typeof deleteSlackMessage;
+  identity?: SlackSendIdentity;
 }): SlackDraftStream {
   const maxChars = Math.min(params.maxChars ?? SLACK_STREAM_MAX_CHARS, SLACK_STREAM_MAX_CHARS);
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
@@ -69,6 +70,7 @@ export function createSlackDraftStream(params: {
         token: params.token,
         accountId: params.accountId,
         threadTs: params.resolveThreadTs?.(),
+        ...(params.identity ? { identity: params.identity } : {}),
       });
       streamChannelId = sent.channelId || streamChannelId;
       streamMessageId = sent.messageId || streamMessageId;

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -373,7 +373,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     onMessageSent: () => replyPlan.markSent(),
     log: logVerbose,
     warn: logVerbose,
-    identity: slackIdentity,
+    ...(slackIdentity ? { identity: slackIdentity } : {}),
   });
   let hasStreamedMessage = false;
   const streamMode = slackStreaming.draftMode;

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -373,6 +373,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     onMessageSent: () => replyPlan.markSent(),
     log: logVerbose,
     warn: logVerbose,
+    identity: slackIdentity,
   });
   let hasStreamedMessage = false;
   const streamMode = slackStreaming.draftMode;


### PR DESCRIPTION
## Summary

Pass agent `identity.name` and `identity.emoji` as `username` and `icon_emoji` in Slack `chat.postMessage` calls when the `chat:write.customize` scope is available.

## Background

The core infrastructure already existed:
- `SlackSendIdentity` type in `send.ts`
- `postSlackMessageBestEffort` with graceful fallback when `chat:write.customize` is missing
- Outbound delivery path wiring identity from agent config

However, several send paths had gaps where identity was not forwarded.

## Changes

| File | Change |
|------|--------|
| `src/slack/draft-stream.ts` | Accept `identity` param, forward to `sendMessageSlack` on initial stream message |
| `src/slack/monitor/message-handler/dispatch.ts` | Pass resolved `slackIdentity` to `createSlackDraftStream` |
| `src/slack/actions.ts` | Accept `identity` in `sendSlackMessage` and forward to `sendMessageSlack` |
| `src/agents/tools/slack-actions.ts` | Add `identity` to `SlackActionContext`, pass through agent tool `sendMessage` |
| `src/slack/draft-stream.test.ts` | New test: verify identity is forwarded to send function |

## Graceful Fallback

When `chat:write.customize` scope is not available, the existing `postSlackMessageBestEffort` catches the `missing_scope` error and retries without custom identity fields. No breaking changes.

## Testing

- All 389 existing Slack tests pass
- New test added for identity passthrough in draft stream

Refs: AI-260