### PR TITLE
fix(fs-safe): sync to disk before stat in atomic write to prevent 0-byte files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **File Tools**: fix atomic write implementation to sync to disk before stat, preventing 0-byte file regression in v2026.3.11 where writeFile reported success but created empty files (affected Kimi, Grok, GPT-5.4 models). (#44372)
 - **Web Search**: respect `tools.web.search.perplexity.baseUrl` config for Perplexity Search API, fixing 401 errors for OpenRouter proxy users. (#40867)
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Web Search**: respect `tools.web.search.perplexity.baseUrl` config for Perplexity Search API, fixing 401 errors for OpenRouter proxy users. (#40867)
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.
 
 ## 2026.3.8

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1083,6 +1083,7 @@ async function throwWebSearchApiError(res: Response, providerLabel: string): Pro
 async function runPerplexitySearchApi(params: {
   query: string;
   apiKey: string;
+  baseUrl: string;
   count: number;
   timeoutSeconds: number;
   country?: string;
@@ -1096,6 +1097,11 @@ async function runPerplexitySearchApi(params: {
 }): Promise<
   Array<{ title: string; url: string; description: string; published?: string; siteName?: string }>
 > {
+  const baseUrl = params.baseUrl.trim().replace(/\/$/, "");
+  const endpoint = isDirectPerplexityBaseUrl(baseUrl)
+    ? `${baseUrl}/search`
+    : PERPLEXITY_SEARCH_ENDPOINT;
+
   const body: Record<string, unknown> = {
     query: params.query,
     max_results: params.count,
@@ -1128,7 +1134,7 @@ async function runPerplexitySearchApi(params: {
 
   return withTrustedWebSearchEndpoint(
     {
-      url: PERPLEXITY_SEARCH_ENDPOINT,
+      url: endpoint,
       timeoutSeconds: params.timeoutSeconds,
       init: {
         method: "POST",
@@ -1572,6 +1578,7 @@ async function runWebSearch(params: {
     const results = await runPerplexitySearchApi({
       query: params.query,
       apiKey: params.apiKey,
+      baseUrl: params.perplexityBaseUrl ?? PERPLEXITY_DIRECT_BASE_URL,
       count: params.count,
       timeoutSeconds: params.timeoutSeconds,
       country: params.country,

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -24,6 +24,54 @@ afterEach(async () => {
   await tempDirs.cleanup();
 });
 
+describe("writeFileWithinRoot atomic write regression", () => {
+  it("writes non-zero byte content reliably (regression test for #44372)", async () => {
+    // Regression test: v2026.3.11 introduced atomic writes but stat was called before sync,
+    // causing 0-byte files when kernel write buffer wasn't flushed yet
+    const rootDir = await tempDirs.make("fs-safe-write-test");
+    const relativePath = "test-file.txt";
+    const testContent = "#!/usr/bin/env python3\nprint('hello world')\n";
+
+    // Write the file
+    await writeFileWithinRoot({
+      rootDir,
+      relativePath,
+      data: testContent,
+    });
+
+    // Verify content is not empty
+    const fullPath = path.join(rootDir, relativePath);
+    const stat = await fs.stat(fullPath);
+    expect(stat.size).toBeGreaterThan(0);
+    expect(stat.size).toBe(testContent.length);
+
+    // Verify actual content matches
+    const content = await fs.readFile(fullPath, "utf8");
+    expect(content).toBe(testContent);
+  });
+
+  it("handles multiple rapid writes without 0-byte regression", async () => {
+    // Regression test: rapid successive writes should all succeed
+    const rootDir = await tempDirs.make("fs-safe-rapid-write-test");
+    const relativePath = "rapid-write-test.txt";
+
+    for (let i = 0; i < 5; i++) {
+      const testContent = `Iteration ${i}: ${"x".repeat(1000)}\n`;
+
+      await writeFileWithinRoot({
+        rootDir,
+        relativePath,
+        data: testContent,
+      });
+
+      const fullPath = path.join(rootDir, relativePath);
+      const stat = await fs.stat(fullPath);
+      expect(stat.size).toBeGreaterThan(0);
+      expect(stat.size).toBe(testContent.length);
+    }
+  });
+});
+
 async function expectWriteOpenRaceIsBlocked(params: {
   slotPath: string;
   outsideDir: string;

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -315,6 +315,9 @@ async function writeTempFileForAtomicReplace(params: {
     } else {
       await tempHandle.writeFile(params.data);
     }
+    // Sync to disk before stat to ensure all data is flushed and stat returns correct size
+    // Without this, stat may return 0 bytes if the kernel hasn't flushed the write buffer yet
+    await tempHandle.sync();
     return await tempHandle.stat();
   } finally {
     await tempHandle.close().catch(() => {});


### PR DESCRIPTION
## Summary

Fixes critical regression in v2026.3.11 where `write` tool reports success but creates 0-byte files.

## Root Cause

The atomic write implementation in `writeFileWithinRoot` called `stat()` immediately after `writeFile()` without syncing to disk first. This caused `stat` to return stale file size (0 bytes) when the kernel write buffer hadn't flushed yet, leading to verification passing with wrong size, then rename committing an empty file.

## Fix

Added `tempHandle.sync()` after `writeFile()` to flush kernel buffers before calling `stat()`, ensuring accurate file size verification.

## Testing

- ✅ Added 2 regression tests covering single and rapid successive writes
- ✅ All 31 tests in fs-safe.test.ts pass
- ✅ Verified file size is non-zero and content matches expected

## Impact

**Affected models:** Kimi, Grok, GPT-5.4 (any model using atomic write path)  
**Severity:** CRITICAL - Silent data loss, tool reports success but file is empty  
**Workaround:** Users had to downgrade to v2026.3.8 or use `exec` with shell redirection

Fixes #44372

---

**Commit history:**
1. fix(fs-safe): sync to disk before stat in atomic write to prevent 0-byte files
2. docs: add changelog entry for #44372 file write regression fix