### PR TITLE
fix(config): restore SecretRef id field when redacted (#44357)

### DIFF
--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -1134,4 +1134,102 @@ describe("realredactConfigSnapshot_real", () => {
     expect(restored.agents.defaults.memorySearch.remote.apiKey).toBe("1234");
     expect(restored.agents.list[0].memorySearch.remote.apiKey).toBe("6789");
   });
+
+  it("restores SecretRef id field when redacted (#44357)", () => {
+    const hints = mainSchemaHints;
+    const originalConfig = {
+      channels: {
+        telegram: {
+          botToken: {
+            source: "exec" as const,
+            provider: "default",
+            id: "telegram/bot-token",
+          },
+        },
+        discord: {
+          token: {
+            source: "exec" as const,
+            provider: "vault",
+            id: "discord/bot-token",
+          },
+        },
+      },
+    };
+    const snapshot = makeSnapshot(originalConfig);
+
+    // Redact - this should redact only the id field, not the whole SecretRef object
+    const redacted = redactConfigSnapshot(snapshot, hints);
+    const config = redacted.config as typeof originalConfig;
+
+    // SecretRef structure should be preserved, only id should be redacted
+    expect(config.channels.telegram.botToken).toEqual({
+      source: "exec",
+      provider: "default",
+      id: REDACTED_SENTINEL,
+    });
+    expect(config.channels.discord.token).toEqual({
+      source: "exec",
+      provider: "vault",
+      id: REDACTED_SENTINEL,
+    });
+
+    // Restore - the id field should be restored from original
+    const restored = restoreRedactedValues(
+      redacted.config,
+      snapshot.config,
+      hints,
+    ) as typeof originalConfig;
+
+    expect(restored.channels.telegram.botToken).toEqual({
+      source: "exec",
+      provider: "default",
+      id: "telegram/bot-token",
+    });
+    expect(restored.channels.discord.token).toEqual({
+      source: "exec",
+      provider: "vault",
+      id: "discord/bot-token",
+    });
+
+    // Full round-trip should preserve everything
+    expect(restored).toEqual(originalConfig);
+  });
+
+  it("allows user to change SecretRef id field explicitly", () => {
+    const hints = mainSchemaHints;
+    const originalConfig = {
+      channels: {
+        telegram: {
+          botToken: {
+            source: "exec" as const,
+            provider: "default",
+            id: "telegram/old-path",
+          },
+        },
+      },
+    };
+    const snapshot = makeSnapshot(originalConfig);
+
+    // User modifies the id field explicitly (not using sentinel)
+    const userModified = {
+      channels: {
+        telegram: {
+          botToken: {
+            source: "exec" as const,
+            provider: "default",
+            id: "telegram/new-path",
+          },
+        },
+      },
+    };
+
+    // Restore should preserve user's explicit change
+    const restored = restoreRedactedValues(
+      userModified,
+      snapshot.config,
+      hints,
+    ) as typeof originalConfig;
+
+    expect(restored.channels.telegram.botToken.id).toBe("telegram/new-path");
+  });
 });

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -627,7 +627,18 @@ function restoreRedactedValuesWithLookup(
         if (value === REDACTED_SENTINEL) {
           result[key] = restoreOriginalValueOrThrow({ key, path: candidate, original: orig });
         } else if (typeof value === "object" && value !== null) {
-          result[key] = restoreRedactedValuesWithLookup(value, orig[key], lookup, candidate, hints);
+          // Check if this is a SecretRef with redacted id field (#44357)
+          const incomingObj = value as Record<string, unknown>;
+          if (isSecretRefShape(incomingObj) && incomingObj.id === REDACTED_SENTINEL) {
+            const originalObj = toObjectRecord(orig[key]);
+            if (isSecretRefShape(originalObj)) {
+              result[key] = { ...incomingObj, id: originalObj.id };
+            } else {
+              result[key] = restoreRedactedValuesWithLookup(value, orig[key], lookup, candidate, hints);
+            }
+          } else {
+            result[key] = restoreRedactedValuesWithLookup(value, orig[key], lookup, candidate, hints);
+          }
         }
         break;
       }
@@ -637,7 +648,18 @@ function restoreRedactedValuesWithLookup(
       if (!markedNonSensitive && isSensitivePath(path) && value === REDACTED_SENTINEL) {
         result[key] = restoreOriginalValueOrThrow({ key, path, original: orig });
       } else if (typeof value === "object" && value !== null) {
-        result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+        // Check if this is a SecretRef with redacted id field (#44357)
+        const incomingObj = value as Record<string, unknown>;
+        if (isSecretRefShape(incomingObj) && incomingObj.id === REDACTED_SENTINEL) {
+          const originalObj = toObjectRecord(orig[key]);
+          if (isSecretRefShape(originalObj)) {
+            result[key] = { ...incomingObj, id: originalObj.id };
+          } else {
+            result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+          }
+        } else {
+          result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+        }
       }
     }
   }
@@ -679,7 +701,18 @@ function restoreRedactedValuesGuessing(
     ) {
       result[key] = restoreOriginalValueOrThrow({ key, path, original: orig });
     } else if (typeof value === "object" && value !== null) {
-      result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+      // Check if this is a SecretRef with redacted id field (#44357)
+      const incomingObj = value as Record<string, unknown>;
+      if (isSecretRefShape(incomingObj) && incomingObj.id === REDACTED_SENTINEL) {
+        const originalObj = toObjectRecord(orig[key]);
+        if (isSecretRefShape(originalObj)) {
+          result[key] = { ...incomingObj, id: originalObj.id };
+        } else {
+          result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+        }
+      } else {
+        result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+      }
     } else {
       result[key] = value;
     }


### PR DESCRIPTION
## Summary

Fixes Control UI config.set failures when SecretRef fields are present (#44357). Previously, the gateway would redact SecretRef id values to `__OPENCLAW_REDACTED__` during config.get, but the restore logic didn't handle SecretRef objects specifically, causing validation to reject the sentinel value.

## Root Cause

When a SecretRef object is redacted:
```javascript
{ source: "exec", provider: "default", id: "path/to/secret" }
  ↓ redact
{ source: "exec", provider: "default", id: "__OPENCLAW_REDACTED__" }
```

The restore logic checked for `value === REDACTED_SENTINEL`, but for SecretRef objects, the `value` is the entire object, not the sentinel. The sentinel is inside the `id` field, so it was never restored before validation.

## Fix

Added logic to both `restoreRedactedValuesWithLookup` and `restoreRedactedValuesGuessing` to:
1. Detect SecretRef shapes (`isSecretRefShape`)
2. Check if the `id` field contains `__OPENCLAW_REDACTED__`
3. Restore the `id` from the original config

This happens before Zod validation, so the restored SecretRef passes validation.

## Testing

Added two test cases:
1. **Restoration test**: Verifies SecretRef id restoration preserves structure during redact → restore round-trip
2. **User modification test**: Verifies users can still explicitly change SecretRef id values (not using the sentinel)

## Impact

- **Before**: Users with SecretRef-based credentials couldn't save ANY config changes through Control UI (UI was read-only)
- **After**: SecretRef fields are transparently preserved during config.set, Control UI works normally

## Workaround (No Longer Needed)

Users previously had to edit `~/.openclaw/openclaw.json` directly instead of using the Control UI.

Closes #44357