### PR TITLE
fix(cli): guard zsh compdef call for non-interactive shells

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -401,9 +401,7 @@ _${rootCmd}_root_completion() {
 
 ${generateZshSubcommands(program, rootCmd)}
 
-if (( \${+functions[compdef]} )); then
-  compdef _${rootCmd}_root_completion ${rootCmd}
-fi
+[ -n "$ZSH_VERSION" ] && (( \${+functions[compdef]} )) && compdef _${rootCmd}_root_completion ${rootCmd}
 `;
   return script;
 }

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -401,7 +401,7 @@ _${rootCmd}_root_completion() {
 
 ${generateZshSubcommands(program, rootCmd)}
 
-[ -n "$ZSH_VERSION" ] && (( \${+functions[compdef]} )) && compdef _${rootCmd}_root_completion ${rootCmd}
+[ -n "\${ZSH_VERSION-}" ] && (( \${+functions[compdef]} )) && compdef _${rootCmd}_root_completion ${rootCmd}
 `;
   return script;
 }

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -401,7 +401,9 @@ _${rootCmd}_root_completion() {
 
 ${generateZshSubcommands(program, rootCmd)}
 
-compdef _${rootCmd}_root_completion ${rootCmd}
+if (( \${+functions[compdef]} )); then
+  compdef _${rootCmd}_root_completion ${rootCmd}
+fi
 `;
   return script;
 }


### PR DESCRIPTION
## Summary

- Problem: Sourcing the zsh completion script in non-zsh shells (bash, sh) or before `compinit` emits `command not found: compdef`.
- Why it matters: Users who source completions from `.profile` or `.bashrc` see noisy errors on every shell startup.
- What changed: Wrapped the `compdef` call in `${+functions[compdef]}` guard so it only runs when `compdef` is actually available.
- What did NOT change: Completion behavior when compinit is loaded; the guard is a no-op in that case.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #14289

## User-visible / Behavior Changes

- No more "command not found: compdef" error when sourcing completions in bash/sh or before compinit.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Source the openclaw zsh completion script from a bash shell
2. Observe no `compdef` error

### Expected

- Silent completion script sourcing

### Actual (before fix)

- `command not found: compdef` printed to stderr

## Evidence

- Code inspection: the `compdef` function is only defined after `compinit` runs in zsh. The guard checks `${+functions[compdef]}` which is standard zsh practice.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit
- Known bad symptoms: completion registration silently skipped in zsh (would need explicit `compdef` call)

## Risks and Mitigations

None