### PR TITLE
fix(agents): unified fallback retry safety — images, partial execution, system context

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -88,6 +88,7 @@ import {
   resolveDefaultModelForAgent,
   resolveThinkingDefault,
 } from "./model-selection.js";
+import type { FailoverReason } from "./pi-embedded-helpers.js";
 import { prepareSessionManagerForRun } from "./pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent } from "./pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "./skills.js";
@@ -171,11 +172,44 @@ async function persistSessionEntry(params: PersistSessionEntryParams): Promise<v
   params.sessionStore[params.sessionKey] = persisted;
 }
 
-function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boolean }): string {
-  if (!params.isFallbackRetry) {
-    return params.body;
+function resolveRetryImages(
+  images: AgentCommandOpts["images"],
+  isFallbackRetry: boolean,
+  previousFailureReason?: FailoverReason,
+  primaryProvider?: string,
+  currentProvider?: string,
+): AgentCommandOpts["images"] {
+  if (!isFallbackRetry) {
+    return images;
   }
-  return "Continue where you left off. The previous model attempt failed or timed out.";
+  // Cross-provider fallback: strip images to avoid unintended third-party disclosure
+  if (primaryProvider && currentProvider && primaryProvider !== currentProvider) {
+    return undefined;
+  }
+  // Same-provider format error: strip images (model can't handle modality)
+  if (previousFailureReason === "format") {
+    return undefined;
+  }
+  return images;
+}
+
+function buildPartialExecutionSystemContext(partialExecution?: {
+  toolNames: string[];
+  didSendViaMessagingTool: boolean;
+}): string | undefined {
+  if (!partialExecution || partialExecution.toolNames.length === 0) {
+    return undefined;
+  }
+  const toolList = partialExecution.toolNames.join(", ");
+  const messagingWarning = partialExecution.didSendViaMessagingTool
+    ? " Messages were already sent to the user — do NOT re-send them."
+    : "";
+  return (
+    `The previous model attempt partially executed before failing. ` +
+    `It completed these tool calls: ${toolList}.${messagingWarning} ` +
+    `Do not repeat actions that have already been performed. ` +
+    `Review the conversation history and continue from where the previous attempt left off.`
+  );
 }
 
 function prependInternalEventContext(
@@ -376,16 +410,30 @@ function runAgentAttempt(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
+  primaryProvider?: string;
+  previousFailureReason?: FailoverReason;
+  previousPartialExecution?: { toolNames: string[]; didSendViaMessagingTool: boolean };
 }) {
-  const effectivePrompt = resolveFallbackRetryPrompt({
-    body: params.body,
-    isFallbackRetry: params.isFallbackRetry,
-  });
+  // Fallback retries only fire on thrown errors (not partial streaming results),
+  // so the original prompt is always safe to re-send. The orphaned-user-message
+  // repair in attempt.ts handles any residual duplicate user turns.
+  const effectivePrompt = params.body;
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,
   );
   const bootstrapPromptWarningSignature =
     bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
+  // Suppress partial execution context on cross-provider retries to avoid
+  // leaking internal tool names to a different LLM provider (CWE-200).
+  const isCrossProviderRetry =
+    params.isFallbackRetry &&
+    !!params.primaryProvider &&
+    params.primaryProvider !== params.providerOverride;
+  const partialExecContext = isCrossProviderRetry
+    ? undefined
+    : buildPartialExecutionSystemContext(params.previousPartialExecution);
+  const effectiveExtraSystemPrompt =
+    [params.opts.extraSystemPrompt, partialExecContext].filter(Boolean).join("\n\n") || undefined;
   if (isCliProvider(params.providerOverride, params.cfg)) {
     const cliSessionId = getCliSessionId(params.sessionEntry, params.providerOverride);
     const runCliWithSession = (nextCliSessionId: string | undefined) =>
@@ -402,11 +450,17 @@ function runAgentAttempt(params: {
         thinkLevel: params.resolvedThinkLevel,
         timeoutMs: params.timeoutMs,
         runId: params.runId,
-        extraSystemPrompt: params.opts.extraSystemPrompt,
+        extraSystemPrompt: effectiveExtraSystemPrompt,
         cliSessionId: nextCliSessionId,
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
-        images: params.isFallbackRetry ? undefined : params.opts.images,
+        images: resolveRetryImages(
+          params.opts.images,
+          params.isFallbackRetry,
+          params.previousFailureReason,
+          params.primaryProvider,
+          params.providerOverride,
+        ),
         streamParams: params.opts.streamParams,
       });
     return runCliWithSession(cliSessionId).catch(async (err) => {
@@ -510,7 +564,13 @@ function runAgentAttempt(params: {
     config: params.cfg,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
-    images: params.isFallbackRetry ? undefined : params.opts.images,
+    images: resolveRetryImages(
+      params.opts.images,
+      params.isFallbackRetry,
+      params.previousFailureReason,
+      params.primaryProvider,
+      params.providerOverride,
+    ),
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,
@@ -522,11 +582,12 @@ function runAgentAttempt(params: {
     runId: params.runId,
     lane: params.opts.lane,
     abortSignal: params.opts.abortSignal,
-    extraSystemPrompt: params.opts.extraSystemPrompt,
+    extraSystemPrompt: effectiveExtraSystemPrompt,
     inputProvenance: params.opts.inputProvenance,
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    suppressPromptImageDetection: isCrossProviderRetry,
     onAgentEvent: params.onAgentEvent,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,
@@ -1178,6 +1239,8 @@ async function agentCommandInternal(
         agentDir,
         fallbacksOverride: effectiveFallbacksOverride,
         run: (providerOverride, modelOverride, runOptions) => {
+          // TODO: isFallbackRetry is derivable from `runOptions?.previousFailureReason !== undefined`;
+          // consider removing it in a future cleanup pass.
           const isFallbackRetry = fallbackAttemptIndex > 0;
           fallbackAttemptIndex += 1;
           return runAgentAttempt({
@@ -1206,6 +1269,9 @@ async function agentCommandInternal(
             sessionStore,
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            primaryProvider: provider,
+            previousFailureReason: runOptions?.previousFailureReason,
+            previousPartialExecution: runOptions?.previousPartialExecution,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (
@@ -1331,3 +1397,6 @@ export async function agentCommandFromIngress(
     deps,
   );
 }
+
+/** @internal – exposed for unit tests only */
+export const _testInternals = { resolveRetryImages, buildPartialExecutionSystemContext } as const;

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -429,6 +429,10 @@ function runAgentAttempt(params: {
     params.isFallbackRetry &&
     !!params.primaryProvider &&
     params.primaryProvider !== params.providerOverride;
+  // Suppress prompt-based image detection whenever images were intentionally
+  // stripped — cross-provider retries (privacy) and format errors (modality).
+  const shouldSuppressPromptImageDetection =
+    isCrossProviderRetry || (params.isFallbackRetry && params.previousFailureReason === "format");
   const partialExecContext = isCrossProviderRetry
     ? undefined
     : buildPartialExecutionSystemContext(params.previousPartialExecution);
@@ -587,7 +591,7 @@ function runAgentAttempt(params: {
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
-    suppressPromptImageDetection: isCrossProviderRetry,
+    suppressPromptImageDetection: shouldSuppressPromptImageDetection,
     onAgentEvent: params.onAgentEvent,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  FailoverError,
   coerceToFailoverError,
   describeFailoverError,
   isTimeoutError,
@@ -466,5 +467,45 @@ describe("failover-error", () => {
     const described = describeFailoverError(123);
     expect(described.message).toBe("123");
     expect(described.reason).toBeUndefined();
+  });
+
+  describe("sanitizeToolNames", () => {
+    it("strips non-alphanumeric/dash/underscore characters", () => {
+      expect(FailoverError.sanitizeToolNames(["send_message", "read<file>"])).toEqual([
+        "send_message",
+        "readfile",
+      ]);
+    });
+
+    it("truncates names to 100 characters", () => {
+      const longName = "a".repeat(150);
+      expect(FailoverError.sanitizeToolNames([longName])[0]).toHaveLength(100);
+    });
+
+    it("limits to 20 tool names", () => {
+      const names = Array.from({ length: 25 }, (_, i) => `tool_${i}`);
+      expect(FailoverError.sanitizeToolNames(names)).toHaveLength(20);
+    });
+
+    it("filters out names that become empty after sanitization", () => {
+      expect(FailoverError.sanitizeToolNames(["valid", "!!!"])).toEqual(["valid"]);
+    });
+  });
+
+  it("constructs FailoverError with partialExecution from toolMetas", () => {
+    const toolMetas = [{ toolName: "send_message", meta: "telegram" }, { toolName: "read_file" }];
+    const sanitized = FailoverError.sanitizeToolNames(toolMetas.map((t) => t.toolName));
+    expect(sanitized).toEqual(["send_message", "read_file"]);
+
+    const error = new FailoverError("timeout", {
+      reason: "timeout",
+      partialExecution: {
+        hadToolExecution: true,
+        toolNames: sanitized,
+        didSendViaMessagingTool: true,
+      },
+    });
+    expect(error.partialExecution?.toolNames).toEqual(["send_message", "read_file"]);
+    expect(error.partialExecution?.didSendViaMessagingTool).toBe(true);
   });
 });

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -8,6 +8,12 @@ import {
 
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
 
+export type PartialExecution = {
+  hadToolExecution: true;
+  toolNames: string[];
+  didSendViaMessagingTool: boolean;
+};
+
 export class FailoverError extends Error {
   readonly reason: FailoverReason;
   readonly provider?: string;
@@ -15,6 +21,7 @@ export class FailoverError extends Error {
   readonly profileId?: string;
   readonly status?: number;
   readonly code?: string;
+  readonly partialExecution?: PartialExecution;
 
   constructor(
     message: string,
@@ -26,6 +33,7 @@ export class FailoverError extends Error {
       status?: number;
       code?: string;
       cause?: unknown;
+      partialExecution?: PartialExecution;
     },
   ) {
     super(message, { cause: params.cause });
@@ -36,6 +44,14 @@ export class FailoverError extends Error {
     this.profileId = params.profileId;
     this.status = params.status;
     this.code = params.code;
+    this.partialExecution = params.partialExecution;
+  }
+
+  static sanitizeToolNames(names: string[]): string[] {
+    return names
+      .slice(0, 20)
+      .map((n) => n.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 100))
+      .filter(Boolean);
   }
 }
 
@@ -280,6 +296,7 @@ export function describeFailoverError(err: unknown): {
   reason?: FailoverReason;
   status?: number;
   code?: string;
+  partialExecution?: PartialExecution;
 } {
   if (isFailoverError(err)) {
     return {
@@ -287,6 +304,7 @@ export function describeFailoverError(err: unknown): {
       reason: err.reason,
       status: err.status,
       code: err.code,
+      partialExecution: err.partialExecution,
     };
   }
   const message = getErrorMessage(err) || String(err);

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -8,6 +8,7 @@ import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { FailoverError } from "./failover-error.js";
 import { isAnthropicBillingError } from "./live-auth-keys.js";
 import { runWithImageModelFallback, runWithModelFallback } from "./model-fallback.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
@@ -303,7 +304,7 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("gpt-4.1-mini");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5"],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -341,7 +342,7 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("openrouter/deepseek-chat");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-haiku-3-5"],
-      ["openrouter", "openrouter/deepseek-chat"],
+      ["openrouter", "openrouter/deepseek-chat", { previousFailureReason: "rate_limit" }],
     ]);
   });
 
@@ -372,7 +373,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["openai", "gpt-4.1-mini"],
-      ["anthropic", "claude-haiku-3-5"],
+      ["anthropic", "claude-haiku-3-5", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -443,7 +444,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4"],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -675,7 +676,7 @@ describe("runWithModelFallback", () => {
 
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5"],
-      ["anthropic", "claude-haiku-3-5"],
+      ["anthropic", "claude-haiku-3-5", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -758,7 +759,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-sonnet-4"],
-      ["openai", "gpt-4o"],
+      ["openai", "gpt-4o", { previousFailureReason: "rate_limit" }],
     ]);
   });
 
@@ -1025,7 +1026,9 @@ describe("runWithModelFallback", () => {
       expect(result.result).toBe("fallback success");
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-20250514");
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5"); // Fallback tried
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5", {
+        previousFailureReason: "rate_limit",
+      }); // Fallback tried
     });
 
     it("allows fallbacks with model version differences within same provider", async () => {
@@ -1054,7 +1057,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
 
     it("still skips fallbacks when using different provider than config", async () => {
@@ -1085,7 +1090,9 @@ describe("runWithModelFallback", () => {
       expect(result.result).toBe("config primary worked");
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini"); // Original request
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6"); // Config primary as final fallback
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6", {
+        previousFailureReason: "auth",
+      }); // Config primary as final fallback
     });
 
     it("uses fallbacks when session model exactly matches config primary", async () => {
@@ -1114,7 +1121,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("fallback worked");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
   });
 
@@ -1316,7 +1325,9 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
       }); // Rate limit allows attempt
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile"); // Cross-provider works
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      }); // Cross-provider works
     });
 
     it("limits cooldown probes to one per provider before moving to cross-provider fallback", async () => {
@@ -1356,7 +1367,9 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
       });
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
 
     it("does not consume transient probe slot when first same-provider probe fails with model_not_found", async () => {
@@ -1396,7 +1409,158 @@ describe("runWithModelFallback", () => {
       });
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5", {
         allowTransientCooldownProbe: true,
+        previousFailureReason: "model_not_found",
       });
+    });
+  });
+
+  describe("previousFailureReason forwarding", () => {
+    it("does not pass previousFailureReason on the first attempt", async () => {
+      const cfg = makeCfg();
+      const run = vi.fn().mockResolvedValueOnce("ok");
+
+      await runWithModelFallback({ cfg, provider: "anthropic", model: "claude-opus-4-5", run });
+
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(run.mock.calls[0]?.[2]).toBeUndefined();
+    });
+
+    it("forwards rate_limit reason after a 429 failure", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("rate limited", { reason: "rate_limit", status: 429 }),
+        )
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousFailureReason: "rate_limit" }),
+      );
+    });
+
+    it("forwards format reason after a 400 failure", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new FailoverError("bad request", { reason: "format", status: 400 }))
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousFailureReason: "format" }),
+      );
+    });
+
+    it("forwards partialExecution from failed attempt to next candidate", async () => {
+      const cfg = makeCfg();
+      const partialExec = {
+        hadToolExecution: true as const,
+        toolNames: ["send_message"],
+        didSendViaMessagingTool: true,
+      };
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("timeout", {
+            reason: "timeout",
+            partialExecution: partialExec,
+          }),
+        )
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousPartialExecution: partialExec }),
+      );
+    });
+
+    it("preserves earlier partialExecution when later attempt has none", async () => {
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-5",
+              fallbacks: ["anthropic/claude-haiku-3-5", "openai/gpt-4.1-mini"],
+            },
+          },
+        },
+      });
+      const partialExec = {
+        hadToolExecution: true as const,
+        toolNames: ["send_message"],
+        didSendViaMessagingTool: true,
+      };
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("timeout", {
+            reason: "timeout",
+            partialExecution: partialExec,
+          }),
+        )
+        .mockRejectedValueOnce(new FailoverError("rate limited", { reason: "rate_limit" }))
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(3);
+      // Third call should still have the partialExecution from the first failure
+      expect(run.mock.calls[2]?.[2]).toEqual(
+        expect.objectContaining({ previousPartialExecution: partialExec }),
+      );
+    });
+
+    it("forwards timeout reason after a timeout failure", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new FailoverError("timed out", { reason: "timeout", status: 408 }))
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({ previousFailureReason: "timeout" }),
+      );
     });
   });
 });

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1542,6 +1542,58 @@ describe("runWithModelFallback", () => {
       );
     });
 
+    it("merges partialExecution across multiple failed attempts", async () => {
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-5",
+              fallbacks: ["anthropic/claude-haiku-3-5", "openai/gpt-4.1-mini"],
+            },
+          },
+        },
+      });
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("timeout", {
+            reason: "timeout",
+            partialExecution: {
+              hadToolExecution: true as const,
+              toolNames: ["send_message"],
+              didSendViaMessagingTool: true,
+            },
+          }),
+        )
+        .mockRejectedValueOnce(
+          new FailoverError("rate limited", {
+            reason: "rate_limit",
+            partialExecution: {
+              hadToolExecution: true as const,
+              toolNames: ["read_file"],
+              didSendViaMessagingTool: false,
+            },
+          }),
+        )
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(3);
+      // Third call should have merged partialExecution: union of tool names, OR of messaging flag
+      const opts = run.mock.calls[2]?.[2];
+      expect(opts?.previousPartialExecution?.toolNames).toEqual(
+        expect.arrayContaining(["send_message", "read_file"]),
+      );
+      expect(opts?.previousPartialExecution?.didSendViaMessagingTool).toBe(true);
+    });
+
     it("forwards timeout reason after a timeout failure", async () => {
       const cfg = makeCfg();
       const run = vi

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -732,7 +732,26 @@ export async function runWithModelFallback<T>(params: {
       lastError = isKnownFailover ? normalized : err;
       const described = describeFailoverError(normalized);
       previousFailureReason = described.reason ?? "unknown";
-      lastPartialExecution = described.partialExecution ?? lastPartialExecution;
+      // Merge partial execution state across attempts: union tool names and OR
+      // the messaging flag so later retries don't lose side-effect history from
+      // earlier failed attempts (e.g. attempt 1 sent a message, attempt 2 only
+      // read a file — the messaging warning must carry forward).
+      if (described.partialExecution) {
+        lastPartialExecution = lastPartialExecution
+          ? {
+              ...lastPartialExecution,
+              toolNames: [
+                ...new Set([
+                  ...lastPartialExecution.toolNames,
+                  ...described.partialExecution.toolNames,
+                ]),
+              ],
+              didSendViaMessagingTool:
+                lastPartialExecution.didSendViaMessagingTool ||
+                described.partialExecution.didSendViaMessagingTool,
+            }
+          : described.partialExecution;
+      }
       attempts.push({
         provider: candidate.provider,
         model: candidate.model,

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -18,6 +18,7 @@ import {
   describeFailoverError,
   isFailoverError,
   isTimeoutError,
+  type PartialExecution,
 } from "./failover-error.js";
 import {
   shouldAllowCooldownProbeForReason,
@@ -41,6 +42,8 @@ const log = createSubsystemLogger("model-fallback");
 
 export type ModelFallbackRunOptions = {
   allowTransientCooldownProbe?: boolean;
+  previousFailureReason?: FailoverReason;
+  previousPartialExecution?: PartialExecution;
 };
 
 type ModelFallbackRunFn<T> = (
@@ -535,6 +538,8 @@ export async function runWithModelFallback<T>(params: {
     : null;
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
+  let previousFailureReason: FailoverReason | undefined;
+  let lastPartialExecution: PartialExecution | undefined;
   const cooldownProbeUsedProviders = new Set<string>();
 
   const hasFallbackCandidates = candidates.length > 1;
@@ -655,11 +660,19 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
+    const effectiveOptions: ModelFallbackRunOptions | undefined =
+      previousFailureReason || lastPartialExecution || runOptions
+        ? {
+            ...runOptions,
+            ...(previousFailureReason && { previousFailureReason }),
+            ...(lastPartialExecution && { previousPartialExecution: lastPartialExecution }),
+          }
+        : undefined;
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,
       attempts,
-      options: runOptions,
+      options: effectiveOptions,
     });
     if ("success" in attemptRun) {
       if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {
@@ -718,6 +731,8 @@ export async function runWithModelFallback<T>(params: {
 
       lastError = isKnownFailover ? normalized : err;
       const described = describeFailoverError(normalized);
+      previousFailureReason = described.reason ?? "unknown";
+      lastPartialExecution = described.partialExecution ?? lastPartialExecution;
       attempts.push({
         provider: candidate.provider,
         model: candidate.model,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -901,6 +901,7 @@ export async function runEmbeddedPiAgent(
             skillsSnapshot: params.skillsSnapshot,
             prompt,
             images: params.images,
+            suppressPromptImageDetection: params.suppressPromptImageDetection,
             clientTools: params.clientTools,
             disableTools: params.disableTools,
             provider,
@@ -1529,6 +1530,22 @@ export async function runEmbeddedPiAgent(
                 model: activeErrorContext.model,
                 profileId: lastProfileId,
                 status,
+                partialExecution: (() => {
+                  if (attempt.toolMetas.length === 0) {
+                    return undefined;
+                  }
+                  const sanitizedToolNames = FailoverError.sanitizeToolNames(
+                    attempt.toolMetas.map((t) => t.toolName),
+                  );
+                  if (sanitizedToolNames.length === 0) {
+                    return undefined;
+                  }
+                  return {
+                    hadToolExecution: true as const,
+                    toolNames: sanitizedToolNames,
+                    didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                  };
+                })(),
               });
             }
             logAssistantFailoverDecision("surface_error");

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2809,20 +2809,22 @@ export async function runEmbeddedAttempt(
 
           // Detect and load images referenced in the prompt for vision-capable models.
           // Images are prompt-local only (pi-like behavior).
-          const imageResult = await detectAndLoadPromptImages({
-            prompt: effectivePrompt,
-            workspaceDir: effectiveWorkspace,
-            model: params.model,
-            existingImages: params.images,
-            maxBytes: MAX_IMAGE_BYTES,
-            maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
-            workspaceOnly: effectiveFsWorkspaceOnly,
-            // Enforce sandbox path restrictions when sandbox is enabled
-            sandbox:
-              sandbox?.enabled && sandbox?.fsBridge
-                ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
-                : undefined,
-          });
+          const imageResult = params.suppressPromptImageDetection
+            ? { images: params.images ?? [], detectedRefs: [], loadedCount: 0, skippedCount: 0 }
+            : await detectAndLoadPromptImages({
+                prompt: effectivePrompt,
+                workspaceDir: effectiveWorkspace,
+                model: params.model,
+                existingImages: params.images,
+                maxBytes: MAX_IMAGE_BYTES,
+                maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
+                workspaceOnly: effectiveFsWorkspaceOnly,
+                // Enforce sandbox path restrictions when sandbox is enabled
+                sandbox:
+                  sandbox?.enabled && sandbox?.fsBridge
+                    ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
+                    : undefined,
+              });
 
           cacheTrace?.recordStage("prompt:images", {
             prompt: effectivePrompt,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -129,4 +129,10 @@ export type RunEmbeddedPiAgentParams = {
    * where transient service pressure is often model-scoped.
    */
   allowTransientCooldownProbe?: boolean;
+  /**
+   * When true, skip prompt-based image detection (detectAndLoadPromptImages).
+   * Used on cross-provider fallback retries to prevent local images referenced
+   * in the prompt from being loaded and sent to a different provider.
+   */
+  suppressPromptImageDetection?: boolean;
 };

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -26,7 +26,7 @@ import { buildOutboundSessionContext } from "../infra/outbound/session-context.j
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { agentCommand, agentCommandFromIngress } from "./agent.js";
+import { _testInternals, agentCommand, agentCommandFromIngress } from "./agent.js";
 
 vi.mock("../logging/subsystem.js", () => {
   const createMockLogger = () => ({
@@ -1249,5 +1249,274 @@ describe("agentCommand", () => {
 
       expect(runtime.log).toHaveBeenCalledWith("ok");
     });
+  });
+
+  it("forwards original prompt body on fallback retry", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:subagent:prompt-test": {
+          sessionId: "session-prompt",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-5",
+        },
+      });
+
+      mockConfig(home, store, {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["openai/gpt-5.2"],
+        },
+        models: {
+          "anthropic/claude-opus-4-5": {},
+          "openai/gpt-4.1-mini": {},
+          "openai/gpt-5.2": {},
+        },
+      });
+
+      vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+        { id: "claude-opus-4-5", name: "Opus", provider: "anthropic" },
+        { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
+        { id: "gpt-5.2", name: "GPT-5.2", provider: "openai" },
+      ]);
+      vi.mocked(runEmbeddedPiAgent)
+        .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+        .mockResolvedValueOnce({
+          payloads: [{ text: "ok" }],
+          meta: {
+            durationMs: 5,
+            agentMeta: { sessionId: "session-prompt", provider: "openai", model: "gpt-5.2" },
+          },
+        });
+
+      const originalMessage = "Summarize the quarterly report";
+      await agentCommand(
+        {
+          message: originalMessage,
+          sessionKey: "agent:main:subagent:prompt-test",
+        },
+        runtime,
+      );
+
+      const calls = vi.mocked(runEmbeddedPiAgent).mock.calls;
+      expect(calls).toHaveLength(2);
+      // Both attempts must receive the original prompt, not a "Continue where you left off" string
+      expect(calls[0]?.[0]?.prompt).toBe(originalMessage);
+      expect(calls[1]?.[0]?.prompt).toBe(originalMessage);
+    });
+  });
+
+  it("strips images on cross-provider fallback retry", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:subagent:image-strip": {
+          sessionId: "session-image-strip",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-5",
+        },
+      });
+
+      mockConfig(home, store, {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["openai/gpt-5.2"],
+        },
+        models: {
+          "anthropic/claude-opus-4-5": {},
+          "openai/gpt-4.1-mini": {},
+          "openai/gpt-5.2": {},
+        },
+      });
+
+      vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+        { id: "claude-opus-4-5", name: "Opus", provider: "anthropic" },
+        { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
+        { id: "gpt-5.2", name: "GPT-5.2", provider: "openai" },
+      ]);
+      vi.mocked(runEmbeddedPiAgent)
+        .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+        .mockResolvedValueOnce({
+          payloads: [{ text: "ok" }],
+          meta: {
+            durationMs: 5,
+            agentMeta: { sessionId: "session-image-strip", provider: "openai", model: "gpt-5.2" },
+          },
+        });
+
+      const fakeImages = [{ type: "image" as const, data: "abc", mimeType: "image/png" }];
+      await agentCommand(
+        {
+          message: "describe this image",
+          sessionKey: "agent:main:subagent:image-strip",
+          images: fakeImages,
+        },
+        runtime,
+      );
+
+      const calls = vi.mocked(runEmbeddedPiAgent).mock.calls;
+      expect(calls).toHaveLength(2);
+      // First attempt (anthropic) should receive images
+      expect(calls[0]?.[0]?.images).toBe(fakeImages);
+      // Second attempt (openai, cross-provider) should have images stripped
+      expect(calls[1]?.[0]?.images).toBeUndefined();
+    });
+  });
+
+  it("suppresses prompt image detection on cross-provider fallback retry", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:subagent:suppress-detect": {
+          sessionId: "session-suppress-detect",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-5",
+        },
+      });
+
+      mockConfig(home, store, {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["openai/gpt-5.2"],
+        },
+        models: {
+          "anthropic/claude-opus-4-5": {},
+          "openai/gpt-4.1-mini": {},
+          "openai/gpt-5.2": {},
+        },
+      });
+
+      vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+        { id: "claude-opus-4-5", name: "Opus", provider: "anthropic" },
+        { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
+        { id: "gpt-5.2", name: "GPT-5.2", provider: "openai" },
+      ]);
+      vi.mocked(runEmbeddedPiAgent)
+        .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+        .mockResolvedValueOnce({
+          payloads: [{ text: "ok" }],
+          meta: {
+            durationMs: 5,
+            agentMeta: {
+              sessionId: "session-suppress-detect",
+              provider: "openai",
+              model: "gpt-5.2",
+            },
+          },
+        });
+
+      await agentCommand(
+        {
+          message: "check /tmp/photo.png",
+          sessionKey: "agent:main:subagent:suppress-detect",
+        },
+        runtime,
+      );
+
+      const calls = vi.mocked(runEmbeddedPiAgent).mock.calls;
+      expect(calls).toHaveLength(2);
+      // First attempt (primary provider) should not suppress prompt image detection
+      expect(calls[0]?.[0]?.suppressPromptImageDetection).toBeFalsy();
+      // Second attempt (cross-provider fallback) should suppress prompt image detection
+      expect(calls[1]?.[0]?.suppressPromptImageDetection).toBe(true);
+    });
+  });
+});
+
+describe("resolveRetryImages", () => {
+  const { resolveRetryImages } = _testInternals;
+  const fakeImages = [{ type: "image" as const, data: "abc", mimeType: "image/png" }];
+
+  it("preserves images when not a fallback retry", () => {
+    expect(resolveRetryImages(fakeImages, false)).toBe(fakeImages);
+  });
+
+  it("strips images on format failure reason", () => {
+    expect(resolveRetryImages(fakeImages, true, "format")).toBeUndefined();
+  });
+
+  it("preserves images on same-provider rate_limit failure reason", () => {
+    expect(resolveRetryImages(fakeImages, true, "rate_limit", "openai", "openai")).toBe(fakeImages);
+  });
+
+  it("preserves images on timeout failure reason", () => {
+    expect(resolveRetryImages(fakeImages, true, "timeout")).toBe(fakeImages);
+  });
+
+  it("preserves images on auth failure reason", () => {
+    expect(resolveRetryImages(fakeImages, true, "auth")).toBe(fakeImages);
+  });
+
+  it("preserves images when previousFailureReason is undefined", () => {
+    expect(resolveRetryImages(fakeImages, true, undefined)).toBe(fakeImages);
+  });
+
+  it("strips images on cross-provider fallback (rate_limit)", () => {
+    expect(
+      resolveRetryImages(fakeImages, true, "rate_limit", "openai", "anthropic"),
+    ).toBeUndefined();
+  });
+
+  it("preserves images on same-provider fallback (rate_limit)", () => {
+    expect(resolveRetryImages(fakeImages, true, "rate_limit", "anthropic", "anthropic")).toBe(
+      fakeImages,
+    );
+  });
+
+  it("strips images on cross-provider fallback even without format error", () => {
+    expect(resolveRetryImages(fakeImages, true, "timeout", "anthropic", "google")).toBeUndefined();
+  });
+
+  it("strips images on cross-provider fallback even when previousFailureReason is undefined", () => {
+    expect(resolveRetryImages(fakeImages, true, undefined, "anthropic", "openai")).toBeUndefined();
+  });
+
+  it("strips images on same-provider format error (existing behavior)", () => {
+    expect(resolveRetryImages(fakeImages, true, "format", "openai", "openai")).toBeUndefined();
+  });
+});
+
+describe("buildPartialExecutionSystemContext", () => {
+  const { buildPartialExecutionSystemContext } = _testInternals;
+
+  it("returns undefined when no partial execution", () => {
+    expect(buildPartialExecutionSystemContext(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when toolNames is empty", () => {
+    expect(
+      buildPartialExecutionSystemContext({
+        toolNames: [],
+        didSendViaMessagingTool: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("includes tool names in warning", () => {
+    const result = buildPartialExecutionSystemContext({
+      toolNames: ["send_message", "read_file"],
+      didSendViaMessagingTool: false,
+    });
+    expect(result).toContain("send_message, read_file");
+    expect(result).toContain("Do not repeat actions");
+  });
+
+  it("includes messaging warning when didSendViaMessagingTool is true", () => {
+    const result = buildPartialExecutionSystemContext({
+      toolNames: ["send_message"],
+      didSendViaMessagingTool: true,
+    });
+    expect(result).toContain("do NOT re-send");
+  });
+
+  it("omits messaging warning when didSendViaMessagingTool is false", () => {
+    const result = buildPartialExecutionSystemContext({
+      toolNames: ["read_file"],
+      didSendViaMessagingTool: false,
+    });
+    expect(result).not.toContain("re-send");
   });
 });


### PR DESCRIPTION
## Summary

Consolidates three draft PRs (#43331, #43485, #43507) into a single focused change that handles fallback retry safety:

- **Cross-provider image privacy:** Strip explicitly-supplied images when fallback targets a different provider. Suppress prompt-based image detection (`detectAndLoadPromptImages`) on cross-provider retry to prevent local image files from being loaded and sent.
- **Partial execution detection:** Capture tool execution metadata (`toolMetas`) from the embedded runner, attach sanitized tool names to `FailoverError`, and thread through the fallback loop with `lastPartialExecution ?? previous` preservation for multi-hop chains.
- **System context injection:** Partial execution warnings are injected via `extraSystemPrompt` (system-level context) rather than prepended to the user message. This keeps the warning in the proper prompt layer and avoids models treating `[System: ...]` markers as user text.

Closes #43481, closes #43482, closes #43492

## Architectural constraints

The pi-coding-agent library's `AgentSession.prompt()` always adds a new user turn — there is no "retry last turn" API. The library's internal auto-retry uses `agent.continue()` which avoids duplicate turns, but this operates within a single `runEmbeddedPiAgent()` lifecycle. OpenClaw's model fallback system creates a new embedded runner invocation per candidate (new session setup, new streamFn), so `continue()` cannot be used across fallback candidates without restructuring the runner lifecycle or modifying the library.

The orphaned-user-message repair in `attempt.ts` correctly handles the re-submission pattern: it branches the session tree (pointer move, not deletion) to prevent consecutive user turns, then the original prompt is re-sent via `prompt()`. This is working as designed.

### Alternatives explored

- **`agent.continue()` across fallback candidates:** Not viable — `continue()` uses live `streamFn` and model references, but the embedded runner configures these per-invocation. Would require sharing a session across candidates.
- **`sendCustomMessage({ deliverAs: "nextTurn" })`:** Public API for context injection, but queues for the *next* `prompt()` call — timing doesn't align with the fallback retry flow.
- **Session-level retry coordination:** Would require the embedded runner to support a "retry mode" that skips `prompt()` and reuses the orphaned user turn. Feasible but requires fundamental runner restructuring.

## Non-goals

- Changing the pi-coding-agent library
- Restructuring the embedded runner lifecycle
- Gating cross-provider prompt text forwarding (architectural decision about the fallback system's trust model — see Aisle finding on #43485)

## Test plan

- [x] `resolveRetryImages` unit tests: cross-provider strip, same-provider preserve, format error strip, undefined failureReason
- [x] `resolveRetryImages` integration test: images stripped through full `agentCommand` → `runEmbeddedPiAgent` chain
- [x] `suppressPromptImageDetection` integration test: flag passed on cross-provider retry
- [x] `FailoverError.sanitizeToolNames` unit tests: character stripping, truncation, limit, empty filtering
- [x] `buildPartialExecutionSystemContext` unit tests: undefined/empty/with-tools/with-messaging-warning
- [x] Partial execution forwarding in `runWithModelFallback`: single-hop and multi-hop preservation
- [x] `pnpm check` clean
- [x] `pnpm build` succeeds