### PR TITLE
test(compaction): make workspace path assertion portable

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -325,7 +326,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
 
     expect(ensureRuntimePluginsLoaded).toHaveBeenCalledWith({
       config: undefined,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: path.resolve("/tmp/workspace"),
     });
   });
 


### PR DESCRIPTION
## Summary

- Problem: `compact.hooks.test.ts` hard-coded a POSIX workspace path in the runtime-plugin bootstrap assertion.
- Why it matters: the test fails on Windows even though the implementation is correct and already resolves the workspace path using the host platform.
- What changed: switched the expected value to `path.resolve(/tmp/workspace)` and imported `node:path` so the assertion matches platform-native behavior.
- What did NOT change (scope boundary): no runtime compaction logic, hook payloads, or plugin bootstrapping behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #

## User-visible / Behavior Changes

- None at runtime. This only makes the compaction hook test portable across platforms.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm exec vitest run src/agents/pi-embedded-runner/compact.hooks.test.ts` on Windows.
2. Observe the hard-coded `/tmp/workspace` assertion fail before the patch.
3. Apply the portable expectation and rerun the test file.

### Expected

- The test should pass on both Windows and POSIX hosts.

### Actual

- The updated assertion now resolves the expected workspace path the same way the implementation does, and the test passes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran the full `compact.hooks.test.ts` file on Windows.
- Additional gate: ran `pnpm build:plugin-sdk:dts` to catch unrelated type fallout.
- What I did not verify: full repo CI or deployment workflows were not run locally.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- Revert the single test-file change.
- Known bad symptoms reviewers should watch for: none outside this test file.