### PR TITLE
fix(web): clear stale Baileys creds before forced WhatsApp relink

### DIFF
--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -136,6 +136,12 @@ export async function startWebLoginWithQr(
 
   await resetActiveLogin(account.accountId);
 
+  // Clear stale on-disk credentials before creating a new socket,
+  // otherwise Baileys loads old creds.json and gets stuck at "logging in".
+  if (opts.force && hasWeb) {
+    await logoutWeb({ authDir: account.authDir, isLegacyAuthDir: account.isLegacyAuthDir });
+  }
+
   let resolveQr: ((qr: string) => void) | null = null;
   let rejectQr: ((err: Error) => void) | null = null;
   const qrPromise = new Promise<string>((resolve, reject) => {

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -139,7 +139,11 @@ export async function startWebLoginWithQr(
   // Clear stale on-disk credentials before creating a new socket,
   // otherwise Baileys loads old creds.json and gets stuck at "logging in".
   if (opts.force && hasWeb) {
-    await logoutWeb({ authDir: account.authDir, isLegacyAuthDir: account.isLegacyAuthDir });
+    await logoutWeb({
+      authDir: account.authDir,
+      isLegacyAuthDir: account.isLegacyAuthDir,
+      runtime,
+    });
   }
 
   let resolveQr: ((qr: string) => void) | null = null;


### PR DESCRIPTION
## Summary

- Problem: `openclaw link whatsapp --force` gets stuck at "logging in" because Baileys loads stale creds.json from the auth directory.
- Why it matters: Users must manually delete `~/.openclaw/credentials/whatsapp-*` to re-pair, which is not discoverable.
- What changed: Before creating a new Baileys socket on forced relink, call `logoutWeb()` to clear stale on-disk credentials.
- What did NOT change: Normal (non-force) pairing flow; `logoutWeb` is only called when `opts.force && hasWeb`.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #4686

## User-visible / Behavior Changes

- `openclaw link whatsapp --force` now cleanly re-pairs without manual credential directory cleanup.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No (existing `logoutWeb` function already handles credential cleanup)
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Link WhatsApp via `openclaw link whatsapp`
2. Run `openclaw link whatsapp --force` to re-pair
3. Observe QR code appears cleanly

### Expected

- Fresh QR code pairing flow starts

### Actual (before fix)

- Gets stuck at "logging in" using old credentials

## Evidence

- Root cause confirmed in `src/web/login-qr.ts`: `resetActiveLogin` clears in-memory state but not the on-disk auth directory. Baileys `useMultiFileAuthState` loads `creds.json` on next socket creation.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit
- Known bad symptoms: forced relink might fail to log out cleanly (user can still manually delete auth dir)

## Risks and Mitigations

- Risk: `logoutWeb` could fail if auth dir is already gone
  - Mitigation: `logoutWeb` already handles missing files gracefully