### PR TITLE
fix(webui): support drag-drop image attach and prevent own-run final history wipe

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -305,9 +305,14 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
       payload.sessionKey,
     );
   }
+  const activeRunIdBeforeEvent = host.chatRunId;
   const state = handleChatEvent(host as unknown as OpenClawApp, payload);
   const historyReloaded = handleTerminalChatEvent(host, payload, state);
-  if (state === "final" && !historyReloaded && shouldReloadHistoryForFinalEvent(payload)) {
+  if (
+    state === "final" &&
+    !historyReloaded &&
+    shouldReloadHistoryForFinalEvent(payload, { activeRunIdBeforeEvent })
+  ) {
     void loadChatHistory(host as unknown as OpenClawApp);
   }
 }

--- a/ui/src/ui/chat-event-reload.test.ts
+++ b/ui/src/ui/chat-event-reload.test.ts
@@ -23,6 +23,19 @@ describe("shouldReloadHistoryForFinalEvent", () => {
     ).toBe(true);
   });
 
+  it("returns false for own-run final event without message payload", () => {
+    expect(
+      shouldReloadHistoryForFinalEvent(
+        {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+        },
+        { activeRunIdBeforeEvent: "run-1" },
+      ),
+    ).toBe(false);
+  });
+
   it("returns false when final event includes assistant payload", () => {
     expect(
       shouldReloadHistoryForFinalEvent({

--- a/ui/src/ui/chat-event-reload.ts
+++ b/ui/src/ui/chat-event-reload.ts
@@ -1,7 +1,17 @@
 import type { ChatEventPayload } from "./controllers/chat.ts";
 
-export function shouldReloadHistoryForFinalEvent(payload?: ChatEventPayload): boolean {
+export function shouldReloadHistoryForFinalEvent(
+  payload?: ChatEventPayload,
+  opts?: { activeRunIdBeforeEvent?: string | null },
+): boolean {
   if (!payload || payload.state !== "final") {
+    return false;
+  }
+  if (
+    opts?.activeRunIdBeforeEvent &&
+    payload.runId &&
+    payload.runId === opts.activeRunIdBeforeEvent
+  ) {
     return false;
   }
   if (!payload.message || typeof payload.message !== "object") {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -601,6 +601,48 @@ describe("abortChatRun", () => {
   });
 });
 
+describe("sendChatMessage attachments", () => {
+  it("sends image attachments to chat.send and keeps optimistic image block in chatMessages", async () => {
+    const request = vi.fn().mockResolvedValue({});
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+    const dataUrl = "data:image/png;base64,aGVsbG8=";
+
+    const runId = await sendChatMessage(state, "", [
+      {
+        id: "att-1",
+        dataUrl,
+        mimeType: "image/png",
+      },
+    ]);
+
+    expect(typeof runId).toBe("string");
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({
+        sessionKey: "main",
+        message: "",
+        deliver: false,
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            content: "aGVsbG8=",
+          },
+        ],
+      }),
+    );
+    const optimistic = state.chatMessages[state.chatMessages.length - 1] as Record<string, unknown>;
+    const content = optimistic.content as Array<Record<string, unknown>>;
+    expect(Array.isArray(content)).toBe(true);
+    const imageBlock = content.find((entry) => entry.type === "image");
+    expect(imageBlock).toBeTruthy();
+  });
+});
+
 describe("loadChatHistory", () => {
   it("filters assistant NO_REPLY messages and keeps user NO_REPLY messages", async () => {
     const request = vi.fn().mockResolvedValue({

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -396,36 +396,6 @@ function handleFileSelect(e: Event, props: ChatProps) {
   input.value = "";
 }
 
-function handleDrop(e: DragEvent, props: ChatProps) {
-  e.preventDefault();
-  const files = e.dataTransfer?.files;
-  if (!files || !props.onAttachmentsChange) {
-    return;
-  }
-  const current = props.attachments ?? [];
-  const additions: ChatAttachment[] = [];
-  let pending = 0;
-  for (const file of files) {
-    if (!isSupportedChatAttachmentMimeType(file.type)) {
-      continue;
-    }
-    pending++;
-    const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      additions.push({
-        id: generateAttachmentId(),
-        dataUrl: reader.result as string,
-        mimeType: file.type,
-      });
-      pending--;
-      if (pending === 0) {
-        props.onAttachmentsChange?.([...current, ...additions]);
-      }
-    });
-    reader.readAsDataURL(file);
-  }
-}
-
 function renderAttachmentPreview(props: ChatProps): TemplateResult | typeof nothing {
   const attachments = props.attachments ?? [];
   if (attachments.length === 0) {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -169,6 +169,7 @@ function createChatEphemeralState(): ChatEphemeralState {
 }
 
 const vs = createChatEphemeralState();
+let latestChatAttachments: ChatAttachment[] = [];
 
 /**
  * Reset chat view ephemeral state when navigating away.
@@ -301,7 +302,6 @@ function addFilesAsAttachments(files: File[], props: ChatProps) {
   if (!props.onAttachmentsChange || files.length === 0) {
     return;
   }
-  let nextAttachments = [...(props.attachments ?? [])];
   for (const file of files) {
     if (!file.type.startsWith("image/")) {
       continue;
@@ -314,7 +314,8 @@ function addFilesAsAttachments(files: File[], props: ChatProps) {
         dataUrl,
         mimeType: file.type,
       };
-      nextAttachments = [...nextAttachments, newAttachment];
+      const nextAttachments = [...latestChatAttachments, newAttachment];
+      latestChatAttachments = nextAttachments;
       props.onAttachmentsChange?.(nextAttachments);
     });
     reader.readAsDataURL(file);
@@ -807,6 +808,7 @@ function renderSlashMenu(
 }
 
 export function renderChat(props: ChatProps) {
+  latestChatAttachments = props.attachments ?? [];
   const canCompose = props.connected;
   const isBusy = props.sending || props.stream !== null;
   const canAbort = Boolean(props.canAbort && props.onAbort);

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -354,12 +354,16 @@ function handleDragOver(e: DragEvent) {
 }
 
 function handleDrop(e: DragEvent, props: ChatProps) {
-  const allFiles = Array.from(e.dataTransfer?.files ?? []);
-  if (allFiles.length === 0) {
+  const types = e.dataTransfer?.types;
+  if (!types || !Array.from(types).includes("Files")) {
     return;
   }
   e.preventDefault();
   e.stopPropagation();
+  const allFiles = Array.from(e.dataTransfer?.files ?? []);
+  if (allFiles.length === 0) {
+    return;
+  }
   const files = allFiles.filter((file) => file.type.startsWith("image/"));
   if (files.length === 0) {
     return;
@@ -1073,11 +1077,7 @@ export function renderChat(props: ChatProps) {
   };
 
   return html`
-    <section
-      class="card chat"
-      @drop=${(e: DragEvent) => handleDrop(e, props)}
-      @dragover=${(e: DragEvent) => e.preventDefault()}
-    >
+    <section class="card chat">
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
       ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1079,7 +1079,11 @@ export function renderChat(props: ChatProps) {
   };
 
   return html`
-    <section class="card chat">
+    <section
+      class="card chat"
+      @drop=${(e: DragEvent) => handleDrop(e, props)}
+      @dragover=${(e: DragEvent) => handleDragOver(e)}
+    >
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
       ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -297,6 +297,30 @@ function generateAttachmentId(): string {
   return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
+function addFilesAsAttachments(files: File[], props: ChatProps) {
+  if (!props.onAttachmentsChange || files.length === 0) {
+    return;
+  }
+  let nextAttachments = [...(props.attachments ?? [])];
+  for (const file of files) {
+    if (!file.type.startsWith("image/")) {
+      continue;
+    }
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      const dataUrl = reader.result as string;
+      const newAttachment: ChatAttachment = {
+        id: generateAttachmentId(),
+        dataUrl,
+        mimeType: file.type,
+      };
+      nextAttachments = [...nextAttachments, newAttachment];
+      props.onAttachmentsChange?.(nextAttachments);
+    });
+    reader.readAsDataURL(file);
+  }
+}
+
 function handlePaste(e: ClipboardEvent, props: ChatProps) {
   const items = e.clipboardData?.items;
   if (!items || !props.onAttachmentsChange) {
@@ -313,24 +337,33 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
     return;
   }
   e.preventDefault();
-  for (const item of imageItems) {
-    const file = item.getAsFile();
-    if (!file) {
-      continue;
-    }
-    const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      const dataUrl = reader.result as string;
-      const newAttachment: ChatAttachment = {
-        id: generateAttachmentId(),
-        dataUrl,
-        mimeType: file.type,
-      };
-      const current = props.attachments ?? [];
-      props.onAttachmentsChange?.([...current, newAttachment]);
-    });
-    reader.readAsDataURL(file);
+  const files = imageItems
+    .map((item) => item.getAsFile())
+    .filter((file): file is File => file !== null);
+  addFilesAsAttachments(files, props);
+}
+
+function handleDragOver(e: DragEvent) {
+  const types = e.dataTransfer?.types;
+  if (!types) {
+    return;
   }
+  if (Array.from(types).includes("Files")) {
+    e.preventDefault();
+  }
+}
+
+function handleDrop(e: DragEvent, props: ChatProps) {
+  const allFiles = Array.from(e.dataTransfer?.files ?? []);
+  if (allFiles.length === 0) {
+    return;
+  }
+  e.preventDefault();
+  const files = allFiles.filter((file) => file.type.startsWith("image/"));
+  if (files.length === 0) {
+    return;
+  }
+  addFilesAsAttachments(files, props);
 }
 
 function handleFileSelect(e: Event, props: ChatProps) {
@@ -1202,6 +1235,8 @@ export function renderChat(props: ChatProps) {
           @keydown=${handleKeyDown}
           @input=${handleInput}
           @paste=${(e: ClipboardEvent) => handlePaste(e, props)}
+          @dragover=${(e: DragEvent) => handleDragOver(e)}
+          @drop=${(e: DragEvent) => handleDrop(e, props)}
           placeholder=${vs.sttRecording ? "Listening..." : placeholder}
           rows="1"
         ></textarea>

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -359,6 +359,7 @@ function handleDrop(e: DragEvent, props: ChatProps) {
     return;
   }
   e.preventDefault();
+  e.stopPropagation();
   const files = allFiles.filter((file) => file.type.startsWith("image/"));
   if (files.length === 0) {
     return;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -344,19 +344,26 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
   addFilesAsAttachments(files, props);
 }
 
-function handleDragOver(e: DragEvent) {
+function handleDragOver(e: DragEvent, interceptNonFileDrops = false) {
   const types = e.dataTransfer?.types;
   if (!types) {
+    if (interceptNonFileDrops) {
+      e.preventDefault();
+    }
     return;
   }
-  if (Array.from(types).includes("Files")) {
+  if (interceptNonFileDrops || Array.from(types).includes("Files")) {
     e.preventDefault();
   }
 }
 
-function handleDrop(e: DragEvent, props: ChatProps) {
+function handleDrop(e: DragEvent, props: ChatProps, interceptNonFileDrops = false) {
   const types = e.dataTransfer?.types;
   if (!types || !Array.from(types).includes("Files")) {
+    if (interceptNonFileDrops) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     return;
   }
   e.preventDefault();
@@ -1081,8 +1088,8 @@ export function renderChat(props: ChatProps) {
   return html`
     <section
       class="card chat"
-      @drop=${(e: DragEvent) => handleDrop(e, props)}
-      @dragover=${(e: DragEvent) => handleDragOver(e)}
+      @drop=${(e: DragEvent) => handleDrop(e, props, true)}
+      @dragover=${(e: DragEvent) => handleDragOver(e, true)}
     >
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
       ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}


### PR DESCRIPTION
## Problem
1. WebUI chat can only attach images via paste; drag/drop is not supported.
2. In some runs, images appear before send but disappear after send because final events may trigger an immediate history reload that replaces optimistic local user messages.

## Root Cause
- Composer textarea only handled `paste` image input, no `dragover/drop` pipeline.
- `handleChatGatewayEvent` could call `loadChatHistory` on `final` events with missing payload message, even when it was the same active run; this can wipe optimistic local attachment messages before history catches up.

## Changes
- Add image drag/drop support in WebUI chat composer:
  - `@dragover` accepts file drops.
  - `@drop` reads image files and appends them as attachments (same pipeline as paste).
- Preserve optimistic attachment messages for own runs:
  - Track `activeRunIdBeforeEvent`.
  - Skip final-event history reload when the final event belongs to the currently active run.
- Add/extend tests:
  - `sendChatMessage` attachment test verifies image is forwarded to `chat.send` and optimistic image block is retained.
  - `shouldReloadHistoryForFinalEvent` test for own-run final-without-message => no reload.

## Validation
- `pnpm vitest run ui/src/ui/controllers/chat.test.ts`
- `pnpm oxlint ui/src/ui/views/chat.ts ui/src/ui/app-gateway.ts ui/src/ui/chat-event-reload.ts ui/src/ui/chat-event-reload.test.ts ui/src/ui/controllers/chat.test.ts`
- `pnpm oxfmt --check ui/src/ui/views/chat.ts ui/src/ui/app-gateway.ts ui/src/ui/chat-event-reload.ts ui/src/ui/chat-event-reload.test.ts ui/src/ui/controllers/chat.test.ts`

## Compatibility
- Backward compatible; no config schema changes.
- Existing paste workflow unchanged.
