### PR TITLE
fix(chrome-extension): preserve dark mode on attach

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -62,6 +62,50 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function colorSchemeStorageKey(tabId) {
+  return `colorScheme:${tabId}`
+}
+
+async function detectTabColorScheme(tabId) {
+  try {
+    const [{ result }] = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => {
+        try {
+          return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+        } catch {
+          return null
+        }
+      },
+    })
+    const scheme = result === 'dark' || result === 'light' ? result : null
+    if (scheme) {
+      await chrome.storage.session.set({ [colorSchemeStorageKey(tabId)]: scheme })
+    }
+    return scheme
+  } catch {
+    return null
+  }
+}
+
+async function getStoredTabColorScheme(tabId) {
+  try {
+    const stored = await chrome.storage.session.get([colorSchemeStorageKey(tabId)])
+    const scheme = stored[colorSchemeStorageKey(tabId)]
+    return scheme === 'dark' || scheme === 'light' ? scheme : null
+  } catch {
+    return null
+  }
+}
+
+async function clearStoredTabColorScheme(tabId) {
+  try {
+    await chrome.storage.session.remove([colorSchemeStorageKey(tabId)])
+  } catch {
+    // ignore
+  }
+}
+
 async function validateAttachedTab(tabId) {
   try {
     await chrome.tabs.get(tabId)
@@ -509,8 +553,17 @@ function getTabByTargetId(targetId) {
 
 async function attachTab(tabId, opts = {}) {
   const debuggee = { tabId }
+  const detectedScheme = opts.colorScheme || (await detectTabColorScheme(tabId)) || (await getStoredTabColorScheme(tabId))
+
   await chrome.debugger.attach(debuggee, '1.3')
   await chrome.debugger.sendCommand(debuggee, 'Page.enable').catch(() => {})
+  if (detectedScheme) {
+    await chrome.debugger
+      .sendCommand(debuggee, 'Emulation.setEmulatedMedia', {
+        features: [{ name: 'prefers-color-scheme', value: detectedScheme }],
+      })
+      .catch(() => {})
+  }
 
   const info = /** @type {any} */ (await chrome.debugger.sendCommand(debuggee, 'Target.getTargetInfo'))
   const targetInfo = info?.targetInfo
@@ -588,6 +641,7 @@ async function detachTab(tabId, reason) {
 
   if (tab?.sessionId) tabBySession.delete(tab.sessionId)
   tabs.delete(tabId)
+  await clearStoredTabColorScheme(tabId)
 
   try {
     await chrome.debugger.detach({ tabId })

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -558,6 +558,8 @@ async function attachTab(tabId, opts = {}) {
   await chrome.debugger.attach(debuggee, '1.3')
   await chrome.debugger.sendCommand(debuggee, 'Page.enable').catch(() => {})
   if (detectedScheme) {
+    // Preserve the tab's existing color-scheme preference after debugger attach.
+    // Without restoring this, attach can knock pages out of their current theme.
     await chrome.debugger
       .sendCommand(debuggee, 'Emulation.setEmulatedMedia', {
         features: [{ name: 'prefers-color-scheme', value: detectedScheme }],

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -930,6 +930,7 @@ async function onDebuggerDetach(source, reason) {
 
 // Tab lifecycle listeners — clean up stale entries.
 chrome.tabs.onRemoved.addListener((tabId) => void whenReady(() => {
+  void clearStoredTabColorScheme(tabId)
   reattachPending.delete(tabId)
   if (!tabs.has(tabId)) return
   const tab = tabs.get(tabId)

--- a/assets/chrome-extension/manifest.json
+++ b/assets/chrome-extension/manifest.json
@@ -9,7 +9,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["debugger", "tabs", "activeTab", "storage", "alarms", "webNavigation"],
+  "permissions": ["debugger", "tabs", "activeTab", "storage", "alarms", "webNavigation", "scripting"],
   "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
   "background": { "service_worker": "background.js", "type": "module" },
   "action": {


### PR DESCRIPTION
## Summary
- restore `prefers-color-scheme: dark` immediately after debugger attach in the Chrome extension relay
- reduce the white-page / forced-light-mode glitch seen when toggling the extension on existing tabs

## Why
On the desktop Chrome extension path, attaching the debugger could knock pages out of dark mode and sometimes leave them looking white right after attach. The local patch that fixed it was to call `Emulation.setEmulatedMedia` with `prefers-color-scheme=dark` as soon as attach succeeds.

## Testing
- patched the extension locally
- verified the patch worked in live use on the desktop browser path
- syntax-checked `assets/chrome-extension/background.js` with `node -c`
