### PR TITLE
Fix Feishu thread-aware session routing

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -134,6 +134,17 @@ describe("sessions", () => {
       ctx: { From: "12345-678@g.us", ChatType: "group", Provider: "whatsapp" },
       expected: "whatsapp:group:12345-678@g.us",
     },
+    {
+      name: "includes feishu thread ids in group session keys",
+      scope: "per-sender" as const,
+      ctx: {
+        From: "oc_group_chat",
+        ChatType: "group",
+        Provider: "feishu",
+        MessageThreadId: "omt-thread-123",
+      },
+      expected: "feishu:group:oc_group_chat:thread:omt-thread-123",
+    },
   ] as const;
 
   for (const testCase of deriveSessionKeyCases) {
@@ -203,6 +214,18 @@ describe("sessions", () => {
       ctx: { From: "12345-678@g.us" },
       mainKey: "main",
       expected: "agent:main:whatsapp:group:12345-678@g.us",
+    },
+    {
+      name: "keeps feishu group thread sessions isolated",
+      scope: "per-sender" as const,
+      ctx: {
+        From: "oc_group_chat",
+        ChatType: "group",
+        Provider: "feishu",
+        MessageThreadId: "omt-thread-123",
+      },
+      mainKey: "main",
+      expected: "agent:main:feishu:group:oc_group_chat:thread:omt-thread-123",
     },
   ] as const;
 

--- a/src/config/sessions/delivery-info.test.ts
+++ b/src/config/sessions/delivery-info.test.ts
@@ -110,4 +110,27 @@ describe("extractDeliveryInfo", () => {
       threadId: "55",
     });
   });
+
+  it("falls back to persisted thread metadata for legacy session keys", () => {
+    const sessionKey = "agent:main:feishu:group:oc_group_chat";
+    storeState.store[sessionKey] = {
+      ...buildEntry({
+        channel: "feishu",
+        to: "oc_group_chat",
+        accountId: "default",
+      }),
+      lastThreadId: "omt-thread-123",
+    };
+
+    const result = extractDeliveryInfo(sessionKey);
+
+    expect(result).toEqual({
+      deliveryContext: {
+        channel: "feishu",
+        to: "oc_group_chat",
+        accountId: "default",
+      },
+      threadId: "omt-thread-123",
+    });
+  });
 });

--- a/src/config/sessions/delivery-info.ts
+++ b/src/config/sessions/delivery-info.ts
@@ -1,3 +1,4 @@
+import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
 import { loadConfig } from "../io.js";
 import { resolveStorePath } from "./paths.js";
 import { loadSessionStore } from "./store.js";
@@ -35,23 +36,38 @@ export function extractDeliveryInfo(sessionKey: string | undefined): {
   }
 
   let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
+  let resolvedThreadId = threadId;
   try {
     const cfg = loadConfig();
     const storePath = resolveStorePath(cfg.session?.store);
     const store = loadSessionStore(storePath);
-    let entry = store[sessionKey];
-    if (!entry?.deliveryContext && baseSessionKey !== sessionKey) {
-      entry = store[baseSessionKey];
+    const entries = [store[sessionKey]];
+    if (baseSessionKey !== sessionKey) {
+      entries.push(store[baseSessionKey]);
     }
-    if (entry?.deliveryContext) {
-      deliveryContext = {
-        channel: entry.deliveryContext.channel,
-        to: entry.deliveryContext.to,
-        accountId: entry.deliveryContext.accountId,
-      };
+    for (const entry of entries) {
+      if (!deliveryContext && entry?.deliveryContext) {
+        deliveryContext = {
+          channel: entry.deliveryContext.channel,
+          to: entry.deliveryContext.to,
+          accountId: entry.deliveryContext.accountId,
+        };
+      }
+      if (resolvedThreadId == null) {
+        const normalizedThreadId = normalizeDeliveryContext({
+          threadId:
+            entry?.lastThreadId ?? entry?.deliveryContext?.threadId ?? entry?.origin?.threadId,
+        })?.threadId;
+        if (normalizedThreadId != null && normalizedThreadId !== "") {
+          resolvedThreadId = String(normalizedThreadId);
+        }
+      }
+      if (deliveryContext && resolvedThreadId != null) {
+        break;
+      }
     }
   } catch {
     // ignore: best-effort
   }
-  return { deliveryContext, threadId };
+  return { deliveryContext, threadId: resolvedThreadId };
 }

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -1,4 +1,5 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
+import { resolveThreadSessionKeys } from "../../routing/session-key.js";
 import { normalizeHyphenSlug } from "../../shared/string-normalization.js";
 import { listDeliverableMessageChannels } from "../../utils/message-channel.js";
 import type { GroupKeyResolution } from "./types.js";
@@ -97,9 +98,17 @@ export function resolveGroupSessionKey(ctx: MsgContext): GroupKeyResolution | nu
   if (!finalId) {
     return null;
   }
+  const threadId =
+    provider === "feishu" && ctx.MessageThreadId != null
+      ? String(ctx.MessageThreadId).trim()
+      : undefined;
+  const threadKeys = resolveThreadSessionKeys({
+    baseSessionKey: `${provider}:${kind}:${finalId}`,
+    threadId,
+  });
 
   return {
-    key: `${provider}:${kind}:${finalId}`,
+    key: threadKeys.sessionKey,
     channel: provider,
     id: finalId,
     chatType: kind === "channel" ? "channel" : "group",

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -873,13 +873,19 @@ function resolveFeishuSession(
     accountId: params.accountId,
     peer,
   });
+  const threadId = normalizeThreadId(params.threadId ?? params.replyToId);
+  const threadKeys = resolveThreadSessionKeys({
+    baseSessionKey,
+    threadId,
+  });
   return {
-    sessionKey: baseSessionKey,
+    sessionKey: threadKeys.sessionKey,
     baseSessionKey,
     peer,
     chatType: isGroup ? "group" : "direct",
     from: isGroup ? `feishu:group:${trimmed}` : `feishu:${trimmed}`,
     to: trimmed,
+    threadId,
   };
 }
 

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -1071,6 +1071,20 @@ describe("resolveOutboundSessionRoute", () => {
         },
       },
       {
+        name: "Feishu group routes keep thread-aware session keys",
+        cfg: baseConfig,
+        channel: "feishu",
+        target: "group:oc_group_chat",
+        threadId: "omt-thread-123",
+        expected: {
+          sessionKey: "agent:main:feishu:group:oc_group_chat:thread:omt-thread-123",
+          from: "feishu:group:oc_group_chat",
+          to: "oc_group_chat",
+          threadId: "omt-thread-123",
+          chatType: "group",
+        },
+      },
+      {
         name: "Feishu explicit dm prefix keeps direct routing",
         cfg: perChannelPeerCfg,
         channel: "feishu",


### PR DESCRIPTION
## Summary
- add Feishu `MessageThreadId` suffixing to inbound group/channel session keys
- make outbound Feishu session resolution use `resolveThreadSessionKeys` so replies stay in the originating post thread
- keep `extractDeliveryInfo` narrowly compatible by falling back to persisted thread metadata when an older session key lacks `:thread:`

## Scope
This intentionally stays source-local and minimal:
- no dist bundle patching
- no session-store migrations or key renames
- no broad legacy compatibility layer beyond the best-effort thread lookup already stored on the session entry

## Testing
- `vitest run --config vitest.unit.config.ts src/config/sessions.test.ts src/config/sessions/delivery-info.test.ts src/infra/outbound/outbound.test.ts`
- `tsc -p tsconfig.json --noEmit`
