### PR TITLE
fix(cron): stop false legacyPayloadKind warnings for canonical payload kinds

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -75,4 +75,31 @@ describe("normalizeStoredCronJobs", () => {
       channel: "slack",
     });
   });
+
+  it("does not flag already-canonical payload kinds", () => {
+    const jobs = [
+      {
+        id: "canonical-agent-turn",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "agentTurn",
+          message: "ping",
+        },
+      },
+      {
+        id: "canonical-system-event",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "systemEvent",
+          text: "ping",
+        },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+    expect((jobs[0]?.payload as Record<string, unknown> | undefined)?.kind).toBe("agentTurn");
+    expect((jobs[1]?.payload as Record<string, unknown> | undefined)?.kind).toBe("systemEvent");
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -30,10 +30,16 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 function normalizePayloadKind(payload: Record<string, unknown>) {
   const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
   if (raw === "agentturn") {
+    if (payload.kind === "agentTurn") {
+      return false;
+    }
     payload.kind = "agentTurn";
     return true;
   }
   if (raw === "systemevent") {
+    if (payload.kind === "systemEvent") {
+      return false;
+    }
     payload.kind = "systemEvent";
     return true;
   }


### PR DESCRIPTION
## Summary
- fix `normalizePayloadKind()` so it only reports a migration when the payload kind actually changes
- avoid flagging already-canonical `agentTurn` / `systemEvent` values as legacy
- add regression test coverage for canonical payload kinds

## Repro
1. Ensure cron jobs already have canonical payload kinds (`agentTurn`/`systemEvent`).
2. Run `openclaw doctor --fix --yes`.
3. Run `openclaw doctor --non-interactive`.
4. Before this patch, doctor still reports: `jobs needs payload kind normalization`.

## Root cause
`normalizePayloadKind()` lowercased `payload.kind` and returned `true` for `agentturn`/`systemevent` even when the original value was already canonical (`agentTurn`/`systemEvent`).

## Validation
- `corepack pnpm vitest run src/cron/store-migration.test.ts src/commands/doctor-cron.test.ts`
