### PR TITLE
feat(tts): add MiniMax as a TTS provider

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,6 +1,6 @@
 import type { SecretInput } from "./types.secrets.js";
 
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "minimax";
 
 export type TtsMode = "final" | "all";
 
@@ -65,6 +65,20 @@ export type TtsConfig = {
     speed?: number;
     /** System-level instructions for the TTS model (gpt-4o-mini-tts only). */
     instructions?: string;
+  };
+  /** MiniMax TTS configuration. */
+  minimax?: {
+    apiKey?: SecretInput;
+    /** MiniMax TTS model (e.g. "speech-02-hd", "speech-02-turbo"). */
+    model?: string;
+    /** Voice ID (e.g. "male-qn-qingse", "female-shaonv"). */
+    voice?: string;
+    /** Playback speed (0.5–2.0, default 1.0). */
+    speed?: number;
+    /** Volume (0.5–2.0, default 1.0). */
+    vol?: number;
+    /** Audio sample rate in Hz (8000, 16000, 22050, 24000, 32000, 44100). */
+    sampleRate?: number;
   };
   /** Microsoft Edge (node-edge-tts) configuration. */
   edge?: {

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -69,14 +69,29 @@ export type TtsConfig = {
   /** MiniMax TTS configuration. */
   minimax?: {
     apiKey?: SecretInput;
-    /** MiniMax TTS model (e.g. "speech-02-hd", "speech-02-turbo"). */
+    /** MiniMax TTS model (e.g. "speech-2.8-hd", "speech-2.8-turbo"). */
     model?: string;
-    /** Voice ID (e.g. "male-qn-qingse", "female-shaonv"). */
+    /** Voice ID (e.g. "male-qn-qingse", "female-shaonv"). See MiniMax voice list for available IDs. */
     voice?: string;
     /** Playback speed (0.5–2.0, default 1.0). */
     speed?: number;
-    /** Volume (0.5–2.0, default 1.0). */
+    /** Volume (0–10, default 1.0). */
     vol?: number;
+    /** Pitch shift in semitones (−12–12, default 0). */
+    pitch?: number;
+    /** Emotion style applied to the synthesised speech. */
+    emotion?:
+      | "happy"
+      | "sad"
+      | "angry"
+      | "fearful"
+      | "disgusted"
+      | "surprised"
+      | "calm"
+      | "fluent"
+      | "whisper";
+    /** Audio output format (default "mp3"). */
+    outputFormat?: "mp3" | "pcm" | "flac" | "wav";
     /** Audio sample rate in Hz (8000, 16000, 22050, 24000, 32000, 44100). */
     sampleRate?: number;
   };

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -75,7 +75,7 @@ export type TtsConfig = {
     voice?: string;
     /** Playback speed (0.5–2.0, default 1.0). */
     speed?: number;
-    /** Volume (0–10, default 1.0). */
+    /** Volume (>0–10, default 1.0). Must be strictly positive. */
     vol?: number;
     /** Pitch shift in semitones (−12–12, default 0). */
     pitch?: number;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -353,7 +353,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "minimax"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -406,6 +406,17 @@ export const TtsConfigSchema = z
         voice: z.string().optional(),
         speed: z.number().min(0.25).max(4).optional(),
         instructions: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    minimax: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        model: z.string().optional(),
+        voice: z.string().optional(),
+        speed: z.number().min(0.5).max(2).optional(),
+        vol: z.number().min(0.5).max(2).optional(),
+        sampleRate: z.number().int().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -415,7 +415,22 @@ export const TtsConfigSchema = z
         model: z.string().optional(),
         voice: z.string().optional(),
         speed: z.number().min(0.5).max(2).optional(),
-        vol: z.number().min(0.5).max(2).optional(),
+        vol: z.number().positive().max(10).optional(),
+        pitch: z.number().int().min(-12).max(12).optional(),
+        emotion: z
+          .enum([
+            "happy",
+            "sad",
+            "angry",
+            "fearful",
+            "disgusted",
+            "surprised",
+            "calm",
+            "fluent",
+            "whisper",
+          ])
+          .optional(),
+        outputFormat: z.enum(["mp3", "pcm", "flac", "wav"]).optional(),
         sampleRate: z.number().int().optional(),
       })
       .strict()

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -13,6 +13,7 @@ import {
   setTtsEnabled,
   setTtsProvider,
   textToSpeech,
+  TTS_PROVIDERS,
 } from "../../tts/tts.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 import { formatForLog } from "../ws-log.js";
@@ -38,6 +39,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         prefsPath,
         hasOpenAIKey: Boolean(resolveTtsApiKey(config, "openai")),
         hasElevenLabsKey: Boolean(resolveTtsApiKey(config, "elevenlabs")),
+        hasMiniMaxKey: Boolean(resolveTtsApiKey(config, "minimax")),
         edgeEnabled: isTtsProviderConfigured(config, "edge"),
       });
     } catch (err) {
@@ -100,13 +102,13 @@ export const ttsHandlers: GatewayRequestHandlers = {
   },
   "tts.setProvider": async ({ params, respond }) => {
     const provider = typeof params.provider === "string" ? params.provider.trim() : "";
-    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge") {
+    if (!(TTS_PROVIDERS as readonly string[]).includes(provider)) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "Invalid provider. Use openai, elevenlabs, or edge.",
+          `Invalid provider. Use ${TTS_PROVIDERS.join(", ")}.`,
         ),
       );
       return;
@@ -140,6 +142,12 @@ export const ttsHandlers: GatewayRequestHandlers = {
             name: "ElevenLabs",
             configured: Boolean(resolveTtsApiKey(config, "elevenlabs")),
             models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_monolingual_v1"],
+          },
+          {
+            id: "minimax",
+            name: "MiniMax",
+            configured: Boolean(resolveTtsApiKey(config, "minimax")),
+            models: ["speech-02-hd", "speech-02-turbo"],
           },
           {
             id: "edge",

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -147,7 +147,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
             id: "minimax",
             name: "MiniMax",
             configured: Boolean(resolveTtsApiKey(config, "minimax")),
-            models: ["speech-02-hd", "speech-02-turbo"],
+            models: ["speech-2.8-hd", "speech-2.8-turbo", "speech-2.6-hd", "speech-2.6-turbo"],
           },
           {
             id: "edge",

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -716,3 +716,69 @@ export async function edgeTTS(params: {
   });
   await tts.ttsPromise(text, outputPath);
 }
+
+const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.chat/v1";
+export const DEFAULT_MINIMAX_MODEL = "speech-02-hd";
+export const DEFAULT_MINIMAX_VOICE = "male-qn-qingse";
+const MINIMAX_VALID_SAMPLE_RATES = new Set([8000, 16000, 22050, 24000, 32000, 44100]);
+
+export async function minimaxTTS(params: {
+  text: string;
+  apiKey: string;
+  model: string;
+  voice: string;
+  speed?: number;
+  vol?: number;
+  sampleRate?: number;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const { text, apiKey, model, voice, timeoutMs } = params;
+  const speed = params.speed ?? 1.0;
+  const vol = params.vol ?? 1.0;
+  const sampleRate = MINIMAX_VALID_SAMPLE_RATES.has(params.sampleRate ?? 0)
+    ? params.sampleRate!
+    : 32000;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(`${DEFAULT_MINIMAX_BASE_URL}/t2a_v2`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        text,
+        stream: false,
+        voice_setting: { voice_id: voice, speed, vol, pitch: 0 },
+        audio_setting: { sample_rate: sampleRate, bitrate: 128000, format: "mp3", channel: 1 },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(`MiniMax TTS API error (${response.status}): ${body.slice(0, 200)}`);
+    }
+
+    const json = (await response.json()) as {
+      base_resp?: { status_code?: number; status_msg?: string };
+      data?: { audio?: string };
+    };
+    if (json.base_resp?.status_code !== 0) {
+      throw new Error(
+        `MiniMax TTS error: ${json.base_resp?.status_msg ?? "unknown"} (code ${json.base_resp?.status_code})`,
+      );
+    }
+    const hexAudio = json.data?.audio;
+    if (!hexAudio) {
+      throw new Error("MiniMax TTS: empty audio in response");
+    }
+    return Buffer.from(hexAudio, "hex");
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -745,7 +745,7 @@ export async function edgeTTS(params: {
 }
 
 const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.chat/v1";
-export const DEFAULT_MINIMAX_MODEL = "speech-02-hd";
+export const DEFAULT_MINIMAX_MODEL = "speech-2.8-hd";
 export const DEFAULT_MINIMAX_VOICE = "male-qn-qingse";
 export const MINIMAX_OUTPUT_FORMATS = ["mp3", "pcm", "flac", "wav"] as const;
 export const MINIMAX_EMOTIONS = [

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -156,7 +156,12 @@ export function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
+            if (
+              rawValue === "openai" ||
+              rawValue === "elevenlabs" ||
+              rawValue === "minimax" ||
+              rawValue === "edge"
+            ) {
               overrides.provider = rawValue;
             } else {
               warnings.push(`unsupported provider "${rawValue}"`);
@@ -322,6 +327,28 @@ export function parseTtsDirectives(
               ...overrides.elevenlabs,
               seed: normalizeSeed(Number.parseInt(rawValue, 10)),
             };
+            break;
+          case "minimax_voice":
+          case "minimax_voice_id":
+            if (!policy.allowVoice) {
+              break;
+            }
+            if (rawValue) {
+              overrides.minimax = { ...overrides.minimax, voice: rawValue };
+            }
+            break;
+          case "minimax_emotion":
+            if (!policy.allowVoiceSettings) {
+              break;
+            }
+            if ((MINIMAX_EMOTIONS as readonly string[]).includes(rawValue)) {
+              overrides.minimax = {
+                ...overrides.minimax,
+                emotion: rawValue as (typeof MINIMAX_EMOTIONS)[number],
+              };
+            } else {
+              warnings.push(`invalid MiniMax emotion "${rawValue}"`);
+            }
             break;
           default:
             break;
@@ -720,7 +747,32 @@ export async function edgeTTS(params: {
 const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.chat/v1";
 export const DEFAULT_MINIMAX_MODEL = "speech-02-hd";
 export const DEFAULT_MINIMAX_VOICE = "male-qn-qingse";
+export const MINIMAX_OUTPUT_FORMATS = ["mp3", "pcm", "flac", "wav"] as const;
+export const MINIMAX_EMOTIONS = [
+  "happy",
+  "sad",
+  "angry",
+  "fearful",
+  "disgusted",
+  "surprised",
+  "calm",
+  "fluent",
+  "whisper",
+] as const;
 const MINIMAX_VALID_SAMPLE_RATES = new Set([8000, 16000, 22050, 24000, 32000, 44100]);
+
+export function inferMiniMaxExtension(outputFormat: string): string {
+  switch (outputFormat) {
+    case "flac":
+      return ".flac";
+    case "wav":
+      return ".wav";
+    case "pcm":
+      return ".pcm";
+    default:
+      return ".mp3";
+  }
+}
 
 export async function minimaxTTS(params: {
   text: string;
@@ -729,15 +781,27 @@ export async function minimaxTTS(params: {
   voice: string;
   speed?: number;
   vol?: number;
+  pitch?: number;
+  emotion?: string;
+  outputFormat?: string;
   sampleRate?: number;
   timeoutMs: number;
 }): Promise<Buffer> {
   const { text, apiKey, model, voice, timeoutMs } = params;
   const speed = params.speed ?? 1.0;
   const vol = params.vol ?? 1.0;
+  const pitch = params.pitch ?? 0;
+  const outputFormat = params.outputFormat ?? "mp3";
   const sampleRate = MINIMAX_VALID_SAMPLE_RATES.has(params.sampleRate ?? 0)
     ? params.sampleRate!
     : 32000;
+  // bitrate only applies to mp3
+  const audioBitrate = outputFormat === "mp3" ? 128000 : undefined;
+
+  const voiceSetting: Record<string, unknown> = { voice_id: voice, speed, vol, pitch };
+  if (params.emotion) {
+    voiceSetting.emotion = params.emotion;
+  }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -753,8 +817,13 @@ export async function minimaxTTS(params: {
         model,
         text,
         stream: false,
-        voice_setting: { voice_id: voice, speed, vol, pitch: 0 },
-        audio_setting: { sample_rate: sampleRate, bitrate: 128000, format: "mp3", channel: 1 },
+        voice_setting: voiceSetting,
+        audio_setting: {
+          sample_rate: sampleRate,
+          ...(audioBitrate != null && { bitrate: audioBitrate }),
+          format: outputFormat,
+          channel: 1,
+        },
       }),
       signal: controller.signal,
     });

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -644,7 +644,7 @@ describe("tts", () => {
 
     it("defaults to built-in model and voice when no minimax config given", () => {
       const config = resolveTtsConfig(baseCfg);
-      expect(config.minimax.model).toBe("speech-02-hd");
+      expect(config.minimax.model).toBe("speech-2.8-hd");
       expect(config.minimax.voice).toBe("male-qn-qingse");
       expect(config.minimax.apiKey).toBeUndefined();
     });

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -51,7 +51,7 @@ vi.mock("../agents/custom-api-registry.js", () => ({
   ensureCustomApiRegistered: vi.fn(),
 }));
 
-const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider } = tts;
+const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider, resolveTtsApiKey } = tts;
 
 const {
   isValidVoiceId,
@@ -523,6 +523,17 @@ describe("tts", () => {
             OPENAI_API_KEY: undefined,
             ELEVENLABS_API_KEY: undefined,
             XI_API_KEY: undefined,
+            MINIMAX_API_KEY: "test-minimax-key",
+          },
+          prefsPath: "/tmp/tts-prefs-minimax.json",
+          expected: "minimax",
+        },
+        {
+          env: {
+            OPENAI_API_KEY: undefined,
+            ELEVENLABS_API_KEY: undefined,
+            XI_API_KEY: undefined,
+            MINIMAX_API_KEY: undefined,
           },
           prefsPath: "/tmp/tts-prefs-edge.json",
           expected: "edge",
@@ -588,6 +599,43 @@ describe("tts", () => {
         const config = resolveTtsConfig(baseCfg);
         expect(config.openai.baseUrl).toBe("http://localhost:8880/v1");
       });
+    });
+  });
+
+  describe("resolveTtsConfig – minimax", () => {
+    const baseCfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+      messages: { tts: {} },
+    };
+
+    it("defaults to built-in model and voice when no minimax config given", () => {
+      const config = resolveTtsConfig(baseCfg);
+      expect(config.minimax.model).toBe("speech-02-hd");
+      expect(config.minimax.voice).toBe("male-qn-qingse");
+      expect(config.minimax.apiKey).toBeUndefined();
+    });
+
+    it("picks up MINIMAX_API_KEY env var", () => {
+      withEnv({ MINIMAX_API_KEY: "test-mm-key" }, () => {
+        const config = resolveTtsConfig(baseCfg);
+        const key = resolveTtsApiKey(config, "minimax");
+        expect(key).toBe("test-mm-key");
+      });
+    });
+
+    it("respects config model and voice overrides", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: {
+            minimax: { model: "speech-02-turbo", voice: "female-shaonv", speed: 1.2 },
+          },
+        },
+      };
+      const config = resolveTtsConfig(cfg);
+      expect(config.minimax.model).toBe("speech-02-turbo");
+      expect(config.minimax.voice).toBe("female-shaonv");
+      expect(config.minimax.speed).toBe(1.2);
     });
   });
 

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -310,6 +310,40 @@ describe("tts", () => {
       expect(result.overrides.provider).toBe("edge");
     });
 
+    it("accepts minimax as provider override", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "Hello [[tts:provider=minimax]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.provider).toBe("minimax");
+    });
+
+    it("sets minimax voice via minimax_voice directive", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowVoice: true });
+      const input = "[[tts:minimax_voice=female-shaonv]] Hello";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.minimax?.voice).toBe("female-shaonv");
+      expect(result.cleanedText.trim()).toBe("Hello");
+    });
+
+    it("sets minimax emotion via minimax_emotion directive", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowVoiceSettings: true });
+      const input = "[[tts:minimax_emotion=happy]] Hello";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.minimax?.emotion).toBe("happy");
+    });
+
+    it("rejects invalid minimax emotion", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowVoiceSettings: true });
+      const input = "[[tts:minimax_emotion=robot]] Hello";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.minimax?.emotion).toBeUndefined();
+      expect(result.warnings).toContain('invalid MiniMax emotion "robot"');
+    });
+
     it("rejects provider override by default while keeping voice overrides enabled", () => {
       const policy = resolveModelOverridePolicy({ enabled: true });
       const input = "Hello [[tts:provider=edge voice=alloy]] world";

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -28,6 +28,8 @@ import { stripMarkdown } from "../line/markdown-to-line.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
+  DEFAULT_MINIMAX_MODEL,
+  DEFAULT_MINIMAX_VOICE,
   DEFAULT_OPENAI_BASE_URL,
   edgeTTS,
   elevenLabsTTS,
@@ -35,6 +37,7 @@ import {
   isValidOpenAIModel,
   isValidOpenAIVoice,
   isValidVoiceId,
+  minimaxTTS,
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
   resolveOpenAITtsInstructions,
@@ -121,6 +124,14 @@ export type ResolvedTtsConfig = {
     speed?: number;
     instructions?: string;
   };
+  minimax: {
+    apiKey?: string;
+    model: string;
+    voice: string;
+    speed?: number;
+    vol?: number;
+    sampleRate?: number;
+  };
   edge: {
     enabled: boolean;
     voice: string;
@@ -174,6 +185,10 @@ export type TtsDirectiveOverrides = {
     applyTextNormalization?: "auto" | "on" | "off";
     languageCode?: string;
     voiceSettings?: Partial<ResolvedTtsConfig["elevenlabs"]["voiceSettings"]>;
+  };
+  minimax?: {
+    voice?: string;
+    model?: string;
   };
 };
 
@@ -309,6 +324,17 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
       speed: raw.openai?.speed,
       instructions: raw.openai?.instructions?.trim() || undefined,
+    },
+    minimax: {
+      apiKey: normalizeResolvedSecretInputString({
+        value: raw.minimax?.apiKey,
+        path: "messages.tts.minimax.apiKey",
+      }),
+      model: raw.minimax?.model?.trim() || DEFAULT_MINIMAX_MODEL,
+      voice: raw.minimax?.voice?.trim() || DEFAULT_MINIMAX_VOICE,
+      speed: raw.minimax?.speed,
+      vol: raw.minimax?.vol,
+      sampleRate: raw.minimax?.sampleRate,
     },
     edge: {
       enabled: raw.edge?.enabled ?? true,
@@ -461,6 +487,9 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   if (resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
+  if (resolveTtsApiKey(config, "minimax")) {
+    return "minimax";
+  }
   return "edge";
 }
 
@@ -528,10 +557,13 @@ export function resolveTtsApiKey(
   if (provider === "openai") {
     return config.openai.apiKey || process.env.OPENAI_API_KEY;
   }
+  if (provider === "minimax") {
+    return config.minimax.apiKey || process.env.MINIMAX_API_KEY;
+  }
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "minimax", "edge"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
@@ -688,6 +720,19 @@ export async function textToSpeech(params: {
           voiceSettings,
           timeoutMs: config.timeoutMs,
         });
+      } else if (provider === "minimax") {
+        const minimaxVoiceOverride = params.overrides?.minimax?.voice;
+        const minimaxModelOverride = params.overrides?.minimax?.model;
+        audioBuffer = await minimaxTTS({
+          text: params.text,
+          apiKey,
+          model: minimaxModelOverride ?? config.minimax.model,
+          voice: minimaxVoiceOverride ?? config.minimax.voice,
+          speed: config.minimax.speed,
+          vol: config.minimax.vol,
+          sampleRate: config.minimax.sampleRate,
+          timeoutMs: config.timeoutMs,
+        });
       } else {
         const openaiModelOverride = params.overrides?.openai?.model;
         const openaiVoiceOverride = params.overrides?.openai?.voice;
@@ -718,7 +763,12 @@ export async function textToSpeech(params: {
         audioPath,
         latencyMs,
         provider,
-        outputFormat: provider === "openai" ? output.openai : output.elevenlabs,
+        outputFormat:
+          provider === "openai"
+            ? output.openai
+            : provider === "minimax"
+              ? "mp3"
+              : output.elevenlabs,
         voiceCompatible: output.voiceCompatible,
       };
     } catch (err) {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -826,6 +826,10 @@ export async function textToSpeechTelephony(params: {
         errors.push("edge: unsupported for telephony");
         continue;
       }
+      if (provider === "minimax") {
+        errors.push("minimax: unsupported for telephony");
+        continue;
+      }
 
       const apiKey = resolveTtsApiKey(config, provider);
       if (!apiKey) {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -34,9 +34,11 @@ import {
   edgeTTS,
   elevenLabsTTS,
   inferEdgeExtension,
+  inferMiniMaxExtension,
   isValidOpenAIModel,
   isValidOpenAIVoice,
   isValidVoiceId,
+  MINIMAX_EMOTIONS,
   minimaxTTS,
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
@@ -46,6 +48,7 @@ import {
   scheduleCleanup,
   summarizeText,
 } from "./tts-core.js";
+export { MINIMAX_EMOTIONS } from "./tts-core.js";
 export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES } from "./tts-core.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -130,6 +133,9 @@ export type ResolvedTtsConfig = {
     voice: string;
     speed?: number;
     vol?: number;
+    pitch?: number;
+    emotion?: (typeof MINIMAX_EMOTIONS)[number];
+    outputFormat: string;
     sampleRate?: number;
   };
   edge: {
@@ -189,6 +195,7 @@ export type TtsDirectiveOverrides = {
   minimax?: {
     voice?: string;
     model?: string;
+    emotion?: (typeof MINIMAX_EMOTIONS)[number];
   };
 };
 
@@ -334,6 +341,9 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       voice: raw.minimax?.voice?.trim() || DEFAULT_MINIMAX_VOICE,
       speed: raw.minimax?.speed,
       vol: raw.minimax?.vol,
+      pitch: raw.minimax?.pitch,
+      emotion: raw.minimax?.emotion,
+      outputFormat: raw.minimax?.outputFormat ?? "mp3",
       sampleRate: raw.minimax?.sampleRate,
     },
     edge: {
@@ -723,6 +733,7 @@ export async function textToSpeech(params: {
       } else if (provider === "minimax") {
         const minimaxVoiceOverride = params.overrides?.minimax?.voice;
         const minimaxModelOverride = params.overrides?.minimax?.model;
+        const minimaxEmotionOverride = params.overrides?.minimax?.emotion;
         audioBuffer = await minimaxTTS({
           text: params.text,
           apiKey,
@@ -730,6 +741,9 @@ export async function textToSpeech(params: {
           voice: minimaxVoiceOverride ?? config.minimax.voice,
           speed: config.minimax.speed,
           vol: config.minimax.vol,
+          pitch: config.minimax.pitch,
+          emotion: minimaxEmotionOverride ?? config.minimax.emotion,
+          outputFormat: config.minimax.outputFormat,
           sampleRate: config.minimax.sampleRate,
           timeoutMs: config.timeoutMs,
         });
@@ -754,7 +768,12 @@ export async function textToSpeech(params: {
       const tempRoot = resolvePreferredOpenClawTmpDir();
       mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
       const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
-      const audioPath = path.join(tempDir, `voice-${Date.now()}${output.extension}`);
+      // MiniMax format is configurable; derive extension from it rather than output.extension.
+      const extension =
+        provider === "minimax"
+          ? inferMiniMaxExtension(config.minimax.outputFormat)
+          : output.extension;
+      const audioPath = path.join(tempDir, `voice-${Date.now()}${extension}`);
       writeFileSync(audioPath, audioBuffer);
       scheduleCleanup(tempDir);
 
@@ -767,9 +786,10 @@ export async function textToSpeech(params: {
           provider === "openai"
             ? output.openai
             : provider === "minimax"
-              ? "mp3"
+              ? config.minimax.outputFormat
               : output.elevenlabs,
-        voiceCompatible: output.voiceCompatible,
+        // MiniMax does not support opus; voice-bubble channels fall back to mp3.
+        voiceCompatible: provider === "minimax" ? false : output.voiceCompatible,
       };
     } catch (err) {
       errors.push(formatTtsProviderError(provider, err));


### PR DESCRIPTION
## Summary

Adds MiniMax T2A V2 as a fourth TTS provider alongside OpenAI, ElevenLabs, and Edge TTS.

- New provider id: `"minimax"`
- API: `POST https://api.minimax.chat/v1/t2a_v2`
- Auth: `MINIMAX_API_KEY` env var or `tts.minimax.apiKey` config
- Default model: `speech-2.8-hd`
- Default voice: `male-qn-qingse`
- Supported directives: `[[tts:provider=minimax]]`, `[[tts:minimax_voice=<id>]]`, `[[tts:minimax_emotion=<value>]]`
- Supported emotions: `happy/sad/angry/fearful/disgusted/surprised/calm/fluent/whisper`
- Config fields: `model`, `voice`, `speed` (0.5-2.0), `vol` (0-10], `pitch` (-12 to 12), `emotion`, `outputFormat` (mp3/pcm/flac/wav), `sampleRate`

## Changes

- `src/config/types.tts.ts` — extend `TtsProvider` union; add `minimax` config block
- `src/config/zod-schema.core.ts` — add MiniMax Zod validation
- `src/tts/tts-core.ts` — implement `minimaxTTS()`; add directives
- `src/tts/tts.ts` — wire MiniMax into provider loop and config resolution
- `src/gateway/server-methods/tts.ts` — expose `hasMiniMaxKey` and provider list
- `src/tts/tts.test.ts` — unit tests for config defaults, env key, directives

## Test plan

- [ ] `pnpm test src/tts/tts.test.ts` — all tests pass
- [ ] Set `MINIMAX_API_KEY` and run `tts.convert` via gateway