### PR TITLE
fix(doctor): remove dead notify:true when cron.webhook is unset

### DIFF
--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -246,4 +246,121 @@ describe("maybeRepairLegacyCronStore", () => {
       to: "https://example.invalid/cron-finished",
     });
   });
+
+  it("removes dead notify:true when cron.webhook is unset (no migration target)", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "notify-no-webhook",
+              name: "Notify without webhook",
+              notify: true,
+              createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+              schedule: { kind: "every", everyMs: 60_000 },
+              payload: {
+                kind: "systemEvent",
+                text: "Status",
+              },
+              delivery: { mode: "none" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: { store: storePath },
+        // No cron.webhook configured
+      },
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    // notify:true should be removed as dead metadata (no webhook to migrate to)
+    expect(persisted.jobs[0]?.notify).toBeUndefined();
+    // delivery should remain unchanged
+    expect(persisted.jobs[0]?.delivery).toMatchObject({ mode: "none" });
+    // Should print normalized message, NOT a warning
+    expect(noteSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Cron store normalized"),
+      "Doctor changes",
+    );
+    expect(noteSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("cron.webhook is unset"),
+      "Doctor warnings",
+    );
+  });
+
+  it("removes dead notify:true from announce-delivery jobs when cron.webhook is unset", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "announce-with-notify",
+              name: "Announce job",
+              notify: true,
+              createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+              schedule: { kind: "every", everyMs: 60_000 },
+              sessionTarget: "isolated",
+              payload: { kind: "agentTurn", message: "Status" },
+              delivery: { mode: "announce", channel: "telegram", to: "123" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: { store: storePath },
+        // No cron.webhook configured
+      },
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    // notify:true should be removed — announce delivery is already working
+    expect(persisted.jobs[0]?.notify).toBeUndefined();
+    // announce delivery should be preserved
+    expect(persisted.jobs[0]?.delivery).toMatchObject({
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+    });
+    expect(noteSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Cron store normalized"),
+      "Doctor changes",
+    );
+  });
 });

--- a/src/commands/doctor-cron.ts
+++ b/src/commands/doctor-cron.ts
@@ -104,9 +104,18 @@ function migrateLegacyNotifyFallback(params: {
     }
 
     if (!params.legacyWebhook) {
-      warnings.push(
-        `Cron job "${jobName}" still uses legacy notify fallback, but cron.webhook is unset so doctor cannot migrate it automatically.`,
-      );
+      // Without a webhook URL, `notify: true` has no effect — it is dead
+      // legacy metadata.  Safe to remove it so doctor doesn't loop on the
+      // same unresolvable warning across runs.
+      if (!mode || mode === "none") {
+        delete raw.notify;
+        changed = true;
+        continue;
+      }
+      // For jobs with existing non-webhook delivery (e.g. announce), the
+      // notify flag is also inert.  Remove it silently.
+      delete raw.notify;
+      changed = true;
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes `openclaw doctor --fix` leaving legacy `notify: true` unresolved when `cron.webhook` is not configured, creating a confusing loop where doctor claims normalization succeeded but the same warning persists on subsequent runs.

## Problem

When a cron job has `notify: true` (legacy webhook notification shorthand) and `cron.webhook` is not set in config:

1. `doctor --fix` detects the legacy field and prompts for repair
2. User approves the repair
3. Doctor prints `Cron store normalized at ~/.openclaw/cron/jobs.json`
4. But the `notify: true` field is left in place because there's no webhook URL to migrate to
5. Running `doctor` again shows the same warning — infinite loop

## Root Cause

`migrateLegacyNotifyFallback()` treated the "no webhook URL" case as an unresolvable warning, keeping `notify: true` in the job. But `notify: true` without a webhook target is dead metadata — it has no runtime effect.

## Fix

When `cron.webhook` is unset, safely remove `notify: true` from all jobs since:
- For jobs with `delivery.mode: "none"` or no delivery: `notify` is inert (no webhook to call)
- For jobs with existing delivery (e.g. announce mode): `notify` is also inert (announce delivery works independently)

This breaks the warning loop and ensures the "Cron store normalized" message accurately reflects the store state.

## Changes

- **`src/commands/doctor-cron.ts`**: Replace the unresolvable warning with safe removal of dead `notify` metadata
- **`src/commands/doctor-cron.test.ts`**: Added 2 test cases:
  - Removes `notify:true` when `cron.webhook` is unset and delivery is none
  - Removes `notify:true` from announce-delivery jobs when `cron.webhook` is unset

## Testing

All 6 doctor-cron tests pass (4 existing + 2 new).

Closes #44460