### PR TITLE
fix: normalizePayloadKind returns false when kind is already correct

### DIFF
--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -30,10 +30,12 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 function normalizePayloadKind(payload: Record<string, unknown>) {
   const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
   if (raw === "agentturn") {
+    if (payload.kind === "agentTurn") return false;  // already correct
     payload.kind = "agentTurn";
     return true;
   }
   if (raw === "systemevent") {
+    if (payload.kind === "systemEvent") return false;  // already correct
     payload.kind = "systemEvent";
     return true;
   }


### PR DESCRIPTION
## Summary

Fix `normalizePayloadKind` in `src/cron/store-migration.ts` returning `true` even when `payload.kind` is already the correct camelCase value.

## Problem

When `payload.kind` is already correct (e.g. `"agentTurn"`), the function lowercases it, matches, reassigns the identical value, and returns `true` — falsely indicating a mutation. This causes `openclaw doctor --fix` to perpetually report that migrations are needed.

## Changes

Add equality checks before assignment so already-correct values return `false` (no mutation):

```typescript
if (raw === "agentturn") {
  if (payload.kind === "agentTurn") return false;  // already correct
  payload.kind = "agentTurn";
  return true;
}
```

Same pattern applied for `"systemEvent"`.

Fixes openclaw/openclaw#44505