### PR TITLE
fix(slack): fall back to auth.test for scope discovery when legacy methods fail

### DIFF
--- a/src/slack/scopes.test.ts
+++ b/src/slack/scopes.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchSlackScopes } from "./scopes.js";
+
+// Track all apiCall invocations so we can assert per-method behaviour.
+const apiCallMock = vi.fn();
+
+vi.mock("./client.js", () => ({
+  createSlackWebClient: () => ({ apiCall: apiCallMock }),
+}));
+
+describe("fetchSlackScopes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns scopes from auth.scopes when available", async () => {
+    apiCallMock.mockResolvedValueOnce({ ok: true, scopes: ["chat:write", "channels:read"] });
+
+    const result = await fetchSlackScopes("xoxb-token", 5000);
+    expect(result.ok).toBe(true);
+    expect(result.scopes).toEqual(["channels:read", "chat:write"]);
+    expect(result.source).toBe("auth.scopes");
+    expect(apiCallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to apps.permissions.info when auth.scopes fails", async () => {
+    apiCallMock
+      .mockResolvedValueOnce({ ok: false, error: "unknown_method" })
+      .mockResolvedValueOnce({
+        ok: true,
+        info: { scopes: ["chat:write"] },
+      });
+
+    const result = await fetchSlackScopes("xoxb-token", 5000);
+    expect(result.ok).toBe(true);
+    expect(result.scopes).toEqual(["chat:write"]);
+    expect(result.source).toBe("apps.permissions.info");
+    expect(apiCallMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to auth.test response_metadata.scopes when first two methods fail", async () => {
+    apiCallMock
+      .mockResolvedValueOnce({ ok: false, error: "unknown_method" })
+      .mockResolvedValueOnce({ ok: false, error: "unknown_method" })
+      .mockResolvedValueOnce({
+        ok: true,
+        user_id: "U123",
+        team_id: "T123",
+        response_metadata: { scopes: ["chat:write", "reactions:read"] },
+      });
+
+    const result = await fetchSlackScopes("xoxb-token", 5000);
+    expect(result.ok).toBe(true);
+    expect(result.scopes).toEqual(["chat:write", "reactions:read"]);
+    expect(result.source).toBe("auth.test");
+    expect(apiCallMock).toHaveBeenCalledTimes(3);
+    expect(apiCallMock).toHaveBeenNthCalledWith(1, "auth.scopes");
+    expect(apiCallMock).toHaveBeenNthCalledWith(2, "apps.permissions.info");
+    expect(apiCallMock).toHaveBeenNthCalledWith(3, "auth.test");
+  });
+
+  it("returns error when all three methods fail", async () => {
+    apiCallMock
+      .mockResolvedValueOnce({ ok: false, error: "unknown_method" })
+      .mockResolvedValueOnce({ ok: false, error: "unknown_method" })
+      .mockResolvedValueOnce({ ok: false, error: "invalid_auth" });
+
+    const result = await fetchSlackScopes("xoxb-token", 5000);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("auth.scopes");
+    expect(result.error).toContain("apps.permissions.info");
+    expect(result.error).toContain("auth.test");
+  });
+
+  it("handles thrown errors gracefully", async () => {
+    apiCallMock
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockRejectedValueOnce(new Error("network error"));
+
+    const result = await fetchSlackScopes("xoxb-token", 5000);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("network error");
+  });
+
+  it("extracts scopes from response_metadata.acceptedScopes", async () => {
+    apiCallMock
+      .mockResolvedValueOnce({ ok: false, error: "unknown_method" })
+      .mockResolvedValueOnce({ ok: false, error: "unknown_method" })
+      .mockResolvedValueOnce({
+        ok: true,
+        response_metadata: { acceptedScopes: ["chat:write"] },
+      });
+
+    const result = await fetchSlackScopes("xoxb-token", 5000);
+    expect(result.ok).toBe(true);
+    expect(result.scopes).toEqual(["chat:write"]);
+    expect(result.source).toBe("auth.test");
+  });
+});

--- a/src/slack/scopes.ts
+++ b/src/slack/scopes.ts
@@ -9,7 +9,7 @@ export type SlackScopesResult = {
   error?: string;
 };
 
-type SlackScopesSource = "auth.scopes" | "apps.permissions.info";
+type SlackScopesSource = "auth.scopes" | "apps.permissions.info" | "auth.test";
 
 function collectScopes(value: unknown, into: string[]) {
   if (!value) {
@@ -63,6 +63,13 @@ function extractScopes(payload: unknown): string[] {
     collectScopes((payload.info as { user_scopes?: unknown }).user_scopes, scopes);
     collectScopes((payload.info as { bot_scopes?: unknown }).bot_scopes, scopes);
   }
+  if (isRecord(payload.response_metadata)) {
+    collectScopes(payload.response_metadata.scopes, scopes);
+    collectScopes(
+      (payload.response_metadata as { acceptedScopes?: unknown }).acceptedScopes,
+      scopes,
+    );
+  }
   return normalizeScopes(scopes);
 }
 
@@ -94,7 +101,7 @@ export async function fetchSlackScopes(
   timeoutMs: number,
 ): Promise<SlackScopesResult> {
   const client = createSlackWebClient(token, { timeout: timeoutMs });
-  const attempts: SlackScopesSource[] = ["auth.scopes", "apps.permissions.info"];
+  const attempts: SlackScopesSource[] = ["auth.scopes", "apps.permissions.info", "auth.test"];
   const errors: string[] = [];
 
   for (const method of attempts) {


### PR DESCRIPTION
Closes #44625

## Problem

`openclaw channels capabilities` fails with `unknown_method` for both `auth.scopes` and `apps.permissions.info` on modern Slack bot tokens. These two API methods are workspace-app-only and return `unknown_method` for granular bot tokens created through the new Slack app manifest flow.

## Root cause

`fetchSlackScopes` only tried two methods: `auth.scopes` and `apps.permissions.info`. Neither works for standard bot tokens (xoxb-*), which are the most common token type for new Slack apps.

## Fix

1. Add `auth.test` as a third fallback. This method works for all token types and returns scopes via `response_metadata.scopes` in the response body.
2. Extend `extractScopes` to read `response_metadata.scopes` and `response_metadata.acceptedScopes` from the API response.

The attempt order stays `auth.scopes` -> `apps.permissions.info` -> `auth.test` so existing workspace apps see no change.

## Testing

Added `src/slack/scopes.test.ts` with 6 tests covering:
- Happy path for each of the three methods
- Fallback chain when earlier methods return `unknown_method`
- Network error handling across all methods
- `response_metadata.acceptedScopes` extraction

Co-authored-by: Daniel <dsantoreis@gmail.com>