### PR TITLE
MSTeams: save first DM conversation refs

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -152,4 +152,113 @@ describe("msteams monitor handler authz", () => {
 
     expect(conversationStore.upsert).not.toHaveBeenCalled();
   });
+
+  it("persists the first DM conversation reference before pairing returns", async () => {
+    const upsertPairingRequest = vi.fn(async () => ({ code: "pair-123" }));
+    setMSTeamsRuntime({
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        debounce: {
+          resolveInboundDebounceMs: () => 0,
+          createInboundDebouncer: <T>(params: {
+            onFlush: (entries: T[]) => Promise<void>;
+          }): { enqueue: (entry: T) => Promise<void> } => ({
+            enqueue: async (entry: T) => {
+              await params.onFlush([entry]);
+            },
+          }),
+        },
+        pairing: {
+          readAllowFromStore: vi.fn(async () => []),
+          upsertPairingRequest,
+        },
+        text: {
+          hasControlCommand: () => false,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const conversationStore = {
+      upsert: vi.fn(async () => undefined),
+    };
+    const deps: MSTeamsMessageHandlerDeps = {
+      cfg: {
+        channels: {
+          msteams: {
+            dmPolicy: "pairing",
+            allowFrom: [],
+          },
+        },
+      } as OpenClawConfig,
+      runtime: { error: vi.fn() } as unknown as RuntimeEnv,
+      appId: "test-app",
+      adapter: {} as MSTeamsMessageHandlerDeps["adapter"],
+      tokenProvider: {
+        getAccessToken: vi.fn(async () => "token"),
+      },
+      textLimit: 4000,
+      mediaMaxBytes: 1024 * 1024,
+      conversationStore:
+        conversationStore as unknown as MSTeamsMessageHandlerDeps["conversationStore"],
+      pollStore: {
+        recordVote: vi.fn(async () => null),
+      } as unknown as MSTeamsMessageHandlerDeps["pollStore"],
+      log: {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+      } as unknown as MSTeamsMessageHandlerDeps["log"],
+    };
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "msg-dm-1",
+        type: "message",
+        text: "hello",
+        from: {
+          id: "user-id",
+          aadObjectId: "user-aad",
+          name: "Requester",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "a:dm@thread.tacv2",
+          conversationType: "personal",
+          tenantId: "tenant-1",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.test",
+        locale: "en-US",
+        channelData: {},
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    expect(upsertPairingRequest).toHaveBeenCalledWith({
+      channel: "msteams",
+      accountId: "default",
+      id: "user-aad",
+      meta: { name: "Requester" },
+    });
+    expect(conversationStore.upsert).toHaveBeenCalledWith("a:dm@thread.tacv2", {
+      activityId: "msg-dm-1",
+      user: { id: "user-id", name: "Requester", aadObjectId: "user-aad" },
+      agent: { id: "bot-id", name: "Bot" },
+      bot: { id: "bot-id", name: "Bot" },
+      conversation: {
+        id: "a:dm@thread.tacv2",
+        conversationType: "personal",
+        tenantId: "tenant-1",
+      },
+      teamId: undefined,
+      channelId: "msteams",
+      serviceUrl: "https://service.example.test",
+      locale: "en-US",
+    });
+  });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -197,12 +197,37 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         }).allowed,
     });
     const effectiveDmAllowFrom = access.effectiveAllowFrom;
+    const agent = activity.recipient;
+    const conversationRef: StoredConversationReference = {
+      activityId: activity.id,
+      user: { id: from.id, name: from.name, aadObjectId: from.aadObjectId },
+      agent,
+      bot: agent ? { id: agent.id, name: agent.name } : undefined,
+      conversation: {
+        id: conversationId,
+        conversationType,
+        tenantId: conversation?.tenantId,
+      },
+      teamId,
+      channelId: activity.channelId,
+      serviceUrl: activity.serviceUrl,
+      locale: activity.locale,
+    };
+    const saveConversationRef = () =>
+      conversationStore.upsert(conversationId, conversationRef).catch((err) => {
+        log.debug?.("failed to save conversation reference", {
+          error: formatUnknownError(err),
+        });
+      });
 
     if (isDirectMessage && msteamsCfg && access.decision !== "allow") {
       if (access.reason === "dmPolicy=disabled") {
         log.debug?.("dropping dm (dms disabled)");
         return;
       }
+      // Persist the first DM conversation reference before pairing returns so
+      // approve --notify can proactively message the requester.
+      saveConversationRef();
       const allowMatch = resolveMSTeamsAllowlistMatch({
         allowFrom: effectiveDmAllowFrom,
         senderId,
@@ -317,28 +342,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       return;
     }
 
-    // Build conversation reference for proactive replies.
-    const agent = activity.recipient;
-    const conversationRef: StoredConversationReference = {
-      activityId: activity.id,
-      user: { id: from.id, name: from.name, aadObjectId: from.aadObjectId },
-      agent,
-      bot: agent ? { id: agent.id, name: agent.name } : undefined,
-      conversation: {
-        id: conversationId,
-        conversationType,
-        tenantId: conversation?.tenantId,
-      },
-      teamId,
-      channelId: activity.channelId,
-      serviceUrl: activity.serviceUrl,
-      locale: activity.locale,
-    };
-    conversationStore.upsert(conversationId, conversationRef).catch((err) => {
-      log.debug?.("failed to save conversation reference", {
-        error: formatUnknownError(err),
-      });
-    });
+    saveConversationRef();
 
     const pollVote = extractMSTeamsPollVote(activity);
     if (pollVote) {


### PR DESCRIPTION
Closes #43323.

## Summary
- save the Teams conversation reference before the DM pairing path returns early
- keep the existing group authz behavior unchanged by only doing the early save for direct messages
- add a regression test that covers the first unauthorized DM pairing flow

## Testing
- pnpm test extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
- pnpm test extensions/msteams/src/send.test.ts
- pnpm test extensions/msteams/src/monitor.test.ts
- pnpm exec oxfmt --check extensions/msteams/src/monitor-handler/message-handler.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
- pnpm build
