### PR TITLE
fix(web-ui): filter tool results and security notices from gateway chat

### DIFF
--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -11,10 +11,10 @@ const thinkingCache = new WeakMap<object, string | null>();
  * These are AI-facing context and must never surface in user-visible UI.
  */
 const EXTERNAL_CONTENT_BLOCK_RE =
-  /^SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[\s\S]*?<<<END_EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>\s*/;
+  /SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[\s\S]*?<<<END_EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>\s*/g;
 const EXTERNAL_CONTENT_MARKERS_RE = /<<<(?:END_)?EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>/g;
 const SECURITY_NOTICE_PREFIX_RE =
-  /^SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n- [^\n]+)*/;
+  /SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n- [^\n]+)*/g;
 
 function stripExternalContentMarkers(text: string): string {
   if (!text.includes("EXTERNAL_UNTRUSTED_CONTENT") && !text.includes("SECURITY NOTICE:")) {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -5,14 +5,41 @@ import { stripThinkingTags } from "../format.ts";
 const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
+/**
+ * Strip security notices and external-content boundary markers that are
+ * injected into tool results by the agent framework (wrapExternalContent).
+ * These are AI-facing context and must never surface in user-visible UI.
+ */
+const EXTERNAL_CONTENT_BLOCK_RE =
+  /^SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[\s\S]*?<<<END_EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>\s*/;
+const EXTERNAL_CONTENT_MARKERS_RE = /<<<(?:END_)?EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>/g;
+const SECURITY_NOTICE_PREFIX_RE =
+  /^SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n- [^\n]+)*/;
+
+function stripExternalContentMarkers(text: string): string {
+  if (!text.includes("EXTERNAL_UNTRUSTED_CONTENT") && !text.includes("SECURITY NOTICE:")) {
+    return text;
+  }
+  // Try to strip the entire wrapped block (security notice + markers + content inside).
+  let result = text.replace(EXTERNAL_CONTENT_BLOCK_RE, "");
+  // Strip any remaining markers.
+  result = result.replace(EXTERNAL_CONTENT_MARKERS_RE, "");
+  // Strip standalone security notice prefix (in case it appears without markers).
+  result = result.replace(SECURITY_NOTICE_PREFIX_RE, "");
+  return result.trim();
+}
+
 function processMessageText(text: string, role: string): string {
   const shouldStripInboundMetadata = role.toLowerCase() === "user";
+  let processed: string;
   if (role === "assistant") {
-    return stripThinkingTags(text);
+    processed = stripThinkingTags(text);
+  } else {
+    processed = shouldStripInboundMetadata
+      ? stripInboundMetadata(stripEnvelope(text))
+      : stripEnvelope(text);
   }
-  return shouldStripInboundMetadata
-    ? stripInboundMetadata(stripEnvelope(text))
-    : stripEnvelope(text);
+  return stripExternalContentMarkers(processed);
 }
 
 export function extractText(message: unknown): string | null {
@@ -22,7 +49,7 @@ export function extractText(message: unknown): string | null {
   if (!raw) {
     return null;
   }
-  return processMessageText(raw, role);
+  return processMessageText(raw, role) || null;
 }
 
 export function extractTextCached(message: unknown): string | null {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1380,21 +1380,19 @@ function shouldFilterToolMessage(normalizedRole: string, raw: Record<string, unk
     return true;
   }
 
-  // Filter assistant messages that contain ONLY tool-call content blocks (no text).
-  // These are intermediate tool invocation turns the user doesn't need to see.
-  if (normalizedRole === "assistant" && Array.isArray(raw.content)) {
-    const hasText = (raw.content as Array<Record<string, unknown>>).some((block) => {
-      const type = typeof block?.type === "string" ? block.type.toLowerCase() : "";
-      return type === "text" && typeof block.text === "string" && block.text.trim().length > 0;
-    });
-    if (!hasText) {
-      const hasToolCall = (raw.content as Array<Record<string, unknown>>).some((block) => {
+  // Filter assistant messages whose content blocks are exclusively tool-call plumbing
+  // (no text, images, or other meaningful output). Mixed-content turns (e.g. text +
+  // tool_use, or image + tool_use) are kept so non-tool output still renders.
+  if (normalizedRole.toLowerCase() === "assistant" && Array.isArray(raw.content)) {
+    const blocks = raw.content as Array<Record<string, unknown>>;
+    const allToolCall =
+      blocks.length > 0 &&
+      blocks.every((block) => {
         const type = typeof block?.type === "string" ? block.type.toLowerCase() : "";
         return TOOL_CALL_CONTENT_TYPES.has(type);
       });
-      if (hasToolCall) {
-        return true;
-      }
+    if (allToolCall) {
+      return true;
     }
   }
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1364,6 +1364,43 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   return result;
 }
 
+/**
+ * Roles that are internal agent plumbing and should never appear in the chat window.
+ * Pi stores tool results as `role: "toolResult"`, the Anthropic API uses user messages
+ * with `tool_result` content blocks (normalizeMessage reclassifies those as "toolResult"),
+ * and some providers use `role: "tool"` or `role: "function"`.
+ */
+const TOOL_ROLES = new Set(["toolresult", "tool_result", "tool", "function"]);
+
+const TOOL_CALL_CONTENT_TYPES = new Set(["tool_use", "tooluse", "toolcall", "tool_call"]);
+
+function shouldFilterToolMessage(normalizedRole: string, raw: Record<string, unknown>): boolean {
+  // Filter any message whose role marks it as a tool result / tool / function.
+  if (TOOL_ROLES.has(normalizedRole.toLowerCase())) {
+    return true;
+  }
+
+  // Filter assistant messages that contain ONLY tool-call content blocks (no text).
+  // These are intermediate tool invocation turns the user doesn't need to see.
+  if (normalizedRole === "assistant" && Array.isArray(raw.content)) {
+    const hasText = (raw.content as Array<Record<string, unknown>>).some((block) => {
+      const type = typeof block?.type === "string" ? block.type.toLowerCase() : "";
+      return type === "text" && typeof block.text === "string" && block.text.trim().length > 0;
+    });
+    if (!hasText) {
+      const hasToolCall = (raw.content as Array<Record<string, unknown>>).some((block) => {
+        const type = typeof block?.type === "string" ? block.type.toLowerCase() : "";
+        return TOOL_CALL_CONTENT_TYPES.has(type);
+      });
+      if (hasToolCall) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
   const history = Array.isArray(props.messages) ? props.messages : [];
@@ -1398,7 +1435,11 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       continue;
     }
 
-    if (!props.showThinking && normalized.role.toLowerCase() === "toolresult") {
+    // Always filter tool-related messages from the chat history.
+    // Tool results (Pi's "toolResult" role, or user messages reclassified as toolResult
+    // due to tool_result content blocks) must never render raw text in the chat window.
+    // Messages with role "tool" or "function" are also internal agent plumbing.
+    if (shouldFilterToolMessage(normalized.role, raw)) {
       continue;
     }
 


### PR DESCRIPTION
Tool result messages (Pi's role: "toolResult", Anthropic's tool_result content blocks, and role: "tool"/"function") were previously only hidden when showThinking was off. When enabled, raw web_fetch JSON envelopes and SECURITY NOTICE prefixes leaked into the chat window.

- Always filter tool-related messages from chat history regardless of showThinking (tool results, tool role, function role)
- Filter assistant messages that contain only tool-call blocks with no text (intermediate invocation turns)
- Add safety-net stripping of EXTERNAL_UNTRUSTED_CONTENT markers and SECURITY NOTICE prefixes in extractText as defense-in-depth

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
