### PR TITLE
fix(ollama): respect user-configured num_ctx from openclaw.json

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -324,6 +324,7 @@ async function createOllamaTestStream(params: {
   options?: {
     apiKey?: string;
     maxTokens?: number;
+    num_ctx?: number;
     signal?: AbortSignal;
     headers?: Record<string, string>;
   };
@@ -381,6 +382,31 @@ describe("createOllamaStreamFn", () => {
         };
         expect(requestBody.options.num_ctx).toBe(131072);
         expect(requestBody.options.num_predict).toBe(123);
+      },
+    );
+  });
+
+  it("prefers user-configured num_ctx over model.contextWindow", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          options: { num_ctx: 8192 },
+        });
+
+        const events = await collectStreamEvents(stream);
+        expect(events.at(-1)?.type).toBe("done");
+
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const requestBody = JSON.parse(requestInit.body as string) as {
+          options: { num_ctx?: number };
+        };
+        // User's num_ctx (8192) should override model.contextWindow (131072)
+        expect(requestBody.options.num_ctx).toBe(8192);
       },
     );
   });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -451,7 +451,17 @@ export function createOllamaStreamFn(
 
         // Ollama defaults to num_ctx=4096 which is too small for large
         // system prompts + many tool definitions. Use model's contextWindow.
-        const ollamaOptions: Record<string, unknown> = { num_ctx: model.contextWindow ?? 65536 };
+        // Allow user-configured num_ctx (via options) to override the
+        // auto-discovered GGUF context_length (model.contextWindow).
+        const optionsRecord = options as Record<string, unknown> | undefined;
+        const rawNumCtx = optionsRecord?.num_ctx;
+        const userNumCtx =
+          typeof rawNumCtx === "number" && Number.isFinite(rawNumCtx) && rawNumCtx > 0
+            ? rawNumCtx
+            : undefined;
+        const ollamaOptions: Record<string, unknown> = {
+          num_ctx: userNumCtx ?? model.contextWindow ?? 65536,
+        };
         if (typeof options?.temperature === "number") {
           ollamaOptions.temperature = options.temperature;
         }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -124,6 +124,11 @@ function createStreamFnWithExtraParams(
       ? (extraParams.provider as Record<string, unknown>)
       : undefined;
 
+  // Pass through num_ctx so native Ollama stream can use it as an override.
+  if (typeof extraParams.num_ctx === "number" && Number.isFinite(extraParams.num_ctx)) {
+    (streamParams as Record<string, unknown>).num_ctx = extraParams.num_ctx;
+  }
+
   if (Object.keys(streamParams).length === 0 && !providerRouting) {
     return undefined;
   }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -125,7 +125,11 @@ function createStreamFnWithExtraParams(
       : undefined;
 
   // Pass through num_ctx so native Ollama stream can use it as an override.
-  if (typeof extraParams.num_ctx === "number" && Number.isFinite(extraParams.num_ctx)) {
+  if (
+    typeof extraParams.num_ctx === "number" &&
+    Number.isFinite(extraParams.num_ctx) &&
+    extraParams.num_ctx > 0
+  ) {
     (streamParams as Record<string, unknown>).num_ctx = extraParams.num_ctx;
   }
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -10,6 +10,7 @@ import {
   resolveOllamaCompatNumCtxEnabled,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
+  resolveUserNumCtx,
   shouldInjectOllamaCompatNumCtx,
   decodeHtmlEntitiesInObject,
   wrapOllamaCompatNumCtx,
@@ -982,6 +983,74 @@ describe("wrapOllamaCompatNumCtx", () => {
     expect(baseFn).toHaveBeenCalledTimes(1);
     expect((payloadSeen?.options as Record<string, unknown> | undefined)?.num_ctx).toBe(202752);
     expect(downstream).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveUserNumCtx", () => {
+  it("returns num_ctx from model params when configured", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "ollama/qwen2.5:14b": {
+              params: { num_ctx: 8192 },
+            },
+          },
+        },
+      },
+    };
+    expect(resolveUserNumCtx(config, "ollama", "qwen2.5:14b")).toBe(8192);
+  });
+
+  it("returns undefined when no model config exists", () => {
+    expect(resolveUserNumCtx({}, "ollama", "qwen2.5:14b")).toBeUndefined();
+  });
+
+  it("returns undefined when params is missing", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "ollama/qwen2.5:14b": {},
+          },
+        },
+      },
+    };
+    expect(resolveUserNumCtx(config, "ollama", "qwen2.5:14b")).toBeUndefined();
+  });
+
+  it("returns undefined when num_ctx is not a number", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "ollama/qwen2.5:14b": {
+              params: { num_ctx: "8192" as unknown as number },
+            },
+          },
+        },
+      },
+    };
+    expect(resolveUserNumCtx(config, "ollama", "qwen2.5:14b")).toBeUndefined();
+  });
+
+  it("returns undefined when num_ctx is zero or negative", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "ollama/qwen2.5:14b": {
+              params: { num_ctx: 0 },
+            },
+          },
+        },
+      },
+    };
+    expect(resolveUserNumCtx(config, "ollama", "qwen2.5:14b")).toBeUndefined();
+  });
+
+  it("returns undefined when config is undefined", () => {
+    expect(resolveUserNumCtx(undefined, "ollama", "qwen2.5:14b")).toBeUndefined();
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -425,6 +425,26 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
     });
 }
 
+/**
+ * Resolve user-configured num_ctx from openclaw.json model params.
+ *
+ * Checks `agents.defaults.models.<provider/modelId>.params.num_ctx` and
+ * returns the value if it's a valid positive number, otherwise undefined.
+ */
+export function resolveUserNumCtx(
+  config: OpenClawConfig | undefined,
+  provider: string,
+  modelId: string,
+): number | undefined {
+  const modelKey = `${provider}/${modelId}`;
+  const modelConfig = config?.agents?.defaults?.models?.[modelKey];
+  const numCtx = modelConfig?.params?.num_ctx;
+  if (typeof numCtx === "number" && Number.isFinite(numCtx) && numCtx > 0) {
+    return numCtx;
+  }
+  return undefined;
+}
+
 function resolveCaseInsensitiveAllowedToolName(
   rawName: string,
   allowedToolNames?: Set<string>,
@@ -1916,10 +1936,14 @@ export async function runEmbeddedAttempt(
         providerId: providerIdForNumCtx,
       });
       if (shouldInjectNumCtx) {
+        const userNumCtx = resolveUserNumCtx(params.config, params.provider, params.modelId);
         const numCtx = Math.max(
           1,
           Math.floor(
-            params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+            userNumCtx ??
+              params.model.contextWindow ??
+              params.model.maxTokens ??
+              DEFAULT_CONTEXT_TOKENS,
           ),
         );
         activeSession.agent.streamFn = wrapOllamaCompatNumCtx(activeSession.agent.streamFn, numCtx);


### PR DESCRIPTION
Closes #44550

## Problem

When a user sets `params.num_ctx` in `openclaw.json` for an Ollama model, the value is ignored. On every startup, OpenClaw queries `/api/show`, reads the GGUF metadata `context_length`, and passes that as `num_ctx` in every `/api/chat` request. This means a 14B model always allocates a 32K context KV cache (~6GB VRAM) even when the user explicitly configures 8K.

## Root cause

Two code paths ignore user config:

1. **OpenAI-compat wrapper** (`attempt.ts`): always injects `model.contextWindow` as `num_ctx`, never checking user-configured params
2. **Native Ollama stream** (`ollama-stream.ts`): only uses discovered `contextWindow`, no mechanism to receive user overrides

## Fix

1. New `resolveUserNumCtx()` helper in `attempt.ts` that looks up the user's `params.num_ctx` from the config model block and uses it when present, falling back to `model.contextWindow` otherwise
2. Forward user `num_ctx` through `extra-params.ts` into the native stream's `options` object
3. Both paths validate `num_ctx > 0` consistently

## Testing

- Unit tests for `resolveUserNumCtx` covering: user override present, missing config, zero/negative values, fallback to contextWindow
- Native stream test confirming `num_ctx` flows through to Ollama API call
- Manual verification: `ollama ps` shows configured context size after restart

Co-authored-by: Daniel <dsantoreis@gmail.com>