### PR TITLE
feat: Include type definitions in agent dispatch prompts

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -7,6 +7,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
 } from "./pi-embedded-helpers.js";
+import { buildTypeDefinitionsPrompt, loadTypeDefinitions } from "./type-definitions.js";
 import {
   filterBootstrapFilesForSession,
   loadWorkspaceBootstrapFiles,
@@ -107,6 +108,7 @@ export async function resolveBootstrapContextForRun(params: {
 }): Promise<{
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];
+  typeDefinitionsPrompt?: string;
 }> {
   const bootstrapFiles = await resolveBootstrapFilesForRun(params);
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
@@ -114,5 +116,13 @@ export async function resolveBootstrapContextForRun(params: {
     totalMaxChars: resolveBootstrapTotalMaxChars(params.config),
     warn: params.warn,
   });
-  return { bootstrapFiles, contextFiles };
+
+  // Load type definitions from src/types or types directory
+  const typeDefinitions = await loadTypeDefinitions({
+    workspaceDir: params.workspaceDir,
+  });
+
+  const typeDefinitionsPrompt = buildTypeDefinitionsPrompt(typeDefinitions);
+
+  return { bootstrapFiles, contextFiles, typeDefinitionsPrompt };
 }

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -105,13 +105,14 @@ export async function runCliAgent(params: {
     .join("\n");
 
   const sessionLabel = params.sessionKey ?? params.sessionId;
-  const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
-    workspaceDir,
-    config: params.config,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionId,
-    warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
-  });
+  const { bootstrapFiles, contextFiles, typeDefinitionsPrompt } =
+    await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: params.config,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+    });
   const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
   const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
   const bootstrapAnalysis = analyzeBootstrapBudget({
@@ -157,6 +158,7 @@ export async function runCliAgent(params: {
     bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
     modelDisplay,
     agentId: sessionAgentId,
+    typeDefinitionsPrompt,
   });
   const systemPromptReport = buildSystemPromptReport({
     source: "run",

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -51,6 +51,7 @@ export function buildSystemPrompt(params: {
   bootstrapTruncationWarningLines?: string[];
   modelDisplay: string;
   agentId?: string;
+  typeDefinitionsPrompt?: string;
 }) {
   const defaultModelRef = resolveDefaultModelForAgent({
     cfg: params.config ?? {},
@@ -95,6 +96,7 @@ export function buildSystemPrompt(params: {
     bootstrapTruncationWarningLines: params.bootstrapTruncationWarningLines,
     ttsHint,
     memoryCitationsMode: params.config?.memory?.citations,
+    typeDefinitionsPrompt: params.typeDefinitionsPrompt,
   });
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1422,7 +1422,7 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
+    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles, typeDefinitionsPrompt } =
       await resolveBootstrapContextForRun({
         workspaceDir: effectiveWorkspace,
         config: params.config,
@@ -1669,6 +1669,7 @@ export async function runEmbeddedAttempt(
       contextFiles,
       bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
       memoryCitationsMode: params.config?.memory?.citations,
+      typeDefinitionsPrompt,
     });
     const systemPromptReport = buildSystemPromptReport({
       source: "run",

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1422,16 +1422,19 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles, typeDefinitionsPrompt } =
-      await resolveBootstrapContextForRun({
-        workspaceDir: effectiveWorkspace,
-        config: params.config,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
-        contextMode: params.bootstrapContextMode,
-        runKind: params.bootstrapContextRunKind,
-      });
+    const {
+      bootstrapFiles: hookAdjustedBootstrapFiles,
+      contextFiles,
+      typeDefinitionsPrompt,
+    } = await resolveBootstrapContextForRun({
+      workspaceDir: effectiveWorkspace,
+      config: params.config,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+      contextMode: params.bootstrapContextMode,
+      runKind: params.bootstrapContextRunKind,
+    });
     const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
     const bootstrapAnalysis = analyzeBootstrapBudget({

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -53,6 +53,7 @@ export function buildEmbeddedSystemPrompt(params: {
   contextFiles?: EmbeddedContextFile[];
   bootstrapTruncationWarningLines?: string[];
   memoryCitationsMode?: MemoryCitationsMode;
+  typeDefinitionsPrompt?: string;
 }): string {
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
@@ -83,6 +84,7 @@ export function buildEmbeddedSystemPrompt(params: {
     contextFiles: params.contextFiles,
     bootstrapTruncationWarningLines: params.bootstrapTruncationWarningLines,
     memoryCitationsMode: params.memoryCitationsMode,
+    typeDefinitionsPrompt: params.typeDefinitionsPrompt,
   });
 }
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -233,6 +233,8 @@ export function buildAgentSystemPrompt(params: {
     channel: string;
   };
   memoryCitationsMode?: MemoryCitationsMode;
+  /** Type definitions prompt from src/types or types directory */
+  typeDefinitionsPrompt?: string;
 }) {
   const acpEnabled = params.acpEnabled !== false;
   const sandboxedRuntime = params.sandboxInfo?.enabled === true;
@@ -620,6 +622,13 @@ export function buildAgentSystemPrompt(params: {
   const validContextFiles = contextFiles.filter(
     (file) => typeof file.path === "string" && file.path.trim().length > 0,
   );
+
+  // Inject type definitions before project context
+  const typeDefinitionsPrompt = params.typeDefinitionsPrompt?.trim();
+  if (typeDefinitionsPrompt) {
+    lines.push(typeDefinitionsPrompt, "");
+  }
+
   if (validContextFiles.length > 0 || bootstrapTruncationWarningLines.length > 0) {
     lines.push("# Project Context", "");
     if (validContextFiles.length > 0) {

--- a/src/agents/type-definitions.test.ts
+++ b/src/agents/type-definitions.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, test, beforeEach, afterEach } from "vitest";
+import { buildTypeDefinitionsPrompt, loadTypeDefinitions } from "./type-definitions.js";
+
+describe("type-definitions", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "type-defs-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("loadTypeDefinitions - finds src/types directory", async () => {
+    const typesDir = path.join(tempDir, "src", "types");
+    await fs.mkdir(typesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(typesDir, "index.ts"),
+      'export type User = { id: string; name: string; };\n',
+    );
+    await fs.writeFile(
+      path.join(typesDir, "models.ts"),
+      'export interface Post { title: string; content: string; }\n',
+    );
+
+    const result = await loadTypeDefinitions({ workspaceDir: tempDir });
+
+    assert.equal(result.exists, true);
+    assert.equal(result.typesDir, "src/types");
+    assert.equal(result.files.length, 2);
+    // index.ts should be first
+    assert.equal(path.basename(result.files[0]!.relativePath), "index.ts");
+    assert.ok(result.files[0]!.content.includes("User"));
+  });
+
+  test("loadTypeDefinitions - falls back to types directory", async () => {
+    const typesDir = path.join(tempDir, "types");
+    await fs.mkdir(typesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(typesDir, "config.ts"),
+      'export type Config = { apiKey: string; };\n',
+    );
+
+    const result = await loadTypeDefinitions({ workspaceDir: tempDir });
+
+    assert.equal(result.exists, true);
+    assert.equal(result.typesDir, "types");
+    assert.equal(result.files.length, 1);
+    assert.ok(result.files[0]!.content.includes("Config"));
+  });
+
+  test("loadTypeDefinitions - skips test files", async () => {
+    const typesDir = path.join(tempDir, "src", "types");
+    await fs.mkdir(typesDir, { recursive: true });
+    await fs.writeFile(path.join(typesDir, "user.ts"), 'export type User = {};\n');
+    await fs.writeFile(path.join(typesDir, "user.test.ts"), 'test("user", () => {});\n');
+    await fs.writeFile(path.join(typesDir, "user.spec.ts"), 'describe("user", () => {});\n');
+
+    const result = await loadTypeDefinitions({ workspaceDir: tempDir });
+
+    assert.equal(result.files.length, 1);
+    assert.equal(path.basename(result.files[0]!.relativePath), "user.ts");
+  });
+
+  test("loadTypeDefinitions - returns empty when no types directory exists", async () => {
+    const result = await loadTypeDefinitions({ workspaceDir: tempDir });
+
+    assert.equal(result.exists, false);
+    assert.equal(result.files.length, 0);
+  });
+
+  test("loadTypeDefinitions - respects size limits", async () => {
+    const typesDir = path.join(tempDir, "src", "types");
+    await fs.mkdir(typesDir, { recursive: true });
+    const largeContent = "export type Large = {\n" + "  field: string;\n".repeat(10000) + "};\n";
+    await fs.writeFile(path.join(typesDir, "large.ts"), largeContent);
+    await fs.writeFile(path.join(typesDir, "small.ts"), 'export type Small = {};\n');
+
+    const result = await loadTypeDefinitions({
+      workspaceDir: tempDir,
+      maxFileBytes: 100, // Very small limit
+      maxTotalBytes: 200,
+    });
+
+    // Should skip the large file but include the small one
+    assert.equal(result.files.length, 1);
+    assert.equal(path.basename(result.files[0]!.relativePath), "small.ts");
+  });
+
+  test("buildTypeDefinitionsPrompt - creates formatted prompt", async () => {
+    const typesDir = path.join(tempDir, "src", "types");
+    await fs.mkdir(typesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(typesDir, "index.ts"),
+      'export type User = { id: string; };\n',
+    );
+
+    const result = await loadTypeDefinitions({ workspaceDir: tempDir });
+    const prompt = buildTypeDefinitionsPrompt(result);
+
+    assert.ok(prompt.includes("# Type Definitions"));
+    assert.ok(prompt.includes("**CRITICAL:** Use ONLY the types defined below"));
+    assert.ok(prompt.includes("## src/types/index.ts"));
+    assert.ok(prompt.includes("```typescript"));
+    assert.ok(prompt.includes("export type User"));
+  });
+
+  test("buildTypeDefinitionsPrompt - returns empty string when no types", () => {
+    const result = {
+      files: [],
+      totalSize: 0,
+      exists: false,
+    };
+
+    const prompt = buildTypeDefinitionsPrompt(result);
+
+    assert.equal(prompt, "");
+  });
+
+  test("loadTypeDefinitions - handles nested directories", async () => {
+    const typesDir = path.join(tempDir, "src", "types");
+    const nestedDir = path.join(typesDir, "models");
+    await fs.mkdir(nestedDir, { recursive: true });
+    await fs.writeFile(path.join(typesDir, "index.ts"), 'export * from "./models";\n');
+    await fs.writeFile(path.join(nestedDir, "user.ts"), 'export type User = {};\n');
+
+    const result = await loadTypeDefinitions({ workspaceDir: tempDir });
+
+    assert.equal(result.files.length, 2);
+    const paths = result.files.map((f) => f.relativePath);
+    assert.ok(paths.some((p) => p.includes("models/user.ts")));
+  });
+});

--- a/src/agents/type-definitions.test.ts
+++ b/src/agents/type-definitions.test.ts
@@ -21,11 +21,11 @@ describe("type-definitions", () => {
     await fs.mkdir(typesDir, { recursive: true });
     await fs.writeFile(
       path.join(typesDir, "index.ts"),
-      'export type User = { id: string; name: string; };\n',
+      "export type User = { id: string; name: string; };\n",
     );
     await fs.writeFile(
       path.join(typesDir, "models.ts"),
-      'export interface Post { title: string; content: string; }\n',
+      "export interface Post { title: string; content: string; }\n",
     );
 
     const result = await loadTypeDefinitions({ workspaceDir: tempDir });
@@ -34,8 +34,8 @@ describe("type-definitions", () => {
     assert.equal(result.typesDir, "src/types");
     assert.equal(result.files.length, 2);
     // index.ts should be first
-    assert.equal(path.basename(result.files[0]!.relativePath), "index.ts");
-    assert.ok(result.files[0]!.content.includes("User"));
+    assert.equal(path.basename(result.files[0].relativePath), "index.ts");
+    assert.ok(result.files[0].content.includes("User"));
   });
 
   test("loadTypeDefinitions - falls back to types directory", async () => {
@@ -43,7 +43,7 @@ describe("type-definitions", () => {
     await fs.mkdir(typesDir, { recursive: true });
     await fs.writeFile(
       path.join(typesDir, "config.ts"),
-      'export type Config = { apiKey: string; };\n',
+      "export type Config = { apiKey: string; };\n",
     );
 
     const result = await loadTypeDefinitions({ workspaceDir: tempDir });
@@ -51,20 +51,20 @@ describe("type-definitions", () => {
     assert.equal(result.exists, true);
     assert.equal(result.typesDir, "types");
     assert.equal(result.files.length, 1);
-    assert.ok(result.files[0]!.content.includes("Config"));
+    assert.ok(result.files[0].content.includes("Config"));
   });
 
   test("loadTypeDefinitions - skips test files", async () => {
     const typesDir = path.join(tempDir, "src", "types");
     await fs.mkdir(typesDir, { recursive: true });
-    await fs.writeFile(path.join(typesDir, "user.ts"), 'export type User = {};\n');
+    await fs.writeFile(path.join(typesDir, "user.ts"), "export type User = {};\n");
     await fs.writeFile(path.join(typesDir, "user.test.ts"), 'test("user", () => {});\n');
     await fs.writeFile(path.join(typesDir, "user.spec.ts"), 'describe("user", () => {});\n');
 
     const result = await loadTypeDefinitions({ workspaceDir: tempDir });
 
     assert.equal(result.files.length, 1);
-    assert.equal(path.basename(result.files[0]!.relativePath), "user.ts");
+    assert.equal(path.basename(result.files[0].relativePath), "user.ts");
   });
 
   test("loadTypeDefinitions - returns empty when no types directory exists", async () => {
@@ -79,7 +79,7 @@ describe("type-definitions", () => {
     await fs.mkdir(typesDir, { recursive: true });
     const largeContent = "export type Large = {\n" + "  field: string;\n".repeat(10000) + "};\n";
     await fs.writeFile(path.join(typesDir, "large.ts"), largeContent);
-    await fs.writeFile(path.join(typesDir, "small.ts"), 'export type Small = {};\n');
+    await fs.writeFile(path.join(typesDir, "small.ts"), "export type Small = {};\n");
 
     const result = await loadTypeDefinitions({
       workspaceDir: tempDir,
@@ -89,16 +89,13 @@ describe("type-definitions", () => {
 
     // Should skip the large file but include the small one
     assert.equal(result.files.length, 1);
-    assert.equal(path.basename(result.files[0]!.relativePath), "small.ts");
+    assert.equal(path.basename(result.files[0].relativePath), "small.ts");
   });
 
   test("buildTypeDefinitionsPrompt - creates formatted prompt", async () => {
     const typesDir = path.join(tempDir, "src", "types");
     await fs.mkdir(typesDir, { recursive: true });
-    await fs.writeFile(
-      path.join(typesDir, "index.ts"),
-      'export type User = { id: string; };\n',
-    );
+    await fs.writeFile(path.join(typesDir, "index.ts"), "export type User = { id: string; };\n");
 
     const result = await loadTypeDefinitions({ workspaceDir: tempDir });
     const prompt = buildTypeDefinitionsPrompt(result);
@@ -127,7 +124,7 @@ describe("type-definitions", () => {
     const nestedDir = path.join(typesDir, "models");
     await fs.mkdir(nestedDir, { recursive: true });
     await fs.writeFile(path.join(typesDir, "index.ts"), 'export * from "./models";\n');
-    await fs.writeFile(path.join(nestedDir, "user.ts"), 'export type User = {};\n');
+    await fs.writeFile(path.join(nestedDir, "user.ts"), "export type User = {};\n");
 
     const result = await loadTypeDefinitions({ workspaceDir: tempDir });
 

--- a/src/agents/type-definitions.ts
+++ b/src/agents/type-definitions.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { openBoundaryFile } from "../infra/boundary-file-read.js";
+
+const MAX_TYPE_FILE_BYTES = 512_000; // 512KB per type file
+const MAX_TOTAL_TYPE_BYTES = 2_000_000; // 2MB total for all types
+
+export type TypeDefinitionFile = {
+  /** Relative path from workspace root */
+  relativePath: string;
+  /** Absolute path to the file */
+  absolutePath: string;
+  /** File content */
+  content: string;
+  /** File size in bytes */
+  size: number;
+};
+
+export type TypeDefinitionsResult = {
+  /** All type definition files found */
+  files: TypeDefinitionFile[];
+  /** Total size in bytes */
+  totalSize: number;
+  /** Directory where types were found (relative to workspace) */
+  typesDir?: string;
+  /** Whether types directory exists */
+  exists: boolean;
+};
+
+/**
+ * Detect and load type definitions from `src/types/` or `types/` directory.
+ * Returns type definition files and metadata for inclusion in agent prompts.
+ */
+export async function loadTypeDefinitions(params: {
+  workspaceDir: string;
+  /** Maximum bytes per file (default: 512KB) */
+  maxFileBytes?: number;
+  /** Maximum total bytes across all files (default: 2MB) */
+  maxTotalBytes?: number;
+}): Promise<TypeDefinitionsResult> {
+  const maxFileBytes = params.maxFileBytes ?? MAX_TYPE_FILE_BYTES;
+  const maxTotalBytes = params.maxTotalBytes ?? MAX_TOTAL_TYPE_BYTES;
+
+  // Try src/types first, then types
+  const candidates = ["src/types", "types"];
+  let typesDir: string | undefined;
+  let typesDirPath: string | undefined;
+
+  for (const candidate of candidates) {
+    const candidatePath = path.join(params.workspaceDir, candidate);
+    try {
+      const stat = await fs.stat(candidatePath);
+      if (stat.isDirectory()) {
+        typesDir = candidate;
+        typesDirPath = candidatePath;
+        break;
+      }
+    } catch {
+      // Try next candidate
+      continue;
+    }
+  }
+
+  if (!typesDir || !typesDirPath) {
+    return {
+      files: [],
+      totalSize: 0,
+      exists: false,
+    };
+  }
+
+  // Scan directory for TypeScript files
+  const files: TypeDefinitionFile[] = [];
+  let totalSize = 0;
+
+  const scanDir = async (dirPath: string, relativeBase: string): Promise<void> => {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.readdir(dirPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const absolutePath = path.join(dirPath, entry.name);
+      const relativePath = path.join(relativeBase, entry.name);
+
+      if (entry.isDirectory()) {
+        // Recursively scan subdirectories
+        await scanDir(absolutePath, relativePath);
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      // Only include .ts and .d.ts files
+      if (
+        !entry.name.endsWith(".ts") &&
+        !entry.name.endsWith(".d.ts") &&
+        !entry.name.endsWith(".tsx")
+      ) {
+        continue;
+      }
+
+      // Skip test files
+      if (
+        entry.name.endsWith(".test.ts") ||
+        entry.name.endsWith(".test.tsx") ||
+        entry.name.endsWith(".spec.ts") ||
+        entry.name.endsWith(".spec.tsx") ||
+        entry.name.includes(".test.") ||
+        entry.name.includes(".spec.")
+      ) {
+        continue;
+      }
+
+      // Check if we've exceeded total size limit
+      if (totalSize >= maxTotalBytes) {
+        break;
+      }
+
+      // Try to read the file
+      const opened = await openBoundaryFile({
+        absolutePath,
+        rootPath: params.workspaceDir,
+        boundaryLabel: "workspace root",
+        maxBytes: maxFileBytes,
+      });
+
+      if (!opened.ok) {
+        continue;
+      }
+
+      try {
+        const content = await fs.readFile(opened.fd, "utf-8");
+        const size = Buffer.byteLength(content, "utf-8");
+
+        // Skip if this file would exceed total limit
+        if (totalSize + size > maxTotalBytes) {
+          continue;
+        }
+
+        files.push({
+          relativePath,
+          absolutePath,
+          content,
+          size,
+        });
+
+        totalSize += size;
+      } catch {
+        // Skip files that can't be read
+      } finally {
+        try {
+          await fs.close(opened.fd);
+        } catch {
+          // Ignore close errors
+        }
+      }
+    }
+  };
+
+  await scanDir(typesDirPath, typesDir);
+
+  // Sort files: index.ts first (barrel export), then alphabetically
+  files.sort((a, b) => {
+    const aIsIndex = path.basename(a.relativePath).toLowerCase() === "index.ts";
+    const bIsIndex = path.basename(b.relativePath).toLowerCase() === "index.ts";
+
+    if (aIsIndex && !bIsIndex) return -1;
+    if (!aIsIndex && bIsIndex) return 1;
+
+    return a.relativePath.localeCompare(b.relativePath);
+  });
+
+  return {
+    files,
+    totalSize,
+    typesDir,
+    exists: true,
+  };
+}
+
+/**
+ * Build type definitions prompt section for agent system prompts.
+ * Returns formatted text to inject before project context files.
+ */
+export function buildTypeDefinitionsPrompt(result: TypeDefinitionsResult): string {
+  if (!result.exists || result.files.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [
+    "# Type Definitions",
+    "",
+    "The following TypeScript type definitions exist in this repository.",
+    "**CRITICAL:** Use ONLY the types defined below. Do NOT create new type names.",
+    "If you need a type that doesn't exist, ask before creating it.",
+    "",
+  ];
+
+  for (const file of result.files) {
+    lines.push(`## ${file.relativePath}`, "", "```typescript", file.content.trim(), "```", "");
+  }
+
+  return lines.join("\n");
+}

--- a/src/agents/type-definitions.ts
+++ b/src/agents/type-definitions.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { openBoundaryFile } from "../infra/boundary-file-read.js";
 
 const MAX_TYPE_FILE_BYTES = 512_000; // 512KB per type file
 const MAX_TOTAL_TYPE_BYTES = 2_000_000; // 2MB total for all types
@@ -122,25 +121,17 @@ export async function loadTypeDefinitions(params: {
       }
 
       // Try to read the file
-      const opened = await openBoundaryFile({
-        absolutePath,
-        rootPath: params.workspaceDir,
-        boundaryLabel: "workspace root",
-        maxBytes: maxFileBytes,
-      });
-
-      if (!opened.ok) {
-        continue;
-      }
-
       try {
-        const content = await fs.readFile(opened.fd, "utf-8");
-        const size = Buffer.byteLength(content, "utf-8");
+        const stat = await fs.stat(absolutePath);
+        const fileSize = stat.size;
 
-        // Skip if this file would exceed total limit
-        if (totalSize + size > maxTotalBytes) {
+        // Check if we've exceeded total size limit or file is too large
+        if (fileSize > maxFileBytes || totalSize + fileSize > maxTotalBytes) {
           continue;
         }
+
+        const content = await fs.readFile(absolutePath, "utf-8");
+        const size = Buffer.byteLength(content, "utf-8");
 
         files.push({
           relativePath,
@@ -152,12 +143,7 @@ export async function loadTypeDefinitions(params: {
         totalSize += size;
       } catch {
         // Skip files that can't be read
-      } finally {
-        try {
-          await fs.close(opened.fd);
-        } catch {
-          // Ignore close errors
-        }
+        continue;
       }
     }
   };
@@ -169,8 +155,12 @@ export async function loadTypeDefinitions(params: {
     const aIsIndex = path.basename(a.relativePath).toLowerCase() === "index.ts";
     const bIsIndex = path.basename(b.relativePath).toLowerCase() === "index.ts";
 
-    if (aIsIndex && !bIsIndex) return -1;
-    if (!aIsIndex && bIsIndex) return 1;
+    if (aIsIndex && !bIsIndex) {
+      return -1;
+    }
+    if (!aIsIndex && bIsIndex) {
+      return 1;
+    }
 
     return a.relativePath.localeCompare(b.relativePath);
   });

--- a/src/agents/type-definitions.ts
+++ b/src/agents/type-definitions.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -73,7 +74,7 @@ export async function loadTypeDefinitions(params: {
   let totalSize = 0;
 
   const scanDir = async (dirPath: string, relativeBase: string): Promise<void> => {
-    let entries: fs.Dirent[];
+    let entries: Dirent[];
     try {
       entries = await fs.readdir(dirPath, { withFileTypes: true });
     } catch {

--- a/src/agents/type-definitions.ts
+++ b/src/agents/type-definitions.ts
@@ -85,8 +85,10 @@ export async function loadTypeDefinitions(params: {
       const relativePath = path.join(relativeBase, entry.name);
 
       if (entry.isDirectory()) {
-        // Recursively scan subdirectories
-        await scanDir(absolutePath, relativePath);
+        // Recursively scan subdirectories (only if we still have budget)
+        if (totalSize < maxTotalBytes) {
+          await scanDir(absolutePath, relativePath);
+        }
         continue;
       }
 
@@ -94,12 +96,8 @@ export async function loadTypeDefinitions(params: {
         continue;
       }
 
-      // Only include .ts and .d.ts files
-      if (
-        !entry.name.endsWith(".ts") &&
-        !entry.name.endsWith(".d.ts") &&
-        !entry.name.endsWith(".tsx")
-      ) {
+      // Only include .ts and .tsx files (this already covers .d.ts)
+      if (!entry.name.endsWith(".ts") && !entry.name.endsWith(".tsx")) {
         continue;
       }
 
@@ -150,10 +148,13 @@ export async function loadTypeDefinitions(params: {
 
   await scanDir(typesDirPath, typesDir);
 
-  // Sort files: index.ts first (barrel export), then alphabetically
+  // Sort files: root index.ts first (barrel export), then alphabetically
   files.sort((a, b) => {
-    const aIsIndex = path.basename(a.relativePath).toLowerCase() === "index.ts";
-    const bIsIndex = path.basename(b.relativePath).toLowerCase() === "index.ts";
+    // Only prioritize root-level index.ts, not nested ones
+    const aIsIndex =
+      a.relativePath === `${typesDir}/index.ts` || a.relativePath === `${typesDir}\\index.ts`;
+    const bIsIndex =
+      b.relativePath === `${typesDir}/index.ts` || b.relativePath === `${typesDir}\\index.ts`;
 
     if (aIsIndex && !bIsIndex) {
       return -1;

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -28,13 +28,16 @@ export async function resolveCommandsSystemPromptBundle(
   params: HandleCommandsParams,
 ): Promise<CommandsSystemPromptBundle> {
   const workspaceDir = params.workspaceDir;
-  const { bootstrapFiles, contextFiles: injectedFiles, typeDefinitionsPrompt } =
-    await resolveBootstrapContextForRun({
-      workspaceDir,
-      config: params.cfg,
-      sessionKey: params.sessionKey,
-      sessionId: params.sessionEntry?.sessionId,
-    });
+  const {
+    bootstrapFiles,
+    contextFiles: injectedFiles,
+    typeDefinitionsPrompt,
+  } = await resolveBootstrapContextForRun({
+    workspaceDir,
+    config: params.cfg,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionEntry?.sessionId,
+  });
   const skillsSnapshot = (() => {
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -28,12 +28,13 @@ export async function resolveCommandsSystemPromptBundle(
   params: HandleCommandsParams,
 ): Promise<CommandsSystemPromptBundle> {
   const workspaceDir = params.workspaceDir;
-  const { bootstrapFiles, contextFiles: injectedFiles } = await resolveBootstrapContextForRun({
-    workspaceDir,
-    config: params.cfg,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionEntry?.sessionId,
-  });
+  const { bootstrapFiles, contextFiles: injectedFiles, typeDefinitionsPrompt } =
+    await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: params.cfg,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionEntry?.sessionId,
+    });
   const skillsSnapshot = (() => {
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {
@@ -130,6 +131,7 @@ export async function resolveCommandsSystemPromptBundle(
     runtimeInfo,
     sandboxInfo,
     memoryCitationsMode: params.cfg?.memory?.citations,
+    typeDefinitionsPrompt,
   });
 
   return { systemPrompt, tools, skillsPrompt, bootstrapFiles, injectedFiles, sandboxRuntime };


### PR DESCRIPTION
## Summary

Auto-detect and include TypeScript type definitions from `src/types` or `types` directory in agent dispatch prompts. This prevents agents from creating incompatible type systems by ensuring they see existing types before implementing features.

## Changes

- ✅ Add `type-definitions.ts` module to scan and load type definitions
- ✅ Integrate type definitions into bootstrap context resolution
- ✅ Inject type definitions prompt before project context files
- ✅ Add explicit instruction: 'Use ONLY the types defined below. Do NOT create new type names.'
- ✅ Include barrel export (`index.ts`) first for visibility
- ✅ Add comprehensive test coverage

## Testing

- Created test suite with 8 test cases covering:
  - Directory detection (src/types and types fallback)
  - Test file exclusion
  - Size limit handling
  - Nested directories
  - Prompt formatting

## Acceptance Criteria

- [x] Dispatch prompt includes type definitions from the repo
- [x] Agent instructions explicitly state to use existing types
- [x] Barrel export (index.ts) appears first in the prompt

Fixes #59