### PR TITLE
fix(line): resolve account credentials before reporting configured status

### DIFF
--- a/extensions/line/src/channel.describeAccount.test.ts
+++ b/extensions/line/src/channel.describeAccount.test.ts
@@ -1,0 +1,51 @@
+import type { OpenClawConfig, PluginRuntime, ResolvedLineAccount } from "openclaw/plugin-sdk/line";
+import { describe, expect, it, vi } from "vitest";
+import { linePlugin } from "./channel.js";
+import { setLineRuntime } from "./runtime.js";
+
+describe("linePlugin config.describeAccount", () => {
+  it("uses resolved account credentials instead of raw config snapshot", () => {
+    const resolveLineAccount = vi.fn(
+      ({ accountId }: { cfg: OpenClawConfig; accountId?: string }) =>
+        ({
+          accountId: accountId ?? "default",
+          name: "LINE",
+          enabled: true,
+          channelAccessToken: "resolved-token",
+          channelSecret: "resolved-secret",
+          tokenSource: "env",
+          config: {},
+        }) as ResolvedLineAccount,
+    );
+
+    const runtime = {
+      channel: {
+        line: {
+          resolveLineAccount,
+          listLineAccountIds: () => ["default"],
+          resolveDefaultLineAccountId: () => "default",
+        },
+      },
+    } as unknown as PluginRuntime;
+    setLineRuntime(runtime);
+
+    const rawAccount = {
+      accountId: "default",
+      name: "LINE",
+      enabled: true,
+      channelAccessToken: "",
+      channelSecret: "",
+      tokenSource: "env",
+      config: {},
+    } as ResolvedLineAccount;
+
+    const snapshot = linePlugin.config.describeAccount?.(rawAccount, {} as OpenClawConfig);
+
+    expect(resolveLineAccount).toHaveBeenCalledWith({ cfg: {}, accountId: "default" });
+    expect(snapshot).toMatchObject({
+      accountId: "default",
+      configured: true,
+      tokenSource: "env",
+    });
+  });
+});

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -135,13 +135,19 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
     ...lineConfigBase,
     isConfigured: (account) =>
       Boolean(account.channelAccessToken?.trim() && account.channelSecret?.trim()),
-    describeAccount: (account) => ({
-      accountId: account.accountId,
-      name: account.name,
-      enabled: account.enabled,
-      configured: Boolean(account.channelAccessToken?.trim() && account.channelSecret?.trim()),
-      tokenSource: account.tokenSource ?? undefined,
-    }),
+    describeAccount: (account, cfg) => {
+      const resolved = getLineRuntime().channel.line.resolveLineAccount({
+        cfg,
+        accountId: account.accountId ?? undefined,
+      });
+      return {
+        accountId: account.accountId,
+        name: account.name,
+        enabled: account.enabled,
+        configured: Boolean(resolved.channelAccessToken?.trim() && resolved.channelSecret?.trim()),
+        tokenSource: resolved.tokenSource ?? account.tokenSource ?? undefined,
+      };
+    },
     ...lineConfigAccessors,
   },
   security: {


### PR DESCRIPTION
## Problem

LINE doctor/status account snapshots derived `configured` from the raw account object passed into `describeAccount()`.

That raw snapshot can be missing credentials that are resolved later from env/files, so correctly configured LINE accounts were incorrectly reported as unconfigured.

## Fix

Resolve the LINE account through the runtime inside `describeAccount()` before computing:

- `configured`
- `tokenSource`

This makes doctor/status snapshots reflect the same resolved credentials used by the actual LINE runtime.

## Tests

Added regression coverage to verify `describeAccount()` uses the resolved LINE account rather than the raw snapshot.

Closes #44546
