### PR TITLE
fix(model-compat): respect explicit supportsUsageInStreaming override

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -445,9 +445,9 @@ Notes:
   - `contextWindow: 200000`
   - `maxTokens: 8192`
 - Recommended: set explicit values that match your proxy/model limits.
-- For `api: "openai-completions"` on non-native endpoints (any non-empty `baseUrl` whose host is not `api.openai.com`), OpenClaw forces `compat.supportsDeveloperRole: false` to avoid provider 400 errors for unsupported `developer` roles.
+- For `api: "openai-completions"` on non-native endpoints (any non-empty `baseUrl` whose host is not `api.openai.com`), OpenClaw forces `compat.supportsDeveloperRole: false` to avoid provider 400 errors for unsupported `developer` roles. An explicit `compat.supportsDeveloperRole: true` is still overridden on non-native endpoints.
 - If `baseUrl` is empty/omitted, OpenClaw keeps the default OpenAI behavior (which resolves to `api.openai.com`).
-- For safety, an explicit `compat.supportsDeveloperRole: true` is still overridden on non-native `openai-completions` endpoints.
+- `compat.supportsUsageInStreaming` defaults to `false` on non-native `openai-completions` endpoints. If your backend supports usage reporting in streaming responses (vLLM, llama.cpp, TGI, Ollama, and others), set `compat.supportsUsageInStreaming: true` to enable token usage tracking in `/status` and session logs.
 
 ## CLI examples
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2033,6 +2033,7 @@ OpenClaw uses the pi-coding-agent model catalog. Add custom providers via `model
 - `models.providers.*.headers`: extra static headers for proxy/tenant routing.
 - `models.providers.*.models`: explicit provider model catalog entries.
 - `models.providers.*.models.*.compat.supportsDeveloperRole`: optional compatibility hint. For `api: "openai-completions"` with a non-empty non-native `baseUrl` (host not `api.openai.com`), OpenClaw forces this to `false` at runtime. Empty/omitted `baseUrl` keeps default OpenAI behavior.
+- `models.providers.*.models.*.compat.supportsUsageInStreaming`: optional compatibility hint. Defaults to `false` on non-native `openai-completions` endpoints. Set to `true` if your backend supports usage reporting in streaming responses (vLLM, llama.cpp, TGI, Ollama). When enabled, OpenClaw sends `stream_options: { include_usage: true }` and captures token usage from the final streaming chunk for `/status` and session logs.
 - `models.bedrockDiscovery`: Bedrock auto-discovery settings root.
 - `models.bedrockDiscovery.enabled`: turn discovery polling on/off.
 - `models.bedrockDiscovery.region`: AWS region for discovery.

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -262,7 +262,7 @@ describe("normalizeModelCompat", () => {
     expect(supportsDeveloperRole(normalized)).toBe(false);
   });
 
-  it("overrides explicit supportsUsageInStreaming true on non-native endpoints", () => {
+  it("preserves explicit supportsUsageInStreaming true on non-native endpoints", () => {
     const model = {
       ...baseModel(),
       provider: "custom-cpa",
@@ -270,7 +270,31 @@ describe("normalizeModelCompat", () => {
       compat: { supportsUsageInStreaming: true },
     };
     const normalized = normalizeModelCompat(model);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
+  });
+
+  it("defaults supportsUsageInStreaming to false when not explicitly set on non-native endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-cpa",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: { supportsDeveloperRole: true },
+    };
+    const normalized = normalizeModelCompat(model);
     expect(supportsUsageInStreaming(normalized)).toBe(false);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+  });
+
+  it("preserves supportsUsageInStreaming true while still forcing supportsDeveloperRole off", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-vllm",
+      baseUrl: "http://localhost:8000/v1",
+      compat: { supportsUsageInStreaming: true, supportsDeveloperRole: true },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
   });
 
   it("does not mutate caller model when forcing supportsDeveloperRole off", () => {

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -52,20 +52,29 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     return model;
   }
 
-  // The `developer` role and stream usage chunks are OpenAI-native behaviors.
-  // Many OpenAI-compatible backends reject `developer` and/or emit usage-only
-  // chunks that break strict parsers expecting choices[0]. For non-native
-  // openai-completions endpoints, force both compat flags off.
+  // The `developer` role is an OpenAI-native behavior. Many OpenAI-compatible
+  // backends reject the `developer` role. For non-native openai-completions
+  // endpoints, always force supportsDeveloperRole off.
+  //
+  // supportsUsageInStreaming defaults to false for non-native endpoints because
+  // some backends emit usage-only chunks that break strict parsers expecting
+  // choices[0]. However, many popular backends (vLLM, llama.cpp, TGI, Ollama)
+  // handle stream usage correctly. Users may explicitly set
+  // supportsUsageInStreaming: true in their model config to opt in.
   const compat = model.compat ?? undefined;
   // When baseUrl is empty the pi-ai library defaults to api.openai.com, so
   // leave compat unchanged and let default native behavior apply.
-  // Note: explicit true values are intentionally overridden for non-native
-  // endpoints for safety.
   const needsForce = baseUrl ? !isOpenAINativeEndpoint(baseUrl) : false;
   if (!needsForce) {
     return model;
   }
-  if (compat?.supportsDeveloperRole === false && compat?.supportsUsageInStreaming === false) {
+
+  const resolvedUsageInStreaming = compat?.supportsUsageInStreaming ?? false;
+
+  if (
+    compat?.supportsDeveloperRole === false &&
+    compat?.supportsUsageInStreaming === resolvedUsageInStreaming
+  ) {
     return model;
   }
 
@@ -73,7 +82,11 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   return {
     ...model,
     compat: compat
-      ? { ...compat, supportsDeveloperRole: false, supportsUsageInStreaming: false }
+      ? {
+          ...compat,
+          supportsDeveloperRole: false,
+          supportsUsageInStreaming: resolvedUsageInStreaming,
+        }
       : { supportsDeveloperRole: false, supportsUsageInStreaming: false },
   } as typeof model;
 }


### PR DESCRIPTION
## Summary

- Allow users to explicitly set `compat.supportsUsageInStreaming: true` in their model config for non-native `openai-completions` endpoints
- When enabled, OpenClaw sends `stream_options: { include_usage: true }` and captures token usage from the final streaming chunk
- Default behavior unchanged: `supportsUsageInStreaming` still defaults to `false` on non-native endpoints

## Problem

`normalizeModelCompat()` unconditionally forced `supportsUsageInStreaming: false` for all non-native OpenAI endpoints, including explicit user overrides. Many popular OpenAI-compatible backends (vLLM, llama.cpp, TGI, Ollama, LMStudio) fully support `stream_options: { include_usage: true }` and return correct usage data in the final SSE chunk. Because OpenClaw disabled this, token usage was always reported as `0` in `/status` and session logs when using these providers.

## Fix

Modified `normalizeModelCompat()` to preserve explicit `supportsUsageInStreaming: true` values from user config while still:
- Forcing `supportsDeveloperRole: false` on all non-native endpoints (safety preserved)
- Defaulting `supportsUsageInStreaming` to `false` when not explicitly set (backward compatible)

## Configuration example

```json5
{
  "models": {
    "providers": {
      "local-vllm": {
        "api": "openai-completions",
        "baseUrl": "http://localhost:8000/v1",
        "models": {
          "qwen3.5-35b": {
            "compat": {
              "supportsUsageInStreaming": true
            }
          }
        }
      }
    }
  }
}
```

## Test plan

- [x] Existing tests updated and pass (35 tests)
- [x] New test: explicit `true` preserved on non-native endpoints
- [x] New test: defaults to `false` when not set
- [x] New test: `supportsUsageInStreaming: true` + `supportsDeveloperRole: true` → usage preserved, developer role still forced off
- [x] Manual: verify `/status` shows token usage with vLLM/llama.cpp backend

Closes #41963
Closes #41542
Supersedes #42202 (closed due to unrelated changes)
Related: #41544 (alternative approach using local IP detection; this PR uses explicit user config which is simpler and works for any endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)