### PR TITLE
fix(wizard): warn user when auth is skipped during onboarding

### DIFF
--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -459,7 +459,7 @@ export async function runOnboardingWizard(
     await prompter.note(
       [
         "No API key configured. Your agent won't respond until you add one.",
-        `Run ${formatCliCommand("openclaw configure --section auth")} to configure API credentials later.`,
+        `Run ${formatCliCommand("openclaw configure --section model")} to configure API credentials later.`,
       ].join("\n"),
       "Auth skipped",
     );

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -459,7 +459,7 @@ export async function runOnboardingWizard(
     await prompter.note(
       [
         "No API key configured. Your agent won't respond until you add one.",
-        `Run ${formatCliCommand("openclaw config set auth")} to configure API credentials later.`,
+        `Run ${formatCliCommand("openclaw configure --section auth")} to configure API credentials later.`,
       ].join("\n"),
       "Auth skipped",
     );

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -455,6 +455,16 @@ export async function runOnboardingWizard(
     }
   }
 
+  if (authChoice === "skip") {
+    await prompter.note(
+      [
+        "No API key configured. Your agent won't respond until you add one.",
+        `Run ${formatCliCommand("openclaw config set auth")} to configure API credentials later.`,
+      ].join("\n"),
+      "Auth skipped",
+    );
+  }
+
   if (authChoiceFromPrompt && authChoice !== "custom-api-key") {
     const modelSelection = await promptDefaultModel({
       config: nextConfig,


### PR DESCRIPTION
## Summary

- Problem: Users who skip auth during onboarding end up with a non-functional agent and no indication of what went wrong.
- Why it matters: New users think setup succeeded but the agent silently fails to respond.
- What changed: Added a `prompter.note()` warning after auth skip explaining that no API key is configured and how to add one later.
- What did NOT change: The ability to skip auth; users can still skip, they just get a clear warning now.

## Change Type (select all)

- [x] Bug fix
- [x] UI / DX

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #16134

## User-visible / Behavior Changes

- When "skip" is chosen during auth onboarding, a note is displayed: "No API key configured. Your agent won't respond until you add one."

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Run `openclaw setup` (or first-run onboarding)
2. Choose "skip" at the auth step
3. Observe the warning note

### Expected

- Clear warning about missing API key with instructions to configure later

### Actual (before fix)

- Silent completion, user confused when agent doesn't respond

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit; skip behavior returns to silent
- Known bad symptoms: note displaying at wrong time (only fires on authChoice === "skip")

## Risks and Mitigations

None