### PR TITLE
fix(agents): skip bootstrap file injection on continuation messages

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1422,16 +1422,24 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
-      await resolveBootstrapContextForRun({
-        workspaceDir: effectiveWorkspace,
-        config: params.config,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
-        contextMode: params.bootstrapContextMode,
-        runKind: params.bootstrapContextRunKind,
-      });
+
+    // Only inject workspace bootstrap files on the first message of a session.
+    // Continuation messages already have them in context, saving ~35k tokens.
+    const isFirstMessage = !(await fs
+      .stat(params.sessionFile)
+      .then(() => true)
+      .catch(() => false));
+    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } = isFirstMessage
+      ? await resolveBootstrapContextForRun({
+          workspaceDir: effectiveWorkspace,
+          config: params.config,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+          contextMode: params.bootstrapContextMode,
+          runKind: params.bootstrapContextRunKind,
+        })
+      : { bootstrapFiles: [], contextFiles: [] };
     const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
     const bootstrapAnalysis = analyzeBootstrapBudget({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1425,6 +1425,7 @@ export async function runEmbeddedAttempt(
 
     // Only inject workspace bootstrap files on the first message of a session.
     // Continuation messages already have them in context, saving ~35k tokens.
+    // Check once and reuse as `hadSessionFile` near the SessionManager.open() call.
     const isFirstMessage = !(await fs
       .stat(params.sessionFile)
       .then(() => true)
@@ -1724,10 +1725,7 @@ export async function runEmbeddedAttempt(
         sessionFile: params.sessionFile,
         warn: (message) => log.warn(message),
       });
-      const hadSessionFile = await fs
-        .stat(params.sessionFile)
-        .then(() => true)
-        .catch(() => false);
+      const hadSessionFile = !isFirstMessage;
 
       const transcriptPolicy = resolveTranscriptPolicy({
         modelApi: params.model?.api,


### PR DESCRIPTION
## Summary

- Problem: Bootstrap files (~35k tokens) are re-injected into every Pi session message, even continuations that already have them in context.
- Why it matters: Wastes ~35k tokens per continuation message, increasing cost and latency.
- What changed: Check whether the session file exists before calling `resolveBootstrapContextForRun()`. If the session file exists (continuation), skip bootstrap injection.
- What did NOT change: First-message behavior; bootstrap files are still injected on the first turn.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #9157

## User-visible / Behavior Changes

- Reduced token usage on Pi session continuation messages (~35k tokens saved per message).
- No behavioral change in responses (context was already present from the first turn).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Start a Pi session and send a message (first turn)
2. Send a follow-up message in the same session
3. Observe token count in the follow-up is ~35k lower

### Expected

- Continuation messages don't re-inject bootstrap files

### Actual (before fix)

- Every message includes full bootstrap files regardless of session state

## Evidence

- Root cause: `resolveBootstrapContextForRun()` is called unconditionally in `attempt.ts`. The session file existence check (`fs.stat(params.sessionFile)`) reliably distinguishes first vs. continuation messages.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit; bootstrap injection returns to every-message behavior
- Known bad symptoms: first message of a session missing bootstrap context (would indicate the session file check is wrong)

## Risks and Mitigations

- Risk: Race condition where session file is created between check and bootstrap call
  - Mitigation: Session file is only created after the full attempt completes; the check runs before any writes