### PR TITLE
docs: fix README message send flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ openclaw onboard --install-daemon
 openclaw gateway --port 18789 --verbose
 
 # Send a message
-openclaw message send --to +1234567890 --message "Hello from OpenClaw"
+openclaw message send --target +1234567890 --message "Hello from OpenClaw"
 
 # Talk to the assistant (optionally deliver back to any connected channel: WhatsApp/Telegram/Slack/Discord/Google Chat/Signal/iMessage/BlueBubbles/IRC/Microsoft Teams/Matrix/Feishu/LINE/Mattermost/Nextcloud Talk/Nostr/Synology Chat/Tlon/Twitch/Zalo/Zalo Personal/WebChat)
 openclaw agent --message "Ship checklist" --thinking high


### PR DESCRIPTION
## Summary

- Problem: `README.md:75` still used `openclaw message send --to ...`, but the current CLI requires `--target`.
- Why it matters: users who copy the README example hit the required-option error for `-t, --target <dest>`.
- What changed: updated the README example to use `openclaw message send --target +1234567890 --message "Hello from OpenClaw"`.
- What did NOT change (scope boundary): no CLI behavior, parsing, or other docs were changed.

## Change Type (select all)

- [x] Docs
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] UI / DX
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #10458

## User-visible / Behavior Changes

- README now shows the correct `--target` flag for `openclaw message send`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): CLI docs
- Relevant config (redacted): N/A

### Steps

1. Check `README.md:75`.
2. Check current CLI option registration in `src/cli/program/message/helpers.ts`.
3. Update the README example to use `--target`.

### Expected

- README example matches the current CLI flag.

### Actual

- Before this PR, README used deprecated/incorrect `--to`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

CLI registration confirms:
`-t, --target <dest>`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: confirmed `README.md:75` now uses `--target`, and confirmed the current CLI registers `-t, --target <dest>` in `src/cli/program/message/helpers.ts`.
- Edge cases checked: none, this is a single-line docs fix.
- What you did **not** verify: no tests run, since this PR does not change runtime behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `README.md`
- Known bad symptoms reviewers should watch for: none beyond stale docs text.

## Risks and Mitigations

None.
