### PR TITLE
fix(reply): block risky smaller-context model switches

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -27,6 +27,7 @@ import {
   withOptions,
 } from "./directive-handling.shared.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel } from "./directives.js";
+import { maybeBlockOversizedModelSwitch } from "./model-switch-guard.js";
 
 function resolveExecDefaults(params: {
   cfg: OpenClawConfig;
@@ -134,6 +135,19 @@ export async function handleDirectiveOnly(
   }
   const modelSelection = modelResolution.modelSelection;
   const profileOverride = modelResolution.profileOverride;
+  const blockedModelSwitchText = modelSelection
+    ? maybeBlockOversizedModelSwitch({
+        cfg: params.cfg,
+        sessionEntry,
+        currentProvider: provider,
+        currentModel: model,
+        targetProvider: modelSelection.provider,
+        targetModel: modelSelection.model,
+      })
+    : undefined;
+  if (blockedModelSwitchText) {
+    return { text: blockedModelSwitchText };
+  }
 
   const resolvedProvider = modelSelection?.provider ?? provider;
   const resolvedModel = modelSelection?.model ?? model;

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -25,7 +25,8 @@ vi.mock("../../agents/sandbox.js", () => ({
   resolveSandboxRuntimeStatus: vi.fn(() => ({ sandboxed: false })),
 }));
 
-vi.mock("../../config/sessions.js", () => ({
+vi.mock("../../config/sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/sessions.js")>()),
   updateSessionStore: vi.fn(async () => {}),
 }));
 
@@ -69,6 +70,32 @@ function setAuthProfiles(
       store: { version: 1, profiles },
     },
   ]);
+}
+
+function configWithContextWindows(overrides?: { agentContextTokens?: number }): OpenClawConfig {
+  return {
+    commands: { text: true },
+    agents: {
+      defaults: {
+        ...(typeof overrides?.agentContextTokens === "number"
+          ? { contextTokens: overrides.agentContextTokens }
+          : {}),
+        compaction: {
+          reserveTokensFloor: 20_000,
+        },
+      },
+    },
+    models: {
+      providers: {
+        anthropic: {
+          models: [{ id: "claude-opus-4-5", contextWindow: 200_000 }],
+        },
+        openai: {
+          models: [{ id: "gpt-4o", contextWindow: 128_000 }],
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
 }
 
 function resolveModelSelectionForCommand(params: {
@@ -629,6 +656,70 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(result?.text ?? "").not.toContain("failed");
   });
 
+  it("rejects switching to a smaller-context model when recorded session usage is already too large", async () => {
+    const directives = parseInlineDirectives("/model openai/gpt-4o");
+    const sessionEntry = createSessionEntry({
+      totalTokens: 150_000,
+      totalTokensFresh: true,
+    });
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        cfg: configWithContextWindows(),
+        directives,
+        sessionEntry,
+      }),
+    );
+
+    expect(result?.text).toContain("Can't switch to openai/gpt-4o yet.");
+    expect(result?.text).toContain("/compact");
+    expect(result?.text).toContain("/new");
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+  });
+
+  it("does not block a model switch when cached session usage is stale", async () => {
+    const directives = parseInlineDirectives("/model openai/gpt-4o");
+    const sessionEntry = createSessionEntry({
+      totalTokens: 150_000,
+      totalTokensFresh: false,
+    });
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        cfg: configWithContextWindows(),
+        directives,
+        sessionEntry,
+      }),
+    );
+
+    expect(result?.text).toContain("Model set to");
+    expect(result?.text).toContain("openai/gpt-4o");
+    expect(sessionEntry.providerOverride).toBe("openai");
+    expect(sessionEntry.modelOverride).toBe("gpt-4o");
+  });
+
+  it("blocks a model switch when the effective runtime context cap is smaller than the target model window", async () => {
+    const directives = parseInlineDirectives("/model openai/gpt-4o");
+    const sessionEntry = createSessionEntry({
+      totalTokens: 80_000,
+      totalTokensFresh: true,
+    });
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        cfg: configWithContextWindows({ agentContextTokens: 90_000 }),
+        directives,
+        sessionEntry,
+      }),
+    );
+
+    expect(result?.text).toContain("Can't switch to openai/gpt-4o yet.");
+    expect(result?.text).toContain("70k/90k");
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+  });
+
   it("persists thinkingLevel=off (does not clear)", async () => {
     const directives = parseInlineDirectives("/think off");
     const sessionEntry = createSessionEntry({ thinkingLevel: "low" });
@@ -731,5 +822,149 @@ describe("persistInlineDirectives internal exec scope gate", () => {
     expect(sessionEntry.execSecurity).toBeUndefined();
     expect(sessionEntry.execAsk).toBeUndefined();
     expect(sessionEntry.execNode).toBeUndefined();
+  });
+});
+
+describe("persistInlineDirectives model-switch context guard", () => {
+  it("does not persist an oversized switch during inline directive persistence", async () => {
+    const directives = parseInlineDirectives("please continue /model openai/gpt-4o");
+    const sessionEntry = createSessionEntry({
+      totalTokens: 150_000,
+      totalTokensFresh: true,
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const result = await persistInlineDirectives({
+      directives,
+      effectiveModelDirective: "openai/gpt-4o",
+      cfg: configWithContextWindows(),
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+      agentCfg: configWithContextWindows().agents?.defaults,
+    });
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-5");
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+  });
+
+  it("does not persist other inline directive side effects when the model switch is blocked", async () => {
+    const directives = parseInlineDirectives("please continue /model openai/gpt-4o /think high");
+    const sessionEntry = createSessionEntry({
+      totalTokens: 150_000,
+      totalTokensFresh: true,
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const result = await persistInlineDirectives({
+      directives,
+      effectiveModelDirective: "openai/gpt-4o",
+      cfg: configWithContextWindows(),
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+      agentCfg: configWithContextWindows().agents?.defaults,
+    });
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-5");
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.thinkingLevel).toBeUndefined();
+  });
+
+  it("does not persist other inline directive side effects when the blocked model switch uses fuzzy resolution", async () => {
+    const directives = parseInlineDirectives("please continue /model gpt-4o /think high");
+    const sessionEntry = createSessionEntry({
+      totalTokens: 150_000,
+      totalTokensFresh: true,
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const result = await persistInlineDirectives({
+      directives,
+      effectiveModelDirective: "gpt-4o",
+      cfg: configWithContextWindows(),
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+      agentCfg: configWithContextWindows().agents?.defaults,
+    });
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-5");
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.thinkingLevel).toBeUndefined();
+  });
+
+  it("does not persist other inline directive side effects when the model directive fails to resolve", async () => {
+    const directives = parseInlineDirectives(
+      "please continue /model openai/gpt-4o@missing-profile /think high",
+    );
+    const sessionEntry = createSessionEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const result = await persistInlineDirectives({
+      directives,
+      effectiveModelDirective: "openai/gpt-4o",
+      cfg: baseConfig(),
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+      agentCfg: baseConfig().agents?.defaults,
+    });
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-5");
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.thinkingLevel).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -826,6 +826,18 @@ describe("persistInlineDirectives internal exec scope gate", () => {
 });
 
 describe("persistInlineDirectives model-switch context guard", () => {
+  const allowedModelKeys = new Set(["anthropic/claude-opus-4-5", "openai/gpt-4o"]);
+  const sessionKey = "agent:main:dm:1";
+  const storePath = "/tmp/sessions.json";
+
+  function createSessionEntry(overrides?: Partial<SessionEntry>): SessionEntry {
+    return {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      ...overrides,
+    };
+  }
+
   it("does not persist an oversized switch during inline directive persistence", async () => {
     const directives = parseInlineDirectives("please continue /model openai/gpt-4o");
     const sessionEntry = createSessionEntry({

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -101,7 +101,7 @@ export async function persistInlineDirectives(params: {
       provider,
       model,
       contextTokens:
-        agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+        agentCfg?.contextTokens ?? lookupCachedContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
     };
   }
   if (
@@ -123,7 +123,7 @@ export async function persistInlineDirectives(params: {
       provider,
       model,
       contextTokens:
-        agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+        agentCfg?.contextTokens ?? lookupCachedContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
     };
   }
 

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -12,6 +12,7 @@ import type { SessionEntry } from "../../config/sessions/types.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import { resolveProfileOverride } from "./directive-handling.auth.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import {
@@ -19,6 +20,7 @@ import {
   enqueueModeSwitchEvents,
 } from "./directive-handling.shared.js";
 import type { ElevatedLevel, ReasoningLevel } from "./directives.js";
+import { maybeBlockOversizedModelSwitch } from "./model-switch-guard.js";
 
 export async function persistInlineDirectives(params: {
   directives: InlineDirectives;
@@ -68,7 +70,62 @@ export async function persistInlineDirectives(params: {
   const activeAgentId = sessionKey
     ? resolveSessionAgentId({ sessionKey, config: cfg })
     : resolveDefaultAgentId(cfg);
-  const agentDir = params.agentDir ?? resolveAgentDir(cfg, activeAgentId);
+  const agentDir = resolveAgentDir(cfg, activeAgentId);
+  const modelDirective =
+    directives.hasModelDirective && params.effectiveModelDirective
+      ? params.effectiveModelDirective
+      : undefined;
+  const modelResolution = modelDirective
+    ? resolveModelSelectionFromDirective({
+        directives: {
+          ...directives,
+          hasModelDirective: true,
+          rawModelDirective: modelDirective,
+        },
+        cfg,
+        agentDir,
+        defaultProvider,
+        defaultModel,
+        aliasIndex,
+        allowedModelKeys,
+        allowedModelCatalog: [],
+        provider,
+      })
+    : {};
+  const resolvedModelSelection = modelResolution.modelSelection;
+  if (modelDirective && modelResolution.errorText) {
+    // Mixed-message flows already surfaced the model-selection error to the
+    // user in the fast lane. Keep persistence aligned by skipping any inline
+    // state writes after the same failed `/model` directive.
+    return {
+      provider,
+      model,
+      contextTokens:
+        agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    };
+  }
+  if (
+    resolvedModelSelection &&
+    sessionEntry &&
+    maybeBlockOversizedModelSwitch({
+      cfg,
+      sessionEntry,
+      currentProvider: provider,
+      currentModel: model,
+      targetProvider: resolvedModelSelection.provider,
+      targetModel: resolvedModelSelection.model,
+    })
+  ) {
+    // Mixed-message flows already surfaced the blocked switch to the user in
+    // the fast lane. Keep persistence aligned by skipping all inline state
+    // writes for the same blocked model switch.
+    return {
+      provider,
+      model,
+      contextTokens:
+        agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    };
+  }
 
   if (sessionEntry && sessionStore && sessionKey) {
     const prevElevatedLevel =
@@ -138,43 +195,45 @@ export async function persistInlineDirectives(params: {
       }
     }
 
-    const modelDirective =
-      directives.hasModelDirective && params.effectiveModelDirective
-        ? params.effectiveModelDirective
-        : undefined;
-    if (modelDirective) {
-      const modelResolution = resolveModelSelectionFromDirective({
-        directives: {
-          ...directives,
-          hasModelDirective: true,
-          rawModelDirective: modelDirective,
-        },
+    if (resolvedModelSelection) {
+      let profileOverride = modelResolution.profileOverride;
+      if (directives.rawModelProfile && profileOverride === undefined) {
+        const profileResolved = resolveProfileOverride({
+          rawProfile: directives.rawModelProfile,
+          provider: resolvedModelSelection.provider,
+          cfg,
+          agentDir,
+        });
+        if (profileResolved.error) {
+          throw new Error(profileResolved.error);
+        }
+        profileOverride = profileResolved.profileId;
+      }
+      const blockedModelSwitchText = maybeBlockOversizedModelSwitch({
         cfg,
-        agentDir,
-        defaultProvider,
-        defaultModel,
-        aliasIndex,
-        allowedModelKeys,
-        allowedModelCatalog: [],
-        provider,
+        sessionEntry,
+        currentProvider: provider,
+        currentModel: model,
+        targetProvider: resolvedModelSelection.provider,
+        targetModel: resolvedModelSelection.model,
       });
-      if (modelResolution.modelSelection) {
+      // The fast-lane `/model` path already returns the user-facing error.
+      // Keep persistence aligned so inline directives cannot write the
+      // blocked selection into the session store afterward.
+      if (!blockedModelSwitchText) {
         const { updated: modelUpdated } = applyModelOverrideToSessionEntry({
           entry: sessionEntry,
-          selection: modelResolution.modelSelection,
-          profileOverride: modelResolution.profileOverride,
+          selection: resolvedModelSelection,
+          profileOverride,
         });
-        provider = modelResolution.modelSelection.provider;
-        model = modelResolution.modelSelection.model;
+        provider = resolvedModelSelection.provider;
+        model = resolvedModelSelection.model;
         const nextLabel = `${provider}/${model}`;
         if (nextLabel !== initialModelLabel) {
-          enqueueSystemEvent(
-            formatModelSwitchEvent(nextLabel, modelResolution.modelSelection.alias),
-            {
-              sessionKey,
-              contextKey: `model:${nextLabel}`,
-            },
-          );
+          enqueueSystemEvent(formatModelSwitchEvent(nextLabel, resolvedModelSelection.alias), {
+            sessionKey,
+            contextKey: `model:${nextLabel}`,
+          });
         }
         updated = updated || modelUpdated;
       }

--- a/src/auto-reply/reply/model-switch-guard.test.ts
+++ b/src/auto-reply/reply/model-switch-guard.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { lookupContextTokensMock } = vi.hoisted(() => ({
+  lookupContextTokensMock: vi.fn(),
+}));
+
+vi.mock("../../agents/context.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/context.js")>();
+  return {
+    ...actual,
+    lookupContextTokens: lookupContextTokensMock,
+  };
+});
+
+import type { OpenClawConfig } from "../../config/config.js";
+import { maybeBlockOversizedModelSwitch } from "./model-switch-guard.js";
+
+describe("maybeBlockOversizedModelSwitch", () => {
+  beforeEach(() => {
+    lookupContextTokensMock.mockReset();
+  });
+
+  it("uses the smallest bare-model budget when providers share the same model id", () => {
+    lookupContextTokensMock.mockReturnValue(200_000);
+
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: {
+            reserveTokensFloor: 20_000,
+          },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: {
+            models: [{ id: "shared-budget-model", contextWindow: 200_000 }],
+          },
+          openrouter: {
+            models: [{ id: "shared-budget-model", contextWindow: 128_000 }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = maybeBlockOversizedModelSwitch({
+      cfg,
+      sessionEntry: {
+        totalTokens: 150_000,
+        totalTokensFresh: true,
+      },
+      currentProvider: "anthropic",
+      currentModel: "shared-budget-model",
+      targetProvider: "openrouter",
+      targetModel: "shared-budget-model",
+    });
+
+    expect(result).toContain("Can't switch to openrouter/shared-budget-model yet.");
+    expect(result).toContain("108k/128k");
+    expect(lookupContextTokensMock).toHaveBeenCalledWith("shared-budget-model");
+  });
+
+  it("does not block when the target model budget is unknown", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: {
+            reserveTokensFloor: 20_000,
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = maybeBlockOversizedModelSwitch({
+      cfg,
+      sessionEntry: {
+        totalTokens: 190_000,
+        totalTokensFresh: true,
+      },
+      currentProvider: "anthropic",
+      currentModel: "claude-opus-4-5",
+      targetProvider: "openrouter",
+      targetModel: "__codex_unknown_context_window_model__",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("still blocks when an explicit agent context cap is configured for an unknown model", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          contextTokens: 90_000,
+          compaction: {
+            reserveTokensFloor: 20_000,
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = maybeBlockOversizedModelSwitch({
+      cfg,
+      sessionEntry: {
+        totalTokens: 80_000,
+        totalTokensFresh: true,
+      },
+      currentProvider: "anthropic",
+      currentModel: "claude-opus-4-5",
+      targetProvider: "openrouter",
+      targetModel: "__codex_unknown_context_window_model_with_cap__",
+    });
+
+    expect(result).toContain(
+      "Can't switch to openrouter/__codex_unknown_context_window_model_with_cap__ yet.",
+    );
+    expect(result).toContain("70k/90k");
+  });
+});

--- a/src/auto-reply/reply/model-switch-guard.ts
+++ b/src/auto-reply/reply/model-switch-guard.ts
@@ -1,0 +1,125 @@
+import { lookupContextTokens } from "../../agents/context.js";
+import { resolveCompactionReserveTokensFloor } from "../../agents/pi-settings.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
+import { formatTokenCount } from "../../utils/usage-format.js";
+
+function normalizePositiveInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function resolveConfiguredModelContextWindow(params: {
+  cfg: OpenClawConfig;
+  model: string;
+}): number | undefined {
+  const providers = params.cfg.models?.providers;
+  if (!providers || typeof providers !== "object") {
+    return undefined;
+  }
+
+  let smallest: number | undefined;
+  for (const providerConfig of Object.values(providers)) {
+    const models = providerConfig?.models;
+    if (!Array.isArray(models)) {
+      continue;
+    }
+    for (const modelConfig of models) {
+      if (
+        modelConfig?.id !== params.model ||
+        typeof modelConfig.contextWindow !== "number" ||
+        !Number.isFinite(modelConfig.contextWindow) ||
+        modelConfig.contextWindow <= 0
+      ) {
+        continue;
+      }
+      const contextWindow = Math.floor(modelConfig.contextWindow);
+      if (smallest === undefined || contextWindow < smallest) {
+        smallest = contextWindow;
+      }
+    }
+  }
+  return smallest;
+}
+
+function resolveEffectiveContextWindowTokens(params: {
+  cfg: OpenClawConfig;
+  model: string;
+}): number | undefined {
+  const cachedWindow = normalizePositiveInt(lookupContextTokens(params.model));
+  const configuredWindow = resolveConfiguredModelContextWindow(params);
+  const contextWindow =
+    cachedWindow !== undefined && configuredWindow !== undefined
+      ? Math.min(cachedWindow, configuredWindow)
+      : (cachedWindow ?? configuredWindow);
+  const configuredCap = normalizePositiveInt(params.cfg.agents?.defaults?.contextTokens);
+  if (contextWindow === undefined) {
+    // Refuse a switch only when we have a real budget signal. Falling back to
+    // the global default here would block unknown/high-context models purely
+    // because the catalog is incomplete.
+    return configuredCap;
+  }
+
+  if (configuredCap !== undefined && configuredCap < contextWindow) {
+    return configuredCap;
+  }
+
+  return contextWindow;
+}
+
+export function maybeBlockOversizedModelSwitch(params: {
+  cfg: OpenClawConfig;
+  sessionEntry?: Pick<SessionEntry, "totalTokens" | "totalTokensFresh"> | null;
+  currentProvider?: string;
+  currentModel?: string;
+  targetProvider: string;
+  targetModel: string;
+}): string | undefined {
+  const currentProvider = params.currentProvider?.trim();
+  const currentModel = params.currentModel?.trim();
+  const targetProvider = params.targetProvider.trim();
+  const targetModel = params.targetModel.trim();
+
+  if (currentProvider === targetProvider && currentModel === targetModel) {
+    return undefined;
+  }
+
+  const recordedTokens = resolveFreshSessionTotalTokens(params.sessionEntry);
+  if (recordedTokens === undefined) {
+    return undefined;
+  }
+
+  const contextWindowTokens = resolveEffectiveContextWindowTokens({
+    cfg: params.cfg,
+    model: targetModel,
+  });
+  if (
+    typeof contextWindowTokens !== "number" ||
+    !Number.isFinite(contextWindowTokens) ||
+    contextWindowTokens <= 0
+  ) {
+    return undefined;
+  }
+
+  const reserveTokens = Math.min(
+    Math.max(0, resolveCompactionReserveTokensFloor(params.cfg)),
+    Math.max(0, contextWindowTokens - 1),
+  );
+  // Refuse switches that would immediately drop the session into an unsafe
+  // budget for the target model on the very next turn.
+  const safeBudgetTokens = Math.max(1, contextWindowTokens - reserveTokens);
+  if (recordedTokens <= safeBudgetTokens) {
+    return undefined;
+  }
+
+  return [
+    `Can't switch to ${targetProvider}/${targetModel} yet.`,
+    "",
+    `Recorded session context: ${formatTokenCount(recordedTokens)} tokens.`,
+    `Target model budget: about ${formatTokenCount(safeBudgetTokens)}/${formatTokenCount(contextWindowTokens)} tokens (reserve ${formatTokenCount(reserveTokens)}).`,
+    "Run /compact first, or use /new to start a fresh session before switching.",
+    "Current model unchanged.",
+  ].join("\n");
+}

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,6 +1157,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "google-gemini-cli-auth",
+    idHint: "google-gemini-cli-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/google-gemini-cli-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "google-gemini-cli-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["google-gemini-cli"],
+    },
+  },
+  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1859,6 +1882,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
+    },
+  },
+  {
+    dirName: "minimax-portal-auth",
+    idHint: "minimax-portal-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/minimax-portal-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "minimax-portal-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["minimax-portal"],
     },
   },
   {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,29 +1157,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
-    dirName: "google-gemini-cli-auth",
-    idHint: "google-gemini-cli-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/google-gemini-cli-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "google-gemini-cli-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["google-gemini-cli"],
-    },
-  },
-  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1882,29 +1859,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
-    },
-  },
-  {
-    dirName: "minimax-portal-auth",
-    idHint: "minimax-portal-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/minimax-portal-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "minimax-portal-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["minimax-portal"],
     },
   },
   {


### PR DESCRIPTION
## Summary

- Problem: `/model` accepted switches to smaller-context models even when the recorded session context was already too large for the target model.
- Why it matters: the very next turn could fall straight into overflow/compaction failure territory, which is the core failure behind #44303.
- What changed: added a shared preflight guard that refuses risky model switches, keeps the current model unchanged, and tells the user to `/compact` or `/new`; wired it into both the immediate `/model` path and the later persistence path so inline directives cannot sneak the switch through.
- What did NOT change (scope boundary): this PR does not auto-compact on switch, does not change compaction internals, and does not change memory-flush threshold scaling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44303
- Related #17034
- Related #9409

## User-visible / Behavior Changes

- If a session is already larger than a target model's safe working budget, `/model <provider/model>` now refuses the switch instead of accepting it and risking an immediate overflow on the next turn.
- The refusal message explains the recorded session size, the target model budget, and recommends `/compact` or `/new`.
- Inline model directives are kept consistent with the same guard and no longer persist the blocked selection behind the scenes.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm 10.23.0
- Model/provider: synthetic config with `anthropic/claude-opus-4-5` at 200k and `openai/gpt-4o` at 128k
- Integration/channel (if any): reply directive handling tests
- Relevant config (redacted): `agents.defaults.compaction.reserveTokensFloor=20000`

### Steps

1. Create a session with recorded token usage above the smaller model's safe budget.
2. Issue `/model openai/gpt-4o`.
3. Observe whether the switch is accepted or rejected.

### Expected

- The switch is rejected before the next turn runs.
- The current model remains unchanged.
- Inline directive persistence also skips the blocked switch.

### Actual

- Added tests reproduce the old behavior first; with this patch, the guard now blocks the risky switch and preserves the current model.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: direct `/model` command rejection when the target safe budget is already exceeded; inline directive persistence does not write the blocked switch.
- Edge cases checked: normal `/model` success path still passes existing tests; commands reply-path tests still pass.
- What you did **not** verify: live Telegram reproduction against a real gateway process.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/auto-reply/reply/directive-handling.impl.ts`, `src/auto-reply/reply/directive-handling.persist.ts`, `src/auto-reply/reply/model-switch-guard.ts`
- Known bad symptoms reviewers should watch for: legitimate model switches being blocked when the session token snapshot is badly stale.

## Risks and Mitigations

- Risk: a stale recorded token total could conservatively block a switch that would have fit.
  - Mitigation: this is fail-safe compared with allowing a switch that immediately overflows; the message tells the user to `/compact` or `/new`, and the PR intentionally does not alter compaction logic itself.
