### PR TITLE
fix(memory): add qmd get fallback for get memory read file

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -2252,7 +2252,7 @@ describe("QmdMemoryManager", () => {
     const { manager } = await createManager();
     const result = await manager.readFile({ relPath: "qmd/workspace-main/slugified-note.md" });
     expect(result).toEqual({
-      text: "hello from qmd get",
+      text: "hello from qmd get\n",
       path: "qmd/workspace-main/slugified-note.md",
     });
     await manager.close();

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -2239,6 +2239,62 @@ describe("QmdMemoryManager", () => {
     }
   });
 
+  it("falls back to qmd get for missing qmd files (slugified paths)", async () => {
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "get" && args[1] === "qmd://workspace-main/slugified-note.md") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "hello from qmd get\n");
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const result = await manager.readFile({ relPath: "qmd/workspace-main/slugified-note.md" });
+    expect(result).toEqual({
+      text: "hello from qmd get",
+      path: "qmd/workspace-main/slugified-note.md",
+    });
+    await manager.close();
+  });
+
+  it("falls back to qmd get and applies from/lines slicing", async () => {
+    const content = "line-1\nline-2\nline-3\nline-4\nline-5\n";
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "get") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", content);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const result = await manager.readFile({
+      relPath: "qmd/workspace-main/sliced.md",
+      from: 2,
+      lines: 2,
+    });
+    expect(result).toEqual({ text: "line-2\nline-3", path: "qmd/workspace-main/sliced.md" });
+    await manager.close();
+  });
+
+  it("returns empty text when qmd get fallback also fails", async () => {
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "get") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stderr", "not found", 1);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const result = await manager.readFile({ relPath: "qmd/workspace-main/no-such-doc.md" });
+    expect(result).toEqual({ text: "", path: "qmd/workspace-main/no-such-doc.md" });
+    await manager.close();
+  });
+
   it("reuses exported session markdown files when inputs are unchanged", async () => {
     const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -895,7 +895,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (statResult.missing) {
       // Fall back to `qmd get` which can resolve slugified paths.
       if (relPath.startsWith("qmd/")) {
-        const qmdFile = relPath.replace("qmd/", "qmd://");
+        const qmdFile = relPath.replace(/^qmd\//, "qmd://");
         const qmdText = await this.getQmdFile(qmdFile);
         if (qmdText !== null) {
           if (params.from !== undefined || params.lines !== undefined) {
@@ -1784,8 +1784,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       const result = await this.runQmd(["get", file], {
         timeoutMs: this.qmd.limits.timeoutMs,
       });
-      const text = result.stdout?.trim();
-      return text || null;
+      return result.stdout ?? null;
     } catch {
       return null;
     }

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -893,6 +893,20 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const statResult = await statRegularFile(absPath);
     if (statResult.missing) {
+      // Fall back to `qmd get` which can resolve slugified paths.
+      if (relPath.startsWith("qmd/")) {
+        const qmdFile = relPath.replace("qmd/", "qmd://");
+        const qmdText = await this.getQmdFile(qmdFile);
+        if (qmdText !== null) {
+          if (params.from !== undefined || params.lines !== undefined) {
+            const allLines = qmdText.split("\n");
+            const start = Math.max(1, params.from ?? 1);
+            const count = Math.max(1, params.lines ?? allLines.length);
+            return { text: allLines.slice(start - 1, start - 1 + count).join("\n"), path: relPath };
+          }
+          return { text: qmdText, path: relPath };
+        }
+      }
       return { text: "", path: relPath };
     }
     if (params.from !== undefined || params.lines !== undefined) {
@@ -1763,6 +1777,18 @@ export class QmdMemoryManager implements MemorySearchManager {
       return false;
     }
     return !path.isAbsolute(relativePath);
+  }
+
+  private async getQmdFile(file: string): Promise<string | null> {
+    try {
+      const result = await this.runQmd(["get", file], {
+        timeoutMs: this.qmd.limits.timeoutMs,
+      });
+      const text = result.stdout?.trim();
+      return text || null;
+    } catch {
+      return null;
+    }
   }
 
   private resolveReadPath(relPath: string): string {


### PR DESCRIPTION
## Summary

- Problem: When a qmd document path is slugified (e.g. by the qmd index), the file doesn't exist at the expected filesystem location and `readFile` returns empty text
- Why it matters: Agents reading memory docs get blank content for valid qmd documents with slugified paths
- What changed: Added a `qmd get` fallback in `readFile` — when a `qmd/` file is missing on disk, it converts the path to a `qmd://` URI and delegates to `qmd get` which can resolve slugified paths. Extracted `getQmdFile` as a clean helper that accepts a ready URI
- What did NOT change (scope boundary): Path-traversal protections (`resolveReadPath` collection allow-list + `isWithinRoot`) still run before the fallback; no changes to write paths or search

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Related: n/a

## User-visible / Behavior Changes

Memory `readFile` now returns document content for slugified qmd paths instead of empty text.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — `qmd get` is already available; this adds a new call site bounded by existing collection allow-list and `isWithinRoot` checks
- Data access scope changed? No

## Repro + Verification

### Steps

1. Create a qmd collection with a document that gets a slugified path
2. Call `readFile` with the slugified `qmd/<collection>/<slug>.md` path
3. Before fix: returns `{ text: "" }`; after fix: returns the document content

### Expected

- Document content returned via `qmd get` fallback

### Actual (before fix)

- Empty text returned

## Evidence

- [x] Failing test/log before + passing after
- 3 new tests: happy-path fallback, `from`/`lines` slicing, `qmd get` failure gracefully returns empty text

## Human Verification (required)

- Verified scenarios: all 3 new tests pass (`pnpm test -- src/memory/qmd-manager.test.ts`)
- Edge cases checked: `qmd get` failure returns empty text (not error); `from`/`lines` slicing works on fallback content
- What you did **not** verify: end-to-end with a real `qmd` binary (mocked in tests)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the commit on `src/memory/qmd-manager.ts`
- Known bad symptoms reviewers should watch for: unexpected `qmd get` spawns for non-slugified paths (should not happen — fallback only triggers when file is missing on disk)

## Risks and Mitigations

- Risk: Extra `qmd get` spawn for genuinely missing files (not slugified, just nonexistent)
  - Mitigation: `getQmdFile` returns `null` on failure; falls through to existing empty-text return. Cost is one bounded subprocess call with the configured timeout.