### PR TITLE
docs(telegram): add recovery hardening guidance

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -874,6 +874,8 @@ channels:
       - `OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY=1`
       - `OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY=1`
       - `OPENCLAW_TELEGRAM_DNS_RESULT_ORDER=ipv4first`
+    - For unattended hosts that must confirm recovery after a restart/update, pair the transport settings above with a small host-level watchdog that checks `openclaw health --json` periodically and sends a one-shot Telegram recovery message only when health transitions from unhealthy -> healthy.
+    - Important implementation note for systemd timers/services: use the absolute OpenClaw binary path (for example `~/.local/bin/openclaw`) because user-local bin may be missing from the default timer/service PATH.
     - Validate DNS answers:
 
 ```bash

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -875,7 +875,9 @@ channels:
       - `OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY=1`
       - `OPENCLAW_TELEGRAM_DNS_RESULT_ORDER=ipv4first`
     - For unattended hosts that must confirm recovery after a restart/update, pair the transport settings above with a small host-level watchdog that checks `openclaw health --json` periodically and sends a one-shot Telegram recovery message only when health transitions from unhealthy -> healthy.
-    - Important implementation note for systemd timers/services: use the absolute OpenClaw binary path (for example `~/.local/bin/openclaw`) because user-local bin may be missing from the default timer/service PATH.
+    - Important implementation note for systemd:
+      - for **systemd user** timers/services, use `%h/.local/bin/openclaw` (or a fully resolved home path such as `/home/username/.local/bin/openclaw`) because user-local bin may be missing from the default timer/service PATH, and `~` is **not** expanded by systemd
+      - for **system** timers/services, do **not** execute from user-writable paths like `%h/.local/bin`; prefer a root-owned path such as `/usr/local/bin/openclaw`
     - Validate DNS answers:
 
 ```bash

--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -49,6 +49,7 @@ Full troubleshooting: [/channels/whatsapp#troubleshooting-quick](/channels/whats
 | `/start` but no usable reply flow | `openclaw pairing list telegram`                | Approve pairing or change DM policy.                                        |
 | Bot online but group stays silent | Verify mention requirement and bot privacy mode | Disable privacy mode for group visibility or mention bot.                   |
 | Send failures with network errors | Inspect logs for Telegram API call failures     | Fix DNS/IPv6/proxy routing to `api.telegram.org`.                           |
+| Replies do not resume after restart/update | `openclaw health --json` + Telegram probe + logs | Tune `channels.telegram.retry` / `channels.telegram.network.*`; consider a host-level recovery watchdog for restart/update resilience. |
 | Upgraded and allowlist blocks you | `openclaw security audit` and config allowlists | Run `openclaw doctor --fix` or replace `@username` with numeric sender IDs. |
 
 Full troubleshooting: [/channels/telegram#troubleshooting](/channels/telegram#troubleshooting)

--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -44,13 +44,13 @@ Full troubleshooting: [/channels/whatsapp#troubleshooting-quick](/channels/whats
 
 ### Telegram failure signatures
 
-| Symptom                           | Fastest check                                   | Fix                                                                         |
-| --------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------- |
-| `/start` but no usable reply flow | `openclaw pairing list telegram`                | Approve pairing or change DM policy.                                        |
-| Bot online but group stays silent | Verify mention requirement and bot privacy mode | Disable privacy mode for group visibility or mention bot.                   |
-| Send failures with network errors | Inspect logs for Telegram API call failures     | Fix DNS/IPv6/proxy routing to `api.telegram.org`.                           |
+| Symptom                                    | Fastest check                                    | Fix                                                                                                                                    |
+| ------------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `/start` but no usable reply flow          | `openclaw pairing list telegram`                 | Approve pairing or change DM policy.                                                                                                   |
+| Bot online but group stays silent          | Verify mention requirement and bot privacy mode  | Disable privacy mode for group visibility or mention bot.                                                                              |
+| Send failures with network errors          | Inspect logs for Telegram API call failures      | Fix DNS/IPv6/proxy routing to `api.telegram.org`.                                                                                      |
 | Replies do not resume after restart/update | `openclaw health --json` + Telegram probe + logs | Tune `channels.telegram.retry` / `channels.telegram.network.*`; consider a host-level recovery watchdog for restart/update resilience. |
-| Upgraded and allowlist blocks you | `openclaw security audit` and config allowlists | Run `openclaw doctor --fix` or replace `@username` with numeric sender IDs. |
+| Upgraded and allowlist blocks you          | `openclaw security audit` and config allowlists  | Run `openclaw doctor --fix` or replace `@username` with numeric sender IDs.                                                            |
 
 Full troubleshooting: [/channels/telegram#troubleshooting](/channels/telegram#troubleshooting)
 


### PR DESCRIPTION
## Summary
Adds a small Telegram troubleshooting/docs enhancement for restart/update resilience.

## What changed
- documents a common failure mode where Telegram replies do not resume cleanly after restart/update
- points operators at the existing `channels.telegram.retry` and `channels.telegram.network.*` knobs
- recommends an optional host-level recovery watchdog for unattended deployments
- notes that systemd timers/services should use an absolute OpenClaw binary path because user-local bin may be absent from the default PATH

## Why
We validated this recovery pattern in a real deployment while hardening Telegram reliability after update/restart events. This PR keeps the upstreamable part small and reusable: troubleshooting guidance plus the operational note that makes the watchdog pattern actually work under systemd.

## Scope
Docs only. No runtime behavior changes.
