### PR TITLE
fix(logging): correct levelToMinLevel mapping and related filter logic for tslog v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Docs: https://docs.openclaw.ai
 - iOS/gateway: replace string-matched connection error UI with structured gateway connection problems, preserve actionable pairing/auth failures over later generic disconnect noise, and surface reusable problem banners and details across onboarding, settings, and root status surfaces. (#62650) Thanks @ngutman.
 - Git/env sanitization: block additional Git repository-plumbing env variables such as `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, and `GIT_NAMESPACE` so host-run Git commands cannot be redirected to attacker-chosen repository state through inherited or request-scoped env. (#62002) Thanks @eleqtrizit.
 - Host exec/env sanitization: block additional request-scoped credential and config-path overrides such as `KUBECONFIG`, cloud credential-path env, `CARGO_HOME`, and `HELM_HOME` so host-run tools can no longer be redirected to attacker-chosen config or state. (#59119) Thanks @eleqtrizit.
+- Logging: make `logging.level` and `logging.consoleLevel` honor the documented severity threshold ordering again, and keep child loggers inheriting the parent `minLevel`. (#44646) Thanks @zhumengzhu.
 
 ## 2026.4.5
 

--- a/src/logging/level-filter.test.ts
+++ b/src/logging/level-filter.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { readLoggingConfigMock } = vi.hoisted(() => ({
+  readLoggingConfigMock: vi.fn(() => undefined),
+}));
+
+vi.mock("./config.js", () => ({
+  readLoggingConfig: readLoggingConfigMock,
+}));
+
+vi.mock("./node-require.js", () => ({
+  resolveNodeRequireFromMeta: () => () => {
+    throw new Error("config fallback not used");
+  },
+}));
+
+let logging: typeof import("../logging.js");
+
+beforeAll(async () => {
+  logging = await import("../logging.js");
+});
+
+beforeEach(() => {
+  delete process.env.OPENCLAW_TEST_FILE_LOG;
+  delete process.env.OPENCLAW_LOG_LEVEL;
+  readLoggingConfigMock.mockClear();
+  logging.resetLogger();
+  logging.setLoggerOverride(null);
+});
+
+afterEach(() => {
+  delete process.env.OPENCLAW_TEST_FILE_LOG;
+  delete process.env.OPENCLAW_LOG_LEVEL;
+  logging.resetLogger();
+  logging.setLoggerOverride(null);
+  vi.restoreAllMocks();
+});
+
+describe("isFileLogLevelEnabled", () => {
+  it("returns false for all levels when configured as silent", () => {
+    logging.setLoggerOverride({ level: "silent" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
+  });
+
+  it("passes only fatal when configured as fatal", () => {
+    logging.setLoggerOverride({ level: "fatal" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
+  });
+
+  it("passes fatal and error when configured as error", () => {
+    logging.setLoggerOverride({ level: "error" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
+  });
+
+  it("passes fatal, error, warn, info when configured as info", () => {
+    logging.setLoggerOverride({ level: "info" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
+  });
+
+  it("passes all levels when configured as trace", () => {
+    logging.setLoggerOverride({ level: "trace" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(true);
+  });
+});
+
+describe("getChildLogger minLevel inheritance", () => {
+  it("child logger inherits parent minLevel when no level is specified", () => {
+    logging.setLoggerOverride({ level: "warn" });
+    const child = logging.getChildLogger({ component: "test" });
+    expect(child.settings.minLevel).toBe(logging.levelToMinLevel("warn"));
+  });
+
+  it("child logger uses its own level when explicitly specified", () => {
+    logging.setLoggerOverride({ level: "warn" });
+    const child = logging.getChildLogger({ component: "test" }, { level: "error" });
+    expect(child.settings.minLevel).toBe(logging.levelToMinLevel("error"));
+  });
+
+  it("child logger does not default to minLevel=0 (allow-all) when no level given", () => {
+    logging.setLoggerOverride({ level: "fatal" });
+    const child = logging.getChildLogger({ component: "test" });
+    expect(child.settings.minLevel).not.toBe(0);
+    expect(child.settings.minLevel).toBe(logging.levelToMinLevel("fatal"));
+  });
+});

--- a/src/logging/level-filter.test.ts
+++ b/src/logging/level-filter.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { readLoggingConfigMock } = vi.hoisted(() => ({
+const { readLoggingConfigMock, shouldSkipMutatingLoggingConfigReadMock } = vi.hoisted(() => ({
   readLoggingConfigMock: vi.fn(() => undefined),
+  shouldSkipMutatingLoggingConfigReadMock: vi.fn(() => false),
 }));
 
 vi.mock("./config.js", () => ({
   readLoggingConfig: readLoggingConfigMock,
+  shouldSkipMutatingLoggingConfigRead: shouldSkipMutatingLoggingConfigReadMock,
 }));
 
 vi.mock("./node-require.js", () => ({
@@ -24,6 +26,8 @@ beforeEach(() => {
   delete process.env.OPENCLAW_TEST_FILE_LOG;
   delete process.env.OPENCLAW_LOG_LEVEL;
   readLoggingConfigMock.mockClear();
+  shouldSkipMutatingLoggingConfigReadMock.mockReset();
+  shouldSkipMutatingLoggingConfigReadMock.mockReturnValue(false);
   logging.resetLogger();
   logging.setLoggerOverride(null);
 });
@@ -106,5 +110,19 @@ describe("getChildLogger minLevel inheritance", () => {
     const child = logging.getChildLogger({ component: "test" });
     expect(child.settings.minLevel).not.toBe(0);
     expect(child.settings.minLevel).toBe(logging.levelToMinLevel("fatal"));
+  });
+
+  it("pino child logger propagates the parent minLevel", () => {
+    logging.setLoggerOverride({ level: "error" });
+    const base = logging.getLogger();
+    const getSubLoggerSpy = vi.spyOn(base, "getSubLogger");
+
+    logging.toPinoLikeLogger(base, "info").child({ component: "test" });
+
+    expect(getSubLoggerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        minLevel: logging.levelToMinLevel("error"),
+      }),
+    );
   });
 });

--- a/src/logging/level-filter.test.ts
+++ b/src/logging/level-filter.test.ts
@@ -90,6 +90,11 @@ describe("isFileLogLevelEnabled", () => {
     expect(logging.isFileLogLevelEnabled("debug")).toBe(true);
     expect(logging.isFileLogLevelEnabled("trace")).toBe(true);
   });
+
+  it("never treats silent as an emittable file level", () => {
+    logging.setLoggerOverride({ level: "info" });
+    expect(logging.isFileLogLevelEnabled("silent")).toBe(false);
+  });
 });
 
 describe("getChildLogger minLevel inheritance", () => {

--- a/src/logging/levels.test.ts
+++ b/src/logging/levels.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { levelToMinLevel } from "./levels.js";
+
+describe("levelToMinLevel", () => {
+  it("returns tslog v4 logLevelId values in ascending order", () => {
+    expect(levelToMinLevel("trace")).toBe(1);
+    expect(levelToMinLevel("debug")).toBe(2);
+    expect(levelToMinLevel("info")).toBe(3);
+    expect(levelToMinLevel("warn")).toBe(4);
+    expect(levelToMinLevel("error")).toBe(5);
+    expect(levelToMinLevel("fatal")).toBe(6);
+  });
+
+  it("maps silent to Infinity to suppress all logs", () => {
+    expect(levelToMinLevel("silent")).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("fatal has a higher value than trace (not inverted)", () => {
+    expect(levelToMinLevel("fatal")).toBeGreaterThan(levelToMinLevel("trace"));
+  });
+
+  it("each level is strictly more restrictive than the one below it", () => {
+    const ordered = ["trace", "debug", "info", "warn", "error", "fatal"] as const;
+    for (let i = 1; i < ordered.length; i++) {
+      expect(levelToMinLevel(ordered[i])).toBeGreaterThan(levelToMinLevel(ordered[i - 1]));
+    }
+  });
+});

--- a/src/logging/levels.ts
+++ b/src/logging/levels.ts
@@ -23,14 +23,15 @@ export function normalizeLogLevel(level?: string, fallback: LogLevel = "info") {
 }
 
 export function levelToMinLevel(level: LogLevel): number {
-  // tslog level ordering: fatal=0, error=1, warn=2, info=3, debug=4, trace=5
+  // tslog v4 logLevelId (src/index.ts): silly=0, trace=1, debug=2, info=3, warn=4, error=5, fatal=6
+  // tslog filters: logLevelId < minLevel is dropped, so higher minLevel = more restrictive.
   const map: Record<LogLevel, number> = {
-    fatal: 0,
-    error: 1,
-    warn: 2,
+    trace: 1,
+    debug: 2,
     info: 3,
-    debug: 4,
-    trace: 5,
+    warn: 4,
+    error: 5,
+    fatal: 6,
     silent: Number.POSITIVE_INFINITY,
   };
   return map[level];

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -151,7 +151,7 @@ export function isFileLogLevelEnabled(level: LogLevel): boolean {
   if (settings.level === "silent") {
     return false;
   }
-  return levelToMinLevel(level) <= levelToMinLevel(settings.level);
+  return levelToMinLevel(level) >= levelToMinLevel(settings.level);
 }
 
 function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
@@ -254,7 +254,7 @@ export function getChildLogger(
   opts?: { level?: LogLevel },
 ): TsLogger<LogObj> {
   const base = getLogger();
-  const minLevel = opts?.level ? levelToMinLevel(opts.level) : undefined;
+  const minLevel = opts?.level ? levelToMinLevel(opts.level) : base.settings.minLevel;
   const name = bindings ? JSON.stringify(bindings) : undefined;
   return base.getSubLogger({
     name,

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -148,6 +148,9 @@ export function isFileLogLevelEnabled(level: LogLevel): boolean {
   if (!loggingState.cachedSettings) {
     loggingState.cachedSettings = settings;
   }
+  if (level === "silent") {
+    return false;
+  }
   if (settings.level === "silent") {
     return false;
   }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -269,6 +269,7 @@ export function toPinoLikeLogger(logger: TsLogger<LogObj>, level: LogLevel): Pin
     toPinoLikeLogger(
       logger.getSubLogger({
         name: bindings ? JSON.stringify(bindings) : undefined,
+        minLevel: logger.settings.minLevel,
       }),
       level,
     );

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -54,6 +54,13 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(traceLogger.isEnabled("debug", "console")).toBe(true);
   });
 
+  it("never treats silent as an emittable console level", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "info" });
+    const log = createSubsystemLogger("agent/embedded");
+
+    expect(log.isEnabled("silent", "console")).toBe(false);
+  });
+
   it("returns false when neither console nor file logging would emit", () => {
     setLoggerOverride({ level: "silent", consoleLevel: "silent" });
     const log = createSubsystemLogger("agent/embedded");

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -41,6 +41,19 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(log.isEnabled("debug", "file")).toBe(false);
   });
 
+  it("uses threshold ordering for non-equal console levels", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "fatal" });
+    const fatalOnly = createSubsystemLogger("agent/embedded");
+
+    expect(fatalOnly.isEnabled("error", "console")).toBe(false);
+    expect(fatalOnly.isEnabled("fatal", "console")).toBe(true);
+
+    setLoggerOverride({ level: "silent", consoleLevel: "trace" });
+    const traceLogger = createSubsystemLogger("agent/embedded");
+
+    expect(traceLogger.isEnabled("debug", "console")).toBe(true);
+  });
+
   it("returns false when neither console nor file logging would emit", () => {
     setLoggerOverride({ level: "silent", consoleLevel: "silent" });
     const log = createSubsystemLogger("agent/embedded");

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -30,6 +30,9 @@ export type SubsystemLogger = {
 };
 
 function shouldLogToConsole(level: LogLevel, settings: { level: LogLevel }): boolean {
+  if (level === "silent") {
+    return false;
+  }
   if (settings.level === "silent") {
     return false;
   }

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -35,7 +35,7 @@ function shouldLogToConsole(level: LogLevel, settings: { level: LogLevel }): boo
   }
   const current = levelToMinLevel(level);
   const min = levelToMinLevel(settings.level);
-  return current <= min;
+  return current >= min;
 }
 
 type ChalkInstance = InstanceType<typeof Chalk>;


### PR DESCRIPTION
## Summary
- **Problem:** `levelToMinLevel()` in `src/logging/levels.ts` mapped log levels in the wrong direction — `fatal` was mapped to `0` and `trace` to `5`, but tslog v4's actual internal `logLevelId` is the opposite (`trace=1, fatal=6`). tslog drops entries where `logLevelId < minLevel`, so the entire filter was inverted.
- **Why it matters:** Setting `logging.level: fatal` would pass `minLevel=0` to tslog and log everything; setting `trace` would pass `minLevel=5` and suppress most logs. The `logging.level` config had no useful effect.
- **What changed:** (1) Reversed the `levelToMinLevel` map to match tslog v4's actual level IDs. (2) Flipped the `isFileLogLevelEnabled` comparison from `<=` to `>=` to match the corrected map direction. (3) Fixed `getChildLogger` to inherit `base.settings.minLevel` instead of passing `undefined` (which tslog defaults to `0`, allowing all logs regardless of parent config). (4) Fixed toPinoLikeLogger's buildChild to propagate minLevel to sub-loggers, closing the same inheritance gap in the Pino adapter path. (5) Fixed `shouldLogToConsole` comparison direction in `subsystem.ts` — same `<=` → `>=` correction for console-level filtering.
- **What did NOT change:** Log format, log file location, transport logic, console logging, public API surface — all untouched.
> **AI-assisted** (Claude). Fully tested — 80 tests pass including new regression tests. Verified tslog v4 source directly. Author understands the code and has reviewed every change.
## Change Type (select all)
- [x] Bug fix
## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra
## Linked Issue/PR
- Closes #29448
## User-visible / Behavior Changes
`logging.level` config now works as documented. Previously the level filter was inverted — `fatal` logged everything, `trace` suppressed most logs. After this fix, `fatal` logs only fatal entries, `info` logs info and above, etc.
## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
## Repro + Verification
### Steps
1. Set `logging.level: fatal` in config
2. Run `openclaw gateway`
3. Inspect the log file
### Expected
- Only `fatal`-level entries appear in the log file
### Actual (before fix)
- All log levels (`debug`, `info`, `warn`, etc.) appear — filter is completely bypassed
## Evidence
- [x] Failing test/log before + passing after
15 test files, 80 tests pass (`pnpm test -- src/logging/`), including new regression tests covering:
- `levelToMinLevel` correct tslog v4 ID values and strict ascending order
- `isFileLogLevelEnabled` filter direction for every level (`trace` through `fatal` and `silent`)
- `getChildLogger` inheriting parent `minLevel` instead of defaulting to `0` (allow-all)
`pnpm build` and `pnpm check` also pass cleanly.

Note: `src/infra/net/proxy-fetch.test.ts` fails in CI (2 tests) but is unrelated to this change — it tests Windows proxy environment variable handling and fails on the Windows CI runner independently of this PR.

## Human Verification (required)
- Verified scenarios: tslog v4 source (`src/index.ts`) confirmed actual `logLevelId` values (`trace=1, debug=2, info=3, warn=4, error=5, fatal=6`) and filter logic (`logLevelId < minLevel → drop`). All three fix points validated by dedicated regression tests.
- Edge cases checked: `silent` level (mapped to `Infinity`) still suppresses all logs. `getChildLogger` without explicit level now correctly inherits parent level instead of defaulting to `minLevel=0`.
- What you did **not** verify: live gateway integration test with all channel types.
## Review Conversations
- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.
## Compatibility / Migration
- Backward compatible? **No** — intentional behavior change. Users who accidentally relied on the inverted behavior will see different output. Expected real-world impact is near-zero since the old behavior was a bug.
- Config/env changes? No
- Migration needed? No
## Failure Recovery (if this breaks)
- How to revert: `git revert` the fix commit (`302b019`) or restore the old map in `src/logging/levels.ts`
- Known bad symptoms: if logs stop appearing entirely after upgrade, verify `logging.level` is set to a recognized value (`trace` / `debug` / `info` / `warn` / `error` / `fatal`)
## Risks and Mitigations
- Risk: Users with `logging.level: trace` or `debug` who previously got filtered output will now see full verbose logs.
  - Mitigation: This is correct behavior; the old output was a bug. Documented in User-visible Changes above.
