### PR TITLE
fix: prevent session file corruption from concurrent writes after lock loss

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1702,10 +1702,6 @@ export async function runEmbeddedAttempt(
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
     let systemPromptText = systemPromptOverride();
 
-    // AbortController for lock-loss: when the watchdog force-releases the session lock,
-    // signal the agent run to stop so it doesn't continue writing to the session file.
-    const lockLossController = new AbortController();
-
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
       maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
@@ -1716,7 +1712,7 @@ export async function runEmbeddedAttempt(
           `[attempt] session lock force-released by watchdog, aborting run: ` +
             `runId=${params.runId} sessionId=${params.sessionId}`,
         );
-        lockLossController.abort(new Error("session lock force-released by watchdog"));
+        runAbortController.abort(new Error("session lock force-released by watchdog"));
       },
     });
 
@@ -1759,7 +1755,7 @@ export async function runEmbeddedAttempt(
             `[attempt] write guard detected lock loss, aborting: ` +
               `runId=${params.runId} sessionId=${params.sessionId}`,
           );
-          lockLossController.abort(new Error("session lock lost during write"));
+          runAbortController.abort(new Error("session lock lost during write"));
         },
       });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -77,6 +77,7 @@ import { isXaiProvider } from "../../schema/clean-for-xai.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
+import { installSessionWriteGuard } from "../../session-write-guard.js";
 import {
   acquireSessionWriteLock,
   resolveSessionLockMaxHoldFromTimeout,
@@ -1701,16 +1702,28 @@ export async function runEmbeddedAttempt(
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
     let systemPromptText = systemPromptOverride();
 
+    // AbortController for lock-loss: when the watchdog force-releases the session lock,
+    // signal the agent run to stop so it doesn't continue writing to the session file.
+    const lockLossController = new AbortController();
+
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
       maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
         timeoutMs: params.timeoutMs,
       }),
+      onForceRelease: () => {
+        log.warn(
+          `[attempt] session lock force-released by watchdog, aborting run: ` +
+            `runId=${params.runId} sessionId=${params.sessionId}`,
+        );
+        lockLossController.abort(new Error("session lock force-released by watchdog"));
+      },
     });
 
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;
+    let removeWriteGuard: (() => void) | undefined;
     try {
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
@@ -1736,6 +1749,19 @@ export async function runEmbeddedAttempt(
         allowedToolNames,
       });
       trackSessionManagerAccess(params.sessionFile);
+
+      // Install write guard: prevents writes after lock loss and ensures fsync.
+      removeWriteGuard = installSessionWriteGuard({
+        sessionManager,
+        sessionFile: params.sessionFile,
+        onLockLost: () => {
+          log.warn(
+            `[attempt] write guard detected lock loss, aborting: ` +
+              `runId=${params.runId} sessionId=${params.sessionId}`,
+          );
+          lockLossController.abort(new Error("session lock lost during write"));
+        },
+      });
 
       if (hadSessionFile && params.contextEngine?.bootstrap) {
         try {
@@ -2801,6 +2827,9 @@ export async function runEmbeddedAttempt(
         sessionManager,
         clearPendingOnTimeout: true,
       });
+      // Remove write guard before releasing lock to prevent false-positive lock-loss errors
+      // during the final flush above.
+      removeWriteGuard?.();
       session?.dispose();
       releaseWsSession(params.sessionId);
       await sessionLock.release();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1713,6 +1713,8 @@ export async function runEmbeddedAttempt(
             `runId=${params.runId} sessionId=${params.sessionId}`,
         );
         runAbortController.abort(new Error("session lock force-released by watchdog"));
+        // Also abort the active session to stop in-flight streaming/tool execution.
+        void session?.abort();
       },
     });
 
@@ -1756,6 +1758,7 @@ export async function runEmbeddedAttempt(
               `runId=${params.runId} sessionId=${params.sessionId}`,
           );
           runAbortController.abort(new Error("session lock lost during write"));
+          void session?.abort();
         },
       });
 

--- a/src/agents/session-write-guard.test.ts
+++ b/src/agents/session-write-guard.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock isSessionLockHeld to control lock state in tests.
+const lockHeldState = { value: true };
+vi.mock("./session-write-lock.js", () => ({
+  isSessionLockHeld: () => lockHeldState.value,
+}));
+
+import { installSessionWriteGuard } from "./session-write-guard.js";
+
+function createMockSessionManager() {
+  const writes: string[] = [];
+  const rewrites: string[] = [];
+  return {
+    _persist(data: string) {
+      writes.push(data);
+    },
+    _rewriteFile(content: string) {
+      rewrites.push(content);
+    },
+    writes,
+    rewrites,
+  };
+}
+
+describe("installSessionWriteGuard", () => {
+  it("allows writes when lock is held", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-guard-"));
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(sessionFile, "", "utf8");
+    try {
+      lockHeldState.value = true;
+      const sm = createMockSessionManager();
+      const dispose = installSessionWriteGuard({
+        sessionManager: sm as never,
+        sessionFile,
+      });
+
+      sm._persist("line1\n");
+      expect(sm.writes).toEqual(["line1\n"]);
+
+      sm._rewriteFile("full content");
+      expect(sm.rewrites).toEqual(["full content"]);
+
+      dispose();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects writes when lock is lost", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-guard-"));
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(sessionFile, "", "utf8");
+    try {
+      lockHeldState.value = true;
+      const sm = createMockSessionManager();
+      let lockLostCalled = false;
+      const dispose = installSessionWriteGuard({
+        sessionManager: sm as never,
+        sessionFile,
+        onLockLost: () => {
+          lockLostCalled = true;
+        },
+      });
+
+      // Simulate lock loss.
+      lockHeldState.value = false;
+
+      expect(() => sm._persist("bad write\n")).toThrow(/write rejected/);
+      expect(lockLostCalled).toBe(true);
+      expect(sm.writes).toEqual([]);
+
+      dispose();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("restores original methods on dispose", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-guard-"));
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(sessionFile, "", "utf8");
+    try {
+      lockHeldState.value = true;
+      const sm = createMockSessionManager();
+      // oxlint-disable-next-line typescript/unbound-method
+      const originalPersist = sm._persist;
+      // oxlint-disable-next-line typescript/unbound-method
+      const originalRewrite = sm._rewriteFile;
+
+      const dispose = installSessionWriteGuard({
+        sessionManager: sm as never,
+        sessionFile,
+      });
+
+      // oxlint-disable-next-line typescript/unbound-method
+      expect(sm._persist).not.toBe(originalPersist);
+      // oxlint-disable-next-line typescript/unbound-method
+      expect(sm._rewriteFile).not.toBe(originalRewrite);
+
+      dispose();
+
+      // oxlint-disable-next-line typescript/unbound-method
+      expect(sm._persist).toBe(originalPersist);
+      // oxlint-disable-next-line typescript/unbound-method
+      expect(sm._rewriteFile).toBe(originalRewrite);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows writes after dispose even if lock is lost", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-guard-"));
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(sessionFile, "", "utf8");
+    try {
+      lockHeldState.value = true;
+      const sm = createMockSessionManager();
+      const dispose = installSessionWriteGuard({
+        sessionManager: sm as never,
+        sessionFile,
+      });
+
+      dispose();
+      lockHeldState.value = false;
+
+      // After dispose, original methods are restored — no guard check.
+      sm._persist("after dispose\n");
+      expect(sm.writes).toEqual(["after dispose\n"]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/session-write-guard.ts
+++ b/src/agents/session-write-guard.ts
@@ -30,13 +30,18 @@ export function installSessionWriteGuard(params: {
 
   // Track whether the guard has been disposed.
   let disposed = false;
+  // Ensure onLockLost fires at most once to avoid duplicate log/abort calls.
+  let lockLostNotified = false;
 
   function assertLockHeld(): void {
     if (disposed) {
       return;
     }
     if (!isSessionLockHeld(sessionFile)) {
-      onLockLost?.();
+      if (!lockLostNotified) {
+        lockLostNotified = true;
+        onLockLost?.();
+      }
       throw new Error(
         `[session-write-guard] write rejected: session lock no longer held for ${sessionFile}`,
       );

--- a/src/agents/session-write-guard.ts
+++ b/src/agents/session-write-guard.ts
@@ -1,0 +1,90 @@
+import fsSync from "node:fs";
+import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import { isSessionLockHeld } from "./session-write-lock.js";
+
+// SessionManager's _persist and _rewriteFile are private, so we access them
+// via an untyped record to monkey-patch write guards onto the instance.
+type SessionManagerInternal = Record<string, unknown>;
+
+/**
+ * Install a write guard on a SessionManager instance that:
+ * 1. Checks lock ownership before every write (prevents "ghost writes" after lock loss).
+ * 2. Calls fsync after each write to ensure data is flushed to disk.
+ *
+ * This is a monkey-patch on the SessionManager's internal _persist and _rewriteFile
+ * methods. It returns a dispose function that restores the originals.
+ */
+export function installSessionWriteGuard(params: {
+  sessionManager: SessionManager;
+  sessionFile: string;
+  onLockLost?: () => void;
+}): () => void {
+  const { sessionManager, sessionFile, onLockLost } = params;
+
+  // Access the internal methods via the instance. SessionManager from pi-coding-agent
+  // uses _persist (appendFileSync) and _rewriteFile (writeFileSync) for all writes.
+  const sm = sessionManager as unknown as SessionManagerInternal;
+
+  const originalPersist = sm._persist;
+  const originalRewriteFile = sm._rewriteFile;
+
+  // Track whether the guard has been disposed.
+  let disposed = false;
+
+  function assertLockHeld(): void {
+    if (disposed) {
+      return;
+    }
+    if (!isSessionLockHeld(sessionFile)) {
+      onLockLost?.();
+      throw new Error(
+        `[session-write-guard] write rejected: session lock no longer held for ${sessionFile}`,
+      );
+    }
+  }
+
+  function fsyncFile(filePath: string): void {
+    let fd: number | undefined;
+    try {
+      fd = fsSync.openSync(filePath, "r");
+      fsSync.fsyncSync(fd);
+    } catch {
+      // Best effort — fsync failure on some filesystems (e.g., network mounts)
+      // should not block the write path.
+    } finally {
+      if (fd !== undefined) {
+        try {
+          fsSync.closeSync(fd);
+        } catch {
+          // Ignore close errors.
+        }
+      }
+    }
+  }
+
+  if (typeof originalPersist === "function") {
+    sm._persist = function guardedPersist(data: string): void {
+      assertLockHeld();
+      (originalPersist as (data: string) => void).call(sm, data);
+      fsyncFile(sessionFile);
+    };
+  }
+
+  if (typeof originalRewriteFile === "function") {
+    sm._rewriteFile = function guardedRewriteFile(content: string): void {
+      assertLockHeld();
+      (originalRewriteFile as (content: string) => void).call(sm, content);
+      fsyncFile(sessionFile);
+    };
+  }
+
+  return () => {
+    disposed = true;
+    if (originalPersist) {
+      sm._persist = originalPersist;
+    }
+    if (originalRewriteFile) {
+      sm._rewriteFile = originalRewriteFile;
+    }
+  };
+}

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -18,6 +18,7 @@ import {
   __testing,
   acquireSessionWriteLock,
   cleanStaleLockFiles,
+  isSessionLockHeld,
   resolveSessionLockMaxHoldFromTimeout,
 } from "./session-write-lock.js";
 
@@ -396,5 +397,40 @@ describe("acquireSessionWriteLock", () => {
 
     expect(process.listeners("SIGINT")).toContain(keepAlive);
     process.off("SIGINT", keepAlive);
+  });
+
+  it("calls onForceRelease when watchdog releases a lock", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const sessionFile = path.join(root, "session.jsonl");
+      let forceReleaseCalled = false;
+      await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 500,
+        maxHoldMs: 1,
+        onForceRelease: () => {
+          forceReleaseCalled = true;
+        },
+      });
+
+      await __testing.runLockWatchdogCheck(Date.now() + 1000);
+      expect(forceReleaseCalled).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("isSessionLockHeld returns true when lock is held", async () => {
+    await withTempSessionLockFile(async ({ sessionFile }) => {
+      expect(isSessionLockHeld(sessionFile)).toBe(false);
+
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+      expect(isSessionLockHeld(sessionFile)).toBe(true);
+
+      await lock.release();
+      expect(isSessionLockHeld(sessionFile)).toBe(false);
+    });
   });
 });

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -22,6 +22,7 @@ type HeldLock = {
   acquiredAt: number;
   maxHoldMs: number;
   releasePromise?: Promise<void>;
+  onForceRelease?: () => void;
 };
 
 export type SessionLockInspection = {
@@ -202,6 +203,16 @@ async function runLockWatchdogCheck(nowMs = Date.now()): Promise<number> {
     console.warn(
       `[session-write-lock] releasing lock held for ${heldForMs}ms (max=${held.maxHoldMs}ms): ${held.lockPath}`,
     );
+
+    // Notify the holder before releasing so it can abort writes.
+    const callback = held.onForceRelease;
+    if (callback) {
+      try {
+        callback();
+      } catch {
+        // Best effort — don't let callback failures block lock cleanup.
+      }
+    }
 
     const didRelease = await releaseHeldLock(sessionFile, held, { force: true });
     if (didRelease) {
@@ -441,12 +452,31 @@ export async function cleanStaleLockFiles(params: {
   return { locks, cleaned };
 }
 
+/**
+ * Check whether the current process still holds the session write lock for the given file.
+ * Useful for write guards that need to verify lock ownership before persisting data.
+ */
+export function isSessionLockHeld(sessionFile: string): boolean {
+  const resolved = path.resolve(sessionFile);
+  // Try realpath to match the normalization in acquireSessionWriteLock.
+  let dir = path.dirname(resolved);
+  try {
+    dir = fsSync.realpathSync(dir);
+  } catch {
+    // Fall back to resolved path if realpath fails.
+  }
+  const normalizedSessionFile = path.join(dir, path.basename(resolved));
+  return HELD_LOCKS.has(normalizedSessionFile);
+}
+
 export async function acquireSessionWriteLock(params: {
   sessionFile: string;
   timeoutMs?: number;
   staleMs?: number;
   maxHoldMs?: number;
   allowReentrant?: boolean;
+  /** Called when the watchdog force-releases this lock due to exceeding maxHoldMs. */
+  onForceRelease?: () => void;
 }): Promise<{
   release: () => Promise<void>;
 }> {
@@ -470,6 +500,9 @@ export async function acquireSessionWriteLock(params: {
   const held = HELD_LOCKS.get(normalizedSessionFile);
   if (allowReentrant && held) {
     held.count += 1;
+    if (params.onForceRelease) {
+      held.onForceRelease = params.onForceRelease;
+    }
     return {
       release: async () => {
         await releaseHeldLock(normalizedSessionFile, held);
@@ -497,6 +530,7 @@ export async function acquireSessionWriteLock(params: {
         lockPath,
         acquiredAt: Date.now(),
         maxHoldMs,
+        onForceRelease: params.onForceRelease,
       };
       HELD_LOCKS.set(normalizedSessionFile, createdHeld);
       return {
@@ -557,4 +591,5 @@ export const __testing = {
   handleTerminationSignal,
   releaseAllLocksSync,
   runLockWatchdogCheck,
+  HELD_LOCKS,
 };


### PR DESCRIPTION
## Summary

- **Root cause**: when the watchdog force-releases a session lock (held > `maxHoldMs`), the original writer continues writing unaware, producing interleaved JSONL lines and orphaned `toolCall`/`toolResult` pairs that cause `tool_use ids were found without tool_result blocks` errors on the next run.
- Add `onForceRelease` callback to `acquireSessionWriteLock` — the watchdog notifies the holder before releasing, which aborts the agent run immediately via AbortController
- Add `isSessionLockHeld()` for runtime lock ownership checks
- New `session-write-guard.ts` — monkey-patches SessionManager's `_persist`/`_rewriteFile` to reject writes when lock is lost and fsync after each write for crash safety
- Wire everything in `attempt.ts`: install write guard after SessionManager creation, clean up in finally block

## Test plan

- [x] New tests for `onForceRelease` callback invocation on watchdog release
- [x] New tests for `isSessionLockHeld()` returning correct state
- [x] New test suite for `installSessionWriteGuard` (4 tests: allows writes, rejects on lock loss, restores on dispose, allows after dispose)
- [x] All 24 existing + new tests pass
- [x] TypeScript type-check passes (`pnpm tsgo`)
- [x] Lint/format passes (`pnpm check`)
- [ ] Manual testing with concurrent heartbeat + message processing on gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)