### PR TITLE
fix(doctor): skip feishu auto-enable when alternative feishu plugin is enabled

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -209,6 +209,34 @@ describe("applyPluginAutoEnable", () => {
     expect(result.changes).toEqual([]);
   });
 
+  it("does not auto-enable built-in feishu when alternative feishu plugin is already enabled", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        channels: {
+          feishu: {
+            appId: "cli_test_appid",
+            appSecret: "cli_test_secret",
+          },
+        },
+        plugins: {
+          entries: {
+            "openclaw-lark": { enabled: true },
+          },
+        },
+      },
+      env: {},
+      manifestRegistry: makeRegistry([
+        { id: "feishu", channels: ["feishu"] },
+        { id: "openclaw-lark", channels: ["feishu"] },
+      ]),
+    });
+
+    expect(result.config.channels?.feishu?.enabled).toBeUndefined();
+    expect(result.config.plugins?.entries?.feishu?.enabled).toBeUndefined();
+    expect(result.config.plugins?.entries?.["openclaw-lark"]?.enabled).toBe(true);
+    expect(result.changes).toEqual([]);
+  });
+
   it("auto-enables irc when configured via env", () => {
     const result = applyPluginAutoEnable({
       config: {},

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -461,6 +461,55 @@ function registerPluginEntry(cfg: OpenClawConfig, pluginId: string): OpenClawCon
   };
 }
 
+function hasEnabledAlternativePluginForChannels(params: {
+  cfg: OpenClawConfig;
+  channelIds: string[];
+  pluginId: string;
+  registry: PluginManifestRegistry;
+}): boolean {
+  if (params.channelIds.length === 0) {
+    return false;
+  }
+  const entries = params.cfg.plugins?.entries;
+  if (!entries || typeof entries !== "object") {
+    return false;
+  }
+  const channelSet = new Set(params.channelIds);
+  for (const record of params.registry.plugins) {
+    if (record.id === params.pluginId) {
+      continue;
+    }
+    if (!record.channels.some((channelId) => channelSet.has(channelId))) {
+      continue;
+    }
+    if (entries[record.id]?.enabled !== true) {
+      continue;
+    }
+    if (isPluginDenied(params.cfg, record.id)) {
+      continue;
+    }
+    if (isPluginExplicitlyDisabled(params.cfg, record.id)) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+function resolvePluginChannelIds(pluginId: string, registry: PluginManifestRegistry): string[] {
+  const builtInChannelId = normalizeChatChannelId(pluginId);
+  if (builtInChannelId) {
+    return [builtInChannelId];
+  }
+  const record = registry.plugins.find((entry) => entry.id === pluginId);
+  if (!record) {
+    return [];
+  }
+  return record.channels.filter(
+    (channelId) => typeof channelId === "string" && channelId.length > 0,
+  );
+}
+
 function formatAutoEnableChange(entry: PluginEnableChange): string {
   let reason = entry.reason.trim();
   const channelId = normalizeChatChannelId(entry.pluginId);
@@ -503,6 +552,16 @@ export function applyPluginAutoEnable(params: {
       continue;
     }
     if (shouldSkipPreferredPluginAutoEnable(next, entry, configured, env)) {
+      continue;
+    }
+    if (
+      hasEnabledAlternativePluginForChannels({
+        cfg: next,
+        channelIds: resolvePluginChannelIds(entry.pluginId, registry),
+        pluginId: entry.pluginId,
+        registry,
+      })
+    ) {
       continue;
     }
     const allow = next.plugins?.allow;


### PR DESCRIPTION
## Summary
- prevent plugin auto-enable from enabling a plugin when another enabled plugin already handles the same channel(s)
- this avoids `doctor --fix` enabling built-in `feishu` when `openclaw-lark` is already enabled
- add regression test for `channels.feishu` + `plugins.entries.openclaw-lark.enabled=true`

## Testing
- `corepack pnpm exec vitest run src/config/plugin-auto-enable.test.ts`

Closes #44722