### PR TITLE
fix(gateway): filter model picker to configured providers

### DIFF
--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -25,7 +25,7 @@ export const modelsHandlers: GatewayRequestHandlers = {
     try {
       const catalog = await context.loadGatewayModelCatalog();
       const cfg = loadConfig();
-      const { allowedCatalog } = buildAllowedModelSet({
+      const { allowAny, allowedCatalog } = buildAllowedModelSet({
         cfg,
         catalog,
         defaultProvider: DEFAULT_PROVIDER,
@@ -34,7 +34,7 @@ export const modelsHandlers: GatewayRequestHandlers = {
       // filter the full catalog to providers that have at least one auth
       // profile so the picker isn't overwhelmed with 600+ unconfigured models.
       let models: typeof catalog;
-      if (allowedCatalog.length > 0) {
+      if (!allowAny) {
         models = allowedCatalog;
       } else {
         const profiles = cfg?.auth?.profiles;

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -30,7 +30,22 @@ export const modelsHandlers: GatewayRequestHandlers = {
         catalog,
         defaultProvider: DEFAULT_PROVIDER,
       });
-      const models = allowedCatalog.length > 0 ? allowedCatalog : catalog;
+      // When an explicit model allowlist is configured, use it. Otherwise
+      // filter the full catalog to providers that have at least one auth
+      // profile so the picker isn't overwhelmed with 600+ unconfigured models.
+      let models: typeof catalog;
+      if (allowedCatalog.length > 0) {
+        models = allowedCatalog;
+      } else {
+        const profiles = cfg?.auth?.profiles;
+        const providerSet = new Set(
+          Object.values(profiles ?? {})
+            .map((p) => (p as { provider?: string }).provider)
+            .filter(Boolean),
+        );
+        models =
+          providerSet.size > 0 ? catalog.filter((m) => providerSet.has(m.provider)) : catalog;
+      }
       respond(true, { models }, undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -45,7 +45,9 @@ export const modelsHandlers: GatewayRequestHandlers = {
             .map((p) => normalizeProviderId(p as string)),
         );
         models =
-          providerSet.size > 0 ? catalog.filter((m) => providerSet.has(m.provider)) : catalog;
+          providerSet.size > 0
+            ? catalog.filter((m) => providerSet.has(normalizeProviderId(m.provider)))
+            : catalog;
       }
       respond(true, { models }, undefined);
     } catch (err) {

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
-import { buildAllowedModelSet } from "../../agents/model-selection.js";
+import { buildAllowedModelSet, normalizeProviderId } from "../../agents/model-selection.js";
 import { loadConfig } from "../../config/config.js";
 import {
   ErrorCodes,
@@ -41,7 +41,8 @@ export const modelsHandlers: GatewayRequestHandlers = {
         const providerSet = new Set(
           Object.values(profiles ?? {})
             .map((p) => (p as { provider?: string }).provider)
-            .filter(Boolean),
+            .filter(Boolean)
+            .map((p) => normalizeProviderId(p as string)),
         );
         models =
           providerSet.size > 0 ? catalog.filter((m) => providerSet.has(m.provider)) : catalog;


### PR DESCRIPTION
## Summary

- Problem: The model picker (`models.list`) returns the entire catalog (~600 models) when no explicit allowlist is configured, overwhelming the UI.
- Why it matters: Users with 1-2 providers configured see hundreds of irrelevant models from unconfigured providers.
- What changed: When no allowlist is set, filter the catalog to only providers that have at least one auth profile configured.
- What did NOT change: Behavior when an explicit model allowlist is configured (that path is unchanged).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #4349

## User-visible / Behavior Changes

- Model picker now shows only models from providers the user has actually configured auth profiles for.
- If no auth profiles exist at all, the full catalog is returned (no regression).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Configure auth profiles for 1-2 providers (e.g. OpenAI, Anthropic)
2. Open the model picker in the Canvas UI
3. Observe only models from configured providers appear

### Expected

- ~50 relevant models shown

### Actual (before fix)

- 600+ models from all providers shown

## Evidence

- Root cause: `models.list` handler had no provider-level filtering when `allowedCatalog` was empty.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit; the picker reverts to showing the full catalog
- Known bad symptoms: models from a configured provider missing from picker

## Risks and Mitigations

- Risk: Auth profile provider field might not match catalog provider field
  - Mitigation: Both use the same provider string constants from the config schema