### PR TITLE
Allow negative group chat IDs in groupAllowFrom

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,73 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
-    const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
-
+  it("accepts positive sender IDs", () => {
+    const result = normalizeAllowFrom(["745123456", "123"]);
     expect(result).toEqual({
-      entries: ["745123456"],
+      entries: ["745123456", "123"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: [],
+    });
+  });
+
+  it("accepts negative Telegram group chat IDs", () => {
+    const result = normalizeAllowFrom(["-1003890514701", " tg:-100999 ", "745123456"]);
+    expect(result).toEqual({
+      entries: ["-1003890514701", "-100999", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("rejects non-numeric strings", () => {
+    const result = normalizeAllowFrom(["@someone", "abc", "12.34"]);
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: ["@someone", "abc", "12.34"],
+    });
+  });
+
+  it("handles wildcard", () => {
+    const result = normalizeAllowFrom(["*", "745123456"]);
+    expect(result).toEqual({
+      entries: ["745123456"],
+      hasWildcard: true,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("handles mixed valid and invalid entries", () => {
+    const result = normalizeAllowFrom(["-1001234567890", "745123456", "@someone"]);
+    expect(result).toEqual({
+      entries: ["-1001234567890", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: ["@someone"],
+    });
+  });
+
+  it("returns empty for undefined input", () => {
+    const result = normalizeAllowFrom(undefined);
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: false,
+      invalidEntries: [],
+    });
+  });
+
+  it("strips telegram prefix before validation", () => {
+    const result = normalizeAllowFrom(["telegram:-1001234567890", "tg:745123456"]);
+    expect(result).toEqual({
+      entries: ["-1001234567890", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
     });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -45,11 +45,12 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  // Allow negative IDs: Telegram group/supergroup chat IDs are always negative
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
- Update regex in normalizeAllowFrom to accept negative IDs (Telegram groups use negative chat IDs)
- Expand test coverage for positive IDs, negative IDs, non-numeric strings, wildcards, mixed entries, undefined input, and prefix stripping