### PR TITLE
fix(cron): include cache tokens in run log telemetry

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -731,8 +731,16 @@ export async function runCronIsolatedAgentTurn(params: {
         cronSession.sessionEntry.totalTokens = undefined;
         cronSession.sessionEntry.totalTokensFresh = false;
       }
-      cronSession.sessionEntry.cacheRead = usage.cacheRead ?? 0;
-      cronSession.sessionEntry.cacheWrite = usage.cacheWrite ?? 0;
+      const cacheRead = usage.cacheRead ?? 0;
+      const cacheWrite = usage.cacheWrite ?? 0;
+      cronSession.sessionEntry.cacheRead = cacheRead;
+      cronSession.sessionEntry.cacheWrite = cacheWrite;
+      if (cacheRead > 0) {
+        telemetryUsage.cache_read_tokens = cacheRead;
+      }
+      if (cacheWrite > 0) {
+        telemetryUsage.cache_write_tokens = cacheWrite;
+      }
 
       telemetry = {
         model: modelUsed,


### PR DESCRIPTION
## Summary

- Cron run telemetry was missing `cache_read_tokens` and `cache_write_tokens` in the usage object written to the run log JSONL. The values were saved to the session entry but never added to `telemetryUsage`.
- Downstream consumers (e.g. AlphaClaw's cost estimation via `deriveCostBreakdown`) computed cost from only `input_tokens` + `output_tokens`, significantly understating actual spend for jobs that rely on prompt caching.
- For example, a job with 2.3M total tokens (mostly cache reads) across 120 runs showed ~$0.45 estimated cost instead of the correct ~$1–2+ range.

## Test plan

- [x] Existing `run-log.test.ts` tests pass (they already verify cache token fields round-trip correctly when present)
- [ ] Deploy and verify that new cron runs include `cache_read_tokens` / `cache_write_tokens` in the JSONL entries
- [ ] Confirm AlphaClaw insights panel cost figures become consistent with token counts