### PR TITLE
fix(ci): restore generated protocol swift outputs

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1106,6 +1106,7 @@ public struct PushTestResult: Codable, Sendable {
     public let tokensuffix: String
     public let topic: String
     public let environment: String
+    public let transport: String
 
     public init(
         ok: Bool,
@@ -1114,7 +1115,8 @@ public struct PushTestResult: Codable, Sendable {
         reason: String?,
         tokensuffix: String,
         topic: String,
-        environment: String)
+        environment: String,
+        transport: String)
     {
         self.ok = ok
         self.status = status
@@ -1123,6 +1125,7 @@ public struct PushTestResult: Codable, Sendable {
         self.tokensuffix = tokensuffix
         self.topic = topic
         self.environment = environment
+        self.transport = transport
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1133,6 +1136,7 @@ public struct PushTestResult: Codable, Sendable {
         case tokensuffix = "tokenSuffix"
         case topic
         case environment
+        case transport
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1106,6 +1106,7 @@ public struct PushTestResult: Codable, Sendable {
     public let tokensuffix: String
     public let topic: String
     public let environment: String
+    public let transport: String
 
     public init(
         ok: Bool,
@@ -1114,7 +1115,8 @@ public struct PushTestResult: Codable, Sendable {
         reason: String?,
         tokensuffix: String,
         topic: String,
-        environment: String)
+        environment: String,
+        transport: String)
     {
         self.ok = ok
         self.status = status
@@ -1123,6 +1125,7 @@ public struct PushTestResult: Codable, Sendable {
         self.tokensuffix = tokensuffix
         self.topic = topic
         self.environment = environment
+        self.transport = transport
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1133,6 +1136,7 @@ public struct PushTestResult: Codable, Sendable {
         case tokensuffix = "tokenSuffix"
         case topic
         case environment
+        case transport
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
     "plugins:sync": "node --import tsx scripts/sync-plugin-versions.ts",
     "prepack": "pnpm build && pnpm ui:build",
     "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0",
-    "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",
+    "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",
     "release:check": "node --import tsx scripts/release-check.ts",


### PR DESCRIPTION
## Summary

- Problem: `pnpm protocol:check` is red on `main` because the committed Swift protocol outputs are stale relative to the current TypeScript gateway schema.
- Why it matters: the protocol lane fails immediately in CI and blocks unrelated merges until the generated files are restored.
- What changed: regenerated both Swift `GatewayModels.swift` outputs so `PushTestResult` includes `transport` again, and updated `protocol:check` to diff both Swift destinations because the generator writes both files.
- What did NOT change (scope boundary): no runtime protocol logic or schema definitions changed; this PR only restores generated artifacts and tightens the CI guard.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #25561
- Related #44266

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.3.2
- Runtime/container: Node 24 / pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): clean checkout from `origin/main`

### Steps

1. Check out current `origin/main` at `7332e6d6098dd6d2ddb849963ac5748da2c409ac`.
2. Run `pnpm protocol:check`.
3. Observe the generated diff in both Swift protocol outputs for `PushTestResult.transport`.
4. Apply this branch and rerun `pnpm protocol:check`.

### Expected

- `pnpm protocol:check` exits cleanly with no generated diffs.

### Actual

- On `main`, the check regenerates both Swift files and fails because the committed outputs are stale.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the failing `pnpm protocol:check` diff against `origin/main`; committed the regenerated Swift files and reran `pnpm protocol:check` successfully on this branch; ran `pnpm exec vitest run src/gateway/protocol/push.test.ts`.
- Edge cases checked: confirmed both generated Swift destinations drifted together and that the check now explicitly covers both paths.
- What you did **not** verify: full repo CI matrix beyond the protocol lane and targeted schema test.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `49c311f24`.
- Files/config to restore: `package.json`, `apps/macos/Sources/OpenClawProtocol/GatewayModels.swift`, `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`.
- Known bad symptoms reviewers should watch for: `pnpm protocol:check` reintroducing diffs for either Swift output.

## Risks and Mitigations

- Risk: a future commit can still overwrite generated Swift artifacts with stale content.
  - Mitigation: `protocol:check` now diffs both Swift destinations, matching the generator's write set.
