### PR TITLE
fix(telegram): normalize MEDIA directives in reply delivery

### DIFF
--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -17,18 +17,14 @@ export function parseReplyDirectives(
   raw: string,
   options: { currentMessageId?: string; silentToken?: string } = {},
 ): ReplyDirectiveParseResult {
-  const split = splitMediaFromOutput(raw);
-  let text = split.text ?? "";
-
-  const replyParsed = parseInlineDirectives(text, {
+  const replyParsed = parseInlineDirectives(raw, {
     currentMessageId: options.currentMessageId,
     stripAudioTag: false,
     stripReplyTags: true,
   });
 
-  if (replyParsed.hasReplyTag) {
-    text = replyParsed.text;
-  }
+  const split = splitMediaFromOutput(replyParsed.text);
+  let text = split.text ?? "";
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent = isSilentReplyText(text, silentToken);

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -42,13 +42,16 @@ function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | unde
 
 export function normalizeReplyPayloadsForDelivery(
   payloads: readonly ReplyPayload[],
+  options: { currentMessageId?: string } = {},
 ): ReplyPayload[] {
   const normalized: ReplyPayload[] = [];
   for (const payload of payloads) {
     if (shouldSuppressReasoningPayload(payload)) {
       continue;
     }
-    const parsed = parseReplyDirectives(payload.text ?? "");
+    const parsed = parseReplyDirectives(payload.text ?? "", {
+      currentMessageId: options.currentMessageId,
+    });
     const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
     const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;
     const mergedMedia = mergeMediaUrls(

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -445,6 +445,7 @@ export const dispatchTelegramMessage = async ({
   };
   const deliveryBaseOptions = {
     chatId: String(chatId),
+    currentMessageId: typeof msg.message_id === "number" ? String(msg.message_id) : undefined,
     accountId: route.accountId,
     sessionKeyForInternalHooks: ctxPayload.SessionKey,
     mirrorIsGroup: isGroup,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -517,6 +517,7 @@ export const registerTelegramNativeCommands = ({
   };
   const buildCommandDeliveryBaseOptions = (params: {
     chatId: string | number;
+    currentMessageId?: string;
     accountId: string;
     sessionKeyForInternalHooks?: string;
     mirrorIsGroup?: boolean;
@@ -527,6 +528,7 @@ export const registerTelegramNativeCommands = ({
     chunkMode: ReturnType<typeof resolveChunkMode>;
   }) => ({
     chatId: String(params.chatId),
+    currentMessageId: params.currentMessageId,
     accountId: params.accountId,
     sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
     mirrorIsGroup: params.mirrorIsGroup,
@@ -672,6 +674,7 @@ export const registerTelegramNativeCommands = ({
             });
           const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
             chatId,
+            currentMessageId: String(msg.message_id),
             accountId: route.accountId,
             sessionKeyForInternalHooks: commandSessionKey,
             mirrorIsGroup: isGroup,
@@ -846,6 +849,7 @@ export const registerTelegramNativeCommands = ({
           const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
           const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
             chatId,
+            currentMessageId: String(msg.message_id),
             accountId: route.accountId,
             sessionKeyForInternalHooks: route.sessionKey,
             mirrorIsGroup: isGroup,

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -13,6 +13,7 @@ import {
   toPluginMessageSentEvent,
 } from "../../hooks/message-hook-mappers.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { normalizeReplyPayloadsForDelivery } from "../../infra/outbound/payloads.js";
 import { buildOutboundMediaLoadOptions } from "../../media/load-options.js";
 import { isGifMedia, kindFromMime } from "../../media/mime.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -558,6 +558,7 @@ function emitMessageSentHooks(params: {
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
+  currentMessageId?: string;
   chatId: string;
   accountId?: string;
   sessionKeyForInternalHooks?: string;
@@ -592,7 +593,18 @@ export async function deliverReplies(params: {
     chunkMode: params.chunkMode ?? "length",
     tableMode: params.tableMode,
   });
-  for (const originalReply of params.replies) {
+  const validReplies: ReplyPayload[] = [];
+  for (const reply of params.replies) {
+    if (!reply) {
+      params.runtime.error?.(danger("reply is null or undefined"));
+      continue;
+    }
+    validReplies.push(reply);
+  }
+
+  for (const originalReply of normalizeReplyPayloadsForDelivery(validReplies, {
+    currentMessageId: params.currentMessageId,
+  })) {
     let reply = originalReply;
     const mediaList = reply?.mediaUrls?.length
       ? reply.mediaUrls

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -150,6 +150,7 @@ describe("deliverReplies", () => {
     });
 
     expect(runtime.error).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("null or undefined"));
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage.mock.calls[0]?.[1]).toBe("hello");
   });
@@ -314,6 +315,87 @@ describe("deliverReplies", () => {
         }),
       }),
       expect.objectContaining({ channelId: "telegram", conversationId: "123" }),
+    );
+  });
+
+  it("parses inline MEDIA directives in telegram replies and sends photo instead of text", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn();
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 22, chat: { id: "123" } });
+    const bot = createBot({ sendMessage, sendPhoto });
+
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    await deliverWith({
+      replies: [{ text: "Here you go\nMEDIA:./photo.jpg" }],
+      runtime,
+      bot,
+      mediaLocalRoots: ["."],
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendPhoto).toHaveBeenCalledTimes(1);
+    expect(sendPhoto).toHaveBeenCalledWith(
+      "123",
+      expect.anything(),
+      expect.objectContaining({
+        caption: "Here you go",
+        parse_mode: "HTML",
+      }),
+    );
+    expect(loadWebMedia).toHaveBeenCalledWith("./photo.jpg", {
+      localRoots: ["."],
+    });
+  });
+
+  it("parses reply tags from telegram reply text before delivery", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 23, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      replies: [{ text: "[[reply_to:42]] hello" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "all",
+      textLimit: 4000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.stringContaining("hello"),
+      expect.objectContaining({
+        reply_to_message_id: 42,
+      }),
+    );
+  });
+
+  it("resolves [[reply_to_current]] using currentMessageId in telegram delivery", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 24, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      replies: [{ text: "[[reply_to_current]] hello" }],
+      currentMessageId: "77",
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "all",
+      textLimit: 4000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.stringContaining("hello"),
+      expect.objectContaining({
+        reply_to_message_id: 77,
+      }),
     );
   });
 
@@ -564,7 +646,7 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("throws when formatted and plain fallback text are both empty", async () => {
+  it("skips whitespace-only replies after normalization", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn();
     const bot = { api: { sendMessage } } as unknown as Bot;
@@ -579,7 +661,7 @@ describe("deliverReplies", () => {
         replyToMode: "off",
         textLimit: 4000,
       }),
-    ).rejects.toThrow("empty formatted text and empty plain fallback");
+    ).resolves.toEqual({ delivered: false });
     expect(sendMessage).not.toHaveBeenCalled();
   });
 

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -399,6 +399,36 @@ describe("deliverReplies", () => {
     );
   });
 
+  it("parses reply tags before MEDIA directives on the same line", async () => {
+    const runtime = createRuntime(false);
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 25, chat: { id: "123" } });
+    const sendMessage = vi.fn();
+    const bot = createBot({ sendPhoto, sendMessage });
+
+    mockMediaLoad("./photo.jpg", "image/jpeg", "photo-bytes");
+
+    await deliverReplies({
+      replies: [{ text: "[[reply_to:42]] MEDIA:./photo.jpg" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "all",
+      textLimit: 4000,
+      mediaLocalRoots: ["."],
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendPhoto).toHaveBeenCalledTimes(1);
+    expect(sendPhoto).toHaveBeenCalledWith(
+      "123",
+      expect.anything(),
+      expect.objectContaining({
+        reply_to_message_id: 42,
+      }),
+    );
+  });
+
   it("invokes onVoiceRecording before sending a voice note", async () => {
     const events: string[] = [];
     const runtime = createRuntime(false);


### PR DESCRIPTION
## Summary
This fixes Telegram reply-media delivery for agent-generated replies that include inline `MEDIA:` directives.

## What was broken
There were two related gaps:

1. `src/telegram/bot/delivery.replies.ts` iterated raw `ReplyPayload`s directly, so inline directives embedded in reply text (especially `MEDIA:...`, reply tags, silent/audio tags) were not normalized before Telegram delivery.
2. `parseReplyDirectives()` extracted media before stripping `[[reply_to_current]]` / `[[reply_to:<id>]]`, so a reply tag on the same logical line could hide a `MEDIA:` token from `splitMediaFromOutput()`.

## Fix
- Run `normalizeReplyPayloadsForDelivery()` in the dedicated Telegram bot reply loop.
- Strip reply tags before media extraction in `parseReplyDirectives()`.

## Result
Telegram replies containing media directives now correctly deliver media instead of falling back to plain `sendMessage`, and reply-tag + media combinations are normalized consistently with the rest of the outbound pipeline.

## Tests
- added/updated Telegram delivery tests for inline `MEDIA:` replies
- covered reply-tag parsing before delivery
- verified reply-directive parsing still passes

### Narrow validation
- `corepack pnpm vitest run src/auto-reply/reply.directive.parse.test.ts src/telegram/bot/delivery.test.ts`
