### PR TITLE
Updated default model from openai-codex/gpt-5.3-codex to openai-codex/gpt-5.4 in tests.

### DIFF
--- a/changelog/fragments/openai-codex-auth-tests-gpt54.md
+++ b/changelog/fragments/openai-codex-auth-tests-gpt54.md
@@ -1,0 +1,1 @@
+- tests: align OpenAI Codex auth login expectations with the `gpt-5.4` default model to prevent stale CI failures. (#44367) thanks @jrrcdev

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -183,7 +183,7 @@ describe("modelsAuthLoginCommand", () => {
       "Auth profile: openai-codex:user@example.com (openai-codex/oauth)",
     );
     expect(runtime.log).toHaveBeenCalledWith(
-      "Default model available: openai-codex/gpt-5.3-codex (use --set-default to apply)",
+      "Default model available: openai-codex/gpt-5.4 (use --set-default to apply)",
     );
   });
 
@@ -193,9 +193,9 @@ describe("modelsAuthLoginCommand", () => {
     await modelsAuthLoginCommand({ provider: "openai-codex", setDefault: true }, runtime);
 
     expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
-      primary: "openai-codex/gpt-5.3-codex",
+      primary: "openai-codex/gpt-5.4",
     });
-    expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.3-codex");
+    expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.4");
   });
 
   it("keeps existing plugin error behavior for non built-in providers", async () => {


### PR DESCRIPTION
## Summary

- **Problem:** Two tests in `models/auth.test.ts` expected the old default model `openai-codex/gpt-5.3-codex` and the old log text. The codebase default was already `openai-codex/gpt-5.4` (in `openai-codex-model-default.ts`), so the tests were out of date and failing.
- **Why it matters:** Keeps CI green and keeps test expectations aligned with the current default so future changes don’t hide real regressions.
- **What changed:** In `src/commands/models/auth.test.ts`, updated the two Codex login tests to assert on `openai-codex/gpt-5.4` and the matching “Default model available” / “Default model set to” log messages.
- **What did NOT change (scope boundary):** No production code, no change to `OPENAI_CODEX_DEFAULT_MODEL`, no user-facing behavior, and no other test files.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None. Test-only change; default model and CLI behavior are unchanged.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node/Bun (repo test env)
- Model/provider: N/A (tests are mocked)
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. Before change: run `npx vitest run src/commands/models/auth.test.ts`.
2. Observe failures in “supports built-in openai-codex login without provider plugins” and “applies openai-codex default model when --set-default is used” (expected `gpt-5.3-codex`, received `gpt-5.4`).
3. After change: run the same command; both tests pass.

### Expected

- Tests pass and assert on the current default `openai-codex/gpt-5.4` and its log messages.

### Actual

- Same as expected after the fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

(Optional) Paste the before-fix test failure (AssertionError on `gpt-5.3-codex` vs `gpt-5.4`) and the after-fix “Tests 6 passed” (or equivalent) output.

## Human Verification (required)

- **Verified scenarios:** Ran `vitest run src/commands/models/auth.test.ts` (or full `pnpm test` for models auth); the two updated tests pass; no other tests in that file were changed or broken.
- **Edge cases checked:** None beyond “tests match current default.”
- **What you did not verify:** No manual CLI login or gateway run; mocks only.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert:** Revert the single-file test-assertion change in `src/commands/models/auth.test.ts`.
- **Files/config to restore:** `src/commands/models/auth.test.ts` only.
- **Known bad symptoms reviewers should watch for:** None; change is test-only.

## Risks and Mitigations

None. Test expectations were updated to match existing production default; no behavior or defaults were changed.