### PR TITLE
fix(cron): suppress isolated cron interim narration from announce delivery

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,5 +1,5 @@
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -390,12 +390,25 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-    if (synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
+    if (isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN)) {
       return params.withRunSession({
         status: "ok",
         summary,
         outputText,
         delivered: true,
+        ...params.telemetry,
+      });
+    }
+
+    // If the final text still looks like an interim/status narration,
+    // suppress announce delivery instead of leaking chatty no-data updates.
+    if (isLikelyInterimCronMessage(synthesizedText)) {
+      deliveryAttempted = true;
+      return params.withRunSession({
+        status: "ok",
+        summary,
+        outputText,
+        deliveryAttempted,
         ...params.telemetry,
       });
     }


### PR DESCRIPTION
## What
This PR hardens isolated cron announce delivery to prevent chatty no-data/status text from being sent to users.

### Changes
- Use `isSilentReplyText(...)` (instead of exact token equality) when checking silent responses in `src/cron/isolated-agent/delivery-dispatch.ts`.
- Suppress delivery when synthesized text is classified as an interim cron message (`isLikelyInterimCronMessage(...)`) in `finalizeTextDelivery`.

## Why
In Telegram + isolated cron workflows, runs that should be silent (`NO_REPLY` / no-data) can leak narration/status messages. This change adds a stronger guard in the delivery layer so those interim/no-data texts are not announced.

## Related
- Closes #44213
- Adjacent: #19824, #43274, #42321

## Notes
- This patch intentionally avoids locale-specific phrase matching changes.
- I could not run local tests in this environment because the repo bootstrap/toolchain wasn't installed (`pnpm ... vitest` unavailable before install).
