### PR TITLE
fix(discord): add fetch timeout to voice message upload and webhook send

### DIFF
--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -360,26 +360,35 @@ export async function sendWebhookMessageDiscord(
   const replyTo = typeof opts.replyTo === "string" ? opts.replyTo.trim() : "";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
 
-  const response = await fetch(
-    resolveWebhookExecutionUrl({
-      webhookId,
-      webhookToken,
-      threadId: opts.threadId,
-      wait: opts.wait,
-    }),
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        content: rewrittenText,
-        username: opts.username?.trim() || undefined,
-        avatar_url: opts.avatarUrl?.trim() || undefined,
-        ...(messageReference ? { message_reference: messageReference } : {}),
+  let response: Response;
+  try {
+    response = await fetch(
+      resolveWebhookExecutionUrl({
+        webhookId,
+        webhookToken,
+        threadId: opts.threadId,
+        wait: opts.wait,
       }),
-    },
-  );
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          content: rewrittenText,
+          username: opts.username?.trim() || undefined,
+          avatar_url: opts.avatarUrl?.trim() || undefined,
+          ...(messageReference ? { message_reference: messageReference } : {}),
+        }),
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+  } catch (err) {
+    throw new Error(
+      `Discord webhook send failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
   if (!response.ok) {
     const raw = await response.text().catch(() => "");
     throw new Error(

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -274,6 +274,7 @@ export async function sendDiscordVoiceMessage(
       body: JSON.stringify({
         files: [{ filename, file_size: fileSize, id: "0" }],
       }),
+      signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok) {
       if (res.status === 429) {
@@ -309,13 +310,22 @@ export async function sendDiscordVoiceMessage(
 
   // Step 2: Upload the file to Discord's CDN
   // Note: Not wrapped in retry runner - upload URLs are single-use and CDN behavior differs
-  const uploadResponse = await fetch(upload_url, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "audio/ogg",
-    },
-    body: new Uint8Array(audioBuffer),
-  });
+  let uploadResponse: Response;
+  try {
+    uploadResponse = await fetch(upload_url, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "audio/ogg",
+      },
+      body: new Uint8Array(audioBuffer),
+      signal: AbortSignal.timeout(60_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Failed to upload voice message: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   if (!uploadResponse.ok) {
     throw new Error(`Failed to upload voice message: ${uploadResponse.status}`);


### PR DESCRIPTION
## Summary

`voice-message.ts` and `send.outbound.ts` call `fetch()` without an `AbortSignal.timeout()`, so a hung connection blocks the event loop indefinitely with no error surfaced.

Changes:
- **voice-message.ts** attachment URL request: add 30 s timeout (inside retry runner — timeout errors are not retried, only `RateLimitError` is)
- **voice-message.ts** CDN upload: add 60 s timeout with try/catch (longer timeout for large audio payloads; upload URLs are single-use)
- **send.outbound.ts** webhook execute: add 30 s timeout with try/catch

lobster-biscuit
