### PR TITLE
fix(cli): add windowsHide to restart script spawn to suppress console windows

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -287,6 +287,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("/bin/sh", [scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -302,6 +303,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -317,6 +319,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", `"${scriptPath}"`], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
     });
   });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -169,6 +169,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    windowsHide: true,
   });
   child.unref();
 }


### PR DESCRIPTION
## Problem

On Windows, the `runRestartScript()` function in the update-cli restart helper spawns a detached `cmd.exe` process without `windowsHide: true`. This causes multiple visible command prompt windows to briefly flash during gateway restarts, showing `findstr` commands from the port-checking loop.

## Root cause

The spawn call in `restart-helper.ts` was missing the `windowsHide` option, even though every other spawn site in the codebase already includes it (`machine-name.ts`, `invoke.ts`, `resolve.ts`, `windows-spawn.ts`, etc).

## Fix

Add `windowsHide: true` to the spawn options in `runRestartScript()`. This is a no-op on non-Windows platforms and suppresses console window creation on Windows.

## Testing

- All 20 existing tests in `restart-helper.test.ts` updated and passing
- Tests now verify the `windowsHide: true` option is included in spawn calls for both Linux and Windows paths

Fixes #44693