### PR TITLE
feat(skills): add references/ auto-load support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: add `sessions_yield` so orchestrators can end the current turn immediately, skip queued tool work, and carry a hidden follow-up payload into the next session turn. (#36537) thanks @jriff
 - Docs/Kubernetes: Add a starter K8s install path with raw manifests, Kind setup, and deployment docs. Thanks @sallyom @dzianisv @egkristi
 - Control UI/dashboard-v2: refresh the gateway dashboard with modular overview, chat, config, agent, and session views, plus a command palette, mobile bottom tabs, and richer chat tools like slash commands, search, export, and pinned messages. (#41503) Thanks @BunsDev.
+- Skills/references: load `references/` markdown files alongside `SKILL.md` so agents automatically receive supplemental context without growing the main skill file. Files are merged in alphabetical order by default; list specific files via frontmatter `references.autoLoad` to control which are included. Thanks @leejini92.
 
 ### Fixes
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -295,6 +295,35 @@ copy). Workspace skills are user-owned and override both on name conflicts.
 
 See [Skills config](/tools/skills-config) for the full configuration schema.
 
+## References directory
+
+Each skill can include a `references/` subdirectory with supplemental `.md` files. OpenClaw automatically appends these files to the skill content so the agent has full context without a bloated `SKILL.md`.
+
+**Default behavior** — all `.md` files in `references/` are loaded in alphabetical order:
+
+```
+skills/
+  my-skill/
+    SKILL.md          ← loaded first
+    references/
+      commands.md     ← appended second
+      examples.md     ← appended third
+```
+
+**Selective loading** — list specific files in frontmatter to control which are included:
+
+```yaml
+metadata:
+  openclaw:
+    references:
+      autoLoad:
+        - commands.md # always loaded
+      onDemand:
+        - examples.md # reserved for future on-demand loading
+```
+
+> Security: only `.md` files inside the skill's own directory are loaded; path traversal attempts are silently rejected.
+
 ## Looking for more skills?
 
 Browse [https://clawhub.com](https://clawhub.com).

--- a/src/agents/skills/frontmatter.test.ts
+++ b/src/agents/skills/frontmatter.test.ts
@@ -65,3 +65,47 @@ describe("resolveOpenClawMetadata install validation", () => {
     expect(install).toBeUndefined();
   });
 });
+
+describe("resolveOpenClawMetadata references parsing", () => {
+  function resolveRefs(frontmatter: Record<string, string>) {
+    return resolveOpenClawMetadata(frontmatter)?.references;
+  }
+
+  it("parses autoLoad and onDemand lists", () => {
+    const refs = resolveRefs({
+      metadata: '{"openclaw":{"references":{"autoLoad":["a.md","b.md"],"onDemand":["c.md"]}}}',
+    });
+    expect(refs).toEqual({
+      autoLoad: ["a.md", "b.md"],
+      onDemand: ["c.md"],
+    });
+  });
+
+  it("parses autoLoad only", () => {
+    const refs = resolveRefs({
+      metadata: '{"openclaw":{"references":{"autoLoad":["guide.md"]}}}',
+    });
+    expect(refs).toEqual({ autoLoad: ["guide.md"] });
+  });
+
+  it("returns undefined references when not specified", () => {
+    const refs = resolveRefs({
+      metadata: '{"openclaw":{"always":true}}',
+    });
+    expect(refs).toBeUndefined();
+  });
+
+  it("returns undefined references when references block is empty", () => {
+    const refs = resolveRefs({
+      metadata: '{"openclaw":{"references":{}}}',
+    });
+    expect(refs).toBeUndefined();
+  });
+
+  it("handles comma-separated string for autoLoad", () => {
+    const refs = resolveRefs({
+      metadata: '{"openclaw":{"references":{"autoLoad":"a.md, b.md"}}}',
+    });
+    expect(refs).toEqual({ autoLoad: ["a.md", "b.md"] });
+  });
+});

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -193,6 +193,22 @@ export function resolveOpenClawMetadata(
   const requires = resolveOpenClawManifestRequires(metadataObj);
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
+
+  // Parse references block
+  const refsObj = metadataObj.references;
+  let references: OpenClawSkillMetadata["references"];
+  if (refsObj && typeof refsObj === "object") {
+    const refsRecord = refsObj as Record<string, unknown>;
+    const autoLoad = normalizeStringList(refsRecord.autoLoad);
+    const onDemand = normalizeStringList(refsRecord.onDemand);
+    if (autoLoad.length > 0 || onDemand.length > 0) {
+      references = {
+        ...(autoLoad.length > 0 ? { autoLoad } : {}),
+        ...(onDemand.length > 0 ? { onDemand } : {}),
+      };
+    }
+  }
+
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
     emoji: typeof metadataObj.emoji === "string" ? metadataObj.emoji : undefined,
@@ -202,6 +218,7 @@ export function resolveOpenClawMetadata(
     os: osRaw.length > 0 ? osRaw : undefined,
     requires: requires,
     install: install.length > 0 ? install : undefined,
+    references,
   };
 }
 

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -30,6 +30,12 @@ export type OpenClawSkillMetadata = {
     config?: string[];
   };
   install?: SkillInstallSpec[];
+  references?: {
+    /** Files to always load from references/ when the skill is activated. */
+    autoLoad?: string[];
+    /** Files to load on demand (reserved for future use). */
+    onDemand?: string[];
+  };
 };
 
 export type SkillInvocationPolicy = {
@@ -68,6 +74,8 @@ export type SkillEntry = {
   frontmatter: ParsedSkillFrontmatter;
   metadata?: OpenClawSkillMetadata;
   invocation?: SkillInvocationPolicy;
+  /** Content loaded from references/ directory, to be appended to SKILL.md when synced. */
+  referencesContent?: string;
 };
 
 export type SkillEligibilityContext = {

--- a/src/agents/skills/workspace.references.test.ts
+++ b/src/agents/skills/workspace.references.test.ts
@@ -1,0 +1,236 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeSkill } from "../skills.e2e-test-helpers.js";
+import { loadWorkspaceSkillEntries } from "./workspace.js";
+
+const tempDirs: string[] = [];
+
+async function createTempWorkspaceDir() {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-refs-"));
+  tempDirs.push(workspaceDir);
+  return workspaceDir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function writeSkillWithReferences(params: {
+  skillDir: string;
+  name: string;
+  description: string;
+  metadata?: string;
+  references?: Record<string, string>;
+}) {
+  await writeSkill({
+    dir: params.skillDir,
+    name: params.name,
+    description: params.description,
+    metadata: params.metadata,
+  });
+  if (params.references) {
+    const refsDir = path.join(params.skillDir, "references");
+    await fs.mkdir(refsDir, { recursive: true });
+    for (const [filename, content] of Object.entries(params.references)) {
+      await fs.writeFile(path.join(refsDir, filename), content, "utf-8");
+    }
+  }
+}
+
+describe("workspace skill references loading", () => {
+  it("loads all .md files from references/ when no autoLoad is specified", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const skillDir = path.join(workspaceDir, "skills", "my-skill");
+
+    await writeSkillWithReferences({
+      skillDir,
+      name: "my-skill",
+      description: "A test skill",
+      references: {
+        "guide.md": "# Guide\nSome guide content.",
+        "api-spec.md": "# API Spec\nAPI specification.",
+        "not-markdown.txt": "This should be ignored.",
+      },
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    const entry = entries.find((e) => e.skill.name === "my-skill");
+    expect(entry).toBeDefined();
+    expect(entry!.referencesContent).toBeDefined();
+    // Should include both .md files but not .txt
+    expect(entry!.referencesContent).toContain("<!-- references/api-spec.md -->");
+    expect(entry!.referencesContent).toContain("# API Spec");
+    expect(entry!.referencesContent).toContain("<!-- references/guide.md -->");
+    expect(entry!.referencesContent).toContain("# Guide");
+    expect(entry!.referencesContent).not.toContain("not-markdown.txt");
+    // Alphabetical order: api-spec.md before guide.md
+    const apiIdx = entry!.referencesContent!.indexOf("api-spec.md");
+    const guideIdx = entry!.referencesContent!.indexOf("guide.md");
+    expect(apiIdx).toBeLessThan(guideIdx);
+  });
+
+  it("loads only autoLoad files when specified in frontmatter", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const skillDir = path.join(workspaceDir, "skills", "selective-skill");
+
+    await writeSkillWithReferences({
+      skillDir,
+      name: "selective-skill",
+      description: "A skill with selective references",
+      metadata: '{"openclaw":{"references":{"autoLoad":["important.md"]}}}',
+      references: {
+        "important.md": "# Important\nCritical reference.",
+        "optional.md": "# Optional\nNot loaded by default.",
+      },
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    const entry = entries.find((e) => e.skill.name === "selective-skill");
+    expect(entry).toBeDefined();
+    expect(entry!.referencesContent).toContain("<!-- references/important.md -->");
+    expect(entry!.referencesContent).toContain("# Important");
+    // optional.md should NOT be loaded since autoLoad explicitly lists only important.md
+    expect(entry!.referencesContent).not.toContain("optional.md");
+  });
+
+  it("returns no referencesContent when references/ does not exist", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const skillDir = path.join(workspaceDir, "skills", "no-refs-skill");
+
+    await writeSkill({
+      dir: skillDir,
+      name: "no-refs-skill",
+      description: "A skill without references",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    const entry = entries.find((e) => e.skill.name === "no-refs-skill");
+    expect(entry).toBeDefined();
+    expect(entry!.referencesContent).toBeUndefined();
+  });
+
+  it("returns no referencesContent when references/ is empty", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const skillDir = path.join(workspaceDir, "skills", "empty-refs");
+
+    await writeSkill({
+      dir: skillDir,
+      name: "empty-refs",
+      description: "A skill with empty references",
+    });
+    await fs.mkdir(path.join(skillDir, "references"), { recursive: true });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    const entry = entries.find((e) => e.skill.name === "empty-refs");
+    expect(entry).toBeDefined();
+    expect(entry!.referencesContent).toBeUndefined();
+  });
+
+  it("skips filenames with path traversal patterns", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const skillDir = path.join(workspaceDir, "skills", "traversal-skill");
+
+    await writeSkillWithReferences({
+      skillDir,
+      name: "traversal-skill",
+      description: "A skill to test path traversal defense",
+      metadata:
+        '{"openclaw":{"references":{"autoLoad":["../../../etc/passwd.md","safe.md","..\\\\secret.md"]}}}',
+      references: {
+        "safe.md": "# Safe\nThis is safe.",
+      },
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    const entry = entries.find((e) => e.skill.name === "traversal-skill");
+    expect(entry).toBeDefined();
+    // Only the safe file should be loaded
+    expect(entry!.referencesContent).toContain("<!-- references/safe.md -->");
+    expect(entry!.referencesContent).not.toContain("passwd");
+    expect(entry!.referencesContent).not.toContain("secret");
+  });
+
+  it("skips non-.md filenames in autoLoad", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const skillDir = path.join(workspaceDir, "skills", "ext-skill");
+
+    await writeSkillWithReferences({
+      skillDir,
+      name: "ext-skill",
+      description: "A skill with non-md autoLoad entries",
+      metadata: '{"openclaw":{"references":{"autoLoad":["good.md","evil.sh"]}}}',
+      references: {
+        "good.md": "# Good\nGood content.",
+        "evil.sh": "#!/bin/bash\nrm -rf /",
+      },
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    const entry = entries.find((e) => e.skill.name === "ext-skill");
+    expect(entry).toBeDefined();
+    expect(entry!.referencesContent).toContain("<!-- references/good.md -->");
+    expect(entry!.referencesContent).not.toContain("evil.sh");
+    expect(entry!.referencesContent).not.toContain("rm -rf");
+  });
+
+  it("parses references metadata from frontmatter correctly", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const skillDir = path.join(workspaceDir, "skills", "meta-skill");
+
+    await writeSkillWithReferences({
+      skillDir,
+      name: "meta-skill",
+      description: "A skill with full references metadata",
+      metadata: '{"openclaw":{"references":{"autoLoad":["a.md","b.md"],"onDemand":["c.md"]}}}',
+      references: {
+        "a.md": "Content A",
+        "b.md": "Content B",
+        "c.md": "Content C",
+      },
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    const entry = entries.find((e) => e.skill.name === "meta-skill");
+    expect(entry).toBeDefined();
+    expect(entry!.metadata?.references).toEqual({
+      autoLoad: ["a.md", "b.md"],
+      onDemand: ["c.md"],
+    });
+    // Only autoLoad files should be in referencesContent (not onDemand)
+    expect(entry!.referencesContent).toContain("Content A");
+    expect(entry!.referencesContent).toContain("Content B");
+    expect(entry!.referencesContent).not.toContain("Content C");
+  });
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -22,6 +22,7 @@ import {
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
 import type {
+  OpenClawSkillMetadata,
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
   SkillCommandSpec,
@@ -289,6 +290,102 @@ function unwrapLoadedSkills(loaded: unknown): Skill[] {
   return [];
 }
 
+/**
+ * Load autoLoad references from a skill's references/ directory.
+ * Returns content to append to SKILL.md when synced, or empty string if none.
+ *
+ * autoLoad list comes from frontmatter:
+ *   metadata:
+ *     openclaw:
+ *       references:
+ *         autoLoad: ["agents-catalog.md"]
+ *
+ * If no autoLoad list is specified but a references/ directory exists,
+ * all .md files are loaded in alphabetical order (default behavior).
+ */
+function loadSkillReferencesContent(
+  skill: Skill,
+  metadata: OpenClawSkillMetadata | undefined,
+  limits: ResolvedSkillsLimits,
+): string {
+  const refsDir = path.join(skill.baseDir, "references");
+  if (!fs.existsSync(refsDir)) {
+    return "";
+  }
+
+  let filesToLoad: string[];
+  const autoLoad = metadata?.references?.autoLoad;
+
+  if (autoLoad && autoLoad.length > 0) {
+    // Only load explicitly listed files
+    filesToLoad = autoLoad;
+  } else {
+    // Default: load all .md files in references/ alphabetically
+    try {
+      const entries = fs.readdirSync(refsDir, { withFileTypes: true });
+      filesToLoad = entries
+        .filter((e) => e.isFile() && e.name.endsWith(".md"))
+        .map((e) => e.name)
+        .sort();
+    } catch {
+      return "";
+    }
+  }
+
+  if (filesToLoad.length === 0) {
+    return "";
+  }
+
+  const parts: string[] = [];
+  for (const filename of filesToLoad) {
+    // Security: only allow .md files, no path traversal
+    if (
+      !filename.endsWith(".md") ||
+      filename.includes("/") ||
+      filename.includes("\\") ||
+      filename.includes("..")
+    ) {
+      skillsLogger.warn("Skipping invalid reference filename.", {
+        skill: skill.name,
+        filename,
+      });
+      continue;
+    }
+    const refPath = path.join(refsDir, filename);
+    const refRealPath = tryRealpath(refPath);
+    if (!refRealPath) continue;
+
+    // Security: ensure the reference file is inside the skill's baseDir
+    const baseDirRealPath = tryRealpath(skill.baseDir);
+    if (!baseDirRealPath || !isPathInside(baseDirRealPath, refRealPath)) {
+      skillsLogger.warn("Skipping reference file outside skill directory.", {
+        skill: skill.name,
+        filename,
+        refPath: refRealPath,
+      });
+      continue;
+    }
+
+    try {
+      const stat = fs.statSync(refRealPath);
+      if (stat.size > limits.maxSkillFileBytes) {
+        skillsLogger.warn("Skipping oversized reference file.", {
+          skill: skill.name,
+          filename,
+          size: stat.size,
+        });
+        continue;
+      }
+      const content = fs.readFileSync(refRealPath, "utf-8");
+      parts.push(`\n\n<!-- references/${filename} -->\n${content}`);
+    } catch {
+      skillsLogger.warn("Failed to load reference file.", { skill: skill.name, filename });
+    }
+  }
+
+  return parts.join("");
+}
+
 function loadSkillEntries(
   workspaceDir: string,
   opts?: {
@@ -516,11 +613,14 @@ function loadSkillEntries(
     } catch {
       // ignore malformed skills
     }
+    const metadata = resolveOpenClawMetadata(frontmatter);
+    const referencesContent = loadSkillReferencesContent(skill, metadata, limits);
     return {
       skill,
       frontmatter,
-      metadata: resolveOpenClawMetadata(frontmatter),
+      metadata,
       invocation: resolveSkillInvocationPolicy(frontmatter),
+      ...(referencesContent ? { referencesContent } : {}),
     };
   });
   return skillEntries;
@@ -757,6 +857,18 @@ export async function syncSkillsToWorkspace(params: {
           recursive: true,
           force: true,
         });
+        // Append references content to the synced SKILL.md so sandbox agents
+        // see the merged content when reading the skill file.
+        if (entry.referencesContent) {
+          const destSkillMd = path.join(dest, "SKILL.md");
+          try {
+            await fsp.appendFile(destSkillMd, entry.referencesContent, "utf-8");
+          } catch {
+            skillsLogger.warn(
+              `Failed to append references to synced SKILL.md for ${entry.skill.name}.`,
+            );
+          }
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : JSON.stringify(error);
         skillsLogger.warn(`Failed to copy ${entry.skill.name} to sandbox: ${message}`);

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -336,7 +336,19 @@ function loadSkillReferencesContent(
     return "";
   }
 
+  // Resolve base directory once before the loop.
+  // If it cannot be resolved, bail out early with a clear warning rather than
+  // emitting a misleading "outside skill directory" message for every file.
+  const baseDirRealPath = tryRealpath(skill.baseDir);
+  if (!baseDirRealPath) {
+    skillsLogger.warn("Cannot resolve skill base directory, skipping all references.", {
+      skill: skill.name,
+    });
+    return "";
+  }
+
   const parts: string[] = [];
+  let totalBytes = 0;
   for (const filename of filesToLoad) {
     // Security: only allow .md files, no path traversal
     if (
@@ -356,8 +368,7 @@ function loadSkillReferencesContent(
     if (!refRealPath) continue;
 
     // Security: ensure the reference file is inside the skill's baseDir
-    const baseDirRealPath = tryRealpath(skill.baseDir);
-    if (!baseDirRealPath || !isPathInside(baseDirRealPath, refRealPath)) {
+    if (!isPathInside(baseDirRealPath, refRealPath)) {
       skillsLogger.warn("Skipping reference file outside skill directory.", {
         skill: skill.name,
         filename,
@@ -376,7 +387,17 @@ function loadSkillReferencesContent(
         });
         continue;
       }
+      // Guard against unbounded combined references content.
+      if (totalBytes + stat.size > limits.maxSkillFileBytes) {
+        skillsLogger.warn("Skipping remaining references: combined size limit reached.", {
+          skill: skill.name,
+          filename,
+          totalBytes,
+        });
+        break;
+      }
       const content = fs.readFileSync(refRealPath, "utf-8");
+      totalBytes += stat.size;
       parts.push(`\n\n<!-- references/${filename} -->\n${content}`);
     } catch {
       skillsLogger.warn("Failed to load reference file.", { skill: skill.name, filename });


### PR DESCRIPTION
## Problem

When a skill's SKILL.md grows large with detailed commands, examples, and reference tables, the entire file is loaded into context every time the skill runs. There is no way to split supplemental content into separate files while keeping it available to the agent.

## Solution

Add automatic loading of a `references/` subdirectory alongside `SKILL.md`.

### Behavior

- **Default**: All `.md` files in `references/` are loaded and appended to skill content in alphabetical order
- **Selective**: Specify `references.autoLoad` in frontmatter to control which files are included
- **Security**: Only `.md` files inside the skill's own directory are loaded; path traversal is blocked

### Frontmatter example

```yaml
metadata:
  openclaw:
    references:
      autoLoad:
        - commands.md    # always loaded
      onDemand:
        - examples.md    # reserved for future on-demand loading
```

### Files changed

- `src/agents/skills/types.ts` — add `references` to `OpenClawSkillMetadata`, add `referencesContent` to `SkillEntry`
- `src/agents/skills/frontmatter.ts` — parse `references` block from frontmatter
- `src/agents/skills/workspace.ts` — `loadSkillReferencesContent()` + integration in `loadSkillEntries`
- `src/agents/skills/frontmatter.test.ts` — 5 new tests
- `src/agents/skills/workspace.references.test.ts` — 7 new integration tests (new file)

### Tests

30/30 skill tests pass. 12 new tests added.

Thanks @leejini92
