### PR TITLE
fix: gateway restart sends SIGUSR1 via systemctl reload instead of SIGTERM (#44490)

### DIFF
--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -57,6 +57,9 @@ export function buildSystemdUnit({
     "",
     "[Service]",
     `ExecStart=${execStart}`,
+    // Send SIGUSR1 on reload so the gateway performs a graceful in-process
+    // restart (drain active tasks, then re-init) instead of a hard stop.
+    "ExecReload=/bin/kill -USR1 $MAINPID",
     "Restart=always",
     "RestartSec=5",
     "TimeoutStopSec=30",

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -62,7 +62,10 @@ const assertRestartSuccess = async (env: NodeJS.ProcessEnv) => {
   const { write, stdout } = createWritableStreamMock();
   await restartSystemdService({ stdout, env });
   expect(write).toHaveBeenCalledTimes(1);
-  expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+  const output = String(write.mock.calls[0]?.[0]);
+  expect(
+    output.includes("Restarted systemd service") || output.includes("Reloaded systemd service"),
+  ).toBe(true);
 };
 
 describe("systemd availability", () => {
@@ -631,7 +634,10 @@ describe("readSystemdServiceExecStart", () => {
 
 describe("systemd service control", () => {
   const assertMachineRestartArgs = (args: string[]) => {
-    expect(args).toEqual(["--machine", "debian@", "--user", "restart", "openclaw-gateway.service"]);
+    // Accept both reload (SIGUSR1 path) and restart (fallback path)
+    const action = args[3];
+    expect(["reload", "restart"]).toContain(action);
+    expect(args).toEqual(["--machine", "debian@", "--user", action, "openclaw-gateway.service"]);
   };
 
   beforeEach(() => {
@@ -674,14 +680,37 @@ describe("systemd service control", () => {
     });
   });
 
-  it("restarts a profile-specific user unit", async () => {
+  it("restarts a profile-specific user unit via reload (SIGUSR1)", async () => {
     execFileMock
+      // assertSystemdAvailable → status
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      // reload (sends SIGUSR1 via ExecReload)
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "restart", "openclaw-gateway-work.service"]);
+        expect(args).toEqual(["--user", "reload", "openclaw-gateway-work.service"]);
         cb(null, "", "");
       });
     await assertRestartSuccess({ OPENCLAW_PROFILE: "work" });
+  });
+
+  it("falls back to hard restart when reload fails (no ExecReload)", async () => {
+    execFileMock
+      // assertSystemdAvailable → status
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      // reload fails (unit has no ExecReload)
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "reload", "openclaw-gateway.service"]);
+        const err = new Error("reload failed") as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", "Job type reload is not applicable");
+      })
+      // assertSystemdAvailable → status (for fallback restart)
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      // hard restart
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
+        cb(null, "", "");
+      });
+    await assertRestartSuccess({});
   });
 
   it("surfaces stop failures with systemctl detail", async () => {
@@ -741,7 +770,10 @@ describe("systemd service control", () => {
         cb(null, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
+        // reload or restart depending on ExecReload availability
+        const action = args[1];
+        expect(["reload", "restart"]).toContain(action);
+        expect(args).toEqual(["--user", action, "openclaw-gateway.service"]);
         cb(null, "", "");
       });
     await assertRestartSuccess({ SUDO_USER: "root", USER: "root" });
@@ -762,7 +794,10 @@ describe("systemd service control", () => {
         cb(null, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
+        // reload attempt (direct scope fails, then machine scope)
+        const action = args[1];
+        expect(["reload", "restart"]).toContain(action);
+        expect(args).toEqual(["--user", action, "openclaw-gateway.service"]);
         const err = createExecFileError("Failed to connect to user scope bus", {
           stderr: "Failed to connect to user scope bus",
         });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -572,6 +572,19 @@ export async function restartSystemdService({
   stdout,
   env,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
+  // Prefer reload (SIGUSR1 via ExecReload) for a graceful in-process restart
+  // that drains active tasks before re-initializing. Fall back to full restart
+  // only when the unit has no ExecReload (older installs before the fix).
+  const serviceEnv = env ?? process.env;
+  await assertSystemdAvailable(serviceEnv);
+  const serviceName = resolveSystemdServiceName(serviceEnv);
+  const unitName = `${serviceName}.service`;
+  const reload = await execSystemctlUser(serviceEnv, ["reload", unitName]);
+  if (reload.code === 0) {
+    stdout.write(`${formatLine("Reloaded systemd service (SIGUSR1)", unitName)}\n`);
+    return { outcome: "completed" };
+  }
+  // reload failed (likely no ExecReload in unit); fall back to hard restart.
   await runSystemdServiceAction({
     stdout,
     env,


### PR DESCRIPTION
## Problem

Running `openclaw gateway restart` when the gateway is managed by systemd stops the service but fails to restart it properly. The gateway log shows it received SIGTERM instead of SIGUSR1.

## Root Cause

When the systemd service is loaded, `runServiceRestart()` in `lifecycle-core.ts` calls `service.restart()`, which maps to `restartSystemdService()` in `systemd.ts`. This function ran `systemctl --user restart <unit>`, which sends **SIGTERM** to stop the process, then starts a new one.

However, the gateway run-loop (`run-loop.ts`) treats SIGTERM as a **stop** signal — it shuts down gracefully and exits. The process never performs an in-process restart. Systemd eventually restarts it via `Restart=always` after `RestartSec=5`, but this is a cold restart, not the intended graceful restart.

The correct restart path is **SIGUSR1**, which triggers a graceful in-process restart: drain active tasks, close the server, then re-initialize. This is what `restartGatewayWithoutServiceManager()` already does for unmanaged processes.

## Fix

1. **`systemd-unit.ts`**: Add `ExecReload=/bin/kill -USR1 $MAINPID` to the systemd unit template so `systemctl reload` sends SIGUSR1.
2. **`systemd.ts`**: Change `restartSystemdService()` to try `systemctl reload` first (graceful SIGUSR1). Falls back to `systemctl restart` for older unit files that lack `ExecReload`.

## Why macOS is unaffected

On macOS, `restartLaunchAgent()` uses `launchctl kickstart -k`, which kills and restarts the process externally. With `KeepAlive=true`, launchd handles the full lifecycle — the gateway does not need to self-restart.

## Files Changed

- `src/daemon/systemd-unit.ts` — Added `ExecReload` directive
- `src/daemon/systemd.ts` — Prefer reload over restart
- `src/daemon/systemd.test.ts` — Updated and added tests

Fixes #44490