### PR TITLE
fix(docker): allow whitespace in OPENCLAW_CONFIG_DIR/WORKSPACE

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -144,9 +144,15 @@ validate_mount_path_value() {
   if contains_disallowed_chars "$value"; then
     fail "$label contains unsupported control characters."
   fi
-  if [[ "$value" =~ [[:space:]] ]]; then
-    fail "$label cannot contain whitespace."
-  fi
+  # Whitespace is valid in host paths. We'll quote YAML volume entries when rendering
+  # docker-compose.extra.yml.
+}
+
+yaml_quote() {
+  # YAML single-quote escaping: ' -> ''
+  local value="$1"
+  value=${value//"'"/"''"}
+  printf "'%s'" "$value"
 }
 
 validate_named_volume() {
@@ -163,8 +169,13 @@ validate_mount_spec() {
   fi
   # Keep mount specs strict to avoid YAML structure injection.
   # Expected format: source:target[:options]
-  if [[ ! "$mount" =~ ^[^[:space:],:]+:[^[:space:],:]+(:[^[:space:],:]+)?$ ]]; then
-    fail "Invalid mount format '$mount'. Expected source:target[:options] without spaces."
+  # - allow whitespace (we quote YAML volume entries)
+  # - disallow commas (used as OPENCLAW_EXTRA_MOUNTS separator)
+  if [[ "$mount" == *","* ]]; then
+    fail "Invalid mount format '$mount'. Commas are not allowed inside a mount spec."
+  fi
+  if [[ ! "$mount" =~ ^[^:]+:[^:]+(:[^:]+)?$ ]]; then
+    fail "Invalid mount format '$mount'. Expected source:target[:options]."
   fi
 }
 
@@ -279,14 +290,14 @@ YAML
     validate_mount_spec "$gateway_home_mount"
     validate_mount_spec "$gateway_config_mount"
     validate_mount_spec "$gateway_workspace_mount"
-    printf '      - %s\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s\n' "$(yaml_quote "$gateway_home_mount")" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s\n' "$(yaml_quote "$gateway_config_mount")" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s\n' "$(yaml_quote "$gateway_workspace_mount")" >>"$EXTRA_COMPOSE_FILE"
   fi
 
   for mount in "$@"; do
     validate_mount_spec "$mount"
-    printf '      - %s\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s\n' "$(yaml_quote "$mount")" >>"$EXTRA_COMPOSE_FILE"
   done
 
   cat >>"$EXTRA_COMPOSE_FILE" <<'YAML'
@@ -295,14 +306,14 @@ YAML
 YAML
 
   if [[ -n "$home_volume" ]]; then
-    printf '      - %s\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s\n' "$(yaml_quote "$gateway_home_mount")" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s\n' "$(yaml_quote "$gateway_config_mount")" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s\n' "$(yaml_quote "$gateway_workspace_mount")" >>"$EXTRA_COMPOSE_FILE"
   fi
 
   for mount in "$@"; do
     validate_mount_spec "$mount"
-    printf '      - %s\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - %s\n' "$(yaml_quote "$mount")" >>"$EXTRA_COMPOSE_FILE"
   done
 
   if [[ -n "$home_volume" && "$home_volume" != *"/"* ]]; then

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -190,6 +190,28 @@ describe("docker-setup.sh", () => {
     expect(log).toContain("run --rm openclaw-cli config set gateway.bind lan");
   });
 
+  it("handles whitespace in OPENCLAW_CONFIG_DIR/OPENCLAW_WORKSPACE_DIR when writing docker-compose.extra.yml", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    const configDir = join(activeSandbox.rootDir, "config dir with spaces");
+    const workspaceDir = join(activeSandbox.rootDir, "workspace dir with spaces");
+
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_CONFIG_DIR: configDir,
+      OPENCLAW_WORKSPACE_DIR: workspaceDir,
+      OPENCLAW_HOME_VOLUME: "openclaw-home",
+    });
+
+    expect(result.status).toBe(0);
+
+    const extraCompose = await readFile(
+      join(activeSandbox.rootDir, "docker-compose.extra.yml"),
+      "utf8",
+    );
+    // YAML volume entries should be quoted so whitespace is preserved.
+    expect(extraCompose).toContain(`'${configDir}:/home/node/.openclaw'`);
+    expect(extraCompose).toContain(`'${workspaceDir}:/home/node/.openclaw/workspace'`);
+  });
+
   it("precreates config identity dir for CLI device auth writes", async () => {
     const activeSandbox = requireSandbox(sandbox);
     const configDir = join(activeSandbox.rootDir, "config-identity");


### PR DESCRIPTION
Fixes #44599.

### Summary
Allow `OPENCLAW_CONFIG_DIR` / `OPENCLAW_WORKSPACE_DIR` to contain whitespace in `docker-setup.sh`.

### What changed
- Permit whitespace in `validate_mount_path_value` (still rejects control chars).
- Quote generated volume entries in `docker-compose.extra.yml` using YAML single-quote escaping so whitespace is preserved.
- Relax `validate_mount_spec` to allow whitespace while still rejecting control chars / commas and enforcing `source:target[:options]` shape.
- Add e2e coverage that runs `docker-setup.sh` with config/workspace directories containing spaces and asserts the extra compose file contains quoted mounts.

### Notes
This is intended to address Windows/macOS home paths that commonly include spaces.
