### PR TITLE
fix: use default Xcode.app instead of non-existent Xcode_26.1.app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,7 +507,7 @@ jobs:
       # --- Xcode/Swift setup ---
       - name: Select Xcode 26.1
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.app
+          sudo xcode-select -s /Applications/Xcode.app
           xcodebuild -version
 
       - name: Install XcodeGen / SwiftLint / SwiftFormat
@@ -567,7 +567,7 @@ jobs:
 
       - name: Select Xcode 26.1
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.app
+          sudo xcode-select -s /Applications/Xcode.app
           xcodebuild -version
 
       - name: Install XcodeGen


### PR DESCRIPTION
GitHub Actions runners don't have versioned Xcode paths like `Xcode_26.1.app`. This PR updates the xcode-select calls to use the default `/Applications/Xcode.app` which all runners have.

Changes:
- Line 510: Xcode_26.1.app → Xcode.app
- Line 570: Xcode_26.1.app → Xcode.app

This fixes CI failures from the 'Select Xcode 26.1' step failing with 'invalid developer directory'.