### PR TITLE
fix(agents): reset error counts when 429 cooldown expires

### DIFF
--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -212,6 +212,12 @@ export function clearExpiredCooldowns(store: AuthProfileStore, now?: number): bo
 
     if (cooldownExpired) {
       stats.cooldownUntil = undefined;
+      // Reset transient error counters when cooldown expires so the next
+      // failure doesn't escalate backoff using stale counts. Without this,
+      // cross-provider fallbacks are blocked after a 429 because the primary
+      // provider's error count keeps growing and re-enters cooldown instantly.
+      stats.errorCount = 0;
+      stats.failureCounts = undefined;
       profileMutated = true;
     }
     if (disabledExpired) {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -216,8 +216,12 @@ export function clearExpiredCooldowns(store: AuthProfileStore, now?: number): bo
       // failure doesn't escalate backoff using stale counts. Without this,
       // cross-provider fallbacks are blocked after a 429 because the primary
       // provider's error count keeps growing and re-enters cooldown instantly.
-      stats.errorCount = 0;
-      stats.failureCounts = undefined;
+      // Only reset counters here if no disabledUntil is still active;
+      // otherwise the billing/auth error history would be wiped prematurely.
+      if (!isActiveUnusableWindow(stats.disabledUntil, ts)) {
+        stats.errorCount = 0;
+        stats.failureCounts = undefined;
+      }
       profileMutated = true;
     }
     if (disabledExpired) {


### PR DESCRIPTION
## Summary

- Problem: After a 429 rate-limit cooldown expires, stale error counts cause the provider to re-enter cooldown immediately on the next failure, permanently blocking cross-provider fallback.
- Why it matters: Users with multi-provider setups get stuck on one provider after a single 429 event.
- What changed: Reset `errorCount` and `failureCounts` when a cooldown period expires, giving the provider a clean slate.
- What did NOT change: Cooldown duration calculation, `disabledUntil` handling, or the escalation logic itself.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens
- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #11972

## User-visible / Behavior Changes

- After a 429 cooldown expires, the provider starts fresh instead of immediately re-entering cooldown on the next error.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Configure multiple auth profiles (e.g., OpenAI + Anthropic)
2. Trigger a 429 on the primary provider
3. Wait for cooldown to expire
4. Send another message that fails on primary
5. Observe fallback to secondary works

### Expected

- Provider gets one more chance after cooldown, fallback chain works

### Actual (before fix)

- Primary immediately re-enters cooldown due to stale errorCount, blocking fallback permanently

## Evidence

- Root cause in `src/agents/auth-profiles/usage.ts`: `clearExpiredCooldowns()` clears `cooldownUntil` but leaves `errorCount`/`failureCounts` intact. The next `recordProfileError()` call sees the existing count and escalates the cooldown duration, effectively making it permanent.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit; cooldown behavior returns to previous (sticky) behavior
- Known bad symptoms: providers recovering too quickly from sustained rate-limiting (mitigated by the escalation logic still applying to new errors)

## Risks and Mitigations

- Risk: Resetting counts could make cooldowns less effective under sustained load
  - Mitigation: The cooldown duration itself is unchanged; only the error count resets, so the next failure starts a fresh escalation sequence