### PR TITLE
fix(memory): fall back to qmd get for slugified paths

### DIFF
--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -893,6 +893,13 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const statResult = await statRegularFile(absPath);
     if (statResult.missing) {
+      // Fall back to `qmd get` which can resolve slugified paths.
+      if (relPath.startsWith("qmd/")) {
+        const qmdText = await this.getQmdDoc(relPath);
+        if (qmdText !== null) {
+          return { text: qmdText, path: relPath };
+        }
+      }
       return { text: "", path: relPath };
     }
     if (params.from !== undefined || params.lines !== undefined) {
@@ -1792,6 +1799,23 @@ export class QmdMemoryManager implements MemorySearchManager {
       return false;
     }
     return !path.isAbsolute(relativePath);
+  }
+
+  private async getQmdDoc(relPath: string): Promise<string | null> {
+    const [, collection, ...rest] = relPath.split("/");
+    if (!collection || rest.length === 0) {
+      return null;
+    }
+    const uri = `qmd://${collection}/${rest.join("/")}`;
+    try {
+      const result = await this.runQmd(["get", uri], {
+        timeoutMs: this.qmd.limits.timeoutMs,
+      });
+      const text = result.stdout?.trim();
+      return text || null;
+    } catch {
+      return null;
+    }
   }
 
   private resolveReadPath(relPath: string): string {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -897,6 +897,12 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (relPath.startsWith("qmd/")) {
         const qmdText = await this.getQmdDoc(relPath);
         if (qmdText !== null) {
+          if (params.from !== undefined || params.lines !== undefined) {
+            const allLines = qmdText.split("\n");
+            const start = Math.max(1, params.from ?? 1);
+            const count = Math.max(1, params.lines ?? allLines.length);
+            return { text: allLines.slice(start - 1, start - 1 + count).join("\n"), path: relPath };
+          }
           return { text: qmdText, path: relPath };
         }
       }


### PR DESCRIPTION
## Summary

- When qmd indexes files it slugifies filenames (e.g. `My Recipe Notes.md` → `my-recipe-notes.md`), so filesystem reads via `readFile()` fail with ENOENT
- Added `getQmdDoc()` fallback that retrieves document content via `qmd get` using `qmd://` URIs when the filesystem path doesn't exist
- This allows `memory_get` tool calls to return full document content for qmd search results

## AI-assisted

- [x] Mark as AI-assisted in the PR title or description
- [x] Lightly tested — verified in Docker container with qmd
- [x] Author understands what the code does
- [x] `pnpm build && pnpm check && pnpm test` all passing (906 test files, 7495 tests)

## Test plan

- [x] Verified `qmd get` resolves slugified paths in running container
- [x] Confirmed `readFile()` fallback returns full document content
- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] `pnpm test` passes (7495 tests, 0 failures)


🤖 Generated with [Claude Code](https://claude.com/claude-code)