### PR TITLE
ui(channels): always include built-in channel cards

### DIFF
--- a/ui/src/ui/views/channels.resolveChannelOrder.node.test.ts
+++ b/ui/src/ui/views/channels.resolveChannelOrder.node.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { ChannelsStatusSnapshot } from "../types.ts";
+import { BUILTIN_CHANNEL_ORDER, resolveChannelOrder } from "./channels.ts";
+
+describe("resolveChannelOrder", () => {
+  it("includes built-in channels even when snapshot.channelMeta only contains custom channels", () => {
+    const snapshot = {
+      ts: Date.now(),
+      channelOrder: [],
+      channelLabels: {},
+      channels: {},
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+      channelMeta: [
+        {
+          id: "icenter",
+          label: "iCenter",
+          detailLabel: "iCenter",
+        },
+      ],
+    };
+
+    expect(resolveChannelOrder(snapshot as unknown as ChannelsStatusSnapshot)).toEqual([
+      "icenter",
+      ...BUILTIN_CHANNEL_ORDER,
+    ]);
+  });
+
+  it("preserves snapshot.channelOrder and appends missing built-ins after", () => {
+    const snapshot = {
+      ts: Date.now(),
+      channelOrder: ["slack", "icenter", "telegram"],
+      channelLabels: {},
+      channels: {},
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+    };
+
+    expect(resolveChannelOrder(snapshot as unknown as ChannelsStatusSnapshot)).toEqual([
+      "slack",
+      "icenter",
+      "telegram",
+      // missing built-ins appended in default order
+      "whatsapp",
+      "discord",
+      "googlechat",
+      "signal",
+      "imessage",
+      "nostr",
+    ]);
+  });
+
+  it("falls back to built-in channels when there is no snapshot", () => {
+    expect(resolveChannelOrder(null)).toEqual(BUILTIN_CHANNEL_ORDER);
+  });
+});

--- a/ui/src/ui/views/channels.ts
+++ b/ui/src/ui/views/channels.ts
@@ -89,14 +89,40 @@ ${props.snapshot ? JSON.stringify(props.snapshot, null, 2) : "No snapshot yet."}
   `;
 }
 
-function resolveChannelOrder(snapshot: ChannelsStatusSnapshot | null): ChannelKey[] {
-  if (snapshot?.channelMeta?.length) {
-    return snapshot.channelMeta.map((entry) => entry.id);
+export const BUILTIN_CHANNEL_ORDER: ChannelKey[] = [
+  "whatsapp",
+  "telegram",
+  "discord",
+  "googlechat",
+  "slack",
+  "signal",
+  "imessage",
+  "nostr",
+];
+
+function uniqPreserve<T>(items: T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const item of items) {
+    if (seen.has(item)) {
+      continue;
+    }
+    seen.add(item);
+    out.push(item);
   }
-  if (snapshot?.channelOrder?.length) {
-    return snapshot.channelOrder;
-  }
-  return ["whatsapp", "telegram", "discord", "googlechat", "slack", "signal", "imessage", "nostr"];
+  return out;
+}
+
+export function resolveChannelOrder(snapshot: ChannelsStatusSnapshot | null): ChannelKey[] {
+  const preferred: ChannelKey[] = snapshot?.channelMeta?.length
+    ? snapshot.channelMeta.map((entry) => entry.id)
+    : snapshot?.channelOrder?.length
+      ? snapshot.channelOrder
+      : [];
+
+  // Even if the gateway snapshot only lists custom channels, we still want to show
+  // all built-in channel cards in the Control UI.
+  return uniqPreserve([...preferred, ...BUILTIN_CHANNEL_ORDER]);
 }
 
 function renderChannel(key: ChannelKey, props: ChannelsProps, data: ChannelsChannelData) {


### PR DESCRIPTION
## Summary
Fixes Control UI "Channels" page ordering so that built-in channel cards are always shown, even when the gateway snapshot only contains custom channel plugins.

## Changes
- Update `resolveChannelOrder()` to merge the snapshot-provided order/meta with the built-in channel list (dedupe, preserve order: snapshot first, built-ins appended).
- Add a unit test covering:
  - custom-only `channelMeta`
  - mixed `channelOrder`
  - no snapshot fallback

## Testing
- `pnpm build`
- `pnpm check`
- `pnpm test`

## Related
- Fixes #31379

## AI-assisted
This PR was created with AI assistance (OpenClaw agent) for implementation and test authoring; changes were reviewed locally before pushing.