### PR TITLE
fix(tts): use OGG/Opus for edge-tts on Telegram to render native voice memos

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -293,6 +293,34 @@ describe("tts", () => {
         expect(resolveEdgeOutputFormat(config), testCase.name).toBe(testCase.expected);
       }
     });
+
+    it("uses ogg-opus for voice-bubble channels (telegram/feishu/whatsapp) when format is not user-configured", () => {
+      const config = resolveTtsConfig(baseCfg);
+      expect(resolveEdgeOutputFormat(config, "telegram")).toBe("ogg-24khz-16bit-mono-opus");
+      expect(resolveEdgeOutputFormat(config, "feishu")).toBe("ogg-24khz-16bit-mono-opus");
+      expect(resolveEdgeOutputFormat(config, "whatsapp")).toBe("ogg-24khz-16bit-mono-opus");
+    });
+
+    it("keeps default mp3 for non-voice-bubble channels", () => {
+      const config = resolveTtsConfig(baseCfg);
+      expect(resolveEdgeOutputFormat(config, "discord")).toBe("audio-24khz-48kbitrate-mono-mp3");
+      expect(resolveEdgeOutputFormat(config, null)).toBe("audio-24khz-48kbitrate-mono-mp3");
+      expect(resolveEdgeOutputFormat(config, undefined)).toBe("audio-24khz-48kbitrate-mono-mp3");
+    });
+
+    it("respects user-configured edge format even on voice-bubble channels", () => {
+      const customCfg: OpenClawConfig = {
+        ...baseCfg,
+        messages: {
+          tts: {
+            edge: { outputFormat: "audio-24khz-96kbitrate-mono-mp3" },
+          },
+        },
+      };
+      const config = resolveTtsConfig(customCfg);
+      // User explicitly set a format — don't override it.
+      expect(resolveEdgeOutputFormat(config, "telegram")).toBe("audio-24khz-96kbitrate-mono-mp3");
+    });
   });
 
   describe("parseTtsDirectives", () => {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -72,6 +72,9 @@ const TELEGRAM_OUTPUT = {
   // ElevenLabs output formats use codec_sample_rate_bitrate naming.
   // Opus @ 48kHz/64kbps is a good voice-note tradeoff for Telegram.
   elevenlabs: "opus_48000_64",
+  // Edge-TTS: use OGG/Opus so Telegram renders a native voice bubble
+  // instead of a generic audio file attachment (sendVoice requires Opus for waveform UI).
+  edge: "ogg-24khz-16bit-mono-opus",
   extension: ".opus",
   voiceCompatible: true,
 };
@@ -514,7 +517,14 @@ function resolveChannelId(channel: string | undefined): ChannelId | null {
   return channel ? normalizeChannelId(channel) : null;
 }
 
-function resolveEdgeOutputFormat(config: ResolvedTtsConfig): string {
+function resolveEdgeOutputFormat(config: ResolvedTtsConfig, channelId?: string | null): string {
+  // When the user hasn't explicitly configured an edge output format and the
+  // target channel is a voice-bubble channel (Telegram, Feishu, WhatsApp),
+  // produce OGG/Opus so that the audio renders as a native voice memo with
+  // waveform UI instead of a generic audio file attachment.
+  if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId) && !config.edge.outputFormatConfigured) {
+    return TELEGRAM_OUTPUT.edge;
+  }
   return config.edge.outputFormat;
 }
 
@@ -623,7 +633,7 @@ export async function textToSpeech(params: {
         const tempRoot = resolvePreferredOpenClawTmpDir();
         mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
         const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
-        let edgeOutputFormat = resolveEdgeOutputFormat(config);
+        let edgeOutputFormat = resolveEdgeOutputFormat(config, channelId);
         const fallbackEdgeOutputFormat =
           edgeOutputFormat !== DEFAULT_EDGE_OUTPUT_FORMAT ? DEFAULT_EDGE_OUTPUT_FORMAT : undefined;
 


### PR DESCRIPTION
## Summary

Fixes edge-TTS audio rendering as a generic audio file on Telegram instead of a native voice memo with waveform UI.

## Problem

The built-in `tts` tool on Telegram delivers edge-TTS voice audio using MP3 format, which causes Telegram to render it as a generic audio file attachment (with filename, "Unknown artist" metadata, and music note icon) instead of a native voice memo with inline waveform playback.

OpenAI and ElevenLabs providers already switch to Opus output when the target channel is Telegram/Feishu/WhatsApp (voice-bubble channels), but edge-TTS was missing this channel-aware format selection — it always used `config.edge.outputFormat` (default: `audio-24khz-48kbitrate-mono-mp3`) regardless of channel.

## Changes

- **`src/tts/tts.ts`**: 
  - Added `edge: "ogg-24khz-16bit-mono-opus"` to `TELEGRAM_OUTPUT` constant
  - Made `resolveEdgeOutputFormat()` channel-aware: when the target is a voice-bubble channel and the user hasn't explicitly configured a custom edge output format, it returns OGG/Opus instead of MP3
  - Passes `channelId` through to the edge-tts format resolver in `textToSpeech()`

- **`src/tts/tts.test.ts`**: Added 3 test cases covering:
  - OGG/Opus selection for voice-bubble channels (telegram/feishu/whatsapp)
  - MP3 preserved for non-voice-bubble channels (discord, null, undefined)
  - User-configured edge format respected even on voice-bubble channels

## Backward Compatibility

- Non-Telegram channels still get MP3 (default behavior unchanged)
- Users who explicitly set `messages.tts.edge.outputFormat` in config keep their preference (the override only applies when `outputFormatConfigured` is false)
- Only the default edge format is overridden for voice-bubble channels

## Testing

All 35 TTS tests pass including the 3 new ones. Audio compatibility tests (23 tests) also pass.

Closes #44459