### PR TITLE
Windows: hide detached restart console

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -287,6 +287,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("/bin/sh", [scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -302,6 +303,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -317,6 +319,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", `"${scriptPath}"`], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
     });
   });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -169,6 +169,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    windowsHide: true,
   });
   child.unref();
 }


### PR DESCRIPTION
## Summary

- Problem: `runRestartScript()` spawns detached restart scripts without `windowsHide: true`, which can flash a visible `cmd.exe` window on Windows.
- Why it matters: restart/update flows should stay backgrounded; surfacing an extra console window is noisy and makes the restart helper feel broken.
- What changed: added `windowsHide: true` to the detached spawn options and updated the focused unit tests to assert the spawned process stays hidden.
- What did NOT change (scope boundary): this does not change restart script contents, process lifetime, or non-restart spawn behavior elsewhere in the codebase.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44693
- Related #44655

## User-visible / Behavior Changes

- Windows restart/update helper processes no longer request a visible console window.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (unit-test verification); issue concerns Windows spawn flags
- Runtime/container: local Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): none

### Steps

1. Inspect `src/cli/update-cli/restart-helper.ts` and the existing `runRestartScript()` tests.
2. Add `windowsHide: true` to the detached spawn options.
3. Run `pnpm exec vitest run --config vitest.unit.config.ts src/cli/update-cli/restart-helper.test.ts`.

### Expected

- Detached restart scripts request hidden console windows on Windows.
- Focused restart-helper tests pass.

### Actual

- After the change, `runRestartScript()` passes `windowsHide: true` and the focused test file passes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: inspected the Windows restart helper path, updated the spawn options, and ran the focused `restart-helper` unit tests locally.
- Edge cases checked: Windows quoted-script path handling still uses the existing cmd.exe quoting path; Linux spawn expectations still pass with the shared spawn options.
- What you did **not** verify: I did not run a live Windows restart flow on a Windows host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit c6957e8feaddc333e6fabc45bdc75db8a22e5556
- Files/config to restore: `src/cli/update-cli/restart-helper.ts`, `src/cli/update-cli/restart-helper.test.ts`
- Known bad symptoms reviewers should watch for: unexpected restart-helper test failures around spawn option assertions

## Risks and Mitigations

- Risk: `windowsHide` is now passed in the shared spawn options object for both Windows and non-Windows tests.
  - Mitigation: the focused Linux and Windows unit tests now both assert the full spawn option shape.
