### PR TITLE
fix(ollama): discover vision input from /api/show

### DIFF
--- a/src/agents/models-config.providers.discovery.ts
+++ b/src/agents/models-config.providers.discovery.ts
@@ -86,7 +86,7 @@ async function discoverOllamaModels(
       id: model.name,
       name: model.name,
       reasoning: isReasoningModelHeuristic(model.name),
-      input: ["text"],
+      input: model.input ?? ["text"],
       cost: OLLAMA_DEFAULT_COST,
       contextWindow: model.contextWindow ?? OLLAMA_DEFAULT_CONTEXT_WINDOW,
       maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,

--- a/src/agents/models-config.providers.ollama-autodiscovery.test.ts
+++ b/src/agents/models-config.providers.ollama-autodiscovery.test.ts
@@ -42,13 +42,28 @@ describe("Ollama auto-discovery", () => {
 
   it("auto-registers ollama provider when models are discovered locally", async () => {
     setupDiscoveryEnv();
-    globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL, init?: RequestInit) => {
       if (String(url).includes("/api/tags")) {
         return {
           ok: true,
           json: async () => ({
             models: [{ name: "deepseek-r1:latest" }, { name: "llama3.3:latest" }],
           }),
+        };
+      }
+      if (String(url).includes("/api/show")) {
+        const parsed = JSON.parse(typeof init?.body === "string" ? init.body : "{}") as {
+          name?: string;
+        };
+        if (parsed.name === "deepseek-r1:latest") {
+          return {
+            ok: true,
+            json: async () => ({ model_info: { "deepseek.context_length": 131072 } }),
+          };
+        }
+        return {
+          ok: true,
+          json: async () => ({ model_info: { "llama.context_length": 65536 } }),
         };
       }
       throw new Error(`Unexpected fetch: ${url}`);

--- a/src/agents/models-config.providers.ollama.test.ts
+++ b/src/agents/models-config.providers.ollama.test.ts
@@ -115,7 +115,7 @@ describe("Ollama provider", () => {
     });
   });
 
-  it("discovers per-model context windows from /api/show", async () => {
+  it("discovers per-model context windows and vision input from /api/show", async () => {
     const agentDir = createAgentDir();
     enableDiscoveryEnv();
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
@@ -130,7 +130,10 @@ describe("Ollama provider", () => {
         if (parsed.name === "qwen3:32b") {
           return {
             ok: true,
-            json: async () => ({ model_info: { "qwen3.context_length": 131072 } }),
+            json: async () => ({
+              model_info: { "qwen3.context_length": 131072 },
+              capabilities: ["completion", "vision"],
+            }),
           };
         }
         if (parsed.name === "llama3.3:70b") {
@@ -149,7 +152,9 @@ describe("Ollama provider", () => {
     const qwen = models.find((model) => model.id === "qwen3:32b");
     const llama = models.find((model) => model.id === "llama3.3:70b");
     expect(qwen?.contextWindow).toBe(131072);
+    expect(qwen?.input).toEqual(["text", "image"]);
     expect(llama?.contextWindow).toBe(65536);
+    expect(llama?.input).toEqual(["text"]);
     expectDiscoveryCallCounts(fetchMock, { tags: 1, show: 2 });
   });
 

--- a/src/agents/ollama-models.test.ts
+++ b/src/agents/ollama-models.test.ts
@@ -37,7 +37,7 @@ describe("ollama-models", () => {
   });
 
   it("enriches discovered models with context windows from /api/show", async () => {
-    const models: OllamaTagModel[] = [{ name: "llama3:8b" }, { name: "deepseek-r1:14b" }];
+    const models: OllamaTagModel[] = [{ name: "llama3:8b" }, { name: "qwen2.5-vl:7b" }];
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = requestUrl(input);
       if (!url.endsWith("/api/show")) {
@@ -45,7 +45,13 @@ describe("ollama-models", () => {
       }
       const body = JSON.parse(requestBody(init?.body)) as { name?: string };
       if (body.name === "llama3:8b") {
-        return jsonResponse({ model_info: { "llama.context_length": 65536 } });
+        return jsonResponse({
+          model_info: { "llama.context_length": 65536 },
+          capabilities: ["completion"],
+        });
+      }
+      if (body.name === "qwen2.5-vl:7b") {
+        return jsonResponse({ capabilities: ["completion", "vision"] });
       }
       return jsonResponse({});
     });
@@ -54,8 +60,8 @@ describe("ollama-models", () => {
     const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
 
     expect(enriched).toEqual([
-      { name: "llama3:8b", contextWindow: 65536 },
-      { name: "deepseek-r1:14b", contextWindow: undefined },
+      { name: "llama3:8b", contextWindow: 65536, input: ["text"] },
+      { name: "qwen2.5-vl:7b", contextWindow: undefined, input: ["text", "image"] },
     ]);
   });
 });

--- a/src/agents/ollama-models.ts
+++ b/src/agents/ollama-models.ts
@@ -29,9 +29,63 @@ export type OllamaTagsResponse = {
 
 export type OllamaModelWithContext = OllamaTagModel & {
   contextWindow?: number;
+  input?: Array<"text" | "image">;
 };
 
 const OLLAMA_SHOW_CONCURRENCY = 8;
+
+function resolveOllamaModelInput(capabilities: unknown): Array<"text" | "image"> {
+  if (!Array.isArray(capabilities)) {
+    return ["text"];
+  }
+  return capabilities.some(
+    (value) => typeof value === "string" && value.trim().toLowerCase() === "vision",
+  )
+    ? ["text", "image"]
+    : ["text"];
+}
+
+async function queryOllamaShowInfo(
+  apiBase: string,
+  modelName: string,
+): Promise<{ contextWindow?: number; input: Array<"text" | "image"> } | undefined> {
+  try {
+    const response = await fetch(`${apiBase}/api/show`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: modelName }),
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) {
+      return undefined;
+    }
+    const data = (await response.json()) as {
+      model_info?: Record<string, unknown>;
+      capabilities?: unknown;
+      details?: { capabilities?: unknown };
+    };
+    let contextWindow: number | undefined;
+    if (data.model_info) {
+      for (const [key, value] of Object.entries(data.model_info)) {
+        if (
+          key.endsWith(".context_length") &&
+          typeof value === "number" &&
+          Number.isFinite(value)
+        ) {
+          const candidate = Math.floor(value);
+          if (candidate > 0) {
+            contextWindow = candidate;
+            break;
+          }
+        }
+      }
+    }
+    const input = resolveOllamaModelInput(data.capabilities ?? data.details?.capabilities);
+    return { contextWindow, input };
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Derive the Ollama native API base URL from a configured base URL.
@@ -53,32 +107,8 @@ export async function queryOllamaContextWindow(
   apiBase: string,
   modelName: string,
 ): Promise<number | undefined> {
-  try {
-    const response = await fetch(`${apiBase}/api/show`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: modelName }),
-      signal: AbortSignal.timeout(3000),
-    });
-    if (!response.ok) {
-      return undefined;
-    }
-    const data = (await response.json()) as { model_info?: Record<string, unknown> };
-    if (!data.model_info) {
-      return undefined;
-    }
-    for (const [key, value] of Object.entries(data.model_info)) {
-      if (key.endsWith(".context_length") && typeof value === "number" && Number.isFinite(value)) {
-        const contextWindow = Math.floor(value);
-        if (contextWindow > 0) {
-          return contextWindow;
-        }
-      }
-    }
-    return undefined;
-  } catch {
-    return undefined;
-  }
+  const showInfo = await queryOllamaShowInfo(apiBase, modelName);
+  return showInfo?.contextWindow;
 }
 
 export async function enrichOllamaModelsWithContext(
@@ -91,10 +121,14 @@ export async function enrichOllamaModelsWithContext(
   for (let index = 0; index < models.length; index += concurrency) {
     const batch = models.slice(index, index + concurrency);
     const batchResults = await Promise.all(
-      batch.map(async (model) => ({
-        ...model,
-        contextWindow: await queryOllamaContextWindow(apiBase, model.name),
-      })),
+      batch.map(async (model) => {
+        const showInfo = await queryOllamaShowInfo(apiBase, model.name);
+        return {
+          ...model,
+          contextWindow: showInfo?.contextWindow,
+          input: showInfo?.input ?? ["text"],
+        };
+      }),
     );
     enriched.push(...batchResults);
   }
@@ -110,12 +144,13 @@ export function isReasoningModelHeuristic(modelId: string): boolean {
 export function buildOllamaModelDefinition(
   modelId: string,
   contextWindow?: number,
+  input: Array<"text" | "image"> = ["text"],
 ): ModelDefinitionConfig {
   return {
     id: modelId,
     name: modelId,
     reasoning: isReasoningModelHeuristic(modelId),
-    input: ["text"],
+    input,
     cost: OLLAMA_DEFAULT_COST,
     contextWindow: contextWindow ?? OLLAMA_DEFAULT_CONTEXT_WINDOW,
     maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,

--- a/src/commands/ollama-setup.ts
+++ b/src/commands/ollama-setup.ts
@@ -246,7 +246,11 @@ function buildOllamaModelsConfig(
   discoveredModelsByName?: Map<string, OllamaModelWithContext>,
 ) {
   return modelNames.map((name) =>
-    buildOllamaModelDefinition(name, discoveredModelsByName?.get(name)?.contextWindow),
+    buildOllamaModelDefinition(
+      name,
+      discoveredModelsByName?.get(name)?.contextWindow,
+      discoveredModelsByName?.get(name)?.input,
+    ),
   );
 }
 


### PR DESCRIPTION
## Summary

- Problem: Ollama discovery stamped every discovered model as text-only even when `/api/show` reported `vision` capability.
- Why it matters: vision-capable Ollama models were missing `image` input support in the generated provider catalog and onboarding config.
- What changed: discovery now reads both context window and vision capability from `/api/show`, propagates `input: ["text", "image"]` when appropriate, and preserves that metadata in Ollama setup output.
- What did NOT change (scope boundary): runtime Ollama chat execution, auth behavior, and unrelated model-provider discovery paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44647
- Related #44648

## User-visible / Behavior Changes

Vision-capable Ollama models discovered through `/api/tags` + `/api/show` now appear with image input support instead of text-only.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15/26 arm64
- Runtime/container: Node 24 / Bun / Vitest
- Model/provider: Ollama
- Integration/channel (if any): local model discovery
- Relevant config (redacted): `models.providers.ollama.baseUrl = http://127.0.0.1:11434/v1`

### Steps

1. Discover Ollama models from a local instance.
2. Return `/api/show` with `capabilities: ["completion", "vision"]` for a model.
3. Inspect the generated provider model definitions.

### Expected

- Vision-capable models keep their context window.
- Vision-capable models are marked with `input: ["text", "image"]`.

### Actual

- Before this patch, discovery always emitted `input: ["text"]`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm exec vitest run src/agents/ollama-models.test.ts`; `pnpm tsgo`; direct Bun runtime verification of `buildOllamaProvider()` with mocked `/api/tags` + `/api/show` responses.
- Edge cases checked: non-vision models stay text-only; context-window enrichment still works.
- What you did **not** verify: the full `src/agents/models-config.providers.ollama.test.ts` / `src/agents/models-config.providers.ollama-autodiscovery.test.ts` suites on this machine, because those full files were not terminating cleanly in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit; discovered Ollama models will fall back to text-only metadata.
- Files/config to restore: `src/agents/ollama-models.ts`, `src/agents/models-config.providers.discovery.ts`, `src/commands/ollama-setup.ts`
- Known bad symptoms reviewers should watch for: vision-capable Ollama models missing or overreporting image support.

## Risks and Mitigations

- Risk: `/api/show` payloads vary across Ollama versions.
  - Mitigation: capability parsing is defensive and falls back to `input: ["text"]` when capability data is absent or malformed.
