### PR TITLE
fix(cron): report "not-requested" when delivery.mode is "none"

### DIFF
--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -151,14 +151,17 @@ describe("CronService persists delivered status", () => {
     expect(updated?.state.lastDeliveryError).toBeUndefined();
   });
 
-  it("persists lastDelivered=false when isolated job explicitly reports not delivered", async () => {
+  it("persists not-requested when delivery.mode=none and runner reports delivered=false", async () => {
+    // When delivery was never requested (mode: "none"), delivered=false from
+    // the runner should resolve to "not-requested", not "not-delivered".
+    // See: https://github.com/openclaw/openclaw/issues/44533
     const updated = await runIsolatedJobAndReadState({
       job: buildIsolatedAgentTurnJob("delivered-false"),
       delivered: false,
     });
     expectSuccessfulCronRun(updated);
     expect(updated?.state.lastDelivered).toBe(false);
-    expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
     expect(updated?.state.lastDeliveryError).toBeUndefined();
   });
 

--- a/src/cron/service/delivery-status.test.ts
+++ b/src/cron/service/delivery-status.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import { resolveDeliveryStatus } from "./timer.js";
+
+function makeJob(delivery?: { mode?: string }): CronJob {
+  return {
+    id: "test-job",
+    name: "test",
+    schedule: { kind: "every", everyMs: 60_000 },
+    payload: { kind: "agentTurn", message: "hello" },
+    sessionTarget: "isolated",
+    enabled: true,
+    state: {},
+    ...(delivery ? { delivery } : {}),
+  } as CronJob;
+}
+
+describe("resolveDeliveryStatus", () => {
+  it('returns "not-requested" when delivery.mode is "none" and delivered is false', () => {
+    const job = makeJob({ mode: "none" });
+    expect(resolveDeliveryStatus({ job, delivered: false })).toBe("not-requested");
+  });
+
+  it('returns "not-requested" when delivery.mode is "none" and delivered is undefined', () => {
+    const job = makeJob({ mode: "none" });
+    expect(resolveDeliveryStatus({ job })).toBe("not-requested");
+  });
+
+  it('returns "delivered" when delivery.mode is "none" but delivered is true', () => {
+    // A messaging-tool send or other path can mark delivered=true even when
+    // cron delivery was not configured. That real delivery should be reported.
+    const job = makeJob({ mode: "none" });
+    expect(resolveDeliveryStatus({ job, delivered: true })).toBe("delivered");
+  });
+
+  it('returns "delivered" when delivery is requested and delivered is true', () => {
+    const job = makeJob({ mode: "announce" });
+    expect(resolveDeliveryStatus({ job, delivered: true })).toBe("delivered");
+  });
+
+  it('returns "not-delivered" when delivery is requested and delivered is false', () => {
+    const job = makeJob({ mode: "announce" });
+    expect(resolveDeliveryStatus({ job, delivered: false })).toBe("not-delivered");
+  });
+
+  it('returns "unknown" when delivery is requested and delivered is undefined', () => {
+    const job = makeJob({ mode: "announce" });
+    expect(resolveDeliveryStatus({ job })).toBe("unknown");
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -161,14 +161,20 @@ function resolveRetryConfig(cronConfig?: CronConfig) {
   };
 }
 
-function resolveDeliveryStatus(params: { job: CronJob; delivered?: boolean }): CronDeliveryStatus {
+export function resolveDeliveryStatus(params: {
+  job: CronJob;
+  delivered?: boolean;
+}): CronDeliveryStatus {
   if (params.delivered === true) {
     return "delivered";
+  }
+  if (!resolveCronDeliveryPlan(params.job).requested) {
+    return "not-requested";
   }
   if (params.delivered === false) {
     return "not-delivered";
   }
-  return resolveCronDeliveryPlan(params.job).requested ? "unknown" : "not-requested";
+  return "unknown";
 }
 
 function normalizeCronMessageChannel(input: unknown): CronMessageChannel | undefined {


### PR DESCRIPTION
Closes #44533

## Problem

Cron jobs with `delivery: { mode: "none" }` incorrectly report `lastDeliveryStatus: "not-delivered"` instead of `"not-requested"`. This triggers false failure alerts and makes health dashboards misleading.

## Root cause

`resolveDeliveryStatus` checked `delivered === false` before checking whether delivery was even requested. When `delivery.mode = "none"`, the delivery dispatch is skipped and the runner returns `delivered: false`. The old ordering mapped that to `"not-delivered"` even though no delivery was configured.

## Fix

Reorder the check: when the delivery plan says `requested: false`, return `"not-requested"` regardless of the `delivered` flag. The one exception is `delivered: true`, which can still happen through messaging-tool sends and should be reported truthfully.

Before:
```
delivered === true   → "delivered"
delivered === false  → "not-delivered"     ← bug: ignores mode=none
else                 → requested ? "unknown" : "not-requested"
```

After:
```
delivered === true   → "delivered"
!requested           → "not-requested"     ← correct for mode=none
delivered === false  → "not-delivered"
else                 → "unknown"
```

## Testing

- Added `src/cron/service/delivery-status.test.ts` with 6 targeted tests for the reordered logic
- Updated the existing `persists-delivered-status` integration test to expect `"not-requested"` for mode=none jobs
- All 516 cron tests pass

Co-authored-by: Daniel <dsantoreis@gmail.com>