### PR TITLE
fix(acp): preserve final assistant message snapshot before end_turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,7 @@ Docs: https://docs.openclaw.ai
 - Models/provider apiKey persistence hardening: when a provider `apiKey` value equals a known provider env var value, persist the canonical env var name into `models.json` instead of resolved plaintext secrets. (#38889) Thanks @gambletan.
 - Discord/model picker persistence check: add a short post-dispatch settle delay before reading back session model state so picker confirmations stop reporting false mismatch warnings after successful model switches. (#39105) Thanks @akropp.
 - Agents/OpenAI WS compat store flag: omit `store` from `response.create` payloads when model compat sets `supportsStore: false`, preventing strict OpenAI-compatible providers from rejecting websocket requests with unknown-field errors. (#39113) Thanks @scoootscooob.
+- ACP/client final-message delivery: preserve terminal assistant text snapshots before resolving `end_turn`, so ACP clients no longer drop the last visible reply when the gateway sends the final message body on the terminal chat event. (#17615) Thanks @pjeby.
 
 ## 2026.3.2
 

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentSideConnection,
   LoadSessionRequest,
   NewSessionRequest,
   PromptRequest,
@@ -57,6 +58,31 @@ async function expectOversizedPromptRejected(params: { sessionId: string; text: 
   sessionStore.clearAllSessionsForTest();
 }
 
+async function createPromptHarness() {
+  const updates: Array<{ sessionId: string; update: Record<string, unknown> }> = [];
+  const connection = {
+    sessionUpdate: vi.fn(
+      async (payload: { sessionId: string; update: Record<string, unknown> }) => {
+        updates.push(payload);
+      },
+    ),
+  };
+  const request = vi.fn(async () => ({ ok: true })) as GatewayClient["request"];
+  const sessionStore = createInMemorySessionStore();
+  const agent = new AcpGatewayAgent(
+    connection as unknown as AgentSideConnection,
+    createAcpGateway(request),
+    { sessionStore },
+  );
+  await agent.loadSession(createLoadSessionRequest("prompt-session"));
+  const promptPromise = agent.prompt(createPromptRequest("prompt-session", "hello"));
+  const runId = sessionStore.getSession("prompt-session")?.activeRunId;
+  if (!runId) {
+    throw new Error("Expected ACP prompt run to be active");
+  }
+  return { agent, connection, request, updates, sessionStore, promptPromise, runId };
+}
+
 describe("acp session creation rate limit", () => {
   it("rate limits excessive newSession bursts", async () => {
     const sessionStore = createInMemorySessionStore();
@@ -110,5 +136,137 @@ describe("acp prompt size hardening", () => {
       sessionId: "prompt-limit-prefix",
       text: "a".repeat(2 * 1024 * 1024),
     });
+  });
+});
+
+describe("acp final chat snapshots", () => {
+  it("emits final snapshot text before resolving end_turn", async () => {
+    const { agent, updates, promptPromise, runId, sessionStore } = await createPromptHarness();
+
+    await agent.handleGatewayEvent({
+      type: "event" as const,
+      event: "chat",
+      payload: {
+        sessionKey: "prompt-session",
+        runId,
+        state: "final",
+        stopReason: "end_turn",
+        message: {
+          content: [{ type: "text", text: "FINAL TEXT SHOULD BE EMITTED" }],
+        },
+      },
+    });
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    expect(updates.filter((entry) => entry.update.sessionUpdate === "agent_message_chunk")).toEqual(
+      [
+        {
+          sessionId: "prompt-session",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "FINAL TEXT SHOULD BE EMITTED" },
+          },
+        },
+      ],
+    );
+    expect(sessionStore.getSession("prompt-session")?.activeRunId).toBeNull();
+    sessionStore.clearAllSessionsForTest();
+  });
+
+  it("does not duplicate text when final repeats the last delta snapshot", async () => {
+    const { agent, updates, promptPromise, runId, sessionStore } = await createPromptHarness();
+
+    await agent.handleGatewayEvent({
+      type: "event" as const,
+      event: "chat",
+      payload: {
+        sessionKey: "prompt-session",
+        runId,
+        state: "delta",
+        message: {
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      },
+    });
+
+    await agent.handleGatewayEvent({
+      type: "event" as const,
+      event: "chat",
+      payload: {
+        sessionKey: "prompt-session",
+        runId,
+        state: "final",
+        stopReason: "end_turn",
+        message: {
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      },
+    });
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    expect(updates.filter((entry) => entry.update.sessionUpdate === "agent_message_chunk")).toEqual(
+      [
+        {
+          sessionId: "prompt-session",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "Hello world" },
+          },
+        },
+      ],
+    );
+    sessionStore.clearAllSessionsForTest();
+  });
+
+  it("emits only the missing tail when the final snapshot extends prior deltas", async () => {
+    const { agent, updates, promptPromise, runId, sessionStore } = await createPromptHarness();
+
+    await agent.handleGatewayEvent({
+      type: "event" as const,
+      event: "chat",
+      payload: {
+        sessionKey: "prompt-session",
+        runId,
+        state: "delta",
+        message: {
+          content: [{ type: "text", text: "Hello" }],
+        },
+      },
+    });
+
+    await agent.handleGatewayEvent({
+      type: "event" as const,
+      event: "chat",
+      payload: {
+        sessionKey: "prompt-session",
+        runId,
+        state: "final",
+        stopReason: "max_tokens",
+        message: {
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      },
+    });
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "max_tokens" });
+    expect(updates.filter((entry) => entry.update.sessionUpdate === "agent_message_chunk")).toEqual(
+      [
+        {
+          sessionId: "prompt-session",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "Hello" },
+          },
+        },
+        {
+          sessionId: "prompt-session",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: " world" },
+          },
+        },
+      ],
+    );
+    sessionStore.clearAllSessionsForTest();
   });
 });

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -417,9 +417,15 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
 
-    if (state === "delta" && messageData) {
+    const shouldHandleMessageSnapshot = messageData && (state === "delta" || state === "final");
+    if (shouldHandleMessageSnapshot) {
+      // Gateway chat events can carry the latest full assistant snapshot on both
+      // incremental updates and the terminal final event. Process the snapshot
+      // first so ACP clients never drop the last visible assistant text.
       await this.handleDeltaEvent(pending.sessionId, messageData);
-      return;
+      if (state === "delta") {
+        return;
+      }
     }
 
     if (state === "final") {


### PR DESCRIPTION
## Summary

- Problem: ACP translator drops the final assistant text chunk when `state === "final"` because `handleChatEvent` skips `handleDeltaEvent` and jumps straight to `finishPrompt` (#15377)
- Why it matters: ACP clients receive truncated responses — the last visible assistant text is silently discarded
- What changed: Process `messageData` via `handleDeltaEvent` for both `delta` and `final` states before resolving the turn; added 3 regression tests covering final-only, duplicate-final, and partial-tail scenarios
- What did NOT change (scope boundary): No changes to delta handling, `finishPrompt`, session lifecycle, or any other ACP translation logic

Based on #17615 by @pjeby — reworked control flow for clarity and added test coverage.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #15377
- Related #17615

## User-visible / Behavior Changes

ACP clients now receive the complete assistant response. Previously the last text chunk could be silently dropped.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / Bun
- Integration/channel (if any): ACP

### Steps

1. Start ACP gateway
2. Connect via `openclaw acp client`
3. Send a prompt that produces a multi-chunk response

### Expected

- Full response text delivered to ACP client

### Actual (before fix)

- Final text chunk dropped, response appears truncated

## Evidence

- [x] Failing test/log before + passing after

3 new tests in `src/acp/translator.session-rate-limit.test.ts`:
- `emits final snapshot text before resolving end_turn` — verifies final-only messageData is forwarded
- `does not duplicate text when final repeats the last delta snapshot` — verifies dedup via `sentTextLength`
- `emits only the missing tail when the final snapshot extends prior deltas` — verifies partial tail emission

All 117 ACP tests pass (14 test files).

## Human Verification (required)

- Verified scenarios: All 3 new test cases, full ACP test suite (117 tests)
- Edge cases checked: Final with no prior delta, final duplicating last delta, final extending partial delta, `max_tokens` stop reason
- What you did **not** verify: Live ACP client end-to-end (covered by @pjeby in #17615)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 8-line change in `src/acp/translator.ts`
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Duplicate text in ACP responses (would indicate dedup regression)

## Risks and Mitigations

`None`