### PR TITLE
fix(telegram): use proxy-aware fetch fallback for media downloads

### DIFF
--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -5,6 +5,7 @@ import type { TelegramContext } from "./types.js";
 
 const saveMediaBuffer = vi.fn();
 const fetchRemoteMedia = vi.fn();
+const resolveTelegramFetch = vi.fn();
 
 vi.mock("../../media/store.js", () => ({
   saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
@@ -18,6 +19,10 @@ vi.mock("../../globals.js", () => ({
   danger: (s: string) => s,
   warn: (s: string) => s,
   logVerbose: () => {},
+}));
+
+vi.mock("../fetch.js", () => ({
+  resolveTelegramFetch: (...args: unknown[]) => resolveTelegramFetch(...args),
 }));
 
 vi.mock("../sticker-cache.js", () => ({
@@ -164,6 +169,7 @@ describe("resolveMedia getFile retry", () => {
     vi.useFakeTimers();
     fetchRemoteMedia.mockClear();
     saveMediaBuffer.mockClear();
+    resolveTelegramFetch.mockReset();
   });
 
   afterEach(() => {
@@ -346,6 +352,31 @@ describe("resolveMedia getFile retry", () => {
     expect(fetchRemoteMedia).toHaveBeenCalledWith(
       expect.objectContaining({
         fetchImpl: callerFetch,
+      }),
+    );
+  });
+
+  it("falls back to proxy-aware telegram fetch when caller fetch is missing", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_42.pdf" });
+    const proxyAwareFetch = vi.fn() as unknown as typeof fetch;
+    resolveTelegramFetch.mockReturnValue(proxyAwareFetch);
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf-data"),
+      contentType: "application/pdf",
+      fileName: "file_42.pdf",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_42---uuid.pdf",
+      contentType: "application/pdf",
+    });
+
+    const result = await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+    expect(result).not.toBeNull();
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchImpl: proxyAwareFetch,
       }),
     );
   });

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -4,6 +4,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { retryAsync } from "../../infra/retry.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
+import { resolveTelegramFetch } from "../fetch.js";
 import { cacheSticker, getCachedSticker } from "../sticker-cache.js";
 import { resolveTelegramMediaPlaceholder } from "./helpers.js";
 import type { StickerMetadata, TelegramContext } from "./types.js";
@@ -93,7 +94,7 @@ async function resolveTelegramFileWithRetry(
 }
 
 function resolveRequiredFetchImpl(fetchImpl?: typeof fetch): typeof fetch {
-  const resolved = fetchImpl ?? globalThis.fetch;
+  const resolved = fetchImpl ?? resolveTelegramFetch();
   if (!resolved) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }


### PR DESCRIPTION
## Problem

Telegram media downloads could ignore proxy settings in proxied environments when media resolution was invoked without an explicit fetch implementation.

The media downloader fell back to `globalThis.fetch`, which bypassed Telegram's proxy-aware resolver. As a result, text polling still worked, but photo/document downloads failed behind a proxy.

## Fix

Use `resolveTelegramFetch()` as the fallback fetch implementation inside Telegram media resolution.

This makes media downloads inherit the same proxy-aware behavior as the rest of the Telegram channel.

## Tests

Added regression coverage to verify that when no caller fetch is provided, media resolution falls back to the proxy-aware Telegram fetch resolver.

Closes #44311
