### PR TITLE
fix(mattermost): carry thread context to non-inbound reply paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Docs: https://docs.openclaw.ai
 - Config/discovery: accept `discovery.wideArea.domain` in strict config validation so unicast DNS-SD gateway configs no longer fail with an unrecognized-key error. (#35615) Thanks @ingyukoh.
 - Telegram/media errors: redact Telegram file URLs before building media fetch errors so failed inbound downloads do not leak bot tokens into logs. Thanks @space08.
 - Agents/failover: normalize abort-wrapped `429 RESOURCE_EXHAUSTED` provider failures before abort short-circuiting so wrapped Google/Vertex rate limits continue across configured fallback models, including the embedded runner prompt-error path. (#39820) Thanks @lupuletic.
+- Mattermost/thread routing: non-inbound reply paths (TUI/WebUI turns, tool-call callbacks, subagent responses) now correctly route to the originating Mattermost thread when `replyToMode: "all"` is active; also prevents stale `origin.threadId` metadata from resurrecting cleared thread routes. (#44283) thanks @teconomix
 
 ## 2026.3.12
 

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -355,6 +355,29 @@ describe("mattermostPlugin", () => {
         }),
       );
     });
+
+    it("uses threadId as fallback when replyToId is absent", async () => {
+      const sendText = mattermostPlugin.outbound?.sendText;
+      if (!sendText) {
+        return;
+      }
+
+      await sendText({
+        to: "channel:CHAN1",
+        text: "hello",
+        accountId: "default",
+        threadId: "post-root",
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({
+          accountId: "default",
+          replyToId: "post-root",
+        }),
+      );
+    });
   });
 
   describe("config", () => {

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -356,7 +356,7 @@ describe("mattermostPlugin", () => {
       );
     });
 
-    it("uses threadId as fallback when replyToId is absent", async () => {
+    it("uses threadId as fallback when replyToId is absent (sendText)", async () => {
       const sendText = mattermostPlugin.outbound?.sendText;
       if (!sendText) {
         return;
@@ -372,6 +372,30 @@ describe("mattermostPlugin", () => {
       expect(sendMessageMattermostMock).toHaveBeenCalledWith(
         "channel:CHAN1",
         "hello",
+        expect.objectContaining({
+          accountId: "default",
+          replyToId: "post-root",
+        }),
+      );
+    });
+
+    it("uses threadId as fallback when replyToId is absent (sendMedia)", async () => {
+      const sendMedia = mattermostPlugin.outbound?.sendMedia;
+      if (!sendMedia) {
+        return;
+      }
+
+      await sendMedia({
+        to: "channel:CHAN1",
+        text: "caption",
+        mediaUrl: "https://example.com/image.png",
+        accountId: "default",
+        threadId: "post-root",
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "caption",
         expect.objectContaining({
           accountId: "default",
           replyToId: "post-root",

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -390,21 +390,30 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       }
       return { ok: true, to: trimmed };
     },
-    sendText: async ({ cfg, to, text, accountId, replyToId }) => {
+    sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
       const result = await sendMessageMattermost(to, text, {
         cfg,
         accountId: accountId ?? undefined,
-        replyToId: replyToId ?? undefined,
+        replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, replyToId }) => {
+    sendMedia: async ({
+      cfg,
+      to,
+      text,
+      mediaUrl,
+      mediaLocalRoots,
+      accountId,
+      replyToId,
+      threadId,
+    }) => {
       const result = await sendMessageMattermost(to, text, {
         cfg,
         accountId: accountId ?? undefined,
         mediaUrl,
         mediaLocalRoots,
-        replyToId: replyToId ?? undefined,
+        replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
       });
       return { channel: "mattermost", ...result };
     },

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -41,6 +41,12 @@ const acpMocks = vi.hoisted(() => ({
 const sessionBindingMocks = vi.hoisted(() => ({
   listBySession: vi.fn<(targetSessionKey: string) => SessionBindingRecord[]>(() => []),
 }));
+const sessionStoreMocks = vi.hoisted(() => ({
+  currentEntry: undefined as Record<string, unknown> | undefined,
+  loadSessionStore: vi.fn(() => ({})),
+  resolveStorePath: vi.fn(() => "/tmp/mock-sessions.json"),
+  resolveSessionStoreEntry: vi.fn(() => ({ existing: sessionStoreMocks.currentEntry })),
+}));
 const ttsMocks = vi.hoisted(() => {
   const state = {
     synthesizeFinalAudio: false,
@@ -77,9 +83,16 @@ vi.mock("./route-reply.js", () => ({
   isRoutableChannel: (channel: string | undefined) =>
     Boolean(
       channel &&
-      ["telegram", "slack", "discord", "signal", "imessage", "whatsapp", "feishu"].includes(
-        channel,
-      ),
+      [
+        "telegram",
+        "slack",
+        "discord",
+        "signal",
+        "imessage",
+        "whatsapp",
+        "feishu",
+        "mattermost",
+      ].includes(channel),
     ),
   routeReply: mocks.routeReply,
 }));
@@ -99,6 +112,11 @@ vi.mock("../../logging/diagnostic.js", () => ({
   logMessageQueued: diagnosticMocks.logMessageQueued,
   logMessageProcessed: diagnosticMocks.logMessageProcessed,
   logSessionStateChange: diagnosticMocks.logSessionStateChange,
+}));
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: sessionStoreMocks.loadSessionStore,
+  resolveStorePath: sessionStoreMocks.resolveStorePath,
+  resolveSessionStoreEntry: sessionStoreMocks.resolveSessionStoreEntry,
 }));
 
 vi.mock("../../plugins/hook-runner-global.js", () => ({
@@ -228,6 +246,10 @@ describe("dispatchReplyFromConfig", () => {
     acpMocks.requireAcpRuntimeBackend.mockReset();
     sessionBindingMocks.listBySession.mockReset();
     sessionBindingMocks.listBySession.mockReturnValue([]);
+    sessionStoreMocks.currentEntry = undefined;
+    sessionStoreMocks.loadSessionStore.mockClear();
+    sessionStoreMocks.resolveStorePath.mockClear();
+    sessionStoreMocks.resolveSessionStoreEntry.mockClear();
     ttsMocks.state.synthesizeFinalAudio = false;
     ttsMocks.maybeApplyTtsToPayload.mockClear();
     ttsMocks.normalizeTtsAutoMode.mockClear();
@@ -289,6 +311,43 @@ describe("dispatchReplyFromConfig", () => {
         threadId: 123,
         isGroup: true,
         groupId: "telegram:999",
+      }),
+    );
+  });
+
+  it("falls back to session deliveryContext threadId when current ctx has no MessageThreadId", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    sessionStoreMocks.currentEntry = {
+      deliveryContext: {
+        channel: "mattermost",
+        to: "channel:CHAN1",
+        accountId: "default",
+        threadId: "post-root",
+      },
+      lastThreadId: "post-root",
+    };
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "webchat",
+      Surface: "webchat",
+      SessionKey: "agent:main:mattermost:channel:CHAN1:thread:post-root",
+      AccountId: "default",
+      MessageThreadId: undefined,
+      OriginatingChannel: "mattermost",
+      OriginatingTo: "channel:CHAN1",
+      ExplicitDeliverRoute: true,
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "mattermost",
+        to: "channel:CHAN1",
+        threadId: "post-root",
       }),
     );
   });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -113,11 +113,15 @@ vi.mock("../../logging/diagnostic.js", () => ({
   logMessageProcessed: diagnosticMocks.logMessageProcessed,
   logSessionStateChange: diagnosticMocks.logSessionStateChange,
 }));
-vi.mock("../../config/sessions.js", () => ({
-  loadSessionStore: sessionStoreMocks.loadSessionStore,
-  resolveStorePath: sessionStoreMocks.resolveStorePath,
-  resolveSessionStoreEntry: sessionStoreMocks.resolveSessionStoreEntry,
-}));
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    loadSessionStore: sessionStoreMocks.loadSessionStore,
+    resolveStorePath: sessionStoreMocks.resolveStorePath,
+    resolveSessionStoreEntry: sessionStoreMocks.resolveSessionStoreEntry,
+  };
+});
 
 vi.mock("../../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: () => hookMocks.runner,
@@ -315,7 +319,7 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
-  it("falls back to session deliveryContext threadId when current ctx has no MessageThreadId", async () => {
+  it("falls back to thread-scoped session key when current ctx has no MessageThreadId", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();
     sessionStoreMocks.currentEntry = {
@@ -323,9 +327,11 @@ describe("dispatchReplyFromConfig", () => {
         channel: "mattermost",
         to: "channel:CHAN1",
         accountId: "default",
-        threadId: "post-root",
       },
-      lastThreadId: "post-root",
+      origin: {
+        threadId: "stale-origin-root",
+      },
+      lastThreadId: "stale-origin-root",
     };
     const cfg = emptyConfig;
     const dispatcher = createDispatcher();
@@ -355,17 +361,16 @@ describe("dispatchReplyFromConfig", () => {
   it("does not resurrect a cleared route thread from origin metadata", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();
-    // Simulate the real store: lastThreadId is normalised from origin.threadId when
-    // deliveryContext.threadId is absent. Using lastThreadId as a fallback would
-    // incorrectly revive stale thread routing.
+    // Simulate the real store: lastThreadId and deliveryContext.threadId may be normalised from
+    // origin.threadId on read, but a non-thread session key must still route to channel root.
     sessionStoreMocks.currentEntry = {
       deliveryContext: {
         channel: "mattermost",
         to: "channel:CHAN1",
         accountId: "default",
-        // threadId deliberately absent — the route was cleared
+        threadId: "stale-root",
       },
-      lastThreadId: "stale-root", // normalised from origin.threadId by loadSessionStore
+      lastThreadId: "stale-root",
       origin: {
         threadId: "stale-root",
       },

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -355,12 +355,17 @@ describe("dispatchReplyFromConfig", () => {
   it("does not resurrect a cleared route thread from origin metadata", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();
+    // Simulate the real store: lastThreadId is normalised from origin.threadId when
+    // deliveryContext.threadId is absent. Using lastThreadId as a fallback would
+    // incorrectly revive stale thread routing.
     sessionStoreMocks.currentEntry = {
       deliveryContext: {
         channel: "mattermost",
         to: "channel:CHAN1",
         accountId: "default",
+        // threadId deliberately absent — the route was cleared
       },
+      lastThreadId: "stale-root", // normalised from origin.threadId by loadSessionStore
       origin: {
         threadId: "stale-root",
       },

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -352,6 +352,45 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("does not resurrect a cleared route thread from origin metadata", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    sessionStoreMocks.currentEntry = {
+      deliveryContext: {
+        channel: "mattermost",
+        to: "channel:CHAN1",
+        accountId: "default",
+      },
+      origin: {
+        threadId: "stale-root",
+      },
+    };
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "webchat",
+      Surface: "webchat",
+      SessionKey: "agent:main:mattermost:channel:CHAN1",
+      AccountId: "default",
+      MessageThreadId: undefined,
+      OriginatingChannel: "mattermost",
+      OriginatingTo: "channel:CHAN1",
+      ExplicitDeliverRoute: true,
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    const routeCall = mocks.routeReply.mock.calls[0]?.[0] as
+      | { channel?: string; to?: string; threadId?: string | number }
+      | undefined;
+    expect(routeCall).toMatchObject({
+      channel: "mattermost",
+      to: "channel:CHAN1",
+    });
+    expect(routeCall?.threadId).toBeUndefined();
+  });
+
   it("forces suppressTyping when routing to a different originating channel", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -25,6 +25,7 @@ import {
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
+import { deliveryContextFromSession } from "../../utils/delivery-context.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
@@ -172,6 +173,8 @@ export async function dispatchReplyFromConfig(params: {
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
+  const routeThreadId =
+    ctx.MessageThreadId ?? deliveryContextFromSession(sessionStoreEntry.entry)?.threadId;
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();
@@ -260,7 +263,7 @@ export async function dispatchReplyFromConfig(params: {
       to: originatingTo,
       sessionKey: ctx.SessionKey,
       accountId: ctx.AccountId,
-      threadId: ctx.MessageThreadId,
+      threadId: routeThreadId,
       cfg,
       abortSignal,
       mirror,
@@ -289,7 +292,7 @@ export async function dispatchReplyFromConfig(params: {
           to: originatingTo,
           sessionKey: ctx.SessionKey,
           accountId: ctx.AccountId,
-          threadId: ctx.MessageThreadId,
+          threadId: routeThreadId,
           cfg,
           isGroup,
           groupId,
@@ -519,7 +522,7 @@ export async function dispatchReplyFromConfig(params: {
           to: originatingTo,
           sessionKey: ctx.SessionKey,
           accountId: ctx.AccountId,
-          threadId: ctx.MessageThreadId,
+          threadId: routeThreadId,
           cfg,
           isGroup,
           groupId,
@@ -571,7 +574,7 @@ export async function dispatchReplyFromConfig(params: {
               to: originatingTo,
               sessionKey: ctx.SessionKey,
               accountId: ctx.AccountId,
-              threadId: ctx.MessageThreadId,
+              threadId: routeThreadId,
               cfg,
               isGroup,
               groupId,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2,6 +2,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   loadSessionStore,
+  parseSessionThreadInfo,
   resolveSessionStoreEntry,
   resolveStorePath,
   type SessionEntry,
@@ -172,10 +173,12 @@ export async function dispatchReplyFromConfig(params: {
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
-  // Only use the active delivery context's threadId. `lastThreadId` is not safe here because
-  // `loadSessionStore` normalises it from `origin.threadId`, which can outlive an intentionally
-  // cleared delivery route and would resurrect stale thread routing.
-  const routeThreadId = ctx.MessageThreadId ?? sessionStoreEntry.entry?.deliveryContext?.threadId;
+  // Restore route thread context only from the active turn or the thread-scoped session key.
+  // Do not read thread ids from the normalised session store here: `origin.threadId` can be
+  // folded back into lastThreadId/deliveryContext during store normalisation and resurrect a
+  // stale route after thread delivery was intentionally cleared.
+  const routeThreadId =
+    ctx.MessageThreadId ?? parseSessionThreadInfo(acpDispatchSessionKey).threadId;
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -25,7 +25,6 @@ import {
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
-import { deliveryContextFromSession } from "../../utils/delivery-context.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
@@ -173,8 +172,10 @@ export async function dispatchReplyFromConfig(params: {
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
-  const routeThreadId =
-    ctx.MessageThreadId ?? deliveryContextFromSession(sessionStoreEntry.entry)?.threadId;
+  // Preserve cleared route threads; `origin.threadId` can outlive the active delivery route.
+  const persistedRouteThreadId =
+    sessionStoreEntry.entry?.deliveryContext?.threadId ?? sessionStoreEntry.entry?.lastThreadId;
+  const routeThreadId = ctx.MessageThreadId ?? persistedRouteThreadId;
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -172,10 +172,10 @@ export async function dispatchReplyFromConfig(params: {
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
-  // Preserve cleared route threads; `origin.threadId` can outlive the active delivery route.
-  const persistedRouteThreadId =
-    sessionStoreEntry.entry?.deliveryContext?.threadId ?? sessionStoreEntry.entry?.lastThreadId;
-  const routeThreadId = ctx.MessageThreadId ?? persistedRouteThreadId;
+  // Only use the active delivery context's threadId. `lastThreadId` is not safe here because
+  // `loadSessionStore` normalises it from `origin.threadId`, which can outlive an intentionally
+  // cleared delivery route and would resurrect stale thread routing.
+  const routeThreadId = ctx.MessageThreadId ?? sessionStoreEntry.entry?.deliveryContext?.threadId;
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mattermostPlugin } from "../../../extensions/mattermost/src/channel.js";
 import { discordOutbound } from "../../channels/plugins/outbound/discord.js";
 import { imessageOutbound } from "../../channels/plugins/outbound/imessage.js";
 import { signalOutbound } from "../../channels/plugins/outbound/signal.js";
@@ -24,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   sendMessageSlack: vi.fn(async () => ({ messageId: "m1", channelId: "c1" })),
   sendMessageTelegram: vi.fn(async () => ({ messageId: "m1", chatId: "c1" })),
   sendMessageWhatsApp: vi.fn(async () => ({ messageId: "m1", toJid: "jid" })),
+  sendMessageMattermost: vi.fn(async () => ({ messageId: "m1", channelId: "c1" })),
   deliverOutboundPayloads: vi.fn(),
 }));
 
@@ -45,6 +47,9 @@ vi.mock("../../telegram/send.js", () => ({
 vi.mock("../../web/outbound.js", () => ({
   sendMessageWhatsApp: mocks.sendMessageWhatsApp,
   sendPollWhatsApp: mocks.sendMessageWhatsApp,
+}));
+vi.mock("../../../extensions/mattermost/src/mattermost/send.js", () => ({
+  sendMessageMattermost: mocks.sendMessageMattermost,
 }));
 vi.mock("../../infra/outbound/deliver.js", async () => {
   const actual = await vi.importActual<typeof import("../../infra/outbound/deliver.js")>(
@@ -335,6 +340,33 @@ describe("routeReply", () => {
     );
   });
 
+  it("uses threadId as replyToId for Mattermost when replyToId is missing", async () => {
+    mocks.deliverOutboundPayloads.mockResolvedValue([]);
+    await routeReply({
+      payload: { text: "hi" },
+      channel: "mattermost",
+      to: "channel:CHAN1",
+      threadId: "post-root",
+      cfg: {
+        channels: {
+          mattermost: {
+            enabled: true,
+            botToken: "test-token",
+            baseUrl: "https://chat.example.com",
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "mattermost",
+        to: "channel:CHAN1",
+        replyToId: "post-root",
+        threadId: "post-root",
+      }),
+    );
+  });
+
   it("sends multiple mediaUrls (caption only on first)", async () => {
     mocks.sendMessageSlack.mockClear();
     await routeReply({
@@ -499,6 +531,11 @@ const defaultRegistry = createTestRegistry([
     plugin: createMSTeamsPlugin({
       outbound: createMSTeamsOutbound(),
     }),
+    source: "test",
+  },
+  {
+    pluginId: "mattermost",
+    plugin: mattermostPlugin,
     source: "test",
   },
 ]);

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -149,7 +149,9 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
 
   const resolvedReplyToId =
     replyToId ??
-    (channelId === "slack" && threadId != null && threadId !== "" ? String(threadId) : undefined);
+    ((channelId === "slack" || channelId === "mattermost") && threadId != null && threadId !== ""
+      ? String(threadId)
+      : undefined);
   const resolvedThreadId = channelId === "slack" ? null : (threadId ?? null);
 
   try {

--- a/src/signal/monitor.tool-result.test-harness.ts
+++ b/src/signal/monitor.tool-result.test-harness.ts
@@ -91,12 +91,16 @@ vi.mock("../pairing/pairing-store.js", () => ({
   upsertChannelPairingRequest: (...args: unknown[]) => upsertPairingRequestMock(...args),
 }));
 
-vi.mock("../config/sessions.js", () => ({
-  resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
-  updateLastRoute: (...args: unknown[]) => updateLastRouteMock(...args),
-  readSessionUpdatedAt: vi.fn(() => undefined),
-  recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions.js")>();
+  return {
+    ...actual,
+    resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
+    updateLastRoute: (...args: unknown[]) => updateLastRouteMock(...args),
+    readSessionUpdatedAt: vi.fn(() => undefined),
+    recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 vi.mock("./client.js", () => ({
   streamSignalEvents: (...args: unknown[]) => streamMock(...args),

--- a/src/slack/monitor.test-helpers.ts
+++ b/src/slack/monitor.test-helpers.ts
@@ -180,13 +180,17 @@ vi.mock("../pairing/pairing-store.js", () => ({
     slackTestState.upsertPairingRequestMock(...args),
 }));
 
-vi.mock("../config/sessions.js", () => ({
-  resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
-  updateLastRoute: (...args: unknown[]) => slackTestState.updateLastRouteMock(...args),
-  resolveSessionKey: vi.fn(),
-  readSessionUpdatedAt: vi.fn(() => undefined),
-  recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions.js")>();
+  return {
+    ...actual,
+    resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
+    updateLastRoute: (...args: unknown[]) => slackTestState.updateLastRouteMock(...args),
+    resolveSessionKey: vi.fn(),
+    readSessionUpdatedAt: vi.fn(() => undefined),
+    recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 vi.mock("@slack/bolt", () => {
   const handlers = new Map<string, SlackHandler>();


### PR DESCRIPTION
## Problem

When `replyToMode: "all"` is active, replies to Mattermost threads only land in the correct thread when triggered by a **direct inbound Mattermost message**. Any other reply path — TUI/WebUI turns, tool call callbacks, subagent responses, or explicit `message` tool calls — ignores the thread context and posts to the **channel root** instead.

Reported in #39759.

## Root Cause

Three gaps in the outbound routing path for non-inbound-triggered deliveries:

**Gap 1 — `dispatch-from-config.ts`:**
`sendPayloadAsync` passed `ctx.MessageThreadId` to `routeReply`. For TUI/WebUI turns the current context is a webchat surface, so `ctx.MessageThreadId` is `undefined`. The session entry's `deliveryContext.threadId` (set when the session was originally created from an inbound Mattermost message) was never consulted.

**Gap 2 — `route-reply.ts`:**
The threadId→replyToId fallback was Slack-only:
```ts
replyToId ?? (channelId === "slack" ? String(threadId) : undefined)
```
Mattermost uses the same `root_id` mechanic as Slack's `thread_ts` but was excluded.

**Gap 3 — `extensions/mattermost/src/channel.ts`:**
`sendText`/`sendMedia` destructured only `replyToId`, silently ignoring `threadId` even when it was present in the outbound context.

## Fix

All three gaps addressed in a single change:

1. **`dispatch-from-config.ts`**: fall back to `deliveryContextFromSession(sessionStoreEntry.entry)?.threadId` when `ctx.MessageThreadId` is absent. This uses the session store's persisted delivery context, which already stores the thread root ID from the original inbound message.

2. **`route-reply.ts`**: extend the threadId→replyToId fallback to include Mattermost alongside Slack.

3. **`extensions/mattermost/src/channel.ts`**: accept `threadId` in `sendText`/`sendMedia` and use it as a defense-in-depth fallback when `replyToId` is not set.

## How to test

1. Configure `channels.mattermost.replyToMode: "all"` 
2. Send a message to the bot from a Mattermost channel → bot replies in-thread ✅ (was already working)
3. Send a follow-up from the TUI/WebUI to the same session → reply lands in thread ✅ (was broken)
4. Trigger a long tool call that spawns a subagent → final response lands in thread ✅ (was broken)

## Tests

- Added `route-reply.test.ts`: `uses threadId as replyToId for Mattermost when replyToId is missing`
- Added `dispatch-from-config.test.ts`: `falls back to session deliveryContext threadId when current ctx has no MessageThreadId`
- Added `channel.test.ts`: `uses threadId as fallback when replyToId is absent`
- All 83 affected tests pass; `pnpm check` and `pnpm build` clean locally.
