### PR TITLE
fix(macos): fail fast when gateway startup already failed

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -375,19 +375,29 @@ final class GatewayProcessManager {
         Task { await ControlChannel.shared.configure() }
     }
 
+    private func shouldAbortReadinessWait(for status: Status) -> Bool {
+        guard case let .failed(message) = status else { return false }
+        // `enableLaunchdGateway` can mark startup as timed out after 6s, while callers
+        // may intentionally wait longer before giving up.
+        if self.lastFailureReason == "launchd start timeout" {
+            return false
+        }
+        return message != "Gateway did not start in time"
+    }
+
     func waitForGatewayReady(timeout: TimeInterval = 6) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if !self.desiredActive { return false }
             // Startup can fail before readiness polling begins (for example missing CLI).
             // Return immediately so callers can surface the concrete failure reason.
-            if case .failed = self.status { return false }
+            if self.shouldAbortReadinessWait(for: self.status) { return false }
             do {
                 _ = try await self.connection.requestRaw(method: .health, timeoutMs: 1500)
                 self.clearLastFailure()
                 return true
             } catch {
-                if case .failed = self.status { return false }
+                if self.shouldAbortReadinessWait(for: self.status) { return false }
                 try? await Task.sleep(nanoseconds: 300_000_000)
             }
         }

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -387,6 +387,7 @@ final class GatewayProcessManager {
                 self.clearLastFailure()
                 return true
             } catch {
+                if case .failed = self.status { return false }
                 try? await Task.sleep(nanoseconds: 300_000_000)
             }
         }

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -377,11 +377,8 @@ final class GatewayProcessManager {
 
     private func shouldAbortReadinessWait(for status: Status) -> Bool {
         guard case let .failed(message) = status else { return false }
-        // `enableLaunchdGateway` can mark startup as timed out after 6s, while callers
-        // may intentionally wait longer before giving up.
-        if self.lastFailureReason == "launchd start timeout" {
-            return false
-        }
+        // Only treat the active startup-timeout status as recoverable.
+        // Using prior failure metadata here can mask new fatal failures.
         return message != "Gateway did not start in time"
     }
 

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -379,6 +379,9 @@ final class GatewayProcessManager {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if !self.desiredActive { return false }
+            // Startup can fail before readiness polling begins (for example missing CLI).
+            // Return immediately so callers can surface the concrete failure reason.
+            if case .failed = self.status { return false }
             do {
                 _ = try await self.connection.requestRaw(method: .health, timeoutMs: 1500)
                 self.clearLastFailure()
@@ -419,6 +422,10 @@ final class GatewayProcessManager {
 extension GatewayProcessManager {
     func setTestingConnection(_ connection: GatewayConnection?) {
         self.testingConnection = connection
+    }
+
+    func setTestingStatus(_ status: Status) {
+        self.status = status
     }
 
     func setTestingDesiredActive(_ active: Bool) {

--- a/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
@@ -27,16 +27,46 @@ private func bridgeToLocal(_ value: ProtocolAnyCodable?) -> AnyCodable? {
     value.map(bridgeToLocal)
 }
 
-func onboardingGatewayReadyFailureDescription(status: GatewayProcessManager.Status) -> String {
-    if case let .failed(message) = status {
-        let singleLine = message
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\r", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let redactedHome = singleLine.replacingOccurrences(of: NSHomeDirectory(), with: "~")
-        if !redactedHome.isEmpty {
-            return String(redactedHome.prefix(220))
+private let onboardingBidiControlScalars: Set<UInt32> = [
+    0x202A, // LRE
+    0x202B, // RLE
+    0x202C, // PDF
+    0x202D, // LRO
+    0x202E, // RLO
+    0x2066, // LRI
+    0x2067, // RLI
+    0x2068, // FSI
+    0x2069, // PDI
+]
+
+private func normalizeGatewayFailureMessage(_ message: String) -> String {
+    let filteredScalars = message.unicodeScalars.filter { scalar in
+        if CharacterSet.controlCharacters.contains(scalar) {
+            return false
         }
+        return !onboardingBidiControlScalars.contains(scalar.value)
+    }
+    return String(String.UnicodeScalarView(filteredScalars))
+        .replacingOccurrences(of: "\t", with: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+func onboardingGatewayReadyFailureDescription(status: GatewayProcessManager.Status) -> String {
+    if case let .failed(rawMessage) = status {
+        let message = normalizeGatewayFailureMessage(rawMessage).lowercased()
+        if message.contains("openclaw cli not found") || message.contains("cli not found") {
+            return "OpenClaw CLI not found. Install the CLI and try again."
+        }
+        if message.contains("node") && message.contains("not found") {
+            return "Node.js runtime not found. Install Node.js 22+ and try again."
+        }
+        if message.contains("launchd disabled") {
+            return "Gateway auto-start is disabled. Enable launchd or start the gateway manually."
+        }
+        if message.contains("did not start in time") || message.contains("timeout") {
+            return "Gateway did not start in time. Check Gateway logs and try again."
+        }
+        return "Gateway failed to start. Check Gateway logs for details."
     }
     return "Gateway did not become ready. Check that it is running."
 }
@@ -138,7 +168,7 @@ final class OnboardingWizardModel {
             }
             self.status = "error"
             self.errorMessage = error.localizedDescription
-            onboardingWizardLogger.error("submit failed: \(error.localizedDescription, privacy: .public)")
+            onboardingWizardLogger.error("submit failed: \(error.localizedDescription, privacy: .private)")
         }
     }
 
@@ -152,7 +182,7 @@ final class OnboardingWizardModel {
         } catch {
             self.status = "error"
             self.errorMessage = error.localizedDescription
-            onboardingWizardLogger.error("cancel failed: \(error.localizedDescription, privacy: .public)")
+            onboardingWizardLogger.error("cancel failed: \(error.localizedDescription, privacy: .private)")
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
@@ -29,7 +29,14 @@ private func bridgeToLocal(_ value: ProtocolAnyCodable?) -> AnyCodable? {
 
 func onboardingGatewayReadyFailureDescription(status: GatewayProcessManager.Status) -> String {
     if case let .failed(message) = status {
-        return message
+        let singleLine = message
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let redactedHome = singleLine.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+        if !redactedHome.isEmpty {
+            return String(redactedHome.prefix(220))
+        }
     }
     return "Gateway did not become ready. Check that it is running."
 }
@@ -104,7 +111,7 @@ final class OnboardingWizardModel {
         } catch {
             self.status = "error"
             self.errorMessage = error.localizedDescription
-            onboardingWizardLogger.error("start failed: \(error.localizedDescription, privacy: .public)")
+            onboardingWizardLogger.error("start failed: \(error.localizedDescription, privacy: .private)")
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
@@ -27,6 +27,13 @@ private func bridgeToLocal(_ value: ProtocolAnyCodable?) -> AnyCodable? {
     value.map(bridgeToLocal)
 }
 
+func onboardingGatewayReadyFailureDescription(status: GatewayProcessManager.Status) -> String {
+    if case let .failed(message) = status {
+        return message
+    }
+    return "Gateway did not become ready. Check that it is running."
+}
+
 @MainActor
 @Observable
 final class OnboardingWizardModel {
@@ -83,7 +90,8 @@ final class OnboardingWizardModel {
                 throw NSError(
                     domain: "Gateway",
                     code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "Gateway did not become ready. Check that it is running."])
+                    userInfo: [NSLocalizedDescriptionKey: onboardingGatewayReadyFailureDescription(
+                        status: GatewayProcessManager.shared.status)])
             }
             var params: [String: AnyCodable] = ["mode": AnyCodable("local")]
             if let workspace, !workspace.isEmpty {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -3,6 +3,14 @@ import OpenClawKit
 import Testing
 @testable import OpenClaw
 
+private actor SendAttemptCounter {
+    private(set) var value = 0
+
+    func increment() {
+        self.value += 1
+    }
+}
+
 @Suite(.serialized)
 @MainActor
 struct GatewayProcessManagerTests {
@@ -34,5 +42,38 @@ struct GatewayProcessManagerTests {
         let ready = await manager.waitForGatewayReady(timeout: 0.5)
         #expect(ready)
         #expect(manager.lastFailureReason == nil)
+    }
+
+    @Test func `returns immediately when startup already failed`() async throws {
+        let sendAttempts = SendAttemptCounter()
+        let session = GatewayTestWebSocketSession(
+            taskFactory: {
+                GatewayTestWebSocketTask(
+                    sendHook: { _, _, _ in
+                        await sendAttempts.increment()
+                    })
+            })
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let connection = GatewayConnection(
+            configProvider: { (url: url, token: nil, password: nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+
+        let manager = GatewayProcessManager.shared
+        manager.setTestingConnection(connection)
+        manager.setTestingDesiredActive(true)
+        manager.setTestingStatus(.failed("openclaw CLI not found in PATH; install the CLI."))
+        defer {
+            manager.setTestingConnection(nil)
+            manager.setTestingDesiredActive(false)
+            manager.setTestingStatus(.stopped)
+        }
+
+        let startedAt = Date()
+        let ready = await manager.waitForGatewayReady(timeout: 0.5)
+        let elapsed = Date().timeIntervalSince(startedAt)
+
+        #expect(ready == false)
+        #expect(elapsed < 0.2)
+        #expect(await sendAttempts.value == 0)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -79,6 +79,41 @@ struct GatewayProcessManagerTests {
         #expect(await sendAttempts.value == 0)
     }
 
+    @Test func `stale launchd timeout reason does not bypass fatal fail-fast`() async throws {
+        let sendAttempts = SendAttemptCounter()
+        let session = GatewayTestWebSocketSession(
+            taskFactory: {
+                GatewayTestWebSocketTask(
+                    sendHook: { _, _, _ in
+                        await sendAttempts.increment()
+                    })
+            })
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let connection = GatewayConnection(
+            configProvider: { (url: url, token: nil, password: nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+
+        let manager = GatewayProcessManager.shared
+        manager.setTestingConnection(connection)
+        manager.setTestingDesiredActive(true)
+        manager.setTestingStatus(.failed("openclaw CLI not found in PATH; install the CLI."))
+        manager.setTestingLastFailureReason("launchd start timeout")
+        defer {
+            manager.setTestingConnection(nil)
+            manager.setTestingDesiredActive(false)
+            manager.setTestingStatus(.stopped)
+            manager.setTestingLastFailureReason(nil)
+        }
+
+        let startedAt = Date()
+        let ready = await manager.waitForGatewayReady(timeout: 0.5)
+        let elapsed = Date().timeIntervalSince(startedAt)
+
+        #expect(ready == false)
+        #expect(elapsed < 0.2)
+        #expect(await sendAttempts.value == 0)
+    }
+
     @Test func `continues probing when launchd startup timeout is recoverable`() async throws {
         let sendAttempts = SendAttemptCounter()
         let session = GatewayTestWebSocketSession(

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -62,10 +62,12 @@ struct GatewayProcessManagerTests {
         manager.setTestingConnection(connection)
         manager.setTestingDesiredActive(true)
         manager.setTestingStatus(.failed("openclaw CLI not found in PATH; install the CLI."))
+        manager.setTestingLastFailureReason("cli missing")
         defer {
             manager.setTestingConnection(nil)
             manager.setTestingDesiredActive(false)
             manager.setTestingStatus(.stopped)
+            manager.setTestingLastFailureReason(nil)
         }
 
         let startedAt = Date()
@@ -75,5 +77,41 @@ struct GatewayProcessManagerTests {
         #expect(ready == false)
         #expect(elapsed < 0.2)
         #expect(await sendAttempts.value == 0)
+    }
+
+    @Test func `continues probing when launchd startup timeout is recoverable`() async throws {
+        let sendAttempts = SendAttemptCounter()
+        let session = GatewayTestWebSocketSession(
+            taskFactory: {
+                GatewayTestWebSocketTask(
+                    sendHook: { task, message, sendIndex in
+                        guard sendIndex > 0 else { return }
+                        await sendAttempts.increment()
+                        guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+                        task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                    })
+            })
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let connection = GatewayConnection(
+            configProvider: { (url: url, token: nil, password: nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+
+        let manager = GatewayProcessManager.shared
+        manager.setTestingConnection(connection)
+        manager.setTestingDesiredActive(true)
+        manager.setTestingStatus(.failed("Gateway did not start in time"))
+        manager.setTestingLastFailureReason("launchd start timeout")
+        defer {
+            manager.setTestingConnection(nil)
+            manager.setTestingDesiredActive(false)
+            manager.setTestingStatus(.stopped)
+            manager.setTestingLastFailureReason(nil)
+        }
+
+        let ready = await manager.waitForGatewayReady(timeout: 0.5)
+
+        #expect(ready)
+        #expect(await sendAttempts.value > 0)
+        #expect(manager.lastFailureReason == nil)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingWizardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingWizardTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import OpenClaw
 
@@ -12,5 +13,13 @@ struct OnboardingWizardTests {
     @Test func `uses generic message when startup failure reason is unavailable`() {
         let description = onboardingGatewayReadyFailureDescription(status: .starting)
         #expect(description == "Gateway did not become ready. Check that it is running.")
+    }
+
+    @Test func `sanitizes startup failure reason for display`() {
+        let raw = "\(NSHomeDirectory())/openclaw\nfailed to start"
+        let description = onboardingGatewayReadyFailureDescription(status: .failed(raw))
+        #expect(!description.contains(NSHomeDirectory()))
+        #expect(!description.contains("\n"))
+        #expect(description.contains("~/openclaw"))
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingWizardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingWizardTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct OnboardingWizardTests {
     @Test func `uses startup failure reason when available`() {
         let description = onboardingGatewayReadyFailureDescription(status: .failed("openclaw CLI not found"))
-        #expect(description == "openclaw CLI not found")
+        #expect(description == "OpenClaw CLI not found. Install the CLI and try again.")
     }
 
     @Test func `uses generic message when startup failure reason is unavailable`() {
@@ -15,11 +15,14 @@ struct OnboardingWizardTests {
         #expect(description == "Gateway did not become ready. Check that it is running.")
     }
 
-    @Test func `sanitizes startup failure reason for display`() {
-        let raw = "\(NSHomeDirectory())/openclaw\nfailed to start"
+    @Test func `maps timeout failures to safe message`() {
+        let description = onboardingGatewayReadyFailureDescription(status: .failed("Gateway did not start in time"))
+        #expect(description == "Gateway did not start in time. Check Gateway logs and try again.")
+    }
+
+    @Test func `falls back to generic failure message for unclassified content`() {
+        let raw = "mysterious\u{202E}\n\tfailure at /Volumes/secret/path"
         let description = onboardingGatewayReadyFailureDescription(status: .failed(raw))
-        #expect(!description.contains(NSHomeDirectory()))
-        #expect(!description.contains("\n"))
-        #expect(description.contains("~/openclaw"))
+        #expect(description == "Gateway failed to start. Check Gateway logs for details.")
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingWizardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingWizardTests.swift
@@ -1,0 +1,16 @@
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct OnboardingWizardTests {
+    @Test func `uses startup failure reason when available`() {
+        let description = onboardingGatewayReadyFailureDescription(status: .failed("openclaw CLI not found"))
+        #expect(description == "openclaw CLI not found")
+    }
+
+    @Test func `uses generic message when startup failure reason is unavailable`() {
+        let description = onboardingGatewayReadyFailureDescription(status: .starting)
+        #expect(description == "Gateway did not become ready. Check that it is running.")
+    }
+}

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,6 +1157,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "google-gemini-cli-auth",
+    idHint: "google-gemini-cli-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/google-gemini-cli-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "google-gemini-cli-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["google-gemini-cli"],
+    },
+  },
+  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1859,6 +1882,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
+    },
+  },
+  {
+    dirName: "minimax-portal-auth",
+    idHint: "minimax-portal-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/minimax-portal-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "minimax-portal-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["minimax-portal"],
     },
   },
   {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,29 +1157,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
-    dirName: "google-gemini-cli-auth",
-    idHint: "google-gemini-cli-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/google-gemini-cli-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "google-gemini-cli-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["google-gemini-cli"],
-    },
-  },
-  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1882,29 +1859,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
-    },
-  },
-  {
-    dirName: "minimax-portal-auth",
-    idHint: "minimax-portal-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/minimax-portal-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "minimax-portal-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["minimax-portal"],
     },
   },
   {


### PR DESCRIPTION
## Summary

Fixes #6156.

This PR addresses the exact onboarding failure loop where macOS startup has already failed (for example missing CLI), but the wizard still waits for the full readiness timeout and then shows a generic message.

- `GatewayProcessManager.waitForGatewayReady()` now returns immediately when `status == .failed(...)`.
- `OnboardingWizardModel` now surfaces the concrete startup failure reason when readiness fails, instead of always showing the generic timeout text.
- Added regression tests for both behaviors.

## Scope and non-goals

This is intentionally narrow to reduce merge risk and avoid bundling unrelated behavior changes:

- Included: fail-fast readiness + surfaced failure reason.
- Not included: menu UX changes for "Configure later" reversibility, or CLI IPv6 fallback changes.

## Why this shape

@xksteven's prior PR #8260 identified the same root cause clearly. That PR was closed stale before merge. This patch keeps the core bug fix path and adds targeted tests to lock behavior down.

## Testing

Local runs on fresh `origin/main` baseline, then after patch:

- `swift test --package-path apps/macos --filter 'GatewayProcessManagerTests|OnboardingWizardTests'`
- `swiftformat --lint apps/macos/Sources/OpenClaw/GatewayProcessManager.swift apps/macos/Sources/OpenClaw/OnboardingWizard.swift apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift apps/macos/Tests/OpenClawIPCTests/OnboardingWizardTests.swift --config .swiftformat`
- `swiftlint lint --config .swiftlint.yml --strict apps/macos/Sources/OpenClaw/GatewayProcessManager.swift apps/macos/Sources/OpenClaw/OnboardingWizard.swift apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift apps/macos/Tests/OpenClawIPCTests/OnboardingWizardTests.swift`
