### PR TITLE
Status: ignore stale context snapshots

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -91,6 +91,29 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Queue: collect");
   });
 
+  it("shows unknown context usage when the stored total token snapshot is stale", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 200_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        inputTokens: 1_200,
+        outputTokens: 800,
+        totalTokens: 0,
+        totalTokensFresh: false,
+        contextTokens: 200_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).toContain("Context: ?/200k");
+  });
+
   it("falls back to sessionEntry levels when resolved levels are not passed", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -15,6 +15,7 @@ import { isCommandFlagEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveMainSessionKey,
+  resolveFreshSessionTotalTokens,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   type SessionEntry,
@@ -459,7 +460,8 @@ export function buildStatusMessage(args: StatusArgs): string {
   let outputTokens = entry?.outputTokens;
   let cacheRead = entry?.cacheRead;
   let cacheWrite = entry?.cacheWrite;
-  let totalTokens = entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
+  // Only show stored context usage when the snapshot is marked fresh.
+  let totalTokens = resolveFreshSessionTotalTokens(entry);
 
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).


### PR DESCRIPTION
## Summary
- ignore stale `sessionEntry.totalTokens` snapshots in `buildStatusMessage()`
- keep using transcript-derived usage when `includeTranscriptUsage` can recover a fresher prompt-size snapshot
- add a regression test for stale `totalTokensFresh=false` entries so `session_status` reports unknown context usage instead of `0/...`

## Testing
- pnpm test src/auto-reply/status.test.ts
- pnpm exec oxfmt --check src/auto-reply/status.ts src/auto-reply/status.test.ts
- pnpm build

Closes #43987
