### PR TITLE
Heartbeat: retry active-session wakes before draining events

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as embeddedRunTesting,
+  setActiveEmbeddedRun,
+} from "../agents/pi-embedded-runner/runs.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import * as replyModule from "../auto-reply/reply.js";
 import { whatsappOutbound } from "../channels/plugins/outbound/whatsapp.js";
@@ -27,7 +31,7 @@ import {
   resolveHeartbeatDeliveryTarget,
   resolveHeartbeatSenderContext,
 } from "./outbound/targets.js";
-import { enqueueSystemEvent, resetSystemEventsForTest } from "./system-events.js";
+import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "./system-events.js";
 
 // Avoid pulling optional runtime deps during isolated runs.
 vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
@@ -105,6 +109,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   resetSystemEventsForTest();
+  embeddedRunTesting.resetActiveEmbeddedRuns();
   if (testRegistry) {
     setActivePluginRegistry(testRegistry);
   }
@@ -1309,6 +1314,65 @@ describe("runHeartbeatOnce", () => {
       expect(calledCtx.Body).not.toContain("Please relay the command output to the user");
     } finally {
       replySpy.mockRestore();
+    }
+  });
+
+  it("returns requests-in-flight without draining system events when the target session is active", async () => {
+    const tmpDir = await createCaseDir("hb-active-session-retry");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "none" },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid-active",
+          updatedAt: Date.now(),
+          lastChannel: "whatsapp",
+          lastTo: "120363401234567890@g.us",
+        },
+      }),
+    );
+    enqueueSystemEvent("Cron: continue background task", {
+      sessionKey,
+      contextKey: "cron:continue-background-task",
+    });
+
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    const sendWhatsApp = vi
+      .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    setActiveEmbeddedRun("sid-active", {
+      queueMessage: async () => {},
+      isStreaming: () => false,
+      isCompacting: () => false,
+      abort: () => {},
+    });
+
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "cron:continue-background-task",
+        deps: createHeartbeatDeps(sendWhatsApp),
+      });
+
+      expect(res).toEqual({ status: "skipped", reason: "requests-in-flight" });
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(sendWhatsApp).not.toHaveBeenCalled();
+      expect(peekSystemEvents(sessionKey)).toEqual(["Cron: continue background task"]);
+    } finally {
+      replySpy.mockRestore();
+      embeddedRunTesting.resetActiveEmbeddedRuns();
     }
   });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -7,6 +7,7 @@ import {
 } from "../agents/agent-scope.js";
 import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
 import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
+import { isEmbeddedPiRunActive } from "../agents/pi-embedded.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
@@ -658,6 +659,14 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: preflight.skipReason };
   }
   const { entry, sessionKey, storePath } = preflight.session;
+  const activeSessionId = entry?.sessionId?.trim();
+  if (activeSessionId && isEmbeddedPiRunActive(activeSessionId)) {
+    // Preserve queued system events for the next retry. If we call
+    // getReplyFromConfig while the target session is still running, the
+    // session-updates path drains those events before runReplyAgent drops the
+    // heartbeat as active. That turns a temporary busy state into a lost wake.
+    return { status: "skipped", reason: "requests-in-flight" };
+  }
   const previousUpdatedAt = entry?.updatedAt;
   const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
   const heartbeatAccountId = heartbeat?.accountId?.trim();


### PR DESCRIPTION
## Summary

- Problem: heartbeat-triggered follow-up work could be lost when the target session was still active.
- Why it matters: OpenClaw could say it would continue later, then stay idle until a human sent another message to wake the session again.
- What changed: `runHeartbeatOnce()` now checks whether the target embedded session is still active before entering the reply path. If it is, heartbeat returns `requests-in-flight` so the existing wake retry flow keeps the system event queued instead of draining it early.
- What did NOT change (scope boundary): this PR does not change general session recovery, CLI backend watchdog behavior, or all other possible causes of stalled long-running work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Heartbeat follow-up work for an already-active session is no longer silently dropped after draining queued system events.

When a heartbeat targets a session that is still running, OpenClaw now defers through the existing `requests-in-flight` retry path so the queued “continue later” event is preserved for the retry instead of being consumed and lost.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local dev checkout
- Model/provider: N/A
- Integration/channel (if any): heartbeat/session continuation path
- Relevant config (redacted): local session store + heartbeat-enabled config

### Steps

1. Queue a heartbeat-driven system event for a session that already has an active embedded run.
2. Trigger `runHeartbeatOnce()` for that session.
3. Observe whether the system event is preserved for retry or drained before the heartbeat is dropped.

### Expected

- Heartbeat should return `requests-in-flight`.
- The queued system event should remain available for the retry.
- Existing heartbeat retry scheduling should continue to work.

### Actual

- Before this change, heartbeat could enter the reply path, drain queued system events, and then get dropped because the target session was still active.
- That left the session appearing stuck until another inbound message re-triggered work.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/infra/heartbeat-runner.returns-default-unset.test.ts`
  - `pnpm test src/infra/heartbeat-runner.scheduler.test.ts`
  - `pnpm test src/infra/heartbeat-wake.test.ts`
  - `pnpm test src/infra/system-events.test.ts`
  - `pnpm build`
- Edge cases checked:
  - active target sessions return `requests-in-flight`
  - queued system events are preserved in that active-session case
  - existing heartbeat scheduler retry behavior still passes unchanged
  - heartbeat wake coalescing/retry tests still pass unchanged
  - system event draining tests still pass unchanged
- What I did **not** verify:
  - a full end-to-end real messaging-channel reproduction outside the test suite
  - full `pnpm check`, which is currently blocked by unrelated existing `extensions/tlon/**` type-resolution errors for `@tloncorp/api`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/infra/heartbeat-runner.ts`
- Known bad symptoms reviewers should watch for:
  - heartbeat retries no longer firing after `requests-in-flight`
  - queued continuation events being consumed without a follow-up run

## Risks and Mitigations

- Risk:
  - Heartbeats for active sessions now short-circuit earlier than before.
- Mitigation:
  - The short-circuit only applies when the exact target session is already active, and it reuses the existing `requests-in-flight` retry path covered by scheduler and wake tests.

## AI Assistance

This PR was AI-assisted. I reviewed the change and ran the verification commands listed above.
