### PR TITLE
fix(agents): fail closed on malformed kimi tool-call JSON

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -802,9 +802,29 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
   });
 
   it("does not repair tool arguments when trailing junk exceeds the Kimi-specific allowance", async () => {
-    const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
-    const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const partialToolCall = {
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/tmp/report.txt" },
+    };
+    const streamedToolCall = {
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/tmp/report.txt" },
+    };
+    const endMessageToolCall = {
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/tmp/report.txt" },
+    };
+    const finalToolCall = {
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/tmp/report.txt" },
+    };
     const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const endMessage = { role: "assistant", content: [endMessageToolCall] };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
     const baseFn = vi.fn(() =>
       createFakeStream({
         events: [
@@ -819,9 +839,10 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
             contentIndex: 0,
             toolCall: streamedToolCall,
             partial: partialMessage,
+            message: endMessage,
           },
         ],
-        resultMessage: { role: "assistant", content: [partialToolCall] },
+        resultMessage: finalMessage,
       }),
     );
 
@@ -829,15 +850,39 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
     for await (const _item of stream) {
       // drain
     }
+    const result = await stream.result();
 
     expect(partialToolCall.arguments).toEqual({});
     expect(streamedToolCall.arguments).toEqual({});
+    expect(endMessageToolCall.arguments).toEqual({});
+    expect(finalToolCall.arguments).toEqual({});
+    expect(result).toBe(finalMessage);
   });
 
   it("clears a cached repair when later deltas make the trailing suffix invalid", async () => {
-    const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
-    const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const partialToolCall = {
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/tmp/report.txt" },
+    };
+    const streamedToolCall = {
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/tmp/report.txt" },
+    };
+    const endMessageToolCall = {
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/tmp/report.txt" },
+    };
+    const finalToolCall = {
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/tmp/report.txt" },
+    };
     const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const endMessage = { role: "assistant", content: [endMessageToolCall] };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
     const baseFn = vi.fn(() =>
       createFakeStream({
         events: [
@@ -864,9 +909,10 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
             contentIndex: 0,
             toolCall: streamedToolCall,
             partial: partialMessage,
+            message: endMessage,
           },
         ],
-        resultMessage: { role: "assistant", content: [partialToolCall] },
+        resultMessage: finalMessage,
       }),
     );
 
@@ -874,9 +920,71 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
     for await (const _item of stream) {
       // drain
     }
+    const result = await stream.result();
 
     expect(partialToolCall.arguments).toEqual({});
     expect(streamedToolCall.arguments).toEqual({});
+    expect(endMessageToolCall.arguments).toEqual({});
+    expect(finalToolCall.arguments).toEqual({});
+    expect(result).toBe(finalMessage);
+  });
+
+  it("clears malformed final tool arguments when Kimi leaves a string unterminated", async () => {
+    const partialToolCall = {
+      type: "toolCall",
+      name: "write",
+      arguments: { path: "/tmp/report.txt", content: "" },
+    };
+    const streamedToolCall = {
+      type: "toolCall",
+      name: "write",
+      arguments: { path: "/tmp/report.txt", content: "" },
+    };
+    const endMessageToolCall = {
+      type: "toolCall",
+      name: "write",
+      arguments: { path: "/tmp/report.txt", content: "" },
+    };
+    const finalToolCall = {
+      type: "toolCall",
+      name: "write",
+      arguments: { path: "/tmp/report.txt", content: "" },
+    };
+    const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const endMessage = { role: "assistant", content: [endMessageToolCall] };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: '{"path":"/tmp/report.txt","content":"',
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+            message: endMessage,
+          },
+        ],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    for await (const _item of stream) {
+      // drain
+    }
+    const result = await stream.result();
+
+    expect(partialToolCall.arguments).toEqual({});
+    expect(streamedToolCall.arguments).toEqual({});
+    expect(endMessageToolCall.arguments).toEqual({});
+    expect(finalToolCall.arguments).toEqual({});
+    expect(result).toBe(finalMessage);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -848,35 +848,47 @@ type ToolCallArgumentRepair = {
   trailingSuffix: string;
 };
 
-function tryParseMalformedToolCallArguments(raw: string): ToolCallArgumentRepair | undefined {
+function tryParseCompleteToolCallArguments(raw: string): Record<string, unknown> | undefined {
   if (!raw.trim()) {
     return undefined;
   }
   try {
-    JSON.parse(raw);
-    return undefined;
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
   } catch {
-    const jsonPrefix = extractBalancedJsonPrefix(raw);
-    if (!jsonPrefix) {
-      return undefined;
-    }
-    const suffix = raw.slice(raw.indexOf(jsonPrefix) + jsonPrefix.length).trim();
-    if (
-      suffix.length === 0 ||
-      suffix.length > MAX_TOOLCALL_REPAIR_TRAILING_CHARS ||
-      !TOOLCALL_REPAIR_ALLOWED_TRAILING_RE.test(suffix)
-    ) {
-      return undefined;
-    }
-    try {
-      const parsed = JSON.parse(jsonPrefix) as unknown;
-      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? { args: parsed as Record<string, unknown>, trailingSuffix: suffix }
-        : undefined;
-    } catch {
-      return undefined;
-    }
+    return undefined;
   }
+}
+
+function tryParseMalformedToolCallArguments(raw: string): ToolCallArgumentRepair | undefined {
+  if (!raw.trim()) {
+    return undefined;
+  }
+  if (tryParseCompleteToolCallArguments(raw)) {
+    return undefined;
+  }
+  const jsonPrefix = extractBalancedJsonPrefix(raw);
+  if (!jsonPrefix) {
+    return undefined;
+  }
+  const suffix = raw.slice(raw.indexOf(jsonPrefix) + jsonPrefix.length).trim();
+  if (
+    suffix.length === 0 ||
+    suffix.length > MAX_TOOLCALL_REPAIR_TRAILING_CHARS ||
+    !TOOLCALL_REPAIR_ALLOWED_TRAILING_RE.test(suffix)
+  ) {
+    return undefined;
+  }
+  const parsed = tryParseCompleteToolCallArguments(jsonPrefix);
+  return parsed ? { args: parsed, trailingSuffix: suffix } : undefined;
+}
+
+function isMalformedFinalToolCallArguments(raw: string | undefined): boolean {
+  return (
+    typeof raw === "string" && raw.trim().length > 0 && !tryParseCompleteToolCallArguments(raw)
+  );
 }
 
 function repairToolCallArgumentsInMessage(
@@ -921,6 +933,34 @@ function clearToolCallArgumentsInMessage(message: unknown, contentIndex: number)
   typedBlock.arguments = {};
 }
 
+function clearMalformedToolCallArgumentsForDispatch(params: {
+  event: {
+    contentIndex?: number;
+    partial?: unknown;
+    message?: unknown;
+    toolCall?: unknown;
+  };
+}): void {
+  const contentIndex = params.event.contentIndex;
+  if (typeof contentIndex !== "number" || !Number.isInteger(contentIndex)) {
+    return;
+  }
+  if (params.event.toolCall && typeof params.event.toolCall === "object") {
+    (params.event.toolCall as { arguments?: unknown }).arguments = {};
+  }
+  clearToolCallArgumentsInMessage(params.event.partial, contentIndex);
+  clearToolCallArgumentsInMessage(params.event.message, contentIndex);
+}
+
+function clearMalformedToolCallArgumentsInMessage(
+  message: unknown,
+  contentIndices: Set<number>,
+): void {
+  for (const index of contentIndices) {
+    clearToolCallArgumentsInMessage(message, index);
+  }
+}
+
 function repairMalformedToolCallArgumentsInMessage(
   message: unknown,
   repairedArgsByIndex: Map<number, Record<string, unknown>>,
@@ -942,14 +982,17 @@ function wrapStreamRepairMalformedToolCallArguments(
 ): ReturnType<typeof streamSimple> {
   const partialJsonByIndex = new Map<number, string>();
   const repairedArgsByIndex = new Map<number, Record<string, unknown>>();
+  const clearedArgsIndices = new Set<number>();
   const disabledIndices = new Set<number>();
   const loggedRepairIndices = new Set<number>();
   const originalResult = stream.result.bind(stream);
   stream.result = async () => {
     const message = await originalResult();
     repairMalformedToolCallArgumentsInMessage(message, repairedArgsByIndex);
+    clearMalformedToolCallArgumentsInMessage(message, clearedArgsIndices);
     partialJsonByIndex.clear();
     repairedArgsByIndex.clear();
+    clearedArgsIndices.clear();
     disabledIndices.clear();
     loggedRepairIndices.clear();
     return message;
@@ -1014,12 +1057,21 @@ function wrapStreamRepairMalformedToolCallArguments(
               event.type === "toolcall_end"
             ) {
               const repairedArgs = repairedArgsByIndex.get(event.contentIndex);
+              const rawPartialJson = partialJsonByIndex.get(event.contentIndex);
               if (repairedArgs) {
+                clearedArgsIndices.delete(event.contentIndex);
                 if (event.toolCall && typeof event.toolCall === "object") {
                   (event.toolCall as { arguments?: unknown }).arguments = repairedArgs;
                 }
                 repairToolCallArgumentsInMessage(event.partial, event.contentIndex, repairedArgs);
                 repairToolCallArgumentsInMessage(event.message, event.contentIndex, repairedArgs);
+              } else if (isMalformedFinalToolCallArguments(rawPartialJson)) {
+                clearedArgsIndices.add(event.contentIndex);
+                clearMalformedToolCallArgumentsForDispatch({ event });
+                if (!loggedRepairIndices.has(event.contentIndex)) {
+                  loggedRepairIndices.add(event.contentIndex);
+                  log.warn("discarding malformed kimi-coding tool call arguments at toolcall_end");
+                }
               }
               partialJsonByIndex.delete(event.contentIndex);
               disabledIndices.delete(event.contentIndex);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -935,7 +935,7 @@ function clearToolCallArgumentsInMessage(message: unknown, contentIndex: number)
 
 function clearMalformedToolCallArgumentsForDispatch(params: {
   event: {
-    contentIndex?: number;
+    contentIndex?: unknown;
     partial?: unknown;
     message?: unknown;
     toolCall?: unknown;


### PR DESCRIPTION
## Summary
Fix kimi-coding Anthropic tool-call handling so unrecoverable malformed final JSON does not dispatch partial arguments to tools.

## What changed
- add a complete-JSON check for kimi tool calls at `toolcall_end`
- if no repair succeeded and the final payload is still malformed, clear the tool arguments across streamed/event/final snapshots
- extend regression coverage for:
  - trailing junk beyond the Kimi repair allowance
  - repairs that become invalid after later deltas
  - unterminated string payloads that would otherwise look like empty write content

## Why
`partial-json` can surface partial argument objects from malformed payloads. For Kimi write/read calls that can turn a malformed tool call into a silent bad dispatch instead of a validation failure.

## Verification
- `vitest run src/agents/pi-embedded-runner/run/attempt.test.ts -t wrapStreamFnRepairMalformedToolCallArguments`

Fixes #44372
