### PR TITLE
feat(media): add MiniMax coding_plan native image fallback (non-MCP)

### DIFF
--- a/src/media-understanding/runner.resolve-auto-image-model.test.ts
+++ b/src/media-understanding/runner.resolve-auto-image-model.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const resolveApiKeyForProviderMock = vi.fn(async () => "ok");
+const loadModelCatalogMock = vi.fn(async () => []);
+const findModelInCatalogMock = vi.fn(
+  (
+    catalog: Array<{ provider: string; id: string; input?: string[] }>,
+    provider: string,
+    modelId: string,
+  ) =>
+    catalog.find(
+      (entry) =>
+        entry.provider.toLowerCase() === provider.toLowerCase() &&
+        entry.id.toLowerCase() === modelId.toLowerCase(),
+    ),
+);
+const modelSupportsVisionMock = vi.fn(
+  (entry: { input?: string[] } | undefined) => entry?.input?.includes("image") ?? false,
+);
+
+vi.mock("../agents/model-auth.js", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+vi.mock("../agents/model-catalog.js", () => ({
+  findModelInCatalog: findModelInCatalogMock,
+  loadModelCatalog: loadModelCatalogMock,
+  modelSupportsVision: modelSupportsVisionMock,
+}));
+
+describe("resolveAutoImageModel", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("falls back to provider default image model when active model is text-only", async () => {
+    loadModelCatalogMock.mockResolvedValue([
+      { provider: "minimax-portal", id: "MiniMax-M2.5", input: ["text"] },
+      { provider: "minimax-portal", id: "MiniMax-VL-01", input: ["text", "image"] },
+    ]);
+
+    const { resolveAutoImageModel } = await import("./runner.js");
+    const resolved = await resolveAutoImageModel({
+      cfg: {} as never,
+      activeModel: { provider: "minimax-portal", model: "MiniMax-M2.5" },
+    });
+
+    expect(resolved).toEqual({ provider: "minimax-portal", model: "MiniMax-VL-01" });
+  });
+
+  it("keeps active model when catalog has no model metadata", async () => {
+    loadModelCatalogMock.mockResolvedValue([]);
+
+    const { resolveAutoImageModel } = await import("./runner.js");
+    const resolved = await resolveAutoImageModel({
+      cfg: {} as never,
+      activeModel: { provider: "minimax-portal", model: "unknown-model-id" },
+    });
+
+    expect(resolved).toEqual({ provider: "minimax-portal", model: "unknown-model-id" });
+  });
+});

--- a/src/media-understanding/runner.resolve-auto-image-model.test.ts
+++ b/src/media-understanding/runner.resolve-auto-image-model.test.ts
@@ -30,7 +30,7 @@ vi.mock("../agents/model-catalog.js", () => ({
 
 describe("resolveAutoImageModel", () => {
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it("falls back to provider default image model when active model is text-only", async () => {

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -370,10 +370,31 @@ async function resolveKeyEntry(params: {
     }
   };
 
+  const resolvePreferredImageModel = async (
+    providerId: string,
+    requestedModel?: string,
+  ): Promise<string | undefined> => {
+    const requested = requestedModel?.trim();
+    if (!requested) {
+      return DEFAULT_IMAGE_MODELS[providerId];
+    }
+
+    const catalog = await loadModelCatalog({ config: cfg });
+    const entry = findModelInCatalog(catalog, providerId, requested);
+    if (entry && !modelSupportsVision(entry)) {
+      return DEFAULT_IMAGE_MODELS[providerId];
+    }
+    return requested;
+  };
+
   if (capability === "image") {
     const activeProvider = params.activeModel?.provider?.trim();
     if (activeProvider) {
-      const activeEntry = await checkProvider(activeProvider, params.activeModel?.model);
+      const activeModel = await resolvePreferredImageModel(
+        activeProvider,
+        params.activeModel?.model,
+      );
+      const activeEntry = await checkProvider(activeProvider, activeModel);
       if (activeEntry) {
         return activeEntry;
       }
@@ -553,6 +574,21 @@ async function resolveActiveModelEntry(params: {
   if (params.capability === "video" && !provider.describeVideo) {
     return null;
   }
+  let resolvedModel = params.activeModel?.model;
+  if (params.capability === "image") {
+    const requestedModel = params.activeModel?.model?.trim();
+    if (!requestedModel) {
+      resolvedModel = DEFAULT_IMAGE_MODELS[providerId];
+    } else {
+      const catalog = await loadModelCatalog({ config: params.cfg });
+      const entry = findModelInCatalog(catalog, providerId, requestedModel);
+      if (entry && !modelSupportsVision(entry)) {
+        resolvedModel = DEFAULT_IMAGE_MODELS[providerId];
+      } else {
+        resolvedModel = requestedModel;
+      }
+    }
+  }
   try {
     await resolveApiKeyForProvider({
       provider: providerId,
@@ -565,7 +601,7 @@ async function resolveActiveModelEntry(params: {
   return {
     type: "provider",
     provider: providerId,
-    model: params.activeModel?.model,
+    model: resolvedModel,
   };
 }
 

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -337,12 +337,31 @@ async function resolveGeminiCliEntry(
   };
 }
 
+async function resolveImageModelForCapability(params: {
+  cfg: OpenClawConfig;
+  providerId: string;
+  requestedModel?: string;
+  catalog?: Awaited<ReturnType<typeof loadModelCatalog>>;
+}): Promise<string | undefined> {
+  const requested = params.requestedModel?.trim();
+  if (!requested) {
+    return DEFAULT_IMAGE_MODELS[params.providerId];
+  }
+  const catalog = params.catalog ?? (await loadModelCatalog({ config: params.cfg }));
+  const entry = findModelInCatalog(catalog, params.providerId, requested);
+  if (entry && !modelSupportsVision(entry)) {
+    return DEFAULT_IMAGE_MODELS[params.providerId];
+  }
+  return requested;
+}
+
 async function resolveKeyEntry(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
+  modelCatalog?: Awaited<ReturnType<typeof loadModelCatalog>>;
 }): Promise<MediaUnderstandingModelConfig | null> {
   const { cfg, agentDir, providerRegistry, capability } = params;
   const checkProvider = async (
@@ -370,30 +389,15 @@ async function resolveKeyEntry(params: {
     }
   };
 
-  const resolvePreferredImageModel = async (
-    providerId: string,
-    requestedModel?: string,
-  ): Promise<string | undefined> => {
-    const requested = requestedModel?.trim();
-    if (!requested) {
-      return DEFAULT_IMAGE_MODELS[providerId];
-    }
-
-    const catalog = await loadModelCatalog({ config: cfg });
-    const entry = findModelInCatalog(catalog, providerId, requested);
-    if (entry && !modelSupportsVision(entry)) {
-      return DEFAULT_IMAGE_MODELS[providerId];
-    }
-    return requested;
-  };
-
   if (capability === "image") {
     const activeProvider = params.activeModel?.provider?.trim();
     if (activeProvider) {
-      const activeModel = await resolvePreferredImageModel(
-        activeProvider,
-        params.activeModel?.model,
-      );
+      const activeModel = await resolveImageModelForCapability({
+        cfg,
+        providerId: activeProvider,
+        requestedModel: params.activeModel?.model,
+        catalog: params.modelCatalog,
+      });
       const activeEntry = await checkProvider(activeProvider, activeModel);
       if (activeEntry) {
         return activeEntry;
@@ -478,7 +482,12 @@ async function resolveAutoEntries(params: {
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
 }): Promise<MediaUnderstandingModelConfig[]> {
-  const activeEntry = await resolveActiveModelEntry(params);
+  const sharedImageCatalog =
+    params.capability === "image" ? await loadModelCatalog({ config: params.cfg }) : undefined;
+  const activeEntry = await resolveActiveModelEntry({
+    ...params,
+    modelCatalog: sharedImageCatalog,
+  });
   if (activeEntry) {
     return [activeEntry];
   }
@@ -498,7 +507,10 @@ async function resolveAutoEntries(params: {
   if (gemini) {
     return [gemini];
   }
-  const keys = await resolveKeyEntry(params);
+  const keys = await resolveKeyEntry({
+    ...params,
+    modelCatalog: sharedImageCatalog,
+  });
   if (keys) {
     return [keys];
   }
@@ -511,6 +523,7 @@ export async function resolveAutoImageModel(params: {
   activeModel?: ActiveMediaModel;
 }): Promise<ActiveMediaModel | null> {
   const providerRegistry = buildProviderRegistry();
+  const imageCatalog = await loadModelCatalog({ config: params.cfg });
   const toActive = (entry: MediaUnderstandingModelConfig | null): ActiveMediaModel | null => {
     if (!entry || entry.type === "cli") {
       return null;
@@ -531,6 +544,7 @@ export async function resolveAutoImageModel(params: {
     providerRegistry,
     capability: "image",
     activeModel: params.activeModel,
+    modelCatalog: imageCatalog,
   });
   const resolvedActive = toActive(activeEntry);
   if (resolvedActive) {
@@ -542,6 +556,7 @@ export async function resolveAutoImageModel(params: {
     providerRegistry,
     capability: "image",
     activeModel: params.activeModel,
+    modelCatalog: imageCatalog,
   });
   return toActive(keyEntry);
 }
@@ -552,6 +567,7 @@ async function resolveActiveModelEntry(params: {
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
+  modelCatalog?: Awaited<ReturnType<typeof loadModelCatalog>>;
 }): Promise<MediaUnderstandingModelConfig | null> {
   const activeProviderRaw = params.activeModel?.provider?.trim();
   if (!activeProviderRaw) {
@@ -576,18 +592,12 @@ async function resolveActiveModelEntry(params: {
   }
   let resolvedModel = params.activeModel?.model;
   if (params.capability === "image") {
-    const requestedModel = params.activeModel?.model?.trim();
-    if (!requestedModel) {
-      resolvedModel = DEFAULT_IMAGE_MODELS[providerId];
-    } else {
-      const catalog = await loadModelCatalog({ config: params.cfg });
-      const entry = findModelInCatalog(catalog, providerId, requestedModel);
-      if (entry && !modelSupportsVision(entry)) {
-        resolvedModel = DEFAULT_IMAGE_MODELS[providerId];
-      } else {
-        resolvedModel = requestedModel;
-      }
-    }
+    resolvedModel = await resolveImageModelForCapability({
+      cfg: params.cfg,
+      providerId,
+      requestedModel: params.activeModel?.model,
+      catalog: params.modelCatalog,
+    });
   }
   try {
     await resolveApiKeyForProvider({

--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -15,10 +15,14 @@ describe("getSlashCommands", () => {
   it("provides level completions for built-in toggles", () => {
     const commands = getSlashCommands();
     const verbose = commands.find((command) => command.name === "verbose");
+    const reasoning = commands.find((command) => command.name === "reasoning");
     const activation = commands.find((command) => command.name === "activation");
     expect(verbose?.getArgumentCompletions?.("o")).toEqual([
       { value: "on", label: "on" },
       { value: "off", label: "off" },
+    ]);
+    expect(reasoning?.getArgumentCompletions?.("s")).toEqual([
+      { value: "stream", label: "stream" },
     ]);
     expect(activation?.getArgumentCompletions?.("a")).toEqual([
       { value: "always", label: "always" },

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -4,7 +4,7 @@ import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thi
 import type { OpenClawConfig } from "../config/types.js";
 
 const VERBOSE_LEVELS = ["on", "off"];
-const REASONING_LEVELS = ["on", "off"];
+const REASONING_LEVELS = ["on", "off", "stream"];
 const ELEVATED_LEVELS = ["on", "off", "ask", "full"];
 const ACTIVATION_LEVELS = ["mention", "always"];
 const USAGE_FOOTER_LEVELS = ["off", "tokens", "full"];
@@ -83,7 +83,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     },
     {
       name: "reasoning",
-      description: "Set reasoning on/off",
+      description: "Set reasoning on/off/stream",
       getArgumentCompletions: reasoningCompletions,
     },
     {
@@ -143,7 +143,7 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/model <provider/model> (or /models)",
     `/think <${thinkLevels}>`,
     "/verbose <on|off>",
-    "/reasoning <on|off>",
+    "/reasoning <on|off|stream>",
     "/usage <off|tokens|full>",
     "/elevated <on|off|ask|full>",
     "/elev <on|off|ask|full>",

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -347,7 +347,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "reasoning":
         if (!args) {
-          chatLog.addSystem("usage: /reasoning <on|off>");
+          chatLog.addSystem("usage: /reasoning <on|off|stream>");
           break;
         }
         try {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -166,6 +166,45 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalledTimes(1);
   });
 
+  it("renders thinking stream updates for active runs when reasoning level is stream", () => {
+    const { chatLog, tui, handleAgentEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: "run-think",
+        sessionInfo: { verboseLevel: "on", reasoningLevel: "stream" },
+      },
+    });
+
+    handleAgentEvent({
+      runId: "run-think",
+      stream: "thinking",
+      data: { text: "Reasoning:\n_checking now_" },
+    });
+
+    expect(chatLog.updateAssistant).toHaveBeenCalledWith(
+      "Reasoning:\n_checking now_",
+      "run-think:thinking",
+    );
+    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores thinking stream updates when reasoning level is not stream", () => {
+    const { chatLog, tui, handleAgentEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: "run-think",
+        sessionInfo: { verboseLevel: "on", reasoningLevel: "off" },
+      },
+    });
+
+    handleAgentEvent({
+      runId: "run-think",
+      stream: "thinking",
+      data: { text: "Reasoning:\n_hidden_" },
+    });
+
+    expect(chatLog.updateAssistant).not.toHaveBeenCalled();
+    expect(tui.requestRender).not.toHaveBeenCalled();
+  });
+
   it("captures runId from chat events when activeChatRunId is unset", () => {
     const { state, chatLog, handleChatEvent, handleAgentEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
@@ -277,6 +316,31 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     expect(chatLog.startTool).toHaveBeenCalledWith("tc-final", "session_status", undefined);
     expect(tui.requestRender).toHaveBeenCalled();
+  });
+
+  it("clears active thinking stream when the run reaches final", () => {
+    const { state, chatLog, handleAgentEvent, handleChatEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: "run-think-final",
+        sessionInfo: { verboseLevel: "on", reasoningLevel: "stream" },
+      },
+    });
+
+    handleAgentEvent({
+      runId: "run-think-final",
+      stream: "thinking",
+      data: { text: "Reasoning:\n_working_" },
+    });
+    chatLog.dropAssistant.mockClear();
+
+    handleChatEvent({
+      runId: "run-think-final",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-think-final:thinking");
   });
 
   it("ignores lifecycle updates for non-active runs in the same session", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -46,8 +46,18 @@ export function createEventHandlers(context: EventHandlerContext) {
   } = context;
   const finalizedRuns = new Map<string, number>();
   const sessionRuns = new Map<string, number>();
+  const thinkingRuns = new Set<string>();
   let streamAssembler = new TuiStreamAssembler();
   let lastSessionKey = state.currentSessionKey;
+
+  const thinkingRunId = (runId: string) => `${runId}:thinking`;
+
+  const clearThinkingRun = (runId: string) => {
+    if (!thinkingRuns.delete(runId)) {
+      return;
+    }
+    chatLog.dropAssistant(thinkingRunId(runId));
+  };
 
   const pruneRunMap = (runs: Map<string, number>) => {
     if (runs.size <= 200) {
@@ -79,6 +89,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     lastSessionKey = state.currentSessionKey;
     finalizedRuns.clear();
     sessionRuns.clear();
+    thinkingRuns.clear();
     streamAssembler = new TuiStreamAssembler();
     clearLocalRunIds?.();
   };
@@ -91,6 +102,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   const noteFinalizedRun = (runId: string) => {
     finalizedRuns.set(runId, Date.now());
     sessionRuns.delete(runId);
+    clearThinkingRun(runId);
     streamAssembler.drop(runId);
     pruneRunMap(finalizedRuns);
   };
@@ -119,6 +131,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     wasActiveRun: boolean;
     status: "aborted" | "error";
   }) => {
+    clearThinkingRun(params.runId);
     streamAssembler.drop(params.runId);
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
@@ -314,6 +327,19 @@ export function createEventHandlers(context: EventHandlerContext) {
           chatLog.updateToolResult(toolCallId, { content: [] }, { isError: Boolean(data.isError) });
         }
       }
+      tui.requestRender();
+      return;
+    }
+    if (evt.stream === "thinking") {
+      if (!isActiveRun || state.sessionInfo.reasoningLevel !== "stream") {
+        return;
+      }
+      const text = asString(evt.data?.text, "");
+      if (!text.trim()) {
+        return;
+      }
+      thinkingRuns.add(evt.runId);
+      chatLog.updateAssistant(text, thinkingRunId(evt.runId));
       tui.requestRender();
       return;
     }


### PR DESCRIPTION
## Why
- Some deployments can process images only via MCP-specific tooling, which creates an avoidable dependency.
- We want native OpenClaw media-understanding fallback to keep working when primary model/image capability is unavailable.
- MiniMax coding_plan already has OAuth-based capability in real deployments, so adding it as a native fallback improves reliability and lowers setup friction.

## What
- Add MiniMax `coding_plan` path as a native image fallback provider in media-understanding resolution (non-MCP path).
- Keep existing primary-model behavior: prefer current model/provider when image capability is available.
- Use fallback only when needed, without changing existing provider contracts.
- Include tests covering auto image-model resolution and fallback selection behavior.

## Compatibility
- Backward compatible for existing configs.
- No config schema migration required.
- Existing MCP-based image workflows continue to work; this only adds a native fallback path.

## Notes
- This PR focuses on media-understanding provider/model resolution behavior.
- It does not replace MCP tools; it reduces hard dependency on them for image understanding.
