### PR TITLE
fix(skills): do not enforce realpath containment for managed skills

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -198,6 +198,20 @@ function warnEscapedSkillPath(params: {
   });
 }
 
+/**
+ * Determine whether realpath boundary enforcement should apply to a given skill source.
+ *
+ * Only workspace/extra/project sources are untrusted and need containment checks.
+ * Managed/personal/bundled roots are user-owned shared roots and should not be restricted.
+ */
+function shouldEnforceContainedSkillPaths(source: string): boolean {
+  return (
+    source === "openclaw-workspace" ||
+    source === "openclaw-extra" ||
+    source === "agents-skills-project"
+  );
+}
+
 function resolveContainedSkillPath(params: {
   source: string;
   rootDir: string;
@@ -207,6 +221,11 @@ function resolveContainedSkillPath(params: {
   const candidateRealPath = tryRealpath(params.candidatePath);
   if (!candidateRealPath) {
     return null;
+  }
+  // Only enforce containment for untrusted sources (workspace/extra/project).
+  // Managed/personal/bundled roots are trusted and may use symlinks.
+  if (!shouldEnforceContainedSkillPaths(params.source)) {
+    return candidateRealPath;
   }
   if (isPathInside(params.rootRealPath, candidateRealPath)) {
     return candidateRealPath;


### PR DESCRIPTION
## Summary

- Problem: Skills installed via `clawhub install` in WSL environment are rejected with "Skipping skill path that resolves outside its configured root"
- Why it matters: Managed skills in `~/.openclaw/skills` should be trusted, not subject to realpath boundary checks
- What changed: Added `shouldEnforceContainedSkillPaths()` to scope containment checks to only untrusted sources
- What did NOT change: Size checks and normal loading behavior remain unchanged

## Change Type

- [x] Bug fix

## Scope

- [x] Skills system

## Linked Issue

- Fixes #44051

## User-visible Changes

Skills installed via clawhub in WSL/symlink environments will now load correctly.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- Data access scope changed? No - only trusted sources (managed/personal/bundled) are exempt from containment checks

## Evidence

- [x] Root cause identified and fix is minimal

## Review Conversations

- [x] I will resolve all bot review conversations

## Compatibility

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks

None. Containment checks still apply to untrusted sources (workspace/extra/project).