### PR TITLE
UI: fix regex escaping in tool patterns

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -10,6 +10,7 @@ import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
+import { escapeRegExp } from "./regex.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode, ThemeName } from "./theme.ts";
 import type { SessionsListResult } from "./types.ts";
@@ -410,7 +411,7 @@ export function resolveSessionDisplayName(
     if (!prefix) {
       return name;
     }
-    const prefixPattern = new RegExp(`^${prefix.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\s*`, "i");
+    const prefixPattern = new RegExp(`^${escapeRegExp(prefix)}\\s*`, "i");
     return prefixPattern.test(name) ? name : `${prefix} ${name}`;
   };
 

--- a/ui/src/ui/regex.test.ts
+++ b/ui/src/ui/regex.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { escapeRegExp } from "./regex.ts";
+
+describe("escapeRegExp", () => {
+  it("escapes square brackets in literal text", () => {
+    const literal = "exec[child]*";
+    const pattern = new RegExp(`^${escapeRegExp(literal)}$`);
+
+    expect(pattern.test(literal)).toBe(true);
+    expect(pattern.test("execchild*")).toBe(false);
+  });
+});

--- a/ui/src/ui/regex.ts
+++ b/ui/src/ui/regex.ts
@@ -1,0 +1,3 @@
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  isAllowedByPolicy,
+  matchesList,
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
   sortLocaleStrings,
@@ -96,5 +98,17 @@ describe("sortLocaleStrings", () => {
 
   it("accepts any iterable input, including sets", () => {
     expect(sortLocaleStrings(new Set(["beta", "alpha"]))).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("tool policy wildcard matching", () => {
+  it("treats square brackets as literal characters in wildcard patterns", () => {
+    expect(matchesList("exec[child]-stdout", ["exec[child]*"])).toBe(true);
+    expect(
+      isAllowedByPolicy("exec[child]-stdout", {
+        allow: ["exec[child]*"],
+        deny: [],
+      }),
+    ).toBe(true);
   });
 });

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -4,6 +4,7 @@ import {
   normalizeToolName,
   resolveToolProfilePolicy,
 } from "../../../../src/agents/tool-policy-shared.js";
+import { escapeRegExp } from "../regex.ts";
 import type {
   AgentIdentityResult,
   AgentsFilesListResult,
@@ -601,7 +602,7 @@ function compilePattern(pattern: string): CompiledPattern {
   if (!normalized.includes("*")) {
     return { kind: "exact", value: normalized };
   }
-  const escaped = normalized.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
+  const escaped = escapeRegExp(normalized);
   return { kind: "regex", value: new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`) };
 }
 


### PR DESCRIPTION
## Summary
- add a shared UI regex escaping helper for literal text
- fix wildcard tool-policy matching when patterns contain square brackets
- reuse the same helper in session display-name prefix matching to avoid the same escape bug there

## Testing
- pnpm exec vitest run --config vitest.config.ts src/ui/regex.test.ts src/ui/views/agents-utils.test.ts src/ui/app-render.helpers.node.test.ts
- pnpm check
- pnpm build
