### PR TITLE
Zalo: rate limit invalid webhook secret guesses before auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Security/WebSocket preauth: shorten unauthenticated handshake retention and reject oversized pre-auth frames before application-layer parsing to reduce pre-pairing exposure on unsupported public deployments. (`GHSA-jv4g-m82p-2j93`)(#44089) (`GHSA-xwx2-ppv2-wx98`)(#44089) Thanks @ez-lbz and @vincentkoc.
 - Security/Feishu reactions: preserve looked-up group chat typing and fail closed on ambiguous reaction context so group authorization and mention gating cannot be bypassed through synthetic `p2p` reactions. (`GHSA-m69h-jm2f-2pv8`)(#44088) Thanks @zpbrent and @vincentkoc.
 - Security/LINE webhook: require signatures for empty-event POST probes too so unsigned requests no longer confirm webhook reachability with a `200` response. (`GHSA-mhxh-9pjm-w7q5`)(#44090) Thanks @TerminalsandCoffee and @vincentkoc.
+- Security/Zalo webhook: rate limit invalid secret guesses before auth so weak webhook secrets cannot be brute-forced through unauthenticated churned requests without pre-auth `429` responses. (`GHSA-5m9r-p9g7-679c`)(#44173) Thanks @zpbrent and @vincentkoc.
 
 ### Changes
 

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -348,6 +348,27 @@ describe("handleZaloWebhookRequest", () => {
     }
   });
 
+  it("still returns 401 before 415 when both secret and content-type are invalid", async () => {
+    const unregister = registerTarget({ path: "/hook-auth-before-type" });
+
+    try {
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/hook-auth-before-type`, {
+          method: "POST",
+          headers: {
+            "x-bot-api-secret-token": "invalid-token", // pragma: allowlist secret
+            "content-type": "text/plain",
+          },
+          body: "not-json",
+        });
+
+        expect(response.status).toBe(401);
+      });
+    } finally {
+      unregister();
+    }
+  });
+
   it("scopes DM pairing store reads and writes to accountId", async () => {
     const { core, readAllowFromStore, upsertPairingRequest } = createPairingAuthCore({
       pairingCreated: false,

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -283,6 +283,7 @@ describe("handleZaloWebhookRequest", () => {
 
     try {
       await withServer(webhookRequestHandler, async (baseUrl) => {
+        let saw429 = false;
         for (let i = 0; i < 200; i += 1) {
           const response = await fetch(`${baseUrl}/hook-query-status?nonce=${i}`, {
             method: "POST",
@@ -292,10 +293,15 @@ describe("handleZaloWebhookRequest", () => {
             },
             body: "{}",
           });
-          expect(response.status).toBe(401);
+          expect([401, 429]).toContain(response.status);
+          if (response.status === 429) {
+            saw429 = true;
+            break;
+          }
         }
 
-        expect(getZaloWebhookStatusCounterSizeForTest()).toBe(1);
+        expect(saw429).toBe(true);
+        expect(getZaloWebhookStatusCounterSizeForTest()).toBe(2);
       });
     } finally {
       unregister();
@@ -311,6 +317,26 @@ describe("handleZaloWebhookRequest", () => {
           baseUrl,
           path: "/hook-query-rate",
           secret: "secret", // pragma: allowlist secret
+          withNonceQuery: true,
+        });
+
+        expect(saw429).toBe(true);
+        expect(getZaloWebhookRateLimitStateSizeForTest()).toBe(1);
+      });
+    } finally {
+      unregister();
+    }
+  });
+
+  it("rate limits unauthorized secret guesses before authentication succeeds", async () => {
+    const unregister = registerTarget({ path: "/hook-preauth-rate" });
+
+    try {
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        const saw429 = await postUntilRateLimited({
+          baseUrl,
+          path: "/hook-preauth-rate",
+          secret: "invalid-token", // pragma: allowlist secret
           withNonceQuery: true,
         });
 

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -348,6 +348,36 @@ describe("handleZaloWebhookRequest", () => {
     }
   });
 
+  it("does not let unauthorized floods rate-limit authenticated traffic from the same remote address", async () => {
+    const unregister = registerTarget({ path: "/hook-preauth-split" });
+
+    try {
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        const saw429 = await postUntilRateLimited({
+          baseUrl,
+          path: "/hook-preauth-split",
+          secret: "invalid-token", // pragma: allowlist secret
+          withNonceQuery: true,
+        });
+
+        expect(saw429).toBe(true);
+
+        const validResponse = await fetch(`${baseUrl}/hook-preauth-split`, {
+          method: "POST",
+          headers: {
+            "x-bot-api-secret-token": "secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ event_name: "message.unsupported.received" }),
+        });
+
+        expect(validResponse.status).toBe(200);
+      });
+    } finally {
+      unregister();
+    }
+  });
+
   it("still returns 401 before 415 when both secret and content-type are invalid", async () => {
     const unregister = registerTarget({ path: "/hook-auth-before-type" });
 

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -348,25 +348,39 @@ describe("handleZaloWebhookRequest", () => {
     }
   });
 
-  it("does not let unauthorized floods rate-limit authenticated traffic from the same remote address", async () => {
-    const unregister = registerTarget({ path: "/hook-preauth-split" });
+  it("does not let unauthorized floods rate-limit authenticated traffic from a different trusted forwarded client IP", async () => {
+    const unregister = registerTarget({
+      path: "/hook-preauth-split",
+      config: {
+        gateway: {
+          trustedProxies: ["127.0.0.1"],
+        },
+      } as OpenClawConfig,
+    });
 
     try {
       await withServer(webhookRequestHandler, async (baseUrl) => {
-        const saw429 = await postUntilRateLimited({
-          baseUrl,
-          path: "/hook-preauth-split",
-          secret: "invalid-token", // pragma: allowlist secret
-          withNonceQuery: true,
-        });
-
-        expect(saw429).toBe(true);
+        for (let i = 0; i < 130; i += 1) {
+          const response = await fetch(`${baseUrl}/hook-preauth-split?nonce=${i}`, {
+            method: "POST",
+            headers: {
+              "x-bot-api-secret-token": "invalid-token", // pragma: allowlist secret
+              "content-type": "application/json",
+              "x-forwarded-for": "203.0.113.10",
+            },
+            body: "{}",
+          });
+          if (response.status === 429) {
+            break;
+          }
+        }
 
         const validResponse = await fetch(`${baseUrl}/hook-preauth-split`, {
           method: "POST",
           headers: {
             "x-bot-api-secret-token": "secret",
             "content-type": "application/json",
+            "x-forwarded-for": "198.51.100.20",
           },
           body: JSON.stringify({ event_name: "message.unsupported.received" }),
         });

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -16,6 +16,7 @@ import {
   WEBHOOK_ANOMALY_COUNTER_DEFAULTS,
   WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "openclaw/plugin-sdk/zalo";
+import { resolveClientIp } from "../../../src/gateway/net.js";
 import type { ResolvedZaloAccount } from "./accounts.js";
 import type { ZaloFetch, ZaloUpdate } from "./api.js";
 import type { ZaloRuntimeEnv } from "./monitor.js";
@@ -109,6 +110,10 @@ function recordWebhookStatus(
   });
 }
 
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
 export function registerZaloWebhookTarget(
   target: ZaloWebhookTarget,
   opts?: {
@@ -140,11 +145,19 @@ export async function handleZaloWebhookRequest(
     targetsByPath: webhookTargets,
     allowMethods: ["POST"],
     handle: async ({ targets, path }) => {
-      const headerToken = String(req.headers["x-bot-api-secret-token"] ?? "");
-      const authBucket = targets.some((entry) => timingSafeEquals(entry.secret, headerToken))
-        ? "auth"
-        : "unauth";
-      const rateLimitKey = `${path}:${authBucket}:${req.socket.remoteAddress ?? "unknown"}`;
+      const trustedProxies = targets[0]?.config.gateway?.trustedProxies;
+      const allowRealIpFallback = targets[0]?.config.gateway?.allowRealIpFallback === true;
+      const clientIp =
+        resolveClientIp({
+          remoteAddr: req.socket.remoteAddress,
+          forwardedFor: headerValue(req.headers["x-forwarded-for"]),
+          realIp: headerValue(req.headers["x-real-ip"]),
+          trustedProxies,
+          allowRealIpFallback,
+        }) ??
+        req.socket.remoteAddress ??
+        "unknown";
+      const rateLimitKey = `${path}:${clientIp}`;
       const nowMs = Date.now();
       if (
         !applyBasicWebhookRequestGuards({
@@ -159,6 +172,7 @@ export async function handleZaloWebhookRequest(
         return true;
       }
 
+      const headerToken = String(req.headers["x-bot-api-secret-token"] ?? "");
       const target = resolveWebhookTargetWithAuthOrRejectSync({
         targets,
         res,

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -140,7 +140,11 @@ export async function handleZaloWebhookRequest(
     targetsByPath: webhookTargets,
     allowMethods: ["POST"],
     handle: async ({ targets, path }) => {
-      const rateLimitKey = `${path}:${req.socket.remoteAddress ?? "unknown"}`;
+      const headerToken = String(req.headers["x-bot-api-secret-token"] ?? "");
+      const authBucket = targets.some((entry) => timingSafeEquals(entry.secret, headerToken))
+        ? "auth"
+        : "unauth";
+      const rateLimitKey = `${path}:${authBucket}:${req.socket.remoteAddress ?? "unknown"}`;
       const nowMs = Date.now();
       if (
         !applyBasicWebhookRequestGuards({
@@ -155,7 +159,6 @@ export async function handleZaloWebhookRequest(
         return true;
       }
 
-      const headerToken = String(req.headers["x-bot-api-secret-token"] ?? "");
       const target = resolveWebhookTargetWithAuthOrRejectSync({
         targets,
         res,

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -149,7 +149,6 @@ export async function handleZaloWebhookRequest(
           rateLimiter: webhookRateLimiter,
           rateLimitKey,
           nowMs,
-          requireJsonContentType: true,
         })
       ) {
         recordWebhookStatus(targets[0]?.runtime, path, res.statusCode);
@@ -164,6 +163,18 @@ export async function handleZaloWebhookRequest(
       });
       if (!target) {
         recordWebhookStatus(targets[0]?.runtime, path, res.statusCode);
+        return true;
+      }
+      // Preserve the historical 401-before-415 ordering for invalid secrets while still
+      // consuming rate-limit budget on unauthenticated guesses.
+      if (
+        !applyBasicWebhookRequestGuards({
+          req,
+          res,
+          requireJsonContentType: true,
+        })
+      ) {
+        recordWebhookStatus(target.runtime, path, res.statusCode);
         return true;
       }
       const body = await readJsonWebhookBodyOrReject({

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -140,19 +140,8 @@ export async function handleZaloWebhookRequest(
     targetsByPath: webhookTargets,
     allowMethods: ["POST"],
     handle: async ({ targets, path }) => {
-      const headerToken = String(req.headers["x-bot-api-secret-token"] ?? "");
-      const target = resolveWebhookTargetWithAuthOrRejectSync({
-        targets,
-        res,
-        isMatch: (entry) => timingSafeEquals(entry.secret, headerToken),
-      });
-      if (!target) {
-        recordWebhookStatus(targets[0]?.runtime, path, res.statusCode);
-        return true;
-      }
       const rateLimitKey = `${path}:${req.socket.remoteAddress ?? "unknown"}`;
       const nowMs = Date.now();
-
       if (
         !applyBasicWebhookRequestGuards({
           req,
@@ -163,7 +152,18 @@ export async function handleZaloWebhookRequest(
           requireJsonContentType: true,
         })
       ) {
-        recordWebhookStatus(target.runtime, path, res.statusCode);
+        recordWebhookStatus(targets[0]?.runtime, path, res.statusCode);
+        return true;
+      }
+
+      const headerToken = String(req.headers["x-bot-api-secret-token"] ?? "");
+      const target = resolveWebhookTargetWithAuthOrRejectSync({
+        targets,
+        res,
+        isMatch: (entry) => timingSafeEquals(entry.secret, headerToken),
+      });
+      if (!target) {
+        recordWebhookStatus(targets[0]?.runtime, path, res.statusCode);
         return true;
       }
       const body = await readJsonWebhookBodyOrReject({


### PR DESCRIPTION
## Summary

- Problem: the Zalo webhook handler only applied rate limiting after secret authentication, so invalid-secret guesses never consumed limiter budget.
- Why it matters: weak but policy-compliant webhook secrets could be brute-forced without triggering pre-auth 429 responses.
- What changed: shared request guards now run before secret matching, so unauthorized guesses are rate-limited the same way authenticated traffic is.
- What did NOT change (scope boundary): authenticated webhook processing, replay dedupe, and account scoping behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related GHSA-5m9r-p9g7-679c

## User-visible / Behavior Changes

Repeated invalid Zalo webhook secret guesses now receive `429 Too Many Requests` once the per-path limiter threshold is reached.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: invalid secret guesses now hit the same fixed-window limiter before authentication succeeds, reducing brute-force headroom for weak secrets.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Zalo webhook
- Relevant config (redacted): webhook mode with 8-character secret

### Steps

1. Register a Zalo webhook target with an 8-character secret.
2. Send many POST requests with churned query strings and an invalid `x-bot-api-secret-token`.
3. Observe whether the pre-auth path ever returns `429`.

### Expected

- Invalid secret guesses eventually receive `429 Too Many Requests` before any successful authentication.

### Actual

- With this patch, invalid guesses hit the same limiter and return `429`; regression tests cover both authenticated and unauthorized churned-query traffic.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the brute-force path on the vulnerable tree; verified the patched branch returns `429` for unauthorized guesses and still rate-limits authenticated churned-query traffic.
- Edge cases checked: replay dedupe and status counter aggregation still behave as expected after moving the guard order.
- What you did **not** verify: live Zalo delivery against external infrastructure.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the branch.
- Files/config to restore: `extensions/zalo/src/monitor.webhook.ts`
- Known bad symptoms reviewers should watch for: unauthorized webhook traffic reaching 401 responses longer than expected instead of tripping rate limiting.

## Risks and Mitigations

- Risk: unauthorized traffic now records both 401 and 429 anomaly buckets for the same path once the limiter trips.
- Mitigation: the counter cardinality remains bounded by status code, and regression tests cover the new behavior.
