### PR TITLE
docs(skills): clarify model-usage portable input mode

### DIFF
--- a/skills/model-usage/SKILL.md
+++ b/skills/model-usage/SKILL.md
@@ -28,7 +28,7 @@ metadata:
 
 Get per-model usage cost from CodexBar's local cost logs. Supports "current model" (most recent daily entry) or "all models" summaries for Codex or Claude.
 
-TODO: add Linux CLI support guidance once CodexBar CLI install path is documented for Linux.
+Live CodexBar CLI invocation in this skill is currently documented for macOS only. The bundled Python summarizer is still portable: if you already have exported CodexBar JSON, `--input` mode works anywhere Python is available.
 
 ## Quick start
 
@@ -51,6 +51,8 @@ python {baseDir}/scripts/model_usage.py --provider claude --mode all --format js
 ## Inputs
 
 - Default: runs `codexbar cost --format json --provider <codex|claude>`.
+- macOS: use the bundled CodexBar CLI install path above for live local usage reads.
+- Linux/other platforms: use `--input` with exported CodexBar JSON until this skill documents a supported local CodexBar install path for that platform.
 - File or stdin:
 
 ```bash


### PR DESCRIPTION
## Summary

- Problem: `skills/model-usage` documented a macOS install path for live CodexBar reads but left Linux/other-platform behavior implicit.
- Why it matters: users can already use the bundled Python summarizer portably with exported CodexBar JSON, but the skill did not say that clearly.
- What changed: clarified that live CodexBar CLI usage is documented for macOS only today, and documented the portable `--input` workflow for Linux/other platforms.
- What did NOT change (scope boundary): no runtime behavior, metadata gating, or install automation changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Users now get an explicit platform note: live CodexBar reads are documented for macOS, and `--input` mode is the portable path on Linux/other platforms.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows host, repo docs change only
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Read `skills/model-usage/SKILL.md` overview and input sections before the change.
2. Verify the skill documented only the macOS CodexBar install path while the examples already supported file/stdin input.
3. Read the updated skill and confirm the portable `--input` path is now documented explicitly.

### Expected

- The skill should state the supported macOS live path and the portable file-input fallback clearly.

### Actual

- The updated docs now make that distinction explicit.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the updated skill text against the existing examples and script interface.
- Edge cases checked: confirmed the change does not claim unsupported Linux live-install behavior.
- What you did **not** verify: live CodexBar execution on Linux.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the doc edit.
- Files/config to restore: `skills/model-usage/SKILL.md`
- Known bad symptoms reviewers should watch for: none beyond wording clarity.

## Risks and Mitigations

- Risk: wording could imply Linux live CodexBar support that has not been verified.
- Mitigation: the PR explicitly limits Linux/other-platform guidance to `--input` mode only.