### PR TITLE
fix(session): preserve model override across daily freshness resets

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1557,6 +1557,57 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     expect(result.sessionEntry.verboseLevel).toBeUndefined();
     expect(result.sessionEntry.thinkingLevel).toBeUndefined();
   });
+
+  it("preserves modelOverride and providerOverride across daily freshness resets", async () => {
+    // Daily freshness resets (e.g. 4am boundary) have resetTriggered=false, so
+    // modelOverride/providerOverride must be preserved outside the resetTriggered guard.
+    vi.useFakeTimers();
+    try {
+      // Simulate: it is 5am, session was last active at 3am (before 4am daily boundary)
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const storePath = await createStorePath("openclaw-freshness-model-override-");
+      const sessionKey = "agent:main:telegram:dm:model-override-user";
+      const existingSessionId = "stale-session-model-override";
+
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+          modelOverride: "claude-opus-4",
+          providerOverride: "anthropic",
+        },
+      });
+
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const result = await initSessionState({
+        ctx: {
+          Body: "hello",
+          RawBody: "hello",
+          CommandBody: "hello",
+          From: "model-override-user",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.resetTriggered).toBe(false);
+      expect(result.sessionId).not.toBe(existingSessionId);
+      // Model/provider overrides must survive daily freshness resets
+      expect(result.sessionEntry.modelOverride).toBe("claude-opus-4");
+      expect(result.sessionEntry.providerOverride).toBe("anthropic");
+      // Behavior overrides are NOT carried over for non-resetTriggered resets
+      expect(result.sessionEntry.verboseLevel).toBeUndefined();
+      expect(result.sessionEntry.thinkingLevel).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("drainFormattedSystemEvents", () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -380,6 +380,12 @@ export async function initSessionState(params: {
     isNewSession = true;
     systemSent = false;
     abortedLastRun = false;
+    // Always preserve model/provider overrides across session resets
+    // (including daily freshness resets, not just explicit /reset or /new)
+    if (entry) {
+      persistedModelOverride = entry.modelOverride;
+      persistedProviderOverride = entry.providerOverride;
+    }
     // When a reset trigger (/new, /reset) starts a new session, carry over
     // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
     // so the user doesn't have to re-enable them every time.
@@ -388,8 +394,6 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
       persistedLabel = entry.label;
     }
   }


### PR DESCRIPTION
## Problem

When a user sets a per-session model via the `/model` command, the override is lost every day after the 4 AM freshness reset. The user has to re-run `/model` every morning to restore their preference.

## Root Cause

In `src/auto-reply/reply/session.ts`, the `else` branch that creates a new session only preserves `modelOverride` and `providerOverride` inside the `if (resetTriggered && entry)` guard:

```typescript
} else {
  sessionId = crypto.randomUUID();
  isNewSession = true;
  // ...
  if (resetTriggered && entry) {  // ← daily resets have resetTriggered=false
    // ...
    persistedModelOverride = entry.modelOverride;
    persistedProviderOverride = entry.providerOverride;
    // ...
  }
}
```

Daily freshness resets (4 AM boundary) go through this `else` branch with `resetTriggered = false`, so `modelOverride` and `providerOverride` are silently dropped.

## Fix

Move `modelOverride`/`providerOverride` preservation outside the `resetTriggered` guard, to a broader `if (entry)` check. Behavior overrides (verbose, thinking, reasoning, ttsAuto, label) remain gated behind `resetTriggered` — they are intentionally only carried over for explicit `/reset` or `/new` commands.

```typescript
} else {
  sessionId = crypto.randomUUID();
  isNewSession = true;
  // Always preserve model/provider overrides across session resets
  // (including daily freshness resets, not just explicit /reset or /new)
  if (entry) {
    persistedModelOverride = entry.modelOverride;
    persistedProviderOverride = entry.providerOverride;
  }
  if (resetTriggered && entry) {
    persistedThinking = entry.thinkingLevel;
    persistedVerbose = entry.verboseLevel;
    persistedReasoning = entry.reasoningLevel;
    persistedTtsAuto = entry.ttsAuto;
    persistedLabel = entry.label;
  }
}
```

## Impact

- **Daily/idle freshness reset path**: `modelOverride` and `providerOverride` now survive — this is the fix.
- **First-ever session creation**: `entry` is `undefined`, so the new `if (entry)` block is a no-op — no change.
- **Explicit `/reset` or `/new`**: Both guards fire, behavior unchanged.

## Test

Added a test case `"preserves modelOverride and providerOverride across daily freshness resets"` to the existing `initSessionState preserves behavior overrides` describe block, using `vi.useFakeTimers()` to simulate a 5 AM arrival with the session last updated at 3 AM (stale). All 51 tests pass.