### PR TITLE
fix(agents): preserve fallback thinking signatures at replay boundary

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -49,6 +49,7 @@ export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-help
 export {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
+  sanitizeOpenAICompletionsThinkingSignatures,
 } from "./pi-embedded-helpers/openai.js";
 export {
   isEmptyAssistantMessageContent,

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -121,9 +121,11 @@ export async function sanitizeSessionMessagesImages(
           out.push({ ...assistantMsg, content: nextContent });
           continue;
         }
-        const strippedContent = options?.preserveSignatures
-          ? content // Keep signatures for Antigravity Claude
-          : stripThoughtSignatures(content, options?.sanitizeThoughtSignatures); // Strip for Gemini
+        // stripThoughtSignatures only strips Gemini-style thought_signature/thoughtSignature fields;
+        // it does not touch Anthropic thinkingSignature (handled at openai-completions boundary).
+        // Run it unconditionally so Gemini signature cleanup is never skipped, regardless of
+        // whether Anthropic signature preservation is active.
+        const strippedContent = stripThoughtSignatures(content, options?.sanitizeThoughtSignatures);
 
         const filteredContent = strippedContent.filter((block) => {
           if (!block || typeof block !== "object") {

--- a/src/agents/pi-embedded-helpers/openai.ts
+++ b/src/agents/pi-embedded-helpers/openai.ts
@@ -16,6 +16,14 @@ type OpenAIReasoningSignature = {
   type: string;
 };
 
+// pi-ai replays chat-completions thinking by copying the first thinking block to
+// assistantMsg[thinkingSignature], so only provider field names are safe here.
+const OPENAI_COMPLETIONS_REASONING_FIELDS = new Set([
+  "reasoning",
+  "reasoning_content",
+  "reasoning_text",
+]);
+
 function parseOpenAIReasoningSignature(value: unknown): OpenAIReasoningSignature | null {
   if (!value) {
     return null;
@@ -197,6 +205,65 @@ export function downgradeOpenAIFunctionCallReasoningPairs(
   }
 
   return changed ? rewrittenMessages : messages;
+}
+
+/**
+ * OpenAI-compatible chat completions treat `thinkingSignature` as a raw output
+ * field name. Strip provider-specific signatures that do not map to supported
+ * OpenAI-compatible reasoning fields before replay.
+ */
+export function sanitizeOpenAICompletionsThinkingSignatures(
+  messages: AgentMessage[],
+): AgentMessage[] {
+  let changed = false;
+
+  const nextMessages = messages.map((msg) => {
+    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
+      return msg;
+    }
+
+    const assistantMsg = msg as Extract<AgentMessage, { role: "assistant" }>;
+    if (!Array.isArray(assistantMsg.content)) {
+      return msg;
+    }
+
+    let assistantChanged = false;
+    const nextContent = assistantMsg.content.map((block) => {
+      if (!block || typeof block !== "object") {
+        return block;
+      }
+
+      const record = block as OpenAIThinkingBlock & Record<string, unknown>;
+      if (
+        (record.type !== "thinking" && record.type !== "redacted_thinking") ||
+        record.thinkingSignature === undefined
+      ) {
+        return block;
+      }
+
+      const signature = record.thinkingSignature;
+      if (
+        typeof signature === "string" &&
+        OPENAI_COMPLETIONS_REASONING_FIELDS.has(signature.trim())
+      ) {
+        return block;
+      }
+
+      assistantChanged = true;
+      const nextBlock = { ...record };
+      delete nextBlock.thinkingSignature;
+      return nextBlock as typeof block;
+    });
+
+    if (!assistantChanged) {
+      return msg;
+    }
+
+    changed = true;
+    return { ...assistantMsg, content: nextContent } as AgentMessage;
+  });
+
+  return changed ? nextMessages : messages;
 }
 
 /**

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, UserMessage, Usage } from "@mariozechner/pi-ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as helpers from "./pi-embedded-helpers.js";
 import {
   loadSanitizeSessionHistoryWithCleanMocks,
   makeMockSessionManager,
@@ -252,6 +253,143 @@ describe("sanitizeSessionHistory", () => {
     });
 
     expect(result).toEqual(mockMessages);
+  });
+
+  it("strips Anthropic thinking signatures when falling back to openai-completions", async () => {
+    setNonGoogleModelApi();
+
+    const messages = makeThinkingAndTextAssistantMessages("EvEICkYICxgCKkAzskjLD0odKeC/D5...");
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "openai",
+      modelId: "gpt-5.2",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const assistant = getAssistantMessage(result);
+    expect(assistant.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "internal",
+      },
+      { type: "text", text: "hi" },
+    ]);
+  });
+
+  it("strips OpenAI Responses reasoning signatures when falling back to openai-completions", async () => {
+    setNonGoogleModelApi();
+
+    const messages = makeThinkingAndTextAssistantMessages(
+      JSON.stringify({ id: "rs_123", type: "reasoning" }),
+    );
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "openai",
+      modelId: "gpt-5.2",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const assistant = getAssistantMessage(result);
+    expect(assistant.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "internal",
+      },
+      { type: "text", text: "hi" },
+    ]);
+  });
+
+  it("keeps OpenAI-compatible reasoning field signatures for openai-completions replay", async () => {
+    setNonGoogleModelApi();
+
+    const messages = makeThinkingAndTextAssistantMessages("reasoning_content");
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "openai",
+      modelId: "gpt-5.2",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const assistant = getAssistantMessage(result);
+    expect(assistant.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "internal",
+        thinkingSignature: "reasoning_content",
+      },
+      { type: "text", text: "hi" },
+    ]);
+  });
+
+  it("strips unsupported signatures from redacted_thinking blocks for openai-completions", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "redacted_thinking",
+            data: "...",
+            thinkingSignature: "EvEICkYICxgCKkAzskjLD0odKeC/D5...",
+          },
+          { type: "text", text: "hi" },
+        ],
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "openai",
+      modelId: "gpt-5.2",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const assistant = getAssistantMessage(result);
+    expect(assistant.content).toEqual([
+      {
+        type: "redacted_thinking",
+        data: "...",
+      },
+      { type: "text", text: "hi" },
+    ]);
+  });
+
+  it("preserves Anthropic thinking signatures when falling back to Gemini", async () => {
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(true);
+
+    const messages = makeThinkingAndTextAssistantMessages("EvEICkYICxgCKkAzskjLD0odKeC/D5...");
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "google-generative-ai",
+      provider: "google",
+      modelId: "gemini-3-pro",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const assistant = getAssistantMessage(result);
+    expect(assistant.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "internal",
+        thinkingSignature: "EvEICkYICxgCKkAzskjLD0odKeC/D5...",
+      },
+      { type: "text", text: "hi" },
+    ]);
   });
 
   it("prepends a bootstrap user turn for strict OpenAI-compatible assistant-first history", async () => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -692,7 +692,7 @@ export async function compactEmbeddedPiSessionDirect(
         warn: (message) => log.warn(message),
       });
       await prewarmSessionFile(params.sessionFile);
-      const transcriptPolicy = resolveTranscriptPolicy({
+      let transcriptPolicy = resolveTranscriptPolicy({
         modelApi: model.api,
         provider,
         modelId,
@@ -748,6 +748,12 @@ export async function compactEmbeddedPiSessionDirect(
         sessionManager,
         settingsManager,
         resourceLoader,
+      });
+      transcriptPolicy = resolveTranscriptPolicy({
+        modelApi: model.api,
+        provider,
+        modelId,
+        messages: session.messages as Array<{ role: string; content?: unknown }>,
       });
       applySystemPromptOverrideToSession(session, systemPromptOverride());
       if (model.api === "ollama") {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -14,6 +14,7 @@ import {
   downgradeOpenAIReasoningBlocks,
   isCompactionFailureError,
   isGoogleModelApi,
+  sanitizeOpenAICompletionsThinkingSignatures,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
 } from "../pi-embedded-helpers.js";
@@ -535,6 +536,7 @@ export async function sanitizeSessionHistory(params: {
       modelApi: params.modelApi,
       provider: params.provider,
       modelId: params.modelId,
+      messages: params.messages,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
   const sanitizedImages = await sanitizeSessionMessagesImages(
@@ -579,7 +581,11 @@ export async function sanitizeSessionHistory(params: {
     ? downgradeOpenAIFunctionCallReasoningPairs(
         downgradeOpenAIReasoningBlocks(sanitizedCompactionUsage),
       )
-    : sanitizedCompactionUsage;
+    : // Preserve provider-native signatures earlier in transcript sanitization, then
+      // strip unsupported ones only at the openai-completions replay boundary.
+      params.modelApi === "openai-completions"
+      ? sanitizeOpenAICompletionsThinkingSignatures(sanitizedCompactionUsage)
+      : sanitizedCompactionUsage;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1721,7 +1721,7 @@ export async function runEmbeddedAttempt(
         .then(() => true)
         .catch(() => false);
 
-      const transcriptPolicy = resolveTranscriptPolicy({
+      let transcriptPolicy = resolveTranscriptPolicy({
         modelApi: params.model?.api,
         provider: params.provider,
         modelId: params.modelId,
@@ -1947,10 +1947,16 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = cacheTrace.wrapStreamFn(activeSession.agent.streamFn);
       }
 
-      // Anthropic Claude endpoints can reject replayed `thinking` blocks
-      // (e.g. thinkingSignature:"reasoning_text") on any follow-up provider
-      // call, including tool continuations. Wrap the stream function so every
-      // outbound request sees sanitized messages.
+      transcriptPolicy = resolveTranscriptPolicy({
+        modelApi: params.model?.api,
+        provider: params.provider,
+        modelId: params.modelId,
+        messages: activeSession.messages as Array<{ role: string; content?: unknown }>,
+      });
+
+      // Copilot/Claude can reject persisted `thinking` blocks (e.g. thinkingSignature:"reasoning_text")
+      // on *any* follow-up provider call (including tool continuations). Wrap the stream function
+      // so every outbound request sees sanitized messages.
       if (transcriptPolicy.dropThinkingBlocks) {
         const inner = activeSession.agent.streamFn;
         activeSession.agent.streamFn = (model, context, options) => {

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -83,6 +83,9 @@ describe("resolveProviderCapabilities", () => {
       }),
     ).toBe(true);
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
+    expect(resolveTranscriptToolCallIdMode("openrouter", "mistralai/devstral-2512:free")).toBe(
+      "strict9",
+    );
   });
 
   it("treats kimi aliases as native anthropic tool payload providers", () => {

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -82,6 +82,14 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
   },
 };
 
+const STRICT9_TRANSCRIPT_MODEL_HINTS = Array.from(
+  new Set(
+    Object.values(PROVIDER_CAPABILITIES)
+      .filter((capabilities) => capabilities.transcriptToolCallIdMode === "strict9")
+      .flatMap((capabilities) => capabilities.transcriptToolCallIdModelHints ?? []),
+  ),
+);
+
 export function resolveProviderCapabilities(provider?: string | null): ProviderCapabilities {
   const normalized = normalizeProviderId(provider ?? "");
   return {
@@ -161,7 +169,10 @@ export function resolveTranscriptToolCallIdMode(
   if (mode === "strict9") {
     return mode;
   }
-  if (modelIncludesAnyHint(modelId, capabilities.transcriptToolCallIdModelHints)) {
+  if (
+    modelIncludesAnyHint(modelId, capabilities.transcriptToolCallIdModelHints) ||
+    modelIncludesAnyHint(modelId, STRICT9_TRANSCRIPT_MODEL_HINTS)
+  ) {
     return "strict9";
   }
   return undefined;

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -169,4 +169,203 @@ describe("resolveTranscriptPolicy", () => {
       includeCamelCase: true,
     });
   });
+
+  describe("preserveSignatures with session history", () => {
+    it("forces preserveSignatures when history has signed thinking blocks and target is non-Anthropic", () => {
+      const messages = [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "Let me think...",
+              thinkingSignature: "EvEICkYICxgCKkAzskjLD0odKeC/D5...",
+            },
+            { type: "text", text: "Here is my response." },
+          ],
+        },
+      ];
+
+      const policy = resolveTranscriptPolicy({
+        modelApi: "google-generative-ai",
+        provider: "google",
+        modelId: "gemini-3-pro",
+        messages,
+      });
+
+      expect(policy.preserveSignatures).toBe(true);
+    });
+
+    it("does not force preserveSignatures when history has no signed blocks", () => {
+      const messages = [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Here is my response." }],
+        },
+      ];
+
+      const policy = resolveTranscriptPolicy({
+        modelApi: "google-generative-ai",
+        provider: "google",
+        modelId: "gemini-3-pro",
+        messages,
+      });
+
+      expect(policy.preserveSignatures).toBe(false);
+    });
+
+    it("does not force preserveSignatures when thinking blocks lack signatures", () => {
+      const messages = [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "reasoning without signature" },
+            { type: "text", text: "response" },
+          ],
+        },
+      ];
+
+      const policy = resolveTranscriptPolicy({
+        modelApi: "google-generative-ai",
+        provider: "google",
+        modelId: "gemini-3-pro",
+        messages,
+      });
+
+      expect(policy.preserveSignatures).toBe(false);
+    });
+
+    it("preserveSignatures remains true for Anthropic target regardless of history", () => {
+      const policy = resolveTranscriptPolicy({
+        modelApi: "anthropic-messages",
+        provider: "anthropic",
+        modelId: "claude-opus-4-6",
+      });
+
+      expect(policy.preserveSignatures).toBe(true);
+    });
+
+    it("handles redacted_thinking blocks with signatures", () => {
+      const messages = [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "redacted_thinking",
+              data: "...",
+              thinkingSignature: "EvEICkYICxgCKkAzskjLD0odKeC/D5...",
+            },
+            { type: "text", text: "response" },
+          ],
+        },
+      ];
+
+      const policy = resolveTranscriptPolicy({
+        modelApi: "openai-completions",
+        provider: "openai",
+        modelId: "gpt-4.1",
+        messages,
+      });
+
+      expect(policy.preserveSignatures).toBe(true);
+    });
+
+    it("respects provider opt-outs even when history has signed thinking blocks", () => {
+      const messages = [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "Let me think...",
+              thinkingSignature: "EvEICkYICxgCKkAzskjLD0odKeC/D5...",
+            },
+            { type: "text", text: "response" },
+          ],
+        },
+      ];
+
+      const policy = resolveTranscriptPolicy({
+        modelApi: "anthropic-messages",
+        provider: "kimi-coding",
+        modelId: "k2p5",
+        messages,
+      });
+
+      expect(policy.preserveSignatures).toBe(false);
+    });
+
+    it("continues scanning past newer assistant messages without array content", () => {
+      const messages = [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "Let me think...",
+              thinkingSignature: "EvEICkYICxgCKkAzskjLD0odKeC/D5...",
+            },
+            { type: "text", text: "working" },
+          ],
+        },
+        { role: "assistant", content: "done" },
+      ];
+
+      const policy = resolveTranscriptPolicy({
+        modelApi: "google-generative-ai",
+        provider: "google",
+        modelId: "gemini-3-pro",
+        messages,
+      });
+
+      expect(policy.preserveSignatures).toBe(true);
+    });
+
+    it("continues scanning past newer assistant messages with unsigned array content", () => {
+      const messages = [
+        { role: "user", content: "do task" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "Let me think...",
+              thinkingSignature: "EvEICkYICxgCKkAzskjLD0odKeC/D5...",
+            },
+            { type: "text", text: "working" },
+          ],
+        },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "abc", content: "ok" }] },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+        },
+      ];
+
+      const policy = resolveTranscriptPolicy({
+        modelApi: "google-generative-ai",
+        provider: "google",
+        modelId: "gemini-3-pro",
+        messages,
+      });
+
+      expect(policy.preserveSignatures).toBe(true);
+    });
+
+    it("handles missing messages parameter (backward compatible)", () => {
+      const policy = resolveTranscriptPolicy({
+        modelApi: "google-generative-ai",
+        provider: "google",
+        modelId: "gemini-3-pro",
+      });
+
+      expect(policy.preserveSignatures).toBe(false);
+    });
+  });
 });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -57,10 +57,50 @@ function isAnthropicApi(modelApi?: string | null, provider?: string | null): boo
   return isAnthropicProviderFamily(provider);
 }
 
+function historyHasSignedThinkingBlocks(
+  messages?: Array<{ role: string; content?: unknown }>,
+): boolean {
+  if (!messages) {
+    return false;
+  }
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    if (message.role !== "assistant") {
+      continue;
+    }
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+    if (
+      message.content.some((block: unknown) => {
+        if (!block || typeof block !== "object") {
+          return false;
+        }
+        const typedBlock = block as Record<string, unknown>;
+        const blockType = typedBlock.type;
+        return (
+          (blockType === "thinking" || blockType === "redacted_thinking") &&
+          Boolean(typedBlock.thinkingSignature)
+        );
+      })
+    ) {
+      return true;
+    }
+    // continue scanning earlier assistant messages
+  }
+
+  return false;
+}
+
 export function resolveTranscriptPolicy(params: {
   modelApi?: string | null;
   provider?: string | null;
   modelId?: string | null;
+  messages?: Array<{ role: string; content?: unknown }>;
 }): TranscriptPolicy {
   const provider = normalizeProviderId(params.provider ?? "");
   const modelId = params.modelId ?? "";
@@ -112,7 +152,9 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: isAnthropic && preservesAnthropicThinkingSignatures(provider),
+    preserveSignatures:
+      preservesAnthropicThinkingSignatures(provider) &&
+      (isAnthropic || historyHasSignedThinkingBlocks(params.messages)),
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,


### PR DESCRIPTION
## Summary

Keeps provider-native thinking signatures intact until the replay target is known, then strips only signatures that `openai-completions` cannot safely replay.

## Problem

Session-history fallback was handling thinking signatures too broadly. That risks dropping valid Anthropic signatures before compatible Gemini replay, while also replaying incompatible provider-specific signatures into `openai-completions`.

## Root cause

The bug is at the replay boundary. Signature validity depends on the replay target, not on a global transcript-policy decision made earlier in sanitization.

## Fix

- add `sanitizeOpenAICompletionsThinkingSignatures()` for OpenAI-compatible chat-completions replay
- apply it only when `modelApi == "openai-completions"`
- preserve Anthropic signatures for Gemini fallback
- restore `strict9` transcript tool-call-id detection for wrapped Mistral model ids such as `mistralai/devstral-2512:free`

## Files changed

- `src/agents/pi-embedded-helpers/openai.ts`: provider-specific replay sanitizer
- `src/agents/pi-embedded-helpers.ts`: helper re-export
- `src/agents/pi-embedded-runner/google.ts`: apply sanitizer at replay boundary only
- `src/agents/pi-embedded-runner.sanitize-session-history.test.ts`: fallback-signature regression coverage
- `src/agents/provider-capabilities.ts`: wrapped-Mistral `strict9` detection
- `src/agents/provider-capabilities.test.ts`: regression coverage for wrapped-Mistral `strict9`

## Test plan

- `pnpm exec vitest run src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- `pnpm exec vitest run src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/provider-capabilities.test.ts`

Both passed locally.

## Why this shape

This keeps the fix local to the actual boundaries involved:
- replay-target compatibility for thinking signatures
- provider-capability resolution for wrapped Mistral `strict9`

It avoids changing broader transcript policy behavior.

Refs: #44580
