### PR TITLE
feat: per-agent TTS voice configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ ui/src/ui/__screenshots__
 ui/src/ui/views/__screenshots__
 ui/.vitest-attachments
 docs/superpowers
+
+dist-runtime/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 docker-compose.override.yml
 docker-compose.extra.yml
 dist
+dist-runtime
 pnpm-lock.yaml
 bun.lock
 bun.lockb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@
 - GitHub searching footgun: don't limit yourself to the first 500 issues or PRs when wanting to search all. Unless you're supposed to look at the most recent, keep going until you've reached the last page in the search
 - Security advisory analysis: before triage/severity decisions, read `SECURITY.md` to align with OpenClaw's trust model and design boundaries.
 
+## Local Fork Principle
+
+- This local OpenClaw repo exists to build features we actually need, but it still needs to rebase and merge cleanly onto newer upstream releases later.
+- Prefer the least-coupled solution that solves the real need, so local changes stay easier to carry forward and produce fewer upstream merge conflicts.
+- If deeper integration is truly necessary, do it, but keep that tradeoff explicit instead of defaulting to the most intertwined design.
+- For this fork, `local/junyu` is the local integration branch where we merge/rebase new features. When creating PRs in this fork, target `local/junyu` by default, not `main`, unless explicitly told otherwise.
+
 ## Auto-close labels (issues and PRs)
 
 - If an issue/PR matches one of the reasons below, apply the label and let `.github/workflows/auto-response.yml` handle comment/close/lock.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1634,6 +1634,12 @@ Batches rapid text-only messages from the same sender into a single agent turn. 
         model: "gpt-4o-mini-tts",
         voice: "alloy",
       },
+      inworld: {
+        apiKey: "inworld_base64_api_key",
+        baseUrl: "https://api.inworld.ai",
+        voiceId: "Dennis",
+        modelId: "inworld-tts-1.5-max",
+      },
     },
   },
 }
@@ -1642,9 +1648,10 @@ Batches rapid text-only messages from the same sender into a single agent turn. 
 - `auto` controls auto-TTS. `/tts off|always|inbound|tagged` overrides per session.
 - `summaryModel` overrides `agents.defaults.model.primary` for auto-summary.
 - `modelOverrides` is enabled by default; `modelOverrides.allowProvider` defaults to `false` (opt-in).
-- API keys fall back to `ELEVENLABS_API_KEY`/`XI_API_KEY` and `OPENAI_API_KEY`.
+- API keys fall back to `ELEVENLABS_API_KEY`/`XI_API_KEY`, `INWORLD_API_KEY`, and `OPENAI_API_KEY`.
 - `openai.baseUrl` overrides the OpenAI TTS endpoint. Resolution order is config, then `OPENAI_TTS_BASE_URL`, then `https://api.openai.com/v1`.
 - When `openai.baseUrl` points to a non-OpenAI endpoint, OpenClaw treats it as an OpenAI-compatible TTS server and relaxes model/voice validation.
+- `inworld.baseUrl` overrides the InWorld API endpoint. Resolution order is config, then `INWORLD_API_BASE_URL`, then `https://api.inworld.ai`.
 
 ---
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1294,6 +1294,13 @@ scripts/sandbox-browser-setup.sh   # optional browser image
             cwd: "/workspace/openclaw",
           },
         },
+        voice: {
+          provider: "openai",
+          openai: {
+            voice: "ballad",
+            model: "gpt-4o-mini-tts",
+          },
+        },
         subagents: { allowAgents: ["*"] },
         tools: {
           profile: "coding",
@@ -1312,6 +1319,9 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `model`: string form overrides `primary` only; object form `{ primary, fallbacks }` overrides both (`[]` disables global fallbacks). Cron jobs that only override `primary` still inherit default fallbacks unless you set `fallbacks: []`.
 - `params`: per-agent stream params merged over the selected model entry in `agents.defaults.models`. Use this for agent-specific overrides like `cacheRetention`, `temperature`, or `maxTokens` without duplicating the whole model catalog.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
+- `voice`: optional per-agent TTS voice config merged on top of `messages.tts`.
+  Use provider-specific nested blocks like `openai`, `elevenlabs`, `inworld`, or `edge`.
+  This only changes voice identity/settings; shared TTS infrastructure still comes from `messages.tts`.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -9,12 +9,14 @@ title: "Text-to-Speech"
 
 # Text-to-speech (TTS)
 
-OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, or Edge TTS.
+OpenClaw can convert outbound replies into audio using ElevenLabs, InWorld AI, OpenAI, or Edge TTS.
 It works anywhere OpenClaw can send audio; Telegram gets a round voice-note bubble.
+InWorld support currently targets normal message TTS; telephony continues to use other providers.
 
 ## Supported services
 
 - **ElevenLabs** (primary or fallback provider)
+- **InWorld AI** (primary or fallback provider; high-quality voices with low latency)
 - **OpenAI** (primary or fallback provider; also used for summaries)
 - **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when no API keys)
 
@@ -32,9 +34,10 @@ does not publish limits, so assume similar or lower limits. citeturn0searc
 
 ## Optional keys
 
-If you want OpenAI or ElevenLabs:
+If you want OpenAI, ElevenLabs, or InWorld AI:
 
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
+- `INWORLD_API_KEY` (Base64 API key from your InWorld workspace)
 - `OPENAI_API_KEY`
 
 Edge TTS does **not** require an API key. If no API keys are found, OpenClaw defaults
@@ -50,6 +53,8 @@ so that provider must also be authenticated if you enable summaries.
 - [OpenAI Audio API reference](https://platform.openai.com/docs/api-reference/audio)
 - [ElevenLabs Text to Speech](https://elevenlabs.io/docs/api-reference/text-to-speech)
 - [ElevenLabs Authentication](https://elevenlabs.io/docs/api-reference/authentication)
+- [InWorld AI TTS](https://docs.inworld.ai/docs/tts/tts)
+- [InWorld API Examples](https://github.com/inworld-ai/inworld-api-examples)
 - [node-edge-tts](https://github.com/SchneeHertz/node-edge-tts)
 - [Microsoft Speech output formats](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech#audio-outputs)
 
@@ -112,6 +117,24 @@ Full schema is in [Gateway configuration](/gateway/configuration).
           useSpeakerBoost: true,
           speed: 1.0,
         },
+      },
+    },
+  },
+}
+```
+
+### InWorld AI primary
+
+```json5
+{
+  messages: {
+    tts: {
+      auto: "always",
+      provider: "inworld",
+      inworld: {
+        apiKey: "your_base64_api_key", // or set INWORLD_API_KEY env var
+        voiceId: "Dennis", // Alex, Ashley, Craig, Dennis, Hades, Mark, etc.
+        modelId: "inworld-tts-1.5-max", // or inworld-tts-1.5-mini for lower latency
       },
     },
   },
@@ -205,9 +228,9 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts]]` tags.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: `"elevenlabs"`, `"openai"`, or `"edge"` (fallback is automatic).
+- `provider`: `"elevenlabs"`, `"inworld"`, `"openai"`, or `"edge"` (fallback is automatic).
 - If `provider` is **unset**, OpenClaw prefers `openai` (if key), then `elevenlabs` (if key),
-  otherwise `edge`.
+  then `inworld` (if key), otherwise `edge`.
 - `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
   - Accepts `provider/model` or a configured model alias.
 - `modelOverrides`: allow the model to emit TTS directives (on by default).
@@ -215,7 +238,10 @@ Then run:
 - `maxTextLength`: hard cap for TTS input (chars). `/tts audio` fails if exceeded.
 - `timeoutMs`: request timeout (ms).
 - `prefsPath`: override the local prefs JSON path (provider/limit/summary).
-- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`, `OPENAI_API_KEY`).
+- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`, `INWORLD_API_KEY`, `OPENAI_API_KEY`).
+- `inworld.baseUrl`: override InWorld API base URL (default `https://api.inworld.ai`). Also accepts `INWORLD_API_BASE_URL` env var.
+- `inworld.voiceId`: InWorld voice name (default `Dennis`). Available voices: Alex, Ashley, Craig, Deborah, Dennis, Dominus, Edward, Elizabeth, Hades, Heitor, Julia, Mark, Olivia, Pixie, Priya, Ronald, Sarah, Shaun, Theodore, Timothy, Wendy.
+- `inworld.modelId`: InWorld model (default `inworld-tts-1.5-max`). Available: `inworld-tts-1.5-max` (quality) and `inworld-tts-1.5-mini` (speed).
 - `elevenlabs.baseUrl`: override ElevenLabs API base URL.
 - `openai.baseUrl`: override the OpenAI TTS endpoint.
   - Resolution order: `messages.tts.openai.baseUrl` -> `OPENAI_TTS_BASE_URL` -> `https://api.openai.com/v1`
@@ -260,9 +286,9 @@ Here you go.
 
 Available directive keys (when enabled):
 
-- `provider` (`openai` | `elevenlabs` | `edge`, requires `allowProvider: true`)
-- `voice` (OpenAI voice) or `voiceId` (ElevenLabs)
-- `model` (OpenAI TTS model or ElevenLabs model id)
+- `provider` (`openai` | `elevenlabs` | `inworld` | `edge`, requires `allowProvider: true`)
+- `voice` (OpenAI voice) or `voiceId` (ElevenLabs) or `inworld_voice` (InWorld)
+- `model` (OpenAI TTS model or ElevenLabs model id) or `inworld_model` (InWorld model)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`
 - `applyTextNormalization` (`auto|on|off`)
 - `languageCode` (ISO 639-1)
@@ -317,7 +343,7 @@ These override `messages.tts.*` for that host.
 
 - **Telegram**: Opus voice note (`opus_48000_64` from ElevenLabs, `opus` from OpenAI).
   - 48kHz / 64kbps is a good voice-note tradeoff and required for the round bubble.
-- **Other channels**: MP3 (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI).
+- **Other channels**: MP3 (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI/InWorld).
   - 44.1kHz / 128kbps is the default balance for speech clarity.
 - **Edge TTS**: uses `edge.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
   - `node-edge-tts` accepts an `outputFormat`, but not all formats are available
@@ -327,7 +353,7 @@ These override `messages.tts.*` for that host.
     guaranteed Opus voice notes. citeturn1search1
   - If the configured Edge output format fails, OpenClaw retries with MP3.
 
-OpenAI/ElevenLabs formats are fixed; Telegram expects Opus for voice-note UX.
+OpenAI/ElevenLabs formats are fixed; InWorld currently uses MP3 for message TTS and is not used for telephony.
 
 ## Auto-TTS behavior
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -191,6 +191,56 @@ Full schema is in [Gateway configuration](/gateway/configuration).
 }
 ```
 
+### Per-agent voice config
+
+Use `agents.list[].voice` when different agents should speak with different
+providers or voices while still sharing the same global TTS infrastructure
+(API keys, base URLs, timeouts, and fallback wiring).
+
+```json5
+{
+  messages: {
+    tts: {
+      auto: "always",
+      provider: "openai",
+      openai: { apiKey: "openai_api_key", voice: "alloy" },
+      inworld: { apiKey: "inworld_key", voiceId: "Dennis" },
+    },
+  },
+  agents: {
+    list: [
+      {
+        id: "narrator",
+        voice: {
+          provider: "openai",
+          openai: {
+            voice: "ballad",
+            model: "gpt-4o-mini-tts",
+          },
+        },
+      },
+      {
+        id: "storyteller",
+        voice: {
+          provider: "inworld",
+          inworld: {
+            voiceId: "Ashley",
+            modelId: "inworld-tts-1.5-mini",
+          },
+        },
+      },
+    ],
+  },
+}
+```
+
+Notes:
+
+- `agents.list[].voice` only overrides voice identity/settings. Infrastructure
+  still comes from `messages.tts`.
+- `/tts` prefs stay shared by default. Per-agent voice config sets defaults, but
+  slash-command/runtime overrides still use the shared `prefsPath`.
+
 ### Only reply with audio after an inbound voice note
 
 ```json5
@@ -328,7 +378,7 @@ Optional allowlist (enable provider switching while keeping other knobs configur
 
 Slash commands write local overrides to `prefsPath` (default:
 `~/.openclaw/settings/tts.json`, override with `OPENCLAW_TTS_PREFS` or
-`messages.tts.prefsPath`).
+`messages.tts.prefsPath`). These overrides are shared across agents by default.
 
 Stored fields:
 

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
+import type { AgentVoiceConfig } from "../config/types.tts.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   DEFAULT_AGENT_ID,
@@ -39,6 +40,7 @@ type ResolvedAgentConfig = {
   subagents?: AgentEntry["subagents"];
   sandbox?: AgentEntry["sandbox"];
   tools?: AgentEntry["tools"];
+  voice?: AgentVoiceConfig;
 };
 
 let defaultAgentWarned = false;
@@ -141,6 +143,7 @@ export function resolveAgentConfig(
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,
     sandbox: entry.sandbox,
     tools: entry.tools,
+    voice: entry.voice,
   };
 }
 

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -72,7 +72,9 @@ export function buildSystemPrompt(params: {
       shell: detectRuntimeShell(),
     },
   });
-  const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+  const ttsHint = params.config
+    ? buildTtsSystemPromptHint(params.config, params.agentId)
+    : undefined;
   const ownerDisplay = resolveOwnerDisplaySetting(params.config);
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -160,6 +160,12 @@ export function createOpenClawTools(
     createTtsTool({
       agentChannel: options?.agentChannel,
       config: options?.config,
+      agentId:
+        options?.requesterAgentIdOverride ??
+        resolveSessionAgentId({
+          sessionKey: options?.agentSessionKey,
+          config: options?.config,
+        }),
     }),
     createGatewayTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -654,7 +654,9 @@ export async function compactEmbeddedPiSessionDirect(
       cwd: process.cwd(),
       moduleUrl: import.meta.url,
     });
-    const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const ttsHint = params.config
+      ? buildTtsSystemPromptHint(params.config, sessionAgentId)
+      : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1636,7 +1636,9 @@ export async function runEmbeddedAttempt(
       cwd: process.cwd(),
       moduleUrl: import.meta.url,
     });
-    const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const ttsHint = params.config
+      ? buildTtsSystemPromptHint(params.config, sessionAgentId)
+      : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
 
     const appendPrompt = buildEmbeddedSystemPrompt({

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -17,6 +17,8 @@ const TtsToolSchema = Type.Object({
 export function createTtsTool(opts?: {
   config?: OpenClawConfig;
   agentChannel?: GatewayMessageChannel;
+  /** Agent ID for per-agent voice overrides. */
+  agentId?: string;
 }): AnyAgentTool {
   return {
     label: "TTS",
@@ -32,6 +34,7 @@ export function createTtsTool(opts?: {
         text,
         cfg,
         channel: channel ?? opts?.agentChannel,
+        agentId: opts?.agentId,
       });
 
       if (result.success && result.audioPath) {

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -107,7 +107,7 @@ export async function resolveCommandsSystemPromptBundle(
         },
       }
     : { enabled: false };
-  const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg) : undefined;
+  const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg, sessionAgentId) : undefined;
 
   const systemPrompt = buildAgentSystemPrompt({
     workspaceDir,

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -56,7 +56,8 @@ function ttsUsage(): ReplyPayload {
       `**Providers:**\n` +
       `• edge — Free, fast (default)\n` +
       `• openai — High quality (requires API key)\n` +
-      `• elevenlabs — Premium voices (requires API key)\n\n` +
+      `• elevenlabs — Premium voices (requires API key)\n` +
+      `• inworld — InWorld AI voices (requires API key)\n\n` +
       `**Text Limit (default: 1500, max: 4096):**\n` +
       `When text exceeds the limit:\n` +
       `• Summary ON: AI summarizes, then generates audio\n` +
@@ -161,6 +162,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     if (!args.trim()) {
       const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
       const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
+      const hasInworld = Boolean(resolveTtsApiKey(config, "inworld"));
       const hasEdge = isTtsProviderConfigured(config, "edge");
       return {
         shouldContinue: false,
@@ -170,14 +172,20 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
             `Primary: ${currentProvider}\n` +
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
+            `InWorld key: ${hasInworld ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
-            `Usage: /tts provider openai | elevenlabs | edge`,
+            `Usage: /tts provider openai | elevenlabs | inworld | edge`,
         },
       };
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge") {
+    if (
+      requested !== "openai" &&
+      requested !== "elevenlabs" &&
+      requested !== "inworld" &&
+      requested !== "edge"
+    ) {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -7,7 +7,7 @@ import {
   isTtsEnabled,
   isTtsProviderConfigured,
   resolveTtsApiKey,
-  resolveTtsConfig,
+  resolveTtsConfigForAgent,
   resolveTtsPrefsPath,
   setLastTtsAttempt,
   setSummarizationEnabled,
@@ -85,7 +85,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     return { shouldContinue: false };
   }
 
-  const config = resolveTtsConfig(params.cfg);
+  const config = resolveTtsConfigForAgent(params.cfg, params.agentId);
   const prefsPath = resolveTtsPrefsPath(config);
   const action = parsed.action;
   const args = parsed.args;
@@ -123,18 +123,22 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
       cfg: params.cfg,
       channel: params.command.channel,
       prefsPath,
+      agentId: params.agentId,
     });
 
     if (result.success && result.audioPath) {
       // Store last attempt for `/tts status`.
-      setLastTtsAttempt({
-        timestamp: Date.now(),
-        success: true,
-        textLength: args.length,
-        summarized: false,
-        provider: result.provider,
-        latencyMs: result.latencyMs,
-      });
+      setLastTtsAttempt(
+        {
+          timestamp: Date.now(),
+          success: true,
+          textLength: args.length,
+          summarized: false,
+          provider: result.provider,
+          latencyMs: result.latencyMs,
+        },
+        params.agentId,
+      );
       const payload: ReplyPayload = {
         mediaUrl: result.audioPath,
         audioAsVoice: result.voiceCompatible === true,
@@ -143,14 +147,17 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     }
 
     // Store failure details for `/tts status`.
-    setLastTtsAttempt({
-      timestamp: Date.now(),
-      success: false,
-      textLength: args.length,
-      summarized: false,
-      error: result.error,
-      latencyMs: Date.now() - start,
-    });
+    setLastTtsAttempt(
+      {
+        timestamp: Date.now(),
+        success: false,
+        textLength: args.length,
+        summarized: false,
+        error: result.error,
+        latencyMs: Date.now() - start,
+      },
+      params.agentId,
+    );
     return {
       shouldContinue: false,
       reply: { text: `❌ Error generating audio: ${result.error ?? "unknown error"}` },
@@ -260,7 +267,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     const hasKey = isTtsProviderConfigured(config, provider);
     const maxLength = getTtsMaxLength(prefsPath);
     const summarize = isSummarizationEnabled(prefsPath);
-    const last = getLastTtsAttempt();
+    const last = getLastTtsAttempt(params.agentId);
     const lines = [
       "📊 TTS status",
       `State: ${enabled ? "✅ enabled" : "❌ disabled"}`,

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -53,6 +53,8 @@ export function createAcpDispatchDeliveryCoordinator(params: {
   originatingChannel?: string;
   originatingTo?: string;
   onReplyStart?: () => Promise<void> | void;
+  /** Agent ID for per-agent TTS voice overrides. */
+  agentId?: string;
 }): AcpDispatchDeliveryCoordinator {
   const state: AcpDispatchDeliveryState = {
     startedReplyLifecycle: false,
@@ -138,6 +140,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       kind,
       inboundAudio: params.inboundAudio,
       ttsAuto: params.sessionTtsAuto,
+      agentId: params.agentId,
     });
 
     if (params.shouldRouteToOriginating && params.originatingChannel && params.originatingTo) {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -39,7 +39,9 @@ const ttsMocks = vi.hoisted(() => ({
     const params = paramsUnknown as { payload: unknown };
     return params.payload;
   }),
-  resolveTtsConfig: vi.fn((_cfg: OpenClawConfig) => ({ mode: "final" })),
+  resolveTtsConfigForAgent: vi.fn((_cfg: OpenClawConfig, _agentId?: string) => ({
+    mode: "final",
+  })),
 }));
 
 const sessionMetaMocks = vi.hoisted(() => ({
@@ -73,7 +75,8 @@ vi.mock("../../infra/outbound/message-action-runner.js", () => ({
 
 vi.mock("../../tts/tts.js", () => ({
   maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
-  resolveTtsConfig: (cfg: OpenClawConfig) => ttsMocks.resolveTtsConfig(cfg),
+  resolveTtsConfigForAgent: (cfg: OpenClawConfig, agentId?: string) =>
+    ttsMocks.resolveTtsConfigForAgent(cfg, agentId),
 }));
 
 vi.mock("../../acp/runtime/session-meta.js", () => ({
@@ -226,8 +229,8 @@ describe("tryDispatchAcpReply", () => {
     messageActionMocks.runMessageAction.mockReset();
     messageActionMocks.runMessageAction.mockResolvedValue({ ok: true as const });
     ttsMocks.maybeApplyTtsToPayload.mockClear();
-    ttsMocks.resolveTtsConfig.mockReset();
-    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    ttsMocks.resolveTtsConfigForAgent.mockReset();
+    ttsMocks.resolveTtsConfigForAgent.mockReturnValue({ mode: "final" });
     sessionMetaMocks.readAcpSessionEntry.mockReset();
     sessionMetaMocks.readAcpSessionEntry.mockReturnValue(null);
     bindingServiceMocks.listBySession.mockReset();

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -22,7 +22,7 @@ import {
   normalizeAttachments,
 } from "../../media-understanding/attachments.normalize.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { maybeApplyTtsToPayload, resolveTtsConfig } from "../../tts/tts.js";
+import { maybeApplyTtsToPayload, resolveTtsConfigForAgent } from "../../tts/tts.js";
 import {
   isCommandEnabled,
   maybeResolveTextAlias,
@@ -215,6 +215,15 @@ export async function tryDispatchAcpReply(params: {
     return null;
   }
 
+  const resolvedAcpAgent =
+    acpResolution.kind === "ready"
+      ? (
+          acpResolution.meta.agent?.trim() ||
+          params.cfg.acp?.defaultAgent?.trim() ||
+          resolveAgentIdFromSessionKey(sessionKey)
+        ).trim()
+      : resolveAgentIdFromSessionKey(sessionKey);
+
   let queuedFinal = false;
   const delivery = createAcpDispatchDeliveryCoordinator({
     cfg: params.cfg,
@@ -227,6 +236,7 @@ export async function tryDispatchAcpReply(params: {
     originatingChannel: params.originatingChannel,
     originatingTo: params.originatingTo,
     onReplyStart: params.onReplyStart,
+    agentId: resolvedAcpAgent,
   });
 
   const identityPendingBeforeTurn = isSessionIdentityPending(
@@ -241,14 +251,6 @@ export async function tryDispatchAcpReply(params: {
         accountIdRaw: params.ctx.AccountId,
       }));
 
-  const resolvedAcpAgent =
-    acpResolution.kind === "ready"
-      ? (
-          acpResolution.meta.agent?.trim() ||
-          params.cfg.acp?.defaultAgent?.trim() ||
-          resolveAgentIdFromSessionKey(sessionKey)
-        ).trim()
-      : resolveAgentIdFromSessionKey(sessionKey);
   const projector = createAcpReplyProjector({
     cfg: params.cfg,
     shouldSendToolSummaries: params.shouldSendToolSummaries,
@@ -312,7 +314,7 @@ export async function tryDispatchAcpReply(params: {
     });
 
     await projector.flush(true);
-    const ttsMode = resolveTtsConfig(params.cfg).mode ?? "final";
+    const ttsMode = resolveTtsConfigForAgent(params.cfg, resolvedAcpAgent).mode ?? "final";
     const accumulatedBlockText = delivery.getAccumulatedBlockText();
     if (ttsMode === "final" && delivery.getBlockCount() > 0 && accumulatedBlockText.trim()) {
       try {
@@ -323,6 +325,7 @@ export async function tryDispatchAcpReply(params: {
           kind: "final",
           inboundAudio: params.inboundAudio,
           ttsAuto: params.sessionTtsAuto,
+          agentId: resolvedAcpAgent,
         });
         if (ttsSyntheticReply.mediaUrl) {
           const delivered = await delivery.deliver("final", {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -69,7 +69,9 @@ const ttsMocks = vi.hoisted(() => {
     normalizeTtsAutoMode: vi.fn((value: unknown) =>
       typeof value === "string" ? value : undefined,
     ),
-    resolveTtsConfig: vi.fn((_cfg: OpenClawConfig) => ({ mode: "final" })),
+    resolveTtsConfigForAgent: vi.fn((_cfg: OpenClawConfig, _agentId?: string) => ({
+      mode: "final",
+    })),
   };
 });
 
@@ -142,7 +144,8 @@ vi.mock("../../infra/outbound/session-binding-service.js", async (importOriginal
 vi.mock("../../tts/tts.js", () => ({
   maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
   normalizeTtsAutoMode: (value: unknown) => ttsMocks.normalizeTtsAutoMode(value),
-  resolveTtsConfig: (cfg: OpenClawConfig) => ttsMocks.resolveTtsConfig(cfg),
+  resolveTtsConfigForAgent: (cfg: OpenClawConfig, agentId?: string) =>
+    ttsMocks.resolveTtsConfigForAgent(cfg, agentId),
 }));
 
 const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
@@ -231,8 +234,8 @@ describe("dispatchReplyFromConfig", () => {
     ttsMocks.state.synthesizeFinalAudio = false;
     ttsMocks.maybeApplyTtsToPayload.mockClear();
     ttsMocks.normalizeTtsAutoMode.mockClear();
-    ttsMocks.resolveTtsConfig.mockClear();
-    ttsMocks.resolveTtsConfig.mockReturnValue({
+    ttsMocks.resolveTtsConfigForAgent.mockClear();
+    ttsMocks.resolveTtsConfigForAgent.mockReturnValue({
       mode: "final",
     });
   });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -24,7 +24,11 @@ import {
 } from "../../logging/diagnostic.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
-import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
+import {
+  maybeApplyTtsToPayload,
+  normalizeTtsAutoMode,
+  resolveTtsConfigForAgent,
+} from "../../tts/tts.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
@@ -174,6 +178,7 @@ export async function dispatchReplyFromConfig(params: {
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
+  const sessionAgentId = resolveSessionAgentId({ sessionKey: acpDispatchSessionKey, config: cfg });
   const hookRunner = getGlobalHookRunner();
 
   // Extract message context for hooks (plugin and internal)
@@ -418,6 +423,7 @@ export async function dispatchReplyFromConfig(params: {
               kind: "tool",
               inboundAudio,
               ttsAuto: sessionTtsAuto,
+              agentId: sessionAgentId,
             });
             const deliveryPayload = resolveToolDeliveryPayload(ttsPayload);
             if (!deliveryPayload) {
@@ -454,6 +460,7 @@ export async function dispatchReplyFromConfig(params: {
               kind: "block",
               inboundAudio,
               ttsAuto: sessionTtsAuto,
+              agentId: sessionAgentId,
             });
             if (shouldRouteToOriginating) {
               await sendPayloadAsync(ttsPayload, context?.abortSignal, false);
@@ -510,6 +517,7 @@ export async function dispatchReplyFromConfig(params: {
         kind: "final",
         inboundAudio,
         ttsAuto: sessionTtsAuto,
+        agentId: sessionAgentId,
       });
       if (shouldRouteToOriginating && originatingChannel && originatingTo) {
         // Route final reply to originating channel.
@@ -538,7 +546,7 @@ export async function dispatchReplyFromConfig(params: {
       }
     }
 
-    const ttsMode = resolveTtsConfig(cfg).mode ?? "final";
+    const ttsMode = resolveTtsConfigForAgent(cfg, sessionAgentId).mode ?? "final";
     // Generate TTS-only reply after block streaming completes (when there's no final reply).
     // This handles the case where block streaming succeeds and drops final payloads,
     // but we still want TTS audio to be generated from the accumulated block content.
@@ -556,6 +564,7 @@ export async function dispatchReplyFromConfig(params: {
           kind: "final",
           inboundAudio,
           ttsAuto: sessionTtsAuto,
+          agentId: sessionAgentId,
         });
         // Only send if TTS was actually applied (mediaUrl exists)
         if (ttsSyntheticReply.mediaUrl) {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -113,6 +113,49 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Reasoning: on");
   });
 
+  it("shows the current agent's resolved voice provider in status output", () => {
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-4o-mini",
+            },
+          },
+          list: [
+            {
+              id: "storyteller",
+              voice: {
+                provider: "inworld",
+                auto: "always",
+              },
+            },
+          ],
+        },
+        messages: {
+          tts: {
+            auto: "always",
+            provider: "openai",
+          },
+        },
+      } as OpenClawConfig,
+      agent: {
+        model: "openai/gpt-4o-mini",
+      },
+      agentId: "storyteller",
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+      },
+      sessionKey: "agent:storyteller:main",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Voice: always");
+    expect(normalized).toContain("provider=inworld");
+  });
+
   it("shows fast mode when enabled", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -30,7 +30,7 @@ import {
   getTtsProvider,
   isSummarizationEnabled,
   resolveTtsAutoMode,
-  resolveTtsConfig,
+  resolveTtsConfigForAgent,
   resolveTtsPrefsPath,
 } from "../tts/tts.js";
 import {
@@ -389,11 +389,12 @@ const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandi
 const formatVoiceModeLine = (
   config?: OpenClawConfig,
   sessionEntry?: SessionEntry,
+  agentId?: string,
 ): string | null => {
   if (!config) {
     return null;
   }
-  const ttsConfig = resolveTtsConfig(config);
+  const ttsConfig = resolveTtsConfigForAgent(config, agentId);
   const prefsPath = resolveTtsPrefsPath(ttsConfig);
   const autoMode = resolveTtsAutoMode({
     config: ttsConfig,
@@ -666,7 +667,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const usageCostLine =
     usagePair && costLine ? `${usagePair} · ${costLine}` : (usagePair ?? costLine);
   const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
-  const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry);
+  const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry, args.agentId);
 
   return [
     versionLine,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -224,6 +224,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional ACP session mode default for this agent (persistent or oneshot).",
   "agents.list[].runtime.acp.cwd":
     "Optional default working directory for this agent's ACP sessions.",
+  "agents.list[].voice":
+    "Optional per-agent TTS voice settings merged on top of messages.tts. Use provider-specific nested blocks (openai, elevenlabs, inworld, edge) for voice/model overrides without duplicating global TTS infrastructure.",
   "agents.list[].identity.avatar":
     "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
   "agents.defaults.heartbeat.suppressToolErrorWarnings":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -56,6 +56,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "diagnostics.cacheTrace.includeSystem": "Cache Trace Include System",
   "agents.list.*.identity.avatar": "Identity Avatar",
   "agents.list.*.skills": "Agent Skill Filter",
+  "agents.list[].voice": "Agent Voice",
   "agents.list[].runtime": "Agent Runtime",
   "agents.list[].runtime.type": "Agent Runtime Type",
   "agents.list[].runtime.acp": "Agent ACP Runtime",

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -4,6 +4,7 @@ import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
+import type { AgentVoiceConfig } from "./types.tts.js";
 
 export type AgentRuntimeAcpConfig = {
   /** ACP harness adapter id (for example codex, claude). */
@@ -87,6 +88,8 @@ export type AgentConfig = {
   tools?: AgentToolsConfig;
   /** Optional runtime descriptor for this agent. */
   runtime?: AgentRuntimeConfig;
+  /** Per-agent voice config (provider-specific voice/model settings, auto mode, etc.) — merged on top of global messages.tts. */
+  voice?: AgentVoiceConfig;
 };
 
 export type AgentsConfig = {

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,6 +1,6 @@
 import type { SecretInput } from "./types.secrets.js";
 
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "inworld";
 
 export type TtsMode = "final" | "all";
 
@@ -65,6 +65,13 @@ export type TtsConfig = {
     speed?: number;
     /** System-level instructions for the TTS model (gpt-4o-mini-tts only). */
     instructions?: string;
+  };
+  /** InWorld AI configuration. */
+  inworld?: {
+    apiKey?: SecretInput;
+    baseUrl?: string;
+    voiceId?: string;
+    modelId?: string;
   };
   /** Microsoft Edge (node-edge-tts) configuration. */
   edge?: {

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -25,6 +25,45 @@ export type TtsModelOverrideConfig = {
   allowSeed?: boolean;
 };
 
+/**
+ * Slim per-agent voice config. Only voice-identity fields — no infrastructure
+ * (apiKey, baseUrl, timeoutMs, prefsPath, etc.). Merged on top of the global
+ * `messages.tts` config by `resolveTtsConfigForAgent`.
+ */
+export type AgentVoiceConfig = {
+  /** TTS provider for this agent. */
+  provider?: TtsProvider;
+  /** Auto-TTS mode for this agent. */
+  auto?: TtsAutoMode;
+  /** Legacy enable/disable flag. */
+  enabled?: boolean;
+  /** Apply TTS to final replies only or all. */
+  mode?: TtsMode;
+  /** OpenAI-specific per-agent voice settings. */
+  openai?: {
+    voice?: string;
+    model?: string;
+    speed?: number;
+    instructions?: string;
+  };
+  /** ElevenLabs-specific per-agent voice settings. */
+  elevenlabs?: {
+    voiceId?: string;
+    modelId?: string;
+    speed?: number;
+  };
+  /** InWorld-specific per-agent voice settings. */
+  inworld?: {
+    voiceId?: string;
+    modelId?: string;
+  };
+  /** Edge-specific per-agent voice settings. */
+  edge?: {
+    voice?: string;
+    lang?: string;
+  };
+};
+
 export type TtsConfig = {
   /** Auto-TTS mode (preferred). */
   auto?: TtsAutoMode;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -7,6 +7,7 @@ import {
   HumanDelaySchema,
   IdentitySchema,
   SecretInputSchema,
+  AgentVoiceConfigSchema,
   ToolsLinksSchema,
   ToolsMediaSchema,
 } from "./zod-schema.core.js";
@@ -772,6 +773,7 @@ export const AgentEntrySchema = z
     params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,
+    voice: AgentVoiceConfigSchema,
   })
   .strict();
 

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -440,6 +440,47 @@ export const TtsConfigSchema = z
   .strict()
   .optional();
 
+export const AgentVoiceConfigSchema = z
+  .object({
+    provider: TtsProviderSchema.optional(),
+    auto: TtsAutoSchema.optional(),
+    enabled: z.boolean().optional(),
+    mode: TtsModeSchema.optional(),
+    openai: z
+      .object({
+        voice: z.string().optional(),
+        model: z.string().optional(),
+        speed: z.number().min(0.25).max(4).optional(),
+        instructions: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    elevenlabs: z
+      .object({
+        voiceId: z.string().optional(),
+        modelId: z.string().optional(),
+        speed: z.number().min(0.5).max(2).optional(),
+      })
+      .strict()
+      .optional(),
+    inworld: z
+      .object({
+        voiceId: z.string().optional(),
+        modelId: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    edge: z
+      .object({
+        voice: z.string().optional(),
+        lang: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
 export const HumanDelaySchema = z
   .object({
     mode: z.union([z.literal("off"), z.literal("natural"), z.literal("custom")]).optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -353,7 +353,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "inworld"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -406,6 +406,15 @@ export const TtsConfigSchema = z
         voice: z.string().optional(),
         speed: z.number().min(0.25).max(4).optional(),
         instructions: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    inworld: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        voiceId: z.string().optional(),
+        modelId: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -1,5 +1,7 @@
 import { loadConfig } from "../../config/config.js";
 import {
+  INWORLD_TTS_MODELS,
+  INWORLD_TTS_VOICES,
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
   getTtsProvider,
@@ -38,6 +40,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         prefsPath,
         hasOpenAIKey: Boolean(resolveTtsApiKey(config, "openai")),
         hasElevenLabsKey: Boolean(resolveTtsApiKey(config, "elevenlabs")),
+        hasInworldKey: Boolean(resolveTtsApiKey(config, "inworld")),
         edgeEnabled: isTtsProviderConfigured(config, "edge"),
       });
     } catch (err) {
@@ -100,13 +103,18 @@ export const ttsHandlers: GatewayRequestHandlers = {
   },
   "tts.setProvider": async ({ params, respond }) => {
     const provider = typeof params.provider === "string" ? params.provider.trim() : "";
-    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge") {
+    if (
+      provider !== "openai" &&
+      provider !== "elevenlabs" &&
+      provider !== "edge" &&
+      provider !== "inworld"
+    ) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "Invalid provider. Use openai, elevenlabs, or edge.",
+          "Invalid provider. Use openai, elevenlabs, inworld, or edge.",
         ),
       );
       return;
@@ -140,6 +148,13 @@ export const ttsHandlers: GatewayRequestHandlers = {
             name: "ElevenLabs",
             configured: Boolean(resolveTtsApiKey(config, "elevenlabs")),
             models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_monolingual_v1"],
+          },
+          {
+            id: "inworld",
+            name: "InWorld AI",
+            configured: Boolean(resolveTtsApiKey(config, "inworld")),
+            models: [...INWORLD_TTS_MODELS],
+            voices: [...INWORLD_TTS_VOICES],
           },
           {
             id: "edge",

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -156,7 +156,12 @@ export function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
+            if (
+              rawValue === "openai" ||
+              rawValue === "elevenlabs" ||
+              rawValue === "inworld" ||
+              rawValue === "edge"
+            ) {
               overrides.provider = rawValue;
             } else {
               warnings.push(`unsupported provider "${rawValue}"`);
@@ -186,6 +191,20 @@ export function parseTtsDirectives(
             } else {
               warnings.push(`invalid ElevenLabs voiceId "${rawValue}"`);
             }
+            break;
+          case "inworld_voice":
+          case "inworldvoice":
+            if (!policy.allowVoice) {
+              break;
+            }
+            overrides.inworld = { ...overrides.inworld, voiceId: rawValue };
+            break;
+          case "inworld_model":
+          case "inworldmodel":
+            if (!policy.allowModelId) {
+              break;
+            }
+            overrides.inworld = { ...overrides.inworld, modelId: rawValue };
             break;
           case "model":
           case "modelid":
@@ -674,6 +693,110 @@ export async function openaiTTS(params: {
     }
 
     return Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// -- InWorld AI TTS ----------------------------------------------------------
+
+const DEFAULT_INWORLD_BASE_URL = "https://api.inworld.ai";
+
+export const INWORLD_TTS_MODELS = ["inworld-tts-1.5-max", "inworld-tts-1.5-mini"] as const;
+
+export const INWORLD_TTS_VOICES = [
+  "Alex",
+  "Ashley",
+  "Craig",
+  "Deborah",
+  "Dennis",
+  "Dominus",
+  "Edward",
+  "Elizabeth",
+  "Hades",
+  "Heitor",
+  "Julia",
+  "Mark",
+  "Olivia",
+  "Pixie",
+  "Priya",
+  "Ronald",
+  "Sarah",
+  "Shaun",
+  "Theodore",
+  "Timothy",
+  "Wendy",
+] as const;
+
+function normalizeInworldBaseUrl(baseUrl?: string): string {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return DEFAULT_INWORLD_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+export async function inworldTTS(params: {
+  text: string;
+  apiKey: string;
+  baseUrl?: string;
+  voiceId: string;
+  modelId: string;
+  audioEncoding: "MP3" | "LINEAR16" | "PCM";
+  sampleRateHertz: number;
+  bitRate?: number;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const {
+    text,
+    apiKey,
+    baseUrl,
+    voiceId,
+    modelId,
+    audioEncoding,
+    sampleRateHertz,
+    bitRate,
+    timeoutMs,
+  } = params;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const url = `${normalizeInworldBaseUrl(baseUrl)}/tts/v1/voice`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      // The current InWorld API reference uses camelCase field names.
+      body: JSON.stringify({
+        text,
+        voiceId,
+        modelId,
+        audioConfig: {
+          audioEncoding,
+          sampleRateHertz,
+          ...(bitRate != null ? { bitRate } : {}),
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      throw new Error(
+        `InWorld TTS API error (${response.status})${errorBody ? `: ${errorBody}` : ""}`,
+      );
+    }
+
+    // InWorld returns JSON with base64-encoded audioContent.
+    const result = (await response.json()) as { audioContent?: string };
+    if (!result.audioContent) {
+      throw new Error("InWorld TTS: no audioContent in response");
+    }
+    return Buffer.from(result.audioContent, "base64");
   } finally {
     clearTimeout(timeout);
   }

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
@@ -65,6 +66,7 @@ const {
   summarizeText,
   resolveOutputFormat,
   resolveEdgeOutputFormat,
+  resolveTtsConfigForAgent,
 } = _test;
 
 const mockAssistantMessage = (content: AssistantMessage["content"]): AssistantMessage => ({
@@ -132,9 +134,66 @@ function createInworldCfg(params?: { includeOpenAIFallback?: boolean }): OpenCla
   };
 }
 
+function createPerAgentVoiceCfg(): OpenClawConfig {
+  return {
+    agents: {
+      defaults: { model: { primary: "openai/gpt-4o-mini" } },
+      list: [
+        {
+          id: "storyteller",
+          voice: {
+            provider: "inworld",
+            auto: "always",
+            mode: "all",
+            inworld: {
+              voiceId: "Ashley",
+              modelId: "inworld-tts-1.5-mini",
+            },
+          },
+        },
+        {
+          id: "announcer",
+          voice: {
+            provider: "openai",
+            openai: {
+              voice: "ballad",
+              model: "gpt-4o-mini-tts",
+              speed: 1.25,
+              instructions: "Speak warmly",
+            },
+          },
+        },
+      ],
+    },
+    messages: {
+      tts: {
+        provider: "openai",
+        openai: {
+          apiKey: "openai-key",
+          model: "gpt-4o-mini-tts",
+          voice: "alloy",
+        },
+        elevenlabs: {
+          apiKey: "elevenlabs-key",
+          voiceId: "pMsXgVXv3BLzUgSXRplE",
+          modelId: "eleven_multilingual_v2",
+        },
+        inworld: {
+          apiKey: "inworld-key",
+          voiceId: "Dennis",
+          modelId: "inworld-tts-1.5-max",
+        },
+      },
+    },
+  };
+}
+
 describe("tts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    tts.setLastTtsAttempt(undefined);
+    tts.setLastTtsAttempt(undefined, "storyteller");
+    tts.setLastTtsAttempt(undefined, "announcer");
     vi.mocked(completeSimple).mockResolvedValue(
       mockAssistantMessage([{ type: "text", text: "Summary" }]),
     );
@@ -308,6 +367,87 @@ describe("tts", () => {
         const config = resolveTtsConfig(testCase.cfg);
         expect(resolveEdgeOutputFormat(config), testCase.name).toBe(testCase.expected);
       }
+    });
+  });
+
+  describe("resolveTtsConfigForAgent", () => {
+    it("merges provider-specific per-agent voice config including InWorld", () => {
+      const config = resolveTtsConfigForAgent(createPerAgentVoiceCfg(), "storyteller");
+
+      expect(config.provider).toBe("inworld");
+      expect(config.auto).toBe("always");
+      expect(config.mode).toBe("all");
+      expect(config.inworld.voiceId).toBe("Ashley");
+      expect(config.inworld.modelId).toBe("inworld-tts-1.5-mini");
+      expect(config.inworld.apiKey).toBe("inworld-key");
+      expect(config.openai.voice).toBe("alloy");
+    });
+
+    it("keeps provider-specific overrides scoped to the matching provider", () => {
+      const config = resolveTtsConfigForAgent(createPerAgentVoiceCfg(), "announcer");
+
+      expect(config.provider).toBe("openai");
+      expect(config.openai.voice).toBe("ballad");
+      expect(config.openai.model).toBe("gpt-4o-mini-tts");
+      expect(config.openai.speed).toBe(1.25);
+      expect(config.openai.instructions).toBe("Speak warmly");
+      expect(config.inworld.voiceId).toBe("Dennis");
+      expect(config.inworld.modelId).toBe("inworld-tts-1.5-max");
+    });
+  });
+
+  describe("resolveTtsPrefsPath", () => {
+    it("keeps the default prefs path shared even when an agent id is present", () => {
+      const config = resolveTtsConfig({
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: { tts: {} },
+      });
+
+      const globalPath = tts.resolveTtsPrefsPath(config);
+      const agentPath = tts.resolveTtsPrefsPath(config);
+
+      expect(globalPath).toContain(path.join("settings", "tts.json"));
+      expect(agentPath).toBe(globalPath);
+    });
+  });
+
+  describe("buildTtsSystemPromptHint", () => {
+    it("includes the resolved default provider for the current agent", () => {
+      const hint = tts.buildTtsSystemPromptHint(createPerAgentVoiceCfg(), "storyteller");
+
+      expect(hint).toContain("default provider: inworld");
+      expect(hint).toContain("agent-specific voice defaults");
+    });
+  });
+
+  describe("last TTS attempt status", () => {
+    it("tracks attempts per agent without leaking between agents", () => {
+      tts.setLastTtsAttempt(
+        {
+          timestamp: 1,
+          success: true,
+          textLength: 12,
+          summarized: false,
+          provider: "openai",
+        },
+        "storyteller",
+      );
+      tts.setLastTtsAttempt(
+        {
+          timestamp: 2,
+          success: false,
+          textLength: 24,
+          summarized: true,
+          error: "failed",
+        },
+        "announcer",
+      );
+
+      expect(tts.getLastTtsAttempt("storyteller")?.timestamp).toBe(1);
+      expect(tts.getLastTtsAttempt("storyteller")?.provider).toBe("openai");
+      expect(tts.getLastTtsAttempt("announcer")?.timestamp).toBe(2);
+      expect(tts.getLastTtsAttempt("announcer")?.error).toBe("failed");
+      expect(tts.getLastTtsAttempt()).toBeUndefined();
     });
   });
 
@@ -721,6 +861,37 @@ describe("tts", () => {
             expect(result.outputFormat).toBe("mp3");
             expect(result.voiceCompatible).toBe(false);
             expect(result.audioPath).toMatch(/\.mp3$/);
+          }
+        },
+      );
+    });
+
+    it("uses per-agent InWorld voice and model overrides", async () => {
+      await withMockedFetch(
+        async () => ({
+          ok: true,
+          json: async () => ({ audioContent: Buffer.from("agent-inworld").toString("base64") }),
+        }),
+        async (fetchMock) => {
+          const result = await tts.textToSpeech({
+            text: "Tell the story",
+            cfg: createPerAgentVoiceCfg(),
+            agentId: "storyteller",
+          });
+
+          expect(result.success).toBe(true);
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+
+          const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+          const body = JSON.parse(init.body as string) as Record<string, unknown>;
+          expect(body).toMatchObject({
+            text: "Tell the story",
+            voiceId: "Ashley",
+            modelId: "inworld-tts-1.5-mini",
+          });
+
+          if (result.success) {
+            expect(result.provider).toBe("inworld");
           }
         },
       );

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -107,6 +107,31 @@ function createOpenAiTelephonyCfg(model: "tts-1" | "gpt-4o-mini-tts"): OpenClawC
   };
 }
 
+function createInworldCfg(params?: { includeOpenAIFallback?: boolean }): OpenClawConfig {
+  return {
+    agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+    messages: {
+      tts: {
+        provider: "inworld",
+        inworld: {
+          apiKey: "inworld-key",
+          voiceId: "Dennis",
+          modelId: "inworld-tts-1.5-max",
+        },
+        ...(params?.includeOpenAIFallback
+          ? {
+              openai: {
+                apiKey: "openai-key",
+                model: "gpt-4o-mini-tts",
+                voice: "alloy",
+              },
+            }
+          : {}),
+      },
+    },
+  };
+}
+
 describe("tts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -308,6 +333,18 @@ describe("tts", () => {
       const result = parseTtsDirectives(input, policy);
 
       expect(result.overrides.provider).toBe("edge");
+    });
+
+    it("accepts inworld provider and inworld-specific override keys", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input =
+        "Hello [[tts:provider=inworld inworld_voice=Ashley inworld_model=inworld-tts-1.5-mini]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.provider).toBe("inworld");
+      expect(result.overrides.inworld?.voiceId).toBe("Ashley");
+      expect(result.overrides.inworld?.modelId).toBe("inworld-tts-1.5-mini");
+      expect(result.warnings).toHaveLength(0);
     });
 
     it("rejects provider override by default while keeping voice overrides enabled", () => {
@@ -633,6 +670,132 @@ describe("tts", () => {
 
     it("includes instructions for gpt-4o-mini-tts", async () => {
       await expectTelephonyInstructions("gpt-4o-mini-tts", "Speak warmly");
+    });
+  });
+
+  describe("textToSpeech – inworld", () => {
+    const withMockedFetch = async (
+      impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<unknown>,
+      run: (fetchMock: ReturnType<typeof vi.fn>) => Promise<void>,
+    ) => {
+      const originalFetch = globalThis.fetch;
+      const fetchMock = vi.fn(impl);
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+      try {
+        await run(fetchMock);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    };
+
+    it("keeps InWorld on MP3 even for Telegram channels", async () => {
+      await withMockedFetch(
+        async () => ({
+          ok: true,
+          json: async () => ({ audioContent: Buffer.from("inworld-mp3").toString("base64") }),
+        }),
+        async (fetchMock) => {
+          const result = await tts.textToSpeech({
+            text: "Hello from InWorld",
+            cfg: createInworldCfg(),
+            channel: "telegram",
+          });
+
+          expect(result.success).toBe(true);
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+
+          const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+          const body = JSON.parse(init.body as string) as Record<string, unknown>;
+          expect(body).toMatchObject({
+            text: "Hello from InWorld",
+            voiceId: "Dennis",
+            modelId: "inworld-tts-1.5-max",
+            audioConfig: {
+              audioEncoding: "MP3",
+              sampleRateHertz: 44100,
+              bitRate: 128000,
+            },
+          });
+
+          if (result.success) {
+            expect(result.outputFormat).toBe("mp3");
+            expect(result.voiceCompatible).toBe(false);
+            expect(result.audioPath).toMatch(/\.mp3$/);
+          }
+        },
+      );
+    });
+
+    it("preserves Telegram opus fallback when an InWorld attempt fails", async () => {
+      await withMockedFetch(
+        async (_input, init) => {
+          const body = JSON.parse(init?.body as string) as Record<string, unknown>;
+          if ("voiceId" in body) {
+            return {
+              ok: false,
+              status: 500,
+              text: async () => "inworld failed",
+            };
+          }
+          return {
+            ok: true,
+            arrayBuffer: async () => new ArrayBuffer(4),
+          };
+        },
+        async (fetchMock) => {
+          const result = await tts.textToSpeech({
+            text: "Fallback me",
+            cfg: createInworldCfg({ includeOpenAIFallback: true }),
+            channel: "telegram",
+          });
+
+          expect(result.success).toBe(true);
+          expect(fetchMock).toHaveBeenCalledTimes(2);
+
+          const [, openAiInit] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
+          const openAiBody = JSON.parse(openAiInit.body as string) as Record<string, unknown>;
+          expect(openAiBody.response_format).toBe("opus");
+
+          if (result.success) {
+            expect(result.provider).toBe("openai");
+            expect(result.outputFormat).toBe("opus");
+            expect(result.voiceCompatible).toBe(true);
+            expect(result.audioPath).toMatch(/\.opus$/);
+          }
+        },
+      );
+    });
+  });
+
+  describe("textToSpeechTelephony – inworld", () => {
+    it("falls back to OpenAI because InWorld is unsupported for telephony", async () => {
+      const originalFetch = globalThis.fetch;
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(4),
+      }));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+      try {
+        const result = await tts.textToSpeechTelephony({
+          text: "Telephony check",
+          cfg: createInworldCfg({ includeOpenAIFallback: true }),
+        });
+
+        expect(result.success).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const body = JSON.parse(init.body as string) as Record<string, unknown>;
+        expect(body.response_format).toBe("pcm");
+
+        if (result.success) {
+          expect(result.provider).toBe("openai");
+          expect(result.outputFormat).toBe("pcm");
+          expect(result.sampleRate).toBe(24000);
+        }
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -32,6 +32,9 @@ import {
   edgeTTS,
   elevenLabsTTS,
   inferEdgeExtension,
+  INWORLD_TTS_MODELS,
+  INWORLD_TTS_VOICES,
+  inworldTTS,
   isValidOpenAIModel,
   isValidOpenAIVoice,
   isValidVoiceId,
@@ -43,7 +46,12 @@ import {
   scheduleCleanup,
   summarizeText,
 } from "./tts-core.js";
-export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES } from "./tts-core.js";
+export {
+  OPENAI_TTS_MODELS,
+  OPENAI_TTS_VOICES,
+  INWORLD_TTS_MODELS,
+  INWORLD_TTS_VOICES,
+} from "./tts-core.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_TTS_MAX_LENGTH = 1500;
@@ -55,6 +63,9 @@ const DEFAULT_ELEVENLABS_VOICE_ID = "pMsXgVXv3BLzUgSXRplE";
 const DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2";
 const DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts";
 const DEFAULT_OPENAI_VOICE = "alloy";
+const DEFAULT_INWORLD_BASE_URL = "https://api.inworld.ai";
+const DEFAULT_INWORLD_VOICE_ID = "Dennis";
+const DEFAULT_INWORLD_MODEL_ID = "inworld-tts-1.5-max";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
@@ -81,6 +92,15 @@ const DEFAULT_OUTPUT = {
   elevenlabs: "mp3_44100_128",
   extension: ".mp3",
   voiceCompatible: false,
+};
+
+const INWORLD_DEFAULT_OUTPUT = {
+  audioEncoding: "MP3" as const,
+  outputFormat: "mp3",
+  extension: ".mp3",
+  voiceCompatible: false,
+  sampleRateHertz: 44100,
+  bitRate: 128000,
 };
 
 const TELEPHONY_OUTPUT = {
@@ -120,6 +140,12 @@ export type ResolvedTtsConfig = {
     voice: string;
     speed?: number;
     instructions?: string;
+  };
+  inworld: {
+    apiKey?: string;
+    baseUrl: string;
+    voiceId: string;
+    modelId: string;
   };
   edge: {
     enabled: boolean;
@@ -174,6 +200,10 @@ export type TtsDirectiveOverrides = {
     applyTextNormalization?: "auto" | "on" | "off";
     languageCode?: string;
     voiceSettings?: Partial<ResolvedTtsConfig["elevenlabs"]["voiceSettings"]>;
+  };
+  inworld?: {
+    voiceId?: string;
+    modelId?: string;
   };
 };
 
@@ -309,6 +339,19 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
       speed: raw.openai?.speed,
       instructions: raw.openai?.instructions?.trim() || undefined,
+    },
+    inworld: {
+      apiKey: normalizeResolvedSecretInputString({
+        value: raw.inworld?.apiKey,
+        path: "messages.tts.inworld.apiKey",
+      }),
+      baseUrl: (
+        raw.inworld?.baseUrl?.trim() ||
+        process.env.INWORLD_API_BASE_URL?.trim() ||
+        DEFAULT_INWORLD_BASE_URL
+      ).replace(/\/+$/, ""),
+      voiceId: raw.inworld?.voiceId?.trim() || DEFAULT_INWORLD_VOICE_ID,
+      modelId: raw.inworld?.modelId?.trim() || DEFAULT_INWORLD_MODEL_ID,
     },
     edge: {
       enabled: raw.edge?.enabled ?? true,
@@ -461,6 +504,9 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   if (resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
+  if (resolveTtsApiKey(config, "inworld")) {
+    return "inworld";
+  }
   return "edge";
 }
 
@@ -528,10 +574,13 @@ export function resolveTtsApiKey(
   if (provider === "openai") {
     return config.openai.apiKey || process.env.OPENAI_API_KEY;
   }
+  if (provider === "inworld") {
+    return config.inworld.apiKey || process.env.INWORLD_API_KEY;
+  }
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "inworld", "edge"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
@@ -541,6 +590,7 @@ export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: Tts
   if (provider === "edge") {
     return config.edge.enabled;
   }
+  // All other providers (openai, elevenlabs, inworld) require an API key.
   return Boolean(resolveTtsApiKey(config, provider));
 }
 
@@ -714,6 +764,40 @@ export async function textToSpeech(params: {
           voiceSettings,
           timeoutMs: config.timeoutMs,
         });
+      } else if (provider === "inworld") {
+        // Keep the HTTP integration on a single MP3 path until InWorld's
+        // non-streaming Opus encoding is both documented and verified.
+        const inworldOutput = INWORLD_DEFAULT_OUTPUT;
+        const voiceIdOverride = params.overrides?.inworld?.voiceId;
+        const modelIdOverride = params.overrides?.inworld?.modelId;
+        audioBuffer = await inworldTTS({
+          text: params.text,
+          apiKey,
+          baseUrl: config.inworld.baseUrl,
+          voiceId: voiceIdOverride ?? config.inworld.voiceId,
+          modelId: modelIdOverride ?? config.inworld.modelId,
+          audioEncoding: inworldOutput.audioEncoding,
+          sampleRateHertz: inworldOutput.sampleRateHertz,
+          bitRate: inworldOutput.bitRate,
+          timeoutMs: config.timeoutMs,
+        });
+
+        const latencyMs = Date.now() - providerStart;
+        const tempRoot = resolvePreferredOpenClawTmpDir();
+        mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+        const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
+        const audioPath = path.join(tempDir, `voice-${Date.now()}${inworldOutput.extension}`);
+        writeFileSync(audioPath, audioBuffer);
+        scheduleCleanup(tempDir);
+
+        return {
+          success: true,
+          audioPath,
+          latencyMs,
+          provider,
+          outputFormat: inworldOutput.outputFormat,
+          voiceCompatible: inworldOutput.voiceCompatible,
+        };
       } else {
         const openaiModelOverride = params.overrides?.openai?.model;
         const openaiVoiceOverride = params.overrides?.openai?.voice;
@@ -776,8 +860,8 @@ export async function textToSpeechTelephony(params: {
   for (const provider of providers) {
     const providerStart = Date.now();
     try {
-      if (provider === "edge") {
-        errors.push("edge: unsupported for telephony");
+      if (provider === "edge" || provider === "inworld") {
+        errors.push(`${provider}: unsupported for telephony`);
         continue;
       }
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -10,6 +10,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import path from "node:path";
+import { resolveAgentConfig } from "../agents/agent-scope.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
@@ -26,6 +27,7 @@ import { logVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { stripMarkdown } from "../line/markdown-to-line.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
   DEFAULT_OPENAI_BASE_URL,
@@ -245,7 +247,13 @@ type TtsStatusEntry = {
   error?: string;
 };
 
-let lastTtsAttempt: TtsStatusEntry | undefined;
+const GLOBAL_TTS_STATUS_KEY = "__global__";
+const lastTtsAttempts = new Map<string, TtsStatusEntry>();
+
+function resolveTtsStatusKey(agentId?: string): string {
+  const trimmed = agentId?.trim();
+  return trimmed ? normalizeAgentId(trimmed) : GLOBAL_TTS_STATUS_KEY;
+}
 
 export function normalizeTtsAutoMode(value: unknown): TtsAutoMode | undefined {
   if (typeof value !== "string") {
@@ -372,6 +380,65 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
   };
 }
 
+/**
+ * Resolve TTS config for a specific agent by overlaying the agent's provider-aware
+ * `voice` config on top of the global resolved config. Only voice-identity
+ * fields are per-agent; infrastructure (apiKey, baseUrl, timeoutMs, etc.) stays global.
+ */
+export function resolveTtsConfigForAgent(cfg: OpenClawConfig, agentId?: string): ResolvedTtsConfig {
+  const global = resolveTtsConfig(cfg);
+  if (!agentId) {
+    return global;
+  }
+  const v = resolveAgentConfig(cfg, agentId)?.voice;
+  if (!v) {
+    return global;
+  }
+
+  const openaiVoice = v.openai;
+  const elevenlabsVoice = v.elevenlabs;
+  const inworldVoice = v.inworld;
+  const edgeVoice = v.edge;
+  return {
+    ...global,
+    auto:
+      normalizeTtsAutoMode(v.auto) ??
+      (v.enabled != null ? (v.enabled ? "always" : "off") : undefined) ??
+      global.auto,
+    mode: v.mode ?? global.mode,
+    provider: v.provider ?? global.provider,
+    providerSource: v.provider ? "config" : global.providerSource,
+    openai: {
+      ...global.openai,
+      ...(openaiVoice?.voice != null && { voice: openaiVoice.voice }),
+      ...(openaiVoice?.model != null && { model: openaiVoice.model }),
+      ...(openaiVoice?.speed != null && { speed: openaiVoice.speed }),
+      ...(openaiVoice?.instructions != null && { instructions: openaiVoice.instructions }),
+    },
+    elevenlabs: {
+      ...global.elevenlabs,
+      ...(elevenlabsVoice?.voiceId != null && { voiceId: elevenlabsVoice.voiceId }),
+      ...(elevenlabsVoice?.modelId != null && { modelId: elevenlabsVoice.modelId }),
+      ...(elevenlabsVoice?.speed != null && {
+        voiceSettings: {
+          ...global.elevenlabs.voiceSettings,
+          speed: Math.max(0.5, Math.min(2, elevenlabsVoice.speed)),
+        },
+      }),
+    },
+    inworld: {
+      ...global.inworld,
+      ...(inworldVoice?.voiceId != null && { voiceId: inworldVoice.voiceId }),
+      ...(inworldVoice?.modelId != null && { modelId: inworldVoice.modelId }),
+    },
+    edge: {
+      ...global.edge,
+      ...(edgeVoice?.voice != null && { voice: edgeVoice.voice }),
+      ...(edgeVoice?.lang != null && { lang: edgeVoice.lang }),
+    },
+  };
+}
+
 export function resolveTtsPrefsPath(config: ResolvedTtsConfig): string {
   if (config.prefsPath?.trim()) {
     return resolveUserPath(config.prefsPath.trim());
@@ -410,13 +477,17 @@ export function resolveTtsAutoMode(params: {
   return params.config.auto;
 }
 
-export function buildTtsSystemPromptHint(cfg: OpenClawConfig): string | undefined {
-  const config = resolveTtsConfig(cfg);
+export function buildTtsSystemPromptHint(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): string | undefined {
+  const config = resolveTtsConfigForAgent(cfg, agentId);
   const prefsPath = resolveTtsPrefsPath(config);
   const autoMode = resolveTtsAutoMode({ config, prefsPath });
   if (autoMode === "off") {
     return undefined;
   }
+  const provider = getTtsProvider(config, prefsPath);
   const maxLength = getTtsMaxLength(prefsPath);
   const summarize = isSummarizationEnabled(prefsPath) ? "on" : "off";
   const autoHint =
@@ -425,10 +496,14 @@ export function buildTtsSystemPromptHint(cfg: OpenClawConfig): string | undefine
       : autoMode === "tagged"
         ? "Only use TTS when you include [[tts]] or [[tts:text]] tags."
         : undefined;
+  const hasAgentVoiceDefaults = Boolean(agentId && resolveAgentConfig(cfg, agentId)?.voice);
   return [
-    "Voice (TTS) is enabled.",
+    `Voice (TTS) is enabled (default provider: ${provider}).`,
     autoHint,
     `Keep spoken text ≤${maxLength} chars to avoid auto-summary (summary ${summarize}).`,
+    hasAgentVoiceDefaults
+      ? "Any configured agent-specific voice defaults are applied when that provider is used."
+      : undefined,
     "Use [[tts:...]] and optional [[tts:text]]...[[/tts:text]] to control voice/expressiveness.",
   ]
     .filter(Boolean)
@@ -538,12 +613,17 @@ export function setSummarizationEnabled(prefsPath: string, enabled: boolean): vo
   });
 }
 
-export function getLastTtsAttempt(): TtsStatusEntry | undefined {
-  return lastTtsAttempt;
+export function getLastTtsAttempt(agentId?: string): TtsStatusEntry | undefined {
+  return lastTtsAttempts.get(resolveTtsStatusKey(agentId));
 }
 
-export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
-  lastTtsAttempt = entry;
+export function setLastTtsAttempt(entry: TtsStatusEntry | undefined, agentId?: string): void {
+  const key = resolveTtsStatusKey(agentId);
+  if (entry) {
+    lastTtsAttempts.set(key, entry);
+    return;
+  }
+  lastTtsAttempts.delete(key);
 }
 
 /** Channels that require opus audio and support voice-bubble playback */
@@ -614,6 +694,7 @@ function resolveTtsRequestSetup(params: {
   cfg: OpenClawConfig;
   prefsPath?: string;
   providerOverride?: TtsProvider;
+  agentId?: string;
 }):
   | {
       config: ResolvedTtsConfig;
@@ -622,7 +703,7 @@ function resolveTtsRequestSetup(params: {
   | {
       error: string;
     } {
-  const config = resolveTtsConfig(params.cfg);
+  const config = resolveTtsConfigForAgent(params.cfg, params.agentId);
   const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
   if (params.text.length > config.maxTextLength) {
     return {
@@ -644,12 +725,15 @@ export async function textToSpeech(params: {
   prefsPath?: string;
   channel?: string;
   overrides?: TtsDirectiveOverrides;
+  /** Optional agent ID for per-agent voice overrides. */
+  agentId?: string;
 }): Promise<TtsResult> {
   const setup = resolveTtsRequestSetup({
     text: params.text,
     cfg: params.cfg,
     prefsPath: params.prefsPath,
     providerOverride: params.overrides?.provider,
+    agentId: params.agentId,
   });
   if ("error" in setup) {
     return { success: false, error: setup.error };
@@ -933,8 +1017,10 @@ export async function maybeApplyTtsToPayload(params: {
   kind?: "tool" | "block" | "final";
   inboundAudio?: boolean;
   ttsAuto?: string;
+  /** Optional agent ID for per-agent voice overrides. */
+  agentId?: string;
 }): Promise<ReplyPayload> {
-  const config = resolveTtsConfig(params.cfg);
+  const config = resolveTtsConfigForAgent(params.cfg, params.agentId);
   const prefsPath = resolveTtsPrefsPath(config);
   const autoMode = resolveTtsAutoMode({
     config,
@@ -1036,17 +1122,21 @@ export async function maybeApplyTtsToPayload(params: {
     prefsPath,
     channel: params.channel,
     overrides: directives.overrides,
+    agentId: params.agentId,
   });
 
   if (result.success && result.audioPath) {
-    lastTtsAttempt = {
-      timestamp: Date.now(),
-      success: true,
-      textLength: text.length,
-      summarized: wasSummarized,
-      provider: result.provider,
-      latencyMs: result.latencyMs,
-    };
+    setLastTtsAttempt(
+      {
+        timestamp: Date.now(),
+        success: true,
+        textLength: text.length,
+        summarized: wasSummarized,
+        provider: result.provider,
+        latencyMs: result.latencyMs,
+      },
+      params.agentId,
+    );
 
     const channelId = resolveChannelId(params.channel);
     const shouldVoice =
@@ -1059,13 +1149,16 @@ export async function maybeApplyTtsToPayload(params: {
     return finalPayload;
   }
 
-  lastTtsAttempt = {
-    timestamp: Date.now(),
-    success: false,
-    textLength: text.length,
-    summarized: wasSummarized,
-    error: result.error,
-  };
+  setLastTtsAttempt(
+    {
+      timestamp: Date.now(),
+      success: false,
+      textLength: text.length,
+      summarized: wasSummarized,
+      error: result.error,
+    },
+    params.agentId,
+  );
 
   const latency = Date.now() - ttsStart;
   logVerbose(`TTS: conversion failed after ${latency}ms (${result.error ?? "unknown"}).`);
@@ -1084,4 +1177,5 @@ export const _test = {
   summarizeText,
   resolveOutputFormat,
   resolveEdgeOutputFormat,
+  resolveTtsConfigForAgent,
 };


### PR DESCRIPTION
## Summary

Add per-agent TTS voice configuration so each agent can use a different voice identity (provider, voice, speed, model, language) while sharing global TTS infrastructure (API keys, endpoints, timeouts).

### Design

- **New `AgentVoiceConfig` type** — a flat, 10-field subset covering only voice-identity knobs (`provider`, `voice`, `voiceId`, `model`, `speed`, `instructions`, `lang`, `auto`, `enabled`, `mode`)
- **`voice` field on `AgentConfig`** — matches the naming pattern of other per-agent overrides (`humanDelay`, `heartbeat`, `identity`)
- **`resolveTtsConfigForAgent(cfg, agentId)`** — overlays agent voice fields onto the global `ResolvedTtsConfig`, mapping flat fields to provider-specific structs (OpenAI, ElevenLabs, Edge)
- **ElevenLabs speed clamping** — schema allows 0.25–4.0 (provider-agnostic), but values are clamped to 0.5–2.0 when mapping to ElevenLabs

### Example config

```yaml
messages:
  tts:
    provider: openai
    openai:
      voice: alloy
      model: gpt-4o-mini-tts

agents:
  list:
    - id: narrator
      voice:
        voice: nova
        speed: 0.9
    - id: assistant
      voice:
        provider: elevenlabs
        voiceId: abc123
```

### Changes

| File | What |
|------|------|
| `src/config/types.tts.ts` | New `AgentVoiceConfig` type |
| `src/config/zod-schema.core.ts` | `AgentVoiceConfigSchema` validation |
| `src/config/types.agents.ts` | `voice?: AgentVoiceConfig` on `AgentConfig` |
| `src/config/zod-schema.agent-runtime.ts` | Wire schema into `AgentEntrySchema` |
| `src/agents/agent-scope.ts` | Expose `voice` in `ResolvedAgentConfig` |
| `src/tts/tts.ts` | `resolveTtsConfigForAgent()`, `agentId` on `resolveTtsRequestSetup` and `buildTtsSystemPromptHint`, ElevenLabs speed clamping |
| `src/auto-reply/reply/*` | Pass `agentId` through TTS call sites |
| `src/agents/tools/tts-tool.ts` | Accept and forward `agentId` |
| `src/agents/openclaw-tools.ts` | Resolve agent ID with `requesterAgentIdOverride` fallback |
| `src/agents/cli-runner/helpers.ts` | Pass `agentId` to `buildTtsSystemPromptHint` |
| `src/agents/pi-embedded-runner/*` | Pass `agentId` to `buildTtsSystemPromptHint` |
| `src/auto-reply/reply/commands-system-prompt.ts` | Pass `agentId` to `buildTtsSystemPromptHint` |

## Test plan

- [x] `npm run build` passes
- [x] Updated mocks in `dispatch-from-config.test.ts` and `dispatch-acp.test.ts`
- [ ] Manual: configure two agents with different voices, verify each speaks with its own voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)