### PR TITLE
cron: avoid legacy payload kind false positives

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -75,4 +75,43 @@ describe("normalizeStoredCronJobs", () => {
       channel: "slack",
     });
   });
+
+  it("does not flag already canonical payload kinds as legacy", () => {
+    const jobs = [
+      {
+        id: "canonical-agentturn",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: {
+          kind: "agentTurn",
+          message: "ping",
+        },
+        state: {},
+      },
+      {
+        id: "canonical-systemevent",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: {
+          kind: "systemEvent",
+          text: "tick",
+        },
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+    expect(jobs[0]?.payload).toMatchObject({
+      kind: "agentTurn",
+      message: "ping",
+    });
+    expect(jobs[1]?.payload).toMatchObject({
+      kind: "systemEvent",
+      text: "tick",
+    });
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,14 +28,21 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
+  const original = typeof payload.kind === "string" ? payload.kind : "";
+  const raw = original.trim().toLowerCase();
   if (raw === "agentturn") {
-    payload.kind = "agentTurn";
-    return true;
+    if (payload.kind !== "agentTurn") {
+      payload.kind = "agentTurn";
+      return true;
+    }
+    return false;
   }
   if (raw === "systemevent") {
-    payload.kind = "systemEvent";
-    return true;
+    if (payload.kind !== "systemEvent") {
+      payload.kind = "systemEvent";
+      return true;
+    }
+    return false;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

- stop normalizing already-canonical `agentTurn` / `systemEvent` payload kinds as if they were legacy values
- add regression coverage so doctor/migration only reports real legacy payload kinds

## Why

`normalizeStoredCronJobs()` lowercases payload kinds before checking them, so canonical `agentTurn` and `systemEvent` values were being treated as migrations even when no rewrite happened. That produced false-positive legacy warnings in doctor output.

This patch keeps the existing normalization behavior for true legacy spellings, while avoiding noise for already-canonical stores.

## Test plan

- `pnpm test src/cron/store-migration.test.ts src/commands/doctor-cron.test.ts`
