### PR TITLE
fix(cron): prevent false-positive mutation in normalizePayloadKind

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -47,6 +47,74 @@ describe("normalizeStoredCronJobs", () => {
     });
   });
 
+  it("does not report mutation when payload kind is already correctly cased", () => {
+    const jobs = [
+      {
+        id: "correctly-cased-job",
+        schedule: { kind: "cron", expr: "0 * * * *" },
+        payload: {
+          kind: "agentTurn",
+          message: "already correct",
+        },
+      },
+      {
+        id: "correctly-cased-system-event",
+        schedule: { kind: "cron", expr: "0 * * * *" },
+        payload: {
+          kind: "systemEvent",
+          text: "system message",
+        },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    // Should not report legacyPayloadKind issue when kind is already correct
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+    expect(jobs[0]?.payload).toMatchObject({
+      kind: "agentTurn",
+      message: "already correct",
+    });
+    expect(jobs[1]?.payload).toMatchObject({
+      kind: "systemEvent",
+      text: "system message",
+    });
+  });
+
+  it("normalizes incorrectly cased payload kind", () => {
+    const jobs = [
+      {
+        id: "lowercase-agentturn",
+        schedule: { kind: "cron", expr: "0 * * * *" },
+        payload: {
+          kind: "AGENTTURN",
+          message: "uppercase",
+        },
+      },
+      {
+        id: "mixed-case-systemevent",
+        schedule: { kind: "cron", expr: "0 * * * *" },
+        payload: {
+          kind: "SystemEvent",
+          text: "mixed case",
+        },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.legacyPayloadKind).toBe(2);
+    expect(jobs[0]?.payload).toMatchObject({
+      kind: "agentTurn",
+      message: "uppercase",
+    });
+    expect(jobs[1]?.payload).toMatchObject({
+      kind: "systemEvent",
+      text: "mixed case",
+    });
+  });
+
   it("normalizes payload provider alias into channel", () => {
     const jobs = [
       {

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -47,10 +47,11 @@ describe("normalizeStoredCronJobs", () => {
     });
   });
 
-  it("does not report mutation when payload kind is already correctly cased", () => {
+  it("does not report legacyPayloadKind issue when payload kind is already correctly cased", () => {
     const jobs = [
       {
         id: "correctly-cased-job",
+        name: "Test Job",
         schedule: { kind: "cron", expr: "0 * * * *" },
         payload: {
           kind: "agentTurn",
@@ -59,6 +60,7 @@ describe("normalizeStoredCronJobs", () => {
       },
       {
         id: "correctly-cased-system-event",
+        name: "System Event Job",
         schedule: { kind: "cron", expr: "0 * * * *" },
         payload: {
           kind: "systemEvent",
@@ -71,11 +73,13 @@ describe("normalizeStoredCronJobs", () => {
 
     // Should not report legacyPayloadKind issue when kind is already correct
     expect(result.issues.legacyPayloadKind).toBeUndefined();
-    expect(jobs[0]?.payload).toMatchObject({
+    const payload0 = jobs[0]?.payload as Record<string, unknown> | undefined;
+    const payload1 = jobs[1]?.payload as Record<string, unknown> | undefined;
+    expect(payload0).toMatchObject({
       kind: "agentTurn",
       message: "already correct",
     });
-    expect(jobs[1]?.payload).toMatchObject({
+    expect(payload1).toMatchObject({
       kind: "systemEvent",
       text: "system message",
     });
@@ -85,6 +89,7 @@ describe("normalizeStoredCronJobs", () => {
     const jobs = [
       {
         id: "lowercase-agentturn",
+        name: "Uppercase AgentTurn",
         schedule: { kind: "cron", expr: "0 * * * *" },
         payload: {
           kind: "AGENTTURN",
@@ -93,6 +98,7 @@ describe("normalizeStoredCronJobs", () => {
       },
       {
         id: "mixed-case-systemevent",
+        name: "Mixed Case SystemEvent",
         schedule: { kind: "cron", expr: "0 * * * *" },
         payload: {
           kind: "SystemEvent",
@@ -105,11 +111,13 @@ describe("normalizeStoredCronJobs", () => {
 
     expect(result.mutated).toBe(true);
     expect(result.issues.legacyPayloadKind).toBe(2);
-    expect(jobs[0]?.payload).toMatchObject({
+    const payload0 = jobs[0]?.payload as Record<string, unknown> | undefined;
+    const payload1 = jobs[1]?.payload as Record<string, unknown> | undefined;
+    expect(payload0).toMatchObject({
       kind: "agentTurn",
       message: "uppercase",
     });
-    expect(jobs[1]?.payload).toMatchObject({
+    expect(payload1).toMatchObject({
       kind: "systemEvent",
       text: "mixed case",
     });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,14 +28,21 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
-    payload.kind = "agentTurn";
-    return true;
+  const raw = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  const lower = raw.toLowerCase();
+  if (lower === "agentturn") {
+    if (raw !== "agentTurn") {
+      payload.kind = "agentTurn";
+      return true;
+    }
+    return false;
   }
-  if (raw === "systemevent") {
-    payload.kind = "systemEvent";
-    return true;
+  if (lower === "systemevent") {
+    if (raw !== "systemEvent") {
+      payload.kind = "systemEvent";
+      return true;
+    }
+    return false;
   }
   return false;
 }


### PR DESCRIPTION
## Description

Fixes #44186

The `normalizePayloadKind` function was incorrectly reporting mutations even when `payload.kind` was already correctly cased (e.g., 'agentTurn'). This caused `openclaw doctor` to infinitely suggest normalization that never resolves.

## Root Cause

The original implementation compared the lowercased value against the normalized form:

```typescript
const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
if (raw === "agentturn") {
  payload.kind = "agentTurn";
  return true;  // Always returned true, even if already correct
}
```

This meant that even when `payload.kind` was already `"agentTurn"`, the function would:
1. Set `raw` to `"agentturn"` (lowercased)
2. Match the condition
3. Reassign `payload.kind = "agentTurn"`
4. **Return `true`** (indicating a mutation occurred)

This caused the doctor command to continuously report "needs payload kind normalization" even after running `--fix`.

## Solution

The fix compares the original value against the normalized value before reporting a mutation:

```typescript
const raw = typeof payload.kind === "string" ? payload.kind.trim() : "";
const lower = raw.toLowerCase();
if (lower === "agentturn") {
  if (raw !== "agentTurn") {  // Only mutate if actually different
    payload.kind = "agentTurn";
    return true;
  }
  return false;  // No mutation needed
}
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit tests added in `src/cron/store-migration.test.ts`
- [x] Tests verify:
  - No false positive when `kind` is already correct
  - Proper normalization when `kind` is incorrect case
  - Proper handling of both `agentTurn` and `systemEvent` kinds

### Test Coverage

Test file: `src/cron/store-migration.test.ts`

1. **Test: "does not report mutation when payload kind is already correctly cased"**
   - Verifies no false positives for `"agentTurn"` and `"systemEvent"`
   - Ensures `legacyPayloadKind` issue is not reported

2. **Test: "normalizes incorrectly cased payload kind"**
   - Verifies normalization of `"AGENTTURN"` → `"agentTurn"`
   - Verifies normalization of `"SystemEvent"` → `"systemEvent"`
   - Ensures `legacyPayloadKind` issue is reported correctly

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A - no doc changes needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Security Considerations

✅ **No security concerns:**
- No sensitive data handling changes
- No new external dependencies
- No security vulnerabilities introduced
- Changes are purely cosmetic normalization

## Performance Impact

✅ **No performance degradation:**
- Added one additional string comparison check
- O(1) operation
- No impact on runtime performance

## Breaking Changes

✅ **No breaking changes:**
- Pure bug fix
- Maintains backward compatibility
- Existing behavior improved without breaking changes

## AI-Assisted Development

This fix was developed with assistance from CodeBuddy (AI coding assistant) for:
- Code analysis and bug identification
- Test case generation
- Documentation drafting

All code has been reviewed and tested by the contributor.
