### PR TITLE
fix(windows): stop lingering gateway listener after stop

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -263,6 +263,25 @@ describe("runDaemonRestart health checks", () => {
     expect(killSpy).toHaveBeenCalledWith(4300, "SIGTERM");
   });
 
+  it("signals a lingering gateway listener after a managed Windows stop", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    findGatewayPidsOnPortSync.mockReturnValue([4200]);
+    mockSpawnSync.mockReturnValue({
+      error: null,
+      status: 0,
+      stdout:
+        'CommandLine="C:\\\\Program Files\\\\OpenClaw\\\\openclaw.exe" gateway --port 18789\r\n',
+      stderr: "",
+    });
+    runServiceStop.mockResolvedValue(undefined);
+
+    await runDaemonStop({ json: true });
+
+    expect(findGatewayPidsOnPortSync).toHaveBeenCalledWith(18789);
+    expect(killSpy).toHaveBeenCalledWith(4200, "SIGTERM");
+  });
+
   it("signals a single unmanaged gateway process on restart", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -204,12 +204,24 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
   const gatewayPort = await resolveGatewayLifecyclePort(service).catch(() =>
     resolveGatewayPortFallback(),
   );
-  return await runServiceStop({
+  let stopHandledByUnmanagedFallback = false;
+  await runServiceStop({
     serviceNoun: "Gateway",
     service,
     opts,
-    onNotLoaded: async () => stopGatewayWithoutServiceManager(gatewayPort),
+    onNotLoaded: async () => {
+      const handled = await stopGatewayWithoutServiceManager(gatewayPort);
+      if (handled) {
+        stopHandledByUnmanagedFallback = true;
+      }
+      return handled;
+    },
   });
+  if (process.platform === "win32" && !stopHandledByUnmanagedFallback) {
+    // schtasks can report the task as stopped while the previously launched
+    // gateway process is still listening. Clean up any lingering listener.
+    await stopGatewayWithoutServiceManager(gatewayPort);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Problem: `openclaw gateway stop` could stop the Scheduled Task on Windows while leaving the actual gateway listener process running.
- Why it matters: updates and restarts then hit locked install files and stale port 18789 listeners.
- What changed: after a managed stop on Windows, the CLI now re-checks for verified gateway listeners on the gateway port and sends `SIGTERM` to lingering gateway processes.
- What did NOT change (scope boundary): restart behavior, non-Windows stop paths, and unrelated service-manager detection logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44658
- Related #44614

## User-visible / Behavior Changes

On Windows, `openclaw gateway stop` now also terminates a lingering gateway listener if the Scheduled Task reports stopped but the gateway process is still running.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host with Windows-specific lifecycle path covered via tests/mocks
- Runtime/container: Node 24 / Vitest
- Model/provider: N/A
- Integration/channel (if any): Windows Scheduled Task gateway lifecycle
- Relevant config (redacted): default gateway port 18789

### Steps

1. Simulate a managed Windows gateway service stop where the Scheduled Task reports success.
2. Leave a verified gateway listener process still bound to port 18789.
3. Run `openclaw gateway stop`.

### Expected

- The gateway service stops.
- Any lingering verified gateway listener is terminated.

### Actual

- Before this patch, the lingering listener could survive the stop path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm exec vitest run src/cli/daemon-cli/lifecycle.test.ts`
- Edge cases checked: unmanaged fallback stop still works; non-gateway processes are still ignored by PID verification.
- What you did **not** verify: live Windows manual stop on a real Scheduled Task install.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or fall back to manual `Stop-Process` on the lingering gateway PID.
- Files/config to restore: `src/cli/daemon-cli/lifecycle.ts`
- Known bad symptoms reviewers should watch for: non-gateway processes on port 18789 being signaled unexpectedly.

## Risks and Mitigations

- Risk: the cleanup path could overreach if listener PID detection is loose.
  - Mitigation: it still reuses the existing verified gateway argv checks before sending `SIGTERM`.
