### PR TITLE
fix(macos): bail early on gateway failure and surface real error

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -378,6 +378,11 @@ final class GatewayProcessManager {
     func waitForGatewayReady(timeout: TimeInterval = 6) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
+            // Bail early if gateway already failed to start (e.g. CLI not in PATH).
+            if case .failed = self.status {
+                self.appendLog("[gateway] gateway already in failed state, not waiting\n")
+                return false
+            }
             if !self.desiredActive { return false }
             do {
                 _ = try await self.connection.requestRaw(method: .health, timeoutMs: 1500)

--- a/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
@@ -80,10 +80,16 @@ final class OnboardingWizardModel {
         do {
             GatewayProcessManager.shared.setActive(true)
             if await GatewayProcessManager.shared.waitForGatewayReady(timeout: 12) == false {
+                let reason: String
+                if case .failed(let msg) = GatewayProcessManager.shared.status {
+                    reason = msg
+                } else {
+                    reason = "Gateway did not become ready. Check that it is running."
+                }
                 throw NSError(
                     domain: "Gateway",
                     code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "Gateway did not become ready. Check that it is running."])
+                    userInfo: [NSLocalizedDescriptionKey: reason])
             }
             var params: [String: AnyCodable] = ["mode": AnyCodable("local")]
             if let workspace, !workspace.isEmpty {


### PR DESCRIPTION
## Summary

- Problem: macOS app waits the full 12s timeout for a gateway that already failed to start, then shows a generic "did not become ready" error.
- Why it matters: Users wait unnecessarily and get no actionable information about why the gateway failed (e.g., CLI not in PATH).
- What changed: (1) `waitForGatewayReady()` now checks for `.failed` status each iteration and bails early. (2) `OnboardingWizard` extracts the actual failure reason from the gateway status.
- What did NOT change: Happy path behavior when gateway starts successfully.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #6156

## User-visible / Behavior Changes

- Onboarding error message now shows the actual gateway failure reason instead of a generic timeout message.
- Gateway readiness check returns immediately when the gateway is in a failed state.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Swift/SwiftUI (OpenClaw macOS app)

### Steps

1. Remove openclaw CLI from PATH (or break gateway config)
2. Open the macOS app
3. Observe error appears quickly with the real reason

### Expected

- Immediate error: "Failed: Gateway command not found" (or similar)

### Actual (before fix)

- 12s wait, then generic "Gateway did not become ready. Check that it is running."

## Evidence

- Root cause in `GatewayProcessManager.swift:378-397`: the `while` loop only checks `desiredActive` and retries health probes, never checking if status already moved to `.failed`.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit; behavior returns to waiting full timeout
- Known bad symptoms: false-positive early bail if `.failed` is set transiently

## Risks and Mitigations

- Risk: `.failed` status set transiently during normal startup
  - Mitigation: `startIfNeeded()` only sets `.failed` after all retry paths are exhausted