### PR TITLE
fix: use 0o644 as default file mode in Write/Edit tools

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -744,6 +744,7 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
         relativePath: relative,
         data: content,
         mkdir: true,
+        mode: 0o644,
       });
     },
   } as const;
@@ -784,6 +785,7 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
         relativePath: relative,
         data: content,
         mkdir: true,
+        mode: 0o644,
       });
     },
     access: async (absolutePath: string) => {

--- a/src/infra/fs-pinned-write-helper.ts
+++ b/src/infra/fs-pinned-write-helper.ts
@@ -169,7 +169,7 @@ export async function runPinnedWriteHelper(params: {
       params.relativeParentPath,
       params.basename,
       params.mkdir ? "1" : "0",
-      (params.mode || 0o600).toString(8),
+      (params.mode ?? 0o600).toString(8),
     ],
     {
       stdio: ["pipe", "pipe", "pipe"],

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -601,6 +601,8 @@ export async function writeFileWithinRoot(params: {
   data: string | Buffer;
   encoding?: BufferEncoding;
   mkdir?: boolean;
+  /** Default mode for newly created files. Defaults to 0o600. */
+  mode?: number;
 }): Promise<void> {
   if (process.platform === "win32") {
     await writeFileWithinRootLegacy(params);
@@ -610,6 +612,7 @@ export async function writeFileWithinRoot(params: {
   const pinned = await resolvePinnedWriteTargetWithinRoot({
     rootDir: params.rootDir,
     relativePath: params.relativePath,
+    defaultMode: params.mode,
   });
 
   const identity = await runPinnedWriteHelper({
@@ -715,6 +718,7 @@ export async function writeFileFromPathWithinRoot(params: {
 async function resolvePinnedWriteTargetWithinRoot(params: {
   rootDir: string;
   relativePath: string;
+  defaultMode?: number;
 }): Promise<{
   rootReal: string;
   targetPath: string;
@@ -744,7 +748,7 @@ async function resolvePinnedWriteTargetWithinRoot(params: {
   if (!basename || basename === "." || basename === "/") {
     throw new SafeOpenError("invalid-path", "invalid target path");
   }
-  let mode = 0o600;
+  let mode = params.defaultMode ?? 0o600;
   try {
     const opened = await openFileWithinRoot({
       rootDir: params.rootDir,
@@ -771,7 +775,7 @@ async function resolvePinnedWriteTargetWithinRoot(params: {
     relativeParentPath:
       path.posix.dirname(relativePosix) === "." ? "" : path.posix.dirname(relativePosix),
     basename,
-    mode: mode || 0o600,
+    mode: mode ?? params.defaultMode ?? 0o600,
   };
 }
 
@@ -914,11 +918,13 @@ async function writeFileWithinRootLegacy(params: {
   data: string | Buffer;
   encoding?: BufferEncoding;
   mkdir?: boolean;
+  mode?: number;
 }): Promise<void> {
   const target = await openWritableFileWithinRoot({
     rootDir: params.rootDir,
     relativePath: params.relativePath,
     mkdir: params.mkdir,
+    mode: params.mode,
     truncateExisting: false,
   });
   const destinationPath = target.openedRealPath;


### PR DESCRIPTION
## Problem

The Write and Edit tools create new files with mode `0o600` (owner read/write only) by default. This breaks workflows where other processes need to read agent-created files — for example, Syncthing fails to sync files written by an agent to a shared mount with a `permission denied` error on hashing.

## Fix

Add an optional `mode` parameter to `writeFileWithinRoot` and pass it through the internal write pipeline (`resolvePinnedWriteTargetWithinRoot`, `writeFileWithinRootLegacy`). The internal default remains `0o600` — only the user-facing Write/Edit tool call sites explicitly pass `mode: 0o644`.

Changed files:
- `src/infra/fs-safe.ts` — `writeFileWithinRoot` gains optional `mode?`; internal default stays `0o600`
- `src/agents/pi-tools.read.ts` — `createHostWriteOperations` and `createHostEditOperations` pass `mode: 0o644`

## Security

All sensitive internal write paths (session-memory, QMD, device auth, secrets) are **unaffected** — they call `writeFileWithinRoot` without a `mode` parameter and continue to receive the `0o600` default.

Only user-facing Write/Edit tool calls are updated to `0o644`, matching typical umask expectations for user-created documents.

## How to Test

Create a new file via the Write tool and verify `ls -la` shows `-rw-r--r--` instead of `-rw-------`.