### PR TITLE
fix(skills): add trigger phrases to 3 skill descriptions

### DIFF
--- a/skills/gemini/SKILL.md
+++ b/skills/gemini/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini
-description: Gemini CLI for one-shot Q&A, summaries, and generation.
+description: Gemini CLI for one-shot Q&A, summaries, and text generation. Use when user asks to "ask Gemini", wants a second opinion from another AI model, needs a fast summary, or requests generation without using Claude directly.
 homepage: https://ai.google.dev/
 metadata:
   {

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notion
-description: Notion API for creating and managing pages, databases, and blocks.
+description: Notion API for creating and managing pages, databases, and blocks. Use when user asks to "take notes", "create in Notion", "update Notion page", "query database", or needs to organize information in Notion.
 homepage: https://developers.notion.com
 metadata:
   {

--- a/skills/spotify-player/SKILL.md
+++ b/skills/spotify-player/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spotify-player
-description: Terminal Spotify playback/search via spogo (preferred) or spotify_player.
+description: Terminal Spotify playback and search via spogo (preferred) or spotify_player. Use when user asks to "play music", "control Spotify", "search for songs", "skip track", or manage playback like pause, resume, or adjust volume.
 homepage: https://www.spotify.com
 metadata:
   {


### PR DESCRIPTION
## Summary

Per Anthropic's *Complete Guide to Building Skills for Claude* (Jan 2026), skill descriptions should include both:
1. **What it does** (most skills already have this)
2. **When to use it** — specific trigger phrases users might say

Without trigger phrases, Claude has to guess when to load the skill, leading to undertriggering.

## Problem

34 of 52 built-in skills are missing trigger phrases. This PR addresses 3 commonly-used skills.

## Skills Updated

| Skill | Trigger Phrases Added |
|-------|----------------------|
| `gemini` | "ask Gemini", "second opinion", "fast summary" |
| `spotify-player` | "play music", "control Spotify", "skip track" |
| `notion` | "take notes", "create in Notion", "query database" |

## Example Change

**Before:**
```yaml
description: Gemini CLI for one-shot Q&A, summaries, and generation.
```

**After:**
```yaml
description: Gemini CLI for one-shot Q&A, summaries, and text generation. Use when user asks to "ask Gemini", wants a second opinion from another AI model, needs a fast summary, or requests generation without using Claude directly.
```

## Testing

- [x] Verified all 3 skill files have valid YAML frontmatter
- [x] Checked that descriptions don't exceed reasonable length
- [x] Followed existing patterns from skills like `discord` that already have good trigger phrases

## Related Issue

Fixes #43410

## Scope

- [x] Skills / tool execution

## Security Impact

- No new permissions/capabilities
- No secrets/tokens handling changed
- No new network calls
- No command/tool execution surface changed
- No data access scope changed

## Backward Compatibility

Yes - this only adds descriptive text to skill metadata. No functional changes.

---

*Happy to receive feedback and iterate on the trigger phrases!* 🦞