### PR TITLE
fix(update-cli): hide cmd windows for detached restart script on Windows

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -302,6 +302,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -317,6 +318,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", `"${scriptPath}"`], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
     });
   });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -169,6 +169,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    ...(isWindows ? { windowsHide: true } : {}),
   });
   child.unref();
 }


### PR DESCRIPTION
## Summary
- add `windowsHide: true` when spawning detached restart script on Windows
- keep Linux/macOS spawn options unchanged
- update Windows assertions in `restart-helper` tests

## Testing
- `corepack pnpm exec vitest run src/cli/update-cli/restart-helper.test.ts`

Closes #44693