### PR TITLE
[codex] Fix control UI exec approval expiry handling

### DIFF
--- a/src/discord/monitor/exec-approvals.test.ts
+++ b/src/discord/monitor/exec-approvals.test.ts
@@ -123,6 +123,7 @@ type ExecApprovalHandlerInternals = {
   >;
   requestCache: Map<string, ExecApprovalRequest>;
   handleApprovalRequested: (request: ExecApprovalRequest) => Promise<void>;
+  handleApprovalExpired: (expired: { id: string; ts: number }) => Promise<void>;
   handleApprovalTimeout: (approvalId: string, source?: "channel" | "dm") => Promise<void>;
 };
 
@@ -750,6 +751,39 @@ describe("DiscordExecApprovalHandler timeout cleanup", () => {
     expect(internals.pending.has("abc:dm")).toBe(false);
     expect(internals.requestCache.has("abc")).toBe(false);
     expect(internals.requestCache.has("abc2")).toBe(true);
+
+    clearPendingTimeouts(handler);
+  });
+
+  it("finalizes all pending messages for an expired approval", async () => {
+    const handler = createHandler({ enabled: true, approvers: ["123"] });
+    const internals = getHandlerInternals(handler);
+    const request = { ...createRequest(), id: "abc" };
+
+    internals.requestCache.set("abc", request);
+
+    const timeoutIdChannel = setTimeout(() => {}, 0);
+    const timeoutIdDm = setTimeout(() => {}, 0);
+    clearTimeout(timeoutIdChannel);
+    clearTimeout(timeoutIdDm);
+
+    internals.pending.set("abc:channel", {
+      discordMessageId: "m1",
+      discordChannelId: "c1",
+      timeoutId: timeoutIdChannel,
+    });
+    internals.pending.set("abc:dm", {
+      discordMessageId: "m2",
+      discordChannelId: "c2",
+      timeoutId: timeoutIdDm,
+    });
+
+    await internals.handleApprovalExpired({ id: "abc", ts: Date.now() });
+
+    expect(internals.pending.has("abc:channel")).toBe(false);
+    expect(internals.pending.has("abc:dm")).toBe(false);
+    expect(internals.requestCache.has("abc")).toBe(false);
+    expect(mockRestPatch).toHaveBeenCalledTimes(2);
 
     clearPendingTimeouts(handler);
   });

--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -19,6 +19,7 @@ import type { EventFrame } from "../../gateway/protocol/index.js";
 import { resolveExecApprovalCommandDisplay } from "../../infra/exec-approval-command-display.js";
 import { getExecApprovalApproverDmNoticeText } from "../../infra/exec-approval-reply.js";
 import type {
+  ExecApprovalExpired,
   ExecApprovalDecision,
   ExecApprovalRequest,
   ExecApprovalResolved,
@@ -474,6 +475,9 @@ export class DiscordExecApprovalHandler {
     if (evt.event === "exec.approval.requested") {
       const request = evt.payload as ExecApprovalRequest;
       void this.handleApprovalRequested(request);
+    } else if (evt.event === "exec.approval.expired") {
+      const expired = evt.payload as ExecApprovalExpired;
+      void this.handleApprovalExpired(expired);
     } else if (evt.event === "exec.approval.resolved") {
       const resolved = evt.payload as ExecApprovalResolved;
       void this.handleApprovalResolved(resolved);
@@ -651,6 +655,36 @@ export class DiscordExecApprovalHandler {
 
     for (const suffix of [":channel", ":dm", ""]) {
       const key = `${resolved.id}${suffix}`;
+      const pending = this.pending.get(key);
+      if (!pending) {
+        continue;
+      }
+
+      clearTimeout(pending.timeoutId);
+      this.pending.delete(key);
+
+      await this.finalizeMessage(pending.discordChannelId, pending.discordMessageId, container);
+    }
+  }
+
+  private async handleApprovalExpired(expired: ExecApprovalExpired): Promise<void> {
+    const request = this.requestCache.get(expired.id);
+    this.requestCache.delete(expired.id);
+
+    if (!request) {
+      return;
+    }
+
+    logDebug(`discord exec approvals: expired ${expired.id}`);
+
+    const container = createExpiredContainer({
+      request,
+      cfg: this.opts.cfg,
+      accountId: this.opts.accountId,
+    });
+
+    for (const suffix of [":channel", ":dm", ""]) {
+      const key = `${expired.id}${suffix}`;
       const pending = this.pending.get(key);
       if (!pending) {
         continue;

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -8,6 +8,7 @@ const PAIRING_SCOPE = "operator.pairing";
 
 const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
   "exec.approval.requested": [APPROVALS_SCOPE],
+  "exec.approval.expired": [APPROVALS_SCOPE],
   "exec.approval.resolved": [APPROVALS_SCOPE],
   "device.pair.requested": [PAIRING_SCOPE],
   "device.pair.resolved": [PAIRING_SCOPE],

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -128,6 +128,7 @@ export const GATEWAY_EVENTS = [
   "device.pair.resolved",
   "voicewake.changed",
   "exec.approval.requested",
+  "exec.approval.expired",
   "exec.approval.resolved",
   GATEWAY_EVENT_UPDATE_AVAILABLE,
 ];

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -225,6 +225,17 @@ export function createExecApprovalHandlers(
       }
 
       const decision = await decisionPromise;
+      if (decision === null) {
+        context.broadcast(
+          "exec.approval.expired",
+          {
+            id: record.id,
+            ts: Date.now(),
+            request: record.request,
+          },
+          { dropIfSlow: true },
+        );
+      }
       // Send final response with decision for callers using expectFinal:true.
       respond(
         true,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -867,6 +867,46 @@ describe("exec approval handlers", () => {
     );
   });
 
+  it("broadcasts exec.approval.expired when a pending approval times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+      const requestPromise = requestExecApproval({
+        handlers,
+        respond,
+        context,
+        params: {
+          id: "approval-expired",
+          timeoutMs: 10,
+        },
+      });
+
+      await drainApprovalRequestTicks();
+      await vi.runOnlyPendingTimersAsync();
+      await requestPromise;
+
+      expect(broadcasts).toContainEqual(
+        expect.objectContaining({
+          event: "exec.approval.expired",
+          payload: expect.objectContaining({
+            id: "approval-expired",
+            request: expect.objectContaining({
+              command: "echo ok",
+            }),
+          }),
+        }),
+      );
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ id: "approval-expired", decision: null }),
+        undefined,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("forwards turn-source metadata to exec approval forwarding", async () => {
     vi.useFakeTimers();
     try {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -96,6 +96,12 @@ export type ExecApprovalResolved = {
   request?: ExecApprovalRequest["request"];
 };
 
+export type ExecApprovalExpired = {
+  id: string;
+  ts: number;
+  request?: ExecApprovalRequest["request"];
+};
+
 export type ExecApprovalsDefaults = {
   security?: ExecSecurity;
   ask?: ExecAsk;

--- a/src/telegram/exec-approvals-handler.test.ts
+++ b/src/telegram/exec-approvals-handler.test.ts
@@ -153,4 +153,35 @@ describe("TelegramExecApprovalHandler", () => {
       }),
     );
   });
+
+  it("clears buttons from tracked approval messages when expired", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          execApprovals: {
+            enabled: true,
+            approvers: ["8460800771"],
+            target: "both",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, editReplyMarkup } = createHandler(cfg);
+
+    await handler.handleRequested(baseRequest);
+    await handler.handleExpired({
+      id: baseRequest.id,
+      ts: 2000,
+    });
+
+    expect(editReplyMarkup).toHaveBeenCalled();
+    expect(editReplyMarkup).toHaveBeenCalledWith(
+      "-1003841603622",
+      "m1",
+      [],
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+  });
 });

--- a/src/telegram/exec-approvals-handler.ts
+++ b/src/telegram/exec-approvals-handler.ts
@@ -8,7 +8,11 @@ import {
   buildExecApprovalPendingReplyPayload,
   type ExecApprovalPendingReplyParams,
 } from "../infra/exec-approval-reply.js";
-import type { ExecApprovalRequest, ExecApprovalResolved } from "../infra/exec-approvals.js";
+import type {
+  ExecApprovalExpired,
+  ExecApprovalRequest,
+  ExecApprovalResolved,
+} from "../infra/exec-approvals.js";
 import { resolveSessionDeliveryTarget } from "../infra/outbound/targets.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAccountId, parseAgentSessionKey } from "../routing/session-key.js";
@@ -384,9 +388,32 @@ export class TelegramExecApprovalHandler {
     );
   }
 
+  async handleExpired(expired: ExecApprovalExpired): Promise<void> {
+    const pending = this.pending.get(expired.id);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timeoutId);
+    this.pending.delete(expired.id);
+
+    await Promise.allSettled(
+      pending.messages.map(async (message) => {
+        await this.editReplyMarkup(message.chatId, message.messageId, [], {
+          cfg: this.opts.cfg,
+          token: this.opts.token,
+          accountId: this.opts.accountId,
+        });
+      }),
+    );
+  }
+
   private handleGatewayEvent(evt: EventFrame): void {
     if (evt.event === "exec.approval.requested") {
       void this.handleRequested(evt.payload as ExecApprovalRequest);
+      return;
+    }
+    if (evt.event === "exec.approval.expired") {
+      void this.handleExpired(evt.payload as ExecApprovalExpired);
       return;
     }
     if (evt.event === "exec.approval.resolved") {

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -190,6 +190,38 @@ describe("connectGateway", () => {
     });
   });
 
+  it("removes expired exec approvals when the gateway broadcasts an expiry event", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitEvent({
+      event: "exec.approval.requested",
+      payload: {
+        id: "approval-1",
+        request: {
+          command: "echo hello",
+          host: "gateway",
+        },
+        createdAtMs: 1_000,
+        expiresAtMs: Date.now() + 60_000,
+      },
+    });
+    expect(host.execApprovalQueue).toHaveLength(1);
+
+    client.emitEvent({
+      event: "exec.approval.expired",
+      payload: {
+        id: "approval-1",
+        ts: 2_000,
+      },
+    });
+
+    expect(host.execApprovalQueue).toEqual([]);
+  });
+
   it("ignores stale client onClose callbacks after reconnect", () => {
     const host = createHost();
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -22,6 +22,7 @@ import { loadDevices } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import {
   addExecApproval,
+  parseExecApprovalExpired,
   parseExecApprovalRequested,
   parseExecApprovalResolved,
   removeExecApproval,
@@ -382,7 +383,7 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
       host.execApprovalQueue = addExecApproval(host.execApprovalQueue, entry);
       host.execApprovalError = null;
       const delay = Math.max(0, entry.expiresAtMs - Date.now() + 500);
-      window.setTimeout(() => {
+      globalThis.setTimeout(() => {
         host.execApprovalQueue = removeExecApproval(host.execApprovalQueue, entry.id);
       }, delay);
     }
@@ -393,6 +394,14 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     const resolved = parseExecApprovalResolved(evt.payload);
     if (resolved) {
       host.execApprovalQueue = removeExecApproval(host.execApprovalQueue, resolved.id);
+    }
+    return;
+  }
+
+  if (evt.event === "exec.approval.expired") {
+    const expired = parseExecApprovalExpired(evt.payload);
+    if (expired) {
+      host.execApprovalQueue = removeExecApproval(host.execApprovalQueue, expired.id);
     }
     return;
   }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -321,7 +321,10 @@ export type AppViewState = {
     handleNostrProfileSave: () => Promise<void>;
     handleNostrProfileImport: () => Promise<void>;
     handleNostrProfileToggleAdvanced: () => void;
-    handleExecApprovalDecision: (decision: "allow-once" | "allow-always" | "deny") => Promise<void>;
+    handleExecApprovalDecision: (
+      approvalId: string,
+      decision: "allow-once" | "allow-always" | "deny",
+    ) => Promise<void>;
     handleGatewayUrlConfirm: () => void;
     handleGatewayUrlCancel: () => void;
     handleConfigLoad: () => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -57,6 +57,10 @@ import { exportChatMarkdown } from "./chat/export.ts";
 import { loadAssistantIdentity as loadAssistantIdentityInternal } from "./controllers/assistant-identity.ts";
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
+import {
+  removeExecApproval,
+  resolveExecApprovalDecisionTarget,
+} from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
 import type { SkillMessage } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
@@ -636,11 +640,24 @@ export class OpenClawApp extends LitElement {
     handleNostrProfileToggleAdvancedInternal(this);
   }
 
-  async handleExecApprovalDecision(decision: "allow-once" | "allow-always" | "deny") {
-    const active = this.execApprovalQueue[0];
-    if (!active || !this.client || this.execApprovalBusy) {
+  async handleExecApprovalDecision(
+    approvalId: string,
+    decision: "allow-once" | "allow-always" | "deny",
+  ) {
+    if (!this.client || this.execApprovalBusy) {
       return;
     }
+    const target = resolveExecApprovalDecisionTarget(this.execApprovalQueue, approvalId);
+    this.execApprovalQueue = target.queue;
+    if (target.kind === "expired") {
+      this.execApprovalError = "Exec approval expired.";
+      return;
+    }
+    if (target.kind === "missing") {
+      this.execApprovalError = "Exec approval is no longer pending.";
+      return;
+    }
+    const active = target.entry;
     this.execApprovalBusy = true;
     this.execApprovalError = null;
     try {
@@ -648,9 +665,13 @@ export class OpenClawApp extends LitElement {
         id: active.id,
         decision,
       });
-      this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== active.id);
+      this.execApprovalQueue = removeExecApproval(this.execApprovalQueue, active.id);
     } catch (err) {
-      this.execApprovalError = `Exec approval failed: ${String(err)}`;
+      const message = String(err);
+      if (/unknown or expired approval id/i.test(message)) {
+        this.execApprovalQueue = removeExecApproval(this.execApprovalQueue, active.id);
+      }
+      this.execApprovalError = `Exec approval failed: ${message}`;
     } finally {
       this.execApprovalBusy = false;
     }

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  isExecApprovalExpired,
+  parseExecApprovalExpired,
+  resolveExecApprovalDecisionTarget,
+  type ExecApprovalRequest,
+} from "./exec-approval.ts";
+
+function createRequest(overrides: Partial<ExecApprovalRequest> = {}): ExecApprovalRequest {
+  return {
+    id: "approval-1",
+    request: {
+      command: "echo hello",
+      host: "gateway",
+    },
+    createdAtMs: 1_000,
+    expiresAtMs: 11_000,
+    ...overrides,
+  };
+}
+
+describe("parseExecApprovalExpired", () => {
+  it("parses expired payloads that include an id", () => {
+    expect(parseExecApprovalExpired({ id: "approval-1", ts: 2_000 })).toEqual({
+      id: "approval-1",
+      ts: 2_000,
+    });
+  });
+
+  it("rejects expired payloads without an id", () => {
+    expect(parseExecApprovalExpired({ ts: 2_000 })).toBeNull();
+  });
+});
+
+describe("isExecApprovalExpired", () => {
+  it("treats approvals at or before now as expired", () => {
+    expect(isExecApprovalExpired(createRequest({ expiresAtMs: 5_000 }), 5_000)).toBe(true);
+    expect(isExecApprovalExpired(createRequest({ expiresAtMs: 4_999 }), 5_000)).toBe(true);
+    expect(isExecApprovalExpired(createRequest({ expiresAtMs: 5_001 }), 5_000)).toBe(false);
+  });
+});
+
+describe("resolveExecApprovalDecisionTarget", () => {
+  it("resolves the clicked approval by id instead of relying on queue position", () => {
+    const first = createRequest({ id: "approval-1", expiresAtMs: 9_000 });
+    const second = createRequest({ id: "approval-2", expiresAtMs: 10_000 });
+
+    expect(resolveExecApprovalDecisionTarget([first, second], "approval-2", 2_000)).toEqual({
+      kind: "ready",
+      entry: second,
+      queue: [first, second],
+    });
+  });
+
+  it("returns expired and prunes the queue when the clicked approval has timed out", () => {
+    const expired = createRequest({ id: "expired", expiresAtMs: 4_000 });
+    const active = createRequest({ id: "active", expiresAtMs: 8_000 });
+
+    expect(resolveExecApprovalDecisionTarget([expired, active], "expired", 5_000)).toEqual({
+      kind: "expired",
+      queue: [active],
+    });
+  });
+
+  it("returns missing while still pruning unrelated expired approvals", () => {
+    const expired = createRequest({ id: "expired", expiresAtMs: 4_000 });
+    const active = createRequest({ id: "active", expiresAtMs: 8_000 });
+
+    expect(resolveExecApprovalDecisionTarget([expired, active], "missing", 5_000)).toEqual({
+      kind: "missing",
+      queue: [active],
+    });
+  });
+});

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -23,6 +23,16 @@ export type ExecApprovalResolved = {
   ts?: number | null;
 };
 
+export type ExecApprovalExpired = {
+  id: string;
+  ts?: number | null;
+};
+
+export type ExecApprovalDecisionTarget =
+  | { kind: "ready"; entry: ExecApprovalRequest; queue: ExecApprovalRequest[] }
+  | { kind: "expired"; queue: ExecApprovalRequest[] }
+  | { kind: "missing"; queue: ExecApprovalRequest[] };
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -78,16 +88,37 @@ export function parseExecApprovalResolved(payload: unknown): ExecApprovalResolve
   };
 }
 
-export function pruneExecApprovalQueue(queue: ExecApprovalRequest[]): ExecApprovalRequest[] {
-  const now = Date.now();
+export function parseExecApprovalExpired(payload: unknown): ExecApprovalExpired | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const id = typeof payload.id === "string" ? payload.id.trim() : "";
+  if (!id) {
+    return null;
+  }
+  return {
+    id,
+    ts: typeof payload.ts === "number" ? payload.ts : null,
+  };
+}
+
+export function isExecApprovalExpired(entry: ExecApprovalRequest, now = Date.now()): boolean {
+  return entry.expiresAtMs <= now;
+}
+
+export function pruneExecApprovalQueue(
+  queue: ExecApprovalRequest[],
+  now = Date.now(),
+): ExecApprovalRequest[] {
   return queue.filter((entry) => entry.expiresAtMs > now);
 }
 
 export function addExecApproval(
   queue: ExecApprovalRequest[],
   entry: ExecApprovalRequest,
+  now = Date.now(),
 ): ExecApprovalRequest[] {
-  const next = pruneExecApprovalQueue(queue).filter((item) => item.id !== entry.id);
+  const next = pruneExecApprovalQueue(queue, now).filter((item) => item.id !== entry.id);
   next.push(entry);
   return next;
 }
@@ -95,6 +126,31 @@ export function addExecApproval(
 export function removeExecApproval(
   queue: ExecApprovalRequest[],
   id: string,
+  now = Date.now(),
 ): ExecApprovalRequest[] {
-  return pruneExecApprovalQueue(queue).filter((entry) => entry.id !== id);
+  return pruneExecApprovalQueue(queue, now).filter((entry) => entry.id !== id);
+}
+
+export function resolveExecApprovalDecisionTarget(
+  queue: ExecApprovalRequest[],
+  id: string,
+  now = Date.now(),
+): ExecApprovalDecisionTarget {
+  const normalizedId = id.trim();
+  const nextQueue = pruneExecApprovalQueue(queue, now);
+  if (!normalizedId) {
+    return { kind: "missing", queue: nextQueue };
+  }
+  const entry = queue.find((candidate) => candidate.id === normalizedId);
+  if (!entry) {
+    return { kind: "missing", queue: nextQueue };
+  }
+  if (isExecApprovalExpired(entry, now)) {
+    return { kind: "expired", queue: nextQueue };
+  }
+  const active = nextQueue.find((candidate) => candidate.id === normalizedId);
+  if (!active) {
+    return { kind: "missing", queue: nextQueue };
+  }
+  return { kind: "ready", entry: active, queue: nextQueue };
 }

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import type { AppViewState } from "../app-view-state.ts";
+import { isExecApprovalExpired } from "../controllers/exec-approval.ts";
 
 function formatRemaining(ms: number): string {
   const remaining = Math.max(0, ms);
@@ -29,6 +30,7 @@ export function renderExecApprovalPrompt(state: AppViewState) {
   }
   const request = active.request;
   const remainingMs = active.expiresAtMs - Date.now();
+  const expired = isExecApprovalExpired(active);
   const remaining = remainingMs > 0 ? `expires in ${formatRemaining(remainingMs)}` : "expired";
   const queueCount = state.execApprovalQueue.length;
   return html`
@@ -63,22 +65,22 @@ export function renderExecApprovalPrompt(state: AppViewState) {
         <div class="exec-approval-actions">
           <button
             class="btn primary"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-once")}
+            ?disabled=${state.execApprovalBusy || expired}
+            @click=${() => state.handleExecApprovalDecision(active.id, "allow-once")}
           >
             Allow once
           </button>
           <button
             class="btn"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-always")}
+            ?disabled=${state.execApprovalBusy || expired}
+            @click=${() => state.handleExecApprovalDecision(active.id, "allow-always")}
           >
             Always allow
           </button>
           <button
             class="btn danger"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("deny")}
+            ?disabled=${state.execApprovalBusy || expired}
+            @click=${() => state.handleExecApprovalDecision(active.id, "deny")}
           >
             Deny
           </button>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -86,8 +86,10 @@ export default defineConfig({
       "ui/src/ui/views/agents-utils.test.ts",
       "ui/src/ui/views/chat.test.ts",
       "ui/src/ui/views/usage-render-details.test.ts",
+      "ui/src/ui/app-gateway.node.test.ts",
       "ui/src/ui/controllers/agents.test.ts",
       "ui/src/ui/controllers/chat.test.ts",
+      "ui/src/ui/controllers/exec-approval.test.ts",
     ],
     setupFiles: ["test/setup.ts"],
     exclude: [


### PR DESCRIPTION
This change fixes a regression in exec approvals where the Control UI could keep showing a prompt after the gateway had already timed it out, and could also submit the wrong approval when the pending queue changed between render and click.

In the current flow, the Control UI renders the active approval but the button handlers read `execApprovalQueue[0]` again at click time. If the queue changes, the UI can resolve a different request than the one the user actually saw. Separately, approval timeouts only return `decision: null` to the waiter and do not broadcast any operator-facing expiry event, so the Web UI has to rely on its own browser timer to clear the prompt. When that timer is delayed or stale, the UI can still submit a now-invalid approval id and surface `unknown or expired approval id`.

This patch fixes both sides of that behavior. The Control UI now binds the rendered approval id into each button click, rejects expired or missing approvals locally before making the RPC, disables actions for expired prompts, and clears stale entries if the resolve call comes back with the deterministic `unknown or expired approval id` error. On the gateway side, timed out approvals now emit a new `exec.approval.expired` broadcast so operator clients can clear prompts based on gateway state instead of local timing alone. The Web UI, Telegram approval handler, and Discord approval handler now listen for that event and remove their pending approval UI accordingly.

I also added regression coverage for the queue-switch and timeout paths, and included the new UI tests in the main Vitest config so they run in the default test suite.

Validation:
- `pnpm exec vitest run ui/src/ui/controllers/exec-approval.test.ts ui/src/ui/app-gateway.node.test.ts src/gateway/server-methods/server-methods.test.ts src/telegram/exec-approvals-handler.test.ts src/discord/monitor/exec-approvals.test.ts`
- `XDG_CACHE_HOME=/tmp/openclaw-xdg PNPM_HOME=/tmp/openclaw-pnpm-home npm_config_cache=/tmp/openclaw-npm-cache pnpm build`
- `XDG_CACHE_HOME=/tmp/openclaw-xdg PNPM_HOME=/tmp/openclaw-pnpm-home npm_config_cache=/tmp/openclaw-npm-cache pnpm check`
