### PR TITLE
fix(compaction): recover manual /compact in threaded sessions

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -14,6 +14,8 @@ const {
   resolveMemorySearchConfigMock,
   resolveSessionAgentIdMock,
   estimateTokensMock,
+  settingsManagerGetCompactionKeepRecentTokens,
+  settingsManagerApplyOverrides,
 } = vi.hoisted(() => {
   const contextEngineCompactMock = vi.fn(async () => ({
     ok: true as boolean,
@@ -65,6 +67,8 @@ const {
     })),
     resolveSessionAgentIdMock: vi.fn(() => "main"),
     estimateTokensMock: vi.fn((_message?: unknown) => 10),
+    settingsManagerGetCompactionKeepRecentTokens: vi.fn(() => 10),
+    settingsManagerApplyOverrides: vi.fn(),
   };
 });
 
@@ -92,7 +96,11 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
 }));
 
 vi.mock("@mariozechner/pi-coding-agent", () => {
+  class AuthStorage {}
+  class ModelRegistry {}
   return {
+    AuthStorage,
+    ModelRegistry,
     createAgentSession: vi.fn(async () => {
       const session = {
         sessionId: "session-1",
@@ -115,9 +123,10 @@ vi.mock("@mariozechner/pi-coding-agent", () => {
           streamFn: vi.fn(),
         },
         compact: vi.fn(async () => {
+          const result = await sessionCompactImpl();
           // simulate compaction trimming to a single message
           session.messages.splice(1);
-          return await sessionCompactImpl();
+          return result;
         }),
         dispose: vi.fn(),
       };
@@ -291,6 +300,8 @@ vi.mock("../pi-embedded-helpers.js", () => ({
 vi.mock("../pi-project-settings.js", () => ({
   createPreparedEmbeddedPiSettingsManager: vi.fn(() => ({
     getGlobalSettings: vi.fn(() => ({})),
+    getCompactionKeepRecentTokens: settingsManagerGetCompactionKeepRecentTokens,
+    applyOverrides: settingsManagerApplyOverrides,
   })),
 }));
 
@@ -373,6 +384,9 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     resolveSessionAgentIdMock.mockReturnValue("main");
     estimateTokensMock.mockReset();
     estimateTokensMock.mockReturnValue(10);
+    settingsManagerGetCompactionKeepRecentTokens.mockReset();
+    settingsManagerGetCompactionKeepRecentTokens.mockReturnValue(10);
+    settingsManagerApplyOverrides.mockReset();
     unregisterApiProviders(getCustomApiRegistrySourceId("ollama"));
   });
 
@@ -544,6 +558,42 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       },
     });
     expect(sessionHook("compact:after")?.context?.tokenCount).toBe(30);
+  });
+
+  it("retries manual compaction when token estimation fails but history text is present", async () => {
+    estimateTokensMock.mockImplementation((message: unknown) => {
+      const role = (message as { role?: string }).role;
+      if (role === "assistant") {
+        throw new Error("legacy message");
+      }
+      return 10;
+    });
+    sessionCompactImpl
+      .mockRejectedValueOnce(new Error("Compaction cancelled"))
+      .mockResolvedValueOnce({
+        summary: "summary",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 120,
+        details: { ok: true },
+      });
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      customInstructions: "focus on decisions",
+      trigger: "manual",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      compacted: true,
+    });
+    expect(sessionCompactImpl).toHaveBeenCalledTimes(2);
+    expect(settingsManagerApplyOverrides).toHaveBeenCalledWith({
+      compaction: { keepRecentTokens: 1 },
+    });
   });
 
   it("treats pre-compaction token estimation failures as a no-op sanity check", async () => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -225,6 +225,46 @@ function summarizeCompactionMessages(messages: AgentMessage[]): CompactionMessag
   };
 }
 
+function summarizeCompactionRoleCounts(messages: AgentMessage[]): string {
+  if (messages.length === 0) {
+    return "count=0 roles=[] real=0";
+  }
+  const roleCounts = new Map<string, number>();
+  let realCount = 0;
+  for (const message of messages) {
+    const role = typeof message.role === "string" ? message.role : "unknown";
+    roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
+    if (hasRealConversationContent(message)) {
+      realCount += 1;
+    }
+  }
+  const roles = [...roleCounts.entries()].map(([role, count]) => `${role}:${count}`).join(",");
+  return `count=${messages.length} roles=[${roles}] real=${realCount}`;
+}
+
+function resolveManualCompactionRetryKeepRecentTokens(params: {
+  currentKeepRecentTokens: number;
+  estimatedTokens?: number;
+  historyTextChars?: number;
+}): number | null {
+  const estimatedTokens =
+    typeof params.estimatedTokens === "number" && Number.isFinite(params.estimatedTokens)
+      ? Math.max(0, Math.floor(params.estimatedTokens))
+      : typeof params.historyTextChars === "number" &&
+          Number.isFinite(params.historyTextChars) &&
+          params.historyTextChars > 0
+        ? Math.max(1, Math.ceil(params.historyTextChars / 4))
+        : undefined;
+  if (estimatedTokens === undefined || estimatedTokens <= 1) {
+    return null;
+  }
+  const targetKeepRecentTokens = Math.max(1, Math.floor(estimatedTokens / 2));
+  if (targetKeepRecentTokens >= params.currentKeepRecentTokens) {
+    return null;
+  }
+  return targetKeepRecentTokens;
+}
+
 function classifyCompactionReason(reason?: string): string {
   const text = (reason ?? "").trim().toLowerCase();
   if (!text) {
@@ -405,10 +445,24 @@ export async function compactEmbeddedPiSessionDirect(
     modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
   }
   const fail = (reason: string): EmbeddedPiCompactResult => {
+    const classifiedReason = classifyCompactionReason(reason);
+    if (classifiedReason === "already_compacted_recently") {
+      log.warn(
+        `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+          `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
+          `attempt=${attempt} maxAttempts=${maxAttempts} outcome=skipped reason=${classifiedReason} ` +
+          `durationMs=${Date.now() - startedAt}`,
+      );
+      return {
+        ok: true,
+        compacted: false,
+        reason,
+      };
+    }
     log.warn(
       `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
         `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-        `attempt=${attempt} maxAttempts=${maxAttempts} outcome=failed reason=${classifyCompactionReason(reason)} ` +
+        `attempt=${attempt} maxAttempts=${maxAttempts} outcome=failed reason=${classifiedReason} ` +
         `durationMs=${Date.now() - startedAt}`,
     );
     return {
@@ -868,8 +922,8 @@ export async function compactEmbeddedPiSessionDirect(
           }
         }
         const diagEnabled = log.isEnabled("debug");
-        const preMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
-        if (diagEnabled && preMetrics) {
+        const preMetrics = summarizeCompactionMessages(session.messages);
+        if (diagEnabled) {
           log.debug(
             `[compaction-diag] start runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
               `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
@@ -908,9 +962,65 @@ export async function compactEmbeddedPiSessionDirect(
           // If token estimation throws on a malformed message, fall back to 0 so
           // the sanity check below becomes a no-op instead of crashing compaction.
         }
-        const result = await compactWithSafetyTimeout(() =>
-          session.compact(params.customInstructions),
-        );
+        let result: Awaited<ReturnType<typeof session.compact>>;
+        const runCompaction = async () =>
+          await compactWithSafetyTimeout(() => session.compact(params.customInstructions));
+        try {
+          result = await runCompaction();
+        } catch (err) {
+          const reason = describeUnknownError(err);
+          const currentKeepRecentTokens = settingsManager.getCompactionKeepRecentTokens();
+          const retryKeepRecentTokens =
+            trigger === "manual" &&
+            reason.includes("Compaction cancelled") &&
+            session.messages.some(hasRealConversationContent)
+              ? resolveManualCompactionRetryKeepRecentTokens({
+                  currentKeepRecentTokens,
+                  estimatedTokens: preMetrics.estTokens,
+                  historyTextChars: preMetrics.historyTextChars,
+                })
+              : null;
+          if (retryKeepRecentTokens !== null) {
+            log.warn(
+              `[compaction-diag] retrying manual compaction after empty preparation ` +
+                `runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                `diagId=${diagId} provider=${provider}/${modelId} reason=${reason} ` +
+                `keepRecentTokens=${currentKeepRecentTokens} -> ${retryKeepRecentTokens} ` +
+                `pre={${summarizeCompactionRoleCounts(session.messages)}}`,
+            );
+            settingsManager.applyOverrides({
+              compaction: { keepRecentTokens: retryKeepRecentTokens },
+            });
+            try {
+              result = await runCompaction();
+            } catch (retryErr) {
+              const retryReason = describeUnknownError(retryErr);
+              log.warn(
+                `[compaction-diag] session.compact failed after manual retry runId=${runId} ` +
+                  `sessionKey=${params.sessionKey ?? params.sessionId} diagId=${diagId} ` +
+                  `trigger=${trigger} provider=${provider}/${modelId} reason=${retryReason} ` +
+                  `pre={${summarizeCompactionRoleCounts(session.messages)}} ` +
+                  `pre.historyTextChars=${preMetrics.historyTextChars} ` +
+                  `pre.toolResultChars=${preMetrics.toolResultChars} ` +
+                  `pre.estTokens=${preMetrics.estTokens ?? "unknown"} ` +
+                  `contributors=${JSON.stringify(preMetrics.contributors)}`,
+              );
+              throw retryErr;
+            }
+          } else {
+            log.warn(
+              `[compaction-diag] session.compact failed runId=${runId} ` +
+                `sessionKey=${params.sessionKey ?? params.sessionId} diagId=${diagId} ` +
+                `trigger=${trigger} provider=${provider}/${modelId} reason=${reason} ` +
+                `pre={${summarizeCompactionRoleCounts(session.messages)}} ` +
+                `pre.historyTextChars=${preMetrics.historyTextChars} ` +
+                `pre.toolResultChars=${preMetrics.toolResultChars} ` +
+                `pre.estTokens=${preMetrics.estTokens ?? "unknown"} ` +
+                `contributors=${JSON.stringify(preMetrics.contributors)}`,
+            );
+            throw err;
+          }
+        }
         await runPostCompactionSideEffects({
           config: params.config,
           sessionKey: params.sessionKey,

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1528,6 +1528,35 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(getApiKeyMock).not.toHaveBeenCalled();
   });
 
+  it("continues split-turn compaction when turn prefix messages contain real conversation content", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [
+          { role: "user", content: "finish compacting this split turn", timestamp: Date.now() },
+        ] as AgentMessage[],
+        isSplitTurn: true,
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1500,
+        fileOps: { read: [], edited: [], written: [] },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result, getApiKeyMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: null,
+    });
+
+    expect(result).toEqual({ cancel: true });
+    expect(getApiKeyMock).toHaveBeenCalled();
+  });
+
   it("continues when messages include real conversation content", async () => {
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -183,6 +183,26 @@ function isRealConversationMessage(message: AgentMessage): boolean {
   return message.role === "user" || message.role === "assistant" || message.role === "toolResult";
 }
 
+function summarizeMessageRoles(messages: AgentMessage[]): string {
+  if (messages.length === 0) {
+    return "count=0 roles=[] real=0";
+  }
+  const roleCounts = new Map<string, number>();
+  let realCount = 0;
+  for (const message of messages) {
+    const role =
+      typeof (message as { role?: unknown }).role === "string"
+        ? ((message as { role?: string }).role ?? "unknown")
+        : "unknown";
+    roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
+    if (isRealConversationMessage(message)) {
+      realCount += 1;
+    }
+  }
+  const roles = [...roleCounts.entries()].map(([role, count]) => `${role}:${count}`).join(",");
+  return `count=${messages.length} roles=[${roles}] real=${realCount}`;
+}
+
 function computeFileLists(fileOps: FileOperations): {
   readFiles: string[];
   modifiedFiles: string[];
@@ -702,9 +722,17 @@ async function readWorkspaceContextForSummary(): Promise<string> {
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
     const { preparation, customInstructions: eventInstructions, signal } = event;
-    if (!preparation.messagesToSummarize.some(isRealConversationMessage)) {
+    const hasRealMessagesToSummarize =
+      preparation.messagesToSummarize.some(isRealConversationMessage);
+    const hasRealSplitTurnPrefixMessages =
+      preparation.isSplitTurn &&
+      (preparation.turnPrefixMessages ?? []).some(isRealConversationMessage);
+    if (!hasRealMessagesToSummarize && !hasRealSplitTurnPrefixMessages) {
       log.warn(
-        "Compaction safeguard: cancelling compaction with no real conversation messages to summarize.",
+        "Compaction safeguard: cancelling compaction with no real conversation messages to summarize. " +
+          `isSplitTurn=${preparation.isSplitTurn} ` +
+          `messagesToSummarize={${summarizeMessageRoles(preparation.messagesToSummarize)}} ` +
+          `turnPrefixMessages={${summarizeMessageRoles(preparation.turnPrefixMessages ?? [])}}`,
       );
       return { cancel: true };
     }

--- a/src/discord/monitor/native-command.plugin-dispatch.test.ts
+++ b/src/discord/monitor/native-command.plugin-dispatch.test.ts
@@ -4,6 +4,7 @@ import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
+import * as timeoutModule from "../../utils/with-timeout.js";
 import { createDiscordNativeCommand } from "./native-command.js";
 import {
   createMockCommandInteraction,
@@ -65,6 +66,23 @@ function createStatusCommand(cfg: OpenClawConfig) {
   const commandSpec: NativeCommandSpec = {
     name: "status",
     description: "Status",
+    acceptsArgs: false,
+  };
+  return createDiscordNativeCommand({
+    command: commandSpec,
+    cfg,
+    discordConfig: cfg.channels?.discord ?? {},
+    accountId: "default",
+    sessionPrefix: "discord:slash",
+    ephemeralDefault: true,
+    threadBindings: createNoopThreadBindingManager("default"),
+  });
+}
+
+function createCompactCommand(cfg: OpenClawConfig) {
+  const commandSpec: NativeCommandSpec = {
+    name: "compact",
+    description: "Compact",
     acceptsArgs: false,
   };
   return createDiscordNativeCommand({
@@ -339,5 +357,25 @@ describe("Discord native plugin command dispatch", () => {
       channelId,
       boundSessionKey,
     });
+  });
+  it("shows a still-processing follow-up when slash compact exceeds the interaction window", async () => {
+    const cfg = createConfig();
+    const command = createCompactCommand(cfg);
+    const interaction = createInteraction();
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    vi.spyOn(dispatcherModule, "dispatchReplyWithDispatcher").mockImplementation(
+      () => new Promise(() => {}) as never,
+    );
+    vi.spyOn(timeoutModule, "withTimeout").mockRejectedValue(new Error("timeout"));
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("/compact is still processing"),
+        ephemeral: true,
+      }),
+    );
   });
 });

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -95,6 +95,7 @@ import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
 const log = createSubsystemLogger("discord/native-command");
+const DISCORD_LONG_RUNNING_COMMAND_TIMEOUT_MS = 12_000;
 
 function resolveDiscordNativeCommandAllowlistAccess(params: {
   cfg: OpenClawConfig;
@@ -1250,7 +1251,11 @@ export function createDiscordNativeCommand(params: {
           } satisfies CommandArgs)
         : undefined;
       const prompt = buildCommandTextFromArgs(commandDefinition, commandArgsWithRaw);
-      await dispatchDiscordCommandInteraction({
+      const isCompactCommand =
+        command.name === "compact" ||
+        commandDefinition.nativeName === "compact" ||
+        commandDefinition.key === "/compact";
+      const dispatchPromise = dispatchDiscordCommandInteraction({
         interaction,
         prompt,
         command: commandDefinition,
@@ -1259,9 +1264,49 @@ export function createDiscordNativeCommand(params: {
         discordConfig,
         accountId,
         sessionPrefix,
-        preferFollowUp: false,
+        preferFollowUp: isCompactCommand,
         threadBindings,
       });
+      if (isCompactCommand) {
+        try {
+          await withTimeout(dispatchPromise, DISCORD_LONG_RUNNING_COMMAND_TIMEOUT_MS);
+        } catch (error) {
+          if (error instanceof Error && error.message === "timeout") {
+            void dispatchPromise.catch(async (lateError) => {
+              const message =
+                lateError instanceof Error
+                  ? (lateError.stack ?? lateError.message)
+                  : String(lateError);
+              log.error(`discord slash compact failed after timeout: ${message}`);
+              try {
+                await safeDiscordInteractionCall("compact late failure follow-up", () =>
+                  interaction.followUp({
+                    content: "⚠️ /compact failed after starting. Please try again or check logs.",
+                    ephemeral: true,
+                  }),
+                );
+              } catch (followUpError) {
+                const followUpMessage =
+                  followUpError instanceof Error
+                    ? (followUpError.stack ?? followUpError.message)
+                    : String(followUpError);
+                log.error(`discord slash compact late failure notifier failed: ${followUpMessage}`);
+              }
+            });
+            await safeDiscordInteractionCall("compact timeout follow-up", () =>
+              interaction.followUp({
+                content:
+                  "⏳ /compact is still processing. I will post the result here when it finishes.",
+                ephemeral: true,
+              }),
+            );
+            return;
+          }
+          throw error;
+        }
+        return;
+      }
+      await dispatchPromise;
     }
   })();
 }


### PR DESCRIPTION
## Summary

- Problem: manual `/compact` on threaded sessions could fail with `Compaction cancelled` even when the session still had real conversation messages, and Discord slash `/compact` could sit on the thinking placeholder long enough to hit the interaction timeout.
- Why it matters: the issue made manual recovery unreliable in Discord threads and surfaced an upstream compaction edge case as a user-facing failure.
- What changed: retry manual compaction once with a reduced in-memory `keepRecentTokens` when the SDK produces an empty preparation, treat `Already compacted` as a benign skip instead of a failure, and send a Discord follow-up when slash `/compact` is still processing so the interaction does not appear hung.
- What did NOT change (scope boundary): auto compaction behavior was not changed, and the Discord timeout handling is limited to native slash `/compact`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44138
- Related #44138

## User-visible / Behavior Changes

- Manual `/compact` can recover from the empty-preparation compaction failure instead of immediately failing.
- Discord slash `/compact` now sends a still-processing follow-up instead of sitting on the interaction thinking state until timeout.
- Re-running `/compact` on a just-compacted session now reports a skipped/no-op path instead of a hard failure.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- Runtime/container: local dev gateway
- Model/provider: `nvidia/moonshotai/kimi-k2.5`
- Integration/channel (if any): Discord thread slash `/compact`
- Relevant config (redacted): command allowlist enabled for the Discord sender

### Steps

1. Reproduce manual `/compact` in a Discord thread session with enough retained history to hit the SDK preparation bug.
2. Observe the original `Compaction cancelled` failure and the Discord interaction hanging on the thinking placeholder.
3. Re-run manual `/compact` after the fix and verify the retry/timeout-handling behavior.

### Expected

- Manual `/compact` should compact or skip cleanly.
- Discord slash `/compact` should not appear hung while the background compaction is still running.

### Actual

- Before this change, manual `/compact` could fail with `Compaction cancelled` and Discord could sit on the pending interaction until timeout.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the failure on a Discord thread session, confirmed the retry path was hit in logs, confirmed a compaction entry was written, and confirmed later `/compact` requests hit the already-compacted path.
- Edge cases checked: manual retry with reduced `keepRecentTokens`, already-compacted manual retry path, Discord slash timeout follow-up path.
- What you did **not** verify: full cross-channel manual `/compact` coverage and a full `pnpm test` run on the clean latest-remote checkout.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or restore the previous manual compaction flow in `src/agents/pi-embedded-runner/compact.ts` and the Discord slash timeout wrapper in `src/discord/monitor/native-command.ts`.
- Files/config to restore: `src/agents/pi-embedded-runner/compact.ts`, `src/discord/monitor/native-command.ts`
- Known bad symptoms reviewers should watch for: unexpected extra manual compaction retries, Discord slash `/compact` follow-up messages not matching the eventual final result.

## Risks and Mitigations

- Risk: the manual retry could compact slightly more aggressively than before in the specific empty-preparation failure case.
  - Mitigation: the retry is limited to manual compaction, only triggers after `Compaction cancelled`, and only lowers `keepRecentTokens` in-memory for that attempt.
- Risk: Discord slash `/compact` may now show an in-progress follow-up before the final status message lands.
  - Mitigation: the follow-up only appears after a short timeout window and the command continues running so users get clearer feedback instead of a hanging interaction.

AI-assisted: yes. Lightly tested with focused Vitest coverage, local build, and live local Discord repro/log verification.

Made with [Cursor](https://cursor.com)