### PR TITLE
feat(onboarding): complete zh-CN locale onboarding bundle + review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Slack: route handled top-level channel turns in implicit-conversation channels to thread-scoped sessions when Slack reply threading is enabled, keeping the root turn and later thread replies on one OpenClaw session. (#78522) Thanks @zeroth-blip.
 - Telegram: re-probe the primary fetch transport after repeated sticky fallback success so transient IPv4 or pinned-IP fallback promotion can recover without a gateway restart. Fixes #77088. (#77157) Thanks @MkDev11.
+- CLI/setup: add `cli.locale` and `OPENCLAW_LOCALE` support so the setup wizard can select, persist, and reuse English or zh-CN copy across reset flows.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.
 - Codex app-server: pin the managed Codex harness and Codex CLI smoke package to `@openai/codex@0.129.0`, defer OpenClaw integration dynamic tools behind Codex tool search by default, and accept current Codex service-tier values so legacy `fast` settings survive the stable harness upgrade as `priority`.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1136,6 +1136,7 @@ Notes:
 ```json5
 {
   cli: {
+    locale: "zh-CN", // en | zh-CN
     banner: {
       taglineMode: "off", // random | default | off
     },
@@ -1143,6 +1144,8 @@ Notes:
 }
 ```
 
+- `cli.locale` sets the setup wizard language. Supported values are `"en"` and `"zh-CN"`.
+- `OPENCLAW_LOCALE` can override `cli.locale` for one process; values such as `zh_CN.UTF-8` normalize to `zh-CN`.
 - `cli.banner.taglineMode` controls banner tagline style:
   - `"random"` (default): rotating funny/seasonal taglines.
   - `"default"`: fixed neutral tagline (`All your chats, one OpenClaw.`).

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -47,6 +47,8 @@ export const FIELD_HELP: Record<string, string> = {
   "logging.redactPatterns":
     "Additional custom redact regex patterns applied to log output, persisted transcript text, and safety-boundary UI/tool/diagnostic payloads before emission. Use this to mask org-specific tokens and identifiers not covered by built-in redaction rules.",
   cli: "CLI presentation controls for local command output behavior such as banner and tagline style. Use this section to keep startup output aligned with operator preference without changing runtime behavior.",
+  "cli.locale":
+    'Setup wizard language preference: "en" or "zh-CN". OPENCLAW_LOCALE can override this value for one process and accepts normalized variants such as zh_CN.UTF-8.',
   "cli.banner":
     "CLI startup banner controls for title/version line and tagline style behavior. Keep banner enabled for fast version/context checks, then tune tagline mode to your preferred noise level.",
   "cli.banner.taglineMode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -26,6 +26,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "logging.redactSensitive": "Sensitive Data Redaction Mode",
   "logging.redactPatterns": "Custom Redaction Patterns",
   cli: "CLI",
+  "cli.locale": "CLI Locale",
   "cli.banner": "CLI Banner",
   "cli.banner.taglineMode": "CLI Banner Tagline Mode",
   update: "Updates",

--- a/src/config/types.cli.ts
+++ b/src/config/types.cli.ts
@@ -1,6 +1,9 @@
+export type CliLocale = "en" | "zh-CN";
+
 export type CliBannerTaglineMode = "random" | "default" | "off";
 
 export type CliConfig = {
+  locale?: CliLocale;
   banner?: {
     /**
      * Controls CLI banner tagline behavior.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -457,6 +457,7 @@ export const OpenClawSchema = z
       .optional(),
     cli: z
       .object({
+        locale: z.union([z.literal("en"), z.literal("zh-CN")]).optional(),
         banner: z
           .object({
             taglineMode: z

--- a/src/i18n/cli.ts
+++ b/src/i18n/cli.ts
@@ -1,0 +1,611 @@
+import type { CliLocale } from "../config/types.cli.js";
+
+type CliTemplateVars = Record<string, string | number>;
+
+const EN_MESSAGES = {
+  "wizard.setupCancelled": "Setup cancelled.",
+  "wizard.onboardingTitle": "OpenClaw setup",
+  "wizard.securityTitle": "Security",
+  "wizard.securityConfirm":
+    "I understand this is personal-by-default and shared/multi-user use requires lock-down. Continue?",
+  "wizard.modeQuestion": "Setup mode",
+  "wizard.modeQuickstart": "QuickStart",
+  "wizard.modeQuickstartHint": "Configure details later via {configureCommand}.",
+  "wizard.modeManual": "Manual",
+  "wizard.modeManualHint": "Configure port, network, Tailscale, and auth options.",
+  "wizard.quickstartTitle": "QuickStart",
+  "wizard.quickstartSwitchToManual":
+    "QuickStart only supports local gateways. Switching to Manual mode.",
+  "wizard.invalidConfigTitle": "Invalid config",
+  "wizard.configInvalidOutro":
+    "Config invalid. Run `{doctorCommand}` to repair it, then re-run setup.",
+  "wizard.existingConfigDetectedTitle": "Existing config detected",
+  "wizard.configIssuesTitle": "Config issues",
+  "wizard.configHandlingQuestion": "Config handling",
+  "wizard.configHandlingUseExisting": "Use existing values",
+  "wizard.configHandlingUpdate": "Update values",
+  "wizard.configHandlingReset": "Reset",
+  "wizard.resetScopeQuestion": "Reset scope",
+  "wizard.resetScopeConfigOnly": "Config only",
+  "wizard.resetScopeConfigCredsSessions": "Config + creds + sessions",
+  "wizard.resetScopeFull": "Full reset (config + creds + sessions + workspace)",
+  "wizard.setupTargetQuestion": "What do you want to set up?",
+  "wizard.setupTargetLocal": "Local gateway (this machine)",
+  "wizard.setupTargetLocalReachableHint": "Gateway reachable ({url})",
+  "wizard.setupTargetLocalUnreachableHint": "No gateway detected ({url})",
+  "wizard.setupTargetRemote": "Remote gateway (info-only)",
+  "wizard.setupTargetRemoteNoConfigHint": "No remote URL configured yet",
+  "wizard.setupTargetRemoteReachableHint": "Gateway reachable ({url})",
+  "wizard.setupTargetRemoteUnreachableHint": "Configured but unreachable ({url})",
+  "wizard.workspaceDirectoryQuestion": "Workspace directory",
+  "wizard.skipChannelsNote": "Skipping channel setup.",
+  "wizard.channelsTitle": "Channels",
+  "wizard.skipSearchNote": "Skipping search setup.",
+  "wizard.searchTitle": "Search",
+  "wizard.skipSkillsNote": "Skipping skills setup.",
+  "wizard.skillsTitle": "Skills",
+  "wizard.remoteConfigured": "Remote gateway configured.",
+  "wizard.languageQuestion": "Language / 语言",
+  "wizard.languageOptionEnglish": "English",
+  "wizard.languageOptionEnglishHint": "Default",
+  "wizard.languageOptionZhCn": "简体中文",
+  "wizard.languageOptionZhCnHint": "Recommended",
+  "wizard.securityWarningBody":
+    "Security warning — please read.\n\nOpenClaw is a hobby project and still in beta. Expect sharp edges.\nBy default, OpenClaw is a personal agent: one trusted operator boundary.\nThis bot can read files and run actions if tools are enabled.\nA bad prompt can trick it into doing unsafe things.\n\nOpenClaw is not a hostile multi-tenant boundary by default.\nIf multiple users can message one tool-enabled agent, they share that delegated tool authority.\n\nIf you’re not comfortable with security hardening and access control, don’t run OpenClaw.\nAsk someone experienced to help before enabling tools or exposing it to the internet.\n\nRecommended baseline:\n- Pairing/allowlists + mention gating.\n- Multi-user/shared inbox: split trust boundaries (separate gateway/credentials, ideally separate OS users/hosts).\n- Sandbox + least-privilege tools.\n- Shared inboxes: isolate DM sessions (`session.dmScope: per-channel-peer`) and keep tool access minimal.\n- Keep secrets out of the agent’s reachable filesystem.\n- Use the strongest available model for any bot with tools or untrusted inboxes.\n\nRun regularly:\n{auditDeepCommand}\n{auditFixCommand}\n\nMust read: https://docs.openclaw.ai/gateway/security",
+  "wizard.docsConfigLine": "Docs: https://docs.openclaw.ai/gateway/configuration",
+  "wizard.errorInvalidFlow": "Invalid --flow (use quickstart, manual, advanced, or import).",
+  "wizard.quickstartSummaryKeepExisting": "Keeping your current gateway settings:",
+  "wizard.quickstartGatewayPortLine": "Gateway port: {port}",
+  "wizard.quickstartGatewayBindLine": "Gateway bind: {bind}",
+  "wizard.quickstartGatewayCustomIpLine": "Gateway custom IP: {host}",
+  "wizard.quickstartGatewayAuthLine": "Gateway auth: {auth}",
+  "wizard.quickstartTailscaleExposureLine": "Tailscale exposure: {tailscale}",
+  "wizard.quickstartDirectChatLine": "Direct to chat channels.",
+  "wizard.quickstartDefaultGatewayBindLine": "Gateway bind: Loopback (127.0.0.1)",
+  "wizard.quickstartDefaultGatewayAuthLine": "Gateway auth: Token (default)",
+  "wizard.quickstartDefaultTailscaleLine": "Tailscale exposure: Off",
+  "wizard.quickstartBindLoopback": "Loopback (127.0.0.1)",
+  "wizard.quickstartBindLan": "LAN",
+  "wizard.quickstartBindCustom": "Custom IP",
+  "wizard.quickstartBindTailnet": "Tailnet (Tailscale IP)",
+  "wizard.quickstartBindAuto": "Auto",
+  "wizard.quickstartAuthTokenDefault": "Token (default)",
+  "wizard.quickstartAuthPassword": "Password",
+  "wizard.quickstartTailscaleOff": "Off",
+  "wizard.quickstartTailscaleServe": "Serve",
+  "wizard.quickstartTailscaleFunnel": "Funnel",
+  "wizard.gatewayAuthTitle": "Gateway auth",
+  "wizard.gatewayAuthResolveProbeError":
+    "Could not resolve gateway.auth.password SecretRef for onboarding probe.",
+  "wizard.gatewayAuthResolveTokenProbeError":
+    "Could not resolve gateway.auth.token SecretRef for onboarding probe.",
+  "wizard.gatewayAuthResolveRemoteTokenProbeError":
+    "Could not resolve gateway.remote.token SecretRef for onboarding probe.",
+  "wizard.gatewayPortQuestion": "Gateway port",
+  "wizard.invalidPortError": "Invalid port",
+  "wizard.gatewayBindQuestion": "Gateway bind",
+  "wizard.gatewayBindLoopbackLabel": "Loopback (127.0.0.1)",
+  "wizard.gatewayBindLanLabel": "LAN (0.0.0.0)",
+  "wizard.gatewayBindTailnetLabel": "Tailnet (Tailscale IP)",
+  "wizard.gatewayBindAutoLabel": "Auto (Loopback → LAN)",
+  "wizard.gatewayBindCustomLabel": "Custom IP",
+  "wizard.customIpAddressQuestion": "Custom IP address",
+  "wizard.customIpAddressPlaceholder": "192.168.1.100",
+  "wizard.gatewayAuthQuestion": "Gateway auth",
+  "wizard.gatewayAuthTokenLabel": "Token",
+  "wizard.gatewayAuthTokenHint": "Recommended default (local + remote)",
+  "wizard.gatewayAuthPasswordLabel": "Password",
+  "wizard.tailscaleExposureQuestion": "Tailscale exposure",
+  "wizard.tailscaleExposureOffLabel": "Off",
+  "wizard.tailscaleExposureOffHint": "No Tailscale exposure",
+  "wizard.tailscaleExposureServeLabel": "Serve",
+  "wizard.tailscaleExposureServeHint": "Private HTTPS for your tailnet (devices on Tailscale)",
+  "wizard.tailscaleExposureFunnelLabel": "Funnel",
+  "wizard.tailscaleExposureFunnelHint": "Public HTTPS via Tailscale Funnel (internet)",
+  "wizard.tailscaleWarningTitle": "Tailscale Warning",
+  "wizard.tailscaleTitle": "Tailscale",
+  "wizard.tailscaleMissingBinaryBody":
+    "Tailscale binary not found in PATH or /Applications.\nEnsure Tailscale is installed from:\n  https://tailscale.com/download/mac\n\nYou can continue setup, but serve/funnel will fail at runtime.",
+  "wizard.tailscaleDocsBody":
+    "Docs:\nhttps://docs.openclaw.ai/gateway/tailscale\nhttps://docs.openclaw.ai/web",
+  "wizard.tailscaleResetOnExitQuestion": "Reset Tailscale serve/funnel on exit?",
+  "wizard.noteTitle": "Note",
+  "wizard.tailscaleRequiresLoopbackNote":
+    "Tailscale requires bind=loopback. Adjusting bind to loopback.",
+  "wizard.tailscaleFunnelRequiresPasswordNote": "Tailscale funnel requires password auth.",
+  "wizard.gatewayTokenQuestion": "Gateway token (blank to generate)",
+  "wizard.gatewayTokenPlaceholder": "Needed for multi-machine or non-loopback access",
+  "wizard.secretInputGatewayPasswordModeQuestion":
+    "How do you want to provide the gateway password?",
+  "wizard.secretInputEnterPasswordNowLabel": "Enter password now",
+  "wizard.secretInputEnterPasswordNowHint": "Stores the password directly in OpenClaw config",
+  "wizard.secretInputGatewayPasswordSourceQuestion": "Where is this gateway password stored?",
+  "wizard.gatewayPasswordQuestion": "Gateway password",
+  "wizard.shellCompletionTitle": "Shell completion",
+  "wizard.shellCompletionReloadPowerShell":
+    "Restart your shell (or reload your PowerShell profile).",
+  "wizard.shellCompletionReloadSource": "Restart your shell or run: source {profileHint}",
+  "wizard.shellCompletionEnableQuestion": "Enable {shell} shell completion for {cliName}?",
+  "wizard.shellCompletionCacheFailedNote":
+    "Failed to generate completion cache. Run `{cliName} completion --install` later.",
+  "wizard.shellCompletionInstalledNote": "Shell completion installed. {reloadHint}",
+  "wizard.remoteHostUnknown": "host unknown",
+  "wizard.remoteWsUrlMustStartError": "URL must start with ws:// or wss://",
+  "wizard.remoteWsUrlSecurityError":
+    "Use wss:// for remote hosts, or ws://127.0.0.1/localhost via SSH tunnel. Break-glass: OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1 for trusted private networks.",
+  "wizard.remoteDiscoverLanQuestion": "Discover gateway on LAN (Bonjour)?",
+  "wizard.discoveryTitle": "Discovery",
+  "wizard.discoveryRequirementBody":
+    "Bonjour discovery requires dns-sd (macOS) or avahi-browse (Linux).\nDocs: https://docs.openclaw.ai/gateway/discovery",
+  "wizard.discoverySearchingProgress": "Searching for gateways…",
+  "wizard.discoveryFoundProgress": "Found {count} gateway(s)",
+  "wizard.discoveryNoneProgress": "No gateways found",
+  "wizard.remoteSelectGatewayQuestion": "Select gateway",
+  "wizard.remoteEnterUrlManuallyLabel": "Enter URL manually",
+  "wizard.remoteConnectionMethodQuestion": "Connection method",
+  "wizard.remoteConnectionDirectLabel": "Direct gateway WS ({host}:{port})",
+  "wizard.remoteConnectionSshLabel": "SSH tunnel (loopback)",
+  "wizard.directRemoteTitle": "Direct remote",
+  "wizard.remoteDirectDefaultsToTlsLine": "Direct remote access defaults to TLS.",
+  "wizard.remoteDirectUsingLine": "Using: {url}",
+  "wizard.remoteDirectLoopbackHintLine":
+    "If your gateway is loopback-only, choose SSH tunnel and keep ws://127.0.0.1:18789.",
+  "wizard.sshTunnelTitle": "SSH tunnel",
+  "wizard.remoteSshStartTunnelLine": "Start a tunnel before using the CLI:",
+  "wizard.remoteSshDocsLine": "Docs: https://docs.openclaw.ai/gateway/remote",
+  "wizard.remoteGatewayWsUrlQuestion": "Gateway WebSocket URL",
+  "wizard.remoteGatewayAuthQuestion": "Gateway auth",
+  "wizard.remoteGatewayAuthTokenRecommendedLabel": "Token (recommended)",
+  "wizard.remoteGatewayAuthPasswordLabel": "Password",
+  "wizard.remoteGatewayAuthOffLabel": "No auth",
+  "wizard.secretInputGatewayTokenModeQuestion": "How do you want to provide this gateway token?",
+  "wizard.secretInputEnterTokenNowLabel": "Enter token now",
+  "wizard.secretInputEnterTokenNowHint": "Stores the token directly in OpenClaw config",
+  "wizard.secretInputGatewayTokenSourceQuestion": "Where is this gateway token stored?",
+  "wizard.remoteGatewayTokenQuestion": "Gateway token",
+  "wizard.requiredFieldError": "Required",
+  "wizard.secretInputRemoteGatewayPasswordModeQuestion":
+    "How do you want to provide this gateway password?",
+  "wizard.secretInputRemoteGatewayPasswordSourceQuestion": "Where is this gateway password stored?",
+  "wizard.remoteGatewayPasswordQuestion": "Gateway password",
+  "wizard.systemdTitle": "Systemd",
+  "wizard.systemdUnavailableNote":
+    "Systemd user services are unavailable. Skipping lingering checks and service install.",
+  "wizard.systemdLingerReason":
+    "Linux installs use a systemd user service by default. Without lingering, systemd stops the user session on logout/idle and kills the Gateway.",
+  "wizard.installGatewayServiceQuestion": "Install Gateway service (recommended)",
+  "wizard.systemdUnavailableServiceInstallNote":
+    "Systemd user services are unavailable; skipping service install. Use your container supervisor or `docker compose up -d`.",
+  "wizard.gatewayServiceTitle": "Gateway service",
+  "wizard.gatewayServiceRuntimeQuestion": "Gateway service runtime",
+  "wizard.quickstartGatewayRuntimeNodeNote":
+    "QuickStart uses Node for the Gateway service (stable + supported).",
+  "wizard.gatewayServiceAlreadyInstalledQuestion": "Gateway service already installed",
+  "wizard.gatewayServiceActionRestart": "Restart",
+  "wizard.gatewayServiceActionReinstall": "Reinstall",
+  "wizard.gatewayServiceActionSkip": "Skip",
+  "wizard.gatewayServiceRestartingProgress": "Restarting Gateway service…",
+  "wizard.gatewayServiceRestartedDone": "Gateway service restarted.",
+  "wizard.gatewayServiceUninstallingProgress": "Uninstalling Gateway service…",
+  "wizard.gatewayServiceUninstalledDone": "Gateway service uninstalled.",
+  "wizard.gatewayServicePreparingProgress": "Preparing Gateway service…",
+  "wizard.gatewayServiceInstallingProgress": "Installing Gateway service…",
+  "wizard.gatewayServiceInstallFailedDone": "Gateway service install failed.",
+  "wizard.gatewayServiceInstalledDone": "Gateway service installed.",
+  "wizard.gatewayTitle": "Gateway",
+  "wizard.gatewayInstallBlockedError":
+    "Gateway install blocked: {reason} Fix gateway auth config/token input and rerun onboarding.",
+  "wizard.gatewayServiceInstallFailedPrefix": "Gateway service install failed: {error}",
+  "wizard.healthCheckHelpTitle": "Health check help",
+  "wizard.healthCheckDocsLine": "Docs: https://docs.openclaw.ai/gateway/health",
+  "wizard.healthCheckTroubleshootingLine": "https://docs.openclaw.ai/gateway/troubleshooting",
+  "wizard.optionalAppsTitle": "Optional apps",
+  "wizard.optionalAppsBody":
+    "Add nodes for extra features:\n- macOS app (system + notifications)\n- iOS app (camera/canvas)\n- Android app (camera/canvas)",
+  "wizard.gatewayAuthResolveOnboardingAuthError":
+    "Could not resolve gateway.auth.password SecretRef for onboarding auth.",
+  "wizard.controlUiTitle": "Control UI",
+  "wizard.controlUiWebUiLine": "Web UI: {url}",
+  "wizard.controlUiWebUiWithTokenLine": "Web UI (with token): {url}",
+  "wizard.controlUiGatewayWsLine": "Gateway WS: {url}",
+  "wizard.controlUiGatewayStatusReachable": "Gateway: reachable",
+  "wizard.controlUiGatewayStatusNotDetected": "Gateway: not detected",
+  "wizard.controlUiGatewayStatusNotDetectedWithDetail": "Gateway: not detected ({detail})",
+  "wizard.controlUiDocsLine": "Docs: https://docs.openclaw.ai/web/control-ui",
+  "wizard.startTuiBestOptionTitle": "Start TUI (best option!)",
+  "wizard.startTuiBestOptionBody":
+    'This is the defining action that makes your agent you.\nPlease take your time.\nThe more you tell it, the better the experience will be.\nWe will send: "Wake up, my friend!"',
+  "wizard.tokenTitle": "Token",
+  "wizard.tokenInfoBody":
+    "Gateway token: shared auth for the Gateway + Control UI.\nStored in: ~/.openclaw/openclaw.json (gateway.auth.token) or OPENCLAW_GATEWAY_TOKEN.\nView token: {viewTokenCommand}\nGenerate token: {generateTokenCommand}\nThe Control UI keeps dashboard URL tokens in this browser tab's sessionStorage for the selected gateway URL.\nOpen the dashboard anytime: {openDashboardCommand}\nIf prompted: paste the token into Control UI settings (or use the tokenized dashboard URL).",
+  "wizard.hatchQuestion": "How do you want to hatch your bot?",
+  "wizard.hatchOptionTui": "Hatch in TUI (recommended)",
+  "wizard.hatchOptionWeb": "Open the Web UI",
+  "wizard.hatchOptionLater": "Do this later",
+  "wizard.hatchWakeMessage": "Wake up, my friend!",
+  "wizard.dashboardReadyTitle": "Dashboard ready",
+  "wizard.dashboardLinkWithTokenLine": "Dashboard link (with token): {url}",
+  "wizard.dashboardOpenedLine": "Opened in your browser. Keep that tab to control OpenClaw.",
+  "wizard.dashboardCopyLine":
+    "Copy/paste this URL in a browser on this machine to control OpenClaw.",
+  "wizard.laterTitle": "Later",
+  "wizard.laterCommandLine": "When you're ready: {command}",
+  "wizard.skipControlUiPromptsNote": "Skipping Control UI/TUI prompts.",
+  "wizard.workspaceBackupTitle": "Workspace backup",
+  "wizard.workspaceBackupBody":
+    "Back up your agent workspace.\nDocs: https://docs.openclaw.ai/concepts/agent-workspace",
+  "wizard.securityReminderBody":
+    "Running agents on your computer is risky — harden your setup: https://docs.openclaw.ai/security",
+  "wizard.webSearchOptionalTitle": "Web search (optional)",
+  "wizard.webSearchProviderBrave": "Brave Search",
+  "wizard.webSearchProviderPerplexity": "Perplexity Search",
+  "wizard.webSearchEnabledIntro":
+    "Web search is enabled, so your agent can look things up online when needed.",
+  "wizard.webSearchProviderLine": "Provider: {provider}",
+  "wizard.webSearchTitle": "Web search",
+  "wizard.webSearchApiKeyStoredInConfigLine": "API key: stored in config ({path}).",
+  "wizard.webSearchApiKeyStoredInConfigSimple": "API key: stored in config.",
+  "wizard.webSearchApiKeyConfiguredViaSecretRef": "API key: configured via secret reference.",
+  "wizard.webSearchApiKeyProvidedViaEnvLine":
+    "API key: provided via {envVar} env var (Gateway environment).",
+  "wizard.webSearchApiKeyProvidedViaEnvVarsLine": "API key: provided via {envVars} env var.",
+  "wizard.webSearchProviderSelectedNoApiKeyLine":
+    "Provider {provider} is selected but no API key was found.",
+  "wizard.webSearchProviderUnavailableLine":
+    "Web search provider {provider} is selected but unavailable under the current plugin policy.",
+  "wizard.webSearchProviderUnavailableFixLine":
+    "web_search will not work until the provider is re-enabled or a different provider is selected.",
+  "wizard.webSearchWillNotWorkUntilKeyLine": "web_search will not work until a key is added.",
+  "wizard.webSearchRunConfigureWebIndentedLine": "  {command}",
+  "wizard.webSearchGetKeyAtLine": "Get your key at: {url}",
+  "wizard.webSearchConfiguredButDisabledLine":
+    "Web search ({provider}) is configured but disabled.",
+  "wizard.webSearchReenableLine": "Re-enable: {command}",
+  "wizard.webSearchAutoDetectedLine": "Web search is available via {provider} (auto-detected).",
+  "wizard.webSearchSkippedEnableLaterLine": "Web search was skipped. You can enable it later:",
+  "wizard.webSearchDocsLine": "Docs: https://docs.openclaw.ai/tools/web",
+  "wizard.webSearchNeedsApiKeyIntro":
+    "To enable web search, your agent will need an API key for either Perplexity Search or Brave Search.",
+  "wizard.webSearchManagedProviderSkippedLine": "Managed web search provider was skipped.",
+  "wizard.webSearchCodexNativeSummaryLine":
+    "Codex native search: {mode} for Codex-capable models",
+  "wizard.webSearchCodexNativeUseLine": "Used only for Codex-capable models.",
+  "wizard.webSearchCodexNativeTitle": "Codex native search",
+  "wizard.webSearchSetupInteractivelyLine": "Set it up interactively:",
+  "wizard.webSearchRunConfigureWebLine": "- Run: {command}",
+  "wizard.webSearchChooseProviderPasteKeyLine": "- Choose a provider and paste your API key",
+  "wizard.webSearchAlternativeEnvLine":
+    "Alternative: set PERPLEXITY_API_KEY or BRAVE_API_KEY in the Gateway environment (no config changes).",
+  "wizard.whatNowTitle": "What now",
+  "wizard.whatNowBody": 'What now: https://openclaw.ai/showcase ("What People Are Building").',
+  "wizard.outroDashboardOpened":
+    "Onboarding complete. Dashboard opened; keep that tab to control OpenClaw.",
+  "wizard.outroSeededBackground":
+    "Onboarding complete. Web UI seeded in the background; open it anytime with the dashboard link above.",
+  "wizard.outroComplete": "Onboarding complete. Use the dashboard link above to control OpenClaw.",
+} as const;
+
+type CliMessageKey = keyof typeof EN_MESSAGES;
+type CliMessages = Record<CliMessageKey, string>;
+
+const ZH_CN_MESSAGES: CliMessages = {
+  "wizard.setupCancelled": "安装向导已取消。",
+  "wizard.onboardingTitle": "OpenClaw 初始化向导",
+  "wizard.securityTitle": "安全提醒",
+  "wizard.securityConfirm": "我理解默认是个人使用场景，多用户/共享场景需要额外加固。是否继续？",
+  "wizard.modeQuestion": "初始化模式",
+  "wizard.modeQuickstart": "快速开始",
+  "wizard.modeQuickstartHint": "稍后可通过 {configureCommand} 继续细化配置。",
+  "wizard.modeManual": "手动配置",
+  "wizard.modeManualHint": "配置端口、网络、Tailscale 与认证选项。",
+  "wizard.quickstartTitle": "快速开始",
+  "wizard.quickstartSwitchToManual": "快速开始仅支持本地网关，已切换到手动模式。",
+  "wizard.invalidConfigTitle": "配置无效",
+  "wizard.configInvalidOutro": "配置文件无效。请先运行 `{doctorCommand}` 修复，再重新执行初始化。",
+  "wizard.existingConfigDetectedTitle": "检测到已有配置",
+  "wizard.configIssuesTitle": "配置问题",
+  "wizard.configHandlingQuestion": "如何处理现有配置",
+  "wizard.configHandlingUseExisting": "沿用现有配置",
+  "wizard.configHandlingUpdate": "更新配置",
+  "wizard.configHandlingReset": "重置",
+  "wizard.resetScopeQuestion": "重置范围",
+  "wizard.resetScopeConfigOnly": "仅重置配置",
+  "wizard.resetScopeConfigCredsSessions": "重置配置 + 凭据 + 会话",
+  "wizard.resetScopeFull": "完全重置（配置 + 凭据 + 会话 + 工作区）",
+  "wizard.setupTargetQuestion": "你想配置哪一种",
+  "wizard.setupTargetLocal": "本地网关（当前机器）",
+  "wizard.setupTargetLocalReachableHint": "网关可达（{url}）",
+  "wizard.setupTargetLocalUnreachableHint": "未检测到网关（{url}）",
+  "wizard.setupTargetRemote": "远程网关（仅信息配置）",
+  "wizard.setupTargetRemoteNoConfigHint": "尚未配置远程 URL",
+  "wizard.setupTargetRemoteReachableHint": "网关可达（{url}）",
+  "wizard.setupTargetRemoteUnreachableHint": "已配置但不可达（{url}）",
+  "wizard.workspaceDirectoryQuestion": "工作区目录",
+  "wizard.skipChannelsNote": "已跳过频道配置。",
+  "wizard.channelsTitle": "频道",
+  "wizard.skipSearchNote": "已跳过搜索配置。",
+  "wizard.searchTitle": "搜索",
+  "wizard.skipSkillsNote": "已跳过技能配置。",
+  "wizard.skillsTitle": "技能",
+  "wizard.remoteConfigured": "远程网关已配置完成。",
+  "wizard.languageQuestion": "语言 / Language",
+  "wizard.languageOptionEnglish": "English",
+  "wizard.languageOptionEnglishHint": "默认",
+  "wizard.languageOptionZhCn": "简体中文",
+  "wizard.languageOptionZhCnHint": "推荐",
+  "wizard.securityWarningBody":
+    "安全警告——请先阅读。\n\nOpenClaw 仍是偏实验性的项目，可能有不稳定行为。\n默认前提是：个人使用、单一可信操作者边界。\n开启工具后，Bot 可以读文件并执行动作。\n恶意或误导性提示词可能诱导它执行不安全操作。\n\nOpenClaw 默认不是对抗型多租户安全边界。\n若多人都能给同一个可用工具的代理发消息，本质上是在共享被委托的工具权限。\n\n如果你不熟悉安全加固和访问控制，请先不要直接上线。\n启用工具或暴露公网前，建议请有经验的人协助。\n\n基础建议：\n- 配对/白名单 + mention 门控。\n- 多用户/共享收件箱请拆分信任边界（独立网关/凭据，最好独立系统用户或主机）。\n- 沙箱 + 最小权限工具。\n- 共享收件箱中隔离 DM 会话（`session.dmScope: per-channel-peer`）并收紧工具权限。\n- 机密不要放在代理可读路径。\n- 对外开放或接入不可信输入时，优先使用能力更强的模型。\n\n建议定期执行：\n{auditDeepCommand}\n{auditFixCommand}\n\n必读：https://docs.openclaw.ai/gateway/security",
+  "wizard.docsConfigLine": "文档: https://docs.openclaw.ai/gateway/configuration",
+  "wizard.errorInvalidFlow": "无效的 --flow（可选 quickstart、manual、advanced 或 import）。",
+  "wizard.quickstartSummaryKeepExisting": "将沿用你现有的网关设置：",
+  "wizard.quickstartGatewayPortLine": "网关端口: {port}",
+  "wizard.quickstartGatewayBindLine": "网关绑定: {bind}",
+  "wizard.quickstartGatewayCustomIpLine": "网关自定义 IP: {host}",
+  "wizard.quickstartGatewayAuthLine": "网关认证: {auth}",
+  "wizard.quickstartTailscaleExposureLine": "Tailscale 暴露: {tailscale}",
+  "wizard.quickstartDirectChatLine": "直接接入聊天渠道。",
+  "wizard.quickstartDefaultGatewayBindLine": "网关绑定: Loopback (127.0.0.1)",
+  "wizard.quickstartDefaultGatewayAuthLine": "网关认证: Token（默认）",
+  "wizard.quickstartDefaultTailscaleLine": "Tailscale 暴露: Off",
+  "wizard.quickstartBindLoopback": "Loopback (127.0.0.1)",
+  "wizard.quickstartBindLan": "LAN",
+  "wizard.quickstartBindCustom": "自定义 IP",
+  "wizard.quickstartBindTailnet": "Tailnet（Tailscale IP）",
+  "wizard.quickstartBindAuto": "自动",
+  "wizard.quickstartAuthTokenDefault": "Token（默认）",
+  "wizard.quickstartAuthPassword": "密码",
+  "wizard.quickstartTailscaleOff": "关闭",
+  "wizard.quickstartTailscaleServe": "Serve",
+  "wizard.quickstartTailscaleFunnel": "Funnel",
+  "wizard.gatewayAuthTitle": "网关认证",
+  "wizard.gatewayAuthResolveProbeError": "无法解析用于探测的 gateway.auth.password SecretRef。",
+  "wizard.gatewayAuthResolveTokenProbeError": "无法解析用于探测的 gateway.auth.token SecretRef。",
+  "wizard.gatewayAuthResolveRemoteTokenProbeError":
+    "无法解析用于探测的 gateway.remote.token SecretRef。",
+  "wizard.gatewayPortQuestion": "网关端口",
+  "wizard.invalidPortError": "端口无效",
+  "wizard.gatewayBindQuestion": "网关绑定",
+  "wizard.gatewayBindLoopbackLabel": "Loopback (127.0.0.1)",
+  "wizard.gatewayBindLanLabel": "LAN (0.0.0.0)",
+  "wizard.gatewayBindTailnetLabel": "Tailnet（Tailscale IP）",
+  "wizard.gatewayBindAutoLabel": "自动（Loopback → LAN）",
+  "wizard.gatewayBindCustomLabel": "自定义 IP",
+  "wizard.customIpAddressQuestion": "自定义 IP 地址",
+  "wizard.customIpAddressPlaceholder": "192.168.1.100",
+  "wizard.gatewayAuthQuestion": "网关认证",
+  "wizard.gatewayAuthTokenLabel": "Token",
+  "wizard.gatewayAuthTokenHint": "推荐默认值（本地 + 远程）",
+  "wizard.gatewayAuthPasswordLabel": "密码",
+  "wizard.tailscaleExposureQuestion": "Tailscale 暴露方式",
+  "wizard.tailscaleExposureOffLabel": "关闭",
+  "wizard.tailscaleExposureOffHint": "不通过 Tailscale 暴露",
+  "wizard.tailscaleExposureServeLabel": "Serve",
+  "wizard.tailscaleExposureServeHint": "为 tailnet 设备提供私有 HTTPS",
+  "wizard.tailscaleExposureFunnelLabel": "Funnel",
+  "wizard.tailscaleExposureFunnelHint": "通过 Tailscale Funnel 提供公网 HTTPS",
+  "wizard.tailscaleWarningTitle": "Tailscale 警告",
+  "wizard.tailscaleTitle": "Tailscale",
+  "wizard.tailscaleMissingBinaryBody":
+    "在 PATH 或 /Applications 中未找到 Tailscale 可执行文件。\n请先安装 Tailscale：\n  https://tailscale.com/download/mac\n\n你可以继续配置，但 serve/funnel 在运行时会失败。",
+  "wizard.tailscaleDocsBody":
+    "文档：\nhttps://docs.openclaw.ai/gateway/tailscale\nhttps://docs.openclaw.ai/web",
+  "wizard.tailscaleResetOnExitQuestion": "退出时是否重置 Tailscale serve/funnel？",
+  "wizard.noteTitle": "提示",
+  "wizard.tailscaleRequiresLoopbackNote": "Tailscale 要求 bind=loopback，已自动调整为 loopback。",
+  "wizard.tailscaleFunnelRequiresPasswordNote": "Tailscale funnel 需要使用密码认证。",
+  "wizard.gatewayTokenQuestion": "网关 Token（留空自动生成）",
+  "wizard.gatewayTokenPlaceholder": "用于多机访问或非 loopback 访问",
+  "wizard.secretInputGatewayPasswordModeQuestion": "你想如何提供网关密码？",
+  "wizard.secretInputEnterPasswordNowLabel": "现在输入密码",
+  "wizard.secretInputEnterPasswordNowHint": "会将密码直接写入 OpenClaw 配置",
+  "wizard.secretInputGatewayPasswordSourceQuestion": "这个网关密码存放在哪？",
+  "wizard.gatewayPasswordQuestion": "网关密码",
+  "wizard.shellCompletionTitle": "Shell 补全",
+  "wizard.shellCompletionReloadPowerShell": "重启 shell（或重新加载 PowerShell profile）。",
+  "wizard.shellCompletionReloadSource": "重启 shell，或执行：source {profileHint}",
+  "wizard.shellCompletionEnableQuestion": "为 {cliName} 启用 {shell} shell 补全吗？",
+  "wizard.shellCompletionCacheFailedNote":
+    "生成补全缓存失败。你可以稍后运行 `{cliName} completion --install`。",
+  "wizard.shellCompletionInstalledNote": "Shell 补全已安装。{reloadHint}",
+  "wizard.remoteHostUnknown": "未知主机",
+  "wizard.remoteWsUrlMustStartError": "URL 必须以 ws:// 或 wss:// 开头",
+  "wizard.remoteWsUrlSecurityError":
+    "远程主机请使用 wss://，或通过 SSH 隧道使用 ws://127.0.0.1/localhost。紧急放行：可信私网下可设 OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1。",
+  "wizard.remoteDiscoverLanQuestion": "在局域网内发现网关（Bonjour）？",
+  "wizard.discoveryTitle": "发现",
+  "wizard.discoveryRequirementBody":
+    "Bonjour 发现需要 dns-sd（macOS）或 avahi-browse（Linux）。\n文档: https://docs.openclaw.ai/gateway/discovery",
+  "wizard.discoverySearchingProgress": "正在搜索网关…",
+  "wizard.discoveryFoundProgress": "已找到 {count} 个网关",
+  "wizard.discoveryNoneProgress": "未找到网关",
+  "wizard.remoteSelectGatewayQuestion": "选择网关",
+  "wizard.remoteEnterUrlManuallyLabel": "手动输入 URL",
+  "wizard.remoteConnectionMethodQuestion": "连接方式",
+  "wizard.remoteConnectionDirectLabel": "直连网关 WS（{host}:{port}）",
+  "wizard.remoteConnectionSshLabel": "SSH 隧道（loopback）",
+  "wizard.directRemoteTitle": "远程直连",
+  "wizard.remoteDirectDefaultsToTlsLine": "远程直连默认使用 TLS。",
+  "wizard.remoteDirectUsingLine": "当前使用: {url}",
+  "wizard.remoteDirectLoopbackHintLine":
+    "如果网关仅监听 loopback，请选择 SSH 隧道并保留 ws://127.0.0.1:18789。",
+  "wizard.sshTunnelTitle": "SSH 隧道",
+  "wizard.remoteSshStartTunnelLine": "使用 CLI 前请先建立隧道：",
+  "wizard.remoteSshDocsLine": "文档: https://docs.openclaw.ai/gateway/remote",
+  "wizard.remoteGatewayWsUrlQuestion": "网关 WebSocket URL",
+  "wizard.remoteGatewayAuthQuestion": "网关认证",
+  "wizard.remoteGatewayAuthTokenRecommendedLabel": "Token（推荐）",
+  "wizard.remoteGatewayAuthPasswordLabel": "密码",
+  "wizard.remoteGatewayAuthOffLabel": "无认证",
+  "wizard.secretInputGatewayTokenModeQuestion": "你想如何提供这个网关 Token？",
+  "wizard.secretInputEnterTokenNowLabel": "现在输入 Token",
+  "wizard.secretInputEnterTokenNowHint": "会将 Token 直接写入 OpenClaw 配置",
+  "wizard.secretInputGatewayTokenSourceQuestion": "这个网关 Token 存放在哪？",
+  "wizard.remoteGatewayTokenQuestion": "网关 Token",
+  "wizard.requiredFieldError": "必填",
+  "wizard.secretInputRemoteGatewayPasswordModeQuestion": "你想如何提供这个网关密码？",
+  "wizard.secretInputRemoteGatewayPasswordSourceQuestion": "这个网关密码存放在哪？",
+  "wizard.remoteGatewayPasswordQuestion": "网关密码",
+  "wizard.systemdTitle": "Systemd",
+  "wizard.systemdUnavailableNote": "当前不可用 systemd 用户服务，已跳过 lingering 检查和服务安装。",
+  "wizard.systemdLingerReason":
+    "Linux 默认使用 systemd 用户服务运行网关；若未启用 lingering，用户会话在登出/空闲时会被 systemd 回收，网关也会被停止。",
+  "wizard.installGatewayServiceQuestion": "安装网关服务（推荐）",
+  "wizard.systemdUnavailableServiceInstallNote":
+    "当前不可用 systemd 用户服务，已跳过服务安装。请使用你的容器监管器或 `docker compose up -d`。",
+  "wizard.gatewayServiceTitle": "网关服务",
+  "wizard.gatewayServiceRuntimeQuestion": "网关服务运行时",
+  "wizard.quickstartGatewayRuntimeNodeNote":
+    "QuickStart 默认使用 Node 运行网关服务（稳定且受支持）。",
+  "wizard.gatewayServiceAlreadyInstalledQuestion": "检测到已安装网关服务",
+  "wizard.gatewayServiceActionRestart": "重启",
+  "wizard.gatewayServiceActionReinstall": "重装",
+  "wizard.gatewayServiceActionSkip": "跳过",
+  "wizard.gatewayServiceRestartingProgress": "正在重启网关服务…",
+  "wizard.gatewayServiceRestartedDone": "网关服务已重启。",
+  "wizard.gatewayServiceUninstallingProgress": "正在卸载网关服务…",
+  "wizard.gatewayServiceUninstalledDone": "网关服务已卸载。",
+  "wizard.gatewayServicePreparingProgress": "正在准备网关服务…",
+  "wizard.gatewayServiceInstallingProgress": "正在安装网关服务…",
+  "wizard.gatewayServiceInstallFailedDone": "网关服务安装失败。",
+  "wizard.gatewayServiceInstalledDone": "网关服务已安装。",
+  "wizard.gatewayTitle": "网关",
+  "wizard.gatewayInstallBlockedError":
+    "网关安装被阻止：{reason} 请修复 gateway auth 配置/token 输入后重新运行 onboarding。",
+  "wizard.gatewayServiceInstallFailedPrefix": "网关服务安装失败：{error}",
+  "wizard.healthCheckHelpTitle": "健康检查帮助",
+  "wizard.healthCheckDocsLine": "文档: https://docs.openclaw.ai/gateway/health",
+  "wizard.healthCheckTroubleshootingLine": "https://docs.openclaw.ai/gateway/troubleshooting",
+  "wizard.optionalAppsTitle": "可选应用",
+  "wizard.optionalAppsBody":
+    "可添加节点扩展能力：\n- macOS App（系统能力 + 通知）\n- iOS App（相机/canvas）\n- Android App（相机/canvas）",
+  "wizard.gatewayAuthResolveOnboardingAuthError":
+    "无法解析用于 onboarding 认证的 gateway.auth.password SecretRef。",
+  "wizard.controlUiTitle": "控制台 UI",
+  "wizard.controlUiWebUiLine": "Web UI: {url}",
+  "wizard.controlUiWebUiWithTokenLine": "Web UI（含 token）: {url}",
+  "wizard.controlUiGatewayWsLine": "网关 WS: {url}",
+  "wizard.controlUiGatewayStatusReachable": "网关：可达",
+  "wizard.controlUiGatewayStatusNotDetected": "网关：未检测到",
+  "wizard.controlUiGatewayStatusNotDetectedWithDetail": "网关：未检测到（{detail}）",
+  "wizard.controlUiDocsLine": "文档: https://docs.openclaw.ai/web/control-ui",
+  "wizard.startTuiBestOptionTitle": "启动 TUI（最佳选项）",
+  "wizard.startTuiBestOptionBody":
+    '这是让你的 agent 形成个性的关键一步。\n请慢慢来。\n你给的信息越充分，后续体验越好。\n我们会发送："Wake up, my friend!"',
+  "wizard.tokenTitle": "Token",
+  "wizard.tokenInfoBody":
+    "Gateway token 是网关与 Control UI 的共享认证凭据。\n存放位置：~/.openclaw/openclaw.json（gateway.auth.token）或环境变量 OPENCLAW_GATEWAY_TOKEN。\n查看 token：{viewTokenCommand}\n重新生成 token：{generateTokenCommand}\nControl UI 会按所选 gateway URL，把 dashboard URL 中的 token 保存在当前浏览器标签页的 sessionStorage 中。\n随时打开 dashboard：{openDashboardCommand}\n如有提示，请将 token 粘贴到 Control UI 设置中（或直接使用带 token 的 dashboard URL）。",
+  "wizard.hatchQuestion": "你想如何孵化你的 bot？",
+  "wizard.hatchOptionTui": "在 TUI 中孵化（推荐）",
+  "wizard.hatchOptionWeb": "打开 Web UI",
+  "wizard.hatchOptionLater": "稍后再做",
+  "wizard.hatchWakeMessage": "Wake up, my friend!",
+  "wizard.dashboardReadyTitle": "Dashboard 已就绪",
+  "wizard.dashboardLinkWithTokenLine": "Dashboard 链接（含 token）：{url}",
+  "wizard.dashboardOpenedLine": "已在浏览器打开，请保留该标签页来控制 OpenClaw。",
+  "wizard.dashboardCopyLine": "请在本机浏览器中复制/粘贴这个 URL 来控制 OpenClaw。",
+  "wizard.laterTitle": "稍后",
+  "wizard.laterCommandLine": "准备好后执行：{command}",
+  "wizard.skipControlUiPromptsNote": "已跳过 Control UI/TUI 提示。",
+  "wizard.workspaceBackupTitle": "工作区备份",
+  "wizard.workspaceBackupBody":
+    "请备份你的 agent 工作区。\n文档: https://docs.openclaw.ai/concepts/agent-workspace",
+  "wizard.securityReminderBody":
+    "在你的电脑上运行代理有风险——请先完成安全加固：https://docs.openclaw.ai/security",
+  "wizard.webSearchOptionalTitle": "Web 搜索（可选）",
+  "wizard.webSearchProviderBrave": "Brave Search",
+  "wizard.webSearchProviderPerplexity": "Perplexity Search",
+  "wizard.webSearchEnabledIntro": "已启用 Web 搜索，代理可在需要时在线检索信息。",
+  "wizard.webSearchProviderLine": "提供商: {provider}",
+  "wizard.webSearchTitle": "Web 搜索",
+  "wizard.webSearchApiKeyStoredInConfigLine": "API key: 已存入配置（{path}）。",
+  "wizard.webSearchApiKeyStoredInConfigSimple": "API key: 已存入配置。",
+  "wizard.webSearchApiKeyConfiguredViaSecretRef": "API key: 已通过 SecretRef 配置。",
+  "wizard.webSearchApiKeyProvidedViaEnvLine":
+    "API key: 通过环境变量 {envVar} 提供（Gateway 运行环境）。",
+  "wizard.webSearchApiKeyProvidedViaEnvVarsLine": "API key: 通过环境变量 {envVars} 提供。",
+  "wizard.webSearchProviderSelectedNoApiKeyLine": "已选择提供商 {provider}，但未检测到 API key。",
+  "wizard.webSearchProviderUnavailableLine":
+    "已选择 Web 搜索提供商 {provider}，但当前插件策略未开放它。",
+  "wizard.webSearchProviderUnavailableFixLine":
+    "重新启用该提供商或选择其他提供商前，web_search 将无法使用。",
+  "wizard.webSearchWillNotWorkUntilKeyLine": "在补充 key 之前，web_search 将无法使用。",
+  "wizard.webSearchRunConfigureWebIndentedLine": "  {command}",
+  "wizard.webSearchGetKeyAtLine": "获取 key：{url}",
+  "wizard.webSearchConfiguredButDisabledLine": "Web 搜索（{provider}）已配置但当前禁用。",
+  "wizard.webSearchReenableLine": "重新启用：{command}",
+  "wizard.webSearchAutoDetectedLine": "已自动检测到 {provider} 可用于 Web 搜索。",
+  "wizard.webSearchSkippedEnableLaterLine": "已跳过 Web 搜索配置。你可以稍后启用：",
+  "wizard.webSearchDocsLine": "文档: https://docs.openclaw.ai/tools/web",
+  "wizard.webSearchNeedsApiKeyIntro":
+    "要启用 Web 搜索，需要为 Perplexity Search 或 Brave Search 配置 API key。",
+  "wizard.webSearchManagedProviderSkippedLine": "已跳过托管 Web 搜索提供商配置。",
+  "wizard.webSearchCodexNativeSummaryLine":
+    "Codex 原生搜索：{mode}，仅适用于支持 Codex 的模型",
+  "wizard.webSearchCodexNativeUseLine": "仅适用于支持 Codex 的模型。",
+  "wizard.webSearchCodexNativeTitle": "Codex 原生搜索",
+  "wizard.webSearchSetupInteractivelyLine": "可通过交互方式配置：",
+  "wizard.webSearchRunConfigureWebLine": "- 运行：{command}",
+  "wizard.webSearchChooseProviderPasteKeyLine": "- 选择提供商并粘贴 API key",
+  "wizard.webSearchAlternativeEnvLine":
+    "也可以在 Gateway 环境中设置 PERPLEXITY_API_KEY 或 BRAVE_API_KEY（无需改配置文件）。",
+  "wizard.whatNowTitle": "接下来",
+  "wizard.whatNowBody": "接下来：https://openclaw.ai/showcase（What People Are Building）。",
+  "wizard.outroDashboardOpened": "初始化完成。Dashboard 已打开，请保留该标签页控制 OpenClaw。",
+  "wizard.outroSeededBackground":
+    "初始化完成。Web UI 已在后台完成初始化，你可以随时用上面的 dashboard 链接打开。",
+  "wizard.outroComplete": "初始化完成。请使用上方 dashboard 链接控制 OpenClaw。",
+};
+
+export function parseCliLocale(raw: string | null | undefined): CliLocale | undefined {
+  const value = raw?.trim().toLowerCase();
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.replace(/_/g, "-").split(".")[0] ?? value;
+  if (normalized === "en" || normalized.startsWith("en-")) {
+    return "en";
+  }
+  if (normalized === "zh-cn" || normalized === "zh-hans") {
+    return "zh-CN";
+  }
+
+  return undefined;
+}
+
+function normalizeLocale(raw: string): CliLocale {
+  return parseCliLocale(raw) ?? "en";
+}
+
+export function resolveCliLocale(env: NodeJS.ProcessEnv = process.env): CliLocale {
+  const explicit = env.OPENCLAW_LOCALE;
+  if (explicit) {
+    return normalizeLocale(explicit);
+  }
+  const lang = env.LANG;
+  if (lang) {
+    return normalizeLocale(lang);
+  }
+  return "en";
+}
+
+function formatTemplate(message: string, vars?: CliTemplateVars): string {
+  if (!vars) {
+    return message;
+  }
+  return message.replace(/\{([a-zA-Z0-9_]+)\}/g, (full, key) => {
+    const value = vars[key];
+    return value === undefined ? full : String(value);
+  });
+}
+
+export function cliT(
+  key: CliMessageKey,
+  env: NodeJS.ProcessEnv = process.env,
+  vars?: CliTemplateVars,
+): string {
+  const locale = resolveCliLocale(env);
+  const messages = locale === "zh-CN" ? ZH_CN_MESSAGES : EN_MESSAGES;
+  const message = messages[key] ?? EN_MESSAGES[key];
+  return formatTemplate(message, vars);
+}

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describeCodexNativeWebSearch } from "../agents/codex-native-web-search.shared.js";
+import {
+  describeCodexNativeWebSearch,
+  resolveCodexNativeWebSearchConfig,
+} from "../agents/codex-native-web-search.shared.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import {
@@ -26,6 +29,7 @@ import type { OnboardOptions } from "../commands/onboard-types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { describeGatewayServiceRestart, resolveGatewayService } from "../daemon/service.js";
 import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
+import { cliT } from "../i18n/cli.js";
 import { ensureControlUiAssetsBuilt } from "../infra/control-ui-assets.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -63,6 +67,8 @@ export async function finalizeSetupWizard(
   options: FinalizeOnboardingOptions,
 ): Promise<{ launchedTui: boolean }> {
   const { flow, opts, baseConfig, nextConfig, settings, prompter, runtime } = options;
+  const t = (key: Parameters<typeof cliT>[0], vars?: Record<string, string | number>) =>
+    cliT(key, process.env, vars);
   let gatewayProbe: { ok: boolean; detail?: string } = { ok: true };
   let resolvedGatewayPassword = "";
 
@@ -84,10 +90,7 @@ export async function finalizeSetupWizard(
   const systemdAvailable =
     process.platform === "linux" ? await isSystemdUserServiceAvailable() : true;
   if (process.platform === "linux" && !systemdAvailable) {
-    await prompter.note(
-      "Systemd user services are unavailable. Skipping lingering checks and service install.",
-      "Systemd",
-    );
+    await prompter.note(t("wizard.systemdUnavailableNote"), t("wizard.systemdTitle"));
   }
 
   if (process.platform === "linux" && systemdAvailable) {
@@ -98,8 +101,7 @@ export async function finalizeSetupWizard(
         confirm: prompter.confirm,
         note: prompter.note,
       },
-      reason:
-        "Linux installs use a systemd user service by default. Without lingering, systemd stops the user session on logout/idle and kills the Gateway.",
+      reason: t("wizard.systemdLingerReason"),
       requireConfirm: false,
     });
   }
@@ -115,15 +117,15 @@ export async function finalizeSetupWizard(
     installDaemon = true;
   } else {
     installDaemon = await prompter.confirm({
-      message: "Install Gateway service (recommended)",
+      message: t("wizard.installGatewayServiceQuestion"),
       initialValue: true,
     });
   }
 
   if (process.platform === "linux" && !systemdAvailable && installDaemon) {
     await prompter.note(
-      "Systemd user services are unavailable; skipping service install. Use your container supervisor or `docker compose up -d`.",
-      "Gateway service",
+      t("wizard.systemdUnavailableServiceInstallNote"),
+      t("wizard.gatewayServiceTitle"),
     );
     installDaemon = false;
   }
@@ -133,14 +135,14 @@ export async function finalizeSetupWizard(
       flow === "quickstart"
         ? DEFAULT_GATEWAY_DAEMON_RUNTIME
         : await prompter.select({
-            message: "Gateway service runtime",
+            message: t("wizard.gatewayServiceRuntimeQuestion"),
             options: GATEWAY_DAEMON_RUNTIME_OPTIONS,
             initialValue: opts.daemonRuntime ?? DEFAULT_GATEWAY_DAEMON_RUNTIME,
           });
     if (flow === "quickstart") {
       await prompter.note(
-        "QuickStart uses Node for the Gateway service (stable + supported).",
-        "Gateway service runtime",
+        t("wizard.quickstartGatewayRuntimeNodeNote"),
+        t("wizard.gatewayServiceRuntimeQuestion"),
       );
     }
     const service = resolveGatewayService();
@@ -148,20 +150,20 @@ export async function finalizeSetupWizard(
     let restartWasScheduled = false;
     if (loaded) {
       const action = await prompter.select({
-        message: "Gateway service already installed",
+        message: t("wizard.gatewayServiceAlreadyInstalledQuestion"),
         options: [
-          { value: "restart", label: "Restart" },
-          { value: "reinstall", label: "Reinstall" },
-          { value: "skip", label: "Skip" },
+          { value: "restart", label: t("wizard.gatewayServiceActionRestart") },
+          { value: "reinstall", label: t("wizard.gatewayServiceActionReinstall") },
+          { value: "skip", label: t("wizard.gatewayServiceActionSkip") },
         ],
       });
       if (action === "restart") {
-        let restartDoneMessage = "Gateway service restarted.";
+        let restartDoneMessage = t("wizard.gatewayServiceRestartedDone");
         await withWizardProgress(
-          "Gateway service",
+          t("wizard.gatewayServiceTitle"),
           { doneMessage: () => restartDoneMessage },
           async (progress) => {
-            progress.update("Restarting Gateway service…");
+            progress.update(t("wizard.gatewayServiceRestartingProgress"));
             const restartResult = await service.restart({
               env: process.env,
               stdout: process.stdout,
@@ -173,10 +175,10 @@ export async function finalizeSetupWizard(
         );
       } else if (action === "reinstall") {
         await withWizardProgress(
-          "Gateway service",
-          { doneMessage: "Gateway service uninstalled." },
+          t("wizard.gatewayServiceTitle"),
+          { doneMessage: t("wizard.gatewayServiceUninstalledDone") },
           async (progress) => {
-            progress.update("Uninstalling Gateway service…");
+            progress.update(t("wizard.gatewayServiceUninstallingProgress"));
             await service.uninstall({ env: process.env, stdout: process.stdout });
           },
         );
@@ -187,23 +189,21 @@ export async function finalizeSetupWizard(
       !loaded ||
       (!restartWasScheduled && loaded && !(await service.isLoaded({ env: process.env })))
     ) {
-      const progress = prompter.progress("Gateway service");
+      const progress = prompter.progress(t("wizard.gatewayServiceTitle"));
       let installError: string | null = null;
       try {
-        progress.update("Preparing Gateway service…");
+        progress.update(t("wizard.gatewayServicePreparingProgress"));
         const tokenResolution = await resolveGatewayInstallToken({
           config: nextConfig,
           env: process.env,
         });
         for (const warning of tokenResolution.warnings) {
-          await prompter.note(warning, "Gateway service");
+          await prompter.note(warning, t("wizard.gatewayServiceTitle"));
         }
         if (tokenResolution.unavailableReason) {
-          installError = [
-            "Gateway install blocked:",
-            tokenResolution.unavailableReason,
-            "Fix gateway auth config/token input and rerun setup.",
-          ].join(" ");
+          installError = t("wizard.gatewayInstallBlockedError", {
+            reason: tokenResolution.unavailableReason,
+          });
         } else {
           const { programArguments, workingDirectory, environment } = await buildGatewayInstallPlan(
             {
@@ -215,7 +215,7 @@ export async function finalizeSetupWizard(
             },
           );
 
-          progress.update("Installing Gateway service…");
+          progress.update(t("wizard.gatewayServiceInstallingProgress"));
           await service.install({
             env: process.env,
             stdout: process.stdout,
@@ -228,12 +228,17 @@ export async function finalizeSetupWizard(
         installError = formatErrorMessage(err);
       } finally {
         progress.stop(
-          installError ? "Gateway service install failed." : "Gateway service installed.",
+          installError
+            ? t("wizard.gatewayServiceInstallFailedDone")
+            : t("wizard.gatewayServiceInstalledDone"),
         );
       }
       if (installError) {
-        await prompter.note(`Gateway service install failed: ${installError}`, "Gateway");
-        await prompter.note(gatewayInstallErrorHint(), "Gateway");
+        await prompter.note(
+          t("wizard.gatewayServiceInstallFailedPrefix", { error: installError }),
+          t("wizard.gatewayTitle"),
+        );
+        await prompter.note(gatewayInstallErrorHint(), t("wizard.gatewayTitle"));
       }
     }
   }
@@ -249,11 +254,8 @@ export async function finalizeSetupWizard(
         })) ?? "";
     } catch (error) {
       await prompter.note(
-        [
-          "Could not resolve gateway.auth.password SecretRef for setup auth.",
-          formatErrorMessage(error),
-        ].join("\n"),
-        "Gateway auth",
+        [t("wizard.gatewayAuthResolveOnboardingAuthError"), formatErrorMessage(error)].join("\n"),
+        t("wizard.gatewayAuthTitle"),
       );
     }
   }
@@ -302,12 +304,8 @@ export async function finalizeSetupWizard(
       } catch (err) {
         runtime.error(formatHealthCheckFailure(err));
         await prompter.note(
-          [
-            "Docs:",
-            "https://docs.openclaw.ai/gateway/health",
-            "https://docs.openclaw.ai/gateway/troubleshooting",
-          ].join("\n"),
-          "Health check help",
+          [t("wizard.healthCheckDocsLine"), t("wizard.healthCheckTroubleshootingLine")].join("\n"),
+          t("wizard.healthCheckHelpTitle"),
         );
       }
     } else if (installDaemon) {
@@ -319,12 +317,8 @@ export async function finalizeSetupWizard(
         ),
       );
       await prompter.note(
-        [
-          "Docs:",
-          "https://docs.openclaw.ai/gateway/health",
-          "https://docs.openclaw.ai/gateway/troubleshooting",
-        ].join("\n"),
-        "Health check help",
+        [t("wizard.healthCheckDocsLine"), t("wizard.healthCheckTroubleshootingLine")].join("\n"),
+        t("wizard.healthCheckHelpTitle"),
       );
     } else {
       await prompter.note(
@@ -349,15 +343,7 @@ export async function finalizeSetupWizard(
     }
   }
 
-  await prompter.note(
-    [
-      "Add nodes for extra features:",
-      "- macOS app (system + notifications)",
-      "- iOS app (camera/canvas)",
-      "- Android app (camera/canvas)",
-    ].join("\n"),
-    "Optional apps",
-  );
+  await prompter.note(t("wizard.optionalAppsBody"), t("wizard.optionalAppsTitle"));
 
   const controlUiBasePath =
     nextConfig.gateway?.controlUi?.basePath ?? baseConfig.gateway?.controlUi?.basePath;
@@ -380,8 +366,10 @@ export async function finalizeSetupWizard(
     });
   }
   const gatewayStatusLine = gatewayProbe.ok
-    ? "Gateway: reachable"
-    : `Gateway: not detected${gatewayProbe.detail ? ` (${gatewayProbe.detail})` : ""}`;
+    ? t("wizard.controlUiGatewayStatusReachable")
+    : gatewayProbe.detail
+      ? t("wizard.controlUiGatewayStatusNotDetectedWithDetail", { detail: gatewayProbe.detail })
+      : t("wizard.controlUiGatewayStatusNotDetected");
   const bootstrapPath = path.join(
     resolveUserPath(options.workspaceDir),
     DEFAULT_BOOTSTRAP_FILENAME,
@@ -393,17 +381,17 @@ export async function finalizeSetupWizard(
 
   await prompter.note(
     [
-      `Web UI: ${links.httpUrl}`,
+      t("wizard.controlUiWebUiLine", { url: links.httpUrl }),
       settings.authMode === "token" && settings.gatewayToken
-        ? `Web UI (with token): ${authedUrl}`
+        ? t("wizard.controlUiWebUiWithTokenLine", { url: authedUrl })
         : undefined,
-      `Gateway WS: ${links.wsUrl}`,
+      t("wizard.controlUiGatewayWsLine", { url: links.wsUrl }),
       gatewayStatusLine,
-      "Docs: https://docs.openclaw.ai/web/control-ui",
+      t("wizard.controlUiDocsLine"),
     ]
       .filter(Boolean)
       .join("\n"),
-    "Control UI",
+    t("wizard.controlUiTitle"),
   );
 
   let controlUiOpened = false;
@@ -414,40 +402,28 @@ export async function finalizeSetupWizard(
 
   if (!opts.skipUi) {
     if (hasBootstrap) {
-      await prompter.note(
-        [
-          "This is the defining action that makes your agent you.",
-          "Please take your time.",
-          "The more you tell it, the better the experience will be.",
-          'We will send: "Wake up, my friend!"',
-        ].join("\n"),
-        "Start TUI (best option!)",
-      );
+      await prompter.note(t("wizard.startTuiBestOptionBody"), t("wizard.startTuiBestOptionTitle"));
     }
 
     if (gatewayProbe.ok) {
       await prompter.note(
-        [
-          "Gateway token: shared auth for the Gateway + Control UI.",
-          "Stored in: $OPENCLAW_CONFIG_PATH (default: ~/.openclaw/openclaw.json) under gateway.auth.token, or in OPENCLAW_GATEWAY_TOKEN.",
-          `View token: ${formatCliCommand("openclaw config get gateway.auth.token")}`,
-          `Generate token: ${formatCliCommand("openclaw doctor --generate-gateway-token")}`,
-          "Web UI keeps dashboard URL tokens in memory for the current tab and strips them from the URL after load.",
-          `Open the dashboard anytime: ${formatCliCommand("openclaw dashboard --no-open")}`,
-          "If prompted: paste the token into Control UI settings (or use the tokenized dashboard URL).",
-        ].join("\n"),
-        "Token",
+        t("wizard.tokenInfoBody", {
+          viewTokenCommand: formatCliCommand("openclaw config get gateway.auth.token"),
+          generateTokenCommand: formatCliCommand("openclaw doctor --generate-gateway-token"),
+          openDashboardCommand: formatCliCommand("openclaw dashboard --no-open"),
+        }),
+        t("wizard.tokenTitle"),
       );
     }
 
     const hatchOptions: { value: "tui" | "web" | "later"; label: string }[] = [
-      { value: "tui", label: "Hatch in Terminal (recommended)" },
-      ...(gatewayProbe.ok ? [{ value: "web" as const, label: "Open the Web UI" }] : []),
-      { value: "later", label: "Do this later" },
+      { value: "tui", label: t("wizard.hatchOptionTui") },
+      ...(gatewayProbe.ok ? [{ value: "web" as const, label: t("wizard.hatchOptionWeb") }] : []),
+      { value: "later", label: t("wizard.hatchOptionLater") },
     ];
 
     hatchChoice = await prompter.select({
-      message: "How do you want to hatch your bot?",
+      message: t("wizard.hatchQuestion"),
       options: hatchOptions,
       initialValue: "tui",
     });
@@ -458,7 +434,7 @@ export async function finalizeSetupWizard(
         await launchTuiCli({
           local: true,
           deliver: false,
-          message: hasBootstrap ? "Wake up, my friend!" : undefined,
+          message: hasBootstrap ? t("wizard.hatchWakeMessage") : undefined,
           timeoutMs: HATCH_TUI_TIMEOUT_MS,
         });
       } finally {
@@ -485,38 +461,29 @@ export async function finalizeSetupWizard(
       }
       await prompter.note(
         [
-          `Dashboard link (with token): ${authedUrl}`,
-          controlUiOpened
-            ? "Opened in your browser. Keep that tab to control OpenClaw."
-            : "Copy/paste this URL in a browser on this machine to control OpenClaw.",
+          t("wizard.dashboardLinkWithTokenLine", { url: authedUrl }),
+          controlUiOpened ? t("wizard.dashboardOpenedLine") : t("wizard.dashboardCopyLine"),
           controlUiOpenHint,
         ]
           .filter(Boolean)
           .join("\n"),
-        "Dashboard ready",
+        t("wizard.dashboardReadyTitle"),
       );
     } else {
       await prompter.note(
-        `When you're ready: ${formatCliCommand("openclaw dashboard --no-open")}`,
-        "Later",
+        t("wizard.laterCommandLine", {
+          command: formatCliCommand("openclaw dashboard --no-open"),
+        }),
+        t("wizard.laterTitle"),
       );
     }
   } else if (opts.skipUi) {
-    await prompter.note("Skipping Control UI/TUI prompts.", "Control UI");
+    await prompter.note(t("wizard.skipControlUiPromptsNote"), t("wizard.controlUiTitle"));
   }
 
-  await prompter.note(
-    [
-      "Back up your agent workspace.",
-      "Docs: https://docs.openclaw.ai/concepts/agent-workspace",
-    ].join("\n"),
-    "Workspace backup",
-  );
+  await prompter.note(t("wizard.workspaceBackupBody"), t("wizard.workspaceBackupTitle"));
 
-  await prompter.note(
-    "Running agents on your computer is risky — harden your setup: https://docs.openclaw.ai/security",
-    "Security",
-  );
+  await prompter.note(t("wizard.securityReminderBody"), t("wizard.securityTitle"));
 
   await setupWizardShellCompletion({ flow, prompter });
 
@@ -547,19 +514,18 @@ export async function finalizeSetupWizard(
 
     await prompter.note(
       [
-        `Dashboard link (with token): ${authedUrl}`,
-        controlUiOpened
-          ? "Opened in your browser. Keep that tab to control OpenClaw."
-          : "Copy/paste this URL in a browser on this machine to control OpenClaw.",
+        t("wizard.dashboardLinkWithTokenLine", { url: authedUrl }),
+        controlUiOpened ? t("wizard.dashboardOpenedLine") : t("wizard.dashboardCopyLine"),
         controlUiOpenHint,
       ]
         .filter(Boolean)
         .join("\n"),
-      "Dashboard ready",
+      t("wizard.dashboardReadyTitle"),
     );
   }
 
   const codexNativeSummary = describeCodexNativeWebSearch(nextConfig);
+  const codexNativeSearch = resolveCodexNativeWebSearchConfig(nextConfig);
   const webSearchProvider = nextConfig.tools?.web?.search?.provider;
   const webSearchEnabled = nextConfig.tools?.web?.search?.enabled;
   const configuredSearchProviders = listConfiguredWebSearchProviders({ config: nextConfig });
@@ -572,55 +538,65 @@ export async function finalizeSetupWizard(
     const envAvailable = entry ? hasKeyInEnv(entry) : false;
     const hasKey = keyConfigured || envAvailable;
     const keySource = storedKey
-      ? "API key: stored in config."
+      ? t("wizard.webSearchApiKeyStoredInConfigSimple")
       : keyConfigured
-        ? "API key: configured via secret reference."
+        ? t("wizard.webSearchApiKeyConfiguredViaSecretRef")
         : envAvailable
-          ? `API key: provided via ${entry?.envVars.join(" / ")} env var.`
+          ? t("wizard.webSearchApiKeyProvidedViaEnvVarsLine", {
+              envVars: entry?.envVars.join(" / ") ?? "",
+            })
           : undefined;
     if (!entry) {
       await prompter.note(
         [
-          `Web search provider ${label} is selected but unavailable under the current plugin policy.`,
-          "web_search will not work until the provider is re-enabled or a different provider is selected.",
-          `  ${formatCliCommand("openclaw configure --section web")}`,
+          t("wizard.webSearchProviderUnavailableLine", { provider: label }),
+          t("wizard.webSearchProviderUnavailableFixLine"),
+          t("wizard.webSearchRunConfigureWebIndentedLine", {
+            command: formatCliCommand("openclaw configure --section web"),
+          }),
           "",
-          "Docs: https://docs.openclaw.ai/tools/web",
+          t("wizard.webSearchDocsLine"),
         ].join("\n"),
-        "Web search",
+        t("wizard.webSearchTitle"),
       );
     } else if (webSearchEnabled !== false && hasKey) {
       await prompter.note(
         [
-          "Web search is enabled, so your agent can look things up online when needed.",
+          t("wizard.webSearchEnabledIntro"),
           "",
-          `Provider: ${label}`,
+          t("wizard.webSearchProviderLine", { provider: label }),
           ...(keySource ? [keySource] : []),
-          "Docs: https://docs.openclaw.ai/tools/web",
+          t("wizard.webSearchDocsLine"),
         ].join("\n"),
-        "Web search",
+        t("wizard.webSearchTitle"),
       );
     } else if (!hasKey) {
       await prompter.note(
         [
-          `Provider ${label} is selected but no API key was found.`,
-          "web_search will not work until a key is added.",
-          `  ${formatCliCommand("openclaw configure --section web")}`,
+          t("wizard.webSearchProviderSelectedNoApiKeyLine", { provider: label }),
+          t("wizard.webSearchWillNotWorkUntilKeyLine"),
+          t("wizard.webSearchRunConfigureWebIndentedLine", {
+            command: formatCliCommand("openclaw configure --section web"),
+          }),
           "",
-          `Get your key at: ${entry?.signupUrl ?? "https://docs.openclaw.ai/tools/web"}`,
-          "Docs: https://docs.openclaw.ai/tools/web",
+          t("wizard.webSearchGetKeyAtLine", {
+            url: entry?.signupUrl ?? "https://docs.openclaw.ai/tools/web",
+          }),
+          t("wizard.webSearchDocsLine"),
         ].join("\n"),
-        "Web search",
+        t("wizard.webSearchTitle"),
       );
     } else {
       await prompter.note(
         [
-          `Web search (${label}) is configured but disabled.`,
-          `Re-enable: ${formatCliCommand("openclaw configure --section web")}`,
+          t("wizard.webSearchConfiguredButDisabledLine", { provider: label }),
+          t("wizard.webSearchReenableLine", {
+            command: formatCliCommand("openclaw configure --section web"),
+          }),
           "",
-          "Docs: https://docs.openclaw.ai/tools/web",
+          t("wizard.webSearchDocsLine"),
         ].join("\n"),
-        "Web search",
+        t("wizard.webSearchTitle"),
       );
     }
   } else {
@@ -633,29 +609,33 @@ export async function finalizeSetupWizard(
     if (legacyDetected) {
       await prompter.note(
         [
-          `Web search is available via ${legacyDetected.label} (auto-detected).`,
-          "Docs: https://docs.openclaw.ai/tools/web",
+          t("wizard.webSearchAutoDetectedLine", { provider: legacyDetected.label }),
+          t("wizard.webSearchDocsLine"),
         ].join("\n"),
-        "Web search",
+        t("wizard.webSearchTitle"),
       );
     } else if (codexNativeSummary) {
       await prompter.note(
         [
-          "Managed web search provider was skipped.",
-          codexNativeSummary,
-          "Docs: https://docs.openclaw.ai/tools/web",
+          t("wizard.webSearchManagedProviderSkippedLine"),
+          t("wizard.webSearchCodexNativeSummaryLine", {
+            mode: codexNativeSearch.mode,
+          }),
+          t("wizard.webSearchDocsLine"),
         ].join("\n"),
-        "Web search",
+        t("wizard.webSearchTitle"),
       );
     } else {
       await prompter.note(
         [
-          "Web search was skipped. You can enable it later:",
-          `  ${formatCliCommand("openclaw configure --section web")}`,
+          t("wizard.webSearchSkippedEnableLaterLine"),
+          t("wizard.webSearchRunConfigureWebIndentedLine", {
+            command: formatCliCommand("openclaw configure --section web"),
+          }),
           "",
-          "Docs: https://docs.openclaw.ai/tools/web",
+          t("wizard.webSearchDocsLine"),
         ].join("\n"),
-        "Web search",
+        t("wizard.webSearchTitle"),
       );
     }
   }
@@ -663,25 +643,24 @@ export async function finalizeSetupWizard(
   if (codexNativeSummary) {
     await prompter.note(
       [
-        codexNativeSummary,
-        "Used only for Codex-capable models.",
-        "Docs: https://docs.openclaw.ai/tools/web",
+        t("wizard.webSearchCodexNativeSummaryLine", {
+          mode: codexNativeSearch.mode,
+        }),
+        t("wizard.webSearchCodexNativeUseLine"),
+        t("wizard.webSearchDocsLine"),
       ].join("\n"),
-      "Codex native search",
+      t("wizard.webSearchCodexNativeTitle"),
     );
   }
 
-  await prompter.note(
-    'What now: https://openclaw.ai/showcase ("What People Are Building").',
-    "What now",
-  );
+  await prompter.note(t("wizard.whatNowBody"), t("wizard.whatNowTitle"));
 
   await prompter.outro(
     controlUiOpened
-      ? "Onboarding complete. Dashboard opened; keep that tab to control OpenClaw."
+      ? t("wizard.outroDashboardOpened")
       : seededInBackground
-        ? "Onboarding complete. Web UI seeded in the background; open it anytime with the dashboard link above."
-        : "Onboarding complete. Use the dashboard link above to control OpenClaw.",
+        ? t("wizard.outroSeededBackground")
+        : t("wizard.outroComplete"),
   );
 
   return { launchedTui };

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -11,6 +11,7 @@ import type {
 import { createConfigIO, replaceConfigFile, resolveGatewayPort } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeSecretInputString } from "../config/types.secrets.js";
+import { cliT, parseCliLocale, resolveCliLocale } from "../i18n/cli.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   buildPluginCompatibilitySnapshotNotices,
@@ -70,6 +71,53 @@ async function writeWizardConfigFile(config: OpenClawConfig): Promise<OpenClawCo
 
 async function readSetupConfigFileSnapshot() {
   return await createConfigIO({ pluginValidation: "skip" }).readConfigFileSnapshot();
+}
+
+async function promptCliLocaleSelection(params: {
+  prompter: WizardPrompter;
+  baseConfig: OpenClawConfig;
+  allowPrompt: boolean;
+}): Promise<"en" | "zh-CN" | undefined> {
+  const explicit = parseCliLocale(process.env.OPENCLAW_LOCALE);
+  if (explicit) {
+    process.env.OPENCLAW_LOCALE = explicit;
+    return explicit;
+  }
+
+  const configured = parseCliLocale(params.baseConfig.cli?.locale);
+  if (configured) {
+    process.env.OPENCLAW_LOCALE = configured;
+    return configured;
+  }
+
+  const langDetected = resolveCliLocale({ LANG: process.env.LANG });
+  if (langDetected === "zh-CN") {
+    process.env.OPENCLAW_LOCALE = langDetected;
+    return langDetected;
+  }
+  if (!params.allowPrompt) {
+    return undefined;
+  }
+
+  const localeRaw = await params.prompter.select({
+    message: cliT("wizard.languageQuestion", process.env),
+    options: [
+      {
+        value: "en",
+        label: cliT("wizard.languageOptionEnglish", process.env),
+        hint: cliT("wizard.languageOptionEnglishHint", process.env),
+      },
+      {
+        value: "zh-CN",
+        label: cliT("wizard.languageOptionZhCn", process.env),
+        hint: cliT("wizard.languageOptionZhCnHint", process.env),
+      },
+    ],
+    initialValue: langDetected,
+  });
+  const locale = parseCliLocale(localeRaw) ?? "en";
+  process.env.OPENCLAW_LOCALE = locale;
+  return locale;
 }
 
 async function resolveAuthChoiceModelSelectionPolicy(params: {
@@ -182,9 +230,6 @@ export async function runSetupWizard(
   prompter: WizardPrompter,
 ) {
   const onboardHelpers = await import("../commands/onboard-helpers.js");
-  onboardHelpers.printWizardHeader(runtime);
-  await prompter.intro("OpenClaw setup");
-  await requireRiskAcknowledgement({ opts, prompter });
 
   const snapshot = await readSetupConfigFileSnapshot();
   let baseConfig: OpenClawConfig = snapshot.valid
@@ -194,23 +239,53 @@ export async function runSetupWizard(
     : {};
 
   if (snapshot.exists && !snapshot.valid) {
-    await prompter.note(onboardHelpers.summarizeExistingConfig(baseConfig), "Invalid config");
+    await prompter.note(
+      onboardHelpers.summarizeExistingConfig(baseConfig),
+      cliT("wizard.invalidConfigTitle", process.env),
+    );
     if (snapshot.issues.length > 0) {
       await prompter.note(
         [
           ...snapshot.issues.map((iss) => `- ${iss.path}: ${iss.message}`),
           "",
-          "Docs: https://docs.openclaw.ai/gateway/configuration",
+          cliT("wizard.docsConfigLine", process.env),
         ].join("\n"),
-        "Config issues",
+        cliT("wizard.configIssuesTitle", process.env),
       );
     }
     await prompter.outro(
-      `Config invalid. Run \`${formatCliCommand("openclaw doctor")}\` to repair it, then re-run setup.`,
+      cliT("wizard.configInvalidOutro", process.env, {
+        doctorCommand: formatCliCommand("openclaw doctor"),
+      }),
     );
     runtime.exit(1);
     return;
   }
+
+  const selectedLocale = await promptCliLocaleSelection({
+    prompter,
+    baseConfig,
+    allowPrompt: opts.flow === undefined,
+  });
+  const applySelectedLocale = (config: OpenClawConfig): OpenClawConfig => {
+    if (!selectedLocale) {
+      return config;
+    }
+    return {
+      ...config,
+      cli: {
+        ...config.cli,
+        locale: selectedLocale,
+      },
+    };
+  };
+  baseConfig = applySelectedLocale(baseConfig);
+  const t = (key: Parameters<typeof cliT>[0], vars?: Record<string, string | number>) =>
+    cliT(key, process.env, vars);
+
+  onboardHelpers.printWizardHeader(runtime);
+  await prompter.intro(t("wizard.onboardingTitle"));
+  await requireRiskAcknowledgement({ opts, prompter });
 
   const compatibilityNotices = snapshot.valid
     ? buildPluginCompatibilitySnapshotNotices({ config: baseConfig })
@@ -233,8 +308,10 @@ export async function runSetupWizard(
     );
   }
 
-  const quickstartHint = `Configure details later via ${formatCliCommand("openclaw configure")}.`;
-  const manualHint = "Configure port, network, Tailscale, and auth options.";
+  const quickstartHint = t("wizard.modeQuickstartHint", {
+    configureCommand: formatCliCommand("openclaw configure"),
+  });
+  const manualHint = t("wizard.modeManualHint");
   const migrationDetections = await detectSetupMigrationSources({ config: baseConfig, runtime });
   const firstMigrationDetection = migrationDetections[0];
   const importOption = firstMigrationDetection
@@ -252,7 +329,7 @@ export async function runSetupWizard(
     normalizedExplicitFlow !== "advanced" &&
     normalizedExplicitFlow !== "import"
   ) {
-    runtime.error("Invalid --flow (use quickstart, manual, advanced, or import).");
+    runtime.error(t("wizard.errorInvalidFlow"));
     runtime.exit(1);
     return;
   }
@@ -265,35 +342,32 @@ export async function runSetupWizard(
   let flow: SetupFlowChoice =
     explicitFlow ??
     (await prompter.select({
-      message: "Setup mode",
+      message: t("wizard.modeQuestion"),
       options: [
-        { value: "quickstart", label: "QuickStart", hint: quickstartHint },
-        { value: "advanced", label: "Manual", hint: manualHint },
+        { value: "quickstart", label: t("wizard.modeQuickstart"), hint: quickstartHint },
+        { value: "advanced", label: t("wizard.modeManual"), hint: manualHint },
         ...(importOption ? [importOption] : []),
       ],
       initialValue: "quickstart",
     }));
 
   if (opts.mode === "remote" && flow === "quickstart") {
-    await prompter.note(
-      "QuickStart only supports local gateways. Switching to Manual mode.",
-      "QuickStart",
-    );
+    await prompter.note(t("wizard.quickstartSwitchToManual"), t("wizard.quickstartTitle"));
     flow = "advanced";
   }
 
   if (snapshot.exists) {
     await prompter.note(
       onboardHelpers.summarizeExistingConfig(baseConfig),
-      "Existing config detected",
+      t("wizard.existingConfigDetectedTitle"),
     );
 
     const action = await prompter.select({
-      message: "Config handling",
+      message: t("wizard.configHandlingQuestion"),
       options: [
-        { value: "keep", label: "Use existing values" },
-        { value: "modify", label: "Update values" },
-        { value: "reset", label: "Reset" },
+        { value: "keep", label: t("wizard.configHandlingUseExisting") },
+        { value: "modify", label: t("wizard.configHandlingUpdate") },
+        { value: "reset", label: t("wizard.configHandlingReset") },
       ],
     });
 
@@ -301,21 +375,21 @@ export async function runSetupWizard(
       const workspaceDefault =
         baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE;
       const resetScope = (await prompter.select({
-        message: "Reset scope",
+        message: t("wizard.resetScopeQuestion"),
         options: [
-          { value: "config", label: "Config only" },
+          { value: "config", label: t("wizard.resetScopeConfigOnly") },
           {
             value: "config+creds+sessions",
-            label: "Config + creds + sessions",
+            label: t("wizard.resetScopeConfigCredsSessions"),
           },
           {
             value: "full",
-            label: "Full reset (config + creds + sessions + workspace)",
+            label: t("wizard.resetScopeFull"),
           },
         ],
       })) as ResetScope;
       await onboardHelpers.handleReset(resetScope, resolveUserPath(workspaceDefault), runtime);
-      baseConfig = {};
+      baseConfig = applySelectedLocale({});
     }
   }
 
@@ -326,7 +400,7 @@ export async function runSetupWizard(
       detections: migrationDetections,
       prompter,
       runtime,
-      commitConfigFile: writeWizardConfigFile,
+      commitConfigFile: (config) => writeWizardConfigFile(applySelectedLocale(config)),
     });
     return;
   }
@@ -416,24 +490,30 @@ export async function runSetupWizard(
     };
     const quickstartLines = quickstartGateway.hasExisting
       ? [
-          "Keeping your current gateway settings:",
-          `Gateway port: ${quickstartGateway.port}`,
-          `Gateway bind: ${formatBind(quickstartGateway.bind)}`,
+          t("wizard.quickstartSummaryKeepExisting"),
+          t("wizard.quickstartGatewayPortLine", { port: quickstartGateway.port }),
+          t("wizard.quickstartGatewayBindLine", { bind: formatBind(quickstartGateway.bind) }),
           ...(quickstartGateway.bind === "custom" && quickstartGateway.customBindHost
-            ? [`Gateway custom IP: ${quickstartGateway.customBindHost}`]
+            ? [
+                t("wizard.quickstartGatewayCustomIpLine", {
+                  host: quickstartGateway.customBindHost,
+                }),
+              ]
             : []),
-          `Gateway auth: ${formatAuth(quickstartGateway.authMode)}`,
-          `Tailscale exposure: ${formatTailscale(quickstartGateway.tailscaleMode)}`,
-          "Direct to chat channels.",
+          t("wizard.quickstartGatewayAuthLine", { auth: formatAuth(quickstartGateway.authMode) }),
+          t("wizard.quickstartTailscaleExposureLine", {
+            tailscale: formatTailscale(quickstartGateway.tailscaleMode),
+          }),
+          t("wizard.quickstartDirectChatLine"),
         ]
       : [
-          `Gateway port: ${quickstartGateway.port}`,
-          "Gateway bind: Loopback (127.0.0.1)",
-          "Gateway auth: Token (default)",
-          "Tailscale exposure: Off",
-          "Direct to chat channels.",
+          t("wizard.quickstartGatewayPortLine", { port: quickstartGateway.port }),
+          t("wizard.quickstartDefaultGatewayBindLine"),
+          t("wizard.quickstartDefaultGatewayAuthLine"),
+          t("wizard.quickstartDefaultTailscaleLine"),
+          t("wizard.quickstartDirectChatLine"),
         ];
-    await prompter.note(quickstartLines.join("\n"), "QuickStart");
+    await prompter.note(quickstartLines.join("\n"), t("wizard.quickstartTitle"));
   }
 
   const localPort = resolveGatewayPort(baseConfig);
@@ -451,11 +531,8 @@ export async function runSetupWizard(
     }
   } catch (error) {
     await prompter.note(
-      [
-        "Could not resolve gateway.auth.token SecretRef for setup probe.",
-        formatErrorMessage(error),
-      ].join("\n"),
-      "Gateway auth",
+      [t("wizard.gatewayAuthResolveTokenProbeError"), formatErrorMessage(error)].join("\n"),
+      t("wizard.gatewayAuthTitle"),
     );
   }
   let localGatewayPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
@@ -471,11 +548,8 @@ export async function runSetupWizard(
     }
   } catch (error) {
     await prompter.note(
-      [
-        "Could not resolve gateway.auth.password SecretRef for setup probe.",
-        formatErrorMessage(error),
-      ].join("\n"),
-      "Gateway auth",
+      [t("wizard.gatewayAuthResolveProbeError"), formatErrorMessage(error)].join("\n"),
+      t("wizard.gatewayAuthTitle"),
     );
   }
 
@@ -498,11 +572,8 @@ export async function runSetupWizard(
     }
   } catch (error) {
     await prompter.note(
-      [
-        "Could not resolve gateway.remote.token SecretRef for setup probe.",
-        formatErrorMessage(error),
-      ].join("\n"),
-      "Gateway auth",
+      [t("wizard.gatewayAuthResolveRemoteTokenProbeError"), formatErrorMessage(error)].join("\n"),
+      t("wizard.gatewayAuthTitle"),
     );
   }
   const remoteProbe = remoteUrl
@@ -517,23 +588,23 @@ export async function runSetupWizard(
     (flow === "quickstart"
       ? "local"
       : ((await prompter.select({
-          message: "What do you want to set up?",
+          message: t("wizard.setupTargetQuestion"),
           options: [
             {
               value: "local",
-              label: "Local gateway (this machine)",
+              label: t("wizard.setupTargetLocal"),
               hint: localProbe.ok
-                ? `Gateway reachable (${localUrl})`
-                : `No gateway detected (${localUrl})`,
+                ? t("wizard.setupTargetLocalReachableHint", { url: localUrl })
+                : t("wizard.setupTargetLocalUnreachableHint", { url: localUrl }),
             },
             {
               value: "remote",
-              label: "Remote gateway (info-only)",
+              label: t("wizard.setupTargetRemote"),
               hint: !remoteUrl
-                ? "No remote URL configured yet"
+                ? t("wizard.setupTargetRemoteNoConfigHint")
                 : remoteProbe?.ok
-                  ? `Gateway reachable (${remoteUrl})`
-                  : `Configured but unreachable (${remoteUrl})`,
+                  ? t("wizard.setupTargetRemoteReachableHint", { url: remoteUrl })
+                  : t("wizard.setupTargetRemoteUnreachableHint", { url: remoteUrl }),
             },
           ],
         })) as OnboardMode));
@@ -548,10 +619,13 @@ export async function runSetupWizard(
     if (opts.skipBootstrap) {
       nextConfig = applySkipBootstrapConfig(nextConfig);
     }
-    nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
+    nextConfig = onboardHelpers.applyWizardMetadata(applySelectedLocale(nextConfig), {
+      command: "onboard",
+      mode,
+    });
     nextConfig = await writeWizardConfigFile(nextConfig);
     logConfigUpdated(runtime);
-    await prompter.outro("Remote gateway configured.");
+    await prompter.outro(t("wizard.remoteConfigured"));
     return;
   }
 
@@ -560,7 +634,7 @@ export async function runSetupWizard(
     (flow === "quickstart"
       ? (baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE)
       : await prompter.text({
-          message: "Workspace directory",
+          message: t("wizard.workspaceDirectoryQuestion"),
           initialValue: baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE,
         }));
 
@@ -568,7 +642,9 @@ export async function runSetupWizard(
 
   const { applyLocalSetupWorkspaceConfig, applySkipBootstrapConfig } =
     await import("../commands/onboard-config.js");
-  let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(baseConfig, workspaceDir);
+  let nextConfig: OpenClawConfig = applySelectedLocale(
+    applyLocalSetupWorkspaceConfig(baseConfig, workspaceDir),
+  );
   if (opts.skipBootstrap) {
     nextConfig = applySkipBootstrapConfig(nextConfig);
   }
@@ -714,7 +790,7 @@ export async function runSetupWizard(
   const settings = gateway.settings;
 
   if (opts.skipChannels ?? opts.skipProviders) {
-    await prompter.note("Skipping channel setup.", "Channels");
+    await prompter.note(t("wizard.skipChannelsNote"), t("wizard.channelsTitle"));
   } else {
     const { listChannelPlugins } = await import("../channels/plugins/index.js");
     const { setupChannels } = await import("../commands/onboard-channels.js");
@@ -735,6 +811,7 @@ export async function runSetupWizard(
     });
   }
 
+  nextConfig = applySelectedLocale(nextConfig);
   nextConfig = await writeWizardConfigFile(nextConfig);
   const { logConfigUpdated } = await loadConfigLoggingModule();
   logConfigUpdated(runtime);
@@ -744,7 +821,7 @@ export async function runSetupWizard(
   });
 
   if (opts.skipSearch) {
-    await prompter.note("Skipping search setup.", "Search");
+    await prompter.note(t("wizard.skipSearchNote"), t("wizard.searchTitle"));
   } else {
     const { setupSearch } = await import("../commands/onboard-search.js");
     nextConfig = await setupSearch(nextConfig, runtime, prompter, {
@@ -754,7 +831,7 @@ export async function runSetupWizard(
   }
 
   if (opts.skipSkills) {
-    await prompter.note("Skipping skills setup.", "Skills");
+    await prompter.note(t("wizard.skipSkillsNote"), t("wizard.skillsTitle"));
   } else {
     const { setupSkills } = await import("../commands/onboard-skills.js");
     nextConfig = await setupSkills(nextConfig, workspaceDir, runtime, prompter);
@@ -781,7 +858,10 @@ export async function runSetupWizard(
   const { setupInternalHooks } = await import("../commands/onboard-hooks.js");
   nextConfig = await setupInternalHooks(nextConfig, runtime, prompter);
 
-  nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
+  nextConfig = onboardHelpers.applyWizardMetadata(applySelectedLocale(nextConfig), {
+    command: "onboard",
+    mode,
+  });
   nextConfig = await writeWizardConfigFile(nextConfig);
 
   const { finalizeSetupWizard } = await import("./setup.finalize.js");


### PR DESCRIPTION
## Summary
This bundles the Chinese setup localization work into one reviewable branch and addresses the unresolved review points from the earlier PR set.

### Included
- add CLI setup locale selection (`en` / `zh-CN`) and message catalog
- expand zh-CN localization coverage across setup wizard prompts and finalization notes
- persist selected locale to `config.cli.locale`
- preserve the effective locale from `OPENCLAW_LOCALE`, existing config, LANG auto-detection, and interactive selection even when the user chooses **Reset** during config handling
- localize invalid-config, web-search, Codex-native search, and unavailable-provider setup notes
- align token storage copy with the Control UI `sessionStorage` behavior
- document the public `cli.locale` / `OPENCLAW_LOCALE` config surface and add a changelog entry

## Why this PR
The previous contribution was split across:
- #34368
- #34494
- #34533
- #35432

This PR is a consolidated, maintainer-friendly branch with the follow-up fixes applied.

## Validation
Ran on `openclaw-vn:/root/openclaw_pr44695_rework`:

```bash
git diff --check
node --experimental-strip-types --input-type=module < i18n smoke script
```

Observed:

```text
i18n smoke ok
```

Full `corepack pnpm config:schema:check` / target vitest could not complete on the VN host after the latest main rebase because `corepack pnpm install --frozen-lockfile` filled the 19G root filesystem and failed with `ERR_PNPM_ENOSPC`. CI is the authoritative full validation for this push.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: zh-CN setup locale normalization and translated setup/finalization output, including Codex-native web-search notes and token-storage copy.
- Real environment tested: `openclaw-vn` remote Linux host, `/root/openclaw_pr44695_rework`, PR commit `85d5c33099`.
- Exact steps or command run after this patch:

  ```bash
  cd /root/openclaw_pr44695_rework
  OPENCLAW_LOCALE=zh_CN.UTF-8 node --experimental-strip-types --input-type=module <<'NODE'
  import { cliT, parseCliLocale } from "./src/i18n/cli.ts";
  console.log(`parseCliLocale(zh_CN.UTF-8) => ${parseCliLocale("zh_CN.UTF-8")}`);
  console.log(cliT("wizard.languageQuestion"));
  console.log(cliT("wizard.webSearchCodexNativeSummaryLine", process.env, { mode: "cached" }));
  console.log(cliT("wizard.webSearchProviderUnavailableLine", process.env, { provider: "ExampleSearch" }));
  console.log(cliT("wizard.tokenInfoBody", process.env, {
    viewTokenCommand: "openclaw config get gateway.auth.token",
    generateTokenCommand: "openclaw gateway token rotate",
    openDashboardCommand: "openclaw dashboard",
  }).split("\n")[4]);
  NODE
  ```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live terminal output from the VN host:

  ```text
  parseCliLocale(zh_CN.UTF-8) => zh-CN
  语言 / Language
  Codex 原生搜索：cached，仅适用于支持 Codex 的模型
  已选择 Web 搜索提供商 ExampleSearch，但当前插件策略未开放它。
  Control UI 会按所选 gateway URL，把 dashboard URL 中的 token 保存在当前浏览器标签页的 sessionStorage 中。
  ```

- Observed result after fix: `zh_CN.UTF-8` normalizes to persisted `zh-CN`, the language prompt renders in zh-CN, Codex-native web-search and unavailable-provider setup notes render in zh-CN, and the token note now says `sessionStorage` instead of `localStorage`.
- What was not tested: full interactive setup was not rerun on the VN host because the dependency install needed for the CLI runtime failed with `ERR_PNPM_ENOSPC` on the host root filesystem.
- Before evidence (optional but encouraged): the previous PR head emitted English Codex-native web-search note literals and described Control UI token storage as `localStorage`.
