### PR TITLE
fix(hooks): expose sessionKey and agentId in agent_end and before_agent_start events

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -98,6 +98,30 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     );
   });
 
+  it("omits missing sessionKey from the legacy before_agent_start event", async () => {
+    mockedGlobalHookRunner.hasHooks.mockImplementation(
+      (hookName) => hookName === "before_agent_start",
+    );
+    mockedGlobalHookRunner.runBeforeAgentStart.mockResolvedValueOnce({});
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      sessionId: "test-session",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace",
+      prompt: "hello",
+      timeoutMs: 30000,
+      runId: "run-legacy-omit-session-key",
+    });
+
+    const event = mockedGlobalHookRunner.runBeforeAgentStart.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(event).toBeDefined();
+    expect(event).toMatchObject({ prompt: "hello" });
+    expect(event).not.toHaveProperty("sessionKey");
+  });
+
   it("passes resolved auth profile into run attempts for context-engine afterTurn propagation", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -348,7 +348,11 @@ export async function runEmbeddedPiAgent(
       if (hookRunner?.hasHooks("before_agent_start")) {
         try {
           legacyBeforeAgentStartResult = await hookRunner.runBeforeAgentStart(
-            { prompt: params.prompt },
+            { 
+              prompt: params.prompt,
+              sessionKey: params.sessionKey,
+              agentId: workspaceResolution.agentId,
+            },
             hookCtx,
           );
           modelResolveOverride = {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -350,8 +350,8 @@ export async function runEmbeddedPiAgent(
           legacyBeforeAgentStartResult = await hookRunner.runBeforeAgentStart(
             {
               prompt: params.prompt,
-              sessionKey: params.sessionKey,
-              agentId: workspaceResolution.agentId,
+              ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+              ...(workspaceResolution.agentId ? { agentId: workspaceResolution.agentId } : {}),
             },
             hookCtx,
           );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -348,7 +348,7 @@ export async function runEmbeddedPiAgent(
       if (hookRunner?.hasHooks("before_agent_start")) {
         try {
           legacyBeforeAgentStartResult = await hookRunner.runBeforeAgentStart(
-            { 
+            {
               prompt: params.prompt,
               sessionKey: params.sessionKey,
               agentId: workspaceResolution.agentId,

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
@@ -659,6 +659,62 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
   });
 });
 
+describe("runEmbeddedAttempt legacy agent_end hook payload", () => {
+  const tempPaths: string[] = [];
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness();
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+  });
+
+  it("omits missing sessionKey from the agent_end event", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-end-workspace-"));
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-end-agent-"));
+    const sessionFile = path.join(workspaceDir, "session.jsonl");
+    tempPaths.push(workspaceDir, agentDir);
+    await fs.writeFile(sessionFile, "", "utf8");
+
+    const runAgentEnd = vi.fn(async () => undefined);
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: (hookName: string) => hookName === "agent_end",
+      runAgentEnd,
+    });
+
+    hoisted.createAgentSessionMock.mockImplementation(async () => ({
+      session: createDefaultEmbeddedSession(),
+    }));
+
+    const result = await runEmbeddedAttempt({
+      sessionId: "embedded-session",
+      sessionFile,
+      workspaceDir,
+      agentDir,
+      config: {} as OpenClawConfig,
+      prompt: "hello",
+      timeoutMs: 10_000,
+      runId: "run-agent-end-omit-session-key",
+      provider: "openai",
+      modelId: "gpt-test",
+      model: testModel,
+      authStorage: {} as AuthStorage,
+      modelRegistry: {} as ModelRegistry,
+      thinkLevel: "off",
+      senderIsOwner: true,
+      disableMessageTool: true,
+    });
+
+    expect(result.promptError).toBeNull();
+    expect(runAgentEnd).toHaveBeenCalledTimes(1);
+    const event = runAgentEnd.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(event).toBeDefined();
+    expect(event).toMatchObject({ success: true });
+    expect(event).not.toHaveProperty("sessionKey");
+  });
+});
+
 describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   const tempPaths: string[] = [];
   const sessionKey = "agent:main:discord:channel:test-ctx-engine";

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -114,6 +114,34 @@ describe("resolvePromptBuildHookResult", () => {
     expect(result.prependContext).toBe("from-hook");
   });
 
+  it("includes legacy hook agent context fields only when present", async () => {
+    const hookRunner = createLegacyOnlyHookRunner();
+    const messages = [{ role: "user", content: "ctx" }];
+
+    await resolvePromptBuildHookResult({
+      prompt: "hello",
+      messages,
+      hookCtx: {
+        sessionKey: "agent:assistant-beta:main",
+        agentId: "assistant-beta",
+      },
+      hookRunner,
+    });
+
+    expect(hookRunner.runBeforeAgentStart).toHaveBeenCalledWith(
+      {
+        prompt: "hello",
+        messages,
+        sessionKey: "agent:assistant-beta:main",
+        agentId: "assistant-beta",
+      },
+      {
+        sessionKey: "agent:assistant-beta:main",
+        agentId: "assistant-beta",
+      },
+    );
+  });
+
   it("merges prompt-build and legacy context fields in deterministic order", async () => {
     const hookRunner = {
       hasHooks: vi.fn(() => true),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3080,8 +3080,8 @@ export async function runEmbeddedAttempt(
                 success: !aborted && !promptError,
                 error: promptError ? describeUnknownError(promptError) : undefined,
                 durationMs: Date.now() - promptStartedAt,
-                sessionKey: params.sessionKey,
-                agentId: hookAgentId,
+                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+                ...(hookAgentId ? { agentId: hookAgentId } : {}),
               },
               {
                 agentId: hookAgentId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1439,8 +1439,8 @@ export async function resolvePromptBuildHookResult(params: {
             {
               prompt: params.prompt,
               messages: params.messages,
-              sessionKey: params.hookCtx.sessionKey,
-              agentId: params.hookCtx.agentId,
+              ...(params.hookCtx.sessionKey ? { sessionKey: params.hookCtx.sessionKey } : {}),
+              ...(params.hookCtx.agentId ? { agentId: params.hookCtx.agentId } : {}),
             },
             params.hookCtx,
           )

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -157,7 +157,7 @@ type PromptBuildHookRunner = {
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
   runBeforeAgentStart: (
-    event: { prompt: string; messages: unknown[] },
+    event: { prompt: string; messages?: unknown[]; sessionKey?: string; agentId?: string },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | undefined>;
 };
@@ -1439,6 +1439,8 @@ export async function resolvePromptBuildHookResult(params: {
             {
               prompt: params.prompt,
               messages: params.messages,
+              sessionKey: params.hookCtx.sessionKey,
+              agentId: params.hookCtx.agentId,
             },
             params.hookCtx,
           )
@@ -3078,6 +3080,8 @@ export async function runEmbeddedAttempt(
                 success: !aborted && !promptError,
                 error: promptError ? describeUnknownError(promptError) : undefined,
                 durationMs: Date.now() - promptStartedAt,
+                sessionKey: params.sessionKey,
+                agentId: hookAgentId,
               },
               {
                 agentId: hookAgentId,

--- a/src/plugins/hooks.agent-context.test.ts
+++ b/src/plugins/hooks.agent-context.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for agent context (sessionKey, agentId) in hook events
+ *
+ * Validates that sessionKey and agentId are correctly passed to
+ * agent_end and before_agent_start hook handlers.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { addTestHook, TEST_PLUGIN_AGENT_CTX } from "./hooks.test-helpers.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import type { PluginHookRegistration } from "./types.js";
+
+function addAgentEndHook(
+  registry: PluginRegistry,
+  pluginId: string,
+  handler: (event: { messages: unknown[]; success: boolean; sessionKey?: string; agentId?: string }) => void | Promise<void>,
+  priority?: number,
+) {
+  addTestHook({
+    registry,
+    pluginId,
+    hookName: "agent_end",
+    handler: handler as PluginHookRegistration["handler"],
+    priority,
+  });
+}
+
+function addBeforeAgentStartHook(
+  registry: PluginRegistry,
+  pluginId: string,
+  handler: (event: { prompt: string; messages?: unknown[]; sessionKey?: string; agentId?: string }) => void | Promise<void>,
+  priority?: number,
+) {
+  addTestHook({
+    registry,
+    pluginId,
+    hookName: "before_agent_start",
+    handler: handler as PluginHookRegistration["handler"],
+    priority,
+  });
+}
+
+describe("hook events include sessionKey and agentId", () => {
+  let registry: PluginRegistry;
+  const stubCtx = TEST_PLUGIN_AGENT_CTX;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  describe("agent_end hook", () => {
+    it("receives sessionKey and agentId in event", async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      
+      addAgentEndHook(registry, "memory-plugin", handler);
+      
+      const runner = createHookRunner(registry);
+      const testMessages = [{ role: "user", content: "hello" }];
+      
+      await runner.runAgentEnd(
+        {
+          messages: testMessages,
+          success: true,
+          sessionKey: "agent:assistant-beta:main",
+          agentId: "assistant-beta",
+        },
+        stubCtx,
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: testMessages,
+          success: true,
+          sessionKey: "agent:assistant-beta:main",
+          agentId: "assistant-beta",
+        }),
+        stubCtx,
+      );
+    });
+
+    it("works with default values when sessionKey and agentId are not provided", async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      
+      addAgentEndHook(registry, "memory-plugin", handler);
+      
+      const runner = createHookRunner(registry);
+      const testMessages = [{ role: "user", content: "hello" }];
+      
+      // Call without sessionKey and agentId (backward compatibility)
+      await runner.runAgentEnd(
+        {
+          messages: testMessages,
+          success: true,
+        },
+        stubCtx,
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: testMessages,
+          success: true,
+          sessionKey: undefined,
+          agentId: undefined,
+        }),
+        stubCtx,
+      );
+    });
+  });
+
+  describe("before_agent_start hook", () => {
+    it("receives sessionKey and agentId in event", async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      
+      addBeforeAgentStartHook(registry, "memory-plugin", handler);
+      
+      const runner = createHookRunner(registry);
+      
+      await runner.runBeforeAgentStart(
+        {
+          prompt: "hello",
+          messages: [{ role: "user", content: "hello" }],
+          sessionKey: "agent:assistant-beta:main",
+          agentId: "assistant-beta",
+        },
+        stubCtx,
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: "hello",
+          sessionKey: "agent:assistant-beta:main",
+          agentId: "assistant-beta",
+        }),
+        stubCtx,
+      );
+    });
+
+    it("works with legacy event shape (backward compatibility)", async () => {
+      const handler = vi.fn().mockResolvedValue({ prependContext: "context" });
+      
+      addBeforeAgentStartHook(registry, "legacy-plugin", handler);
+      
+      const runner = createHookRunner(registry);
+      
+      // Call with legacy event shape (without sessionKey and agentId)
+      await runner.runBeforeAgentStart(
+        {
+          prompt: "hello",
+        },
+        stubCtx,
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: "hello",
+          sessionKey: undefined,
+          agentId: undefined,
+        }),
+        stubCtx,
+      );
+    });
+  });
+});

--- a/src/plugins/hooks.agent-context.test.ts
+++ b/src/plugins/hooks.agent-context.test.ts
@@ -13,7 +13,12 @@ import type { PluginHookRegistration } from "./types.js";
 function addAgentEndHook(
   registry: PluginRegistry,
   pluginId: string,
-  handler: (event: { messages: unknown[]; success: boolean; sessionKey?: string; agentId?: string }) => void | Promise<void>,
+  handler: (event: {
+    messages: unknown[];
+    success: boolean;
+    sessionKey?: string;
+    agentId?: string;
+  }) => void | Promise<void>,
   priority?: number,
 ) {
   addTestHook({
@@ -28,7 +33,12 @@ function addAgentEndHook(
 function addBeforeAgentStartHook(
   registry: PluginRegistry,
   pluginId: string,
-  handler: (event: { prompt: string; messages?: unknown[]; sessionKey?: string; agentId?: string }) => void | Promise<void>,
+  handler: (event: {
+    prompt: string;
+    messages?: unknown[];
+    sessionKey?: string;
+    agentId?: string;
+  }) => void | Promise<void>,
   priority?: number,
 ) {
   addTestHook({
@@ -51,12 +61,12 @@ describe("hook events include sessionKey and agentId", () => {
   describe("agent_end hook", () => {
     it("receives sessionKey and agentId in event", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
-      
+
       addAgentEndHook(registry, "memory-plugin", handler);
-      
+
       const runner = createHookRunner(registry);
       const testMessages = [{ role: "user", content: "hello" }];
-      
+
       await runner.runAgentEnd(
         {
           messages: testMessages,
@@ -80,12 +90,12 @@ describe("hook events include sessionKey and agentId", () => {
 
     it("works with default values when sessionKey and agentId are not provided", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
-      
+
       addAgentEndHook(registry, "memory-plugin", handler);
-      
+
       const runner = createHookRunner(registry);
       const testMessages = [{ role: "user", content: "hello" }];
-      
+
       // Call without sessionKey and agentId (backward compatibility)
       await runner.runAgentEnd(
         {
@@ -95,26 +105,23 @@ describe("hook events include sessionKey and agentId", () => {
         stubCtx,
       );
 
-      expect(handler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          messages: testMessages,
-          success: true,
-          sessionKey: undefined,
-          agentId: undefined,
-        }),
-        stubCtx,
-      );
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0]?.[0]).toEqual({
+        messages: testMessages,
+        success: true,
+      });
+      expect(handler.mock.calls[0]?.[1]).toBe(stubCtx);
     });
   });
 
   describe("before_agent_start hook", () => {
     it("receives sessionKey and agentId in event", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
-      
+
       addBeforeAgentStartHook(registry, "memory-plugin", handler);
-      
+
       const runner = createHookRunner(registry);
-      
+
       await runner.runBeforeAgentStart(
         {
           prompt: "hello",
@@ -137,11 +144,11 @@ describe("hook events include sessionKey and agentId", () => {
 
     it("works with legacy event shape (backward compatibility)", async () => {
       const handler = vi.fn().mockResolvedValue({ prependContext: "context" });
-      
+
       addBeforeAgentStartHook(registry, "legacy-plugin", handler);
-      
+
       const runner = createHookRunner(registry);
-      
+
       // Call with legacy event shape (without sessionKey and agentId)
       await runner.runBeforeAgentStart(
         {
@@ -150,14 +157,11 @@ describe("hook events include sessionKey and agentId", () => {
         stubCtx,
       );
 
-      expect(handler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          prompt: "hello",
-          sessionKey: undefined,
-          agentId: undefined,
-        }),
-        stubCtx,
-      );
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0]?.[0]).toEqual({
+        prompt: "hello",
+      });
+      expect(handler.mock.calls[0]?.[1]).toBe(stubCtx);
     });
   });
 });

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1519,6 +1519,10 @@ export type PluginHookBeforeAgentStartEvent = {
   prompt: string;
   /** Optional because legacy hook can run in pre-session phase. */
   messages?: unknown[];
+  /** Session key for this agent run (e.g., "agent:qian-duoduo:main") */
+  sessionKey?: string;
+  /** Agent ID for this run (e.g., "qian-duoduo") */
+  agentId?: string;
 };
 
 export type PluginHookBeforeAgentStartResult = PluginHookBeforePromptBuildResult &
@@ -1579,6 +1583,10 @@ export type PluginHookAgentEndEvent = {
   success: boolean;
   error?: string;
   durationMs?: number;
+  /** Session key for this agent run (e.g., "agent:qian-duoduo:main") */
+  sessionKey?: string;
+  /** Agent ID for this run (e.g., "qian-duoduo") */
+  agentId?: string;
 };
 
 // Compaction hooks


### PR DESCRIPTION
## Problem

Memory plugins (like memos-local) cannot properly identify which agent is running when capturing conversation history via `agent_end` and `before_agent_start` hooks.

Currently, these hooks only receive generic event data without session context:
- `agent_end` event: only has `messages`, `success`, `error`, `durationMs`
- `before_agent_start` event: only has `prompt`, `messages`

This causes all memories to be tagged with `owner: agent:main` even when running as a different agent (e.g., 'qian-duoduo').

## Solution

Add `sessionKey` and `agentId` fields to both event types and populate them when triggering the hooks.

### Changes

- `src/plugins/types.ts`: Add `sessionKey` and `agentId` to:
  - `PluginHookAgentEndEvent`
  - `PluginHookBeforeAgentStartEvent`

- `src/agents/pi-embedded-runner/run/attempt.ts`: Pass `sessionKey` and `agentId` when calling:
  - `runAgentEnd`
  - `runBeforeAgentStart`

- `src/agents/pi-embedded-runner/run.ts`: Pass `sessionKey` and `agentId` when calling:
  - `runBeforeAgentStart` (legacy path)

## Related Issues

- Complements PR #44011 which adds similar fields to message hooks
- Follow-up to locked issue #24495, extending the same session/agent context propagation to hook event payloads
- Fixes multi-agent memory isolation for memos-local and similar plugins

## Testing

After this fix, memory plugins can now correctly identify the agent:

```javascript
api.on("agent_end", async (event) => {
  console.log(event.sessionKey); // "agent:qian-duoduo:main"
  console.log(event.agentId);    // "qian-duoduo"
  // Can now store memories with correct owner
});
```

## Checklist

- [x] Added type definitions for new fields
- [x] Updated all call sites to pass the new data
- [x] Maintains backward compatibility (fields are optional)
- [x] Follows existing code style and conventions

---

**Note**: This is a targeted fix for multi-agent memory isolation. It does not overlap with PR #44011 (message hooks) or PR #14873 (hook context expansion) as those address different hook types.
