### PR TITLE
fix(agents): classify Bedrock inference-profile errors for fallback

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -490,6 +490,30 @@ describe("runWithModelFallback", () => {
     expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
   });
 
+  it("falls back when Bedrock requires an inference profile id", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "Invocation of model ID anthropic.claude-opus-4-5-20251101-v1:0 with on-demand throughput is not supported. Retry your request with the ID or ARN of an inference profile that contains this model.",
+        ),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "amazon-bedrock",
+      model: "anthropic.claude-opus-4-5-20251101-v1:0",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("openai");
+    expect(run.mock.calls[1]?.[1]).toBe("gpt-4.1-mini");
+  });
+
   it("warns when falling back due to model_not_found", async () => {
     setLoggerOverride({ level: "silent", consoleLevel: "warn" });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -803,6 +803,13 @@ describe("classifyFailoverReason", () => {
       classifyFailoverReason("AWS Bedrock: Too many tokens per day. Please try again tomorrow."),
     ).toBe("rate_limit");
   });
+  it("classifies Bedrock inference-profile-required errors as model_not_found", () => {
+    expect(
+      classifyFailoverReason(
+        "Invocation of model ID anthropic.claude-opus-4-5-20251101-v1:0 with on-demand throughput is not supported. Retry your request with the ID or ARN of an inference profile that contains this model.",
+      ),
+    ).toBe("model_not_found");
+  });
   it("classifies provider high-demand / service-unavailable messages as overloaded", () => {
     expect(
       classifyFailoverReason(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -937,6 +937,17 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
     return true;
   }
 
+  // Bedrock now requires inference profile IDs for some Anthropic models.
+  // Treat the old raw model-id rejection as a model lookup failure so
+  // configured fallbacks can recover automatically.
+  if (
+    lower.includes("model id") &&
+    lower.includes("on-demand throughput is not supported") &&
+    lower.includes("inference profile")
+  ) {
+    return true;
+  }
+
   // Google Gemini: "models/X is not found for api version"
   if (/models\/[^\s]+ is not found/i.test(raw)) {
     return true;


### PR DESCRIPTION
## Summary
- classify Bedrock's new inference-profile-required rejection as a `model_not_found` failover reason
- add classifier coverage for the exact Bedrock error shape
- add a fallback regression test proving the next configured model is tried

## Root cause
The fallback machinery already handles `model_not_found` errors, but Bedrock's newer "use an inference profile ID" rejection was not recognized by `isModelNotFoundErrorMessage()`. That left `classifyFailoverReason()` returning `null`, so the runner surfaced a terminal provider error instead of throwing `FailoverError` and advancing to configured fallback models.

## Fix
Treat Bedrock's on-demand-throughput / inference-profile rejection as a model lookup failure. That keeps the existing fallback path intact without broadening unrelated error handling.

## Testing
- `pnpm exec vitest run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts -t "classifies Bedrock inference-profile-required errors as model_not_found"`
- `pnpm exec vitest run src/agents/model-fallback.test.ts -t "falls back when Bedrock requires an inference profile id"`
- `pnpm tsgo`

Closes #44353
