### PR TITLE
Plugins: require explicit trust for workspace-discovered plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Security/WebSocket preauth: shorten unauthenticated handshake retention and reject oversized pre-auth frames before application-layer parsing to reduce pre-pairing exposure on unsupported public deployments. (`GHSA-jv4g-m82p-2j93`)(#44089) (`GHSA-xwx2-ppv2-wx98`)(#44089) Thanks @ez-lbz and @vincentkoc.
 - Security/Feishu reactions: preserve looked-up group chat typing and fail closed on ambiguous reaction context so group authorization and mention gating cannot be bypassed through synthetic `p2p` reactions. (`GHSA-m69h-jm2f-2pv8`)(#44088) Thanks @zpbrent and @vincentkoc.
 - Security/LINE webhook: require signatures for empty-event POST probes too so unsigned requests no longer confirm webhook reachability with a `200` response. (`GHSA-mhxh-9pjm-w7q5`)(#44090) Thanks @TerminalsandCoffee and @vincentkoc.
+- Security/plugins: disable implicit workspace plugin auto-load so cloned repositories cannot execute workspace plugin code without an explicit trust decision. (`GHSA-99qw-6mr3-36qr`)(#44174) Thanks @lintsinghua and @vincentkoc.
 
 ### Changes
 

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -145,4 +145,38 @@ describe("resolveEnableState", () => {
     );
     expect(state).toEqual({ enabled: false, reason: "disabled in config" });
   });
+
+  it("disables workspace plugins by default when they are only auto-discovered from the workspace", () => {
+    const state = resolveEnableState("workspace-helper", "workspace", normalizePluginsConfig({}));
+    expect(state).toEqual({
+      enabled: false,
+      reason: "workspace plugin (disabled by default)",
+    });
+  });
+
+  it("allows workspace plugins when explicitly listed in plugins.allow", () => {
+    const state = resolveEnableState(
+      "workspace-helper",
+      "workspace",
+      normalizePluginsConfig({
+        allow: ["workspace-helper"],
+      }),
+    );
+    expect(state).toEqual({ enabled: true });
+  });
+
+  it("allows workspace plugins when explicitly enabled in plugin entries", () => {
+    const state = resolveEnableState(
+      "workspace-helper",
+      "workspace",
+      normalizePluginsConfig({
+        entries: {
+          "workspace-helper": {
+            enabled: true,
+          },
+        },
+      }),
+    );
+    expect(state).toEqual({ enabled: true });
+  });
 });

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -179,4 +179,18 @@ describe("resolveEnableState", () => {
     );
     expect(state).toEqual({ enabled: true });
   });
+
+  it("does not let the default memory slot auto-enable an untrusted workspace plugin", () => {
+    const state = resolveEnableState(
+      "memory-core",
+      "workspace",
+      normalizePluginsConfig({
+        slots: { memory: "memory-core" },
+      }),
+    );
+    expect(state).toEqual({
+      enabled: false,
+      reason: "workspace plugin (disabled by default)",
+    });
+  });
 });

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -204,11 +204,18 @@ export function resolveEnableState(
   if (config.slots.memory === id) {
     return { enabled: true };
   }
-  if (config.allow.length > 0 && !config.allow.includes(id)) {
+  const explicitlyAllowed = config.allow.includes(id);
+  if (config.allow.length > 0 && !explicitlyAllowed) {
     return { enabled: false, reason: "not in allowlist" };
   }
   if (entry?.enabled === true) {
     return { enabled: true };
+  }
+  if (origin === "workspace") {
+    if (explicitlyAllowed) {
+      return { enabled: true };
+    }
+    return { enabled: false, reason: "workspace plugin (disabled by default)" };
   }
   if (origin === "bundled" && BUNDLED_ENABLED_BY_DEFAULT.has(id)) {
     return { enabled: true };

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -201,21 +201,18 @@ export function resolveEnableState(
   if (entry?.enabled === false) {
     return { enabled: false, reason: "disabled in config" };
   }
+  const explicitlyAllowed = config.allow.includes(id);
+  if (origin === "workspace" && !explicitlyAllowed && entry?.enabled !== true) {
+    return { enabled: false, reason: "workspace plugin (disabled by default)" };
+  }
   if (config.slots.memory === id) {
     return { enabled: true };
   }
-  const explicitlyAllowed = config.allow.includes(id);
   if (config.allow.length > 0 && !explicitlyAllowed) {
     return { enabled: false, reason: "not in allowlist" };
   }
   if (entry?.enabled === true) {
     return { enabled: true };
-  }
-  if (origin === "workspace") {
-    if (explicitlyAllowed) {
-      return { enabled: true };
-    }
-    return { enabled: false, reason: "workspace plugin (disabled by default)" };
   }
   if (origin === "bundled" && BUNDLED_ENABLED_BY_DEFAULT.has(id)) {
     return { enabled: true };

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1162,6 +1162,62 @@ describe("loadOpenClawPlugins", () => {
     ).toBe(true);
   });
 
+  it("does not auto-load workspace-discovered plugins unless explicitly trusted", () => {
+    useNoBundledPlugins();
+    const workspaceDir = makeTempDir();
+    const workspaceExtDir = path.join(workspaceDir, ".openclaw", "extensions", "workspace-helper");
+    fs.mkdirSync(workspaceExtDir, { recursive: true });
+    writePlugin({
+      id: "workspace-helper",
+      body: `module.exports = { id: "workspace-helper", register() {} };`,
+      dir: workspaceExtDir,
+      filename: "index.cjs",
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      config: {
+        plugins: {
+          enabled: true,
+        },
+      },
+    });
+
+    const workspacePlugin = registry.plugins.find((entry) => entry.id === "workspace-helper");
+    expect(workspacePlugin?.origin).toBe("workspace");
+    expect(workspacePlugin?.status).toBe("disabled");
+    expect(workspacePlugin?.error).toContain("workspace plugin (disabled by default)");
+  });
+
+  it("loads workspace-discovered plugins when plugins.allow explicitly trusts them", () => {
+    useNoBundledPlugins();
+    const workspaceDir = makeTempDir();
+    const workspaceExtDir = path.join(workspaceDir, ".openclaw", "extensions", "workspace-helper");
+    fs.mkdirSync(workspaceExtDir, { recursive: true });
+    writePlugin({
+      id: "workspace-helper",
+      body: `module.exports = { id: "workspace-helper", register() {} };`,
+      dir: workspaceExtDir,
+      filename: "index.cjs",
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["workspace-helper"],
+        },
+      },
+    });
+
+    const workspacePlugin = registry.plugins.find((entry) => entry.id === "workspace-helper");
+    expect(workspacePlugin?.origin).toBe("workspace");
+    expect(workspacePlugin?.status).toBe("loaded");
+  });
+
   it("warns when loaded non-bundled plugin has no install/load-path provenance", () => {
     useNoBundledPlugins();
     const stateDir = makeTempDir();


### PR DESCRIPTION
## Summary

- Problem: OpenClaw auto-discovered and default-enabled workspace plugins from `.openclaw/extensions`, so cloned repositories could execute plugin code without an explicit trust decision.
- Why it matters: running the gateway inside an untrusted cloned repo could execute arbitrary workspace plugin code on the host.
- What changed: workspace-discovered plugins are now disabled by default unless explicitly trusted through `plugins.allow` or a per-plugin enable entry.
- What did NOT change (scope boundary): explicitly trusted workspace plugins still load, and non-workspace plugin trust behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related GHSA-99qw-6mr3-36qr

## User-visible / Behavior Changes

Workspace-discovered plugins under `.openclaw/extensions` no longer auto-load by default. Operators must explicitly trust them with `plugins.allow` or an explicit plugin entry.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: the change reduces implicit command/data access by requiring an explicit trust decision before workspace plugin code can execute.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin loader
- Relevant config (redacted): default plugins config with empty `plugins.allow`

### Steps

1. Create a temp workspace containing `.openclaw/extensions/<id>/openclaw.plugin.json` and `index.ts` with a side effect in `register()`.
2. Load plugins with `loadOpenClawPlugins({ workspaceDir, config: {} })`.
3. Observe whether the workspace plugin is loaded automatically.

### Expected

- Workspace plugin is discovered but disabled until explicitly trusted.

### Actual

- With this patch, the workspace plugin is disabled by default and loads only when explicitly allowlisted.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the pre-fix auto-load path with a temp workspace plugin; verified the patched branch disables it by default and still allows explicit trust via `plugins.allow`.
- Edge cases checked: explicit per-plugin enable and explicit allowlist both preserve intended workspace plugin loading.
- What you did **not** verify: full end-to-end gateway startup against every plugin origin.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) Maybe
- If yes, exact upgrade steps: if you intentionally use workspace plugins, add their ids to `plugins.allow` or explicitly enable them in `plugins.entries`.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the branch or explicitly trust the affected workspace plugin.
- Files/config to restore: `src/plugins/config-state.ts`
- Known bad symptoms reviewers should watch for: intentionally used workspace plugins no longer loading until trusted.

## Risks and Mitigations

- Risk: operators relying on implicit workspace plugin loading will see plugins disabled after upgrade.
- Mitigation: explicit allowlist and per-plugin enable paths continue to work, and tests cover both trust mechanisms.
