### PR TITLE
fix: allow root-owned binaries in macOS SIP-protected paths for exec secret provider

### DIFF
--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -267,9 +267,19 @@ async function assertSecurePath(params: {
   if (process.platform !== "win32" && typeof process.getuid === "function" && stat.uid != null) {
     const uid = process.getuid();
     if (stat.uid !== uid) {
-      throw new Error(
-        `${params.label} must be owned by the current user (uid=${uid}): ${effectivePath}`,
-      );
+      // On macOS, system binaries in SIP-protected paths are owned by root:wheel.
+      // These are tamper-proof via SIP, so root ownership is acceptable there.
+      const macOSSystemPaths = ["/usr/bin/", "/usr/sbin/", "/bin/", "/sbin/"];
+      const isRootOwnedSystemBinary =
+        process.platform === "darwin" &&
+        stat.uid === 0 &&
+        macOSSystemPaths.some((p) => effectivePath.startsWith(p));
+
+      if (!isRootOwnedSystemBinary) {
+        throw new Error(
+          `${params.label} must be owned by the current user (uid=${uid}): ${effectivePath}`,
+        );
+      }
     }
   }
   return effectivePath;


### PR DESCRIPTION
On macOS, system binaries like `/usr/bin/security` are owned by `root:wheel` and protected by SIP. The exec secret provider ownership check rejects these with "must be owned by the current user", forcing users to set `allowInsecurePath: true` just to use standard system tools for secret management.

This changes the ownership check to accept root-owned (uid=0) binaries in well-known macOS system paths (`/usr/bin/`, `/usr/sbin/`, `/bin/`, `/sbin/`) where SIP provides tamper protection that is strictly stronger than user-level file ownership.

The `allowInsecurePath` escape hatch still works for other cases.

Fixes #43389

**Testing:** Ran `vitest run src/secrets/resolve.test.ts` — all 17 tests pass. Verified manually that `/usr/bin/security` is accepted without `allowInsecurePath` on macOS 15.4.