### PR TITLE
fix(config): extract Anthropic model aliases to break bundle TDZ

### DIFF
--- a/src/agents/anthropic-model-aliases.ts
+++ b/src/agents/anthropic-model-aliases.ts
@@ -1,0 +1,18 @@
+/**
+ * Anthropic model-id short aliases.
+ *
+ * Extracted into a standalone leaf module so the map is fully initialised
+ * before any config-parsing code references it at startup.  Keeping it in
+ * `model-selection.ts` caused a TDZ `ReferenceError` in the single-file
+ * bundle because the bundler placed the `const` declaration after the
+ * config/defaults code that calls `parseModelRef` during config load.
+ *
+ * See #44724.
+ */
+
+export const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
+  "opus-4.6": "claude-opus-4-6",
+  "opus-4.5": "claude-opus-4-5",
+  "sonnet-4.6": "claude-sonnet-4-6",
+  "sonnet-4.5": "claude-sonnet-4-5",
+};

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -12,6 +12,7 @@ import {
   resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride,
 } from "./agent-scope.js";
+import { ANTHROPIC_MODEL_ALIASES } from "./anthropic-model-aliases.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
@@ -29,13 +30,6 @@ export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh"
 export type ModelAliasIndex = {
   byAlias: Map<string, { alias: string; ref: ModelRef }>;
   byKey: Map<string, string[]>;
-};
-
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
 };
 
 function normalizeAliasKey(value: string): string {


### PR DESCRIPTION
## Problem

Gateway crashes at startup with `ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization` when any Anthropic model or auth profile is present in the config. This includes configs generated by `openclaw configure` itself.

## Root Cause

The single-file bundle places the `ANTHROPIC_MODEL_ALIASES` const declaration (from `model-selection.ts`) at line ~163k, well after the `applyContextPruningDefaults` function (from `config/defaults.ts`) at line ~4k. When the gateway reads its config at startup and Anthropic models are configured, `applyContextPruningDefaults` calls `parseModelRef` -> `normalizeProviderModelId` -> `normalizeAnthropicModelId`, which hits the const while it is still in the temporal dead zone.

## Fix

Extract `ANTHROPIC_MODEL_ALIASES` into a standalone leaf module (`anthropic-model-aliases.ts`) with zero transitive imports. The bundler will initialise this module before any config-parsing code runs, eliminating the TDZ window.

## Testing

- `tsc --noEmit` passes
- Existing tests unaffected (no test references the const directly)
- The alias map contents are unchanged

Closes #44724