### PR TITLE
feat(sandbox): support opensandbox runtime

### DIFF
--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -215,6 +215,32 @@ Common pitfalls:
 - Sandbox exec does **not** inherit host `process.env`. Use
   `agents.defaults.sandbox.docker.env` (or a custom image) for skill API keys.
 
+## OpenSandbox backend (exec-only)
+
+OpenClaw can route sandboxed `exec`/`process` command lifecycle to OpenSandbox
+execd by setting:
+
+- `OPENCLAW_SANDBOX_BACKEND=opensandbox`
+- `OPEN_SANDBOX_EXECD_URL` and `OPEN_SANDBOX_EXECD_ACCESS_TOKEN`
+
+Or use lifecycle discovery:
+
+- `OPEN_SANDBOX_LIFECYCLE_URL`
+- `OPEN_SANDBOX_API_KEY`
+- `OPEN_SANDBOX_SANDBOX_ID`
+- optional `OPEN_SANDBOX_EXECD_PORT` (default `44772`)
+
+Current short-term behavior:
+
+- Background/yield `exec` is supported through OpenSandbox command sessions.
+- `process` `list`/`poll`/`log`/`kill`/`remove` works for those sessions.
+- `process` `write`/`send-keys`/`submit`/`paste` is unavailable for OpenSandbox
+  sessions because current execd APIs do not expose stdin write for a running
+  command session.
+
+When using OpenSandbox backend, filesystem tools (`read`/`write`/`edit`) stay on
+host behavior unless you add a dedicated fs bridge integration.
+
 ## Tool policy + escape hatches
 
 Tool allow/deny policies still apply before sandbox rules. If a tool is denied

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -52,6 +52,13 @@ export interface ProcessSession {
   exited: boolean;
   truncated: boolean;
   backgrounded: boolean;
+  remote?: {
+    provider: "opensandbox";
+    baseUrl: string;
+    accessToken: string;
+    commandSessionId: string;
+    outputCursor?: number;
+  };
 }
 
 export interface FinishedSession {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -26,13 +26,9 @@ import {
   markExited,
   tail,
 } from "./bash-process-registry.js";
-import {
-  buildDockerExecArgs,
-  chunkString,
-  clampWithDefault,
-  readEnvInt,
-} from "./bash-tools.shared.js";
+import { chunkString, clampWithDefault, readEnvInt } from "./bash-tools.shared.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
+import { buildSandboxExecInvocation } from "./sandbox/backend-exec.js";
 import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
 
 // Sanitize inherited host env before merge so dangerous variables from process.env
@@ -391,6 +387,7 @@ export async function runExecProcess(opts: {
         argv: string[];
         env: NodeJS.ProcessEnv;
         stdinMode: "pipe-open" | "pipe-closed";
+        backendId: "exec-host" | "exec-sandbox" | "exec-sandbox-opensandbox";
       }
     | {
         mode: "pty";
@@ -398,22 +395,22 @@ export async function runExecProcess(opts: {
         childFallbackArgv: string[];
         env: NodeJS.ProcessEnv;
         stdinMode: "pipe-open";
+        backendId: "exec-host";
       } = (() => {
     if (opts.sandbox) {
+      const sandboxExec = buildSandboxExecInvocation({
+        sandbox: opts.sandbox,
+        command: execCommand,
+        workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
+        env: shellRuntimeEnv,
+        tty: opts.usePty,
+      });
       return {
         mode: "child" as const,
-        argv: [
-          "docker",
-          ...buildDockerExecArgs({
-            containerName: opts.sandbox.containerName,
-            command: execCommand,
-            workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
-            env: shellRuntimeEnv,
-            tty: opts.usePty,
-          }),
-        ],
-        env: process.env,
+        argv: sandboxExec.argv,
+        env: sandboxExec.env,
         stdinMode: opts.usePty ? ("pipe-open" as const) : ("pipe-closed" as const),
+        backendId: sandboxExec.backendId,
       };
     }
     const { shell, args: shellArgs } = getShellConfig();
@@ -425,6 +422,7 @@ export async function runExecProcess(opts: {
         childFallbackArgv: childArgv,
         env: shellRuntimeEnv,
         stdinMode: "pipe-open" as const,
+        backendId: "exec-host" as const,
       };
     }
     return {
@@ -432,6 +430,7 @@ export async function runExecProcess(opts: {
       argv: childArgv,
       env: shellRuntimeEnv,
       stdinMode: "pipe-closed" as const,
+      backendId: "exec-host" as const,
     };
   })();
 
@@ -457,7 +456,7 @@ export async function runExecProcess(opts: {
     const spawnBase = {
       runId: sessionId,
       sessionId: opts.sessionKey?.trim() || sessionId,
-      backendId: opts.sandbox ? "exec-sandbox" : "exec-host",
+      backendId: spawnSpec.backendId,
       scopeKey: opts.scopeKey,
       cwd: opts.workdir,
       env: spawnSpec.env,

--- a/src/agents/bash-tools.exec.opensandbox.test.ts
+++ b/src/agents/bash-tools.exec.opensandbox.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  getFinishedSession,
+  getSession,
+  resetProcessRegistryForTests,
+} from "./bash-process-registry.js";
+import { createExecTool } from "./bash-tools.exec.js";
+
+const {
+  openSandboxReadCommandOutputMock,
+  openSandboxReadCommandStatusMock,
+  openSandboxStartCommandSessionMock,
+} = vi.hoisted(() => ({
+  openSandboxReadCommandOutputMock: vi.fn(),
+  openSandboxReadCommandStatusMock: vi.fn(),
+  openSandboxStartCommandSessionMock: vi.fn(),
+}));
+
+vi.mock("./sandbox/opensandbox-command.js", () => ({
+  openSandboxReadCommandOutput: (...args: unknown[]) => openSandboxReadCommandOutputMock(...args),
+  openSandboxReadCommandStatus: (...args: unknown[]) => openSandboxReadCommandStatusMock(...args),
+  openSandboxStartCommandSession: (...args: unknown[]) =>
+    openSandboxStartCommandSessionMock(...args),
+}));
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+  openSandboxReadCommandOutputMock.mockReset();
+  openSandboxReadCommandStatusMock.mockReset();
+  openSandboxStartCommandSessionMock.mockReset();
+});
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }) {
+  const item = result.content.find((entry) => entry.type === "text");
+  return item?.text ?? "";
+}
+
+test("opensandbox background exec creates remote process session", async () => {
+  openSandboxStartCommandSessionMock.mockResolvedValue("remote-session-1");
+
+  const execTool = createExecTool({
+    host: "sandbox",
+    security: "full",
+    ask: "off",
+    allowBackground: true,
+    sandbox: {
+      backendKind: "opensandbox",
+      opensandboxBaseUrl: "https://sandbox.example.test/execd",
+      opensandboxAccessToken: "token-1",
+      opensandboxTimeoutSec: 300,
+      containerName: "unused",
+      workspaceDir: process.cwd(),
+      containerWorkdir: "/workspace",
+    },
+  });
+
+  const result = await execTool.execute("toolcall", {
+    command: "echo hello",
+    background: true,
+    timeout: 12,
+  });
+
+  expect(result.details).toMatchObject({
+    status: "running",
+  });
+  const sessionId = (result.details as { sessionId: string }).sessionId;
+  const session = getSession(sessionId);
+  expect(session).toBeDefined();
+  expect(session?.remote).toMatchObject({
+    provider: "opensandbox",
+    baseUrl: "https://sandbox.example.test/execd",
+    accessToken: "token-1",
+    commandSessionId: "remote-session-1",
+    outputCursor: 0,
+  });
+  expect(openSandboxStartCommandSessionMock).toHaveBeenCalledWith({
+    baseUrl: "https://sandbox.example.test/execd",
+    accessToken: "token-1",
+    command: "echo hello",
+    workdir: "/workspace",
+    timeoutSec: 12,
+  });
+  expect(result.content[0]).toMatchObject({ type: "text" });
+  expect(firstText(result as { content: Array<{ type: string; text?: string }> })).toContain(
+    "process write/send-keys/submit/paste are unavailable",
+  );
+});
+
+test("opensandbox yield waits for completion within yield window", async () => {
+  openSandboxStartCommandSessionMock.mockResolvedValue("remote-session-2");
+  openSandboxReadCommandOutputMock.mockResolvedValue([{ fd: 1, msg: "done\n" }]);
+  openSandboxReadCommandStatusMock.mockResolvedValue({ running: false, exitCode: 0 });
+
+  const execTool = createExecTool({
+    host: "sandbox",
+    security: "full",
+    ask: "off",
+    allowBackground: true,
+    sandbox: {
+      backendKind: "opensandbox",
+      opensandboxBaseUrl: "https://sandbox.example.test/execd",
+      opensandboxAccessToken: "token-1",
+      opensandboxTimeoutSec: 300,
+      containerName: "unused",
+      workspaceDir: process.cwd(),
+      containerWorkdir: "/workspace",
+    },
+  });
+
+  const result = await execTool.execute("toolcall", {
+    command: "echo done",
+    yieldMs: 200,
+    timeout: 12,
+  });
+
+  expect(result.details).toMatchObject({
+    status: "completed",
+    exitCode: 0,
+  });
+  expect(firstText(result as { content: Array<{ type: string; text?: string }> })).toContain(
+    "done",
+  );
+  expect(openSandboxReadCommandStatusMock).toHaveBeenCalled();
+  const sessionId = "sessionId" in result.details ? result.details.sessionId : undefined;
+  if (sessionId) {
+    expect(getSession(sessionId)).toBeUndefined();
+    expect(getFinishedSession(sessionId)).toBeUndefined();
+  }
+});
+
+test("opensandbox default yield backgrounds through remote session path", async () => {
+  openSandboxStartCommandSessionMock.mockResolvedValue("remote-session-3");
+  openSandboxReadCommandOutputMock.mockResolvedValue([]);
+  openSandboxReadCommandStatusMock.mockResolvedValue({ running: true });
+
+  const execTool = createExecTool({
+    host: "sandbox",
+    security: "full",
+    ask: "off",
+    allowBackground: true,
+    backgroundMs: 10,
+    sandbox: {
+      backendKind: "opensandbox",
+      opensandboxBaseUrl: "https://sandbox.example.test/execd",
+      opensandboxAccessToken: "token-1",
+      opensandboxTimeoutSec: 300,
+      containerName: "unused",
+      workspaceDir: process.cwd(),
+      containerWorkdir: "/workspace",
+    },
+  });
+
+  const result = await execTool.execute("toolcall", {
+    command: "sleep 999",
+  });
+
+  expect(result.details).toMatchObject({
+    status: "running",
+  });
+  const sessionId = (result.details as { sessionId: string }).sessionId;
+  const session = getSession(sessionId);
+  expect(session?.remote).toMatchObject({
+    provider: "opensandbox",
+    commandSessionId: "remote-session-3",
+  });
+  expect(openSandboxReadCommandStatusMock).toHaveBeenCalled();
+  expect(firstText(result as { content: Array<{ type: string; text?: string }> })).toContain(
+    "Command still running",
+  );
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -9,7 +9,13 @@ import {
 } from "../infra/shell-env.js";
 import { logInfo } from "../logger.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
-import { markBackgrounded } from "./bash-process-registry.js";
+import {
+  addSession,
+  appendOutput,
+  createSessionSlug,
+  markBackgrounded,
+  markExited,
+} from "./bash-process-registry.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
 import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
 import {
@@ -44,6 +50,11 @@ import {
   truncateMiddle,
 } from "./bash-tools.shared.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
+import {
+  openSandboxReadCommandOutput,
+  openSandboxReadCommandStatus,
+  openSandboxStartCommandSession,
+} from "./sandbox/opensandbox-command.js";
 
 export type { BashSandboxConfig } from "./bash-tools.shared.js";
 export type {
@@ -468,6 +479,157 @@ export function createExecTool(
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.
       await validateScriptFileForShellBleed({ command: params.command, workdir });
+
+      if (
+        sandbox?.backendKind === "opensandbox" &&
+        allowBackground &&
+        (backgroundRequested || yieldWindow !== null)
+      ) {
+        const baseUrl = sandbox.opensandboxBaseUrl?.trim();
+        const accessToken = sandbox.opensandboxAccessToken?.trim();
+        if (!baseUrl || !accessToken) {
+          throw new Error(
+            "OpenSandbox background exec requires OPEN_SANDBOX_EXECD_URL and OPEN_SANDBOX_EXECD_ACCESS_TOKEN.",
+          );
+        }
+        const remoteTimeoutSec =
+          explicitTimeoutSec ?? sandbox.opensandboxTimeoutSec ?? defaultTimeoutSec;
+        const commandSessionId = await openSandboxStartCommandSession({
+          baseUrl,
+          accessToken,
+          command: params.command,
+          workdir: containerWorkdir ?? sandbox.containerWorkdir,
+          timeoutSec: remoteTimeoutSec,
+        });
+        const sessionId = createSessionSlug();
+        const startedAt = Date.now();
+        const session = {
+          id: sessionId,
+          command: params.command,
+          scopeKey: defaults?.scopeKey,
+          sessionKey: notifySessionKey,
+          notifyOnExit,
+          notifyOnExitEmptySuccess,
+          exitNotified: false,
+          child: undefined,
+          stdin: undefined,
+          pid: undefined,
+          startedAt,
+          cwd: workdir,
+          maxOutputChars: maxOutput,
+          pendingMaxOutputChars: pendingMaxOutput,
+          totalOutputChars: 0,
+          pendingStdout: [],
+          pendingStderr: [],
+          pendingStdoutChars: 0,
+          pendingStderrChars: 0,
+          aggregated: "",
+          tail: "",
+          exited: false,
+          truncated: false,
+          backgrounded: backgroundRequested,
+          remote: {
+            provider: "opensandbox",
+            baseUrl,
+            accessToken,
+            commandSessionId,
+            outputCursor: 0,
+          },
+        };
+        addSession(session);
+        const syncRemoteSession = async () => {
+          const output = await openSandboxReadCommandOutput({
+            baseUrl,
+            accessToken,
+            sessionId: commandSessionId,
+          });
+          const cursor = Math.max(0, session.remote?.outputCursor ?? 0);
+          const incremental = output.length >= cursor ? output.slice(cursor) : [];
+          for (const item of incremental) {
+            const msg = typeof item.msg === "string" ? item.msg : "";
+            if (!msg) {
+              continue;
+            }
+            appendOutput(session, Number(item.fd) === 2 ? "stderr" : "stdout", msg);
+          }
+          if (session.remote) {
+            session.remote.outputCursor = output.length;
+          }
+          const remoteStatus = await openSandboxReadCommandStatus({
+            baseUrl,
+            accessToken,
+            sessionId: commandSessionId,
+          });
+          const exitCode = Number.isFinite(remoteStatus.exitCode) ? remoteStatus.exitCode : 0;
+          return {
+            exited: !remoteStatus.running,
+            exitCode,
+          };
+        };
+        if (!backgroundRequested && yieldWindow && yieldWindow > 0) {
+          const deadline = Date.now() + yieldWindow;
+          while (Date.now() < deadline) {
+            const remoteState = await syncRemoteSession();
+            if (remoteState.exited) {
+              markExited(
+                session,
+                remoteState.exitCode,
+                null,
+                remoteState.exitCode === 0 ? "completed" : "failed",
+              );
+              const durationMs = Date.now() - startedAt;
+              const aggregated = session.aggregated.trim();
+              if (remoteState.exitCode !== 0) {
+                throw new Error(
+                  aggregated
+                    ? `${aggregated}\n\nProcess exited with code ${remoteState.exitCode}.`
+                    : `Process exited with code ${remoteState.exitCode}.`,
+                );
+              }
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `${getWarningText()}${aggregated || "(no output)"}`,
+                  },
+                ],
+                details: {
+                  status: "completed",
+                  exitCode: remoteState.exitCode,
+                  durationMs,
+                  aggregated,
+                  cwd: workdir,
+                },
+              };
+            }
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) {
+              break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, Math.min(250, remaining)));
+          }
+          markBackgrounded(session);
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `${getWarningText()}Command still running (session ${sessionId}, pid n/a). ` +
+                "Use process (list/poll/log/kill/clear/remove) for follow-up.\n\n" +
+                "Note: OpenSandbox execd does not provide stdin write for running command sessions, " +
+                "so process write/send-keys/submit/paste are unavailable.",
+            },
+          ],
+          details: {
+            status: "running",
+            sessionId,
+            startedAt,
+            cwd: workdir,
+            tail: "",
+          },
+        };
+      }
 
       const run = await runExecProcess({
         command: params.command,

--- a/src/agents/bash-tools.process.opensandbox.test.ts
+++ b/src/agents/bash-tools.process.opensandbox.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  addSession,
+  getFinishedSession,
+  getSession,
+  resetProcessRegistryForTests,
+} from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { createProcessTool } from "./bash-tools.process.js";
+
+const {
+  openSandboxKillCommandSessionMock,
+  openSandboxReadCommandOutputMock,
+  openSandboxReadCommandStatusMock,
+} = vi.hoisted(() => ({
+  openSandboxKillCommandSessionMock: vi.fn(),
+  openSandboxReadCommandOutputMock: vi.fn(),
+  openSandboxReadCommandStatusMock: vi.fn(),
+}));
+
+vi.mock("./sandbox/opensandbox-command.js", () => ({
+  openSandboxReadCommandOutput: (...args: unknown[]) => openSandboxReadCommandOutputMock(...args),
+  openSandboxReadCommandStatus: (...args: unknown[]) => openSandboxReadCommandStatusMock(...args),
+  openSandboxKillCommandSession: (...args: unknown[]) => openSandboxKillCommandSessionMock(...args),
+}));
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+  openSandboxKillCommandSessionMock.mockReset();
+  openSandboxReadCommandOutputMock.mockReset();
+  openSandboxReadCommandStatusMock.mockReset();
+});
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }) {
+  const item = result.content.find((entry) => entry.type === "text");
+  return item?.text ?? "";
+}
+
+test("process poll syncs opensandbox output and completion", async () => {
+  const session = createProcessSessionFixture({
+    id: "sess-os-1",
+    command: "echo hello",
+    backgrounded: true,
+  });
+  session.remote = {
+    provider: "opensandbox",
+    baseUrl: "https://sandbox.example.test/execd",
+    accessToken: "token-1",
+    commandSessionId: "remote-session-1",
+    outputCursor: 0,
+  };
+  addSession(session);
+
+  openSandboxReadCommandOutputMock.mockResolvedValue([{ fd: 1, msg: "hello\n" }]);
+  openSandboxReadCommandStatusMock.mockResolvedValue({ running: false, exitCode: 0 });
+
+  const processTool = createProcessTool();
+  const result = await processTool.execute("toolcall", {
+    action: "poll",
+    sessionId: "sess-os-1",
+  });
+
+  expect(openSandboxReadCommandOutputMock).toHaveBeenCalledWith({
+    baseUrl: "https://sandbox.example.test/execd",
+    accessToken: "token-1",
+    sessionId: "remote-session-1",
+  });
+  expect(openSandboxReadCommandStatusMock).toHaveBeenCalledWith({
+    baseUrl: "https://sandbox.example.test/execd",
+    accessToken: "token-1",
+    sessionId: "remote-session-1",
+  });
+  expect(result.details).toMatchObject({
+    status: "completed",
+    sessionId: "sess-os-1",
+  });
+  expect((result.details as { aggregated?: string }).aggregated ?? "").toContain("hello");
+  expect(firstText(result as { content: Array<{ type: string; text?: string }> })).toContain(
+    "Process exited with code 0",
+  );
+  expect(getFinishedSession("sess-os-1")).toBeDefined();
+});
+
+test("process send-keys fails for opensandbox remote sessions", async () => {
+  const session = createProcessSessionFixture({
+    id: "sess-os-2",
+    command: "bash",
+    backgrounded: true,
+  });
+  session.remote = {
+    provider: "opensandbox",
+    baseUrl: "https://sandbox.example.test/execd",
+    accessToken: "token-1",
+    commandSessionId: "remote-session-2",
+    outputCursor: 0,
+  };
+  addSession(session);
+
+  const processTool = createProcessTool();
+  const result = await processTool.execute("toolcall", {
+    action: "send-keys",
+    sessionId: "sess-os-2",
+    keys: ["Enter"],
+  });
+
+  expect(result.details).toMatchObject({ status: "failed" });
+  expect(firstText(result as { content: Array<{ type: string; text?: string }> })).toContain(
+    "send-keys is unavailable because execd does not expose a command-session stdin write endpoint",
+  );
+  expect(openSandboxReadCommandOutputMock).not.toHaveBeenCalled();
+  expect(openSandboxReadCommandStatusMock).not.toHaveBeenCalled();
+  expect(openSandboxKillCommandSessionMock).not.toHaveBeenCalled();
+});
+
+test("process remove keeps completed status for already-exited opensandbox session", async () => {
+  const session = createProcessSessionFixture({
+    id: "sess-os-3",
+    command: "echo done",
+    backgrounded: true,
+  });
+  session.remote = {
+    provider: "opensandbox",
+    baseUrl: "https://sandbox.example.test/execd",
+    accessToken: "token-1",
+    commandSessionId: "remote-session-3",
+    outputCursor: 0,
+  };
+  session.exited = true;
+  session.exitCode = 0;
+  addSession(session);
+
+  const processTool = createProcessTool();
+  const result = await processTool.execute("toolcall", {
+    action: "remove",
+    sessionId: "sess-os-3",
+  });
+
+  expect(result.details).toMatchObject({ status: "completed" });
+  expect(firstText(result as { content: Array<{ type: string; text?: string }> })).toContain(
+    "Removed remote session sess-os-3.",
+  );
+  expect(openSandboxKillCommandSessionMock).not.toHaveBeenCalled();
+  expect(getSession("sess-os-3")).toBeUndefined();
+  expect(getFinishedSession("sess-os-3")).toBeUndefined();
+});

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -5,6 +5,7 @@ import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.j
 import { killProcessTree } from "../process/kill-tree.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import {
+  appendOutput,
   type ProcessSession,
   deleteSession,
   drainSession,
@@ -18,6 +19,11 @@ import {
 import { deriveSessionName, pad, sliceLogLines, truncateMiddle } from "./bash-tools.shared.js";
 import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import { encodeKeySequence, encodePaste } from "./pty-keys.js";
+import {
+  openSandboxKillCommandSession,
+  openSandboxReadCommandOutput,
+  openSandboxReadCommandStatus,
+} from "./sandbox/opensandbox-command.js";
 
 export type ProcessToolDefaults = {
   cleanupMs?: number;
@@ -114,6 +120,43 @@ function resetPollRetrySuggestion(sessionId: string): void {
   } catch {
     // Ignore diagnostics state failures for process tool behavior.
   }
+}
+
+async function syncOpenSandboxRemoteSession(session: ProcessSession): Promise<{
+  exited: boolean;
+  exitCode?: number;
+}> {
+  const remote = session.remote;
+  if (!remote || remote.provider !== "opensandbox") {
+    return { exited: session.exited, exitCode: session.exitCode ?? undefined };
+  }
+  const output = await openSandboxReadCommandOutput({
+    baseUrl: remote.baseUrl,
+    accessToken: remote.accessToken,
+    sessionId: remote.commandSessionId,
+  });
+  const cursor = Math.max(0, remote.outputCursor ?? 0);
+  const incremental = output.length >= cursor ? output.slice(cursor) : [];
+  for (const item of incremental) {
+    const msg = typeof item.msg === "string" ? item.msg : "";
+    if (!msg) {
+      continue;
+    }
+    const stream = Number(item.fd) === 2 ? "stderr" : "stdout";
+    appendOutput(session, stream, msg);
+  }
+  remote.outputCursor = output.length;
+
+  const status = await openSandboxReadCommandStatus({
+    baseUrl: remote.baseUrl,
+    accessToken: remote.accessToken,
+    sessionId: remote.commandSessionId,
+  });
+  if (status.running) {
+    return { exited: false };
+  }
+  const exitCode = Number.isFinite(status.exitCode) ? status.exitCode : 0;
+  return { exited: true, exitCode };
 }
 
 export function createProcessTool(
@@ -326,8 +369,39 @@ export function createProcessTool(
           if (!scopedSession.backgrounded) {
             return failText(`Session ${params.sessionId} is not backgrounded.`);
           }
+          const isRemoteOpenSandbox =
+            scopedSession.remote?.provider === "opensandbox" && !scopedSession.exited;
           const pollWaitMs = resolvePollWaitMs(params.timeout);
-          if (pollWaitMs > 0 && !scopedSession.exited) {
+          if (isRemoteOpenSandbox) {
+            if (pollWaitMs > 0) {
+              const deadline = Date.now() + pollWaitMs;
+              while (!scopedSession.exited && Date.now() < deadline) {
+                const remoteState = await syncOpenSandboxRemoteSession(scopedSession);
+                if (remoteState.exited) {
+                  markExited(
+                    scopedSession,
+                    remoteState.exitCode ?? 0,
+                    null,
+                    (remoteState.exitCode ?? 0) === 0 ? "completed" : "failed",
+                  );
+                  break;
+                }
+                await new Promise((resolve) =>
+                  setTimeout(resolve, Math.max(0, Math.min(250, deadline - Date.now()))),
+                );
+              }
+            } else {
+              const remoteState = await syncOpenSandboxRemoteSession(scopedSession);
+              if (remoteState.exited) {
+                markExited(
+                  scopedSession,
+                  remoteState.exitCode ?? 0,
+                  null,
+                  (remoteState.exitCode ?? 0) === 0 ? "completed" : "failed",
+                );
+              }
+            }
+          } else if (pollWaitMs > 0 && !scopedSession.exited) {
             const deadline = Date.now() + pollWaitMs;
             while (!scopedSession.exited && Date.now() < deadline) {
               await new Promise((resolve) =>
@@ -398,6 +472,17 @@ export function createProcessTool(
                 details: { status: "failed" },
               };
             }
+            if (scopedSession.remote?.provider === "opensandbox" && !scopedSession.exited) {
+              const remoteState = await syncOpenSandboxRemoteSession(scopedSession);
+              if (remoteState.exited) {
+                markExited(
+                  scopedSession,
+                  remoteState.exitCode ?? 0,
+                  null,
+                  (remoteState.exitCode ?? 0) === 0 ? "completed" : "failed",
+                );
+              }
+            }
             const window = resolveLogSliceWindow(params.offset, params.limit);
             const { slice, totalLines, totalChars } = sliceLogLines(
               scopedSession.aggregated,
@@ -456,6 +541,11 @@ export function createProcessTool(
         }
 
         case "write": {
+          if (scopedSession?.remote?.provider === "opensandbox") {
+            return failedResult(
+              `Session ${params.sessionId} is an OpenSandbox remote session; interactive stdin is unavailable because execd does not expose a command-session stdin write endpoint.`,
+            );
+          }
           const resolved = resolveBackgroundedWritableStdin();
           if (!resolved.ok) {
             return resolved.result;
@@ -473,6 +563,11 @@ export function createProcessTool(
         }
 
         case "send-keys": {
+          if (scopedSession?.remote?.provider === "opensandbox") {
+            return failedResult(
+              `Session ${params.sessionId} is an OpenSandbox remote session; send-keys is unavailable because execd does not expose a command-session stdin write endpoint.`,
+            );
+          }
           const resolved = resolveBackgroundedWritableStdin();
           if (!resolved.ok) {
             return resolved.result;
@@ -502,6 +597,11 @@ export function createProcessTool(
         }
 
         case "submit": {
+          if (scopedSession?.remote?.provider === "opensandbox") {
+            return failedResult(
+              `Session ${params.sessionId} is an OpenSandbox remote session; submit is unavailable because execd does not expose a command-session stdin write endpoint.`,
+            );
+          }
           const resolved = resolveBackgroundedWritableStdin();
           if (!resolved.ok) {
             return resolved.result;
@@ -514,6 +614,11 @@ export function createProcessTool(
         }
 
         case "paste": {
+          if (scopedSession?.remote?.provider === "opensandbox") {
+            return failedResult(
+              `Session ${params.sessionId} is an OpenSandbox remote session; paste is unavailable because execd does not expose a command-session stdin write endpoint.`,
+            );
+          }
           const resolved = resolveBackgroundedWritableStdin();
           if (!resolved.ok) {
             return resolved.result;
@@ -543,6 +648,27 @@ export function createProcessTool(
           }
           if (!scopedSession.backgrounded) {
             return failText(`Session ${params.sessionId} is not backgrounded.`);
+          }
+          if (scopedSession.remote?.provider === "opensandbox") {
+            await openSandboxKillCommandSession({
+              baseUrl: scopedSession.remote.baseUrl,
+              accessToken: scopedSession.remote.accessToken,
+              sessionId: scopedSession.remote.commandSessionId,
+            });
+            markExited(scopedSession, null, "SIGKILL", "failed");
+            resetPollRetrySuggestion(params.sessionId);
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Termination requested for remote session ${params.sessionId}.`,
+                },
+              ],
+              details: {
+                status: "failed",
+                name: deriveSessionName(scopedSession.command),
+              },
+            };
           }
           const canceled = cancelManagedSession(scopedSession.id);
           if (!canceled) {
@@ -593,6 +719,36 @@ export function createProcessTool(
 
         case "remove": {
           if (scopedSession) {
+            if (scopedSession.remote?.provider === "opensandbox") {
+              const exited = scopedSession.exited;
+              const exitCode = scopedSession.exitCode ?? 0;
+              const status =
+                exited && exitCode === 0 && scopedSession.exitSignal == null
+                  ? "completed"
+                  : "failed";
+              if (!exited) {
+                await openSandboxKillCommandSession({
+                  baseUrl: scopedSession.remote.baseUrl,
+                  accessToken: scopedSession.remote.accessToken,
+                  sessionId: scopedSession.remote.commandSessionId,
+                }).catch(() => undefined);
+              }
+              scopedSession.backgrounded = false;
+              deleteSession(params.sessionId);
+              resetPollRetrySuggestion(params.sessionId);
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Removed remote session ${params.sessionId}.`,
+                  },
+                ],
+                details: {
+                  status,
+                  name: deriveSessionName(scopedSession.command),
+                },
+              };
+            }
             const canceled = cancelManagedSession(scopedSession.id);
             if (canceled) {
               // Keep remove semantics deterministic: drop from process registry now.

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -8,6 +8,10 @@ import { assertSandboxPath } from "./sandbox-paths.js";
 const CHUNK_LIMIT = 8 * 1024;
 
 export type BashSandboxConfig = {
+  backendKind?: "docker" | "opensandbox";
+  opensandboxBaseUrl?: string;
+  opensandboxAccessToken?: string;
+  opensandboxTimeoutSec?: number;
   containerName: string;
   workspaceDir: string;
   containerWorkdir: string;

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -5,6 +5,7 @@ import type { SandboxContext } from "./sandbox.js";
 function createSandboxContext(overrides?: Partial<SandboxContext>): SandboxContext {
   const base = {
     enabled: true,
+    backendKind: "docker",
     sessionKey: "session:test",
     workspaceDir: "/tmp/openclaw-sandbox",
     agentWorkspaceDir: "/tmp/openclaw-workspace",
@@ -33,7 +34,7 @@ function createSandboxContext(overrides?: Partial<SandboxContext>): SandboxConte
       containerName: "openclaw-sbx-browser-test",
     },
   } satisfies SandboxContext;
-  return { ...base, ...overrides };
+  return { ...base, ...overrides, backendKind: overrides?.backendKind ?? "docker" };
 }
 
 describe("buildEmbeddedSandboxInfo", () => {

--- a/src/agents/pi-embedded-runner/sandbox-info.ts
+++ b/src/agents/pi-embedded-runner/sandbox-info.ts
@@ -12,6 +12,7 @@ export function buildEmbeddedSandboxInfo(
   const elevatedAllowed = Boolean(execElevated?.enabled && execElevated.allowed);
   return {
     enabled: true,
+    backendKind: sandbox.backendKind,
     workspaceDir: sandbox.workspaceDir,
     containerWorkspaceDir: sandbox.containerWorkdir,
     workspaceAccess: sandbox.workspaceAccess,

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -91,6 +91,7 @@ export type EmbeddedPiCompactResult = {
 
 export type EmbeddedSandboxInfo = {
   enabled: boolean;
+  backendKind?: "docker" | "opensandbox";
   workspaceDir?: string;
   containerWorkspaceDir?: string;
   workspaceAccess?: "none" | "ro" | "rw";

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -574,6 +574,7 @@ describe("Agent-specific tool filtering", () => {
       agentDir: "/tmp/agent-restricted",
       sandbox: {
         enabled: true,
+        backendKind: "docker",
         sessionKey: "agent:restricted:main",
         workspaceDir: "/tmp/sandbox",
         agentWorkspaceDir: "/tmp/test-restricted",

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -340,9 +340,10 @@ export function createOpenClawCodingTools(options?: {
   const fsPolicy = createToolFsPolicy({
     workspaceOnly: isMemoryFlushRun || fsConfig.workspaceOnly,
   });
-  const sandboxRoot = sandbox?.workspaceDir;
-  const sandboxFsBridge = sandbox?.fsBridge;
-  const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
+  const sandboxExecOnly = sandbox?.backendKind === "opensandbox";
+  const sandboxRoot = sandboxExecOnly ? undefined : sandbox?.workspaceDir;
+  const sandboxFsBridge = sandboxExecOnly ? undefined : sandbox?.fsBridge;
+  const allowWorkspaceWrites = sandboxExecOnly ? true : sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
   const workspaceOnly = fsPolicy.workspaceOnly;
   const applyPatchConfig = execConfig.applyPatch;
@@ -375,7 +376,7 @@ export function createOpenClawCodingTools(options?: {
         return [
           workspaceOnly
             ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
-                containerWorkdir: sandbox.containerWorkdir,
+                containerWorkdir: sandbox?.containerWorkdir,
               })
             : sandboxed,
         ];
@@ -435,6 +436,10 @@ export function createOpenClawCodingTools(options?: {
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
     sandbox: sandbox
       ? {
+          backendKind: sandbox.backendKind,
+          opensandboxBaseUrl: sandbox.opensandboxBaseUrl,
+          opensandboxAccessToken: sandbox.opensandboxAccessToken,
+          opensandboxTimeoutSec: sandbox.opensandboxTimeoutSec,
           containerName: sandbox.containerName,
           workspaceDir: sandbox.workspaceDir,
           containerWorkdir: sandbox.containerWorkdir,
@@ -467,7 +472,7 @@ export function createOpenClawCodingTools(options?: {
                   createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
                   sandboxRoot,
                   {
-                    containerWorkdir: sandbox.containerWorkdir,
+                    containerWorkdir: sandbox?.containerWorkdir,
                   },
                 )
               : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
@@ -476,7 +481,7 @@ export function createOpenClawCodingTools(options?: {
                   createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
                   sandboxRoot,
                   {
-                    containerWorkdir: sandbox.containerWorkdir,
+                    containerWorkdir: sandbox?.containerWorkdir,
                   },
                 )
               : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -27,6 +27,11 @@ export {
 } from "./sandbox/runtime-status.js";
 
 export { resolveSandboxToolPolicyForAgent } from "./sandbox/tool-policy.js";
+export type {
+  SandboxBackend,
+  SandboxBackendHandle,
+  SandboxBackendKind,
+} from "./sandbox/backend.js";
 
 export type {
   SandboxBrowserConfig,

--- a/src/agents/sandbox/backend-exec.test.ts
+++ b/src/agents/sandbox/backend-exec.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import { buildSandboxExecInvocation } from "./backend-exec.js";
+
+test("opensandbox foreground invocation preserves merged env payload", () => {
+  const result = buildSandboxExecInvocation({
+    sandbox: {
+      backendKind: "opensandbox",
+      opensandboxBaseUrl: "https://sandbox.example.test/execd",
+      opensandboxAccessToken: "token-1",
+      opensandboxTimeoutSec: 60,
+      containerName: "unused",
+      workspaceDir: "/tmp/ws",
+      containerWorkdir: "/workspace",
+    },
+    command: "printenv",
+    workdir: "/workspace",
+    env: {
+      FOO: "bar",
+      PATH: "/usr/local/bin:/usr/bin",
+    },
+    tty: false,
+  });
+
+  expect(result.backendId).toBe("exec-sandbox-opensandbox");
+  expect(result.env.OPENCLAW_OPENSANDBOX_ENV_JSON).toBe(
+    JSON.stringify({
+      FOO: "bar",
+      PATH: "/usr/local/bin:/usr/bin",
+    }),
+  );
+});

--- a/src/agents/sandbox/backend-exec.ts
+++ b/src/agents/sandbox/backend-exec.ts
@@ -1,0 +1,105 @@
+import { buildDockerExecArgs, type BashSandboxConfig } from "../bash-tools.shared.js";
+
+export type SandboxExecInvocation = {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+  backendId: "exec-sandbox" | "exec-sandbox-opensandbox";
+};
+
+export function buildSandboxExecInvocation(params: {
+  sandbox: BashSandboxConfig;
+  command: string;
+  workdir?: string;
+  env: Record<string, string>;
+  tty: boolean;
+}): SandboxExecInvocation {
+  const backendKind = params.sandbox.backendKind ?? "docker";
+  if (backendKind === "docker") {
+    return {
+      argv: [
+        "docker",
+        ...buildDockerExecArgs({
+          containerName: params.sandbox.containerName,
+          command: params.command,
+          workdir: params.workdir,
+          env: params.env,
+          tty: params.tty,
+        }),
+      ],
+      env: process.env,
+      backendId: "exec-sandbox",
+    };
+  }
+
+  const baseUrl = params.sandbox.opensandboxBaseUrl?.trim();
+  if (!baseUrl) {
+    throw new Error(
+      'Sandbox backend "opensandbox" requires OPEN_SANDBOX_EXECD_URL (or sandbox.opensandboxBaseUrl) to be set.',
+    );
+  }
+  const accessToken = params.sandbox.opensandboxAccessToken?.trim();
+  if (!accessToken) {
+    throw new Error(
+      'Sandbox backend "opensandbox" requires OPEN_SANDBOX_EXECD_ACCESS_TOKEN (or sandbox.opensandboxAccessToken) to be set.',
+    );
+  }
+
+  const timeoutSec =
+    typeof params.sandbox.opensandboxTimeoutSec === "number" &&
+    params.sandbox.opensandboxTimeoutSec > 0
+      ? Math.floor(params.sandbox.opensandboxTimeoutSec)
+      : 1800;
+  const envJson = JSON.stringify(params.env ?? {});
+  const script = [
+    "const base=(process.env.OPENCLAW_OPENSANDBOX_BASE_URL||'').replace(/\\/$/,'');",
+    "const token=process.env.OPENCLAW_OPENSANDBOX_ACCESS_TOKEN||'';",
+    "const command=process.env.OPENCLAW_OPENSANDBOX_COMMAND||'';",
+    "const workdir=process.env.OPENCLAW_OPENSANDBOX_WORKDIR||'/workspace';",
+    "const envJson=process.env.OPENCLAW_OPENSANDBOX_ENV_JSON||'{}';",
+    "const timeoutRaw=process.env.OPENCLAW_OPENSANDBOX_TIMEOUT_SEC||'1800';",
+    "const timeout=Number.parseInt(timeoutRaw,10);",
+    "if(!base){console.error('OPENCLAW_OPENSANDBOX_BASE_URL is required');process.exit(1);}",
+    "if(!token){console.error('OPENCLAW_OPENSANDBOX_ACCESS_TOKEN is required');process.exit(1);}",
+    "if(!command){console.error('OPENCLAW_OPENSANDBOX_COMMAND is required');process.exit(1);}",
+    "let commandEnv={};",
+    "try{const parsed=JSON.parse(envJson);if(parsed&&typeof parsed==='object'&&!Array.isArray(parsed)){commandEnv=parsed;}}catch{console.error('OPENCLAW_OPENSANDBOX_ENV_JSON is invalid JSON');process.exit(1);}",
+    "const headers={'Content-Type':'application/json','X-EXECD-ACCESS-TOKEN':token};",
+    "const body={command,workdir,env:commandEnv,wait:true,timeout:Number.isFinite(timeout)&&timeout>0?timeout:1800};",
+    "const run=async()=>{",
+    "const res=await fetch(base+'/command',{method:'POST',headers,body:JSON.stringify(body)});",
+    "const text=await res.text();",
+    "let payload=null;",
+    "try{payload=text?JSON.parse(text):null;}catch{payload={raw:text};}",
+    "const root=payload&&typeof payload==='object'?payload:null;",
+    "const nested=root&&root.data&&typeof root.data==='object'?root.data:root;",
+    "if(!res.ok){const errRaw=nested&&'error' in nested?nested.error:(nested&&'message' in nested?nested.message:undefined);const msg=(typeof errRaw==='string'&&errRaw.trim())?errRaw.trim():(text||('OpenSandbox execd HTTP '+res.status));console.error(msg);process.exit(1);}",
+    "const output=(nested&&Array.isArray(nested.output)?nested.output:[])||[];",
+    "for(const item of output){",
+    "const fdRaw=item&&typeof item==='object'&&'fd' in item?Number(item.fd):1;",
+    "const msg=item&&typeof item==='object'&&'msg' in item?String(item.msg??''):'';",
+    "if(!msg)continue;",
+    "const stream=fdRaw===2?process.stderr:process.stdout;",
+    "stream.write(msg);",
+    "if(!msg.endsWith('\\n'))stream.write('\\n');",
+    "}",
+    "const exitCodeRaw=(nested&&('exit_code' in nested?nested.exit_code:('exitCode' in nested?nested.exitCode:0)))??0;",
+    "const exitCode=Number(exitCodeRaw);",
+    "process.exit(Number.isFinite(exitCode)?Math.max(0,Math.floor(exitCode)):0);",
+    "};",
+    "run().catch((err)=>{console.error(err&&err.message?err.message:String(err));process.exit(1);});",
+  ].join("");
+
+  return {
+    argv: [process.execPath, "-e", script],
+    env: {
+      ...process.env,
+      OPENCLAW_OPENSANDBOX_BASE_URL: baseUrl,
+      OPENCLAW_OPENSANDBOX_ACCESS_TOKEN: accessToken,
+      OPENCLAW_OPENSANDBOX_COMMAND: params.command,
+      OPENCLAW_OPENSANDBOX_WORKDIR: params.workdir ?? "/workspace",
+      OPENCLAW_OPENSANDBOX_ENV_JSON: envJson,
+      OPENCLAW_OPENSANDBOX_TIMEOUT_SEC: String(timeoutSec),
+    },
+    backendId: "exec-sandbox-opensandbox",
+  };
+}

--- a/src/agents/sandbox/backend.ts
+++ b/src/agents/sandbox/backend.ts
@@ -1,0 +1,25 @@
+export type SandboxBackendKind = "docker" | "opensandbox";
+
+/**
+ * Backend-agnostic sandbox handle used by tool/runtime layers.
+ * `metadata` is intentionally opaque so each backend can evolve independently.
+ */
+export type SandboxBackendHandle = {
+  kind: SandboxBackendKind;
+  metadata?: Record<string, string>;
+};
+
+/**
+ * Minimal backend contract for decoupling gateway orchestration from sandbox runtime.
+ * Current codebase only wires docker execution; OpenSandbox can implement this contract
+ * incrementally without changing higher-level tool orchestration logic.
+ */
+export interface SandboxBackend {
+  kind: SandboxBackendKind;
+  ensureSession(params: {
+    sessionKey: string;
+    workspaceDir: string;
+    agentWorkspaceDir: string;
+  }): Promise<SandboxBackendHandle>;
+  destroySession(params: { sessionKey: string }): Promise<void>;
+}

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -11,6 +11,7 @@ import { ensureSandboxBrowser } from "./browser.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
 import { ensureSandboxContainer } from "./docker.js";
 import { createSandboxFsBridge } from "./fs-bridge.js";
+import { resolveOpenSandboxExecdRuntimeFromEnv } from "./opensandbox-lifecycle.js";
 import { maybePruneSandboxes } from "./prune.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
 import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js";
@@ -116,7 +117,11 @@ export async function resolveSandboxContext(params: {
   }
   const { rawSessionKey, cfg } = resolved;
 
-  await maybePruneSandboxes(cfg);
+  const sandboxBackendEnv = process.env.OPENCLAW_SANDBOX_BACKEND?.trim().toLowerCase();
+  const backendKind = sandboxBackendEnv === "opensandbox" ? "opensandbox" : "docker";
+  if (backendKind === "docker") {
+    await maybePruneSandboxes(cfg);
+  }
 
   const { agentWorkspaceDir, scopeKey, workspaceDir } = await ensureSandboxWorkspaceLayout({
     cfg,
@@ -131,43 +136,74 @@ export async function resolveSandboxContext(params: {
   });
   const resolvedCfg = docker === cfg.docker ? cfg : { ...cfg, docker };
 
-  const containerName = await ensureSandboxContainer({
-    sessionKey: rawSessionKey,
-    workspaceDir,
-    agentWorkspaceDir,
-    cfg: resolvedCfg,
-  });
+  const containerName =
+    backendKind === "docker"
+      ? await ensureSandboxContainer({
+          sessionKey: rawSessionKey,
+          workspaceDir,
+          agentWorkspaceDir,
+          cfg: resolvedCfg,
+        })
+      : `opensandbox-${scopeKey}`;
 
   const evaluateEnabled =
     params.config?.browser?.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED;
 
-  const bridgeAuth = cfg.browser.enabled
-    ? await (async () => {
-        // Sandbox browser bridge server runs on a loopback TCP port; always wire up
-        // the same auth that loopback browser clients will send (token/password).
-        const cfgForAuth = params.config ?? loadConfig();
-        let browserAuth = resolveBrowserControlAuth(cfgForAuth);
-        try {
-          const ensured = await ensureBrowserControlAuth({ cfg: cfgForAuth });
-          browserAuth = ensured.auth;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : JSON.stringify(error);
-          defaultRuntime.error?.(`Sandbox browser auth ensure failed: ${message}`);
-        }
-        return browserAuth;
-      })()
-    : undefined;
-  const browser = await ensureSandboxBrowser({
-    scopeKey,
-    workspaceDir,
-    agentWorkspaceDir,
-    cfg: resolvedCfg,
-    evaluateEnabled,
-    bridgeAuth,
-  });
+  const bridgeAuth =
+    backendKind === "docker" && cfg.browser.enabled
+      ? await (async () => {
+          // Sandbox browser bridge server runs on a loopback TCP port; always wire up
+          // the same auth that loopback browser clients will send (token/password).
+          const cfgForAuth = params.config ?? loadConfig();
+          let browserAuth = resolveBrowserControlAuth(cfgForAuth);
+          try {
+            const ensured = await ensureBrowserControlAuth({ cfg: cfgForAuth });
+            browserAuth = ensured.auth;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : JSON.stringify(error);
+            defaultRuntime.error?.(`Sandbox browser auth ensure failed: ${message}`);
+          }
+          return browserAuth;
+        })()
+      : undefined;
+  const browser =
+    backendKind === "docker"
+      ? await ensureSandboxBrowser({
+          scopeKey,
+          workspaceDir,
+          agentWorkspaceDir,
+          cfg: resolvedCfg,
+          evaluateEnabled,
+          bridgeAuth,
+        })
+      : null;
+
+  const opensandboxResolved =
+    backendKind === "opensandbox"
+      ? await resolveOpenSandboxExecdRuntimeFromEnv({
+          warn: (message) => defaultRuntime.error?.(message),
+        })
+      : { execdBaseUrl: undefined, sandboxId: undefined };
+  const opensandboxBaseUrl = opensandboxResolved.execdBaseUrl;
+  const opensandboxAccessToken = process.env.OPEN_SANDBOX_EXECD_ACCESS_TOKEN?.trim() || undefined;
+  const lifecycleApiKey = process.env.OPEN_SANDBOX_API_KEY?.trim() || undefined;
+  if (backendKind === "opensandbox" && !opensandboxAccessToken && lifecycleApiKey) {
+    defaultRuntime.error?.(
+      "OpenSandbox: OPEN_SANDBOX_API_KEY is for lifecycle endpoints only and cannot be used as an execd access token. Set OPEN_SANDBOX_EXECD_ACCESS_TOKEN.",
+    );
+  }
+  const opensandboxTimeoutRaw = process.env.OPEN_SANDBOX_EXECD_TIMEOUT_SEC?.trim();
+  const opensandboxTimeoutSec =
+    opensandboxTimeoutRaw && Number.isFinite(Number(opensandboxTimeoutRaw))
+      ? Number(opensandboxTimeoutRaw)
+      : undefined;
 
   const sandboxContext: SandboxContext = {
     enabled: true,
+    backendKind,
+    opensandboxBaseUrl,
+    opensandboxAccessToken,
+    opensandboxTimeoutSec,
     sessionKey: rawSessionKey,
     workspaceDir,
     agentWorkspaceDir,
@@ -180,7 +216,9 @@ export async function resolveSandboxContext(params: {
     browser: browser ?? undefined,
   };
 
-  sandboxContext.fsBridge = createSandboxFsBridge({ sandbox: sandboxContext });
+  if (backendKind === "docker") {
+    sandboxContext.fsBridge = createSandboxFsBridge({ sandbox: sandboxContext });
+  }
 
   return sandboxContext;
 }

--- a/src/agents/sandbox/opensandbox-command.ts
+++ b/src/agents/sandbox/opensandbox-command.ts
@@ -1,0 +1,215 @@
+type OpenSandboxOutputItem = {
+  fd?: number;
+  msg?: string;
+};
+
+type OpenSandboxStatusResult = {
+  running: boolean;
+  exitCode?: number;
+};
+
+type FetchJsonResult = {
+  ok: boolean;
+  status: number;
+  payload?: unknown;
+  text?: string;
+};
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/$/, "");
+}
+
+function parseNestedPayload(payload: unknown): Record<string, unknown> | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const record = payload as Record<string, unknown>;
+  const nested = record.data;
+  if (nested && typeof nested === "object") {
+    return nested as Record<string, unknown>;
+  }
+  return record;
+}
+
+function readStringField(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readNumberField(record: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    const parsed = typeof value === "number" ? value : Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+async function fetchJson(params: {
+  url: string;
+  method: "GET" | "POST";
+  accessToken: string;
+  body?: unknown;
+  timeoutMs?: number;
+}): Promise<FetchJsonResult> {
+  const ctrl = new AbortController();
+  const timeout = setTimeout(() => ctrl.abort(), params.timeoutMs ?? 10_000);
+  try {
+    const res = await fetch(params.url, {
+      method: params.method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-EXECD-ACCESS-TOKEN": params.accessToken,
+      },
+      body: params.body === undefined ? undefined : JSON.stringify(params.body),
+      signal: ctrl.signal,
+    });
+    const text = await res.text();
+    if (!text.trim()) {
+      return { ok: res.ok, status: res.status, text };
+    }
+    try {
+      return { ok: res.ok, status: res.status, payload: JSON.parse(text), text };
+    } catch {
+      return { ok: res.ok, status: res.status, text };
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function failWithHttp(prefix: string, result: FetchJsonResult): never {
+  const nested = parseNestedPayload(result.payload);
+  const message =
+    (nested && readStringField(nested, ["error", "message", "msg"])) ||
+    (result.text && result.text.trim()) ||
+    `HTTP ${result.status}`;
+  throw new Error(`${prefix}: ${message}`);
+}
+
+export async function openSandboxStartCommandSession(params: {
+  baseUrl: string;
+  accessToken: string;
+  command: string;
+  workdir: string;
+  timeoutSec: number;
+}): Promise<string> {
+  const url = `${normalizeBaseUrl(params.baseUrl)}/command`;
+  const result = await fetchJson({
+    url,
+    method: "POST",
+    accessToken: params.accessToken,
+    body: {
+      command: params.command,
+      workdir: params.workdir,
+      wait: false,
+      timeout: params.timeoutSec,
+    },
+  });
+  if (!result.ok) {
+    failWithHttp("OpenSandbox start command failed", result);
+  }
+  const nested = parseNestedPayload(result.payload);
+  if (!nested) {
+    throw new Error("OpenSandbox start command failed: empty response payload");
+  }
+  const sessionId = readStringField(nested, [
+    "session_id",
+    "sessionId",
+    "id",
+    "command_session_id",
+    "commandSessionId",
+  ]);
+  if (!sessionId) {
+    throw new Error("OpenSandbox start command failed: missing session id in response");
+  }
+  return sessionId;
+}
+
+export async function openSandboxReadCommandStatus(params: {
+  baseUrl: string;
+  accessToken: string;
+  sessionId: string;
+}): Promise<OpenSandboxStatusResult> {
+  const url = `${normalizeBaseUrl(params.baseUrl)}/command/status/${encodeURIComponent(params.sessionId)}`;
+  const result = await fetchJson({
+    url,
+    method: "GET",
+    accessToken: params.accessToken,
+  });
+  if (!result.ok) {
+    failWithHttp("OpenSandbox command status failed", result);
+  }
+  const nested = parseNestedPayload(result.payload) ?? {};
+  const runningRaw =
+    nested.running ??
+    nested.is_running ??
+    nested.active ??
+    nested.isActive ??
+    nested.in_progress ??
+    nested.inProgress;
+  const running =
+    typeof runningRaw === "boolean"
+      ? runningRaw
+      : typeof runningRaw === "number"
+        ? runningRaw !== 0
+        : typeof runningRaw === "string"
+          ? ["running", "true", "1", "yes"].includes(runningRaw.trim().toLowerCase())
+          : false;
+  const state = readStringField(nested, ["state", "status"]);
+  if (!running && state) {
+    const normalized = state.toLowerCase();
+    if (normalized === "running" || normalized === "pending") {
+      return { running: true };
+    }
+  }
+  const exitCode = readNumberField(nested, ["exit_code", "exitCode", "code"]);
+  return { running, exitCode };
+}
+
+export async function openSandboxReadCommandOutput(params: {
+  baseUrl: string;
+  accessToken: string;
+  sessionId: string;
+}): Promise<OpenSandboxOutputItem[]> {
+  const url = `${normalizeBaseUrl(params.baseUrl)}/command/output/${encodeURIComponent(params.sessionId)}`;
+  const result = await fetchJson({
+    url,
+    method: "GET",
+    accessToken: params.accessToken,
+  });
+  if (!result.ok) {
+    failWithHttp("OpenSandbox command output failed", result);
+  }
+  const nested = parseNestedPayload(result.payload) ?? {};
+  const output = nested.output;
+  if (!Array.isArray(output)) {
+    return [];
+  }
+  return output
+    .filter((item) => item && typeof item === "object")
+    .map((item) => item as OpenSandboxOutputItem);
+}
+
+export async function openSandboxKillCommandSession(params: {
+  baseUrl: string;
+  accessToken: string;
+  sessionId: string;
+}): Promise<void> {
+  const url = `${normalizeBaseUrl(params.baseUrl)}/command/kill/${encodeURIComponent(params.sessionId)}`;
+  const result = await fetchJson({
+    url,
+    method: "POST",
+    accessToken: params.accessToken,
+  });
+  if (!result.ok) {
+    failWithHttp("OpenSandbox kill command failed", result);
+  }
+}

--- a/src/agents/sandbox/opensandbox-lifecycle.ts
+++ b/src/agents/sandbox/opensandbox-lifecycle.ts
@@ -1,0 +1,130 @@
+type ResolveOpenSandboxExecdResult = {
+  execdBaseUrl?: string;
+  sandboxId?: string;
+};
+
+function trimOrUndefined(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function parseEndpointPayload(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const record = payload as Record<string, unknown>;
+  const direct =
+    (typeof record.endpoint === "string" && record.endpoint) ||
+    (typeof record.url === "string" && record.url) ||
+    (typeof record.access_url === "string" && record.access_url);
+  if (direct) {
+    return direct;
+  }
+  const data = record.data;
+  if (data && typeof data === "object") {
+    const nested = data as Record<string, unknown>;
+    return (
+      (typeof nested.endpoint === "string" && nested.endpoint) ||
+      (typeof nested.url === "string" && nested.url) ||
+      (typeof nested.access_url === "string" && nested.access_url) ||
+      undefined
+    );
+  }
+  return undefined;
+}
+
+async function fetchJson(params: {
+  url: string;
+  init?: RequestInit;
+  timeoutMs?: number;
+}): Promise<{ ok: boolean; status: number; payload?: unknown; text?: string }> {
+  const ctrl = new AbortController();
+  const timeout = setTimeout(() => ctrl.abort(), params.timeoutMs ?? 10_000);
+  try {
+    const res = await fetch(params.url, {
+      ...params.init,
+      signal: ctrl.signal,
+    });
+    const text = await res.text();
+    if (!text.trim()) {
+      return { ok: res.ok, status: res.status, text };
+    }
+    try {
+      return { ok: res.ok, status: res.status, payload: JSON.parse(text), text };
+    } catch {
+      return { ok: res.ok, status: res.status, text };
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function resolveOpenSandboxExecdRuntimeFromEnv(params?: {
+  warn?: (message: string) => void;
+}): Promise<ResolveOpenSandboxExecdResult> {
+  const explicitExecdUrl = trimOrUndefined(process.env.OPEN_SANDBOX_EXECD_URL);
+  if (explicitExecdUrl) {
+    return {
+      execdBaseUrl: explicitExecdUrl,
+      sandboxId: trimOrUndefined(process.env.OPEN_SANDBOX_SANDBOX_ID),
+    };
+  }
+
+  const lifecycleBaseUrl = trimOrUndefined(process.env.OPEN_SANDBOX_LIFECYCLE_URL);
+  const apiKey = trimOrUndefined(process.env.OPEN_SANDBOX_API_KEY);
+  const sandboxId = trimOrUndefined(process.env.OPEN_SANDBOX_SANDBOX_ID);
+  const execdPort = Number.parseInt(process.env.OPEN_SANDBOX_EXECD_PORT?.trim() || "44772", 10);
+  const renewTimeoutSec = Number.parseInt(
+    process.env.OPEN_SANDBOX_RENEW_TIMEOUT_SEC?.trim() || "1800",
+    10,
+  );
+  const requestTimeoutMs = Number.parseInt(
+    process.env.OPEN_SANDBOX_LIFECYCLE_TIMEOUT_MS?.trim() || "8000",
+    10,
+  );
+
+  if (!lifecycleBaseUrl || !apiKey || !sandboxId || !Number.isFinite(execdPort) || execdPort <= 0) {
+    return { execdBaseUrl: undefined, sandboxId };
+  }
+
+  const normalizedBase = lifecycleBaseUrl.replace(/\/$/, "");
+  const headers = {
+    "Content-Type": "application/json",
+    "OPEN-SANDBOX-API-KEY": apiKey,
+  };
+  // Best-effort renew; failures should not block command execution when endpoint is still valid.
+  await fetchJson({
+    url: `${normalizedBase}/v1/sandboxes/${encodeURIComponent(sandboxId)}/renew-expiration`,
+    init: {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        timeout: Number.isFinite(renewTimeoutSec) && renewTimeoutSec > 0 ? renewTimeoutSec : 1800,
+      }),
+    },
+    timeoutMs: requestTimeoutMs,
+  }).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    params?.warn?.(`OpenSandbox renew failed for ${sandboxId}: ${message}`);
+  });
+
+  const endpointRes = await fetchJson({
+    url: `${normalizedBase}/v1/sandboxes/${encodeURIComponent(sandboxId)}/endpoints/${execdPort}`,
+    init: { method: "GET", headers },
+    timeoutMs: requestTimeoutMs,
+  });
+  if (!endpointRes.ok) {
+    params?.warn?.(
+      `OpenSandbox endpoint lookup failed for ${sandboxId}:${execdPort} (status ${endpointRes.status}).`,
+    );
+    return { execdBaseUrl: undefined, sandboxId };
+  }
+  const endpoint = parseEndpointPayload(endpointRes.payload);
+  if (!endpoint) {
+    params?.warn?.(
+      `OpenSandbox endpoint payload missing endpoint URL for ${sandboxId}:${execdPort}.`,
+    );
+    return { execdBaseUrl: undefined, sandboxId };
+  }
+  return { execdBaseUrl: endpoint, sandboxId };
+}

--- a/src/agents/sandbox/test-fixtures.ts
+++ b/src/agents/sandbox/test-fixtures.ts
@@ -37,6 +37,7 @@ export function createSandboxTestContext(params?: {
     tools: { allow: ["*"], deny: [] },
     browserAllowHostControl: false,
     ...sandboxOverrides,
+    backendKind: overrides?.backendKind ?? "docker",
     docker,
   };
 }

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -71,6 +71,10 @@ export type SandboxBrowserContext = {
 
 export type SandboxContext = {
   enabled: boolean;
+  backendKind: "docker" | "opensandbox";
+  opensandboxBaseUrl?: string;
+  opensandboxAccessToken?: string;
+  opensandboxTimeoutSec?: number;
   sessionKey: string;
   workspaceDir: string;
   agentWorkspaceDir: string;

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -517,6 +517,9 @@ export function buildAgentSystemPrompt(params: {
     params.sandboxInfo?.enabled
       ? [
           "You are running in a sandboxed runtime (tools execute in Docker).",
+          params.sandboxInfo.backendKind === "opensandbox"
+            ? "Sandbox backend: OpenSandbox execd. Interactive stdin for running sessions is unavailable (process write/send-keys/submit/paste are not supported)."
+            : "",
           "Some tools may be unavailable due to sandbox policy.",
           "Sub-agents stay sandboxed (no elevated/host access). Need outside-sandbox read/write? Don't spawn; ask first.",
           hasSessionsSpawn && acpEnabled

--- a/src/agents/test-helpers/pi-tools-sandbox-context.ts
+++ b/src/agents/test-helpers/pi-tools-sandbox-context.ts
@@ -18,6 +18,7 @@ export function createPiToolsSandboxContext(params: PiToolsSandboxContextParams)
   const workspaceDir = params.workspaceDir;
   return {
     enabled: true,
+    backendKind: "docker",
     sessionKey: params.sessionKey ?? "sandbox:test",
     workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir ?? workspaceDir,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw sandbox execution path was tightly Docker-oriented; no backend abstraction for decoupled gateway/sandbox execution, and no OpenSandbox command-session integration for `exec/process`.
- Why it matters: Gateway-sandbox decoupling needs a remote execution backend path; without it, OpenSandbox cannot be used as a drop-in sandbox executor, and background command lifecycle is incomplete.
- What changed: Added sandbox backend abstraction (`docker`/`opensandbox`), OpenSandbox lifecycle + execd command APIs, OpenSandbox-aware `exec` background session creation, `process` remote poll/log/kill/remove support, and explicit stdin-write limitation handling (`write/send-keys/submit/paste` fail fast for remote sessions). Added docs + focused tests.
- What did NOT change (scope boundary): No full fs bridge for OpenSandbox yet (file tools still host-side fallback in this short-term path); no new interactive stdin capability in OpenSandbox execd (blocked by upstream API).

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New optional backend: set `OPENCLAW_SANDBOX_BACKEND=opensandbox` to route sandbox command execution to OpenSandbox execd.
- For OpenSandbox backend, background/yield `exec` now returns a running session tracked via `process`.
- `process` now supports OpenSandbox remote sessions for `list/poll/log/kill/remove`.
- `process write/send-keys/submit/paste` now return explicit unsupported errors for OpenSandbox remote sessions.
- System prompt / running output now explicitly warns about OpenSandbox stdin-write limitation.
- Docs updated in `docs/gateway/sandboxing.md` with OpenSandbox env/config and short-term boundary notes.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation:
  - Risk: Remote command execution now depends on OpenSandbox endpoints and tokens.
  - Mitigation: Explicit env-gated opt-in backend; hard failure on missing required URL/token; clear boundary that interactive stdin is unavailable; no new OpenSandbox fs write bridge added in this PR.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm (local dev), OpenClaw repo workspace
- Model/provider: N/A (tooling/unit tests)
- Integration/channel (if any): N/A
- Relevant config (redacted): `OPENCLAW_SANDBOX_BACKEND=opensandbox` with OpenSandbox env vars

### Steps

1. Configure OpenSandbox backend env vars (execd URL + token, or lifecycle URL + API key + sandbox ID).
2. Run `exec` with `background: true` under sandbox host path.
3. Use `process poll/log/kill/remove` on returned session; try `process send-keys` on same session.

### Expected

- Background exec creates remote session and is trackable via `process`.
- Poll/log reflect remote output and completion.
- send-keys/write/submit/paste return explicit unsupported error for OpenSandbox remote sessions.

### Actual

- Matched expected behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New unit tests passed:
    - `src/agents/bash-tools.exec.opensandbox.test.ts`
    - `src/agents/bash-tools.process.opensandbox.test.ts`
  - `pnpm tsgo` passes after fixing existing test typing issue in `src/cli/update-cli.test.ts`.
  - `pnpm lint` passes, including fix for `no-base-to-string` in `src/agents/sandbox/opensandbox-command.ts`.
- Edge cases checked:
  - Missing OpenSandbox URL/token causes explicit error on background exec path.
  - Remote session poll handles completion and output cursor update.
  - Unsupported stdin-write actions fail with clear message.
- What you did **not** verify:
  - End-to-end against a live OpenSandbox deployment with real network traffic.
  - Full fs bridge behavior for OpenSandbox (out of scope by design).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): Yes
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:
  - N/A (opt-in backend only).

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Unset `OPENCLAW_SANDBOX_BACKEND=opensandbox` (or set backend back to default docker path).
- Files/config to restore:
  - Env/config: backend + OpenSandbox env vars.
- Known bad symptoms reviewers should watch for:
  - Background exec on OpenSandbox fails due to missing URL/token.
  - Process remote sessions stuck in running if upstream status/output API is unavailable.

## Risks and Mitigations

- Risk: API contract mismatch with OpenSandbox execd payloads/status fields.
  - Mitigation: tolerant field parsing (`running` aliases, `data` nesting) + explicit errors on malformed responses.
- Risk: User expectation mismatch for interactive process control.
  - Mitigation: explicit system prompt + exec running-message warning + fast-fail error text on unsupported actions.
- Risk: Regression to existing docker sandbox path.
  - Mitigation: backend selection is env-gated; existing docker path unchanged; targeted tests added for new backend path.