### PR TITLE
fix(talk-voice): add fetch timeout to ElevenLabs voices API call

### DIFF
--- a/extensions/talk-voice/index.ts
+++ b/extensions/talk-voice/index.ts
@@ -24,11 +24,20 @@ function isLikelyVoiceId(value: string): boolean {
 }
 
 async function listVoices(apiKey: string): Promise<ElevenLabsVoice[]> {
-  const res = await fetch("https://api.elevenlabs.io/v1/voices", {
-    headers: {
-      "xi-api-key": apiKey,
-    },
-  });
+  let res: Response;
+  try {
+    res = await fetch("https://api.elevenlabs.io/v1/voices", {
+      headers: {
+        "xi-api-key": apiKey,
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `ElevenLabs voices API error: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
   if (!res.ok) {
     throw new Error(`ElevenLabs voices API error (${res.status})`);
   }


### PR DESCRIPTION
## Summary

`listVoices()` calls `fetch("https://api.elevenlabs.io/v1/voices")` without an `AbortSignal.timeout()`, so a hung connection blocks the caller indefinitely with no error surfaced.

Add a 15 s timeout (sufficient for a metadata list endpoint) and wrap the fetch in try/catch so timeout and network errors are reported with context instead of propagating as raw `DOMException`.

lobster-biscuit
