### PR TITLE
fix(discord): prevent gateway crash when Discord API returns 503 during proxy reconnect, solve #44529

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/discord/monitor/gateway-plugin.ts
+++ b/src/discord/monitor/gateway-plugin.ts
@@ -64,21 +64,18 @@ export function createDiscordGatewayPlugin(params: {
               dispatcher: fetchAgent,
             } as Record<string, unknown>);
             // Check HTTP status before parsing JSON — non-2xx responses (e.g. Discord 503
-            // during transient outages) return non-JSON bodies that would otherwise throw
-            // an opaque JSON parse error. Carbon calls registerClient() without awaiting,
-            // so any unhandled rejection crashes the entire Node.js process.
+            // during transient outages) return non-JSON bodies that would otherwise cause
+            // an opaque JSON parse error.
+            //
+            // Carbon calls registerClient() without await, so any re-thrown error here
+            // becomes an unhandled promise rejection that crashes the Node.js process.
+            // Instead, emit the error on the gateway emitter so the lifecycle error handler
+            // picks it up, then schedule a backoff reconnect via Carbon's existing mechanism.
             if (!response.ok) {
-              let body = "";
-              try {
-                body = await response.text();
-              } catch {
-                // ignore body read errors
-              }
+              const body = await response.text().catch(() => "");
               const err = new Error(
-                `Failed to get gateway information from Discord: HTTP ${response.status}: ${body.slice(0, 200)}`,
+                `Discord API /gateway/bot failed (${response.status}): ${body || "empty response"}`,
               );
-              // Emit on the gateway emitter so the lifecycle error handler picks it up,
-              // then schedule a reconnect attempt with backoff instead of crashing.
               this.emitter.emit("error", err);
               this.handleReconnectionAttempt({});
               return;

--- a/src/discord/monitor/gateway-plugin.ts
+++ b/src/discord/monitor/gateway-plugin.ts
@@ -63,12 +63,35 @@ export function createDiscordGatewayPlugin(params: {
               },
               dispatcher: fetchAgent,
             } as Record<string, unknown>);
+            // Check HTTP status before parsing JSON — non-2xx responses (e.g. Discord 503
+            // during transient outages) return non-JSON bodies that would otherwise throw
+            // an opaque JSON parse error. Carbon calls registerClient() without awaiting,
+            // so any unhandled rejection crashes the entire Node.js process.
+            if (!response.ok) {
+              let body = "";
+              try {
+                body = await response.text();
+              } catch {
+                // ignore body read errors
+              }
+              const err = new Error(
+                `Failed to get gateway information from Discord: HTTP ${response.status}: ${body.slice(0, 200)}`,
+              );
+              // Emit on the gateway emitter so the lifecycle error handler picks it up,
+              // then schedule a reconnect attempt with backoff instead of crashing.
+              this.emitter.emit("error", err);
+              this.handleReconnectionAttempt({});
+              return;
+            }
             this.gatewayInfo = (await response.json()) as APIGatewayBotInfo;
           } catch (error) {
-            throw new Error(
+            const err = new Error(
               `Failed to get gateway information from Discord: ${error instanceof Error ? error.message : String(error)}`,
               { cause: error },
             );
+            this.emitter.emit("error", err);
+            this.handleReconnectionAttempt({});
+            return;
           }
         }
         return super.registerClient(client);

--- a/src/discord/monitor/provider.proxy.test.ts
+++ b/src/discord/monitor/provider.proxy.test.ts
@@ -34,12 +34,17 @@ const {
   class GatewayPlugin {
     options: unknown;
     gatewayInfo: unknown;
+    emitter = { emit: vi.fn() };
+    handleReconnectionAttemptSpy = vi.fn();
     constructor(options?: unknown, gatewayInfo?: unknown) {
       this.options = options;
       this.gatewayInfo = gatewayInfo;
     }
     async registerClient(client: unknown) {
       baseRegisterClientSpy(client);
+    }
+    handleReconnectionAttempt(opts: unknown) {
+      this.handleReconnectionAttemptSpy(opts);
     }
   }
 
@@ -169,6 +174,7 @@ describe("createDiscordGatewayPlugin", () => {
   it("uses proxy fetch for gateway metadata lookup before registering", async () => {
     const runtime = createRuntime();
     undiciFetchMock.mockResolvedValue({
+      ok: true,
       json: async () => ({ url: "wss://gateway.discord.gg" }),
     } as Response);
     const plugin = createDiscordGatewayPlugin({
@@ -193,5 +199,36 @@ describe("createDiscordGatewayPlugin", () => {
       }),
     );
     expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits error and schedules reconnect when Discord returns a non-2xx response", async () => {
+    const runtime = createRuntime();
+    undiciFetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "upstream connect error or disconnect/reset before headers",
+    } as unknown as Response);
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://proxy.test:8080" },
+      runtime,
+    });
+
+    await (
+      plugin as unknown as {
+        registerClient: (client: { options: { token: string } }) => Promise<void>;
+      }
+    ).registerClient({
+      options: { token: "token-123" },
+    });
+
+    const emitter = (plugin as unknown as { emitter: { emit: ReturnType<typeof vi.fn> } }).emitter;
+    const reconnectSpy = (
+      plugin as unknown as { handleReconnectionAttemptSpy: ReturnType<typeof vi.fn> }
+    ).handleReconnectionAttemptSpy;
+    expect(emitter.emit).toHaveBeenCalledWith("error", expect.any(Error));
+    const emittedError = (emitter.emit.mock.calls[0] as unknown[])[1] as Error;
+    expect(emittedError.message).toContain("HTTP 503");
+    expect(reconnectSpy).toHaveBeenCalledTimes(1);
+    expect(baseRegisterClientSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/discord/monitor/provider.proxy.test.ts
+++ b/src/discord/monitor/provider.proxy.test.ts
@@ -201,12 +201,13 @@ describe("createDiscordGatewayPlugin", () => {
     expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("emits error and schedules reconnect when Discord returns a non-2xx response", async () => {
+  it("emits error and schedules reconnect when Discord returns 503", async () => {
     const runtime = createRuntime();
     undiciFetchMock.mockResolvedValue({
       ok: false,
       status: 503,
-      text: async () => "upstream connect error or disconnect/reset before headers",
+      text: async () =>
+        "upstream connect error or disconnect/reset before headers. reset reason: overflow",
     } as unknown as Response);
     const plugin = createDiscordGatewayPlugin({
       discordConfig: { proxy: "http://proxy.test:8080" },
@@ -218,7 +219,7 @@ describe("createDiscordGatewayPlugin", () => {
         registerClient: (client: { options: { token: string } }) => Promise<void>;
       }
     ).registerClient({
-      options: { token: "token-123" },
+      options: { token: "token-503" },
     });
 
     const emitter = (plugin as unknown as { emitter: { emit: ReturnType<typeof vi.fn> } }).emitter;
@@ -227,7 +228,71 @@ describe("createDiscordGatewayPlugin", () => {
     ).handleReconnectionAttemptSpy;
     expect(emitter.emit).toHaveBeenCalledWith("error", expect.any(Error));
     const emittedError = (emitter.emit.mock.calls[0] as unknown[])[1] as Error;
-    expect(emittedError.message).toContain("HTTP 503");
+    expect(emittedError.message).toMatch(/\/gateway\/bot failed \(503\)/);
+    expect(reconnectSpy).toHaveBeenCalledTimes(1);
+    expect(baseRegisterClientSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits error and schedules reconnect on non-JSON error body (502 HTML)", async () => {
+    const runtime = createRuntime();
+    undiciFetchMock.mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: async () => "<html><body>Bad Gateway</body></html>",
+    } as unknown as Response);
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://proxy.test:8080" },
+      runtime,
+    });
+
+    await (
+      plugin as unknown as {
+        registerClient: (client: { options: { token: string } }) => Promise<void>;
+      }
+    ).registerClient({
+      options: { token: "token-502" },
+    });
+
+    const emitter = (plugin as unknown as { emitter: { emit: ReturnType<typeof vi.fn> } }).emitter;
+    const reconnectSpy = (
+      plugin as unknown as { handleReconnectionAttemptSpy: ReturnType<typeof vi.fn> }
+    ).handleReconnectionAttemptSpy;
+    expect(emitter.emit).toHaveBeenCalledWith("error", expect.any(Error));
+    const emittedError = (emitter.emit.mock.calls[0] as unknown[])[1] as Error;
+    expect(emittedError.message).toMatch(/\/gateway\/bot failed \(502\)/);
+    expect(reconnectSpy).toHaveBeenCalledTimes(1);
+    expect(baseRegisterClientSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits error and schedules reconnect when body stream is already consumed (500)", async () => {
+    const runtime = createRuntime();
+    undiciFetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => {
+        throw new Error("body stream already consumed");
+      },
+    } as unknown as Response);
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://proxy.test:8080" },
+      runtime,
+    });
+
+    await (
+      plugin as unknown as {
+        registerClient: (client: { options: { token: string } }) => Promise<void>;
+      }
+    ).registerClient({
+      options: { token: "token-500" },
+    });
+
+    const emitter = (plugin as unknown as { emitter: { emit: ReturnType<typeof vi.fn> } }).emitter;
+    const reconnectSpy = (
+      plugin as unknown as { handleReconnectionAttemptSpy: ReturnType<typeof vi.fn> }
+    ).handleReconnectionAttemptSpy;
+    expect(emitter.emit).toHaveBeenCalledWith("error", expect.any(Error));
+    const emittedError = (emitter.emit.mock.calls[0] as unknown[])[1] as Error;
+    expect(emittedError.message).toMatch(/\/gateway\/bot failed \(500\): empty response/);
     expect(reconnectSpy).toHaveBeenCalledTimes(1);
     expect(baseRegisterClientSpy).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Fixes an unhandled promise rejection that crashes the entire Node.js gateway process when Discord's API returns a transient 503 (or any non-2xx status) during a proxy-mode bot reconnect attempt.

### Root Cause

`ProxyGatewayPlugin.registerClient()` called `response.json()` on the API response **without first checking `response.ok`**. When Discord returns a 503 during a health-monitor-triggered reconnect, the response body is a non-JSON string like `"upstream connect error or disconnect/reset before headers"`, causing a JSON parse error.

Critically, **Carbon calls `registerClient()` without `await`**, so any thrown error from this async method becomes an unhandled promise rejection — which crashes the entire Node.js gateway process, taking all agents offline.

### Fix

- Add `response.ok` check before calling `response.json()`. On non-2xx responses, read the body as text and build a descriptive error message with the HTTP status code.
- Instead of re-throwing the error (which becomes unhandled since Carbon doesn't await `registerClient()`), **emit it on `this.emitter`** — the gateway lifecycle's error listener picks it up gracefully.
- Call `this.handleReconnectionAttempt({})` to schedule a backoff retry via Carbon's existing reconnect mechanism, so the bot reconnects after the Discord 503 clears.

This same catch block handles both non-2xx HTTP responses and other network errors (e.g. DNS failure, connection refused).

### Before / After

**Before:** Any transient Discord 503 during proxy reconnect → unhandled rejection → gateway process exits → all agents offline for 2–3 minutes until LaunchAgent/systemd restarts the process.

**After:** 503 is caught, logged via the emitter error event, and a backoff reconnect is scheduled. The gateway process stays alive. Other bots/agents are unaffected.

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations (Discord)

## Linked Issue
Fixes #44529

## User-visible / Behavior Changes

Gateway no longer crashes when Discord returns a transient 503 during a proxy-mode health-monitor reconnect. The affected bot will retry with exponential backoff; other bots remain online.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same Discord gateway endpoint, added error handling)
- Command/tool execution surface changed? No

## Repro + Verification

Unit test added in `src/discord/monitor/provider.proxy.test.ts` covering the 503 path:
- Mocks `undiciFetch` to return `{ ok: false, status: 503, text: async () => "upstream connect error..." }`
- Verifies `emitter.emit("error", ...)` is called with an error containing "HTTP 503"
- Verifies `handleReconnectionAttempt({})` is called once
- Verifies `super.registerClient()` is NOT called (no attempt to open WebSocket with bad gateway info)