### PR TITLE
Feat/backup checksum integrity

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -27,8 +27,9 @@ openclaw backup verify ./2026-03-09T00-00-00.000Z-openclaw-backup.tar.gz
 - If the current working directory is inside a backed-up source tree, OpenClaw falls back to your home directory for the default archive location.
 - Existing archive files are never overwritten.
 - Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.
-- `openclaw backup verify <archive>` validates that the archive contains exactly one root manifest, rejects traversal-style archive paths, and checks that every manifest-declared payload exists in the tarball.
+- `openclaw backup verify <archive>` validates structural integrity (one root manifest, no traversal paths, all manifest-declared payloads present) and verifies per-asset SHA-256 checksums when present.
 - `openclaw backup create --verify` runs that validation immediately after writing the archive.
+- Archives created with the current version include per-asset SHA-256 checksums in the manifest (schema v2). Verification of older archives without checksums (schema v1) still passes structural checks.
 - `openclaw backup create --only-config` backs up just the active JSON config file.
 
 ## What gets backed up
@@ -44,7 +45,7 @@ If you use `--only-config`, OpenClaw skips state, credentials, and workspace dis
 
 OpenClaw canonicalizes paths before building the archive. If config, credentials, or a workspace already live inside the state directory, they are not duplicated as separate top-level backup sources. Missing paths are skipped.
 
-The archive payload stores file contents from those source trees, and the embedded `manifest.json` records the resolved absolute source paths plus the archive layout used for each asset.
+The archive payload stores file contents from those source trees, and the embedded `manifest.json` records the resolved absolute source paths, the archive layout, and a SHA-256 checksum for each asset.
 
 ## Invalid config behavior
 

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -389,4 +389,157 @@ describe("backupVerifyCommand", () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("verifies checksums in a round-trip create-verify cycle", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-checksum-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "hello\n", "utf8");
+      await fs.mkdir(path.join(stateDir, "nested"), { recursive: true });
+      await fs.writeFile(path.join(stateDir, "nested", "deep.txt"), "deep content\n", "utf8");
+
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const nowMs = Date.UTC(2026, 2, 9, 3, 0, 0);
+      const created = await backupCreateCommand(runtime, { output: archiveDir, nowMs });
+      const verified = await backupVerifyCommand(runtime, { archive: created.archivePath });
+
+      expect(verified.ok).toBe(true);
+      expect(verified.schemaVersion).toBe(2);
+      expect(verified.checksumsVerified).toBe(true);
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects tampered archive content", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-tamper-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "original\n", "utf8");
+
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const nowMs = Date.UTC(2026, 2, 9, 4, 0, 0);
+      const created = await backupCreateCommand(runtime, { output: archiveDir, nowMs });
+
+      // Extract, tamper with a file, and repack
+      const extractDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-backup-tamper-extract-"),
+      );
+      try {
+        await tar.x({ file: created.archivePath, cwd: extractDir, gzip: true });
+        const archiveRoot = buildBackupArchiveRoot(nowMs);
+
+        // Find and tamper with state.txt inside the archive
+        const stateAssetDir = path.join(extractDir, archiveRoot, "payload");
+        const tamperedFiles = await findFilesRecursive(stateAssetDir, "state.txt");
+        expect(tamperedFiles.length).toBeGreaterThan(0);
+        await fs.writeFile(tamperedFiles[0], "tampered!\n", "utf8");
+
+        // Repack the tampered archive
+        await fs.rm(created.archivePath);
+        await tar.c({ file: created.archivePath, gzip: true, cwd: extractDir }, [archiveRoot]);
+
+        await expect(
+          backupVerifyCommand(runtime, { archive: created.archivePath }),
+        ).rejects.toThrow(/checksum mismatch/i);
+      } finally {
+        await fs.rm(extractDir, { recursive: true, force: true });
+      }
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies a v1 archive without checksums gracefully", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-v1-compat-"));
+    const archivePath = path.join(tempDir, "v1.tar.gz");
+    try {
+      const rootName = "2026-03-09T00-00-00.000Z-openclaw-backup";
+      const root = path.join(tempDir, rootName);
+      const payloadDir = path.join(root, "payload", "posix", "tmp", ".openclaw");
+      await fs.mkdir(payloadDir, { recursive: true });
+      await fs.writeFile(path.join(payloadDir, "state.txt"), "v1 content\n", "utf8");
+      const manifest = {
+        schemaVersion: 1,
+        createdAt: "2026-03-09T00:00:00.000Z",
+        archiveRoot: rootName,
+        runtimeVersion: "test",
+        platform: process.platform,
+        nodeVersion: process.version,
+        assets: [
+          {
+            kind: "state",
+            sourcePath: "/tmp/.openclaw",
+            archivePath: `${rootName}/payload/posix/tmp/.openclaw`,
+          },
+        ],
+      };
+      await fs.writeFile(
+        path.join(root, "manifest.json"),
+        `${JSON.stringify(manifest, null, 2)}\n`,
+      );
+      await tar.c({ file: archivePath, gzip: true, cwd: tempDir }, [rootName]);
+
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const verified = await backupVerifyCommand(runtime, { archive: archivePath });
+
+      expect(verified.ok).toBe(true);
+      expect(verified.schemaVersion).toBe(1);
+      expect(verified.checksumsVerified).toBe(false);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("includes sha256 fields in the manifest for each asset", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-sha256-field-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "checksum test\n", "utf8");
+
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const nowMs = Date.UTC(2026, 2, 9, 5, 0, 0);
+      const created = await backupCreateCommand(runtime, { output: archiveDir, nowMs });
+
+      const extractDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-backup-sha256-extract-"),
+      );
+      try {
+        await tar.x({ file: created.archivePath, cwd: extractDir, gzip: true });
+        const archiveRoot = buildBackupArchiveRoot(nowMs);
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(extractDir, archiveRoot, "manifest.json"), "utf8"),
+        ) as {
+          schemaVersion: number;
+          assets: Array<{ kind: string; sha256: string }>;
+        };
+
+        expect(manifest.schemaVersion).toBe(2);
+        for (const asset of manifest.assets) {
+          expect(asset.sha256).toMatch(/^[a-f0-9]{64}$/);
+        }
+      } finally {
+        await fs.rm(extractDir, { recursive: true, force: true });
+      }
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
 });
+
+async function findFilesRecursive(dir: string, name: string): Promise<string[]> {
+  const results: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await findFilesRecursive(fullPath, name)));
+    } else if (entry.name === name) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -528,6 +528,32 @@ describe("backupVerifyCommand", () => {
       await fs.rm(archiveDir, { recursive: true, force: true });
     }
   });
+  it("produces stable checksums for non-ASCII filenames regardless of locale collation", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-locale-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      // These filenames sort differently under locale-sensitive collation (e.g.
+      // Swedish puts ä after z) vs deterministic byte-order (ä = U+00E4 > z).
+      // A locale-dependent sort in create vs verify would produce a Merkle hash
+      // mismatch even though the file bytes are identical.
+      await fs.writeFile(path.join(stateDir, "ä.txt"), "umlaut\n", "utf8");
+      await fs.writeFile(path.join(stateDir, "z.txt"), "zed\n", "utf8");
+      await fs.writeFile(path.join(stateDir, "ñ.txt"), "enye\n", "utf8");
+      await fs.writeFile(path.join(stateDir, "o.txt"), "oscar\n", "utf8");
+
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const nowMs = Date.UTC(2026, 2, 9, 7, 0, 0);
+      const created = await backupCreateCommand(runtime, { output: archiveDir, nowMs });
+      const verified = await backupVerifyCommand(runtime, { archive: created.archivePath });
+
+      expect(verified.ok).toBe(true);
+      expect(verified.schemaVersion).toBe(2);
+      expect(verified.checksumsVerified).toBe(true);
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
 });
 
 async function findFilesRecursive(dir: string, name: string): Promise<string[]> {

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -383,7 +383,9 @@ async function verifyAssetChecksums(params: {
         fileHashes.push({ relativePath, sha256 });
       }
 
-      fileHashes.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+      fileHashes.sort((a, b) =>
+        a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
+      );
       const hash = createHash("sha256");
       for (const entry of fileHashes) {
         hash.update(`${entry.relativePath}\0${entry.sha256}\n`);

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import path from "node:path";
 import * as tar from "tar";
 import type { RuntimeEnv } from "../runtime.js";
@@ -9,6 +10,7 @@ type BackupManifestAsset = {
   kind: string;
   sourcePath: string;
   archivePath: string;
+  sha256?: string;
 };
 
 type BackupManifest = {
@@ -49,6 +51,8 @@ export type BackupVerifyResult = {
   runtimeVersion: string;
   assetCount: number;
   entryCount: number;
+  schemaVersion: number;
+  checksumsVerified: boolean;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -105,7 +109,7 @@ function parseManifest(raw: string): BackupManifest {
   if (!isRecord(parsed)) {
     throw new Error("Backup manifest must be an object.");
   }
-  if (parsed.schemaVersion !== 1) {
+  if (parsed.schemaVersion !== 1 && parsed.schemaVersion !== 2) {
     throw new Error(`Unsupported backup manifest schemaVersion: ${String(parsed.schemaVersion)}`);
   }
   if (typeof parsed.archiveRoot !== "string" || !parsed.archiveRoot.trim()) {
@@ -136,11 +140,12 @@ function parseManifest(raw: string): BackupManifest {
       kind: asset.kind,
       sourcePath: asset.sourcePath,
       archivePath: asset.archivePath,
+      sha256: typeof asset.sha256 === "string" && asset.sha256.trim() ? asset.sha256 : undefined,
     });
   }
 
   return {
-    schemaVersion: 1,
+    schemaVersion: parsed.schemaVersion,
     archiveRoot: parsed.archiveRoot,
     createdAt: parsed.createdAt,
     runtimeVersion:
@@ -252,15 +257,118 @@ function verifyManifestAgainstEntries(manifest: BackupManifest, entries: Set<str
   }
 }
 
+async function extractEntryContent(params: {
+  archivePath: string;
+  entryPath: string;
+}): Promise<Buffer> {
+  let resultPromise: Promise<Buffer> | undefined;
+  await tar.t({
+    file: params.archivePath,
+    gzip: true,
+    onentry: (entry) => {
+      if (entry.path !== params.entryPath) {
+        entry.resume();
+        return;
+      }
+      resultPromise = new Promise<Buffer>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        entry.on("data", (chunk: Buffer | string) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        entry.on("error", reject);
+        entry.on("end", () => resolve(Buffer.concat(chunks)));
+      });
+    },
+  });
+  if (!resultPromise) {
+    throw new Error(`Archive is missing entry: ${params.entryPath}`);
+  }
+  return resultPromise;
+}
+
+async function verifyAssetChecksums(params: {
+  archivePath: string;
+  manifest: BackupManifest;
+  normalizedEntries: string[];
+}): Promise<void> {
+  for (const asset of params.manifest.assets) {
+    if (!asset.sha256) {
+      continue;
+    }
+
+    const assetArchivePath = normalizeArchivePath(asset.archivePath, "Asset archive path");
+
+    // Collect all archive entries that belong to this asset
+    const assetEntries = params.normalizedEntries
+      .filter((entry) => entry === assetArchivePath || isArchivePathWithin(entry, assetArchivePath))
+      .filter((entry) => !entry.endsWith("/"))
+      .toSorted();
+
+    if (assetEntries.length === 0) {
+      throw new Error(
+        `Checksum verification failed: no entries found for asset ${asset.kind} (${asset.sourcePath})`,
+      );
+    }
+
+    if (assetEntries.length === 1 && assetEntries[0] === assetArchivePath) {
+      // Single file asset
+      const content = await extractEntryContent({
+        archivePath: params.archivePath,
+        entryPath: assetEntries[0],
+      });
+      const computed = createHash("sha256").update(content).digest("hex");
+      if (computed !== asset.sha256) {
+        throw new Error(
+          `Checksum mismatch for asset ${asset.kind} (${asset.sourcePath}): expected ${asset.sha256}, got ${computed}`,
+        );
+      }
+    } else {
+      // Directory asset: compute Merkle-like hash from sorted file entries
+      const fileHashes: Array<{ relativePath: string; sha256: string }> = [];
+
+      for (const entryPath of assetEntries) {
+        const relativePath = path.posix.relative(assetArchivePath, entryPath);
+        if (!relativePath) {
+          continue;
+        }
+        const content = await extractEntryContent({
+          archivePath: params.archivePath,
+          entryPath,
+        });
+        const sha256 = createHash("sha256").update(content).digest("hex");
+        fileHashes.push({ relativePath, sha256 });
+      }
+
+      fileHashes.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+      const hash = createHash("sha256");
+      for (const entry of fileHashes) {
+        hash.update(`${entry.relativePath}\0${entry.sha256}\n`);
+      }
+      const computed = hash.digest("hex");
+      if (computed !== asset.sha256) {
+        throw new Error(
+          `Checksum mismatch for asset ${asset.kind} (${asset.sourcePath}): expected ${asset.sha256}, got ${computed}`,
+        );
+      }
+    }
+  }
+}
+
 function formatResult(result: BackupVerifyResult): string {
-  return [
+  const lines = [
     `Backup archive OK: ${result.archivePath}`,
     `Archive root: ${result.archiveRoot}`,
     `Created at: ${result.createdAt}`,
     `Runtime version: ${result.runtimeVersion}`,
     `Assets verified: ${result.assetCount}`,
     `Archive entries scanned: ${result.entryCount}`,
-  ].join("\n");
+  ];
+  if (result.checksumsVerified) {
+    lines.push("Content checksums: verified");
+  } else {
+    lines.push("Content checksums: not present (schema v1 archive)");
+  }
+  return lines.join("\n");
 }
 
 function findDuplicateNormalizedEntryPath(
@@ -309,6 +417,16 @@ export async function backupVerifyCommand(
   const manifest = parseManifest(manifestRaw);
   verifyManifestAgainstEntries(manifest, normalizedEntrySet);
 
+  const hasChecksums = manifest.schemaVersion >= 2 && manifest.assets.some((asset) => asset.sha256);
+
+  if (hasChecksums) {
+    await verifyAssetChecksums({
+      archivePath,
+      manifest,
+      normalizedEntries: [...normalizedEntrySet],
+    });
+  }
+
   const result: BackupVerifyResult = {
     ok: true,
     archivePath,
@@ -317,6 +435,8 @@ export async function backupVerifyCommand(
     runtimeVersion: manifest.runtimeVersion,
     assetCount: manifest.assets.length,
     entryCount: rawEntries.length,
+    schemaVersion: manifest.schemaVersion,
+    checksumsVerified: hasChecksums,
   };
 
   runtime.log(opts.json ? JSON.stringify(result, null, 2) : formatResult(result));

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -175,13 +175,21 @@ function parseManifest(raw: string): BackupManifest {
   };
 }
 
-async function listArchiveEntries(archivePath: string): Promise<string[]> {
-  const entries: string[] = [];
+type ArchiveEntry = {
+  path: string;
+  isDirectory: boolean;
+};
+
+async function listArchiveEntries(archivePath: string): Promise<ArchiveEntry[]> {
+  const entries: ArchiveEntry[] = [];
   await tar.t({
     file: archivePath,
     gzip: true,
     onentry: (entry) => {
-      entries.push(entry.path);
+      entries.push({
+        path: entry.path,
+        isDirectory: entry.type === "Directory",
+      });
     },
   });
   return entries;
@@ -289,8 +297,18 @@ async function extractEntryContent(params: {
 async function verifyAssetChecksums(params: {
   archivePath: string;
   manifest: BackupManifest;
-  normalizedEntries: string[];
+  archiveEntries: ArchiveEntry[];
 }): Promise<void> {
+  // Map normalized paths to raw paths, excluding directory entries
+  const normalizedToRaw = new Map<string, string>();
+  for (const entry of params.archiveEntries) {
+    if (entry.isDirectory) {
+      continue;
+    }
+    const normalized = normalizeArchivePath(entry.path, "Archive entry");
+    normalizedToRaw.set(normalized, entry.path);
+  }
+
   for (const asset of params.manifest.assets) {
     if (!asset.sha256) {
       continue;
@@ -298,10 +316,9 @@ async function verifyAssetChecksums(params: {
 
     const assetArchivePath = normalizeArchivePath(asset.archivePath, "Asset archive path");
 
-    // Collect all archive entries that belong to this asset
-    const assetEntries = params.normalizedEntries
+    // Collect all file entries that belong to this asset
+    const assetEntries = [...normalizedToRaw.keys()]
       .filter((entry) => entry === assetArchivePath || isArchivePathWithin(entry, assetArchivePath))
-      .filter((entry) => !entry.endsWith("/"))
       .toSorted();
 
     if (assetEntries.length === 0) {
@@ -311,10 +328,11 @@ async function verifyAssetChecksums(params: {
     }
 
     if (assetEntries.length === 1 && assetEntries[0] === assetArchivePath) {
-      // Single file asset
+      // Single file asset: use raw path for extraction
+      const rawPath = normalizedToRaw.get(assetEntries[0])!;
       const content = await extractEntryContent({
         archivePath: params.archivePath,
-        entryPath: assetEntries[0],
+        entryPath: rawPath,
       });
       const computed = createHash("sha256").update(content).digest("hex");
       if (computed !== asset.sha256) {
@@ -331,9 +349,10 @@ async function verifyAssetChecksums(params: {
         if (!relativePath) {
           continue;
         }
+        const rawPath = normalizedToRaw.get(entryPath)!;
         const content = await extractEntryContent({
           archivePath: params.archivePath,
-          entryPath,
+          entryPath: rawPath,
         });
         const sha256 = createHash("sha256").update(content).digest("hex");
         fileHashes.push({ relativePath, sha256 });
@@ -389,14 +408,14 @@ export async function backupVerifyCommand(
   opts: BackupVerifyOptions,
 ): Promise<BackupVerifyResult> {
   const archivePath = resolveUserPath(opts.archive);
-  const rawEntries = await listArchiveEntries(archivePath);
-  if (rawEntries.length === 0) {
+  const archiveEntries = await listArchiveEntries(archivePath);
+  if (archiveEntries.length === 0) {
     throw new Error("Backup archive is empty.");
   }
 
-  const entries = rawEntries.map((entry) => ({
-    raw: entry,
-    normalized: normalizeArchivePath(entry, "Archive entry"),
+  const entries = archiveEntries.map((entry) => ({
+    raw: entry.path,
+    normalized: normalizeArchivePath(entry.path, "Archive entry"),
   }));
   const normalizedEntrySet = new Set(entries.map((entry) => entry.normalized));
 
@@ -423,7 +442,7 @@ export async function backupVerifyCommand(
     await verifyAssetChecksums({
       archivePath,
       manifest,
-      normalizedEntries: [...normalizedEntrySet],
+      archiveEntries,
     });
   }
 
@@ -434,7 +453,7 @@ export async function backupVerifyCommand(
     createdAt: manifest.createdAt,
     runtimeVersion: manifest.runtimeVersion,
     assetCount: manifest.assets.length,
-    entryCount: rawEntries.length,
+    entryCount: archiveEntries.length,
     schemaVersion: manifest.schemaVersion,
     checksumsVerified: hasChecksums,
   };

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -265,11 +265,11 @@ function verifyManifestAgainstEntries(manifest: BackupManifest, entries: Set<str
   }
 }
 
-async function extractMultipleEntries(params: {
+async function hashMultipleEntries(params: {
   archivePath: string;
   entryPaths: Set<string>;
-}): Promise<Map<string, Buffer>> {
-  const results = new Map<string, Buffer>();
+}): Promise<Map<string, string>> {
+  const results = new Map<string, string>();
   const pending: Promise<void>[] = [];
   await tar.t({
     file: params.archivePath,
@@ -281,13 +281,13 @@ async function extractMultipleEntries(params: {
       }
       pending.push(
         new Promise<void>((resolve, reject) => {
-          const chunks: Buffer[] = [];
+          const hash = createHash("sha256");
           entry.on("data", (chunk: Buffer | string) => {
-            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+            hash.update(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
           });
           entry.on("error", reject);
           entry.on("end", () => {
-            results.set(entry.path, Buffer.concat(chunks));
+            results.set(entry.path, hash.digest("hex"));
             resolve();
           });
         }),
@@ -349,21 +349,20 @@ async function verifyAssetChecksums(params: {
     }
   }
 
-  // Single-pass extraction of all needed entries
-  const extractedContent = await extractMultipleEntries({
+  // Single-pass streaming hash of all needed entries (no content buffering)
+  const entryHashes = await hashMultipleEntries({
     archivePath: params.archivePath,
     entryPaths: allNeededRawPaths,
   });
 
-  // Verify checksums using extracted content
+  // Verify checksums using streamed hashes
   for (const { asset, assetArchivePath, entries } of checks) {
     if (entries.length === 1 && entries[0] === assetArchivePath) {
       const rawPath = normalizedToRaw.get(entries[0])!;
-      const content = extractedContent.get(rawPath);
-      if (!content) {
-        throw new Error(`Failed to extract entry for asset ${asset.kind} (${asset.sourcePath})`);
+      const computed = entryHashes.get(rawPath);
+      if (!computed) {
+        throw new Error(`Failed to hash entry for asset ${asset.kind} (${asset.sourcePath})`);
       }
-      const computed = createHash("sha256").update(content).digest("hex");
       if (computed !== asset.sha256) {
         throw new Error(
           `Checksum mismatch for asset ${asset.kind} (${asset.sourcePath}): expected ${asset.sha256}, got ${computed}`,
@@ -377,11 +376,10 @@ async function verifyAssetChecksums(params: {
           continue;
         }
         const rawPath = normalizedToRaw.get(entryPath)!;
-        const content = extractedContent.get(rawPath);
-        if (!content) {
-          throw new Error(`Failed to extract entry for asset ${asset.kind} (${asset.sourcePath})`);
+        const sha256 = entryHashes.get(rawPath);
+        if (!sha256) {
+          throw new Error(`Failed to hash entry for asset ${asset.kind} (${asset.sourcePath})`);
         }
-        const sha256 = createHash("sha256").update(content).digest("hex");
         fileHashes.push({ relativePath, sha256 });
       }
 

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -324,6 +324,11 @@ async function verifyAssetChecksums(params: {
 
   for (const asset of params.manifest.assets) {
     if (!asset.sha256) {
+      if (params.manifest.schemaVersion >= 2) {
+        throw new Error(
+          `Schema v2 asset is missing required checksum: ${asset.kind} (${asset.sourcePath})`,
+        );
+      }
       continue;
     }
 

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -265,33 +265,37 @@ function verifyManifestAgainstEntries(manifest: BackupManifest, entries: Set<str
   }
 }
 
-async function extractEntryContent(params: {
+async function extractMultipleEntries(params: {
   archivePath: string;
-  entryPath: string;
-}): Promise<Buffer> {
-  let resultPromise: Promise<Buffer> | undefined;
+  entryPaths: Set<string>;
+}): Promise<Map<string, Buffer>> {
+  const results = new Map<string, Buffer>();
+  const pending: Promise<void>[] = [];
   await tar.t({
     file: params.archivePath,
     gzip: true,
     onentry: (entry) => {
-      if (entry.path !== params.entryPath) {
+      if (!params.entryPaths.has(entry.path)) {
         entry.resume();
         return;
       }
-      resultPromise = new Promise<Buffer>((resolve, reject) => {
-        const chunks: Buffer[] = [];
-        entry.on("data", (chunk: Buffer | string) => {
-          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-        });
-        entry.on("error", reject);
-        entry.on("end", () => resolve(Buffer.concat(chunks)));
-      });
+      pending.push(
+        new Promise<void>((resolve, reject) => {
+          const chunks: Buffer[] = [];
+          entry.on("data", (chunk: Buffer | string) => {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+          });
+          entry.on("error", reject);
+          entry.on("end", () => {
+            results.set(entry.path, Buffer.concat(chunks));
+            resolve();
+          });
+        }),
+      );
     },
   });
-  if (!resultPromise) {
-    throw new Error(`Archive is missing entry: ${params.entryPath}`);
-  }
-  return resultPromise;
+  await Promise.all(pending);
+  return results;
 }
 
 async function verifyAssetChecksums(params: {
@@ -309,14 +313,21 @@ async function verifyAssetChecksums(params: {
     normalizedToRaw.set(normalized, entry.path);
   }
 
+  // Pre-compute which entries each asset needs and collect all raw paths
+  type AssetCheck = {
+    asset: BackupManifestAsset;
+    assetArchivePath: string;
+    entries: string[];
+  };
+  const checks: AssetCheck[] = [];
+  const allNeededRawPaths = new Set<string>();
+
   for (const asset of params.manifest.assets) {
     if (!asset.sha256) {
       continue;
     }
 
     const assetArchivePath = normalizeArchivePath(asset.archivePath, "Asset archive path");
-
-    // Collect all file entries that belong to this asset
     const assetEntries = [...normalizedToRaw.keys()]
       .filter((entry) => entry === assetArchivePath || isArchivePathWithin(entry, assetArchivePath))
       .toSorted();
@@ -327,13 +338,26 @@ async function verifyAssetChecksums(params: {
       );
     }
 
-    if (assetEntries.length === 1 && assetEntries[0] === assetArchivePath) {
-      // Single file asset: use raw path for extraction
-      const rawPath = normalizedToRaw.get(assetEntries[0])!;
-      const content = await extractEntryContent({
-        archivePath: params.archivePath,
-        entryPath: rawPath,
-      });
+    checks.push({ asset, assetArchivePath, entries: assetEntries });
+    for (const entry of assetEntries) {
+      allNeededRawPaths.add(normalizedToRaw.get(entry)!);
+    }
+  }
+
+  // Single-pass extraction of all needed entries
+  const extractedContent = await extractMultipleEntries({
+    archivePath: params.archivePath,
+    entryPaths: allNeededRawPaths,
+  });
+
+  // Verify checksums using extracted content
+  for (const { asset, assetArchivePath, entries } of checks) {
+    if (entries.length === 1 && entries[0] === assetArchivePath) {
+      const rawPath = normalizedToRaw.get(entries[0])!;
+      const content = extractedContent.get(rawPath);
+      if (!content) {
+        throw new Error(`Failed to extract entry for asset ${asset.kind} (${asset.sourcePath})`);
+      }
       const computed = createHash("sha256").update(content).digest("hex");
       if (computed !== asset.sha256) {
         throw new Error(
@@ -341,19 +365,17 @@ async function verifyAssetChecksums(params: {
         );
       }
     } else {
-      // Directory asset: compute Merkle-like hash from sorted file entries
       const fileHashes: Array<{ relativePath: string; sha256: string }> = [];
-
-      for (const entryPath of assetEntries) {
+      for (const entryPath of entries) {
         const relativePath = path.posix.relative(assetArchivePath, entryPath);
         if (!relativePath) {
           continue;
         }
         const rawPath = normalizedToRaw.get(entryPath)!;
-        const content = await extractEntryContent({
-          archivePath: params.archivePath,
-          entryPath: rawPath,
-        });
+        const content = extractedContent.get(rawPath);
+        if (!content) {
+          throw new Error(`Failed to extract entry for asset ${asset.kind} (${asset.sourcePath})`);
+        }
         const sha256 = createHash("sha256").update(content).digest("hex");
         fileHashes.push({ relativePath, sha256 });
       }
@@ -384,8 +406,10 @@ function formatResult(result: BackupVerifyResult): string {
   ];
   if (result.checksumsVerified) {
     lines.push("Content checksums: verified");
-  } else {
+  } else if (result.schemaVersion < 2) {
     lines.push("Content checksums: not present (schema v1 archive)");
+  } else {
+    lines.push("Content checksums: not present");
   }
   return lines.join("\n");
 }

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -219,7 +219,9 @@ async function collectFileHashes(
   }
 
   await walk(dirPath);
-  results.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  results.sort((a, b) =>
+    a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
+  );
   return results;
 }
 

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -1,5 +1,6 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
+import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -29,10 +30,11 @@ type BackupManifestAsset = {
   kind: BackupAsset["kind"];
   sourcePath: string;
   archivePath: string;
+  sha256: string;
 };
 
 type BackupManifest = {
-  schemaVersion: 1;
+  schemaVersion: 2;
   createdAt: string;
   archiveRoot: string;
   runtimeVersion: string;
@@ -187,12 +189,61 @@ async function canonicalizePathForContainment(targetPath: string): Promise<strin
   }
 }
 
+async function hashFile(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(filePath);
+    stream.on("data", (chunk: Buffer) => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+async function collectFileHashes(
+  dirPath: string,
+): Promise<Array<{ relativePath: string; sha256: string }>> {
+  const results: Array<{ relativePath: string; sha256: string }> = [];
+
+  async function walk(currentPath: string): Promise<void> {
+    const entries = await fs.readdir(currentPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile()) {
+        const relativePath = path.relative(dirPath, fullPath).replaceAll("\\", "/");
+        const sha256 = await hashFile(fullPath);
+        results.push({ relativePath, sha256 });
+      }
+    }
+  }
+
+  await walk(dirPath);
+  results.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  return results;
+}
+
+async function computeAssetHash(sourcePath: string): Promise<string> {
+  const stat = await fs.stat(sourcePath);
+  if (stat.isFile()) {
+    return hashFile(sourcePath);
+  }
+  // For directories, compute a Merkle-like hash from sorted file entries
+  const fileHashes = await collectFileHashes(sourcePath);
+  const hash = createHash("sha256");
+  for (const entry of fileHashes) {
+    hash.update(`${entry.relativePath}\0${entry.sha256}\n`);
+  }
+  return hash.digest("hex");
+}
+
 function buildManifest(params: {
   createdAt: string;
   archiveRoot: string;
   includeWorkspace: boolean;
   onlyConfig: boolean;
   assets: BackupAsset[];
+  assetChecksums: Map<string, string>;
   skipped: BackupCreateResult["skipped"];
   stateDir: string;
   configPath: string;
@@ -200,7 +251,7 @@ function buildManifest(params: {
   workspaceDirs: string[];
 }): BackupManifest {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     createdAt: params.createdAt,
     archiveRoot: params.archiveRoot,
     runtimeVersion: resolveRuntimeServiceVersion(),
@@ -220,6 +271,7 @@ function buildManifest(params: {
       kind: asset.kind,
       sourcePath: asset.sourcePath,
       archivePath: asset.archivePath,
+      sha256: params.assetChecksums.get(asset.sourcePath) ?? "",
     })),
     skipped: params.skipped.map((entry) => ({
       kind: entry.kind,
@@ -328,12 +380,21 @@ export async function createBackupArchive(
   const manifestPath = path.join(tempDir, "manifest.json");
   const tempArchivePath = buildTempArchivePath(outputPath);
   try {
+    const assetChecksums = new Map<string, string>();
+    await Promise.all(
+      result.assets.map(async (asset) => {
+        const sha256 = await computeAssetHash(asset.sourcePath);
+        assetChecksums.set(asset.sourcePath, sha256);
+      }),
+    );
+
     const manifest = buildManifest({
       createdAt,
       archiveRoot,
       includeWorkspace,
       onlyConfig,
       assets: result.assets,
+      assetChecksums,
       skipped: result.skipped,
       stateDir: plan.stateDir,
       configPath: plan.configPath,

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -1,6 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
-import { createReadStream } from "node:fs";
+import { constants as fsConstants, createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -189,56 +188,6 @@ async function canonicalizePathForContainment(targetPath: string): Promise<strin
   }
 }
 
-async function hashFile(filePath: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const hash = createHash("sha256");
-    const stream = createReadStream(filePath);
-    stream.on("data", (chunk: Buffer) => hash.update(chunk));
-    stream.on("error", reject);
-    stream.on("end", () => resolve(hash.digest("hex")));
-  });
-}
-
-async function collectFileHashes(
-  dirPath: string,
-): Promise<Array<{ relativePath: string; sha256: string }>> {
-  const results: Array<{ relativePath: string; sha256: string }> = [];
-
-  async function walk(currentPath: string): Promise<void> {
-    const entries = await fs.readdir(currentPath, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(currentPath, entry.name);
-      if (entry.isDirectory()) {
-        await walk(fullPath);
-      } else if (entry.isFile()) {
-        const relativePath = path.relative(dirPath, fullPath).replaceAll("\\", "/");
-        const sha256 = await hashFile(fullPath);
-        results.push({ relativePath, sha256 });
-      }
-    }
-  }
-
-  await walk(dirPath);
-  results.sort((a, b) =>
-    a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
-  );
-  return results;
-}
-
-async function computeAssetHash(sourcePath: string): Promise<string> {
-  const stat = await fs.stat(sourcePath);
-  if (stat.isFile()) {
-    return hashFile(sourcePath);
-  }
-  // For directories, compute a Merkle-like hash from sorted file entries
-  const fileHashes = await collectFileHashes(sourcePath);
-  const hash = createHash("sha256");
-  for (const entry of fileHashes) {
-    hash.update(`${entry.relativePath}\0${entry.sha256}\n`);
-  }
-  return hash.digest("hex");
-}
-
 function buildManifest(params: {
   createdAt: string;
   archiveRoot: string;
@@ -317,6 +266,53 @@ export function formatBackupCreateSummary(result: BackupCreateResult): string[] 
   return lines;
 }
 
+async function hashFile(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(filePath);
+    stream.on("data", (chunk: Buffer) => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+async function collectFileHashes(
+  dirPath: string,
+): Promise<Array<{ relativePath: string; sha256: string }>> {
+  const entries: Array<{ relativePath: string; sha256: string }> = [];
+  async function walk(dir: string): Promise<void> {
+    const items = await fs.readdir(dir, { withFileTypes: true });
+    for (const item of items) {
+      const fullPath = path.join(dir, item.name);
+      if (item.isDirectory()) {
+        await walk(fullPath);
+      } else if (item.isFile()) {
+        const sha256 = await hashFile(fullPath);
+        const relativePath = path.relative(dirPath, fullPath).replaceAll("\\", "/");
+        entries.push({ relativePath, sha256 });
+      }
+    }
+  }
+  await walk(dirPath);
+  entries.sort((a, b) =>
+    a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
+  );
+  return entries;
+}
+
+async function computeAssetHash(assetPath: string): Promise<string> {
+  const stat = await fs.stat(assetPath);
+  if (stat.isFile()) {
+    return hashFile(assetPath);
+  }
+  const fileHashes = await collectFileHashes(assetPath);
+  const hash = createHash("sha256");
+  for (const entry of fileHashes) {
+    hash.update(`${entry.relativePath}\0${entry.sha256}\n`);
+  }
+  return hash.digest("hex");
+}
+
 function remapArchiveEntryPath(params: {
   entryPath: string;
   manifestPath: string;
@@ -387,53 +383,76 @@ export async function createBackupArchive(
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-"));
   const manifestPath = path.join(tempDir, "manifest.json");
   const tempArchivePath = buildTempArchivePath(outputPath);
+  const initialArchivePath = `${tempArchivePath}.initial`;
   try {
-    // NOTE: Checksums are computed from the filesystem before tar.c() re-reads
-    // the files. A file modified between hashing and packing (TOCTOU) would
-    // produce a checksum that doesn't match the archived bytes. The window is
-    // very small in practice (state/config files rarely change during backup),
-    // and `--verify` catches any discrepancy by re-reading the written archive.
-    const assetChecksums = new Map<string, string>();
-    await Promise.all(
-      result.assets.map(async (asset) => {
-        const sha256 = await computeAssetHash(asset.sourcePath);
-        assetChecksums.set(asset.sourcePath, sha256);
-      }),
-    );
-
-    const manifest = buildManifest({
+    const manifestParams = {
       createdAt,
       archiveRoot,
       includeWorkspace,
       onlyConfig,
       assets: result.assets,
-      assetChecksums,
       skipped: result.skipped,
       stateDir: plan.stateDir,
       configPath: plan.configPath,
       oauthDir: plan.oauthDir,
       workspaceDirs: plan.workspaceDirs,
-    });
-    await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    };
 
+    // --- Pass 1: Pack source files with placeholder checksums ---
+    // Checksums are zeroed out here; we derive real checksums from the archived
+    // bytes in pass 2 to avoid TOCTOU (a file changing between hash and pack).
+    const placeholderChecksums = new Map<string, string>();
+    for (const asset of result.assets) {
+      placeholderChecksums.set(asset.sourcePath, "0".repeat(64));
+    }
+    await fs.writeFile(
+      manifestPath,
+      `${JSON.stringify(buildManifest({ ...manifestParams, assetChecksums: placeholderChecksums }), null, 2)}\n`,
+      "utf8",
+    );
     await tar.c(
       {
-        file: tempArchivePath,
+        file: initialArchivePath,
         gzip: true,
         portable: true,
         preservePaths: true,
         onWriteEntry: (entry) => {
-          entry.path = remapArchiveEntryPath({
-            entryPath: entry.path,
-            manifestPath,
-            archiveRoot,
-          });
+          entry.path = remapArchiveEntryPath({ entryPath: entry.path, manifestPath, archiveRoot });
         },
       },
-      [manifestPath, ...result.assets.map((asset) => asset.sourcePath)],
+      [...result.assets.map((asset) => asset.sourcePath), manifestPath],
     );
+
+    // --- Pass 2: Extract, hash archived bytes, repack with correct checksums ---
+    // Hashing the extracted files (not the live source files) ensures checksums
+    // reflect the bytes actually archived, eliminating the TOCTOU window.
+    const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-stage-"));
+    try {
+      await tar.x({ file: initialArchivePath, cwd: stagingDir, gzip: true });
+
+      const assetChecksums = new Map<string, string>();
+      for (const asset of result.assets) {
+        const extractedPath = path.join(stagingDir, asset.archivePath);
+        assetChecksums.set(asset.sourcePath, await computeAssetHash(extractedPath));
+      }
+
+      const stagingManifestPath = path.join(stagingDir, archiveRoot, "manifest.json");
+      await fs.writeFile(
+        stagingManifestPath,
+        `${JSON.stringify(buildManifest({ ...manifestParams, assetChecksums }), null, 2)}\n`,
+        "utf8",
+      );
+
+      await tar.c({ file: tempArchivePath, gzip: true, portable: true, cwd: stagingDir }, [
+        archiveRoot,
+      ]);
+    } finally {
+      await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+
     await publishTempArchive({ tempArchivePath, outputPath });
   } finally {
+    await fs.rm(initialArchivePath, { force: true }).catch(() => undefined);
     await fs.rm(tempArchivePath, { force: true }).catch(() => undefined);
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
   }

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -267,12 +267,18 @@ function buildManifest(params: {
       oauthDir: params.oauthDir,
       workspaceDirs: params.workspaceDirs,
     },
-    assets: params.assets.map((asset) => ({
-      kind: asset.kind,
-      sourcePath: asset.sourcePath,
-      archivePath: asset.archivePath,
-      sha256: params.assetChecksums.get(asset.sourcePath) ?? "",
-    })),
+    assets: params.assets.map((asset) => {
+      const sha256 = params.assetChecksums.get(asset.sourcePath);
+      if (sha256 === undefined) {
+        throw new Error(`Missing checksum for asset: ${asset.sourcePath}`);
+      }
+      return {
+        kind: asset.kind,
+        sourcePath: asset.sourcePath,
+        archivePath: asset.archivePath,
+        sha256,
+      };
+    }),
     skipped: params.skipped.map((entry) => ({
       kind: entry.kind,
       sourcePath: entry.sourcePath,
@@ -380,6 +386,11 @@ export async function createBackupArchive(
   const manifestPath = path.join(tempDir, "manifest.json");
   const tempArchivePath = buildTempArchivePath(outputPath);
   try {
+    // NOTE: Checksums are computed from the filesystem before tar.c() re-reads
+    // the files. A file modified between hashing and packing (TOCTOU) would
+    // produce a checksum that doesn't match the archived bytes. The window is
+    // very small in practice (state/config files rarely change during backup),
+    // and `--verify` catches any discrepancy by re-reading the written archive.
     const assetChecksums = new Map<string, string>();
     await Promise.all(
       result.assets.map(async (asset) => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw backup verify` only performs structural checks (manifest presence, path safety, entry existence). It cannot detect corrupted or tampered file content within an archive.
- Why it matters: A backup archive that passes structural verification may contain silently corrupted data, making it useless for recovery when it matters most.
- What changed: Archives now embed per-asset SHA-256 checksums in the manifest (schema v2). `backup verify` computes content hashes from archive entries and compares them against the manifest. Single files are hashed directly; directories use a deterministic Merkle-like hash of sorted `relativePath\0sha256\n` entries.
- What did NOT change (scope boundary): No restore functionality, no retention/rotation, no encryption, no cloud storage, no new CLI flags, no new dependencies. The archive format (gzip tar) is unchanged — checksums live only in the manifest JSON.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `openclaw backup create` now produces schema v2 archives with per-asset `sha256` fields in the manifest.
- `openclaw backup verify` output includes a new line: `Content checksums: verified` (v2) or `Content checksums: not present (schema v1 archive)` (v1).
- `BackupVerifyResult` JSON output gains two new fields: `schemaVersion` (number) and `checksumsVerified` (boolean).
- No new CLI flags or config keys. Checksums are always computed on create and always verified when present.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (Arch, kernel 6.18.8)
- Runtime/container: Node 25.6.0, pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Default OpenClaw config

### Steps

1. `openclaw backup create --verify --output /tmp/backup-test/`
2. Observe output includes `Archive verification: passed`
3. `openclaw backup verify /tmp/backup-test/*.tar.gz`
4. Observe output includes `Content checksums: verified`
5. Extract archive, modify a file in the payload, repack, re-verify
6. Observe `Checksum mismatch for asset ...` error

### Expected

- Step 4: Verification passes with checksum confirmation
- Step 6: Verification fails with specific asset and hash details

### Actual

- Matches expected

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

4 new tests added to `backup-verify.test.ts`:
- `verifies checksums in a round-trip create-verify cycle` — creates archive with nested files, verifies checksums match
- `detects tampered archive content` — creates archive, extracts, tampers `state.txt`, repacks, asserts `checksum mismatch` error
- `verifies a v1 archive without checksums gracefully` — hand-crafts a schema v1 archive, confirms `checksumsVerified: false` and `ok: true`
- `includes sha256 fields in the manifest for each asset` — inspects extracted manifest, asserts all assets have valid 64-char hex `sha256`

Full suite: 913 test files passed, 7547 tests passed (2 pre-existing `ERR_MODULE_NOT_FOUND` errors unrelated to this change).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Round-trip create+verify, tampered archive detection, v1 backward compatibility, manifest field presence, all existing backup tests still pass unmodified
- Edge cases checked: Directory entries without trailing slashes in portable tar mode (required using `entry.type === "Directory"` instead of trailing-slash heuristic); nested directory hashing; single-file asset hashing (config-only backup)
- What you did **not** verify: Windows path encoding branch, `--dry-run` checksum behavior (checksums are only computed during actual archive creation, not dry-run), extremely large workspace trees, symlinked files within asset directories

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes` — v1 archives are still verifiable; the verify command accepts both schema versions.
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A. Existing archives remain valid. New archives are schema v2 automatically.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 3 commits on `feat/backup-checksum-integrity`. No config flags to toggle.
- Files/config to restore: `src/infra/backup-create.ts`, `src/commands/backup-verify.ts`, `docs/cli/backup.md`
- Known bad symptoms reviewers should watch for: `Checksum mismatch` errors on valid archives (would indicate a hashing inconsistency between create and verify paths); slow `backup create` on very large workspace trees (hash computation adds a filesystem walk before tar packing).

## Risks and Mitigations

- Risk: Hash computation adds a full filesystem walk before tar packing, effectively doubling I/O for large directories.
  - Mitigation: File hashing uses streaming (`createReadStream`) to avoid memory pressure. The walk is parallelized across assets via `Promise.all`. For most installations, the state directory is small. Large workspaces can be excluded with `--no-include-workspace`.

- Risk: Deterministic Merkle hash depends on consistent `fs.readdir` ordering and `path.relative` behavior across platforms.
  - Mitigation: File entries are explicitly sorted by relative path before hashing. Paths are normalized to forward slashes. The same sorting and normalization is applied in both create and verify paths.
