### PR TITLE
fix(imessage): detect FDA permission errors and improve send reporting

### DIFF
--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -36,34 +36,39 @@ export async function deliverReplies(params: {
     if (!text && mediaList.length === 0) {
       continue;
     }
-    if (mediaList.length === 0) {
-      sentMessageCache?.remember(scope, { text });
-      for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
-        const sent = await sendMessageIMessage(target, chunk, {
-          maxBytes,
-          client,
-          accountId,
-          replyToId: payload.replyToId,
-        });
-        sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
+    try {
+      if (mediaList.length === 0) {
+        sentMessageCache?.remember(scope, { text });
+        for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
+          const sent = await sendMessageIMessage(target, chunk, {
+            maxBytes,
+            client,
+            accountId,
+            replyToId: payload.replyToId,
+          });
+          sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
+        }
+      } else {
+        let first = true;
+        for (const url of mediaList) {
+          const caption = first ? text : "";
+          first = false;
+          const sent = await sendMessageIMessage(target, caption, {
+            mediaUrl: url,
+            maxBytes,
+            client,
+            accountId,
+            replyToId: payload.replyToId,
+          });
+          sentMessageCache?.remember(scope, {
+            text: caption || undefined,
+            messageId: sent.messageId,
+          });
+        }
       }
-    } else {
-      let first = true;
-      for (const url of mediaList) {
-        const caption = first ? text : "";
-        first = false;
-        const sent = await sendMessageIMessage(target, caption, {
-          mediaUrl: url,
-          maxBytes,
-          client,
-          accountId,
-          replyToId: payload.replyToId,
-        });
-        sentMessageCache?.remember(scope, {
-          text: caption || undefined,
-          messageId: sent.messageId,
-        });
-      }
+    } catch (err) {
+      runtime.log?.(`imessage: send failed for ${target}: ${String(err)}`);
+      throw err;
     }
     runtime.log?.(`imessage: delivered reply to ${target}`);
   }

--- a/src/imessage/probe.ts
+++ b/src/imessage/probe.ts
@@ -100,10 +100,10 @@ export async function probeIMessage(
   } catch (err) {
     const msg = String(err);
     // Detect macOS Full Disk Access denial so the user gets an actionable hint.
-    // Narrow the match: require both a permission keyword AND a chat.db/Messages/tccd
-    // reference so non-FDA EPERMs (e.g. IPC socket issues) don't trigger a misleading hint.
+    // Require a real permission keyword AND a chat.db/Messages/tccd reference so
+    // transient TCC daemon errors don't trigger a misleading fatal hint.
     if (
-      (msg.includes("Operation not permitted") || msg.includes("EPERM") || msg.includes("tccd")) &&
+      (msg.includes("Operation not permitted") || msg.includes("EPERM")) &&
       (msg.includes("chat.db") || msg.includes("Messages") || msg.includes("tccd"))
     ) {
       return {

--- a/src/imessage/probe.ts
+++ b/src/imessage/probe.ts
@@ -98,7 +98,17 @@ export async function probeIMessage(
     await client.request("chats.list", { limit: 1 }, { timeoutMs: effectiveTimeout });
     return { ok: true };
   } catch (err) {
-    return { ok: false, error: String(err) };
+    const msg = String(err);
+    // Detect macOS Full Disk Access denial so the user gets an actionable hint.
+    if (msg.includes("Operation not permitted") || msg.includes("EPERM") || msg.includes("tccd")) {
+      return {
+        ok: false,
+        error:
+          "Full Disk Access required. Open System Settings > Privacy & Security > Full Disk Access and enable imsg (or Terminal).",
+        fatal: true,
+      };
+    }
+    return { ok: false, error: msg };
   } finally {
     await client.stop();
   }

--- a/src/imessage/probe.ts
+++ b/src/imessage/probe.ts
@@ -100,7 +100,12 @@ export async function probeIMessage(
   } catch (err) {
     const msg = String(err);
     // Detect macOS Full Disk Access denial so the user gets an actionable hint.
-    if (msg.includes("Operation not permitted") || msg.includes("EPERM") || msg.includes("tccd")) {
+    // Narrow the match: require both a permission keyword AND a chat.db/Messages/tccd
+    // reference so non-FDA EPERMs (e.g. IPC socket issues) don't trigger a misleading hint.
+    if (
+      (msg.includes("Operation not permitted") || msg.includes("EPERM") || msg.includes("tccd")) &&
+      (msg.includes("chat.db") || msg.includes("Messages") || msg.includes("tccd"))
+    ) {
       return {
         ok: false,
         error:

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -179,6 +179,8 @@ export async function sendMessageIMessage(
       timeoutMs: opts.timeoutMs,
     });
     const resolvedId = resolveMessageId(result);
+    // The imsg binary sets `ok` to a non-empty string on success; treat any truthy
+    // value as a success indicator (the binary never sends "false"/"0" for ok).
     if (!resolvedId && !result?.ok) {
       throw new Error("iMessage send returned no message ID and no success indicator");
     }

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -179,8 +179,11 @@ export async function sendMessageIMessage(
       timeoutMs: opts.timeoutMs,
     });
     const resolvedId = resolveMessageId(result);
+    if (!resolvedId && !result?.ok) {
+      throw new Error("iMessage send returned no message ID and no success indicator");
+    }
     return {
-      messageId: resolvedId ?? (result?.ok ? "ok" : "unknown"),
+      messageId: resolvedId ?? "ok",
     };
   } finally {
     if (shouldClose) {


### PR DESCRIPTION
## Summary

- Problem: iMessage probe returns generic errors when macOS Full Disk Access is missing; send returns "unknown" on ambiguous results; delivery failures are not logged.
- Why it matters: Users get unhelpful error messages and can't diagnose why iMessage isn't working. Missing FDA is a common new-user issue.
- What changed: (1) Probe detects "Operation not permitted"/EPERM/tccd errors and returns an actionable "enable Full Disk Access" hint. (2) Send throws on ambiguous results instead of silently returning "unknown". (3) Deliver wraps send calls in try-catch with target-specific logging.
- What did NOT change: Happy-path send/receive behavior.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- Closes #5116

## User-visible / Behavior Changes

- Probe error now says: "Full Disk Access required. Open System Settings > Privacy & Security > Full Disk Access and enable imsg (or Terminal)."
- Send no longer silently returns "unknown" messageId on failure.
- Delivery failures include the target in the log message.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Integration: iMessage

### Steps

1. Disable Full Disk Access for Terminal/imsg
2. Run `openclaw channels status --probe`
3. Observe actionable FDA error

### Expected

- "Full Disk Access required. Open System Settings > Privacy & Security > Full Disk Access..."

### Actual (before fix)

- Generic "Error: Operation not permitted" with no guidance

## Evidence

- macOS TCC framework returns EPERM or mentions "tccd" when Full Disk Access is denied for chat.db access.

## Compatibility / Migration

- Backward compatible? Yes (send now throws where it previously returned "unknown", but callers already handle errors)
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit
- Known bad symptoms: false-positive FDA detection (mitigated by checking specific error strings)

## Risks and Mitigations

- Risk: "Operation not permitted" could come from non-FDA causes
  - Mitigation: The probe only runs on the chats.list RPC call which specifically accesses chat.db, the primary FDA-gated resource