### PR TITLE
docs: add ratelimit-retry to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **Ratelimit Retry** — Automatically retry agent conversations that fail due to provider rate limits (429, budget exhaustion). Queues failed sessions to disk and resumes them when the budget window resets.
+  npm: `@cheapestinference/openclaw-ratelimit-retry`
+  repo: `https://github.com/cheapestinference/openclaw-plugin-ratelimit-retry`
+  install: `openclaw plugins install @cheapestinference/openclaw-ratelimit-retry`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,7 +45,7 @@ Use this format when adding entries:
 
 ## Listed plugins
 
-- **Ratelimit Retry** — Automatically retry agent conversations that fail due to provider rate limits (429, budget exhaustion). Queues failed sessions to disk and resumes them when the budget window resets.
+- **Ratelimit Retry** — Automatically retry agent conversations killed by provider rate limits (429, budget exhaustion) by queuing sessions to disk and resuming when the budget window resets.
   npm: `@cheapestinference/openclaw-ratelimit-retry`
   repo: `https://github.com/cheapestinference/openclaw-plugin-ratelimit-retry`
   install: `openclaw plugins install @cheapestinference/openclaw-ratelimit-retry`


### PR DESCRIPTION
## Summary

- Adds the **ratelimit-retry** plugin to the community plugins listing
- Plugin automatically retries agent conversations killed by provider rate limits (429, budget exhaustion) by queuing sessions to disk and resuming when the budget window resets

## Plugin details

- **npm**: [`@cheapestinference/openclaw-ratelimit-retry`](https://www.npmjs.com/package/@cheapestinference/openclaw-ratelimit-retry)
- **repo**: https://github.com/cheapestinference/openclaw-plugin-ratelimit-retry
- **license**: MIT
- **runtime dependencies**: zero

## How it works

1. Hooks into `agent_end` — detects retriable errors (429, rate limit, budget exceeded)
2. Parks failed sessions in a persistent JSON queue on disk
3. Background service checks every N minutes if the budget window has reset
4. Sends `chat.send` to the original session, resuming with full transcript context
5. If retry fails again with 429, `agent_end` re-fires and re-queues automatically

## Checklist

- [x] Public GitHub repository
- [x] README with installation, configuration, and usage docs
- [x] MIT license
- [x] Issue tracker enabled
- [x] Published on npmjs

🤖 Generated with [Claude Code](https://claude.com/claude-code)