### PR TITLE
fix(memory): retry transient embedding transport failures

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -31,9 +31,10 @@ import {
   buildMemoryEmbeddingBatches,
   buildTextEmbeddingInputs,
   filterNonEmptyMemoryChunks,
+  isRetryableMemoryEmbeddingTransportError,
   isRetryableMemoryEmbeddingError,
   resolveMemoryEmbeddingRetryDelay,
-  runMemoryEmbeddingRetryLoop,
+  runMemoryEmbeddingBatchRetryWithSplit,
 } from "./manager-embedding-policy.js";
 import { deleteMemoryFtsRows } from "./manager-fts-state.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
@@ -272,26 +273,33 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (!provider) {
       throw new Error("Cannot embed batch in FTS-only mode (no embedding provider)");
     }
-    return await runMemoryEmbeddingRetryLoop({
-      run: async () => {
+    return await runMemoryEmbeddingBatchRetryWithSplit({
+      items: texts,
+      run: async (batchTexts) => {
         const timeoutMs = this.resolveEmbeddingTimeout("batch");
         log.debug("memory embeddings: batch start", {
           provider: provider.id,
-          items: texts.length,
+          items: batchTexts.length,
           timeoutMs,
         });
         return await this.withTimeout(
-          provider.embedBatch(texts),
+          provider.embedBatch(batchTexts),
           timeoutMs,
           `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
         );
       },
       isRetryable: isRetryableMemoryEmbeddingError,
+      isSplittable: isRetryableMemoryEmbeddingTransportError,
       waitForRetry: async (delayMs) => {
         await this.waitForEmbeddingRetry(delayMs, "retrying");
       },
       maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
       baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+      onSplit: ({ itemCount, splitAt }) => {
+        log.warn(
+          `memory embeddings transport failed after retries; splitting batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
+        );
+      },
     });
   }
 
@@ -304,26 +312,33 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (!embedBatchInputs) {
       return await this.embedBatchWithRetry(inputs.map((input) => input.text));
     }
-    return await runMemoryEmbeddingRetryLoop({
-      run: async () => {
+    return await runMemoryEmbeddingBatchRetryWithSplit({
+      items: inputs,
+      run: async (batchInputs) => {
         const timeoutMs = this.resolveEmbeddingTimeout("batch");
         log.debug("memory embeddings: structured batch start", {
           provider: provider.id,
-          items: inputs.length,
+          items: batchInputs.length,
           timeoutMs,
         });
         return await this.withTimeout(
-          embedBatchInputs(inputs),
+          embedBatchInputs(batchInputs),
           timeoutMs,
           `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
         );
       },
       isRetryable: isRetryableMemoryEmbeddingError,
+      isSplittable: isRetryableMemoryEmbeddingTransportError,
       waitForRetry: async (delayMs) => {
         await this.waitForEmbeddingRetry(delayMs, "retrying structured batch");
       },
       maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
       baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+      onSplit: ({ itemCount, splitAt }) => {
+        log.warn(
+          `memory embeddings transport failed after retries; splitting structured batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
+        );
+      },
     });
   }
 
@@ -333,7 +348,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       Math.random(),
       EMBEDDING_RETRY_MAX_DELAY_MS,
     );
-    log.warn(`memory embeddings rate limited; ${action} in ${waitMs}ms`);
+    log.warn(`memory embeddings retryable error; ${action} in ${waitMs}ms`);
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }
 

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildMemoryEmbeddingBatches,
   filterNonEmptyMemoryChunks,
+  isRetryableMemoryEmbeddingTransportError,
   isRetryableMemoryEmbeddingError,
   isStructuredInputTooLargeMemoryEmbeddingError,
   resolveMemoryEmbeddingRetryDelay,
+  runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
 
@@ -94,6 +96,73 @@ describe("memory embedding policy", () => {
     expect(result).toBe("ok");
     expect(calls).toBe(2);
     expect(waits).toEqual([500]);
+  });
+
+  it("classifies transient transport embedding errors as retryable", () => {
+    const retryableMessages = [
+      "TypeError: fetch failed",
+      "read ECONNRESET",
+      "socket hang up",
+      "UND_ERR_SOCKET: other side closed",
+      "connection refused",
+    ];
+
+    for (const message of retryableMessages) {
+      expect(isRetryableMemoryEmbeddingTransportError(message)).toBe(true);
+      expect(isRetryableMemoryEmbeddingError(message)).toBe(true);
+    }
+    expect(isRetryableMemoryEmbeddingTransportError("worker terminated by user")).toBe(false);
+    expect(isRetryableMemoryEmbeddingTransportError("embedding validation failed")).toBe(false);
+  });
+
+  it("splits transport-failed batches after retries are exhausted", async () => {
+    const waits: number[] = [];
+    const splits: string[] = [];
+    const run = vi.fn(async (items: string[]) => {
+      if (items.length > 1) {
+        throw new TypeError("fetch failed");
+      }
+      return items.map((item) => [item.charCodeAt(0)]);
+    });
+
+    const result = await runMemoryEmbeddingBatchRetryWithSplit({
+      items: ["a", "b", "c", "d"],
+      run,
+      isRetryable: isRetryableMemoryEmbeddingError,
+      isSplittable: isRetryableMemoryEmbeddingTransportError,
+      waitForRetry: async (delayMs) => {
+        waits.push(delayMs);
+      },
+      maxAttempts: 1,
+      baseDelayMs: 500,
+      onSplit: ({ itemCount, splitAt }) => {
+        splits.push(`${itemCount}:${splitAt}`);
+      },
+    });
+
+    expect(result).toEqual([[97], [98], [99], [100]]);
+    expect(run.mock.calls.map(([items]) => items.length)).toEqual([4, 4, 2, 2, 1, 1, 2, 2, 1, 1]);
+    expect(waits).toEqual([500, 500, 500]);
+    expect(splits).toEqual(["4:2", "2:1", "2:1"]);
+  });
+
+  it("does not split exhausted service retry errors", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("openai embeddings failed: 429 rate limit");
+    });
+
+    await expect(
+      runMemoryEmbeddingBatchRetryWithSplit({
+        items: ["a", "b"],
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        isSplittable: isRetryableMemoryEmbeddingTransportError,
+        waitForRetry: async () => {},
+        maxAttempts: 0,
+        baseDelayMs: 500,
+      }),
+    ).rejects.toThrow("429 rate limit");
+    expect(run).toHaveBeenCalledTimes(1);
   });
 
   it("classifies oversized structured-input errors", () => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -80,9 +80,20 @@ export function buildMemoryEmbeddingBatches<T extends MemoryEmbeddingChunk>(
   return batches;
 }
 
+const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE =
+  /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day)/i;
+
+const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
+  /(fetch failed|network error|socket hang up|socket terminated|other side closed|connection (?:reset|refused|aborted|timed out)|read ECONNRESET|write EPIPE|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN|UND_ERR_(?:CONNECT_TIMEOUT|DNS_RESOLVE_FAILED|CONNECT|SOCKET|HEADERS_TIMEOUT|BODY_TIMEOUT))/i;
+
+export function isRetryableMemoryEmbeddingTransportError(message: string): boolean {
+  return RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message);
+}
+
 export function isRetryableMemoryEmbeddingError(message: string): boolean {
-  return /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day)/i.test(
-    message,
+  return (
+    RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message) ||
+    isRetryableMemoryEmbeddingTransportError(message)
   );
 }
 
@@ -121,6 +132,43 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
       delayMs *= 2;
       attempt += 1;
     }
+  }
+}
+
+export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(params: {
+  items: TInput[];
+  run: (items: TInput[]) => Promise<TOutput[]>;
+  isRetryable: (message: string) => boolean;
+  isSplittable: (message: string) => boolean;
+  waitForRetry: (delayMs: number) => Promise<void>;
+  maxAttempts: number;
+  baseDelayMs: number;
+  onSplit?: (info: { itemCount: number; splitAt: number; message: string }) => void;
+}): Promise<TOutput[]> {
+  try {
+    return await runMemoryEmbeddingRetryLoop({
+      run: async () => await params.run(params.items),
+      isRetryable: params.isRetryable,
+      waitForRetry: params.waitForRetry,
+      maxAttempts: params.maxAttempts,
+      baseDelayMs: params.baseDelayMs,
+    });
+  } catch (err) {
+    const message = formatErrorMessage(err);
+    if (params.items.length <= 1 || !params.isSplittable(message)) {
+      throw err;
+    }
+    const splitAt = Math.ceil(params.items.length / 2);
+    params.onSplit?.({ itemCount: params.items.length, splitAt, message });
+    const left = await runMemoryEmbeddingBatchRetryWithSplit({
+      ...params,
+      items: params.items.slice(0, splitAt),
+    });
+    const right = await runMemoryEmbeddingBatchRetryWithSplit({
+      ...params,
+      items: params.items.slice(splitAt),
+    });
+    return [...left, ...right];
   }
 }
 


### PR DESCRIPTION
## Summary

- Problem: memory embedding batch sync could abort immediately when a remote embedding provider raised transient transport failures such as `fetch failed`, `ECONNRESET`, socket close, or undici socket/connect errors.
- Why it matters: one temporary provider/network failure can prevent otherwise valid memory chunks from being indexed.
- What changed: current `extensions/memory-core` now treats narrow transport failures as retryable, reuses the existing backoff loop, and recursively splits multi-item batches after retry exhaustion while preserving result order.
- What did NOT change (scope boundary): no provider selection, config/schema, timeout constant, cache format, or non-retryable error behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44166
- Related #44167
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the embedding retry classifier covered rate-limit and service-side failures, but not common transient transport failures from fetch/undici/network sockets.
- Missing detection / guardrail: unit coverage did not lock in transport retry classification or the exhausted-retry batch split fallback.
- Contributing context (if known): remote embedding providers can fail a whole batch with transient transport errors even when individual inputs are valid.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/memory/manager-embedding-policy.test.ts`
- Scenario the test should lock in: transient transport errors are retryable; exhausted transport failures split multi-item batches recursively; exhausted service retry errors such as 429 do not split.
- Why this is the smallest reliable guardrail: the retry classifier and split policy are deterministic and can be validated without live provider/network calls.
- Existing test that already covers this (if any): existing tests covered rate-limit, 5xx, and tokens-per-day retry behavior, but not transport failures.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Memory indexing should be more resilient to transient embedding provider transport failures. No config or UI changes.

## Diagram (if applicable)

```text
Before:
[embedding batch] -> [transient transport failure] -> [sync aborts]

After:
[embedding batch] -> [retry with backoff] -> [split batch after retry exhaustion] -> [index valid chunks]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.18.0, pnpm 10.33.0
- Model/provider: mocked embedding provider in unit tests
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run the focused memory embedding policy test.
2. Run the full `extensions/memory-core` test project.
3. Inspect the diff against current `main` to confirm only memory-core policy/ops/test files changed.

### Expected

- Transport failures are retried and, after retry exhaustion, multi-item batches split recursively.
- Non-transport retryable service errors do not trigger batch splitting.
- Single-item batches still fail normally after retry exhaustion.

### Actual

- Matches expected behavior in unit coverage.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification passed:

```bash
pnpm test extensions/memory-core/src/memory/manager-embedding-policy.test.ts
pnpm test extensions/memory-core
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: transport error classification, retry-before-split behavior, recursive split ordering, no split for exhausted 429/service retry errors.
- Edge cases checked: empty batches still return `[]`; single-item batch failures remain terminal; structured and text batch paths both use the same retry/split policy.
- What you did **not** verify: a clean full `pnpm check:changed` run to completion. In this fork checkout it entered fail-safe all-lanes mode; typecheck, lint, and import-cycle checks passed, then the full test lane hit unrelated `src/agents/tools/web-fetch.provider-fallback.test.ts` SSRF failures outside the changed files.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: broader retry classification could hide genuinely persistent provider/network problems for longer.
  - Mitigation: only narrow transport patterns are classified as retryable; single-item batches still fail after retry exhaustion.
- Risk: splitting batches increases provider calls after repeated transport failures.
  - Mitigation: splitting only happens after the existing retry loop is exhausted and only for multi-item batches.
