### PR TITLE
feat: ui.customTabs — add user-configurable navigation tabs with iframe views

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -941,6 +941,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Display name shown for the assistant in UI views, chat chrome, and status contexts. Keep this stable so operators can reliably identify which assistant persona is active.",
   "ui.assistant.avatar":
     "Assistant avatar image source used in UI surfaces (URL, path, or data URI depending on runtime support). Use trusted assets and consistent branding dimensions for clean rendering.",
+  "ui.customTabs":
+    "Array of user-defined iframe tabs embedded in the OpenClaw dashboard nav. Each entry requires id (unique slug), label (display name), and url. Optional icon accepts any IconName key.",
   plugins:
     "Plugin system controls for enabling extensions, constraining load scope, configuring entries, and tracking installs. Keep plugin policy explicit and least-privilege in production environments.",
   "plugins.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -509,6 +509,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "ui.assistant": "Assistant Appearance",
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
+  "ui.customTabs": "Custom Tabs",
   "browser.evaluateEnabled": "Browser Evaluate Enabled",
   "browser.snapshotDefaults": "Browser Snapshot Defaults",
   "browser.snapshotDefaults.mode": "Browser Snapshot Mode",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -393,7 +393,12 @@ export const OpenClawSchema = z
                 id: z.string().min(1),
                 label: z.string().min(1),
                 icon: z.string().optional(),
-                url: z.string().min(1),
+                url: z
+                  .string()
+                  .url()
+                  .refine((u) => /^https?:\/\//i.test(u), {
+                    message: "customTab url must use http or https",
+                  }),
               })
               .strict(),
           )

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -386,6 +386,18 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        customTabs: z
+          .array(
+            z
+              .object({
+                id: z.string().min(1),
+                label: z.string().min(1),
+                icon: z.string().optional(),
+                url: z.string().min(1),
+              })
+              .strict(),
+          )
+          .optional(),
       })
       .strict()
       .optional(),

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -21,6 +21,7 @@ export const de: TranslationMap = {
     settings: "Einstellungen",
     expand: "Seitenleiste ausklappen",
     collapse: "Seitenleiste einklappen",
+    custom: "Custom",
   },
   tabs: {
     agents: "Agenten",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -21,6 +21,7 @@ export const en: TranslationMap = {
     control: "Control",
     agent: "Agent",
     settings: "Settings",
+    custom: "Custom",
     expand: "Expand sidebar",
     collapse: "Collapse sidebar",
     resize: "Resize sidebar",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -21,6 +21,7 @@ export const es: TranslationMap = {
     settings: "Ajustes",
     expand: "Expandir barra lateral",
     collapse: "Contraer barra lateral",
+    custom: "Custom",
   },
   tabs: {
     agents: "Agentes",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -22,6 +22,7 @@ export const pt_BR: TranslationMap = {
     settings: "Configurações",
     expand: "Expandir barra lateral",
     collapse: "Recolher barra lateral",
+    custom: "Custom",
     resize: "Redimensionar barra lateral",
   },
   tabs: {

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -22,6 +22,7 @@ export const zh_CN: TranslationMap = {
     settings: "设置",
     expand: "展开侧边栏",
     collapse: "折叠侧边栏",
+    custom: "Custom",
     resize: "调整侧边栏大小",
   },
   tabs: {

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -22,6 +22,7 @@ export const zh_TW: TranslationMap = {
     settings: "設置",
     expand: "展開側邊欄",
     collapse: "折疊側邊欄",
+    custom: "Custom",
     resize: "調整側邊欄大小",
   },
   tabs: {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -9,7 +9,7 @@ import { OpenClawApp } from "./app.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
-import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
+import { iconForTab, pathForTab, titleForTab, type CustomTab, type Tab } from "./navigation.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode, ThemeName } from "./theme.ts";
 import type { SessionsListResult } from "./types.ts";
@@ -83,6 +83,30 @@ export function renderTab(state: AppViewState, tab: Tab) {
       <span class="nav-item__icon" aria-hidden="true">${icons[iconForTab(tab)]}</span>
       ${!collapsed ? html`<span class="nav-item__text">${titleForTab(tab)}</span>` : nothing}
     </a>
+  `;
+}
+
+/**
+ * Render a single user-defined custom tab nav item.
+ * Clicking sets `state.customTabActive` on click.
+ */
+export function renderCustomTabItem(state: AppViewState, tab: CustomTab) {
+  const isActive = state.customTabActive === tab.id;
+  const collapsed = state.settings.navCollapsed;
+  const iconKey = (tab.icon ?? "globe") as keyof typeof icons;
+  const icon = icons[iconKey] ?? icons["globe"];
+  return html`
+    <button
+      class="nav-item ${isActive ? "nav-item--active" : ""}"
+      @click=${() => {
+        state.customTabActive = tab.id;
+      }}
+      title=${tab.label}
+      type="button"
+    >
+      <span class="nav-item__icon" aria-hidden="true">${icon}</span>
+      ${!collapsed ? html`<span class="nav-item__text">${tab.label}</span>` : nothing}
+    </button>
   `;
 }
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -76,6 +76,7 @@ export function renderTab(state: AppViewState, tab: Tab) {
             void state.loadAssistantIdentity();
           }
         }
+        state.customTabActive = null;
         state.setTab(tab);
       }}
       title=${titleForTab(tab)}
@@ -93,7 +94,7 @@ export function renderTab(state: AppViewState, tab: Tab) {
 export function renderCustomTabItem(state: AppViewState, tab: CustomTab) {
   const isActive = state.customTabActive === tab.id;
   const collapsed = state.settings.navCollapsed;
-  const iconKey = (tab.icon ?? "globe") as keyof typeof icons;
+  const iconKey = tab.icon ?? "globe";
   const icon = icons[iconKey] ?? icons["globe"];
   return html`
     <button

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -478,7 +478,9 @@ export function renderApp(state: AppViewState) {
             const isCustomGroup = group.label === "custom";
             const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
             const hasActiveTab = isCustomGroup
-              ? (group.tabs as import("./navigation.ts").CustomTab[]).some((t) => t.id === state.customTabActive)
+              ? (group.tabs as import("./navigation.ts").CustomTab[]).some(
+                  (t) => t.id === state.customTabActive,
+                )
               : (group.tabs as import("./navigation.ts").Tab[]).some((tab) => tab === state.tab);
             const showItems = hasActiveTab || !isGroupCollapsed;
 
@@ -506,9 +508,14 @@ export function renderApp(state: AppViewState) {
                     : nothing
                 }
                 <div class="nav-group__items">
-                  ${isCustomGroup
-                    ? (group.tabs as import("./navigation.ts").CustomTab[]).map((tab) => renderCustomTabItem(state, tab))
-                    : (group.tabs as import("./navigation.ts").Tab[]).map((tab) => renderTab(state, tab))
+                  ${
+                    isCustomGroup
+                      ? (group.tabs as import("./navigation.ts").CustomTab[]).map((tab) =>
+                          renderCustomTabItem(state, tab),
+                        )
+                      : (group.tabs as import("./navigation.ts").Tab[]).map((tab) =>
+                          renderTab(state, tab),
+                        )
                   }
                 </div>
               </div>
@@ -1910,7 +1917,7 @@ export function renderApp(state: AppViewState) {
 
         ${
           state.customTabActive !== null
-            ? html`<div class="custom-tab-view" style="display:${state.customTabActive !== null ? 'flex' : 'none'}; flex:1; flex-direction:column; height:100%; overflow:hidden;">
+            ? html`<div class="custom-tab-view" style="display:${state.customTabActive !== null ? "flex" : "none"}; flex:1; flex-direction:column; height:100%; overflow:hidden;">
                 ${state.customTabs
                   .filter((tab) => tab.id === state.customTabActive)
                   .map(

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -9,6 +9,7 @@ import { renderUsageTab } from "./app-render-usage-tab.ts";
 import {
   renderChatControls,
   renderChatSessionSelect,
+  renderCustomTabItem,
   renderTab,
   renderTopbarThemeModeToggle,
 } from "./app-render.helpers.ts";
@@ -77,7 +78,7 @@ import {
 import "./components/dashboard-header.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
-import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import { buildTabGroups, normalizeBasePath, subtitleForTab, titleForTab } from "./navigation.ts";
 import { agentLogoUrl } from "./views/agents-utils.ts";
 import {
   resolveAgentConfig,
@@ -473,9 +474,12 @@ export function renderApp(state: AppViewState) {
  
           
           <nav class="sidebar-nav">
-          ${TAB_GROUPS.map((group) => {
+          ${buildTabGroups(state.customTabs).map((group) => {
+            const isCustomGroup = group.label === "custom";
             const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-            const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
+            const hasActiveTab = isCustomGroup
+              ? (group.tabs as import("./navigation.ts").CustomTab[]).some((t) => t.id === state.customTabActive)
+              : (group.tabs as import("./navigation.ts").Tab[]).some((tab) => tab === state.tab);
             const showItems = hasActiveTab || !isGroupCollapsed;
 
             return html`
@@ -502,7 +506,10 @@ export function renderApp(state: AppViewState) {
                     : nothing
                 }
                 <div class="nav-group__items">
-                  ${group.tabs.map((tab) => renderTab(state, tab))}
+                  ${isCustomGroup
+                    ? (group.tabs as import("./navigation.ts").CustomTab[]).map((tab) => renderCustomTabItem(state, tab))
+                    : (group.tabs as import("./navigation.ts").Tab[]).map((tab) => renderTab(state, tab))
+                  }
                 </div>
               </div>
             `;
@@ -1898,6 +1905,26 @@ export function renderApp(state: AppViewState) {
                   onScroll: (event) => state.handleLogsScroll(event),
                 }),
               )
+            : nothing
+        }
+
+        ${
+          state.customTabActive !== null
+            ? html`<div class="custom-tab-view" style="display:${state.customTabActive !== null ? 'flex' : 'none'}; flex:1; flex-direction:column; height:100%; overflow:hidden;">
+                ${state.customTabs
+                  .filter((tab) => tab.id === state.customTabActive)
+                  .map(
+                    (tab) => html`
+                      <iframe
+                        src=${tab.url}
+                        title=${tab.label}
+                        style="flex:1; border:none; width:100%; height:100%;"
+                        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+                        allow="clipboard-read; clipboard-write"
+                      ></iframe>
+                    `,
+                  )}
+              </div>`
             : nothing
         }
       </main>

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -329,7 +329,8 @@ export function renderApp(state: AppViewState) {
   const sessionsCount = state.sessionsResult?.count ?? null;
   const cronNext = state.cronStatus?.nextWakeAtMs ?? null;
   const chatDisabledReason = state.connected ? null : t("chat.disconnected");
-  const isChat = state.tab === "chat";
+  const isCustomTabActive = state.customTabActive !== null;
+  const isChat = !isCustomTabActive && state.tab === "chat";
   const chatFocus = isChat && (state.settings.chatFocusMode || state.onboarding);
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
   const assistantAvatarUrl = resolveAssistantAvatarUrl(state);
@@ -576,7 +577,7 @@ export function renderApp(state: AppViewState) {
           : nothing
       }
       </div>
-      <main class="content ${isChat ? "content--chat" : ""}">
+      <main class="content ${isChat && state.customTabActive === null ? "content--chat" : ""}">
         ${
           state.updateAvailable &&
           state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
@@ -1926,7 +1927,7 @@ export function renderApp(state: AppViewState) {
                         src=${tab.url}
                         title=${tab.label}
                         style="flex:1; border:none; width:100%; height:100%;"
-                        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+                        sandbox="allow-scripts allow-forms allow-popups allow-modals"
                         allow="clipboard-read; clipboard-write"
                       ></iframe>
                     `,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -7,6 +7,7 @@ import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exe
 import type { SkillMessage } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
+import type { CustomTab } from "./navigation.ts";
 import type { UiSettings } from "./storage.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ResolvedTheme, ThemeMode, ThemeName } from "./theme.ts";
@@ -32,7 +33,6 @@ import type {
   StatusSummary,
   ToolsCatalogResult,
 } from "./types.ts";
-import type { CustomTab } from "./navigation.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
 import type { SessionLogEntry } from "./views/usage.ts";

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -32,6 +32,7 @@ import type {
   StatusSummary,
   ToolsCatalogResult,
 } from "./types.ts";
+import type { CustomTab } from "./navigation.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
 import type { SessionLogEntry } from "./views/usage.ts";
@@ -42,6 +43,10 @@ export type AppViewState = {
   loginShowGatewayToken: boolean;
   loginShowGatewayPassword: boolean;
   tab: Tab;
+  /** The currently active custom tab id, or null when a built-in tab is shown. */
+  customTabActive: string | null;
+  /** User-defined custom tabs from `ui.customTabs` config. */
+  customTabs: CustomTab[];
   onboarding: boolean;
   basePath: string;
   connected: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -125,6 +125,8 @@ export class OpenClawApp extends LitElement {
   @state() loginShowGatewayToken = false;
   @state() loginShowGatewayPassword = false;
   @state() tab: Tab = "chat";
+  @state() customTabActive: string | null = null;
+  @state() customTabs: import("./navigation.ts").CustomTab[] = [];
   @state() onboarding = resolveOnboardingMode();
   @state() connected = false;
   @state() theme: ThemeName = this.settings.theme ?? "claw";

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -49,6 +49,8 @@ function createSaveState(): {
       configSearchQuery: "",
       configActiveSection: null,
       configActiveSubsection: null,
+      customTabActive: null,
+      customTabs: [],
       lastError: null,
     },
     request,

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -34,6 +34,8 @@ function createState(): ConfigState {
     configUiHints: {},
     configValid: null,
     connected: false,
+    customTabActive: null,
+    customTabs: [],
     lastError: null,
     updateRunning: false,
   };

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -138,7 +138,10 @@ function parseCustomTabs(config: unknown): import("../navigation.ts").CustomTab[
     result.push({
       id: id.trim(),
       label: label.trim(),
-      icon: typeof icon === "string" ? (icon as import("../navigation.ts").CustomTab["icon"]) : undefined,
+      icon:
+        typeof icon === "string"
+          ? (icon as import("../navigation.ts").CustomTab["icon"])
+          : undefined,
       url: url.trim(),
     });
   }

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -99,6 +99,50 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
     state.configFormOriginal = cloneConfigObject(snapshot.config ?? {});
     state.configRawOriginal = rawFromSnapshot;
   }
+
+  // Extract user-defined custom tabs from `ui.customTabs`.
+  state.customTabs = parseCustomTabs(snapshot.config);
+}
+
+/**
+ * Parse and validate `ui.customTabs` from the raw config object.
+ * Unknown or malformed entries are silently dropped.
+ */
+function parseCustomTabs(config: unknown): import("../navigation.ts").CustomTab[] {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return [];
+  }
+  const ui = (config as Record<string, unknown>).ui;
+  if (!ui || typeof ui !== "object" || Array.isArray(ui)) {
+    return [];
+  }
+  const raw = (ui as Record<string, unknown>).customTabs;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const result: import("../navigation.ts").CustomTab[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      continue;
+    }
+    const { id, label, icon, url } = entry as Record<string, unknown>;
+    if (typeof id !== "string" || !id.trim()) {
+      continue;
+    }
+    if (typeof label !== "string" || !label.trim()) {
+      continue;
+    }
+    if (typeof url !== "string" || !url.trim()) {
+      continue;
+    }
+    result.push({
+      id: id.trim(),
+      label: label.trim(),
+      icon: typeof icon === "string" ? (icon as import("../navigation.ts").CustomTab["icon"]) : undefined,
+      url: url.trim(),
+    });
+  }
+  return result;
 }
 
 function asJsonSchema(value: unknown): JsonSchema | null {

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -34,6 +34,10 @@ export type ConfigState = {
   configActiveSection: string | null;
   configActiveSubsection: string | null;
   lastError: string | null;
+  /** User-defined custom tabs from `ui.customTabs` config. */
+  customTabs: import("../navigation.ts").CustomTab[];
+  /** The currently active custom tab id, or null when a built-in tab is shown. */
+  customTabActive: string | null;
 };
 
 export async function loadConfig(state: ConfigState) {
@@ -101,7 +105,12 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
   }
 
   // Extract user-defined custom tabs from `ui.customTabs`.
-  state.customTabs = parseCustomTabs(snapshot.config);
+  const updatedTabs = parseCustomTabs(snapshot.config);
+  state.customTabs = updatedTabs;
+  // Clear stale active tab if it no longer exists in config.
+  if (state.customTabActive !== null && !updatedTabs.some((t) => t.id === state.customTabActive)) {
+    state.customTabActive = null;
+  }
 }
 
 /**
@@ -135,14 +144,24 @@ function parseCustomTabs(config: unknown): import("../navigation.ts").CustomTab[
     if (typeof url !== "string" || !url.trim()) {
       continue;
     }
+    // Only allow http/https URLs to prevent javascript:/data:/etc injection.
+    const trimmedUrl = url.trim();
+    if (!/^https?:\/\//i.test(trimmedUrl)) {
+      continue;
+    }
+    // Skip duplicate IDs — first entry wins.
+    const trimmedId = id.trim();
+    if (result.some((t) => t.id === trimmedId)) {
+      continue;
+    }
     result.push({
-      id: id.trim(),
+      id: trimmedId,
       label: label.trim(),
       icon:
         typeof icon === "string"
           ? (icon as import("../navigation.ts").CustomTab["icon"])
           : undefined,
-      url: url.trim(),
+      url: trimmedUrl,
     });
   }
   return result;

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -195,3 +195,47 @@ export function titleForTab(tab: Tab) {
 export function subtitleForTab(tab: Tab) {
   return t(`subtitles.${tab}`);
 }
+
+// ─── Custom tab type ──────────────────────────────────────────────────────────
+
+/** A user-defined iframe tab configured via `ui.customTabs` in openclaw.json. */
+export type CustomTab = {
+  /** Unique slug — must not conflict with any built-in Tab name. */
+  id: string;
+  /** Display label shown in the nav and page header. */
+  label: string;
+  /** Optional icon key. Defaults to "globe" when omitted. */
+  icon?: IconName;
+  /** URL loaded in the sandboxed iframe. */
+  url: string;
+};
+
+// ─── Tab groups ───────────────────────────────────────────────────────────────
+
+/**
+ * A nav group containing built-in tabs.  The `tabs` array holds `Tab` values.
+ */
+type BuiltinGroup = { readonly label: string; readonly tabs: readonly Tab[] };
+
+/**
+ * A nav group containing user-defined custom tabs.
+ * Only created when `ui.customTabs` is non-empty.
+ */
+export type CustomGroup = { readonly label: "custom"; readonly tabs: readonly CustomTab[] };
+
+/** Union of all possible nav group shapes. */
+export type TabGroup = BuiltinGroup | CustomGroup;
+
+export const TAB_GROUPS_BASE = TAB_GROUPS as unknown as readonly BuiltinGroup[];
+
+/**
+ * Build the ordered list of nav groups.
+ * If `customTabs` is non-empty a "custom" group is appended after the built-in
+ * groups; otherwise the result is identical to `TAB_GROUPS_BASE`.
+ */
+export function buildTabGroups(customTabs: readonly CustomTab[] = []): readonly TabGroup[] {
+  if (customTabs.length === 0) {
+    return TAB_GROUPS_BASE;
+  }
+  return [...TAB_GROUPS_BASE, { label: "custom" as const, tabs: customTabs }];
+}


### PR DESCRIPTION
## Summary

Adds `ui.customTabs` to the OpenClaw config schema, allowing users to surface custom URLs as first-class tabs in the navigation alongside built-in tabs.

## What's New

### Config schema (`ui.customTabs`)
```json
{
  "ui": {
    "customTabs": [
      { "id": "board", "label": "Board", "url": "https://your-board-url" },
      { "id": "dashboard", "label": "Dashboard", "url": "https://your-dashboard-url" }
    ]
  }
}