### PR TITLE
fix: keep OpenAI transport auto when baseUrl is unset

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1075,6 +1075,7 @@ describe("applyExtraParamsToAgent", () => {
       api: "openai-responses",
       provider: "openai",
       id: "gpt-5",
+      baseUrl: "https://api.openai.com/v1",
     } as Model<"openai-responses">;
     const context: Context = { messages: [] };
     void agent.streamFn?.(model, context, {});
@@ -1082,6 +1083,25 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.transport).toBe("auto");
     expect(calls[0]?.openaiWsWarmup).toBe(true);
+  });
+
+  it("defaults OpenAI transport to SSE for non-OpenAI baseUrl", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5");
+
+    const model = {
+      api: "openai-responses",
+      provider: "openai",
+      id: "gpt-5",
+      baseUrl: "http://localhost:1234/v1",
+    } as Model<"openai-responses">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.transport).toBe("sse");
+    expect(calls[0]?.openaiWsWarmup).toBe(false);
   });
 
   it("lets runtime options override OpenAI default transport", () => {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1075,7 +1075,6 @@ describe("applyExtraParamsToAgent", () => {
       api: "openai-responses",
       provider: "openai",
       id: "gpt-5",
-      baseUrl: "https://api.openai.com/v1",
     } as Model<"openai-responses">;
     const context: Context = { messages: [] };
     void agent.streamFn?.(model, context, {});

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -247,10 +247,12 @@ export function createOpenAIDefaultTransportWrapper(baseStreamFn: StreamFn | und
     const typedOptions = options as
       | (SimpleStreamOptions & { openaiWsWarmup?: boolean })
       | undefined;
+    const inferredTransport =
+      options?.transport ?? (isDirectOpenAIBaseUrl(model.baseUrl) ? "auto" : "sse");
     const mergedOptions = {
       ...options,
-      transport: options?.transport ?? "auto",
-      openaiWsWarmup: typedOptions?.openaiWsWarmup ?? true,
+      transport: inferredTransport,
+      openaiWsWarmup: typedOptions?.openaiWsWarmup ?? inferredTransport === "auto",
     } as SimpleStreamOptions;
     return underlying(model, context, mergedOptions);
   };

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -248,11 +248,14 @@ export function createOpenAIDefaultTransportWrapper(baseStreamFn: StreamFn | und
       | (SimpleStreamOptions & { openaiWsWarmup?: boolean })
       | undefined;
     const inferredTransport =
-      options?.transport ?? (isDirectOpenAIBaseUrl(model.baseUrl) ? "auto" : "sse");
+      options?.transport ??
+      (typeof model.baseUrl === "string" && !isDirectOpenAIBaseUrl(model.baseUrl) ? "sse" : "auto");
+
+    const warmupDefault = inferredTransport !== "sse";
     const mergedOptions = {
       ...options,
       transport: inferredTransport,
-      openaiWsWarmup: typedOptions?.openaiWsWarmup ?? inferredTransport === "auto",
+      openaiWsWarmup: typedOptions?.openaiWsWarmup ?? warmupDefault,
     } as SimpleStreamOptions;
     return underlying(model, context, mergedOptions);
   };


### PR DESCRIPTION
## Summary

Fixes a regression where `createOpenAIDefaultTransportWrapper` treated missing/undefined `baseUrl` as non-OpenAI and defaulted to SSE.

## Changes
- Only force SSE when `baseUrl` is explicitly provided and not a direct OpenAI host
- Keep warm-up enabled by default for auto/websocket transports
- Restore coverage for the unset baseUrl case in `pi-embedded-runner-extraparams.test.ts`

## Testing
- `pnpm test src/agents/pi-embedded-runner-extraparams.test.ts`

Fixes openclaw/openclaw#42270