### PR TITLE
Exec approvals: canonicalize basename allow-always

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -75,6 +75,41 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(patterns).toEqual([exe]);
   });
 
+  it("re-resolves unresolved bare basenames against the host PATH", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const jq = makeExecutable(dir, "jq");
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ""}`;
+    try {
+      const patterns = resolveAllowAlwaysPatterns({
+        segments: [
+          {
+            raw: "jq -r .",
+            argv: ["jq", "-r", "."],
+            resolution: {
+              rawExecutable: "jq",
+              resolvedPath: undefined,
+              executableName: "jq",
+            },
+          },
+        ],
+        cwd: dir,
+        env: { PATH: "" },
+        platform: process.platform,
+      });
+      expect(patterns).toEqual([jq]);
+    } finally {
+      if (oldPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = oldPath;
+      }
+    }
+  });
+
   it("unwraps shell wrappers and persists the inner executable instead", () => {
     if (process.platform === "win32") {
       return;

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -195,6 +195,37 @@ function isSkillAutoAllowedSegment(params: {
   return Boolean(params.skillBinTrust.get(executableName)?.has(resolvedPath));
 }
 
+function resolveAllowAlwaysCandidatePath(params: {
+  segment: ExecCommandSegment;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}): string | undefined {
+  const candidatePath = resolveAllowlistCandidatePath(params.segment.resolution, params.cwd);
+  if (candidatePath) {
+    return candidatePath;
+  }
+
+  const effectiveArgv =
+    params.segment.resolution?.effectiveArgv && params.segment.resolution.effectiveArgv.length > 0
+      ? params.segment.resolution.effectiveArgv
+      : params.segment.argv;
+  const rawExecutable = effectiveArgv[0]?.trim();
+  if (!rawExecutable || isPathScopedExecutableToken(rawExecutable)) {
+    return undefined;
+  }
+
+  // Re-resolve bare basenames against the exec host's ambient PATH so
+  // "Always Allow" persists the same canonical binary users expect from `which`.
+  const hostResolution = resolveCommandResolutionFromArgv(effectiveArgv, params.cwd, {
+    ...params.env,
+    ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+    ...(process.env.Path ? { Path: process.env.Path } : {}),
+    ...(process.env.PATHEXT ? { PATHEXT: process.env.PATHEXT } : {}),
+    ...(process.env.Pathext ? { Pathext: process.env.Pathext } : {}),
+  });
+  return resolveAllowlistCandidatePath(hostResolution, params.cwd);
+}
+
 function evaluateSegments(
   segments: ExecCommandSegment[],
   params: ExecAllowlistContext,
@@ -459,7 +490,11 @@ function collectAllowAlwaysPatterns(params: {
     return;
   }
 
-  const candidatePath = resolveAllowlistCandidatePath(params.segment.resolution, params.cwd);
+  const candidatePath = resolveAllowAlwaysCandidatePath({
+    segment: params.segment,
+    cwd: params.cwd,
+    env: params.env,
+  });
   if (!candidatePath) {
     return;
   }


### PR DESCRIPTION
Closes #43988.

## Summary
- re-resolve unresolved bare executables against the exec host PATH when deriving allow-always patterns
- keep persisted entries concrete by storing the canonical executable path instead of the raw basename
- add a regression test for basename approvals that arrive without a resolved path

## Testing
- pnpm test src/infra/exec-approvals-allow-always.test.ts
- pnpm test src/infra/exec-approvals-config.test.ts
- pnpm exec oxfmt --check src/infra/exec-approvals-allowlist.ts src/infra/exec-approvals-allow-always.test.ts
- pnpm build
