### PR TITLE
fix(windows): add windowsHide:true to restart-helper spawn to suppress console flicker, fix #44693

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -287,6 +287,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("/bin/sh", [scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -302,6 +303,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -317,6 +319,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", `"${scriptPath}"`], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
     });
   });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -169,6 +169,8 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    // Suppress the brief console window that Windows creates for child cmd.exe processes.
+    windowsHide: true,
   });
   child.unref();
 }


### PR DESCRIPTION
## Summary

On Windows, `runRestartScript()` spawns a detached `cmd.exe` process to run the gateway restart batch script. Because `windowsHide: true` was missing from the spawn options, Windows creates a visible console window for `cmd.exe` and for each `netstat | findstr` subprocess in the port-check loop. Users see multiple command prompt windows briefly flickering on every gateway start or restart.

### Root Cause

```typescript
// Before — missing windowsHide
const child = spawn(file, args, {
  detached: true,
  stdio: "ignore",
  // windowsHide: true  ← missing
});
```

Windows' default behavior is to create a new console window for every spawned process that has no parent console to inherit. Since the gateway process doesn't have a visible console, each child gets its own.

### Fix
Add windowsHide: true to the spawn options:

```
const child = spawn(file, args, {
  detached: true,
  stdio: "ignore",
  windowsHide: true,  // suppress console window on Windows
});
```

windowsHide is a Node.js child_process.spawn option that maps to the CREATE_NO_WINDOW / DETACHED_PROCESS flag combination on Windows. It is silently ignored on Linux/macOS, so there is no cross-platform risk.

### Change Type
- [x] Bug fix

### Scope

- [x] UI / DX (Windows gateway startup UX)

### Linked Issue

Fixes #44693

### User-visible / Behavior Changes

Before: Multiple cmd.exe windows briefly flash on screen during every gateway start/restart on Windows.

After: Gateway restarts silently in the background with no visible console windows.

### Security Impact
New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No

### Repro + Verification
All 20 existing restart-helper tests pass with updated assertions that include windowsHide: true in the expected spawn options.