### PR TITLE
fix(cron): harden isolated announce NO_REPLY matching

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -390,18 +390,15 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-    if (isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN)) {
     if (isSilentReplyText(synthesizedText.toUpperCase(), SILENT_REPLY_TOKEN)) {
-
-    // If the final text still looks like an interim/status narration,
-    // suppress announce delivery instead of leaking chatty no-data updates.
-    if (isLikelyInterimCronMessage(synthesizedText)) {
-      deliveryAttempted = true;
       return params.withRunSession({
         status: "ok",
         summary,
         outputText,
-        deliveryAttempted,
+        delivered: true,
+        ...params.telemetry,
+      });
+    }
         ...params.telemetry,
       });
     }

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,5 +1,5 @@
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -390,12 +390,25 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-    if (synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
+    if (isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN)) {
       return params.withRunSession({
         status: "ok",
         summary,
         outputText,
         delivered: true,
+        ...params.telemetry,
+      });
+    }
+
+    // If the final text still looks like an interim/status narration,
+    // suppress announce delivery instead of leaking chatty no-data updates.
+    if (isLikelyInterimCronMessage(synthesizedText)) {
+      deliveryAttempted = true;
+      return params.withRunSession({
+        status: "ok",
+        summary,
+        outputText,
+        deliveryAttempted,
         ...params.telemetry,
       });
     }

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -391,14 +391,7 @@ export async function dispatchCronDelivery(
       });
     }
     if (isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN)) {
-      return params.withRunSession({
-        status: "ok",
-        summary,
-        outputText,
-        delivered: true,
-        ...params.telemetry,
-      });
-    }
+    if (isSilentReplyText(synthesizedText.toUpperCase(), SILENT_REPLY_TOKEN)) {
 
     // If the final text still looks like an interim/status narration,
     // suppress announce delivery instead of leaking chatty no-data updates.

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -399,9 +399,6 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-        ...params.telemetry,
-      });
-    }
     if (params.isAborted()) {
       return params.withRunSession({
         status: "error",


### PR DESCRIPTION
## What
This PR hardens isolated cron announce delivery by making silent-token handling more robust.

### Changes
- Use `isSilentReplyText(...)` in `src/cron/isolated-agent/delivery-dispatch.ts`
- Preserve case-insensitive behavior for `NO_REPLY` matching

## Why
In Telegram + isolated cron workflows, runs that should be silent (`NO_REPLY` / no-data) can leak messages when token matching is too strict.
This PR keeps the scope intentionally narrow to the minimal safe fix for silent-token handling.

## Related
- Closes #44213
- Adjacent: #19824, #43274, #42321
