### PR TITLE
fix(bluebubbles): tolerate sender-less fromMe webhooks

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -27,6 +27,23 @@ describe("normalizeWebhookMessage", () => {
     expect(result?.chatGuid).toBe("iMessage;-;+15551234567");
   });
 
+  it('falls back to "me" when fromMe webhook sender handle and chatGuid handle are missing', () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-self-1",
+        text: "hello",
+        isGroup: false,
+        isFromMe: true,
+        handle: null,
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.senderId).toBe("me");
+    expect(result?.senderIdExplicit).toBe(false);
+  });
+
   it("marks explicit sender handles as explicit identity", () => {
     const result = normalizeWebhookMessage({
       type: "new-message",
@@ -95,6 +112,25 @@ describe("normalizeWebhookReaction", () => {
     expect(result?.senderId).toBe("+15551234567");
     expect(result?.senderIdExplicit).toBe(false);
     expect(result?.messageId).toBe("p:0/msg-1");
+    expect(result?.action).toBe("added");
+  });
+
+  it('falls back to "me" when fromMe reaction sender handle and chatGuid handle are missing', () => {
+    const result = normalizeWebhookReaction({
+      type: "updated-message",
+      data: {
+        guid: "msg-self-2",
+        associatedMessageGuid: "p:0/msg-1",
+        associatedMessageType: 2000,
+        isGroup: false,
+        isFromMe: true,
+        handle: null,
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.senderId).toBe("me");
+    expect(result?.senderIdExplicit).toBe(false);
     expect(result?.action).toBe("added");
   });
 });

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -733,7 +733,9 @@ export function normalizeWebhookMessage(
   // BlueBubbles may omit `handle` in webhook payloads; for DM chat GUIDs we can still infer sender.
   const senderFallbackFromChatGuid =
     !senderIdExplicit && !isGroup && chatGuid ? extractHandleFromChatGuid(chatGuid) : null;
-  const normalizedSender = normalizeBlueBubblesHandle(senderId || senderFallbackFromChatGuid || "");
+  const normalizedSender = normalizeBlueBubblesHandle(
+    senderId || senderFallbackFromChatGuid || (fromMe ? "me" : ""),
+  );
   if (!normalizedSender) {
     return null;
   }
@@ -810,7 +812,9 @@ export function normalizeWebhookReaction(
 
   const senderFallbackFromChatGuid =
     !senderIdExplicit && !isGroup && chatGuid ? extractHandleFromChatGuid(chatGuid) : null;
-  const normalizedSender = normalizeBlueBubblesHandle(senderId || senderFallbackFromChatGuid || "");
+  const normalizedSender = normalizeBlueBubblesHandle(
+    senderId || senderFallbackFromChatGuid || (fromMe ? "me" : ""),
+  );
   if (!normalizedSender) {
     return null;
   }


### PR DESCRIPTION
## Summary

- tolerate sender-less `fromMe` BlueBubbles webhook payloads during normalization
- fall back to `me` when BlueBubbles omits the sender handle on self-originated callbacks
- add regression coverage for both message and reaction payloads

## Why

BlueBubbles sometimes emits `fromMe` webhook payloads without a sender handle. The previous normalization path rejected those payloads early, even though they represent the current user and should survive long enough to reach the existing `fromMe` handling path.

This change keeps the fallback narrow: it only applies when the payload is already marked `fromMe` and no sender handle can be recovered.

## Test plan

- `pnpm test extensions/bluebubbles/src/monitor-normalize.test.ts extensions/bluebubbles/src/monitor.test.ts -t 'from-me|fromMe|sender-less'`
