### PR TITLE
Feat/provider agnostic web tools

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -990,3 +990,10 @@ export function createWebFetchTool(options?: {
     },
   };
 }
+
+export const __testing = {
+  resolveFetchProvider,
+  resolveScrapingBeeApiKey,
+  resolveScrapingBeeConfig,
+  resolveScrapingBeeRenderJs,
+} as const;

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -620,7 +620,7 @@ async function maybeFetchFirecrawlWebFetchPayload(
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
-    `fetch:${params.url}:${params.extractMode}:${params.maxChars}`,
+    `fetch:${params.provider}:${params.url}:${params.extractMode}:${params.maxChars}`,
   );
   const cached = readCache(FETCH_CACHE, cacheKey);
   if (cached) {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -114,6 +114,9 @@ function resolveFetchProvider(params: {
   if (explicit === "firecrawl") {
     return "firecrawl";
   }
+  if (explicit === "scrapingbee") {
+    return "scrapingbee";
+  }
   if (explicit === "readability") {
     return "readability";
   }
@@ -222,6 +225,77 @@ function resolveFirecrawlMaxAgeMsOrDefault(firecrawl?: FirecrawlFetchConfig): nu
     return resolved;
   }
   return DEFAULT_FIRECRAWL_MAX_AGE_MS;
+}
+
+// ---------------------------------------------------------------------------
+// ScrapingBee — thin proxy wrapper (returns HTML, piped through Readability)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SCRAPINGBEE_BASE_URL = "https://app.scrapingbee.com/api/v1";
+
+type ScrapingBeeFetchConfig =
+  | {
+      apiKey?: unknown;
+      renderJs?: boolean;
+      timeoutSeconds?: number;
+    }
+  | undefined;
+
+function resolveScrapingBeeConfig(fetch?: WebFetchConfig): ScrapingBeeFetchConfig {
+  if (!fetch || typeof fetch !== "object") {
+    return undefined;
+  }
+  const sb = "scrapingbee" in fetch ? fetch.scrapingbee : undefined;
+  if (!sb || typeof sb !== "object") {
+    return undefined;
+  }
+  return sb as ScrapingBeeFetchConfig;
+}
+
+function resolveScrapingBeeApiKey(sb?: ScrapingBeeFetchConfig): string | undefined {
+  const fromConfigRaw =
+    sb && "apiKey" in sb
+      ? normalizeResolvedSecretInputString({
+          value: sb.apiKey,
+          path: "tools.web.fetch.scrapingbee.apiKey",
+        })
+      : undefined;
+  const fromConfig = normalizeSecretInput(fromConfigRaw);
+  const fromEnv = normalizeSecretInput(process.env.SCRAPINGBEE_API_KEY);
+  return fromConfig || fromEnv || undefined;
+}
+
+function resolveScrapingBeeRenderJs(sb?: ScrapingBeeFetchConfig): boolean {
+  return sb?.renderJs === true;
+}
+
+async function fetchViaScrapingBee(params: {
+  url: string;
+  apiKey: string;
+  renderJs: boolean;
+  timeoutSeconds: number;
+}): Promise<{ html: string; status: number; resolvedUrl: string }> {
+  const endpoint = new URL(DEFAULT_SCRAPINGBEE_BASE_URL);
+  endpoint.searchParams.set("api_key", params.apiKey);
+  endpoint.searchParams.set("url", params.url);
+  if (params.renderJs) {
+    endpoint.searchParams.set("render_js", "true");
+  }
+
+  const res = await fetch(endpoint.toString(), {
+    method: "GET",
+    headers: { Accept: "text/html" },
+    signal: AbortSignal.timeout(params.timeoutSeconds * 1000),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`ScrapingBee API error (${res.status}): ${detail || res.statusText}`);
+  }
+
+  const html = await res.text();
+  const resolvedUrl = res.headers.get("Spb-resolved-url") || params.url;
+  return { html, status: res.status, resolvedUrl };
 }
 
 function resolveMaxChars(value: unknown, fallback: number, cap: number): number {
@@ -471,20 +545,27 @@ type FirecrawlRuntimeParams = {
   firecrawlTimeoutSeconds: number;
 };
 
-type FetchProvider = "readability" | "firecrawl";
+type FetchProvider = "readability" | "firecrawl" | "scrapingbee";
 
-type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
-  url: string;
-  extractMode: ExtractMode;
-  maxChars: number;
-  maxResponseBytes: number;
-  maxRedirects: number;
-  timeoutSeconds: number;
-  cacheTtlMs: number;
-  userAgent: string;
-  readabilityEnabled: boolean;
-  provider: FetchProvider;
+type ScrapingBeeRuntimeParams = {
+  scrapingBeeApiKey?: string;
+  scrapingBeeRenderJs: boolean;
+  scrapingBeeTimeoutSeconds: number;
 };
+
+type WebFetchRuntimeParams = FirecrawlRuntimeParams &
+  ScrapingBeeRuntimeParams & {
+    url: string;
+    extractMode: ExtractMode;
+    maxChars: number;
+    maxResponseBytes: number;
+    maxRedirects: number;
+    timeoutSeconds: number;
+    cacheTtlMs: number;
+    userAgent: string;
+    readabilityEnabled: boolean;
+    provider: FetchProvider;
+  };
 
 function toFirecrawlContentParams(
   params: FirecrawlRuntimeParams & { url: string; extractMode: ExtractMode },
@@ -573,6 +654,67 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       }
     } catch {
       // Firecrawl failed — fall through to Readability path.
+    }
+  }
+
+  // Provider "scrapingbee": fetch HTML via ScrapingBee proxy, then extract with Readability.
+  if (params.provider === "scrapingbee" && params.scrapingBeeApiKey) {
+    const start = Date.now();
+    try {
+      const sbResult = await fetchViaScrapingBee({
+        url: params.url,
+        apiKey: params.scrapingBeeApiKey,
+        renderJs: params.scrapingBeeRenderJs,
+        timeoutSeconds: params.scrapingBeeTimeoutSeconds,
+      });
+
+      let text = sbResult.html;
+      let title: string | undefined;
+      let extractor = "scrapingbee";
+
+      if (looksLikeHtml(text) && params.readabilityEnabled) {
+        const readable = await extractReadableContent({
+          html: text,
+          url: sbResult.resolvedUrl,
+          extractMode: params.extractMode,
+        });
+        if (readable?.text) {
+          text = readable.text;
+          title = readable.title;
+          extractor = "scrapingbee+readability";
+        }
+      } else if (params.extractMode === "text") {
+        text = markdownToText(text);
+      }
+
+      const wrapped = wrapWebFetchContent(text, params.maxChars);
+      const wrappedTitle = title ? wrapWebFetchField(title) : undefined;
+      const payload: Record<string, unknown> = {
+        url: params.url,
+        finalUrl: sbResult.resolvedUrl,
+        status: sbResult.status,
+        contentType: "text/html",
+        title: wrappedTitle,
+        extractMode: params.extractMode,
+        extractor,
+        provider: "scrapingbee",
+        externalContent: {
+          untrusted: true,
+          source: "web_fetch",
+          wrapped: true,
+        },
+        truncated: wrapped.truncated,
+        length: wrapped.wrappedLength,
+        rawLength: wrapped.rawLength,
+        wrappedLength: wrapped.wrappedLength,
+        fetchedAt: new Date().toISOString(),
+        tookMs: Date.now() - start,
+        text: wrapped.text,
+      };
+      writeCache(FETCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+      return payload;
+    } catch {
+      // ScrapingBee failed — fall through to direct fetch path.
     }
   }
 
@@ -793,6 +935,13 @@ export function createWebFetchTool(options?: {
     firecrawl?.timeoutSeconds ?? fetch?.timeoutSeconds,
     DEFAULT_TIMEOUT_SECONDS,
   );
+  const scrapingBeeConfig = resolveScrapingBeeConfig(fetch);
+  const scrapingBeeApiKey = resolveScrapingBeeApiKey(scrapingBeeConfig);
+  const scrapingBeeRenderJs = resolveScrapingBeeRenderJs(scrapingBeeConfig);
+  const scrapingBeeTimeoutSeconds = resolveTimeoutSeconds(
+    scrapingBeeConfig?.timeoutSeconds ?? fetch?.timeoutSeconds,
+    DEFAULT_TIMEOUT_SECONDS,
+  );
   const provider = resolveFetchProvider({ fetch, firecrawlEnabled });
   const userAgent =
     (fetch && "userAgent" in fetch && typeof fetch.userAgent === "string" && fetch.userAgent) ||
@@ -833,6 +982,9 @@ export function createWebFetchTool(options?: {
         firecrawlProxy: "auto",
         firecrawlStoreInCache: true,
         firecrawlTimeoutSeconds,
+        scrapingBeeApiKey,
+        scrapingBeeRenderJs,
+        scrapingBeeTimeoutSeconds,
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -274,17 +274,17 @@ async function fetchViaScrapingBee(params: {
   apiKey: string;
   renderJs: boolean;
   timeoutSeconds: number;
-}): Promise<{ html: string; status: number; resolvedUrl: string }> {
+}): Promise<{ markdown: string; status: number; resolvedUrl: string }> {
   const endpoint = new URL(DEFAULT_SCRAPINGBEE_BASE_URL);
   endpoint.searchParams.set("api_key", params.apiKey);
   endpoint.searchParams.set("url", params.url);
+  endpoint.searchParams.set("return_page_markdown", "true");
   if (params.renderJs) {
     endpoint.searchParams.set("render_js", "true");
   }
 
   const res = await fetch(endpoint.toString(), {
     method: "GET",
-    headers: { Accept: "text/html" },
     signal: AbortSignal.timeout(params.timeoutSeconds * 1000),
   });
 
@@ -293,9 +293,9 @@ async function fetchViaScrapingBee(params: {
     throw new Error(`ScrapingBee API error (${res.status}): ${detail || res.statusText}`);
   }
 
-  const html = await res.text();
+  const markdown = await res.text();
   const resolvedUrl = res.headers.get("Spb-resolved-url") || params.url;
-  return { html, status: res.status, resolvedUrl };
+  return { markdown, status: res.status, resolvedUrl };
 }
 
 function resolveMaxChars(value: unknown, fallback: number, cap: number): number {
@@ -657,7 +657,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     }
   }
 
-  // Provider "scrapingbee": fetch HTML via ScrapingBee proxy, then extract with Readability.
+  // Provider "scrapingbee": fetch markdown directly via ScrapingBee API.
   if (params.provider === "scrapingbee" && params.scrapingBeeApiKey) {
     const start = Date.now();
     try {
@@ -668,35 +668,18 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
         timeoutSeconds: params.scrapingBeeTimeoutSeconds,
       });
 
-      let text = sbResult.html;
-      let title: string | undefined;
-      let extractor = "scrapingbee";
-
-      if (looksLikeHtml(text) && params.readabilityEnabled) {
-        const readable = await extractReadableContent({
-          html: text,
-          url: sbResult.resolvedUrl,
-          extractMode: params.extractMode,
-        });
-        if (readable?.text) {
-          text = readable.text;
-          title = readable.title;
-          extractor = "scrapingbee+readability";
-        }
-      } else if (params.extractMode === "text") {
+      let text = sbResult.markdown;
+      if (params.extractMode === "text") {
         text = markdownToText(text);
       }
 
       const wrapped = wrapWebFetchContent(text, params.maxChars);
-      const wrappedTitle = title ? wrapWebFetchField(title) : undefined;
       const payload: Record<string, unknown> = {
         url: params.url,
         finalUrl: sbResult.resolvedUrl,
         status: sbResult.status,
-        contentType: "text/html",
-        title: wrappedTitle,
         extractMode: params.extractMode,
-        extractor,
+        extractor: "scrapingbee",
         provider: "scrapingbee",
         externalContent: {
           untrusted: true,

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -293,9 +293,9 @@ async function fetchViaScrapingBee(params: {
     throw new Error(`ScrapingBee API error (${res.status}): ${detail || res.statusText}`);
   }
 
-  const markdown = await res.text();
+  const bodyResult = await readResponseText(res, { maxBytes: DEFAULT_FETCH_MAX_RESPONSE_BYTES });
   const resolvedUrl = res.headers.get("Spb-resolved-url") || params.url;
-  return { markdown, status: res.status, resolvedUrl };
+  return { markdown: bodyResult.text, status: res.status, resolvedUrl };
 }
 
 function resolveMaxChars(value: unknown, fallback: number, cap: number): number {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -545,7 +545,7 @@ type FirecrawlRuntimeParams = {
   firecrawlTimeoutSeconds: number;
 };
 
-type FetchProvider = "readability" | "firecrawl" | "scrapingbee";
+export type FetchProvider = "readability" | "firecrawl" | "scrapingbee";
 
 type ScrapingBeeRuntimeParams = {
   scrapingBeeApiKey?: string;
@@ -637,7 +637,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     throw new Error("Invalid URL: must be http or https");
   }
 
-  // Provider "firecrawl": try Firecrawl first, fall through to Readability on failure.
+  // Provider "firecrawl": use Firecrawl as primary extractor.
   if (params.provider === "firecrawl" && params.firecrawlEnabled && params.firecrawlApiKey) {
     const start = Date.now();
     try {
@@ -652,8 +652,14 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       if (payload) {
         return { ...payload, provider: "firecrawl" };
       }
-    } catch {
-      // Firecrawl failed — fall through to Readability path.
+    } catch (err) {
+      logDebug(
+        `[web-fetch] Firecrawl provider failed for ${redactUrlForDebugLog(params.url)}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw new Error(
+        `Firecrawl fetch failed: ${err instanceof Error ? err.message : "unknown error"}`,
+        { cause: err },
+      );
     }
   }
 
@@ -696,8 +702,14 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       };
       writeCache(FETCH_CACHE, cacheKey, payload, params.cacheTtlMs);
       return payload;
-    } catch {
-      // ScrapingBee failed — fall through to direct fetch path.
+    } catch (err) {
+      logDebug(
+        `[web-fetch] ScrapingBee provider failed for ${redactUrlForDebugLog(params.url)}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw new Error(
+        `ScrapingBee fetch failed: ${err instanceof Error ? err.message : "unknown error"}`,
+        { cause: err },
+      );
     }
   }
 

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -228,7 +228,7 @@ function resolveFirecrawlMaxAgeMsOrDefault(firecrawl?: FirecrawlFetchConfig): nu
 }
 
 // ---------------------------------------------------------------------------
-// ScrapingBee — thin proxy wrapper (returns HTML, piped through Readability)
+// ScrapingBee — thin proxy wrapper (returns markdown via ScrapingBee's own converter)
 // ---------------------------------------------------------------------------
 
 const DEFAULT_SCRAPINGBEE_BASE_URL = "https://app.scrapingbee.com/api/v1";
@@ -283,6 +283,8 @@ async function fetchViaScrapingBee(params: {
     endpoint.searchParams.set("render_js", "true");
   }
 
+  // Direct fetch is safe here: endpoint is the hardcoded ScrapingBee API, not a user URL.
+  // The user-supplied URL is passed as a query param for ScrapingBee to fetch server-side.
   const res = await fetch(endpoint.toString(), {
     method: "GET",
     signal: AbortSignal.timeout(params.timeoutSeconds * 1000),
@@ -652,10 +654,11 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
         finalUrlFallback: params.url,
         statusFallback: 200,
         cacheKey,
-        tookMs: Date.now() - start,
+        tookMs: 0,
       });
+      const elapsed = Date.now() - start;
       if (payload) {
-        return { ...payload, provider: "firecrawl" };
+        return { ...payload, tookMs: elapsed, provider: "firecrawl" };
       }
       throw new Error("Firecrawl fetch failed: no content returned");
     } catch (err) {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -638,7 +638,12 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   }
 
   // Provider "firecrawl": use Firecrawl as primary extractor.
-  if (params.provider === "firecrawl" && params.firecrawlEnabled && params.firecrawlApiKey) {
+  if (params.provider === "firecrawl") {
+    if (!params.firecrawlApiKey) {
+      throw new Error(
+        "Firecrawl fetch provider selected but no API key configured. Set tools.web.fetch.firecrawl.apiKey or FIRECRAWL_API_KEY.",
+      );
+    }
     const start = Date.now();
     try {
       const payload = await maybeFetchFirecrawlWebFetchPayload({
@@ -652,6 +657,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       if (payload) {
         return { ...payload, provider: "firecrawl" };
       }
+      throw new Error("Firecrawl fetch failed: no content returned");
     } catch (err) {
       logDebug(
         `[web-fetch] Firecrawl provider failed for ${redactUrlForDebugLog(params.url)}: ${err instanceof Error ? err.message : String(err)}`,
@@ -664,7 +670,12 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   }
 
   // Provider "scrapingbee": fetch markdown directly via ScrapingBee API.
-  if (params.provider === "scrapingbee" && params.scrapingBeeApiKey) {
+  if (params.provider === "scrapingbee") {
+    if (!params.scrapingBeeApiKey) {
+      throw new Error(
+        "ScrapingBee fetch provider selected but no API key configured. Set tools.web.fetch.scrapingbee.apiKey or SCRAPINGBEE_API_KEY.",
+      );
+    }
     const start = Date.now();
     try {
       const sbResult = await fetchViaScrapingBee({

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -103,6 +103,35 @@ function resolveFetchReadabilityEnabled(fetch?: WebFetchConfig): boolean {
   return true;
 }
 
+function resolveFetchProvider(params: {
+  fetch?: WebFetchConfig;
+  firecrawlEnabled: boolean;
+}): FetchProvider {
+  const explicit =
+    params.fetch && "provider" in params.fetch && typeof params.fetch.provider === "string"
+      ? (params.fetch.provider as string).trim().toLowerCase()
+      : "";
+  if (explicit === "firecrawl") {
+    return "firecrawl";
+  }
+  if (explicit === "readability") {
+    return "readability";
+  }
+  // Backward compat: if firecrawl is explicitly enabled with a key, default to firecrawl.
+  if (params.firecrawlEnabled) {
+    const firecrawlCfg =
+      params.fetch && "firecrawl" in params.fetch ? params.fetch.firecrawl : undefined;
+    if (
+      firecrawlCfg &&
+      typeof firecrawlCfg === "object" &&
+      (firecrawlCfg as { enabled?: boolean }).enabled === true
+    ) {
+      return "firecrawl";
+    }
+  }
+  return "readability";
+}
+
 function resolveFetchMaxCharsCap(fetch?: WebFetchConfig): number {
   const raw =
     fetch && "maxCharsCap" in fetch && typeof fetch.maxCharsCap === "number"
@@ -442,6 +471,8 @@ type FirecrawlRuntimeParams = {
   firecrawlTimeoutSeconds: number;
 };
 
+type FetchProvider = "readability" | "firecrawl";
+
 type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   url: string;
   extractMode: ExtractMode;
@@ -452,6 +483,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  provider: FetchProvider;
 };
 
 function toFirecrawlContentParams(
@@ -522,6 +554,26 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   }
   if (!["http:", "https:"].includes(parsedUrl.protocol)) {
     throw new Error("Invalid URL: must be http or https");
+  }
+
+  // Provider "firecrawl": try Firecrawl first, fall through to Readability on failure.
+  if (params.provider === "firecrawl" && params.firecrawlEnabled && params.firecrawlApiKey) {
+    const start = Date.now();
+    try {
+      const payload = await maybeFetchFirecrawlWebFetchPayload({
+        ...params,
+        urlToFetch: params.url,
+        finalUrlFallback: params.url,
+        statusFallback: 200,
+        cacheKey,
+        tookMs: Date.now() - start,
+      });
+      if (payload) {
+        return { ...payload, provider: "firecrawl" };
+      }
+    } catch {
+      // Firecrawl failed — fall through to Readability path.
+    }
   }
 
   const start = Date.now();
@@ -741,6 +793,7 @@ export function createWebFetchTool(options?: {
     firecrawl?.timeoutSeconds ?? fetch?.timeoutSeconds,
     DEFAULT_TIMEOUT_SECONDS,
   );
+  const provider = resolveFetchProvider({ fetch, firecrawlEnabled });
   const userAgent =
     (fetch && "userAgent" in fetch && typeof fetch.userAgent === "string" && fetch.userAgent) ||
     DEFAULT_FETCH_USER_AGENT;
@@ -771,6 +824,7 @@ export function createWebFetchTool(options?: {
         cacheTtlMs: resolveCacheTtlMs(fetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         userAgent,
         readabilityEnabled,
+        provider,
         firecrawlEnabled,
         firecrawlApiKey,
         firecrawlBaseUrl,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -957,7 +957,9 @@ type FirecrawlSearchResultItem = {
 
 type FirecrawlSearchResponse = {
   success?: boolean;
-  data?: FirecrawlSearchResultItem[];
+  data?: {
+    web?: FirecrawlSearchResultItem[];
+  };
   warning?: string;
   error?: string;
 };
@@ -1694,7 +1696,13 @@ async function runFirecrawlSearch(params: {
         throw new Error(`Firecrawl Search API error: ${data.error || "unknown error"}`);
       }
 
-      const items = Array.isArray(data.data) ? data.data : [];
+      const webResults =
+        data.data && typeof data.data === "object" && "web" in data.data
+          ? data.data.web
+          : Array.isArray(data.data)
+            ? data.data
+            : [];
+      const items = Array.isArray(webResults) ? webResults : [];
       return {
         results: items.map((item) => ({
           url: item.url ?? "",

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1661,7 +1661,6 @@ async function runFirecrawlSearch(params: {
     url: string;
     title: string;
     description: string;
-    markdown?: string;
   }>;
 }> {
   const endpoint = `${params.baseUrl.replace(/\/$/, "")}${FIRECRAWL_SEARCH_ENDPOINT_PATH}`;
@@ -1701,7 +1700,6 @@ async function runFirecrawlSearch(params: {
           url: item.url ?? "",
           title: item.title ?? "",
           description: item.description ?? "",
-          markdown: item.markdown || undefined,
         })),
       };
     },

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -22,7 +22,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as const;
+const SEARCH_PROVIDERS = ["brave", "firecrawl", "gemini", "grok", "kimi", "perplexity"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -34,6 +34,9 @@ const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
 const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
 const PERPLEXITY_KEY_PREFIXES = ["pplx-"];
 const OPENROUTER_KEY_PREFIXES = ["sk-or-"];
+
+const DEFAULT_FIRECRAWL_SEARCH_BASE_URL = "https://api.firecrawl.dev";
+const FIRECRAWL_SEARCH_ENDPOINT_PATH = "/v2/search";
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
@@ -593,6 +596,13 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "firecrawl") {
+    return {
+      error: "missing_firecrawl_api_key",
+      message: `web_search (firecrawl) needs a Firecrawl API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set FIRECRAWL_API_KEY in the Gateway environment.`,
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_perplexity_api_key",
     message:
@@ -608,6 +618,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       : "";
   if (raw === "brave") {
     return "brave";
+  }
+  if (raw === "firecrawl") {
+    return "firecrawl";
   }
   if (raw === "gemini") {
     return "gemini";
@@ -663,6 +676,14 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
         'web_search: no provider configured, auto-detected "perplexity" from available API keys',
       );
       return "perplexity";
+    }
+    // Firecrawl (lowest auto-detect priority — users with Firecrawl likely want it for scrape/browser)
+    const firecrawlSearchConfig = resolveFirecrawlSearchConfig(search);
+    if (resolveFirecrawlSearchApiKey(firecrawlSearchConfig)) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "firecrawl" from available API keys',
+      );
+      return "firecrawl";
     }
   }
 
@@ -888,6 +909,58 @@ function resolveKimiBaseUrl(kimi?: KimiConfig): string {
     kimi && "baseUrl" in kimi && typeof kimi.baseUrl === "string" ? kimi.baseUrl.trim() : "";
   return fromConfig || DEFAULT_KIMI_BASE_URL;
 }
+
+type FirecrawlSearchConfig = {
+  apiKey?: unknown;
+  baseUrl?: string;
+  timeoutSeconds?: number;
+};
+
+function resolveFirecrawlSearchConfig(search?: WebSearchConfig): FirecrawlSearchConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const firecrawl = "firecrawl" in search ? search.firecrawl : undefined;
+  if (!firecrawl || typeof firecrawl !== "object") {
+    return {};
+  }
+  return firecrawl as FirecrawlSearchConfig;
+}
+
+function resolveFirecrawlSearchApiKey(firecrawl?: FirecrawlSearchConfig): string | undefined {
+  const fromConfigRaw =
+    firecrawl && "apiKey" in firecrawl
+      ? normalizeResolvedSecretInputString({
+          value: firecrawl.apiKey,
+          path: "tools.web.search.firecrawl.apiKey",
+        })
+      : undefined;
+  const fromConfig = normalizeSecretInput(fromConfigRaw);
+  const fromEnv = normalizeSecretInput(process.env.FIRECRAWL_API_KEY);
+  return fromConfig || fromEnv || undefined;
+}
+
+function resolveFirecrawlSearchBaseUrl(firecrawl?: FirecrawlSearchConfig): string {
+  const raw =
+    firecrawl && "baseUrl" in firecrawl && typeof firecrawl.baseUrl === "string"
+      ? firecrawl.baseUrl.trim()
+      : "";
+  return raw || DEFAULT_FIRECRAWL_SEARCH_BASE_URL;
+}
+
+type FirecrawlSearchResultItem = {
+  url?: string;
+  title?: string;
+  description?: string;
+  markdown?: string;
+};
+
+type FirecrawlSearchResponse = {
+  success?: boolean;
+  data?: FirecrawlSearchResultItem[];
+  warning?: string;
+  error?: string;
+};
 
 function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
   if (!search || typeof search !== "object") {
@@ -1577,6 +1650,64 @@ async function runBraveLlmContextSearch(params: {
   );
 }
 
+async function runFirecrawlSearch(params: {
+  query: string;
+  count: number;
+  apiKey: string;
+  baseUrl: string;
+  timeoutSeconds: number;
+}): Promise<{
+  results: Array<{
+    url: string;
+    title: string;
+    description: string;
+    markdown?: string;
+  }>;
+}> {
+  const endpoint = `${params.baseUrl.replace(/\/$/, "")}${FIRECRAWL_SEARCH_ENDPOINT_PATH}`;
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: endpoint,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${params.apiKey}`,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          query: params.query,
+          limit: params.count,
+        }),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+        const detail = detailResult.text;
+        throw new Error(`Firecrawl Search API error (${res.status}): ${detail || res.statusText}`);
+      }
+
+      const data = (await res.json()) as FirecrawlSearchResponse;
+      if (data.success === false) {
+        throw new Error(`Firecrawl Search API error: ${data.error || "unknown error"}`);
+      }
+
+      const items = Array.isArray(data.data) ? data.data : [];
+      return {
+        results: items.map((item) => ({
+          url: item.url ?? "",
+          title: item.title ?? "",
+          description: item.description ?? "",
+          markdown: item.markdown || undefined,
+        })),
+      };
+    },
+  );
+}
+
 async function runWebSearch(params: {
   query: string;
   count: number;
@@ -1602,6 +1733,7 @@ async function runWebSearch(params: {
   geminiModel?: string;
   kimiBaseUrl?: string;
   kimiModel?: string;
+  firecrawlBaseUrl?: string;
   braveMode?: "web" | "llm-context";
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
@@ -1769,6 +1901,39 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "firecrawl") {
+    const firecrawlResults = await runFirecrawlSearch({
+      query: params.query,
+      count: params.count,
+      apiKey: params.apiKey,
+      baseUrl: params.firecrawlBaseUrl ?? DEFAULT_FIRECRAWL_SEARCH_BASE_URL,
+      timeoutSeconds: params.timeoutSeconds,
+    });
+
+    const mapped = firecrawlResults.results.map((entry) => ({
+      title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
+      url: entry.url,
+      description: entry.description ? wrapWebContent(entry.description, "web_search") : "",
+      siteName: resolveSiteName(entry.url) || undefined,
+    }));
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: mapped.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      results: mapped,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -1909,6 +2074,7 @@ export function createWebSearchTool(options?: {
   const grokConfig = resolveGrokConfig(search);
   const geminiConfig = resolveGeminiConfig(search);
   const kimiConfig = resolveKimiConfig(search);
+  const firecrawlSearchConfig = resolveFirecrawlSearchConfig(search);
   const braveConfig = resolveBraveConfig(search);
   const braveMode = resolveBraveMode(braveConfig);
 
@@ -1923,9 +2089,11 @@ export function createWebSearchTool(options?: {
           ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
           : provider === "gemini"
             ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : braveMode === "llm-context"
-              ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
-              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+            : provider === "firecrawl"
+              ? "Search the web using Firecrawl. Returns structured results with titles, URLs, and descriptions."
+              : braveMode === "llm-context"
+                ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
+                : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -1949,7 +2117,9 @@ export function createWebSearchTool(options?: {
               ? resolveKimiApiKey(kimiConfig)
               : provider === "gemini"
                 ? resolveGeminiApiKey(geminiConfig)
-                : resolveSearchApiKey(search);
+                : provider === "firecrawl"
+                  ? resolveFirecrawlSearchApiKey(firecrawlSearchConfig)
+                  : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
@@ -2185,6 +2355,7 @@ export function createWebSearchTool(options?: {
         geminiModel: resolveGeminiModel(geminiConfig),
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
+        firecrawlBaseUrl: resolveFirecrawlSearchBaseUrl(firecrawlSearchConfig),
         braveMode,
       });
       return jsonResult(result);
@@ -2219,4 +2390,6 @@ export const __testing = {
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,
   mapBraveLlmContextResults,
+  resolveFirecrawlSearchApiKey,
+  resolveFirecrawlSearchBaseUrl,
 } as const;

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1732,6 +1732,7 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   firecrawlBaseUrl?: string;
+  firecrawlTimeoutSeconds?: number;
   braveMode?: "web" | "llm-context";
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
@@ -1905,7 +1906,7 @@ async function runWebSearch(params: {
       count: params.count,
       apiKey: params.apiKey,
       baseUrl: params.firecrawlBaseUrl ?? DEFAULT_FIRECRAWL_SEARCH_BASE_URL,
-      timeoutSeconds: params.timeoutSeconds,
+      timeoutSeconds: params.firecrawlTimeoutSeconds ?? params.timeoutSeconds,
     });
 
     const mapped = firecrawlResults.results.map((entry) => ({
@@ -2354,6 +2355,7 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         firecrawlBaseUrl: resolveFirecrawlSearchBaseUrl(firecrawlSearchConfig),
+        firecrawlTimeoutSeconds: firecrawlSearchConfig?.timeoutSeconds,
         braveMode,
       });
       return jsonResult(result);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -2355,7 +2355,9 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         firecrawlBaseUrl: resolveFirecrawlSearchBaseUrl(firecrawlSearchConfig),
-        firecrawlTimeoutSeconds: firecrawlSearchConfig?.timeoutSeconds,
+        firecrawlTimeoutSeconds: firecrawlSearchConfig?.timeoutSeconds
+          ? resolveTimeoutSeconds(firecrawlSearchConfig.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS)
+          : undefined,
         braveMode,
       });
       return jsonResult(result);

--- a/src/agents/tools/web-tools.provider-resolution.test.ts
+++ b/src/agents/tools/web-tools.provider-resolution.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ssrf from "../../infra/net/ssrf.js";
+import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import { __testing as fetchInternals } from "./web-fetch.js";
+import { __testing as searchInternals } from "./web-search.js";
+import { createWebFetchTool } from "./web-tools.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeHeaders(map: Record<string, string>): { get: (key: string) => string | null } {
+  return {
+    get: (key) => map[key.toLowerCase()] ?? null,
+  };
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  if ("url" in input && typeof input.url === "string") {
+    return input.url;
+  }
+  return "";
+}
+
+function installMockFetch(
+  impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+) {
+  const mockFetch = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => await impl(input, init),
+  );
+  global.fetch = withFetchPreconnect(mockFetch);
+  return mockFetch;
+}
+
+function createFetchTool(fetchOverrides: Record<string, unknown> = {}) {
+  return createWebFetchTool({
+    config: {
+      tools: {
+        web: {
+          fetch: {
+            cacheTtlMinutes: 0,
+            ...fetchOverrides,
+          },
+        },
+      },
+    },
+    sandboxed: false,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// web_fetch provider resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveFetchProvider", () => {
+  const { resolveFetchProvider } = fetchInternals;
+
+  it("returns readability by default", () => {
+    expect(resolveFetchProvider({ firecrawlEnabled: false })).toBe("readability");
+  });
+
+  it("returns explicit firecrawl provider", () => {
+    expect(
+      resolveFetchProvider({
+        fetch: { provider: "firecrawl" } as Record<string, unknown>,
+        firecrawlEnabled: false,
+      }),
+    ).toBe("firecrawl");
+  });
+
+  it("returns explicit scrapingbee provider", () => {
+    expect(
+      resolveFetchProvider({
+        fetch: { provider: "scrapingbee" } as Record<string, unknown>,
+        firecrawlEnabled: false,
+      }),
+    ).toBe("scrapingbee");
+  });
+
+  it("returns explicit readability provider", () => {
+    expect(
+      resolveFetchProvider({
+        fetch: { provider: "readability" } as Record<string, unknown>,
+        firecrawlEnabled: true,
+      }),
+    ).toBe("readability");
+  });
+
+  it("falls back to firecrawl when firecrawl.enabled is true and firecrawlEnabled", () => {
+    expect(
+      resolveFetchProvider({
+        fetch: { firecrawl: { enabled: true } } as Record<string, unknown>,
+        firecrawlEnabled: true,
+      }),
+    ).toBe("firecrawl");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ScrapingBee config resolution
+// ---------------------------------------------------------------------------
+
+describe("ScrapingBee config resolution", () => {
+  const { resolveScrapingBeeConfig, resolveScrapingBeeApiKey, resolveScrapingBeeRenderJs } =
+    fetchInternals;
+
+  it("returns undefined for missing fetch config", () => {
+    expect(resolveScrapingBeeConfig(undefined)).toBeUndefined();
+  });
+
+  it("extracts scrapingbee sub-config", () => {
+    const config = resolveScrapingBeeConfig({
+      scrapingbee: { apiKey: "sb-test", renderJs: true },
+    } as Record<string, unknown>);
+    expect(config).toMatchObject({ apiKey: "sb-test", renderJs: true });
+  });
+
+  it("resolves API key from config", () => {
+    expect(resolveScrapingBeeApiKey({ apiKey: "sb-key-123" })).toBe("sb-key-123");
+  });
+
+  it("resolves API key from env var", () => {
+    const original = process.env.SCRAPINGBEE_API_KEY;
+    process.env.SCRAPINGBEE_API_KEY = "sb-env-key";
+    try {
+      expect(resolveScrapingBeeApiKey({})).toBe("sb-env-key");
+    } finally {
+      if (original === undefined) {
+        delete process.env.SCRAPINGBEE_API_KEY;
+      } else {
+        process.env.SCRAPINGBEE_API_KEY = original;
+      }
+    }
+  });
+
+  it("defaults renderJs to false", () => {
+    expect(resolveScrapingBeeRenderJs(undefined)).toBe(false);
+    expect(resolveScrapingBeeRenderJs({})).toBe(false);
+  });
+
+  it("respects renderJs: true", () => {
+    expect(resolveScrapingBeeRenderJs({ renderJs: true })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Firecrawl search provider resolution
+// ---------------------------------------------------------------------------
+
+describe("Firecrawl search provider resolution", () => {
+  const { resolveFirecrawlSearchApiKey, resolveFirecrawlSearchBaseUrl } = searchInternals;
+
+  it("resolves API key from config", () => {
+    expect(resolveFirecrawlSearchApiKey({ apiKey: "fc-search-key" })).toBe("fc-search-key");
+  });
+
+  it("resolves API key from env var", () => {
+    const original = process.env.FIRECRAWL_API_KEY;
+    process.env.FIRECRAWL_API_KEY = "fc-env-key";
+    try {
+      expect(resolveFirecrawlSearchApiKey({})).toBe("fc-env-key");
+    } finally {
+      if (original === undefined) {
+        delete process.env.FIRECRAWL_API_KEY;
+      } else {
+        process.env.FIRECRAWL_API_KEY = original;
+      }
+    }
+  });
+
+  it("returns default base URL when not configured", () => {
+    expect(resolveFirecrawlSearchBaseUrl(undefined)).toBe("https://api.firecrawl.dev");
+  });
+
+  it("uses custom base URL from config", () => {
+    expect(resolveFirecrawlSearchBaseUrl({ baseUrl: "https://custom.firecrawl.dev" })).toBe(
+      "https://custom.firecrawl.dev",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ScrapingBee execution path (provider: "scrapingbee")
+// ---------------------------------------------------------------------------
+
+describe("web_fetch with scrapingbee provider", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname) => {
+      const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+      const addresses = ["93.184.216.34"];
+      return {
+        hostname: normalized,
+        addresses,
+        lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses }),
+      };
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("routes through ScrapingBee API and extracts via Readability", async () => {
+    const apiKeyField = ["api", "Key"].join("");
+    const mockFetch = installMockFetch((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes("app.scrapingbee.com")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          url,
+          headers: makeHeaders({
+            "content-type": "text/html",
+            "spb-resolved-url": "https://example.com/resolved",
+          }),
+          text: async () =>
+            "<html><head><title>SB Page</title></head><body><article><p>ScrapingBee content here</p></article></body></html>",
+        } as Response);
+      }
+      return Promise.reject(new Error("unexpected fetch"));
+    });
+
+    const tool = createFetchTool({
+      provider: "scrapingbee",
+      scrapingbee: { [apiKeyField]: "sb-test-key" },
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/page" });
+    const details = result?.details as { extractor?: string; text?: string };
+    expect(details.extractor).toBe("scrapingbee+readability");
+    expect(details.text).toContain("ScrapingBee content here");
+
+    // Verify the ScrapingBee API was called with correct params
+    const sbCall = mockFetch.mock.calls.find((call) =>
+      requestUrl(call[0]).includes("scrapingbee.com"),
+    );
+    expect(sbCall).toBeTruthy();
+    const sbUrl = new URL(requestUrl(sbCall![0]));
+    expect(sbUrl.searchParams.get("api_key")).toBe("sb-test-key");
+    expect(sbUrl.searchParams.get("url")).toBe("https://example.com/page");
+  });
+
+  it("falls back to direct fetch when ScrapingBee fails", async () => {
+    const apiKeyField = ["api", "Key"].join("");
+    installMockFetch((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes("app.scrapingbee.com")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          text: async () => "internal error",
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        url,
+        headers: makeHeaders({ "content-type": "text/html" }),
+        text: async () =>
+          "<html><head><title>Direct</title></head><body><article><p>Direct fetch content</p></article></body></html>",
+      } as Response);
+    });
+
+    const tool = createFetchTool({
+      provider: "scrapingbee",
+      scrapingbee: { [apiKeyField]: "sb-test-key" },
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/fallback" });
+    const details = result?.details as { extractor?: string; text?: string };
+    expect(details.text).toContain("Direct fetch content");
+  });
+
+  it("sends render_js param when configured", async () => {
+    const apiKeyField = ["api", "Key"].join("");
+    const mockFetch = installMockFetch((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes("app.scrapingbee.com")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          url,
+          headers: makeHeaders({ "content-type": "text/html" }),
+          text: async () => "<html><body><article><p>JS rendered</p></article></body></html>",
+        } as Response);
+      }
+      return Promise.reject(new Error("unexpected fetch"));
+    });
+
+    const tool = createFetchTool({
+      provider: "scrapingbee",
+      scrapingbee: { [apiKeyField]: "sb-test-key", renderJs: true },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/js" });
+
+    const sbCall = mockFetch.mock.calls.find((call) =>
+      requestUrl(call[0]).includes("scrapingbee.com"),
+    );
+    const sbUrl = new URL(requestUrl(sbCall![0]));
+    expect(sbUrl.searchParams.get("render_js")).toBe("true");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// web_fetch with firecrawl as primary provider
+// ---------------------------------------------------------------------------
+
+describe("web_fetch with firecrawl as primary provider", () => {
+  const priorFetch = global.fetch;
+  const apiKeyField = ["api", "Key"].join("");
+
+  beforeEach(() => {
+    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname) => {
+      const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+      const addresses = ["93.184.216.34"];
+      return {
+        hostname: normalized,
+        addresses,
+        lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses }),
+      };
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("uses firecrawl as primary extractor when provider is firecrawl", async () => {
+    installMockFetch((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes("api.firecrawl.dev")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            data: {
+              markdown: "Firecrawl primary content",
+              metadata: { title: "FC", sourceURL: url, statusCode: 200 },
+            },
+          }),
+        } as Response);
+      }
+      return Promise.reject(new Error("should not direct-fetch when firecrawl is primary"));
+    });
+
+    const tool = createFetchTool({
+      provider: "firecrawl",
+      firecrawl: { [apiKeyField]: "fc-test-key" },
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/fc" });
+    const details = result?.details as { extractor?: string; text?: string };
+    expect(details.extractor).toBe("firecrawl");
+    expect(details.text).toContain("Firecrawl primary content");
+  });
+});

--- a/src/agents/tools/web-tools.provider-resolution.test.ts
+++ b/src/agents/tools/web-tools.provider-resolution.test.ts
@@ -249,7 +249,7 @@ describe("web_fetch with scrapingbee provider", () => {
     expect(sbUrl.searchParams.get("return_page_markdown")).toBe("true");
   });
 
-  it("falls back to direct fetch when ScrapingBee fails", async () => {
+  it("throws when ScrapingBee provider fails", async () => {
     const apiKeyField = ["api", "Key"].join("");
     installMockFetch((input: RequestInfo | URL) => {
       const url = requestUrl(input);
@@ -260,14 +260,7 @@ describe("web_fetch with scrapingbee provider", () => {
           text: async () => "internal error",
         } as Response);
       }
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        url,
-        headers: makeHeaders({ "content-type": "text/html" }),
-        text: async () =>
-          "<html><head><title>Direct</title></head><body><article><p>Direct fetch content</p></article></body></html>",
-      } as Response);
+      return Promise.reject(new Error("should not direct-fetch"));
     });
 
     const tool = createFetchTool({
@@ -275,9 +268,9 @@ describe("web_fetch with scrapingbee provider", () => {
       scrapingbee: { [apiKeyField]: "sb-test-key" },
     });
 
-    const result = await tool?.execute?.("call", { url: "https://example.com/fallback" });
-    const details = result?.details as { extractor?: string; text?: string };
-    expect(details.text).toContain("Direct fetch content");
+    await expect(tool?.execute?.("call", { url: "https://example.com/fallback" })).rejects.toThrow(
+      "ScrapingBee fetch failed",
+    );
   });
 
   it("sends render_js param when configured", async () => {
@@ -365,5 +358,28 @@ describe("web_fetch with firecrawl as primary provider", () => {
     const details = result?.details as { extractor?: string; text?: string };
     expect(details.extractor).toBe("firecrawl");
     expect(details.text).toContain("Firecrawl primary content");
+  });
+
+  it("throws when firecrawl provider fails instead of silently falling back", async () => {
+    installMockFetch((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes("api.firecrawl.dev")) {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: async () => ({ success: false, error: "blocked" }),
+        } as Response);
+      }
+      return Promise.reject(new Error("should not direct-fetch"));
+    });
+
+    const tool = createFetchTool({
+      provider: "firecrawl",
+      firecrawl: { [apiKeyField]: "fc-test-key" },
+    });
+
+    await expect(tool?.execute?.("call", { url: "https://example.com/fc-fail" })).rejects.toThrow(
+      "Firecrawl fetch failed",
+    );
   });
 });

--- a/src/agents/tools/web-tools.provider-resolution.test.ts
+++ b/src/agents/tools/web-tools.provider-resolution.test.ts
@@ -249,6 +249,16 @@ describe("web_fetch with scrapingbee provider", () => {
     expect(sbUrl.searchParams.get("return_page_markdown")).toBe("true");
   });
 
+  it("throws when scrapingbee provider is set but API key is missing", async () => {
+    const tool = createFetchTool({
+      provider: "scrapingbee",
+    });
+
+    await expect(tool?.execute?.("call", { url: "https://example.com/no-key" })).rejects.toThrow(
+      "no API key configured",
+    );
+  });
+
   it("throws when ScrapingBee provider fails", async () => {
     const apiKeyField = ["api", "Key"].join("");
     installMockFetch((input: RequestInfo | URL) => {
@@ -358,6 +368,16 @@ describe("web_fetch with firecrawl as primary provider", () => {
     const details = result?.details as { extractor?: string; text?: string };
     expect(details.extractor).toBe("firecrawl");
     expect(details.text).toContain("Firecrawl primary content");
+  });
+
+  it("throws when firecrawl provider is set but API key is missing", async () => {
+    const tool = createFetchTool({
+      provider: "firecrawl",
+    });
+
+    await expect(tool?.execute?.("call", { url: "https://example.com/no-key" })).rejects.toThrow(
+      "no API key configured",
+    );
   });
 
   it("throws when firecrawl provider fails instead of silently falling back", async () => {

--- a/src/agents/tools/web-tools.provider-resolution.test.ts
+++ b/src/agents/tools/web-tools.provider-resolution.test.ts
@@ -210,7 +210,7 @@ describe("web_fetch with scrapingbee provider", () => {
     vi.restoreAllMocks();
   });
 
-  it("routes through ScrapingBee API and extracts via Readability", async () => {
+  it("routes through ScrapingBee API and returns markdown directly", async () => {
     const apiKeyField = ["api", "Key"].join("");
     const mockFetch = installMockFetch((input: RequestInfo | URL) => {
       const url = requestUrl(input);
@@ -220,11 +220,9 @@ describe("web_fetch with scrapingbee provider", () => {
           status: 200,
           url,
           headers: makeHeaders({
-            "content-type": "text/html",
             "spb-resolved-url": "https://example.com/resolved",
           }),
-          text: async () =>
-            "<html><head><title>SB Page</title></head><body><article><p>ScrapingBee content here</p></article></body></html>",
+          text: async () => "# ScrapingBee Page\n\nScrapingBee content here",
         } as Response);
       }
       return Promise.reject(new Error("unexpected fetch"));
@@ -237,7 +235,7 @@ describe("web_fetch with scrapingbee provider", () => {
 
     const result = await tool?.execute?.("call", { url: "https://example.com/page" });
     const details = result?.details as { extractor?: string; text?: string };
-    expect(details.extractor).toBe("scrapingbee+readability");
+    expect(details.extractor).toBe("scrapingbee");
     expect(details.text).toContain("ScrapingBee content here");
 
     // Verify the ScrapingBee API was called with correct params
@@ -248,6 +246,7 @@ describe("web_fetch with scrapingbee provider", () => {
     const sbUrl = new URL(requestUrl(sbCall![0]));
     expect(sbUrl.searchParams.get("api_key")).toBe("sb-test-key");
     expect(sbUrl.searchParams.get("url")).toBe("https://example.com/page");
+    expect(sbUrl.searchParams.get("return_page_markdown")).toBe("true");
   });
 
   it("falls back to direct fetch when ScrapingBee fails", async () => {
@@ -291,7 +290,7 @@ describe("web_fetch with scrapingbee provider", () => {
           status: 200,
           url,
           headers: makeHeaders({ "content-type": "text/html" }),
-          text: async () => "<html><body><article><p>JS rendered</p></article></body></html>",
+          text: async () => "# JS Rendered\n\nJS rendered content",
         } as Response);
       }
       return Promise.reject(new Error("unexpected fetch"));

--- a/src/commands/onboard-fetch.test.ts
+++ b/src/commands/onboard-fetch.test.ts
@@ -1,7 +1,38 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { setupFetch } from "./onboard-fetch.js";
+
+vi.mock("./onboard-search.js", async (importOriginal) => {
+  const actual: object = await importOriginal();
+  return {
+    ...actual,
+    runFirecrawlOAuth: vi.fn(async (config: OpenClawConfig) => ({
+      ...config,
+      tools: {
+        ...config.tools,
+        web: {
+          ...config.tools?.web,
+          search: {
+            ...config.tools?.web?.search,
+            provider: "firecrawl",
+            firecrawl: { apiKey: "fc-oauth-key" },
+          },
+          fetch: {
+            ...config.tools?.web?.fetch,
+            provider: "firecrawl",
+            firecrawl: { enabled: true, apiKey: "fc-oauth-key" },
+          },
+        },
+      },
+    })),
+  };
+});
+
+function createRuntime(): RuntimeEnv {
+  return { log: vi.fn() } as unknown as RuntimeEnv;
+}
 
 function createPrompter(params: { selectValue?: string; textValue?: string }): {
   prompter: WizardPrompter;
@@ -31,9 +62,11 @@ afterEach(() => {
 });
 
 describe("setupFetch", () => {
+  const runtime = createRuntime();
+
   it("selects readability provider", async () => {
     const { prompter } = createPrompter({ selectValue: "readability" });
-    const result = await setupFetch({}, prompter);
+    const result = await setupFetch({}, runtime, prompter);
     expect(result.tools?.web?.fetch?.provider).toBe("readability");
   });
 
@@ -48,15 +81,17 @@ describe("setupFetch", () => {
       },
     };
     const { prompter } = createPrompter({ selectValue: "firecrawl" });
-    const result = await setupFetch(config, prompter);
+    const result = await setupFetch(config, runtime, prompter);
     expect(result.tools?.web?.fetch?.provider).toBe("firecrawl");
   });
 
-  it("falls back to readability when firecrawl selected but not authenticated", async () => {
-    const { prompter, notes } = createPrompter({ selectValue: "firecrawl" });
-    const result = await setupFetch({}, prompter);
-    expect(result.tools?.web?.fetch?.provider).toBe("readability");
-    expect(notes.some((n) => n.message.includes("Firecrawl requires an API key"))).toBe(true);
+  it("runs OAuth when firecrawl selected but not authenticated", async () => {
+    const { prompter } = createPrompter({ selectValue: "firecrawl" });
+    const result = await setupFetch({}, runtime, prompter);
+    // runFirecrawlOAuth mock sets both search and fetch providers
+    expect(result.tools?.web?.fetch?.provider).toBe("firecrawl");
+    expect(result.tools?.web?.search?.provider).toBe("firecrawl");
+    expect(result.tools?.web?.fetch?.firecrawl?.apiKey).toBe("fc-oauth-key");
   });
 
   it("prompts for scrapingbee API key and stores it", async () => {
@@ -64,7 +99,7 @@ describe("setupFetch", () => {
       selectValue: "scrapingbee",
       textValue: "sb-test-key-123",
     });
-    const result = await setupFetch({}, prompter);
+    const result = await setupFetch({}, runtime, prompter);
     expect(result.tools?.web?.fetch?.provider).toBe("scrapingbee");
     expect(result.tools?.web?.fetch?.scrapingbee?.apiKey).toBe("sb-test-key-123");
   });
@@ -74,7 +109,7 @@ describe("setupFetch", () => {
       selectValue: "scrapingbee",
       textValue: "",
     });
-    const result = await setupFetch({}, prompter);
+    const result = await setupFetch({}, runtime, prompter);
     expect(result.tools?.web?.fetch?.provider).toBe("readability");
     expect(notes.some((n) => n.message.includes("No API key provided"))).toBe(true);
   });
@@ -82,9 +117,8 @@ describe("setupFetch", () => {
   it("skips scrapingbee key prompt when env var is set", async () => {
     vi.stubEnv("SCRAPINGBEE_API_KEY", "sb-env-key");
     const { prompter } = createPrompter({ selectValue: "scrapingbee" });
-    const result = await setupFetch({}, prompter);
+    const result = await setupFetch({}, runtime, prompter);
     expect(result.tools?.web?.fetch?.provider).toBe("scrapingbee");
-    // Should not have prompted for key
     expect(prompter.text).not.toHaveBeenCalled();
   });
 
@@ -99,7 +133,7 @@ describe("setupFetch", () => {
       },
     };
     const { prompter } = createPrompter({ selectValue: "scrapingbee" });
-    const result = await setupFetch(config, prompter);
+    const result = await setupFetch(config, runtime, prompter);
     expect(result.tools?.web?.fetch?.provider).toBe("scrapingbee");
     expect(prompter.text).not.toHaveBeenCalled();
   });
@@ -107,11 +141,11 @@ describe("setupFetch", () => {
   it("returns config unchanged when user skips", async () => {
     const config: OpenClawConfig = { tools: { web: { fetch: { maxChars: 5000 } } } };
     const { prompter } = createPrompter({ selectValue: "__skip__" });
-    const result = await setupFetch(config, prompter);
+    const result = await setupFetch(config, runtime, prompter);
     expect(result).toEqual(config);
   });
 
-  it("quickstart shows picker and defaults to firecrawl when authenticated", async () => {
+  it("defaults to firecrawl when authenticated", async () => {
     const config: OpenClawConfig = {
       tools: {
         web: {
@@ -122,24 +156,20 @@ describe("setupFetch", () => {
       },
     };
     const { prompter } = createPrompter({ selectValue: "firecrawl" });
-    const result = await setupFetch(config, prompter);
-    expect(result.tools?.web?.fetch?.provider).toBe("firecrawl");
-    expect(prompter.select).toHaveBeenCalled();
+    await setupFetch(config, runtime, prompter);
     const selectCall = (prompter.select as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
       | { initialValue?: string }
       | undefined;
     expect(selectCall?.initialValue).toBe("firecrawl");
   });
 
-  it("defaults to readability when not authenticated", async () => {
-    const { prompter } = createPrompter({ selectValue: "readability" });
-    const result = await setupFetch({}, prompter);
-    expect(result.tools?.web?.fetch?.provider).toBe("readability");
-    expect(prompter.select).toHaveBeenCalled();
+  it("defaults to firecrawl even when not authenticated", async () => {
+    const { prompter } = createPrompter({ selectValue: "firecrawl" });
+    await setupFetch({}, runtime, prompter);
     const selectCall = (prompter.select as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
       | { initialValue?: string }
       | undefined;
-    expect(selectCall?.initialValue).toBe("readability");
+    expect(selectCall?.initialValue).toBe("firecrawl");
   });
 
   it("defaults to existing provider in picker", async () => {
@@ -151,9 +181,7 @@ describe("setupFetch", () => {
       },
     };
     const { prompter } = createPrompter({ selectValue: "scrapingbee" });
-    await setupFetch(config, prompter);
-
-    // Verify initialValue was the existing provider
+    await setupFetch(config, runtime, prompter);
     const selectCall = (prompter.select as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
       | { initialValue?: string }
       | undefined;

--- a/src/commands/onboard-fetch.test.ts
+++ b/src/commands/onboard-fetch.test.ts
@@ -111,7 +111,7 @@ describe("setupFetch", () => {
     expect(result).toEqual(config);
   });
 
-  it("quickstart auto-selects firecrawl when authenticated", async () => {
+  it("quickstart shows picker and defaults to firecrawl when authenticated", async () => {
     const config: OpenClawConfig = {
       tools: {
         web: {
@@ -121,31 +121,25 @@ describe("setupFetch", () => {
         },
       },
     };
-    const { prompter } = createPrompter({});
-    const result = await setupFetch(config, prompter, { quickstartDefaults: true });
+    const { prompter } = createPrompter({ selectValue: "firecrawl" });
+    const result = await setupFetch(config, prompter);
     expect(result.tools?.web?.fetch?.provider).toBe("firecrawl");
-    // Should not have shown any UI
-    expect(prompter.select).not.toHaveBeenCalled();
+    expect(prompter.select).toHaveBeenCalled();
+    const selectCall = (prompter.select as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
+      | { initialValue?: string }
+      | undefined;
+    expect(selectCall?.initialValue).toBe("firecrawl");
   });
 
-  it("quickstart auto-selects readability when not authenticated", async () => {
-    const { prompter } = createPrompter({});
-    const result = await setupFetch({}, prompter, { quickstartDefaults: true });
+  it("defaults to readability when not authenticated", async () => {
+    const { prompter } = createPrompter({ selectValue: "readability" });
+    const result = await setupFetch({}, prompter);
     expect(result.tools?.web?.fetch?.provider).toBe("readability");
-    expect(prompter.select).not.toHaveBeenCalled();
-  });
-
-  it("quickstart preserves existing provider", async () => {
-    const config: OpenClawConfig = {
-      tools: {
-        web: {
-          fetch: { provider: "scrapingbee" },
-        },
-      },
-    };
-    const { prompter } = createPrompter({});
-    const result = await setupFetch(config, prompter, { quickstartDefaults: true });
-    expect(result.tools?.web?.fetch?.provider).toBe("scrapingbee");
+    expect(prompter.select).toHaveBeenCalled();
+    const selectCall = (prompter.select as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
+      | { initialValue?: string }
+      | undefined;
+    expect(selectCall?.initialValue).toBe("readability");
   });
 
   it("defaults to existing provider in picker", async () => {

--- a/src/commands/onboard-fetch.test.ts
+++ b/src/commands/onboard-fetch.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { setupFetch } from "./onboard-fetch.js";
+
+function createPrompter(params: { selectValue?: string; textValue?: string }): {
+  prompter: WizardPrompter;
+  notes: Array<{ title?: string; message: string }>;
+} {
+  const notes: Array<{ title?: string; message: string }> = [];
+  const prompter: WizardPrompter = {
+    intro: vi.fn(async () => {}),
+    outro: vi.fn(async () => {}),
+    note: vi.fn(async (message: string, title?: string) => {
+      notes.push({ title, message });
+    }),
+    select: vi.fn(
+      async () => params.selectValue ?? "readability",
+    ) as unknown as WizardPrompter["select"],
+    multiselect: vi.fn(async () => []) as unknown as WizardPrompter["multiselect"],
+    text: vi.fn(async () => params.textValue ?? ""),
+    confirm: vi.fn(async () => true),
+    progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+  };
+  return { prompter, notes };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("setupFetch", () => {
+  it("selects readability provider", async () => {
+    const { prompter } = createPrompter({ selectValue: "readability" });
+    const result = await setupFetch({}, prompter);
+    expect(result.tools?.web?.fetch?.provider).toBe("readability");
+  });
+
+  it("selects firecrawl when already authenticated", async () => {
+    const config: OpenClawConfig = {
+      tools: {
+        web: {
+          search: {
+            firecrawl: { apiKey: "fc-existing" },
+          },
+        },
+      },
+    };
+    const { prompter } = createPrompter({ selectValue: "firecrawl" });
+    const result = await setupFetch(config, prompter);
+    expect(result.tools?.web?.fetch?.provider).toBe("firecrawl");
+  });
+
+  it("falls back to readability when firecrawl selected but not authenticated", async () => {
+    const { prompter, notes } = createPrompter({ selectValue: "firecrawl" });
+    const result = await setupFetch({}, prompter);
+    expect(result.tools?.web?.fetch?.provider).toBe("readability");
+    expect(notes.some((n) => n.message.includes("Firecrawl requires an API key"))).toBe(true);
+  });
+
+  it("prompts for scrapingbee API key and stores it", async () => {
+    const { prompter } = createPrompter({
+      selectValue: "scrapingbee",
+      textValue: "sb-test-key-123",
+    });
+    const result = await setupFetch({}, prompter);
+    expect(result.tools?.web?.fetch?.provider).toBe("scrapingbee");
+    expect(result.tools?.web?.fetch?.scrapingbee?.apiKey).toBe("sb-test-key-123");
+  });
+
+  it("falls back to readability when scrapingbee key is empty", async () => {
+    const { prompter, notes } = createPrompter({
+      selectValue: "scrapingbee",
+      textValue: "",
+    });
+    const result = await setupFetch({}, prompter);
+    expect(result.tools?.web?.fetch?.provider).toBe("readability");
+    expect(notes.some((n) => n.message.includes("No API key provided"))).toBe(true);
+  });
+
+  it("skips scrapingbee key prompt when env var is set", async () => {
+    vi.stubEnv("SCRAPINGBEE_API_KEY", "sb-env-key");
+    const { prompter } = createPrompter({ selectValue: "scrapingbee" });
+    const result = await setupFetch({}, prompter);
+    expect(result.tools?.web?.fetch?.provider).toBe("scrapingbee");
+    // Should not have prompted for key
+    expect(prompter.text).not.toHaveBeenCalled();
+  });
+
+  it("skips scrapingbee key prompt when config key exists", async () => {
+    const config: OpenClawConfig = {
+      tools: {
+        web: {
+          fetch: {
+            scrapingbee: { apiKey: "sb-config-key" },
+          },
+        },
+      },
+    };
+    const { prompter } = createPrompter({ selectValue: "scrapingbee" });
+    const result = await setupFetch(config, prompter);
+    expect(result.tools?.web?.fetch?.provider).toBe("scrapingbee");
+    expect(prompter.text).not.toHaveBeenCalled();
+  });
+
+  it("returns config unchanged when user skips", async () => {
+    const config: OpenClawConfig = { tools: { web: { fetch: { maxChars: 5000 } } } };
+    const { prompter } = createPrompter({ selectValue: "__skip__" });
+    const result = await setupFetch(config, prompter);
+    expect(result).toEqual(config);
+  });
+
+  it("quickstart auto-selects firecrawl when authenticated", async () => {
+    const config: OpenClawConfig = {
+      tools: {
+        web: {
+          search: {
+            firecrawl: { apiKey: "fc-key" },
+          },
+        },
+      },
+    };
+    const { prompter } = createPrompter({});
+    const result = await setupFetch(config, prompter, { quickstartDefaults: true });
+    expect(result.tools?.web?.fetch?.provider).toBe("firecrawl");
+    // Should not have shown any UI
+    expect(prompter.select).not.toHaveBeenCalled();
+  });
+
+  it("quickstart auto-selects readability when not authenticated", async () => {
+    const { prompter } = createPrompter({});
+    const result = await setupFetch({}, prompter, { quickstartDefaults: true });
+    expect(result.tools?.web?.fetch?.provider).toBe("readability");
+    expect(prompter.select).not.toHaveBeenCalled();
+  });
+
+  it("quickstart preserves existing provider", async () => {
+    const config: OpenClawConfig = {
+      tools: {
+        web: {
+          fetch: { provider: "scrapingbee" },
+        },
+      },
+    };
+    const { prompter } = createPrompter({});
+    const result = await setupFetch(config, prompter, { quickstartDefaults: true });
+    expect(result.tools?.web?.fetch?.provider).toBe("scrapingbee");
+  });
+
+  it("defaults to existing provider in picker", async () => {
+    const config: OpenClawConfig = {
+      tools: {
+        web: {
+          fetch: { provider: "scrapingbee", scrapingbee: { apiKey: "sb-key" } },
+        },
+      },
+    };
+    const { prompter } = createPrompter({ selectValue: "scrapingbee" });
+    await setupFetch(config, prompter);
+
+    // Verify initialValue was the existing provider
+    const selectCall = (prompter.select as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
+      | { initialValue?: string }
+      | undefined;
+    expect(selectCall?.initialValue).toBe("scrapingbee");
+  });
+});

--- a/src/commands/onboard-fetch.ts
+++ b/src/commands/onboard-fetch.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { isFirecrawlAuthenticated } from "./onboard-search.js";
 
-export type FetchProvider = "readability" | "firecrawl";
+export type FetchProvider = "readability" | "firecrawl" | "scrapingbee";
 
 type FetchProviderEntry = {
   value: FetchProvider;
@@ -17,6 +17,11 @@ function buildFetchProviderOptions(config: OpenClawConfig): FetchProviderEntry[]
       value: "firecrawl",
       label: "\uD83D\uDD25 Firecrawl",
       hint: firecrawlReady ? "Already authenticated · recommended" : "Requires Firecrawl API key",
+    },
+    {
+      value: "scrapingbee",
+      label: "ScrapingBee",
+      hint: "Requires API key · JS rendering support",
     },
     {
       value: "readability",
@@ -75,7 +80,9 @@ export async function setupFetch(
 
   // Default to Firecrawl if already authenticated, otherwise readability.
   const defaultProvider: FetchProvider =
-    existingProvider === "firecrawl" || existingProvider === "readability"
+    existingProvider === "firecrawl" ||
+    existingProvider === "scrapingbee" ||
+    existingProvider === "readability"
       ? existingProvider
       : firecrawlReady
         ? "firecrawl"
@@ -110,6 +117,45 @@ export async function setupFetch(
       "Web scraping",
     );
     return applyFetchProvider(config, "readability");
+  }
+
+  // ScrapingBee selected — check env var or prompt for API key.
+  if (choice === "scrapingbee") {
+    const envKey = process.env.SCRAPINGBEE_API_KEY?.trim();
+    const existingKey =
+      typeof config.tools?.web?.fetch?.scrapingbee?.apiKey === "string"
+        ? config.tools.web.fetch.scrapingbee.apiKey
+        : undefined;
+    const hasKey = !!(envKey || existingKey);
+
+    if (!hasKey) {
+      const keyInput = await prompter.text({
+        message: "ScrapingBee API key",
+        placeholder: "Paste your key or set SCRAPINGBEE_API_KEY env var",
+      });
+      const key = keyInput?.trim() ?? "";
+      if (!key) {
+        await prompter.note("No API key provided. Falling back to Readability.", "Web scraping");
+        return applyFetchProvider(config, "readability");
+      }
+      return {
+        ...config,
+        tools: {
+          ...config.tools,
+          web: {
+            ...config.tools?.web,
+            fetch: {
+              ...config.tools?.web?.fetch,
+              provider: "scrapingbee" as const,
+              scrapingbee: {
+                ...config.tools?.web?.fetch?.scrapingbee,
+                apiKey: key,
+              },
+            },
+          },
+        },
+      };
+    }
   }
 
   return applyFetchProvider(config, choice);

--- a/src/commands/onboard-fetch.ts
+++ b/src/commands/onboard-fetch.ts
@@ -46,25 +46,12 @@ function applyFetchProvider(config: OpenClawConfig, provider: FetchProvider): Op
   };
 }
 
-export type SetupFetchOptions = {
-  quickstartDefaults?: boolean;
-};
-
 export async function setupFetch(
   config: OpenClawConfig,
   prompter: WizardPrompter,
-  opts?: SetupFetchOptions,
 ): Promise<OpenClawConfig> {
   const firecrawlReady = isFirecrawlAuthenticated(config);
   const existingProvider = config.tools?.web?.fetch?.provider;
-
-  // QuickStart: auto-select Firecrawl if authenticated, otherwise readability.
-  if (opts?.quickstartDefaults) {
-    if (existingProvider) {
-      return config;
-    }
-    return applyFetchProvider(config, firecrawlReady ? "firecrawl" : "readability");
-  }
 
   await prompter.note(
     [

--- a/src/commands/onboard-fetch.ts
+++ b/src/commands/onboard-fetch.ts
@@ -1,7 +1,8 @@
 import type { FetchProvider } from "../agents/tools/web-fetch.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
-import { isFirecrawlAuthenticated } from "./onboard-search.js";
+import { isFirecrawlAuthenticated, runFirecrawlOAuth } from "./onboard-search.js";
 
 type FetchProviderEntry = {
   value: FetchProvider;
@@ -15,7 +16,9 @@ function buildFetchProviderOptions(config: OpenClawConfig): FetchProviderEntry[]
     {
       value: "firecrawl",
       label: "\uD83D\uDD25 Firecrawl",
-      hint: firecrawlReady ? "Already authenticated · recommended" : "Requires Firecrawl API key",
+      hint: firecrawlReady
+        ? "Already authenticated · recommended"
+        : "Recommended · free 10,000 credits · search + scrape",
     },
     {
       value: "scrapingbee",
@@ -48,6 +51,7 @@ function applyFetchProvider(config: OpenClawConfig, provider: FetchProvider): Op
 
 export async function setupFetch(
   config: OpenClawConfig,
+  runtime: RuntimeEnv,
   prompter: WizardPrompter,
 ): Promise<OpenClawConfig> {
   const firecrawlReady = isFirecrawlAuthenticated(config);
@@ -64,15 +68,13 @@ export async function setupFetch(
 
   const options = buildFetchProviderOptions(config);
 
-  // Default to Firecrawl if already authenticated, otherwise readability.
+  // Default to Firecrawl if already authenticated, otherwise firecrawl (top pick).
   const defaultProvider: FetchProvider =
     existingProvider === "firecrawl" ||
     existingProvider === "scrapingbee" ||
     existingProvider === "readability"
       ? existingProvider
-      : firecrawlReady
-        ? "firecrawl"
-        : "readability";
+      : "firecrawl";
 
   type PickerValue = FetchProvider | "__skip__";
   const choice = await prompter.select<PickerValue>({
@@ -92,17 +94,9 @@ export async function setupFetch(
     return config;
   }
 
-  // Firecrawl selected but not authenticated — warn and fall back.
+  // Firecrawl selected but not authenticated — run OAuth to authenticate.
   if (choice === "firecrawl" && !firecrawlReady) {
-    await prompter.note(
-      [
-        "Firecrawl requires an API key. Select Firecrawl as your search provider first",
-        "to authenticate, or set FIRECRAWL_API_KEY in your environment.",
-        "Falling back to Readability for now.",
-      ].join("\n"),
-      "Web scraping",
-    );
-    return applyFetchProvider(config, "readability");
+    return runFirecrawlOAuth(config, runtime, prompter);
   }
 
   // ScrapingBee selected — check env var or prompt for API key.

--- a/src/commands/onboard-fetch.ts
+++ b/src/commands/onboard-fetch.ts
@@ -1,8 +1,7 @@
+import type { FetchProvider } from "../agents/tools/web-fetch.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { isFirecrawlAuthenticated } from "./onboard-search.js";
-
-export type FetchProvider = "readability" | "firecrawl" | "scrapingbee";
 
 type FetchProviderEntry = {
   value: FetchProvider;

--- a/src/commands/onboard-fetch.ts
+++ b/src/commands/onboard-fetch.ts
@@ -1,0 +1,116 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { isFirecrawlAuthenticated } from "./onboard-search.js";
+
+export type FetchProvider = "readability" | "firecrawl";
+
+type FetchProviderEntry = {
+  value: FetchProvider;
+  label: string;
+  hint: string;
+};
+
+function buildFetchProviderOptions(config: OpenClawConfig): FetchProviderEntry[] {
+  const firecrawlReady = isFirecrawlAuthenticated(config);
+  return [
+    {
+      value: "firecrawl",
+      label: "\uD83D\uDD25 Firecrawl",
+      hint: firecrawlReady ? "Already authenticated · recommended" : "Requires Firecrawl API key",
+    },
+    {
+      value: "readability",
+      label: "Readability (built-in)",
+      hint: "No dependencies · basic HTML extraction",
+    },
+  ];
+}
+
+function applyFetchProvider(config: OpenClawConfig, provider: FetchProvider): OpenClawConfig {
+  return {
+    ...config,
+    tools: {
+      ...config.tools,
+      web: {
+        ...config.tools?.web,
+        fetch: {
+          ...config.tools?.web?.fetch,
+          provider,
+        },
+      },
+    },
+  };
+}
+
+export type SetupFetchOptions = {
+  quickstartDefaults?: boolean;
+};
+
+export async function setupFetch(
+  config: OpenClawConfig,
+  prompter: WizardPrompter,
+  opts?: SetupFetchOptions,
+): Promise<OpenClawConfig> {
+  const firecrawlReady = isFirecrawlAuthenticated(config);
+  const existingProvider = config.tools?.web?.fetch?.provider;
+
+  // QuickStart: auto-select Firecrawl if authenticated, otherwise readability.
+  if (opts?.quickstartDefaults) {
+    if (existingProvider) {
+      return config;
+    }
+    return applyFetchProvider(config, firecrawlReady ? "firecrawl" : "readability");
+  }
+
+  await prompter.note(
+    [
+      "Web scraping lets your agent extract content from URLs.",
+      "Choose a provider for the web_fetch tool.",
+      "Docs: https://docs.openclaw.ai/tools/web",
+    ].join("\n"),
+    "Web scraping",
+  );
+
+  const options = buildFetchProviderOptions(config);
+
+  // Default to Firecrawl if already authenticated, otherwise readability.
+  const defaultProvider: FetchProvider =
+    existingProvider === "firecrawl" || existingProvider === "readability"
+      ? existingProvider
+      : firecrawlReady
+        ? "firecrawl"
+        : "readability";
+
+  type PickerValue = FetchProvider | "__skip__";
+  const choice = await prompter.select<PickerValue>({
+    message: "Scraping provider",
+    options: [
+      ...options,
+      {
+        value: "__skip__" as const,
+        label: "Skip for now",
+        hint: "Configure later with openclaw configure --section web",
+      },
+    ],
+    initialValue: defaultProvider as PickerValue,
+  });
+
+  if (choice === "__skip__") {
+    return config;
+  }
+
+  // Firecrawl selected but not authenticated — warn and fall back.
+  if (choice === "firecrawl" && !firecrawlReady) {
+    await prompter.note(
+      [
+        "Firecrawl requires an API key. Select Firecrawl as your search provider first",
+        "to authenticate, or set FIRECRAWL_API_KEY in your environment.",
+        "Falling back to Readability for now.",
+      ].join("\n"),
+      "Web scraping",
+    );
+    return applyFetchProvider(config, "readability");
+  }
+
+  return applyFetchProvider(config, choice);
+}

--- a/src/commands/onboard-search.pkce.test.ts
+++ b/src/commands/onboard-search.pkce.test.ts
@@ -1,0 +1,351 @@
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { __testing, setupSearch } from "./onboard-search.js";
+
+const {
+  generateSessionId,
+  generateCodeVerifier,
+  generateCodeChallenge,
+  pollFirecrawlAuthStatus,
+  waitForFirecrawlAuth,
+  applyFirecrawlKeyEverywhere,
+  FIRECRAWL_AUTH_STATUS_URL,
+} = __testing;
+
+// ---------------------------------------------------------------------------
+// PKCE crypto helpers
+// ---------------------------------------------------------------------------
+
+describe("PKCE crypto helpers", () => {
+  it("generates a 64-char hex session ID", () => {
+    const id = generateSessionId();
+    expect(id).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("generates unique session IDs", () => {
+    const a = generateSessionId();
+    const b = generateSessionId();
+    expect(a).not.toBe(b);
+  });
+
+  it("generates a base64url code verifier", () => {
+    const verifier = generateCodeVerifier();
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    // 32 random bytes → 43 base64url chars
+    expect(verifier.length).toBe(43);
+  });
+
+  it("generates SHA256 code challenge from verifier", () => {
+    const verifier = generateCodeVerifier();
+    const challenge = generateCodeChallenge(verifier);
+
+    // Verify manually
+    const expected = crypto.createHash("sha256").update(verifier).digest("base64url");
+    expect(challenge).toBe(expected);
+  });
+
+  it("generates different challenges for different verifiers", () => {
+    const v1 = generateCodeVerifier();
+    const v2 = generateCodeVerifier();
+    expect(generateCodeChallenge(v1)).not.toBe(generateCodeChallenge(v2));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pollFirecrawlAuthStatus
+// ---------------------------------------------------------------------------
+
+describe("pollFirecrawlAuthStatus", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns apiKey on successful auth", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ apiKey: "fc-test-key-123", teamName: "TestTeam" }),
+    })) as unknown as typeof fetch;
+
+    const result = await pollFirecrawlAuthStatus("session-123", "verifier-abc");
+    expect(result).toEqual({ apiKey: "fc-test-key-123", teamName: "TestTeam" });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      FIRECRAWL_AUTH_STATUS_URL,
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: "session-123", code_verifier: "verifier-abc" }),
+      }),
+    );
+  });
+
+  it("returns null when auth is pending (no apiKey)", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+
+    const result = await pollFirecrawlAuthStatus("session-123", "verifier-abc");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on non-OK response", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+    })) as unknown as typeof fetch;
+
+    const result = await pollFirecrawlAuthStatus("session-123", "verifier-abc");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// waitForFirecrawlAuth
+// ---------------------------------------------------------------------------
+
+describe("waitForFirecrawlAuth", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns result when poll succeeds on second attempt", async () => {
+    let callCount = 0;
+    global.fetch = vi.fn(async () => {
+      callCount++;
+      if (callCount >= 2) {
+        return {
+          ok: true,
+          json: async () => ({ apiKey: "fc-polled-key" }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+
+    const spin = { update: vi.fn(), stop: vi.fn() };
+    const result = await waitForFirecrawlAuth("sess", "verify", spin);
+
+    expect(result).toEqual({ apiKey: "fc-polled-key" });
+    expect(spin.update).toHaveBeenCalled();
+  });
+
+  it("returns null on timeout", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+
+    // Make Date.now() jump past deadline after first poll.
+    const realDateNow = Date.now;
+    let callCount = 0;
+    Date.now = () => {
+      callCount++;
+      if (callCount > 2) {
+        return realDateNow() + 10 * 60 * 1_000;
+      }
+      return realDateNow();
+    };
+
+    try {
+      const spin = { update: vi.fn(), stop: vi.fn() };
+      const result = await waitForFirecrawlAuth("sess", "verify", spin);
+      expect(result).toBeNull();
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+
+  it("survives network errors and keeps polling", async () => {
+    let callCount = 0;
+    global.fetch = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new Error("network down");
+      }
+      return {
+        ok: true,
+        json: async () => ({ apiKey: "fc-recovered" }),
+      };
+    }) as unknown as typeof fetch;
+
+    const spin = { update: vi.fn(), stop: vi.fn() };
+    const result = await waitForFirecrawlAuth("sess", "verify", spin);
+
+    expect(result).toEqual({ apiKey: "fc-recovered" });
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyFirecrawlKeyEverywhere
+// ---------------------------------------------------------------------------
+
+describe("applyFirecrawlKeyEverywhere", () => {
+  it("sets firecrawl key in both search and fetch config", () => {
+    const config: OpenClawConfig = {};
+    const result = applyFirecrawlKeyEverywhere(config, "fc-everywhere-key");
+
+    expect(result.tools?.web?.search?.provider).toBe("firecrawl");
+    expect(result.tools?.web?.search?.firecrawl?.apiKey).toBe("fc-everywhere-key");
+    expect(result.tools?.web?.fetch?.provider).toBe("firecrawl");
+    expect(result.tools?.web?.fetch?.firecrawl?.apiKey).toBe("fc-everywhere-key");
+    expect(result.tools?.web?.fetch?.firecrawl?.enabled).toBe(true);
+  });
+
+  it("preserves existing config values", () => {
+    const config: OpenClawConfig = {
+      tools: {
+        web: {
+          search: { maxResults: 5 },
+          fetch: { maxChars: 10000 },
+        },
+      },
+    };
+    const result = applyFirecrawlKeyEverywhere(config, "fc-key");
+
+    expect(result.tools?.web?.search?.maxResults).toBe(5);
+    expect(result.tools?.web?.fetch?.maxChars).toBe(10000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setupSearch integration — Firecrawl OAuth flow
+// ---------------------------------------------------------------------------
+
+describe("setupSearch firecrawl OAuth integration", () => {
+  const priorFetch = global.fetch;
+
+  const runtime: RuntimeEnv = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: ((code: number) => {
+      throw new Error(`unexpected exit ${code}`);
+    }) as RuntimeEnv["exit"],
+  };
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  function createPrompter(params: { selectValues?: string[]; textValue?: string }): {
+    prompter: WizardPrompter;
+    notes: Array<{ title?: string; message: string }>;
+  } {
+    const notes: Array<{ title?: string; message: string }> = [];
+    let selectCall = 0;
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async (message: string, title?: string) => {
+        notes.push({ title, message });
+      }),
+      select: vi.fn(async () => {
+        const values = params.selectValues ?? ["firecrawl", "browser"];
+        return values[selectCall++] ?? values[values.length - 1];
+      }) as unknown as WizardPrompter["select"],
+      multiselect: vi.fn(async () => []) as unknown as WizardPrompter["multiselect"],
+      text: vi.fn(async () => params.textValue ?? ""),
+      confirm: vi.fn(async () => true),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+    return { prompter, notes };
+  }
+
+  it("applies firecrawl key to search and fetch on successful OAuth", async () => {
+    // Mock fetch: first call is the poll, immediately returns apiKey
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ apiKey: "fc-oauth-key", teamName: "MyTeam" }),
+    })) as unknown as typeof fetch;
+
+    const { prompter } = createPrompter({
+      selectValues: ["firecrawl", "browser"],
+    });
+
+    const result = await setupSearch({}, runtime, prompter);
+
+    expect(result.tools?.web?.search?.provider).toBe("firecrawl");
+    expect(result.tools?.web?.search?.firecrawl?.apiKey).toBe("fc-oauth-key");
+    expect(result.tools?.web?.fetch?.provider).toBe("firecrawl");
+    expect(result.tools?.web?.fetch?.firecrawl?.apiKey).toBe("fc-oauth-key");
+  });
+
+  it("falls back gracefully when OAuth times out", async () => {
+    // Mock fetch: always returns no apiKey (pending)
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+
+    // Make Date.now jump past deadline after first poll.
+    const realDateNow = Date.now;
+    let callCount = 0;
+    Date.now = () => {
+      callCount++;
+      if (callCount > 2) {
+        return realDateNow() + 10 * 60 * 1_000;
+      }
+      return realDateNow();
+    };
+
+    try {
+      const { prompter, notes } = createPrompter({
+        selectValues: ["firecrawl", "browser"],
+      });
+
+      const result = await setupSearch({}, runtime, prompter);
+
+      // Should return original config unchanged
+      expect(result.tools?.web?.search?.firecrawl?.apiKey).toBeUndefined();
+      // Should show timeout note
+      expect(notes.some((n) => n.message.includes("timed out"))).toBe(true);
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+
+  it("uses manual key entry when user selects paste option", async () => {
+    const { prompter } = createPrompter({
+      selectValues: ["firecrawl", "manual"],
+      textValue: "fc-manual-key",
+    });
+
+    const result = await setupSearch({}, runtime, prompter);
+
+    expect(result.tools?.web?.search?.firecrawl?.apiKey).toBe("fc-manual-key");
+    expect(result.tools?.web?.fetch?.firecrawl?.apiKey).toBe("fc-manual-key");
+  });
+
+  it("skips OAuth when firecrawl is already authenticated", async () => {
+    const config: OpenClawConfig = {
+      tools: {
+        web: {
+          search: {
+            firecrawl: { apiKey: "fc-existing" },
+          },
+        },
+      },
+    };
+
+    const { prompter, notes } = createPrompter({
+      selectValues: ["firecrawl"],
+    });
+
+    const result = await setupSearch(config, runtime, prompter);
+
+    expect(result.tools?.web?.search?.firecrawl?.apiKey).toBe("fc-existing");
+    expect(notes.some((n) => n.message.includes("already authenticated"))).toBe(true);
+  });
+});

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -283,9 +283,9 @@ describe("setupSearch", () => {
     expect(result.tools?.web?.search?.apiKey).toBe("BSA-plain");
   });
 
-  it("exports all 5 providers in SEARCH_PROVIDER_OPTIONS", () => {
-    expect(SEARCH_PROVIDER_OPTIONS).toHaveLength(5);
+  it("exports all 6 providers in SEARCH_PROVIDER_OPTIONS", () => {
+    expect(SEARCH_PROVIDER_OPTIONS).toHaveLength(6);
     const values = SEARCH_PROVIDER_OPTIONS.map((e) => e.value);
-    expect(values).toEqual(["brave", "gemini", "grok", "kimi", "perplexity"]);
+    expect(values).toEqual(["firecrawl", "brave", "gemini", "grok", "kimi", "perplexity"]);
   });
 });

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -116,7 +116,8 @@ export function hasExistingKey(config: OpenClawConfig, provider: SearchProvider)
 
 /** Check if Firecrawl is authenticated (config or env). */
 export function isFirecrawlAuthenticated(config: OpenClawConfig): boolean {
-  return hasExistingKey(config, "firecrawl") || hasKeyInEnv(SEARCH_PROVIDER_OPTIONS[0]);
+  const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === "firecrawl");
+  return hasExistingKey(config, "firecrawl") || (entry ? hasKeyInEnv(entry) : false);
 }
 
 /** Build an env-backed SecretRef for a search provider. */

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -337,7 +337,7 @@ async function waitForFirecrawlAuth(
 // Firecrawl OAuth flow
 // ---------------------------------------------------------------------------
 
-async function runFirecrawlOAuth(
+export async function runFirecrawlOAuth(
   config: OpenClawConfig,
   runtime: RuntimeEnv,
   prompter: WizardPrompter,

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -557,3 +557,15 @@ export async function setupSearch(
     },
   };
 }
+
+export const __testing = {
+  generateSessionId,
+  generateCodeVerifier,
+  generateCodeChallenge,
+  pollFirecrawlAuthStatus,
+  waitForFirecrawlAuth,
+  applyFirecrawlKeyEverywhere,
+  FIRECRAWL_AUTH_STATUS_URL,
+  POLL_INTERVAL_MS,
+  POLL_TIMEOUT_MS,
+} as const;

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -215,7 +215,7 @@ export function applyFirecrawlKeyEverywhere(
 }
 
 function applyProviderOnly(config: OpenClawConfig, provider: SearchProvider): OpenClawConfig {
-  return {
+  const base: OpenClawConfig = {
     ...config,
     tools: {
       ...config.tools,
@@ -229,6 +229,25 @@ function applyProviderOnly(config: OpenClawConfig, provider: SearchProvider): Op
       },
     },
   };
+  // When firecrawl is env-authenticated, also set fetch provider so web_fetch
+  // resolves the key from FIRECRAWL_API_KEY at runtime.
+  if (provider === "firecrawl") {
+    base.tools = {
+      ...base.tools,
+      web: {
+        ...base.tools?.web,
+        fetch: {
+          ...base.tools?.web?.fetch,
+          provider: "firecrawl" as const,
+          firecrawl: {
+            ...base.tools?.web?.fetch?.firecrawl,
+            enabled: true,
+          },
+        },
+      },
+    };
+  }
+  return base;
 }
 
 function preserveDisabledState(original: OpenClawConfig, result: OpenClawConfig): OpenClawConfig {

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   DEFAULT_SECRET_PROVIDER_ALIAS,
@@ -8,9 +9,11 @@ import {
 } from "../config/types.secrets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
+import { isRemoteEnvironment } from "./oauth-env.js";
+import { openUrl } from "./onboard-helpers.js";
 import type { SecretInputMode } from "./onboard-types.js";
 
-export type SearchProvider = "brave" | "gemini" | "grok" | "kimi" | "perplexity";
+export type SearchProvider = "brave" | "firecrawl" | "gemini" | "grok" | "kimi" | "perplexity";
 
 type SearchProviderEntry = {
   value: SearchProvider;
@@ -19,9 +22,21 @@ type SearchProviderEntry = {
   envKeys: string[];
   placeholder: string;
   signupUrl: string;
+  /** If true, provider uses OAuth browser login instead of API key paste. */
+  oauth?: boolean;
 };
 
+// Firecrawl first (recommended), then the rest alphabetically.
 export const SEARCH_PROVIDER_OPTIONS: readonly SearchProviderEntry[] = [
+  {
+    value: "firecrawl",
+    label: "\uD83D\uDD25 Firecrawl",
+    hint: "Recommended · free 10,000 credits · search + scrape",
+    envKeys: ["FIRECRAWL_API_KEY"],
+    placeholder: "fc-...",
+    signupUrl: "https://www.firecrawl.dev/",
+    oauth: true,
+  },
   {
     value: "brave",
     label: "Brave Search",
@@ -73,6 +88,8 @@ function rawKeyValue(config: OpenClawConfig, provider: SearchProvider): unknown 
   switch (provider) {
     case "brave":
       return search?.apiKey;
+    case "firecrawl":
+      return search?.firecrawl?.apiKey;
     case "gemini":
       return search?.gemini?.apiKey;
     case "grok":
@@ -95,6 +112,11 @@ export function resolveExistingKey(
 /** Returns true if a key is configured (plaintext string or SecretRef). */
 export function hasExistingKey(config: OpenClawConfig, provider: SearchProvider): boolean {
   return hasConfiguredSecretInput(rawKeyValue(config, provider));
+}
+
+/** Check if Firecrawl is authenticated (config or env). */
+export function isFirecrawlAuthenticated(config: OpenClawConfig): boolean {
+  return hasExistingKey(config, "firecrawl") || hasKeyInEnv(SEARCH_PROVIDER_OPTIONS[0]);
 }
 
 /** Build an env-backed SecretRef for a search provider. */
@@ -132,6 +154,9 @@ export function applySearchKey(
     case "brave":
       search.apiKey = key;
       break;
+    case "firecrawl":
+      search.firecrawl = { ...search.firecrawl, apiKey: key };
+      break;
     case "gemini":
       search.gemini = { ...search.gemini, apiKey: key };
       break;
@@ -150,6 +175,40 @@ export function applySearchKey(
     tools: {
       ...config.tools,
       web: { ...config.tools?.web, search },
+    },
+  };
+}
+
+/** Apply Firecrawl key to both search and fetch config. */
+export function applyFirecrawlKeyEverywhere(
+  config: OpenClawConfig,
+  apiKey: string,
+): OpenClawConfig {
+  return {
+    ...config,
+    tools: {
+      ...config.tools,
+      web: {
+        ...config.tools?.web,
+        search: {
+          ...config.tools?.web?.search,
+          provider: "firecrawl" as const,
+          enabled: true,
+          firecrawl: {
+            ...config.tools?.web?.search?.firecrawl,
+            apiKey,
+          },
+        },
+        fetch: {
+          ...config.tools?.web?.fetch,
+          provider: "firecrawl" as const,
+          firecrawl: {
+            ...config.tools?.web?.fetch?.firecrawl,
+            enabled: true,
+            apiKey,
+          },
+        },
+      },
     },
   };
 }
@@ -184,6 +243,134 @@ function preserveDisabledState(original: OpenClawConfig, result: OpenClawConfig)
   };
 }
 
+// ---------------------------------------------------------------------------
+// Firecrawl PKCE OAuth helpers
+// ---------------------------------------------------------------------------
+
+function generateSessionId(): string {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+function generateCodeVerifier(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+function generateCodeChallenge(verifier: string): string {
+  const digest = crypto.createHash("sha256").update(verifier).digest();
+  return digest.toString("base64url");
+}
+
+const FIRECRAWL_AUTH_STATUS_URL = "https://firecrawl.dev/api/auth/cli/status";
+const FIRECRAWL_AUTH_URL_BASE = "https://firecrawl.dev/cli-auth";
+const POLL_INTERVAL_MS = 2_000;
+const POLL_TIMEOUT_MS = 5 * 60 * 1_000;
+
+type FirecrawlAuthResult = {
+  apiKey: string;
+  teamName?: string;
+};
+
+async function pollFirecrawlAuthStatus(
+  sessionId: string,
+  codeVerifier: string,
+): Promise<FirecrawlAuthResult | null> {
+  const res = await fetch(FIRECRAWL_AUTH_STATUS_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ session_id: sessionId, code_verifier: codeVerifier }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    return null;
+  }
+  const data = (await res.json()) as { apiKey?: string; teamName?: string };
+  if (data.apiKey) {
+    return { apiKey: data.apiKey, teamName: data.teamName };
+  }
+  return null;
+}
+
+async function waitForFirecrawlAuth(
+  sessionId: string,
+  codeVerifier: string,
+  spin: { update: (msg: string) => void },
+): Promise<FirecrawlAuthResult | null> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  let dots = 0;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    dots = (dots + 1) % 4;
+    spin.update(`Waiting for browser login${".".repeat(dots)}`);
+    try {
+      const result = await pollFirecrawlAuthStatus(sessionId, codeVerifier);
+      if (result) {
+        return result;
+      }
+    } catch {
+      // Network blip — keep polling.
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Firecrawl OAuth flow
+// ---------------------------------------------------------------------------
+
+async function runFirecrawlOAuth(
+  config: OpenClawConfig,
+  runtime: RuntimeEnv,
+  prompter: WizardPrompter,
+): Promise<OpenClawConfig> {
+  try {
+    const sessionId = generateSessionId();
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = generateCodeChallenge(codeVerifier);
+
+    const authUrl = `${FIRECRAWL_AUTH_URL_BASE}?code_challenge=${codeChallenge}&source=openclaw#session_id=${sessionId}`;
+
+    const isRemote = isRemoteEnvironment();
+    if (isRemote) {
+      await prompter.note(`Open this URL in your browser to log in:\n\n${authUrl}`, "Firecrawl");
+    } else {
+      const opened = await openUrl(authUrl);
+      if (!opened) {
+        await prompter.note(
+          `Could not open browser. Visit this URL to log in:\n\n${authUrl}`,
+          "Firecrawl",
+        );
+      }
+    }
+
+    const spin = prompter.progress("Waiting for browser login...");
+    const result = await waitForFirecrawlAuth(sessionId, codeVerifier, spin);
+
+    if (!result) {
+      spin.stop("Timed out waiting for login.");
+      await prompter.note(
+        "Authentication timed out.\nYou can set up Firecrawl later via `openclaw configure --section web`\nor set the FIRECRAWL_API_KEY environment variable.",
+        "Firecrawl",
+      );
+      return config;
+    }
+
+    const teamNote = result.teamName ? ` (team: ${result.teamName})` : "";
+    spin.stop(`Authenticated with Firecrawl${teamNote}`);
+    return applyFirecrawlKeyEverywhere(config, result.apiKey);
+  } catch (err) {
+    runtime.log("Firecrawl auth error:", err instanceof Error ? err.message : String(err));
+    await prompter.note(
+      "Something went wrong during Firecrawl setup.\nYou can set up Firecrawl later via `openclaw configure --section web`\nor set the FIRECRAWL_API_KEY environment variable.",
+      "Firecrawl",
+    );
+    return config;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main setup function
+// ---------------------------------------------------------------------------
+
 export type SetupSearchOptions = {
   quickstartDefaults?: boolean;
   secretInputMode?: SecretInputMode;
@@ -191,7 +378,7 @@ export type SetupSearchOptions = {
 
 export async function setupSearch(
   config: OpenClawConfig,
-  _runtime: RuntimeEnv,
+  runtime: RuntimeEnv,
   prompter: WizardPrompter,
   opts?: SetupSearchOptions,
 ): Promise<OpenClawConfig> {
@@ -222,6 +409,7 @@ export async function setupSearch(
     if (detected) {
       return detected.value;
     }
+    // Default to Firecrawl (first in list, recommended).
     return SEARCH_PROVIDER_OPTIONS[0].value;
   })();
 
@@ -248,6 +436,55 @@ export async function setupSearch(
   const keyConfigured = hasExistingKey(config, choice);
   const envAvailable = hasKeyInEnv(entry);
 
+  // Firecrawl: use OAuth browser login flow.
+  if (choice === "firecrawl") {
+    // Already authenticated — skip OAuth, just apply provider.
+    if (keyConfigured || envAvailable) {
+      if (opts?.quickstartDefaults) {
+        return preserveDisabledState(
+          config,
+          existingKey
+            ? applyFirecrawlKeyEverywhere(config, existingKey)
+            : applyProviderOnly(config, choice),
+        );
+      }
+      await prompter.note("Firecrawl already authenticated.", "Firecrawl");
+      return existingKey
+        ? applyFirecrawlKeyEverywhere(config, existingKey)
+        : applyProviderOnly(config, choice);
+    }
+
+    // Offer OAuth or manual entry.
+    const method = await prompter.select<"browser" | "manual">({
+      message: "How would you like to authenticate?",
+      options: [
+        { value: "browser", label: "Browser login", hint: "recommended — opens firecrawl.dev" },
+        { value: "manual", label: "Paste API key", hint: "if you already have one" },
+      ],
+      initialValue: "browser",
+    });
+
+    if (method === "browser") {
+      return runFirecrawlOAuth(config, runtime, prompter);
+    }
+
+    // Manual entry for firecrawl.
+    const keyInput = await prompter.text({
+      message: "Firecrawl API key",
+      placeholder: "fc-...",
+    });
+    const key = keyInput?.trim() ?? "";
+    if (key) {
+      return applyFirecrawlKeyEverywhere(config, key);
+    }
+    await prompter.note(
+      "No API key stored — web_search won't work until a key is available.\nGet your key at: https://www.firecrawl.dev/\nDocs: https://docs.openclaw.ai/tools/web",
+      "Web search",
+    );
+    return config;
+  }
+
+  // Non-firecrawl providers: standard API key paste flow.
   if (opts?.quickstartDefaults && (keyConfigured || envAvailable)) {
     const result = existingKey
       ? applySearchKey(config, choice, existingKey)

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -508,8 +508,8 @@ export type ToolsConfig = {
     fetch?: {
       /** Enable web fetch tool (default: true). */
       enabled?: boolean;
-      /** Primary extraction provider ("readability" or "firecrawl"). */
-      provider?: "readability" | "firecrawl";
+      /** Primary extraction provider. */
+      provider?: "readability" | "firecrawl" | "scrapingbee";
       /** Max characters to return from fetched content. */
       maxChars?: number;
       /** Hard cap for maxChars (tool or config), defaults to 50000. */
@@ -536,6 +536,14 @@ export type ToolsConfig = {
         /** Max age (ms) for cached Firecrawl content. */
         maxAgeMs?: number;
         /** Timeout in seconds for Firecrawl requests. */
+        timeoutSeconds?: number;
+      };
+      scrapingbee?: {
+        /** ScrapingBee API key (defaults to SCRAPINGBEE_API_KEY env var). */
+        apiKey?: SecretInput;
+        /** Render JavaScript before extracting (default: false). */
+        renderJs?: boolean;
+        /** Timeout in seconds for ScrapingBee requests. */
         timeoutSeconds?: number;
       };
     };

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -446,8 +446,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). */
-      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity";
+      /** Search provider ("brave", "firecrawl", "gemini", "grok", "kimi", or "perplexity"). */
+      provider?: "brave" | "firecrawl" | "gemini" | "grok" | "kimi" | "perplexity";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: SecretInput;
       /** Default search results count (1-10). */
@@ -460,6 +460,15 @@ export type ToolsConfig = {
       brave?: {
         /** Brave Search mode: "web" (standard results) or "llm-context" (pre-extracted page content). Default: "web". */
         mode?: "web" | "llm-context";
+      };
+      /** Firecrawl-specific configuration (used when provider="firecrawl"). */
+      firecrawl?: {
+        /** Firecrawl API key (defaults to FIRECRAWL_API_KEY env var). */
+        apiKey?: SecretInput;
+        /** Firecrawl base URL (default: https://api.firecrawl.dev). */
+        baseUrl?: string;
+        /** Timeout in seconds for Firecrawl search requests. */
+        timeoutSeconds?: number;
       };
       /** Gemini-specific configuration (used when provider="gemini"). */
       gemini?: {
@@ -499,6 +508,8 @@ export type ToolsConfig = {
     fetch?: {
       /** Enable web fetch tool (default: true). */
       enabled?: boolean;
+      /** Primary extraction provider ("readability" or "firecrawl"). */
+      provider?: "readability" | "firecrawl";
       /** Max characters to return from fetched content. */
       maxChars?: number;
       /** Hard cap for maxChars (tool or config), defaults to 50000. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -266,10 +266,10 @@ export const ToolsWebSearchSchema = z
       .union([
         z.literal("brave"),
         z.literal("firecrawl"),
-        z.literal("gemini"),
-        z.literal("grok"),
-        z.literal("kimi"),
         z.literal("perplexity"),
+        z.literal("grok"),
+        z.literal("gemini"),
+        z.literal("kimi"),
       ])
       .optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -330,7 +330,9 @@ export const ToolsWebSearchSchema = z
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("readability"), z.literal("firecrawl")]).optional(),
+    provider: z
+      .union([z.literal("readability"), z.literal("firecrawl"), z.literal("scrapingbee")])
+      .optional(),
     maxChars: z.number().int().positive().optional(),
     maxCharsCap: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -344,6 +346,14 @@ export const ToolsWebFetchSchema = z
         baseUrl: z.string().optional(),
         onlyMainContent: z.boolean().optional(),
         maxAgeMs: z.number().int().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
+    scrapingbee: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        renderJs: z.boolean().optional(),
         timeoutSeconds: z.number().int().positive().optional(),
       })
       .strict()

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -265,10 +265,11 @@ export const ToolsWebSearchSchema = z
     provider: z
       .union([
         z.literal("brave"),
-        z.literal("perplexity"),
-        z.literal("grok"),
+        z.literal("firecrawl"),
         z.literal("gemini"),
+        z.literal("grok"),
         z.literal("kimi"),
+        z.literal("perplexity"),
       ])
       .optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
@@ -314,6 +315,14 @@ export const ToolsWebSearchSchema = z
       })
       .strict()
       .optional(),
+    firecrawl: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();
@@ -321,12 +330,24 @@ export const ToolsWebSearchSchema = z
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
+    provider: z.union([z.literal("readability"), z.literal("firecrawl")]).optional(),
     maxChars: z.number().int().positive().optional(),
     maxCharsCap: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().int().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -10,7 +10,14 @@ import {
   type SecretDefaults,
 } from "./runtime-shared.js";
 
-const WEB_SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as const;
+const WEB_SEARCH_PROVIDERS = [
+  "brave",
+  "firecrawl",
+  "gemini",
+  "grok",
+  "kimi",
+  "perplexity",
+] as const;
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_KEY_PREFIXES = ["pplx-"];
@@ -84,6 +91,7 @@ function normalizeProvider(value: unknown): WebSearchProvider | undefined {
   const normalized = value.trim().toLowerCase();
   if (
     normalized === "brave" ||
+    normalized === "firecrawl" ||
     normalized === "gemini" ||
     normalized === "grok" ||
     normalized === "kimi" ||
@@ -322,6 +330,9 @@ function envVarsForProvider(provider: WebSearchProvider): string[] {
   }
   if (provider === "gemini") {
     return ["GEMINI_API_KEY"];
+  }
+  if (provider === "firecrawl") {
+    return ["FIRECRAWL_API_KEY"];
   }
   if (provider === "grok") {
     return ["XAI_API_KEY"];

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -300,7 +300,7 @@ describe("runOnboardingWizard", () => {
       prompter,
     );
 
-    expect(select).not.toHaveBeenCalled();
+    // select is called once for setupFetch (scrape provider picker always runs)
     expect(setupChannels).not.toHaveBeenCalled();
     expect(setupSkills).not.toHaveBeenCalled();
     expect(healthCommand).not.toHaveBeenCalled();

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -535,9 +535,7 @@ export async function runOnboardingWizard(
   // but always runs — even when search is skipped the user can still pick a scrape provider).
   {
     const { setupFetch } = await import("../commands/onboard-fetch.js");
-    nextConfig = await setupFetch(nextConfig, prompter, {
-      quickstartDefaults: flow === "quickstart",
-    });
+    nextConfig = await setupFetch(nextConfig, prompter);
   }
 
   if (opts.skipSkills) {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -521,6 +521,12 @@ export async function runOnboardingWizard(
     skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
   });
 
+  // Scrape provider first — Firecrawl OAuth here sets key for both scrape and search.
+  {
+    const { setupFetch } = await import("../commands/onboard-fetch.js");
+    nextConfig = await setupFetch(nextConfig, runtime, prompter);
+  }
+
   if (opts.skipSearch) {
     await prompter.note("Skipping search setup.", "Search");
   } else {
@@ -529,13 +535,6 @@ export async function runOnboardingWizard(
       quickstartDefaults: flow === "quickstart",
       secretInputMode: opts.secretInputMode,
     });
-  }
-
-  // Web scraping provider setup (runs after search so Firecrawl auth state is known,
-  // but always runs — even when search is skipped the user can still pick a scrape provider).
-  {
-    const { setupFetch } = await import("../commands/onboard-fetch.js");
-    nextConfig = await setupFetch(nextConfig, prompter);
   }
 
   if (opts.skipSkills) {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -532,7 +532,7 @@ export async function runOnboardingWizard(
   }
 
   // Web scraping provider setup (after search so Firecrawl auth state is known).
-  {
+  if (!opts.skipSearch) {
     const { setupFetch } = await import("../commands/onboard-fetch.js");
     nextConfig = await setupFetch(nextConfig, prompter, {
       quickstartDefaults: flow === "quickstart",

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -531,6 +531,14 @@ export async function runOnboardingWizard(
     });
   }
 
+  // Web scraping provider setup (after search so Firecrawl auth state is known).
+  {
+    const { setupFetch } = await import("../commands/onboard-fetch.js");
+    nextConfig = await setupFetch(nextConfig, prompter, {
+      quickstartDefaults: flow === "quickstart",
+    });
+  }
+
   if (opts.skipSkills) {
     await prompter.note("Skipping skills setup.", "Skills");
   } else {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -531,8 +531,9 @@ export async function runOnboardingWizard(
     });
   }
 
-  // Web scraping provider setup (after search so Firecrawl auth state is known).
-  if (!opts.skipSearch) {
+  // Web scraping provider setup (runs after search so Firecrawl auth state is known,
+  // but always runs — even when search is skipped the user can still pick a scrape provider).
+  {
     const { setupFetch } = await import("../commands/onboard-fetch.js");
     nextConfig = await setupFetch(nextConfig, prompter, {
       quickstartDefaults: flow === "quickstart",


### PR DESCRIPTION
  - Problem: openclaw's web tools were locked to specific providers with no
  user choice. brave/perplexity for search, readability for scrape, firecrawl
   only as a silent fallback
  - Why it matters: users should pick the provider that fits their workflow.
  firecrawl covers both search and scrape behind one auth, scrapingbee as another option as well, easy for additional providers to PR as well, readability kept in place for those as an additional option
  - What changed: added provider field to web_search and web_fetch. two
  onboarding pickers (scrape first, then search) with firecrawl PKCE OAuth.
  explicit providers fail loudly instead of silently degrading
  - What did NOT change (scope boundary): no browser tool changes. existing
  providers untouched. readability path unchanged. no new npm dependencies

  aligns with openclaw's direction of supporting all major providers while
  keeping core lean. UX is improved by surfacing scrape + search options up front directly improving first-run UX. the
  provider-agnostic pattern makes adding more providers trivial

  Change Type (select all)

  - Bug fix
  - Feature [x]
  - Refactor
  - Docs
  - Security hardening
  - Chore/infra

  Scope (select all touched areas)

  - Gateway / orchestration
  - Skills / tool execution
  - Auth / tokens [x]
  - Memory / storage
  - Integrations [x]
  - API / contracts [x]
  - UI / DX [x]
  - CI/CD / infra

  Linked Issue/PR

  - Related: provider-agnostic web tools initiative

  User-visible / Behavior Changes

  - new "scraping provider" picker in onboarding
  (firecrawl/scrapingbee/readability), shows before search picker
  - firecrawl first in both pickers with PKCE OAuth. one browser login covers
   search and scrape
  - new config: tools.web.search.provider accepts "firecrawl",
  tools.web.fetch.provider accepts "firecrawl" | "scrapingbee" |
  "readability"
  - explicit provider with missing key throws with actionable error instead
  of silent fallback

  Security Impact (required)

  - New permissions/capabilities? no
  - Secrets/tokens handling changed? yes, firecrawl PKCE OAuth flow added,
  scrapingbee key stored in config
  - New/changed network calls? yes, firecrawl /v2/search + /v2/scrape,
  scrapingbee /api/v1
  - Command/tool execution surface changed? no
  - Data access scope changed? no
  - If any Yes, explain risk + mitigation: PKCE uses SHA-256 code challenge
  per spec. scrapingbee response capped at 2MB

  Repro + Verification

  Environment

  - OS: macOS 24.1.0
  - Runtime/container: node 24, pnpm
  - Model/provider: firecrawl v2 API
  - Relevant config (redacted): tools.web.search.provider: "firecrawl",
  tools.web.fetch.provider: "firecrawl"

  Steps

  1. pnpm build && openclaw onboard, select firecrawl for scrape,
  authenticate via browser
  2. search picker shows firecrawl as "already authenticated", select it
  3. open tui, run web_search "hello world" and web_fetch
  "https://example.com"

  Expected

  - search returns results with titles/urls/descriptions
  - fetch returns markdown via firecrawl scrape

  Actual

  - confirmed working

  Evidence

  Attach at least one:

  - Failing test/log before + passing after
  - Trace/log snippets
  - Screenshot/recording
  - Perf numbers (if relevant)

  74 tests across 5 files. two rounds of multi-model review (kimi, gemini,
  codex/gpt-5.4, droid) caught and fixed: silent fallback bugs, missing cache
   key prefix, dead config, firecrawl missing from runtime secret resolver,
  unbounded response size, v2 response parsing

  Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: full onboarding flow, firecrawl search + scrape
  returning results, config written correctly
  - Edge cases checked: missing API key throws, key only in env var,
  quickstart shows both pickers, skipSearch doesn't skip scrape

  Review Conversations

  - I replied to or resolved every bot review conversation I addressed in
  this PR.
  - I left unresolved only the conversations that still need reviewer or
  maintainer judgment.

  two rounds of review across four models (kimi, gemini, codex/gpt-5.4,
  droid). every actionable finding fixed and committed. remaining items
  triaged as pre-existing patterns or out of scope

  Compatibility / Migration

  - Backward compatible? yes, no existing config breaks. readability remains
  default when no provider set
  - Config/env changes? yes, new optional fields: tools.web.search.firecrawl,
   tools.web.fetch.provider, tools.web.fetch.scrapingbee. env vars:
  FIRECRAWL_API_KEY, SCRAPINGBEE_API_KEY
  - Migration needed? no

  Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: set search provider back to
  "brave", set fetch provider to "readability" or remove it
  - Files/config to restore: ~/.openclaw/openclaw.json, remove
  firecrawl/scrapingbee keys from web config
  - Known bad symptoms reviewers should watch for: "no API key configured"
  errors when provider set but key missing (intentional)

  Risks and Mitigations

  NA.