### PR TITLE
fix(docker-setup): allow OPENCLAW_CONFIG_DIR paths with spaces

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -144,10 +144,8 @@ validate_mount_path_value() {
   if contains_disallowed_chars "$value"; then
     fail "$label contains unsupported control characters."
   fi
-  if [[ "$value" =~ [[:space:]] ]]; then
-    fail "$label cannot contain whitespace."
-  fi
 }
+
 
 validate_named_volume() {
   local value="$1"

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -205,6 +205,22 @@ describe("docker-setup.sh", () => {
     expect(identityDirStat.isDirectory()).toBe(true);
   });
 
+  it("accepts OPENCLAW_CONFIG_DIR paths with spaces", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    const configDir = join(activeSandbox.rootDir, "config with spaces");
+    const workspaceDir = join(activeSandbox.rootDir, "workspace with spaces");
+
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_CONFIG_DIR: configDir,
+      OPENCLAW_WORKSPACE_DIR: workspaceDir,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const configDirStat = await stat(configDir);
+    expect(configDirStat.isDirectory()).toBe(true);
+  });
+
   it("precreates agent data dirs to avoid EACCES in container", async () => {
     const activeSandbox = requireSandbox(sandbox);
     const configDir = join(activeSandbox.rootDir, "config-agent-dirs");


### PR DESCRIPTION
## Problem

`docker-setup.sh` rejects whitespace in `OPENCLAW_CONFIG_DIR` / `OPENCLAW_WORKSPACE_DIR` with:

- `OPENCLAW_CONFIG_DIR cannot contain whitespace.`

That breaks common Windows / Git Bash setups where the cloned repo or home path contains spaces, even though the script already quotes mount paths correctly.

## Fix

Allow ordinary spaces in mount paths and continue rejecting only control characters.

## Tests

Added an e2e regression test covering `OPENCLAW_CONFIG_DIR` / `OPENCLAW_WORKSPACE_DIR` values with spaces.

Closes #44599
