### PR TITLE
Cron: stop flagging canonical payload kinds

### DIFF
--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -215,6 +215,55 @@ describe("maybeRepairLegacyCronStore", () => {
     );
   });
 
+  it("does not report already canonical payload kinds as legacy", async () => {
+    const storePath = await makeTempStorePath();
+    const createdAtMs = Date.parse("2026-02-01T00:00:00.000Z");
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "canonical-job",
+              name: "Canonical job",
+              createdAtMs,
+              updatedAtMs: createdAtMs,
+              schedule: { kind: "every", everyMs: 60_000, anchorMs: createdAtMs },
+              payload: {
+                kind: "agentTurn",
+                message: "Morning brief",
+              },
+              delivery: { mode: "announce" },
+              sessionTarget: "isolated",
+              state: {},
+              enabled: true,
+              wakeMode: "now",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: {
+          store: storePath,
+        },
+      },
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    expect(noteSpy).not.toHaveBeenCalled();
+  });
+
   it("migrates notify fallback none delivery jobs to cron.webhook", async () => {
     const storePath = await makeTempStorePath();
     await fs.mkdir(path.dirname(storePath), { recursive: true });

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -75,4 +75,47 @@ describe("normalizeStoredCronJobs", () => {
       channel: "slack",
     });
   });
+
+  it("does not flag canonical payload kinds as legacy", () => {
+    const createdAtMs = Date.parse("2026-02-01T00:00:00.000Z");
+    const jobs = [
+      {
+        id: "canonical-agent",
+        name: "Canonical agent",
+        createdAtMs,
+        updatedAtMs: createdAtMs,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: createdAtMs },
+        payload: {
+          kind: "agentTurn",
+          message: "ping",
+        },
+        delivery: { mode: "announce" },
+        sessionTarget: "isolated",
+        state: {},
+        enabled: true,
+        wakeMode: "now",
+      },
+      {
+        id: "canonical-system",
+        name: "Canonical system",
+        createdAtMs,
+        updatedAtMs: createdAtMs,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: createdAtMs },
+        payload: {
+          kind: "systemEvent",
+          text: "pong",
+        },
+        sessionTarget: "main",
+        state: {},
+        enabled: true,
+        wakeMode: "now",
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+    expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn", message: "ping" });
+    expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent", text: "pong" });
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,14 +28,21 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
-    payload.kind = "agentTurn";
-    return true;
+  const raw = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  const normalized = raw.toLowerCase();
+  if (normalized === "agentturn") {
+    if (raw !== "agentTurn") {
+      payload.kind = "agentTurn";
+      return true;
+    }
+    return false;
   }
-  if (raw === "systemevent") {
-    payload.kind = "systemEvent";
-    return true;
+  if (normalized === "systemevent") {
+    if (raw !== "systemEvent") {
+      payload.kind = "systemEvent";
+      return true;
+    }
+    return false;
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- stop counting already-canonical `agentTurn` and `systemEvent` payload kinds as legacy cron payload migrations
- add a store-migration regression test for canonical payload kinds
- add a doctor cron regression test so a normalized store no longer triggers a legacy warning

## Testing
- pnpm test src/cron/store-migration.test.ts src/commands/doctor-cron.test.ts
- pnpm exec oxfmt --check src/cron/store-migration.ts src/cron/store-migration.test.ts src/commands/doctor-cron.test.ts
- pnpm build

Closes #44208
