### PR TITLE
fix(googlechat): honor replyToMode before forcing thread replies

### DIFF
--- a/extensions/googlechat/src/monitor.reply-to-mode.test.ts
+++ b/extensions/googlechat/src/monitor.reply-to-mode.test.ts
@@ -1,0 +1,57 @@
+import type { OpenClawConfig, PluginRuntime, ResolvedGoogleChatAccount } from "openclaw/plugin-sdk/googlechat";
+import { describe, expect, it, vi } from "vitest";
+
+const sendGoogleChatMessage = vi.fn();
+const updateGoogleChatMessage = vi.fn();
+const deleteGoogleChatMessage = vi.fn();
+const uploadGoogleChatAttachment = vi.fn();
+
+vi.mock("./api.js", () => ({
+  sendGoogleChatMessage: (...args: unknown[]) => sendGoogleChatMessage(...args),
+  updateGoogleChatMessage: (...args: unknown[]) => updateGoogleChatMessage(...args),
+  deleteGoogleChatMessage: (...args: unknown[]) => deleteGoogleChatMessage(...args),
+  uploadGoogleChatAttachment: (...args: unknown[]) => uploadGoogleChatAttachment(...args),
+}));
+
+describe("googlechat monitor replyToMode", () => {
+  it("does not force thread replies when replyToMode is off", async () => {
+    const { __testDeliverGoogleChatReply } = await import("./monitor.js");
+
+    sendGoogleChatMessage.mockResolvedValue({});
+    updateGoogleChatMessage.mockResolvedValue({});
+    deleteGoogleChatMessage.mockResolvedValue({});
+
+    const account = {
+      accountId: "default",
+      enabled: true,
+      config: {},
+    } as ResolvedGoogleChatAccount;
+
+    const core = {
+      channel: {
+        media: { fetchRemoteMedia: vi.fn(), saveMediaBuffer: vi.fn() },
+        text: {
+          resolveChunkMode: vi.fn(() => "paragraph"),
+          chunkMarkdownTextWithMode: vi.fn(() => ["hello"]),
+        },
+      },
+    } as unknown as PluginRuntime;
+
+    await __testDeliverGoogleChatReply({
+      payload: { text: "hello", replyToId: "spaces/AAA/threads/BBB" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime: { error: vi.fn() } as any,
+      core: core as any,
+      config: { channels: { googlechat: { replyToMode: "off" } } } as OpenClawConfig,
+    });
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "hello",
+        thread: undefined,
+      }),
+    );
+  });
+});

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -375,6 +375,8 @@ async function deliverGoogleChatReply(params: {
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink, typingMessageName } =
     params;
+  const replyToMode = config.channels?.googlechat?.replyToMode ?? "off";
+  const thread = replyToMode === "off" ? undefined : payload.replyToId;
   const mediaList = payload.mediaUrls?.length
     ? payload.mediaUrls
     : payload.mediaUrl
@@ -431,7 +433,7 @@ async function deliverGoogleChatReply(params: {
           account,
           space: spaceId,
           text: caption,
-          thread: payload.replyToId,
+          thread,
           attachments: [
             { attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName },
           ],
@@ -463,7 +465,7 @@ async function deliverGoogleChatReply(params: {
             account,
             space: spaceId,
             text: chunk,
-            thread: payload.replyToId,
+            thread,
           });
         }
         statusSink?.({ lastOutboundAt: Date.now() });
@@ -473,6 +475,8 @@ async function deliverGoogleChatReply(params: {
     }
   }
 }
+
+export const __testDeliverGoogleChatReply = deliverGoogleChatReply;
 
 async function uploadAttachmentForReply(params: {
   account: ResolvedGoogleChatAccount;


### PR DESCRIPTION
## Problem

Google Chat reply delivery always forwarded `payload.replyToId` as a thread target, even when `channels.googlechat.replyToMode` was set to `off`.

That caused DM replies and non-threaded replies to be posted into threads anyway.

## Fix

Respect `replyToMode` during outbound reply delivery:

- when `replyToMode = off`, do not pass a thread target
- otherwise keep using the inferred reply thread

## Tests

Added regression coverage verifying that `replyToMode: off` suppresses forced thread replies.

Closes #33370
