### PR TITLE
fix(docker): allow whitespace in config and workspace paths

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -144,9 +144,7 @@ validate_mount_path_value() {
   if contains_disallowed_chars "$value"; then
     fail "$label contains unsupported control characters."
   fi
-  if [[ "$value" =~ [[:space:]] ]]; then
-    fail "$label cannot contain whitespace."
-  fi
+  # Note: whitespace in paths is now allowed (e.g., Windows usernames like "C:\Users\John Doe")
 }
 
 validate_named_volume() {
@@ -161,10 +159,11 @@ validate_mount_spec() {
   if contains_disallowed_chars "$mount"; then
     fail "OPENCLAW_EXTRA_MOUNTS entries cannot contain control characters."
   fi
-  # Keep mount specs strict to avoid YAML structure injection.
-  # Expected format: source:target[:options]
-  if [[ ! "$mount" =~ ^[^[:space:],:]+:[^[:space:],:]+(:[^[:space:],:]+)?$ ]]; then
-    fail "Invalid mount format '$mount'. Expected source:target[:options] without spaces."
+  # Relaxed to allow whitespace in paths (e.g., Windows usernames like "C:\Users\John Doe").
+  # YAML output is quoted to handle spaces correctly.
+  # Expected format: source:target[:options] (colons and commas still disallowed in path components)
+  if [[ ! "$mount" =~ ^[^,:]+:[^,:]+(:[^,:]+)?$ ]]; then
+    fail "Invalid mount format '$mount'. Expected source:target[:options] (colons and commas not allowed in paths)."
   fi
 }
 
@@ -279,14 +278,14 @@ YAML
     validate_mount_spec "$gateway_home_mount"
     validate_mount_spec "$gateway_config_mount"
     validate_mount_spec "$gateway_workspace_mount"
-    printf '      - %s\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
   fi
 
   for mount in "$@"; do
     validate_mount_spec "$mount"
-    printf '      - %s\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
   done
 
   cat >>"$EXTRA_COMPOSE_FILE" <<'YAML'
@@ -295,14 +294,14 @@ YAML
 YAML
 
   if [[ -n "$home_volume" ]]; then
-    printf '      - %s\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - %s\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
   fi
 
   for mount in "$@"; do
     validate_mount_spec "$mount"
-    printf '      - %s\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
+    printf '      - "%s"\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
   done
 
   if [[ -n "$home_volume" && "$home_volume" != *"/"* ]]; then

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -160,7 +160,7 @@ validate_mount_spec() {
     fail "OPENCLAW_EXTRA_MOUNTS entries cannot contain control characters."
   fi
   # Relaxed to allow whitespace in paths (e.g., Windows usernames like "C:\Users\John Doe").
-  # YAML output is quoted to handle spaces correctly.
+  # YAML output uses single-quoted scalars to handle spaces and backslashes correctly.
   # Expected format: source:target[:options] (colons and commas still disallowed in path components)
   if [[ ! "$mount" =~ ^[^,:]+:[^,:]+(:[^,:]+)?$ ]]; then
     fail "Invalid mount format '$mount'. Expected source:target[:options] (colons and commas not allowed in paths)."
@@ -278,14 +278,14 @@ YAML
     validate_mount_spec "$gateway_home_mount"
     validate_mount_spec "$gateway_config_mount"
     validate_mount_spec "$gateway_workspace_mount"
-    printf '      - "%s"\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - "%s"\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - "%s"\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf "      - '%s'\n" "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf "      - '%s'\n" "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf "      - '%s'\n" "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
   fi
 
   for mount in "$@"; do
     validate_mount_spec "$mount"
-    printf '      - "%s"\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
+    printf "      - '%s'\n" "$mount" >>"$EXTRA_COMPOSE_FILE"
   done
 
   cat >>"$EXTRA_COMPOSE_FILE" <<'YAML'
@@ -294,14 +294,14 @@ YAML
 YAML
 
   if [[ -n "$home_volume" ]]; then
-    printf '      - "%s"\n' "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - "%s"\n' "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
-    printf '      - "%s"\n' "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf "      - '%s'\n" "$gateway_home_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf "      - '%s'\n" "$gateway_config_mount" >>"$EXTRA_COMPOSE_FILE"
+    printf "      - '%s'\n" "$gateway_workspace_mount" >>"$EXTRA_COMPOSE_FILE"
   fi
 
   for mount in "$@"; do
     validate_mount_spec "$mount"
-    printf '      - "%s"\n' "$mount" >>"$EXTRA_COMPOSE_FILE"
+    printf "      - '%s'\n" "$mount" >>"$EXTRA_COMPOSE_FILE"
   done
 
   if [[ -n "$home_volume" && "$home_volume" != *"/"* ]]; then


### PR DESCRIPTION
Fixes #44599

Windows usernames with spaces (e.g. C:\Users\John Doe) cause docker-setup.sh to bail with "OPENCLAW_CONFIG_DIR cannot contain whitespace". These are perfectly valid paths.

## Problem

validate_mount_path_value rejected any path containing whitespace. On Windows with Git Bash, $HOME often resolves to a path with spaces when the Windows username contains them.

## Root cause

The whitespace check was overly broad. The actual concern is YAML structure injection in the generated docker-compose file, but that only requires rejecting colons, commas, and control characters -- not spaces.

## Changes

- Remove the blanket [[:space:]] rejection from validate_mount_path_value (control characters like tabs/newlines are still caught by contains_disallowed_chars)
- Relax validate_mount_spec regex to allow spaces in source/target segments (colons and commas still blocked)
- Quote volume mount strings in generated YAML so Docker Compose parses spaced paths correctly

## Test Plan

- bash -n docker-setup.sh passes
- The quoting matches Docker Compose documented YAML string handling