### PR TITLE
fix(update): hide Windows restart helper console windows

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -302,6 +302,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -317,6 +318,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", `"${scriptPath}"`], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
     });
   });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -169,6 +169,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    ...(isWindows ? { windowsHide: true } : {}),
   });
   child.unref();
 }


### PR DESCRIPTION
## Problem

The Windows restart helper spawns `cmd.exe` in detached mode without `windowsHide: true`.

That makes visible console windows flash during gateway restarts while the generated script polls the target port.

## Fix

Pass `windowsHide: true` when spawning the detached restart helper on Windows.

## Tests

Updated Windows restart-helper tests to assert `windowsHide: true` is forwarded.

Closes #44693
