### PR TITLE
Slack: support Block Kit payloads in agent replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Models/plugins: move Ollama, vLLM, and SGLang onto the provider-plugin architecture, with provider-owned onboarding, discovery, model-picker setup, and post-selection hooks so core provider wiring is more modular.
 - Docs/Kubernetes: Add a starter K8s install path with raw manifests, Kind setup, and deployment docs. Thanks @sallyom @dzianisv @egkristi
 - Agents/subagents: add `sessions_yield` so orchestrators can end the current turn immediately, skip queued tool work, and carry a hidden follow-up payload into the next session turn. (#36537) thanks @jriff
+- Slack/agent replies: support `channelData.slack.blocks` in the shared reply delivery path so agents can send Block Kit messages through standard Slack outbound delivery. (#44592) Thanks @vincentkoc.
 
 ### Fixes
 

--- a/src/channels/plugins/outbound/slack.sendpayload.test.ts
+++ b/src/channels/plugins/outbound/slack.sendpayload.test.ts
@@ -1,4 +1,4 @@
-import { describe, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ReplyPayload } from "../../../auto-reply/types.js";
 import {
   installSendPayloadContractSuite,
@@ -37,5 +37,67 @@ describe("slackOutbound sendPayload", () => {
     channel: "slack",
     chunking: { mode: "passthrough", longTextLength: 5000 },
     createHarness,
+  });
+
+  it("forwards Slack blocks from channelData", async () => {
+    const { run, sendMock, to } = createHarness({
+      payload: {
+        text: "Fallback summary",
+        channelData: {
+          slack: {
+            blocks: [{ type: "divider" }],
+          },
+        },
+      },
+    });
+
+    const result = await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith(
+      to,
+      "Fallback summary",
+      expect.objectContaining({
+        blocks: [{ type: "divider" }],
+      }),
+    );
+    expect(result).toMatchObject({ channel: "slack", messageId: "sl-1" });
+  });
+
+  it("accepts blocks encoded as JSON strings in Slack channelData", async () => {
+    const { run, sendMock, to } = createHarness({
+      payload: {
+        channelData: {
+          slack: {
+            blocks: '[{"type":"section","text":{"type":"mrkdwn","text":"hello"}}]',
+          },
+        },
+      },
+    });
+
+    await run();
+
+    expect(sendMock).toHaveBeenCalledWith(
+      to,
+      "",
+      expect.objectContaining({
+        blocks: [{ type: "section", text: { type: "mrkdwn", text: "hello" } }],
+      }),
+    );
+  });
+
+  it("rejects invalid Slack blocks from channelData", async () => {
+    const { run, sendMock } = createHarness({
+      payload: {
+        channelData: {
+          slack: {
+            blocks: {},
+          },
+        },
+      },
+    });
+
+    await expect(run()).rejects.toThrow(/blocks must be an array/i);
+    expect(sendMock).not.toHaveBeenCalled();
   });
 });

--- a/src/channels/plugins/outbound/slack.ts
+++ b/src/channels/plugins/outbound/slack.ts
@@ -1,5 +1,6 @@
 import type { OutboundIdentity } from "../../../infra/outbound/identity.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import { parseSlackBlocksInput } from "../../../slack/blocks-input.js";
 import { sendMessageSlack, type SlackSendIdentity } from "../../../slack/send.js";
 import type { ChannelOutboundAdapter } from "../types.js";
 import { sendTextMediaPayload } from "./direct-text-media.js";
@@ -53,6 +54,7 @@ async function sendSlackOutboundMessage(params: {
   text: string;
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
+  blocks?: Parameters<typeof sendMessageSlack>[2]["blocks"];
   accountId?: string | null;
   deps?: { sendSlack?: typeof sendMessageSlack } | null;
   replyToId?: string | null;
@@ -87,17 +89,43 @@ async function sendSlackOutboundMessage(params: {
     ...(params.mediaUrl
       ? { mediaUrl: params.mediaUrl, mediaLocalRoots: params.mediaLocalRoots }
       : {}),
+    ...(params.blocks ? { blocks: params.blocks } : {}),
     ...(slackIdentity ? { identity: slackIdentity } : {}),
   });
   return { channel: "slack" as const, ...result };
+}
+
+function resolveSlackBlocks(channelData: Record<string, unknown> | undefined) {
+  const slackData = channelData?.slack;
+  if (!slackData || typeof slackData !== "object" || Array.isArray(slackData)) {
+    return undefined;
+  }
+  return parseSlackBlocksInput((slackData as { blocks?: unknown }).blocks);
 }
 
 export const slackOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 4000,
-  sendPayload: async (ctx) =>
-    await sendTextMediaPayload({ channel: "slack", ctx, adapter: slackOutbound }),
+  sendPayload: async (ctx) => {
+    const blocks = resolveSlackBlocks(ctx.payload.channelData);
+    if (!blocks) {
+      return await sendTextMediaPayload({ channel: "slack", ctx, adapter: slackOutbound });
+    }
+    return await sendSlackOutboundMessage({
+      cfg: ctx.cfg,
+      to: ctx.to,
+      text: ctx.payload.text ?? "",
+      mediaUrl: ctx.payload.mediaUrl,
+      mediaLocalRoots: ctx.mediaLocalRoots,
+      blocks,
+      accountId: ctx.accountId,
+      deps: ctx.deps,
+      replyToId: ctx.replyToId,
+      threadId: ctx.threadId,
+      identity: ctx.identity,
+    });
+  },
   sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity }) => {
     return await sendSlackOutboundMessage({
       cfg,


### PR DESCRIPTION
## Summary

- Problem: Slack transport already supports Block Kit, but agent replies only flowed through the plain text/media outbound path.
- Why it matters: issue #12602 asks for richer Slack agent output, and plain-text-only replies block the first usable slice.
- What changed: `ReplyPayload.channelData.slack.blocks` is now parsed and forwarded through the Slack outbound adapter to `sendMessageSlack`.
- What did NOT change (scope boundary): this PR does not add generic interactive action handling for arbitrary Block Kit buttons/selects.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #12602

## User-visible / Behavior Changes

Agent replies can now send Slack Block Kit payloads by populating `channelData.slack.blocks` on the reply payload. Plain text Slack replies are unchanged.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Slack outbound adapter
- Relevant config (redacted): N/A

### Steps

1. Create a Slack reply payload with `channelData.slack.blocks`.
2. Deliver it through the standard outbound Slack adapter path.
3. Verify the adapter forwards `blocks` to `sendMessageSlack` and rejects malformed block payloads.

### Expected

- Slack Block Kit payloads are sent through the standard agent reply path.
- Invalid block payloads fail before sending.

### Actual

- Matches expected in targeted tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Vitest coverage for Slack outbound payloads, Slack outbound hook wiring, and low-level Slack block sending.
- Edge cases checked: channelData-only payloads, JSON-encoded blocks, invalid blocks.
- What you did **not** verify: live Slack workspace delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or stop emitting `channelData.slack.blocks`.
- Files/config to restore: `src/channels/plugins/outbound/slack.ts`
- Known bad symptoms reviewers should watch for: Slack replies failing when malformed `channelData.slack.blocks` is produced upstream.

## Risks and Mitigations

- Risk: upstream reply producers can now hand malformed Slack block payloads into the adapter.
  - Mitigation: block payloads are validated via existing Slack block parsing/validation before send.

## AI Assistance

- AI-assisted: yes
- Testing: targeted tests run locally
