### PR TITLE
fix(daemon): trigger SIGUSR1 in-process restart when scheduling launchd handoff

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -459,6 +459,24 @@ export async function restartLaunchAgent({
   // detached handoff. A direct `kickstart -k` would terminate the caller before
   // it can finish the restart command.
   if (isCurrentProcessLaunchdServiceLabel(label)) {
+    // Trigger in-process restart (SIGUSR1) before scheduling handoff.
+    // This ensures the gateway gracefully restarts in-process, while the handoff
+    // script ensures a new instance starts after the current process exits.
+    try {
+      if (process.listenerCount("SIGUSR1") > 0) {
+        process.emit("SIGUSR1");
+      } else {
+        process.kill(process.pid, "SIGUSR1");
+      }
+    } catch (err: unknown) {
+      // If SIGUSR1 fails, log but continue with handoff as fallback.
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      try {
+        stdout.write(`${formatLine("Warning: SIGUSR1 restart failed, using handoff", errorMsg)}\n`);
+      } catch {
+        // Ignore stdout write errors.
+      }
+    }
     const handoff = scheduleDetachedLaunchdRestartHandoff({
       env: serviceEnv,
       mode: "kickstart",


### PR DESCRIPTION
Fixes #44490 - Gateway restart fails to restart service (SIGTERM instead of SIGUSR1)

## Root Cause

When restarting from within the gateway process (detected via `isCurrentProcessLaunchdServiceLabel()`), the code only scheduled a detached handoff script but never triggered the in-process graceful restart via SIGUSR1. This meant the gateway would receive SIGTERM from launchd instead of gracefully restarting.

## Fix

Emit SIGUSR1 before scheduling the handoff script. This ensures:
1. The gateway gracefully restarts in-process (via SIGUSR1 handler)
2. The handoff script waits for the process to exit
3. A new instance starts after the current process terminates

Follows the same pattern used by `emitGatewayRestart()` in `src/infra/restart.ts`.

## Test plan

- [x] All launchd-related tests pass (launchd.test.ts 23 tests)
- [x] Gateway restart from within process triggers SIGUSR1
- [x] Handoff script still starts new instance after process exits