### PR TITLE
Doctor/cron: stop flagging canonical payload kinds as legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/session stores: regenerate the Swift push-test protocol models and align Windows native session-store realpath handling so protocol checks and sync session discovery stop drifting on Windows. (#44266) thanks @jalehman.
 - Context engine/session routing: forward optional `sessionKey` through context-engine lifecycle calls so plugins can see structured routing metadata during bootstrap, assembly, post-turn ingestion, and compaction. (#44157) thanks @jalehman.
 - Agents/failover: classify z.ai `network_error` stop reasons as retryable timeouts so provider connectivity failures trigger fallback instead of surfacing raw unhandled-stop-reason errors. (#43884) Thanks @hougangdev.
+- Doctor/cron: stop flagging canonical `agentTurn` and `systemEvent` cron payload kinds as legacy, so `openclaw doctor` no longer loops on false payload-kind normalization warnings after upgrade.
 
 ## 2026.3.11
 

--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -28,6 +28,68 @@ function makePrompter(confirmResult = true) {
 }
 
 describe("maybeRepairLegacyCronStore", () => {
+  it("does not warn for canonical payload kinds in an already-normalized store", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "canonical-agent",
+              name: "Canonical agent",
+              enabled: true,
+              schedule: { kind: "cron", expr: "0 7 * * *", tz: "UTC", staggerMs: 300_000 },
+              sessionTarget: "isolated",
+              wakeMode: "now",
+              payload: {
+                kind: "agentTurn",
+                message: "Morning brief",
+              },
+              delivery: { mode: "none" },
+              state: {},
+            },
+            {
+              id: "canonical-system",
+              name: "Canonical system",
+              enabled: true,
+              schedule: { kind: "every", everyMs: 60_000 },
+              sessionTarget: "main",
+              wakeMode: "now",
+              payload: {
+                kind: "systemEvent",
+                text: "Status",
+              },
+              delivery: { mode: "none" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    const prompter = makePrompter(true);
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: {
+          store: storePath,
+        },
+      },
+      options: { nonInteractive: true },
+      prompter,
+    });
+
+    expect(prompter.confirm).not.toHaveBeenCalled();
+    expect(noteSpy).not.toHaveBeenCalled();
+  });
+
   it("repairs legacy cron store fields and migrates notify fallback to webhook delivery", async () => {
     const storePath = await makeTempStorePath();
     await fs.mkdir(path.dirname(storePath), { recursive: true });

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { normalizeStoredCronJobs } from "./store-migration.js";
 
+function createCronJob(payload: Record<string, unknown>, sessionTarget: "isolated" | "main") {
+  return {
+    id: typeof payload.kind === "string" ? `job-${payload.kind}` : "job",
+    name: "test",
+    enabled: true,
+    schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC", staggerMs: 300_000 },
+    sessionTarget,
+    wakeMode: "now",
+    payload,
+    delivery: { mode: "none" },
+    state: {},
+  } satisfies Record<string, unknown>;
+}
+
 describe("normalizeStoredCronJobs", () => {
   it("normalizes legacy cron fields and reports migration issues", () => {
     const jobs = [
@@ -74,5 +88,47 @@ describe("normalizeStoredCronJobs", () => {
       mode: "announce",
       channel: "slack",
     });
+  });
+
+  it("does not flag canonical payload kinds as legacy", () => {
+    const jobs = [
+      createCronJob({ kind: "agentTurn", message: "ping" }, "isolated"),
+      createCronJob({ kind: "systemEvent", text: "pong" }, "main"),
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(false);
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+    expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn" });
+    expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent" });
+  });
+
+  it("normalizes lowercase legacy payload kinds", () => {
+    const jobs = [
+      createCronJob({ kind: "agentturn", message: "ping" }, "isolated"),
+      createCronJob({ kind: "systemevent", text: "pong" }, "main"),
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.legacyPayloadKind).toBe(2);
+    expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn" });
+    expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent" });
+  });
+
+  it("normalizes weird casing and whitespace to canonical payload kinds", () => {
+    const jobs = [
+      createCronJob({ kind: " AgentTurn ", message: "ping" }, "isolated"),
+      createCronJob({ kind: "SYSTEMEVENT", text: "pong" }, "main"),
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.legacyPayloadKind).toBe(2);
+    expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn" });
+    expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent" });
   });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,16 +28,22 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
-    payload.kind = "agentTurn";
-    return true;
+  if (typeof payload.kind !== "string") {
+    return false;
   }
-  if (raw === "systemevent") {
-    payload.kind = "systemEvent";
-    return true;
+
+  const trimmed = payload.kind.trim();
+  const lowered = trimmed.toLowerCase();
+  const canonical =
+    lowered === "agentturn" ? "agentTurn" : lowered === "systemevent" ? "systemEvent" : null;
+  if (canonical === null) {
+    return false;
   }
-  return false;
+  if (payload.kind === canonical) {
+    return false;
+  }
+  payload.kind = canonical;
+  return true;
 }
 
 function inferPayloadIfMissing(raw: Record<string, unknown>) {


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` falsely reports cron payload kind normalization for already-canonical `agentTurn` / `systemEvent` values.
- Why it matters: `doctor --fix` can loop forever on clean stores, producing misleading post-upgrade warnings.
- What changed: payload kind normalization now returns a mutation only when the stored value is actually non-canonical; added regression tests for store migration and doctor preview behavior.
- What did NOT change (scope boundary): cron execution, delivery behavior, and scheduler semantics are unchanged.

AI-assisted: Codex.
Testing: `pnpm build`, `pnpm check`, `pnpm test`, plus source-level repros.
Codex review: `codex review --base origin/main` completed with no findings.
I understand this code path: the fix only changes doctor/store normalization reporting and does not affect cron execution semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

`openclaw doctor` no longer warns about payload kind normalization for cron jobs that already store canonical `agentTurn` / `systemEvent` values.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout, Node 22.22.0
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): temp cron store fixtures

### Steps

1. Create a cron store containing canonical `payload.kind: "agentTurn"` or `payload.kind: "systemEvent"`.
2. Run doctor's cron normalization path.
3. Compare with a store using lowercase or oddly-cased legacy values.

### Expected

- Canonical values produce no `legacyPayloadKind` issue and no repair prompt.
- Legacy lowercase / weird-cased values normalize to canonical and report `legacyPayloadKind`.

### Actual

- Before this change, canonical values were lowercased for comparison, falsely counted as legacy, and could cause repeated doctor warnings.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm build`, `pnpm check`, and `pnpm test` all passed locally; source-level smoke checks confirmed canonical `agentTurn` returns no issues and lowercase `agentturn` still normalizes.
- Edge cases checked: canonical `agentTurn`, canonical `systemEvent`, lowercase legacy forms, mixed casing, surrounding whitespace.
- What you did **not** verify: no live gateway/manual doctor run against a real upgraded user store.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `b7503978be2b6fc2106c525105b2f1564b15e05c`
- Files/config to restore: `src/cron/store-migration.ts`
- Known bad symptoms reviewers should watch for: legitimate lowercase / weird-cased legacy payload kinds stop normalizing

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: payload kind normalization could stop cleaning up whitespace or mixed-case legacy variants.
- Mitigation: regression tests cover canonical no-op plus lowercase and weird-casing normalization.
