### PR TITLE
fix(skills): downgrade escaped skill path log from warn to debug

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -190,7 +190,7 @@ function warnEscapedSkillPath(params: {
   candidatePath: string;
   candidateRealPath: string;
 }) {
-  skillsLogger.warn("Skipping skill path that resolves outside its configured root.", {
+  skillsLogger.debug("Skipping skill path that resolves outside its configured root.", {
     source: params.source,
     rootDir: params.rootDir,
     path: params.candidatePath,


### PR DESCRIPTION
## Problem

The skills scanner logs a warn-level message for every path that resolves outside its configured root during directory traversal. On flat skill layouts with many subdirectories (node_modules, references, scripts, etc.), this produces 75+ warnings that bury the actual skill list output.

## Root cause

`warnEscapedSkillPath()` uses `skillsLogger.warn()` for what is routine path filtering, not an exceptional condition. The containment check itself is correct and needs to stay, but warn is the wrong severity for paths being filtered out as expected.

## Fix

Changed the log level from `warn` to `debug`. The other warn-level logs in the same file (oversized SKILL.md, truncated discovery, suspiciously large roots) remain at warn since those indicate actual problems worth surfacing.

## Testing

- Single line change, no logic change
- Verified other `skillsLogger.warn` calls in the file are all for genuinely concerning conditions
- No existing tests reference this specific log message

Closes #44522

Co-authored-by: Daniel <dsantoreis@gmail.com>