### PR TITLE
gateway: harden delivery recovery startup preflight and skip-mode behavior

### DIFF
--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -34,7 +34,6 @@ beforeEach(() => {
 });
 
 describe("delivery recovery target resolution", () => {
-
   it("skips legacy entries without accountId when channel has no configured accounts", () => {
     hoisted.getChannelPlugin.mockReturnValue({
       id: "synologychat",

--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const hoisted = vi.hoisted(() => ({
+  normalizeChannelId: vi.fn<(raw?: string | null) => string | null>(),
+  getChannelPlugin: vi.fn(),
+  resolveChannelDefaultAccountId: vi.fn(),
+}));
+
+vi.mock("../channels/plugins/index.js", () => ({
+  normalizeChannelId: hoisted.normalizeChannelId,
+  getChannelPlugin: hoisted.getChannelPlugin,
+  listChannelPlugins: vi.fn(() => []),
+}));
+
+vi.mock("../channels/plugins/helpers.js", () => ({
+  resolveChannelDefaultAccountId: hoisted.resolveChannelDefaultAccountId,
+}));
+
+import { __testing } from "./server.impl.js";
+
+describe("delivery recovery target resolution", () => {
+  beforeEach(() => {
+    hoisted.normalizeChannelId.mockReset();
+    hoisted.getChannelPlugin.mockReset();
+    hoisted.resolveChannelDefaultAccountId.mockReset();
+
+    hoisted.normalizeChannelId.mockImplementation((raw?: string | null) => {
+      if (typeof raw !== "string") {
+        return null;
+      }
+      const trimmed = raw.trim();
+      return trimmed ? trimmed : null;
+    });
+  });
+
+  it("skips legacy entries without accountId when channel has no configured accounts", () => {
+    hoisted.getChannelPlugin.mockReturnValue({
+      id: "synologychat",
+      config: {
+        listAccountIds: () => [],
+      },
+    });
+    hoisted.resolveChannelDefaultAccountId.mockReturnValue("default");
+
+    const targets = __testing.resolvePendingDeliveryRecoveryTargets({
+      pending: [{ channel: "synologychat" }],
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(targets).toEqual([]);
+  });
+
+  it("uses configured default account for legacy entries when accounts exist", () => {
+    hoisted.getChannelPlugin.mockReturnValue({
+      id: "whatsapp",
+      config: {
+        listAccountIds: () => ["default", "backup"],
+      },
+    });
+    hoisted.resolveChannelDefaultAccountId.mockReturnValue("default");
+
+    const targets = __testing.resolvePendingDeliveryRecoveryTargets({
+      pending: [{ channel: "whatsapp" }],
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(targets).toEqual([{ channel: "whatsapp", accountId: "default" }]);
+  });
+
+  it("skips explicit stale account ids removed from config", () => {
+    hoisted.getChannelPlugin.mockReturnValue({
+      id: "whatsapp",
+      config: {
+        listAccountIds: () => ["live"],
+      },
+    });
+
+    const targets = __testing.resolvePendingDeliveryRecoveryTargets({
+      pending: [{ channel: "whatsapp", accountId: "removed" }],
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(targets).toEqual([]);
+  });
+});

--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import type { ChannelManager } from "./server-channels.js";
 
 const hoisted = vi.hoisted(() => ({
   normalizeChannelId: vi.fn<(raw?: string | null) => string | null>(),
@@ -18,6 +19,46 @@ vi.mock("../channels/plugins/helpers.js", () => ({
 }));
 
 import { __testing } from "./server.impl.js";
+
+type RuntimeAccount = {
+  enabled?: boolean;
+  configured?: boolean;
+  running?: boolean;
+  connected?: boolean;
+};
+
+type RuntimeSnapshot = {
+  channels: Record<string, unknown>;
+  channelAccounts: Record<string, Record<string, RuntimeAccount>>;
+};
+
+function createSnapshot(params: {
+  channel: string;
+  accountId: string;
+  account: RuntimeAccount;
+}): RuntimeSnapshot {
+  return {
+    channels: {},
+    channelAccounts: {
+      [params.channel]: {
+        [params.accountId]: params.account,
+      },
+    },
+  };
+}
+
+function createChannelManager(snapshots: RuntimeSnapshot[]): ChannelManager {
+  let index = 0;
+  const getRuntimeSnapshot = vi.fn(() => snapshots[Math.min(index++, snapshots.length - 1)]);
+  return { getRuntimeSnapshot } as unknown as ChannelManager;
+}
+
+function createTestLog(): { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> } {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+}
 
 beforeEach(() => {
   hoisted.normalizeChannelId.mockReset();
@@ -105,5 +146,126 @@ describe("delivery recovery preflight skip mode", () => {
         OPENCLAW_SKIP_PROVIDERS: "false",
       }),
     ).toBe(false);
+  });
+});
+
+describe("waitForPendingDeliveryChannelReadiness", () => {
+  it("waits until WhatsApp is both running and connected", async () => {
+    const channelManager = createChannelManager([
+      createSnapshot({
+        channel: "whatsapp",
+        accountId: "default",
+        account: { enabled: true, configured: true, running: true, connected: false },
+      }),
+      createSnapshot({
+        channel: "whatsapp",
+        accountId: "default",
+        account: { enabled: true, configured: true, running: true, connected: true },
+      }),
+    ]);
+    const log = createTestLog();
+
+    await __testing.waitForPendingDeliveryChannelReadiness({
+      channelManager,
+      targets: [{ channel: "whatsapp", accountId: "default" }],
+      log,
+      timeoutMs: 500,
+      pollMs: 50,
+    });
+
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Recovery preflight complete: runtime ready"),
+    );
+  });
+
+  it("times out and continues when readiness does not arrive", async () => {
+    const channelManager = createChannelManager([
+      createSnapshot({
+        channel: "whatsapp",
+        accountId: "default",
+        account: { enabled: true, configured: true, running: false, connected: false },
+      }),
+    ]);
+    const log = createTestLog();
+
+    await __testing.waitForPendingDeliveryChannelReadiness({
+      channelManager,
+      targets: [{ channel: "whatsapp", accountId: "default" }],
+      log,
+      timeoutMs: 60,
+      pollMs: 50,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("Recovery preflight timeout"));
+  });
+
+  it("aborts promptly when shutdown signal is triggered", async () => {
+    const channelManager = createChannelManager([
+      createSnapshot({
+        channel: "whatsapp",
+        accountId: "default",
+        account: { enabled: true, configured: true, running: false, connected: false },
+      }),
+    ]);
+    const log = createTestLog();
+    const abortController = new AbortController();
+    setTimeout(() => abortController.abort(), 15);
+
+    await expect(
+      __testing.waitForPendingDeliveryChannelReadiness({
+        channelManager,
+        targets: [{ channel: "whatsapp", accountId: "default" }],
+        log,
+        timeoutMs: 5_000,
+        pollMs: 50,
+        signal: abortController.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("treats disabled/unconfigured accounts as non-blocking", async () => {
+    const channelManager = createChannelManager([
+      createSnapshot({
+        channel: "whatsapp",
+        accountId: "default",
+        account: { enabled: false, configured: false, running: false, connected: false },
+      }),
+    ]);
+    const log = createTestLog();
+
+    await __testing.waitForPendingDeliveryChannelReadiness({
+      channelManager,
+      targets: [{ channel: "whatsapp", accountId: "default" }],
+      log,
+      timeoutMs: 500,
+      pollMs: 50,
+    });
+
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("does not require connected=true for non-WhatsApp channels", async () => {
+    const channelManager = createChannelManager([
+      createSnapshot({
+        channel: "discord",
+        accountId: "default",
+        account: { enabled: true, configured: true, running: true, connected: false },
+      }),
+    ]);
+    const log = createTestLog();
+
+    await __testing.waitForPendingDeliveryChannelReadiness({
+      channelManager,
+      targets: [{ channel: "discord", accountId: "default" }],
+      log,
+      timeoutMs: 500,
+      pollMs: 50,
+    });
+
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Recovery preflight complete: runtime ready"),
+    );
   });
 });

--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -53,22 +53,12 @@ function createChannelManager(snapshots: RuntimeSnapshot[]): ChannelManager {
   return { getRuntimeSnapshot } as unknown as ChannelManager;
 }
 
-type RecoveryPreflightLog = {
-  info: (msg: string) => void;
-  warn: (msg: string) => void;
-};
-
-type TestLog = RecoveryPreflightLog & {
-  infoMock: ReturnType<typeof vi.fn<(msg: string) => void>>;
-  warnMock: ReturnType<typeof vi.fn<(msg: string) => void>>;
-};
-
-function createTestLog(): TestLog {
-  const infoMock = vi.fn<(msg: string) => void>();
-  const warnMock = vi.fn<(msg: string) => void>();
+function createTestLog() {
+  const infoMock = vi.fn<[msg: string], void>();
+  const warnMock = vi.fn<[msg: string], void>();
   return {
-    info: infoMock,
-    warn: warnMock,
+    info: infoMock as (msg: string) => void,
+    warn: warnMock as (msg: string) => void,
     infoMock,
     warnMock,
   };

--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -54,11 +54,15 @@ function createChannelManager(snapshots: RuntimeSnapshot[]): ChannelManager {
 }
 
 function createTestLog() {
-  const infoMock = vi.fn<[msg: string], void>();
-  const warnMock = vi.fn<[msg: string], void>();
+  const infoMock = vi.fn((msg: string) => {
+    void msg;
+  });
+  const warnMock = vi.fn((msg: string) => {
+    void msg;
+  });
   return {
-    info: infoMock as (msg: string) => void,
-    warn: warnMock as (msg: string) => void,
+    info: infoMock,
+    warn: warnMock,
     infoMock,
     warnMock,
   };

--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -19,20 +19,21 @@ vi.mock("../channels/plugins/helpers.js", () => ({
 
 import { __testing } from "./server.impl.js";
 
-describe("delivery recovery target resolution", () => {
-  beforeEach(() => {
-    hoisted.normalizeChannelId.mockReset();
-    hoisted.getChannelPlugin.mockReset();
-    hoisted.resolveChannelDefaultAccountId.mockReset();
+beforeEach(() => {
+  hoisted.normalizeChannelId.mockReset();
+  hoisted.getChannelPlugin.mockReset();
+  hoisted.resolveChannelDefaultAccountId.mockReset();
 
-    hoisted.normalizeChannelId.mockImplementation((raw?: string | null) => {
-      if (typeof raw !== "string") {
-        return null;
-      }
-      const trimmed = raw.trim();
-      return trimmed ? trimmed : null;
-    });
+  hoisted.normalizeChannelId.mockImplementation((raw?: string | null) => {
+    if (typeof raw !== "string") {
+      return null;
+    }
+    const trimmed = raw.trim();
+    return trimmed ? trimmed : null;
   });
+});
+
+describe("delivery recovery target resolution", () => {
 
   it("skips legacy entries without accountId when channel has no configured accounts", () => {
     hoisted.getChannelPlugin.mockReturnValue({
@@ -82,5 +83,28 @@ describe("delivery recovery target resolution", () => {
     });
 
     expect(targets).toEqual([]);
+  });
+});
+
+describe("delivery recovery preflight skip mode", () => {
+  it("skips readiness preflight when OPENCLAW_SKIP_CHANNELS is enabled", () => {
+    expect(
+      __testing.shouldSkipDeliveryRecoveryReadinessPreflight({ OPENCLAW_SKIP_CHANNELS: "1" }),
+    ).toBe(true);
+  });
+
+  it("skips readiness preflight when OPENCLAW_SKIP_PROVIDERS is enabled", () => {
+    expect(
+      __testing.shouldSkipDeliveryRecoveryReadinessPreflight({ OPENCLAW_SKIP_PROVIDERS: "true" }),
+    ).toBe(true);
+  });
+
+  it("does not skip readiness preflight when both flags are disabled", () => {
+    expect(
+      __testing.shouldSkipDeliveryRecoveryReadinessPreflight({
+        OPENCLAW_SKIP_CHANNELS: "0",
+        OPENCLAW_SKIP_PROVIDERS: "false",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -53,10 +53,24 @@ function createChannelManager(snapshots: RuntimeSnapshot[]): ChannelManager {
   return { getRuntimeSnapshot } as unknown as ChannelManager;
 }
 
-function createTestLog(): { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> } {
+type RecoveryPreflightLog = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+};
+
+type TestLog = RecoveryPreflightLog & {
+  infoMock: ReturnType<typeof vi.fn<(msg: string) => void>>;
+  warnMock: ReturnType<typeof vi.fn<(msg: string) => void>>;
+};
+
+function createTestLog(): TestLog {
+  const infoMock = vi.fn<(msg: string) => void>();
+  const warnMock = vi.fn<(msg: string) => void>();
   return {
-    info: vi.fn(),
-    warn: vi.fn(),
+    info: infoMock,
+    warn: warnMock,
+    infoMock,
+    warnMock,
   };
 }
 
@@ -173,8 +187,8 @@ describe("waitForPendingDeliveryChannelReadiness", () => {
       pollMs: 50,
     });
 
-    expect(log.warn).not.toHaveBeenCalled();
-    expect(log.info).toHaveBeenCalledWith(
+    expect(log.warnMock).not.toHaveBeenCalled();
+    expect(log.infoMock).toHaveBeenCalledWith(
       expect.stringContaining("Recovery preflight complete: runtime ready"),
     );
   });
@@ -197,7 +211,9 @@ describe("waitForPendingDeliveryChannelReadiness", () => {
       pollMs: 50,
     });
 
-    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("Recovery preflight timeout"));
+    expect(log.warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("Recovery preflight timeout"),
+    );
   });
 
   it("aborts promptly when shutdown signal is triggered", async () => {
@@ -242,7 +258,7 @@ describe("waitForPendingDeliveryChannelReadiness", () => {
       pollMs: 50,
     });
 
-    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.warnMock).not.toHaveBeenCalled();
   });
 
   it("does not require connected=true for non-WhatsApp channels", async () => {
@@ -263,8 +279,8 @@ describe("waitForPendingDeliveryChannelReadiness", () => {
       pollMs: 50,
     });
 
-    expect(log.warn).not.toHaveBeenCalled();
-    expect(log.info).toHaveBeenCalledWith(
+    expect(log.warnMock).not.toHaveBeenCalled();
+    expect(log.infoMock).toHaveBeenCalledWith(
       expect.stringContaining("Recovery preflight complete: runtime ready"),
     );
   });

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -5,7 +5,13 @@ import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
-import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
+import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
+import {
+  getChannelPlugin,
+  listChannelPlugins,
+  normalizeChannelId,
+  type ChannelId,
+} from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { isRestartEnabled } from "../config/commands.js";
@@ -75,7 +81,7 @@ import {
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
-import { createChannelManager } from "./server-channels.js";
+import { createChannelManager, type ChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
 import { createGatewayCloseHandler } from "./server-close.js";
 import { buildGatewayCronService } from "./server-cron.js";
@@ -207,6 +213,165 @@ function applyGatewayAuthOverridesForStartupPreflight(
       tailscale: mergeGatewayTailscaleConfig(config.gateway?.tailscale, overrides.tailscale),
     },
   };
+}
+
+type PendingDeliveryRecoveryTarget = {
+  channel: ChannelId;
+  accountId: string;
+};
+
+function createAbortError(message: string): Error {
+  const err = new Error(message);
+  err.name = "AbortError";
+  return err;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError("Delivery recovery preflight aborted");
+  }
+}
+
+async function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) {
+    throwIfAborted(signal);
+    return;
+  }
+  if (!signal) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, ms);
+    });
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError("Delivery recovery preflight aborted"));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function resolvePendingDeliveryRecoveryTargets(params: {
+  pending: Array<{ channel?: unknown; accountId?: unknown }>;
+  cfg: OpenClawConfig;
+}): PendingDeliveryRecoveryTarget[] {
+  const targets = new Map<string, PendingDeliveryRecoveryTarget>();
+
+  for (const entry of params.pending) {
+    const channelRaw = typeof entry.channel === "string" ? entry.channel : null;
+    const channel = normalizeChannelId(channelRaw);
+    if (!channel) {
+      continue;
+    }
+    const plugin = getChannelPlugin(channel);
+    if (!plugin) {
+      continue;
+    }
+    const accountIdRaw = typeof entry.accountId === "string" ? entry.accountId.trim() : "";
+    const accountId =
+      accountIdRaw ||
+      resolveChannelDefaultAccountId({
+        plugin,
+        cfg: params.cfg,
+      });
+    const key = `${channel}:${accountId}`;
+    if (!targets.has(key)) {
+      targets.set(key, { channel, accountId });
+    }
+  }
+
+  return [...targets.values()];
+}
+
+function shouldRequireConnectedForRecovery(channel: ChannelId): boolean {
+  // Some channels (e.g. Discord) can send outbound over REST even when runtime
+  // reports connected=false. Restrict the connected gate to channels where
+  // listener/socket readiness is required for outbound delivery.
+  return channel === "whatsapp";
+}
+
+function formatRecoveryTarget(target: PendingDeliveryRecoveryTarget): string {
+  return `${target.channel}:${target.accountId}`;
+}
+
+async function waitForPendingDeliveryChannelReadiness(params: {
+  channelManager: ChannelManager;
+  targets: PendingDeliveryRecoveryTarget[];
+  log: { info: (msg: string) => void; warn: (msg: string) => void };
+  timeoutMs?: number;
+  pollMs?: number;
+  signal?: AbortSignal;
+}): Promise<void> {
+  const targets = [...params.targets].filter(
+    (target, index, arr) =>
+      index ===
+      arr.findIndex(
+        (item) => item.channel === target.channel && item.accountId === target.accountId,
+      ),
+  );
+  if (targets.length === 0) {
+    return;
+  }
+
+  const timeoutMs = params.timeoutMs ?? 15_000;
+  const pollMs = Math.max(50, params.pollMs ?? 250);
+  const deadline = Date.now() + timeoutMs;
+  const targetLabel = targets.map((target) => formatRecoveryTarget(target)).join(", ");
+
+  params.log.info(
+    `Recovery preflight: waiting for runtime readiness (${targetLabel}), timeout ${timeoutMs}ms`,
+  );
+
+  while (true) {
+    throwIfAborted(params.signal);
+
+    const snapshot = params.channelManager.getRuntimeSnapshot();
+    const waiting: string[] = [];
+
+    for (const target of targets) {
+      const accountMap = snapshot.channelAccounts[target.channel];
+      const account = accountMap?.[target.accountId];
+      if (!account) {
+        waiting.push(formatRecoveryTarget(target));
+        continue;
+      }
+      if (account.enabled === false || account.configured === false) {
+        continue;
+      }
+      if (account.running !== true) {
+        waiting.push(formatRecoveryTarget(target));
+        continue;
+      }
+      if (shouldRequireConnectedForRecovery(target.channel) && account.connected !== true) {
+        waiting.push(formatRecoveryTarget(target));
+      }
+    }
+
+    if (waiting.length === 0) {
+      params.log.info(`Recovery preflight complete: runtime ready for ${targetLabel}`);
+      return;
+    }
+
+    const now = Date.now();
+    if (now >= deadline) {
+      params.log.warn(
+        `Recovery preflight timeout after ${timeoutMs}ms; continuing while waiting on: ${waiting.join(", ")}`,
+      );
+      return;
+    }
+
+    await sleepWithAbort(Math.min(pollMs, Math.max(1, deadline - now)), params.signal);
+  }
 }
 
 export type GatewayServer = {
@@ -768,20 +933,6 @@ export async function startGatewayServer(
     void cron.start().catch((err) => logCron.error(`failed to start: ${String(err)}`));
   }
 
-  // Recover pending outbound deliveries from previous crash/restart.
-  if (!minimalTestGateway) {
-    void (async () => {
-      const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
-      const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
-      const logRecovery = log.child("delivery-recovery");
-      await recoverPendingDeliveries({
-        deliver: deliverOutboundPayloads,
-        log: logRecovery,
-        cfg: cfgAtStart,
-      });
-    })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
-  }
-
   const execApprovalManager = new ExecApprovalManager();
   const execApprovalForwarder = createExecApprovalForwarder();
   const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
@@ -939,6 +1090,50 @@ export async function startGatewayServer(
     }));
   }
 
+  const deliveryRecoveryAbort = new AbortController();
+
+  // Recover pending outbound deliveries from previous crash/restart.
+  // Run this after sidecars/channels start to avoid racing channel bootstrap
+  // (e.g., WhatsApp listener registration) during startup.
+  if (!minimalTestGateway) {
+    void (async () => {
+      const { loadPendingDeliveries, recoverPendingDeliveries } =
+        await import("../infra/outbound/delivery-queue.js");
+      const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
+      const logRecovery = log.child("delivery-recovery");
+      const pending = await loadPendingDeliveries();
+      if (pending.length === 0) {
+        return;
+      }
+
+      const targets = resolvePendingDeliveryRecoveryTargets({ pending, cfg: cfgAtStart });
+      if (targets.length > 0) {
+        await waitForPendingDeliveryChannelReadiness({
+          channelManager,
+          targets,
+          log: logRecovery,
+          signal: deliveryRecoveryAbort.signal,
+        });
+      }
+      if (deliveryRecoveryAbort.signal.aborted) {
+        logRecovery.info("Delivery recovery skipped: gateway shutdown in progress.");
+        return;
+      }
+
+      await recoverPendingDeliveries({
+        deliver: deliverOutboundPayloads,
+        log: logRecovery,
+        cfg: cfgAtStart,
+      });
+    })().catch((err) => {
+      if (err instanceof Error && err.name === "AbortError") {
+        log.info("Delivery recovery aborted: gateway shutdown in progress.");
+        return;
+      }
+      log.error(`Delivery recovery failed: ${String(err)}`);
+    });
+  }
+
   // Run gateway_start plugin hook (fire-and-forget)
   if (!minimalTestGateway) {
     const hookRunner = getGlobalHookRunner();
@@ -1046,6 +1241,7 @@ export async function startGatewayServer(
 
   return {
     close: async (opts) => {
+      deliveryRecoveryAbort.abort();
       // Run gateway_stop plugin hook before shutdown
       await runGlobalGatewayStopSafely({
         event: { reason: opts?.reason ?? "gateway stopping" },

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -344,13 +344,11 @@ async function waitForPendingDeliveryChannelReadiness(params: {
   pollMs?: number;
   signal?: AbortSignal;
 }): Promise<void> {
-  const targets = [...params.targets].filter(
-    (target, index, arr) =>
-      index ===
-      arr.findIndex(
-        (item) => item.channel === target.channel && item.accountId === target.accountId,
-      ),
-  );
+  const targetsByKey = new Map<string, PendingDeliveryRecoveryTarget>();
+  for (const target of params.targets) {
+    targetsByKey.set(`${target.channel}:${target.accountId}`, target);
+  }
+  const targets = [...targetsByKey.values()];
   if (targets.length === 0) {
     return;
   }
@@ -409,6 +407,7 @@ async function waitForPendingDeliveryChannelReadiness(params: {
 export const __testing = {
   resolvePendingDeliveryRecoveryTargets,
   shouldSkipDeliveryRecoveryReadinessPreflight,
+  waitForPendingDeliveryChannelReadiness,
 };
 
 export type GatewayServer = {
@@ -1145,17 +1144,19 @@ export async function startGatewayServer(
 
       const targets = resolvePendingDeliveryRecoveryTargets({ pending, cfg: cfgAtStart });
       const skipRecoveryReadinessPreflight = shouldSkipDeliveryRecoveryReadinessPreflight();
-      if (targets.length > 0 && !skipRecoveryReadinessPreflight) {
+      if (skipRecoveryReadinessPreflight) {
+        logRecovery.info(
+          "Delivery recovery skipped: channel startup disabled via OPENCLAW_SKIP_CHANNELS/OPENCLAW_SKIP_PROVIDERS.",
+        );
+        return;
+      }
+      if (targets.length > 0) {
         await waitForPendingDeliveryChannelReadiness({
           channelManager,
           targets,
           log: logRecovery,
           signal: deliveryRecoveryAbort.signal,
         });
-      } else if (targets.length > 0 && skipRecoveryReadinessPreflight) {
-        logRecovery.info(
-          "Recovery preflight skipped: channel startup disabled via OPENCLAW_SKIP_CHANNELS/OPENCLAW_SKIP_PROVIDERS.",
-        );
       }
       if (deliveryRecoveryAbort.signal.aborted) {
         logRecovery.info("Delivery recovery skipped: gateway shutdown in progress.");
@@ -1166,6 +1167,7 @@ export async function startGatewayServer(
         deliver: deliverOutboundPayloads,
         log: logRecovery,
         cfg: cfgAtStart,
+        pending,
       });
     })().catch((err) => {
       if (err instanceof Error && err.name === "AbortError") {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -35,7 +35,7 @@ import {
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
-import { logAcceptedEnvOption } from "../infra/env.js";
+import { isTruthyEnvValue, logAcceptedEnvOption } from "../infra/env.js";
 import { createExecApprovalForwarder } from "../infra/exec-approval-forwarder.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -324,6 +324,12 @@ function shouldRequireConnectedForRecovery(channel: ChannelId): boolean {
   return channel === "whatsapp";
 }
 
+function shouldSkipDeliveryRecoveryReadinessPreflight(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return isTruthyEnvValue(env.OPENCLAW_SKIP_CHANNELS) || isTruthyEnvValue(env.OPENCLAW_SKIP_PROVIDERS);
+}
+
 function formatRecoveryTarget(target: PendingDeliveryRecoveryTarget): string {
   return `${target.channel}:${target.accountId}`;
 }
@@ -400,6 +406,7 @@ async function waitForPendingDeliveryChannelReadiness(params: {
 
 export const __testing = {
   resolvePendingDeliveryRecoveryTargets,
+  shouldSkipDeliveryRecoveryReadinessPreflight,
 };
 
 export type GatewayServer = {
@@ -1135,13 +1142,18 @@ export async function startGatewayServer(
       }
 
       const targets = resolvePendingDeliveryRecoveryTargets({ pending, cfg: cfgAtStart });
-      if (targets.length > 0) {
+      const skipRecoveryReadinessPreflight = shouldSkipDeliveryRecoveryReadinessPreflight();
+      if (targets.length > 0 && !skipRecoveryReadinessPreflight) {
         await waitForPendingDeliveryChannelReadiness({
           channelManager,
           targets,
           log: logRecovery,
           signal: deliveryRecoveryAbort.signal,
         });
+      } else if (targets.length > 0 && skipRecoveryReadinessPreflight) {
+        logRecovery.info(
+          "Recovery preflight skipped: channel startup disabled via OPENCLAW_SKIP_CHANNELS/OPENCLAW_SKIP_PROVIDERS.",
+        );
       }
       if (deliveryRecoveryAbort.signal.aborted) {
         logRecovery.info("Delivery recovery skipped: gateway shutdown in progress.");

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -327,7 +327,9 @@ function shouldRequireConnectedForRecovery(channel: ChannelId): boolean {
 function shouldSkipDeliveryRecoveryReadinessPreflight(
   env: Record<string, string | undefined> = process.env,
 ): boolean {
-  return isTruthyEnvValue(env.OPENCLAW_SKIP_CHANNELS) || isTruthyEnvValue(env.OPENCLAW_SKIP_PROVIDERS);
+  return (
+    isTruthyEnvValue(env.OPENCLAW_SKIP_CHANNELS) || isTruthyEnvValue(env.OPENCLAW_SKIP_PROVIDERS)
+  );
 }
 
 function formatRecoveryTarget(target: PendingDeliveryRecoveryTarget): string {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -301,6 +301,12 @@ function resolvePendingDeliveryRecoveryTargets(params: {
     if (!accountId) {
       continue;
     }
+    if (!configuredAccountSet.has(accountId)) {
+      // Avoid creating synthetic readiness targets (e.g. "default") when the
+      // channel has no configured accounts. Those targets can never appear in
+      // channelAccounts and only force the preflight to time out.
+      continue;
+    }
 
     const key = `${channel}:${accountId}`;
     if (!targets.has(key)) {
@@ -391,6 +397,10 @@ async function waitForPendingDeliveryChannelReadiness(params: {
     await sleepWithAbort(Math.min(pollMs, Math.max(1, deadline - now)), params.signal);
   }
 }
+
+export const __testing = {
+  resolvePendingDeliveryRecoveryTargets,
+};
 
 export type GatewayServer = {
   close: (opts?: { reason?: string; restartExpectedMs?: number | null }) => Promise<void>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -277,13 +277,31 @@ function resolvePendingDeliveryRecoveryTargets(params: {
     if (!plugin) {
       continue;
     }
+
+    const configuredAccountIds = plugin.config
+      .listAccountIds(params.cfg)
+      .map((accountId) => accountId.trim())
+      .filter(Boolean);
+    const configuredAccountSet = new Set(configuredAccountIds);
+
     const accountIdRaw = typeof entry.accountId === "string" ? entry.accountId.trim() : "";
+    if (accountIdRaw && !configuredAccountSet.has(accountIdRaw)) {
+      // Queue may contain stale deliveries for removed accounts. Do not block
+      // startup preflight on targets that can never become ready.
+      continue;
+    }
+
     const accountId =
       accountIdRaw ||
       resolveChannelDefaultAccountId({
         plugin,
         cfg: params.cfg,
+        accountIds: configuredAccountIds,
       });
+    if (!accountId) {
+      continue;
+    }
+
     const key = `${channel}:${accountId}`;
     if (!targets.has(key)) {
       targets.set(key, { channel, accountId });

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -325,10 +325,15 @@ export async function recoverPendingDeliveries(opts: {
   log: RecoveryLogger;
   cfg: OpenClawConfig;
   stateDir?: string;
+  /**
+   * Optional preloaded pending entries to avoid rescanning queue files when
+   * the caller has already read them (e.g. startup preflight target resolution).
+   */
+  pending?: QueuedDelivery[];
   /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next restart. Default: 60 000. */
   maxRecoveryMs?: number;
 }): Promise<RecoverySummary> {
-  const pending = await loadPendingDeliveries(opts.stateDir);
+  const pending = [...(opts.pending ?? (await loadPendingDeliveries(opts.stateDir)))];
   if (pending.length === 0) {
     return { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 };
   }

--- a/src/memory/qmd-process.test.ts
+++ b/src/memory/qmd-process.test.ts
@@ -55,6 +55,22 @@ describe("resolveCliSpawnInvocation", () => {
     expect(invocation.windowsHide).toBe(true);
   });
 
+  it("keeps bare commands direct when no Windows shim is present", () => {
+    process.env.PATH = originalPath ?? "";
+    process.env.PATHEXT = ".EXE;.CMD";
+
+    const invocation = resolveCliSpawnInvocation({
+      command: "qmd",
+      args: ["query", "hello"],
+      env: process.env,
+      packageName: "qmd",
+    });
+
+    expect(invocation.command).toBe("qmd");
+    expect(invocation.argv).toEqual(["query", "hello"]);
+    expect(invocation.shell).not.toBe(true);
+  });
+
   it("fails closed when a Windows cmd shim cannot be resolved without shell execution", async () => {
     const binDir = path.join(tempDir, "bad-bin");
     await fs.mkdir(binDir, { recursive: true });

--- a/src/memory/qmd-process.ts
+++ b/src/memory/qmd-process.ts
@@ -1,5 +1,4 @@
 import { spawn } from "node:child_process";
-import path from "node:path";
 import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
@@ -12,25 +11,6 @@ export type CliSpawnInvocation = {
   windowsHide?: boolean;
 };
 
-function resolveWindowsCommandShim(command: string): string {
-  if (process.platform !== "win32") {
-    return command;
-  }
-  const trimmed = command.trim();
-  if (!trimmed) {
-    return command;
-  }
-  const ext = path.extname(trimmed).toLowerCase();
-  if (ext === ".cmd" || ext === ".exe" || ext === ".bat") {
-    return command;
-  }
-  const base = path.basename(trimmed).toLowerCase();
-  if (base === "qmd" || base === "mcporter") {
-    return `${trimmed}.cmd`;
-  }
-  return command;
-}
-
 export function resolveCliSpawnInvocation(params: {
   command: string;
   args: string[];
@@ -38,7 +18,7 @@ export function resolveCliSpawnInvocation(params: {
   packageName: string;
 }): CliSpawnInvocation {
   const program = resolveWindowsSpawnProgram({
-    command: resolveWindowsCommandShim(params.command),
+    command: params.command,
     platform: process.platform,
     env: params.env,
     execPath: process.execPath,

--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -28,9 +28,31 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-let _currentListener: ActiveWebListener | null = null;
+// Use Symbol keys to prevent build-time token rewrites and ensure isolation across bundled chunks
+const ACTIVE_WEB_LISTENERS_KEY = Symbol.for("openclaw.activeWebListeners");
+const ACTIVE_WEB_CURRENT_LISTENER_KEY = Symbol.for("openclaw.activeWebCurrentListener");
 
-const listeners = new Map<string, ActiveWebListener>();
+type ActiveWebListenerGlobalState = typeof globalThis & {
+  [ACTIVE_WEB_LISTENERS_KEY]?: Map<string, ActiveWebListener>;
+  [ACTIVE_WEB_CURRENT_LISTENER_KEY]?: ActiveWebListener | null;
+};
+
+function getSharedListenersMap(): Map<string, ActiveWebListener> {
+  const state = globalThis as ActiveWebListenerGlobalState;
+  const existing = state[ACTIVE_WEB_LISTENERS_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created = new Map<string, ActiveWebListener>();
+  state[ACTIVE_WEB_LISTENERS_KEY] = created;
+  return created;
+}
+
+const listeners = getSharedListenersMap();
+let _currentListener: ActiveWebListener | null =
+  (globalThis as ActiveWebListenerGlobalState)[ACTIVE_WEB_CURRENT_LISTENER_KEY] ??
+  listeners.get(DEFAULT_ACCOUNT_ID) ??
+  null;
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;
@@ -75,6 +97,7 @@ export function setActiveWebListener(
   }
   if (id === DEFAULT_ACCOUNT_ID) {
     _currentListener = listener;
+    (globalThis as ActiveWebListenerGlobalState)[ACTIVE_WEB_CURRENT_LISTENER_KEY] = listener;
   }
 }
 


### PR DESCRIPTION
## Summary

This branch starts from `openclaw/main`, merges the WhatsApp delivery-recovery startup-race fix from `gbballpack/fix/whatsapp-delivery-recovery-startup-race`, and adds hardening + test coverage.

### Included from original fix branch
- Move startup delivery recovery to run **after** sidecars/channel startup
- Add readiness preflight wait for pending-delivery targets before replay
- Keep preflight fail-open with timeout (non-blocking startup)
- Add active-listener `globalThis`/`Symbol.for` sharing to avoid cross-chunk listener map drift

### Additional hardening in this branch
1. **Skip full recovery when channels/providers are intentionally skipped**
   - If `OPENCLAW_SKIP_CHANNELS=1` or `OPENCLAW_SKIP_PROVIDERS=1`, recovery now returns early.
   - Prevents burning retries when channel startup is intentionally disabled (tests/dev).

2. **Avoid O(n²) dedupe in preflight target handling**
   - Replace `findIndex` dedupe pass with `Map` dedupe.

3. **Avoid double queue scan at startup**
   - `recoverPendingDeliveries` now accepts optional preloaded `pending` entries.
   - Startup preflight can pass through already-loaded queue entries instead of rescanning files.

4. **Expanded preflight tests**
   - Added direct coverage for readiness polling behavior:
     - waits for WhatsApp `running && connected`
     - timeout path
     - abort path
     - disabled/unconfigured non-blocking path
     - non-WhatsApp channels do not require `connected===true`

## Why

This keeps the original startup-race fix intact while tightening behavior in skip-mode and increasing confidence in the polling logic (the core of the fix).

## Test evidence

### Targeted suites (all passing)
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server.impl.delivery-recovery.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts src/infra/outbound/outbound.test.ts`
- `pnpm exec vitest run --config vitest.channels.config.ts src/web/outbound.test.ts`
- `pnpm lint`
- `pnpm build:strict-smoke`

### Full gateway suite baseline comparison
- Branch: `9 failed files / 12 failed tests / 133 passed files`
- Main: `9 failed files / 12 failed tests / 132 passed files`
- Same failing files in both runs; no new gateway-suite regressions introduced by this branch.

## Notes
- `pnpm format:check` currently reports 3 pre-existing CSS format issues on both this branch and `main`:
  - `ui/src/styles/chat/grouped.css`
  - `ui/src/styles/chat/layout.css`
  - `ui/src/styles/layout.css`

## Related
- Context/fix lineage: #41238

---
Supersedes #44324 (reopen blocked by GitHub after branch force-push/recreation).
