### PR TITLE
Media: normalize audio upload filenames

### DIFF
--- a/src/media-understanding/providers/openai/audio.test.ts
+++ b/src/media-understanding/providers/openai/audio.test.ts
@@ -68,6 +68,44 @@ describe("transcribeOpenAiCompatibleAudio", () => {
     }
   });
 
+  it("sends only the basename when fileName includes a path", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+
+    await transcribeOpenAiCompatibleAudio({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "/tmp/private/voice.wav",
+      apiKey: "test-key",
+      timeoutMs: 1234,
+      fetchFn,
+    });
+
+    const form = getRequest().init?.body as FormData;
+    const file = form.get("file") as Blob | { name?: string } | null;
+    expect(file).not.toBeNull();
+    if (file && "name" in file && typeof file.name === "string") {
+      expect(file.name).toBe("voice.wav");
+    }
+  });
+
+  it("falls back to the default upload name for whitespace-only file names", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+
+    await transcribeOpenAiCompatibleAudio({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "   ",
+      apiKey: "test-key",
+      timeoutMs: 1234,
+      fetchFn,
+    });
+
+    const form = getRequest().init?.body as FormData;
+    const file = form.get("file") as Blob | { name?: string } | null;
+    expect(file).not.toBeNull();
+    if (file && "name" in file && typeof file.name === "string") {
+      expect(file.name).toBe("audio");
+    }
+  });
+
   it("throws when the provider response omits text", async () => {
     const { fetchFn } = createRequestCaptureJsonFetch({});
 

--- a/src/media-understanding/providers/openai/audio.ts
+++ b/src/media-understanding/providers/openai/audio.ts
@@ -15,6 +15,15 @@ function resolveModel(model?: string): string {
   return trimmed || DEFAULT_OPENAI_AUDIO_MODEL;
 }
 
+function resolveUploadFileName(fileName?: string): string {
+  const trimmed = fileName?.trim();
+  if (!trimmed) {
+    return "audio";
+  }
+  const baseName = path.basename(trimmed).trim();
+  return baseName || "audio";
+}
+
 export async function transcribeOpenAiCompatibleAudio(
   params: AudioTranscriptionRequest,
 ): Promise<AudioTranscriptionResult> {
@@ -25,7 +34,7 @@ export async function transcribeOpenAiCompatibleAudio(
 
   const model = resolveModel(params.model);
   const form = new FormData();
-  const fileName = params.fileName?.trim() || path.basename(params.fileName) || "audio";
+  const fileName = resolveUploadFileName(params.fileName);
   const bytes = new Uint8Array(params.buffer);
   const blob = new Blob([bytes], {
     type: params.mime ?? "application/octet-stream",


### PR DESCRIPTION
## Summary
- normalize OpenAI-compatible audio upload filenames through basename trimming
- avoid leaking local path segments into multipart upload metadata
- fall back to `audio` when callers pass a whitespace-only filename

## Testing
- pnpm test src/media-understanding/providers/openai/audio.test.ts
- pnpm check
- pnpm build
