### PR TITLE
fix(docker): allow whitespace in config and workspace paths

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -144,9 +144,6 @@ validate_mount_path_value() {
   if contains_disallowed_chars "$value"; then
     fail "$label contains unsupported control characters."
   fi
-  if [[ "$value" =~ [[:space:]] ]]; then
-    fail "$label cannot contain whitespace."
-  fi
 }
 
 validate_named_volume() {
@@ -163,8 +160,9 @@ validate_mount_spec() {
   fi
   # Keep mount specs strict to avoid YAML structure injection.
   # Expected format: source:target[:options]
-  if [[ ! "$mount" =~ ^[^[:space:],:]+:[^[:space:],:]+(:[^[:space:],:]+)?$ ]]; then
-    fail "Invalid mount format '$mount'. Expected source:target[:options] without spaces."
+  # Spaces are allowed in source/target (common on Windows: C:\Users\John Doe\...).
+  if [[ ! "$mount" =~ ^[^,:]+:[^,:]+(:[^,:]+)?$ ]]; then
+    fail "Invalid mount format '$mount'. Expected source:target[:options]."
   fi
 }
 
@@ -279,14 +277,14 @@ YAML
     validate_mount_spec "$gateway_home_mount"
     validate_mount_spec "$gateway_config_mount"
     validate_mount_spec "$gateway_workspace_mount"
-    printf '      - %s\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
   fi
 
   for mount in "$@"; do
     validate_mount_spec "$mount"
-    printf '      - %s\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
   done
 
   cat >>"$EXTRA_COMPOSE_FILE" <<'YAML'
@@ -295,14 +293,14 @@ YAML
 YAML
 
   if [[ -n "$home_volume" ]]; then
-    printf '      - %s\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
   fi
 
   for mount in "$@"; do
     validate_mount_spec "$mount"
-    printf '      - %s\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
   done
 
   if [[ -n "$home_volume" && "$home_volume" != *"/"* ]]; then


### PR DESCRIPTION
Windows usernames with spaces (e.g. `C:\Users\John Doe`) cause docker-setup.sh to bail with "OPENCLAW_CONFIG_DIR cannot contain whitespace". These are perfectly valid paths.

**Problem**

`validate_mount_path_value` rejected any path containing whitespace. On Windows with Git Bash, `$HOME` often resolves to a path with spaces when the Windows username contains them.

**Root cause**

The whitespace check was overly broad. The actual concern is YAML structure injection in the generated docker-compose file, but that only requires rejecting colons, commas, and control characters -- not spaces.

**Fix**

- Remove the blanket `[[:space:]]` rejection from `validate_mount_path_value` (control characters like tabs/newlines are still caught by `contains_disallowed_chars`)
- Relax `validate_mount_spec` regex to allow spaces in source/target segments (colons and commas still blocked)
- Quote volume mount strings in generated YAML so Docker Compose parses spaced paths correctly

**Testing**

`bash -n docker-setup.sh` passes. The quoting matches Docker Compose documented YAML string handling.

Fixes #44599