### PR TITLE
fix(media-tools): apply models.provider baseUrl override in image-tool and pdf-tool

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolveUserPath } from "../../utils.js";
 import { loadWebMedia } from "../../web/media.js";
 import { isMinimaxVlmModel, isMinimaxVlmProvider, minimaxUnderstandImage } from "../minimax-vlm.js";
+import { resolveModelWithRegistry } from "../pi-embedded-runner/model.js";
 import {
   coerceImageAssistantText,
   coerceImageModelConfig,
@@ -14,7 +15,6 @@ import {
 import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
-  resolveModelFromRegistry,
   resolveMediaToolLocalRoots,
   resolveModelRuntimeApiKey,
   resolvePromptAndModelOverride,
@@ -217,7 +217,15 @@ async function runImagePrompt(params: {
     cfg: effectiveCfg,
     modelOverride: params.modelOverride,
     run: async (provider, modelId) => {
-      const model = resolveModelFromRegistry({ modelRegistry, provider, modelId });
+      const model = resolveModelWithRegistry({
+        modelRegistry,
+        provider,
+        modelId,
+        cfg: effectiveCfg,
+      });
+      if (!model) {
+        throw new Error(`Unknown model: ${provider}/${modelId}`);
+      }
       if (!model.input?.includes("image")) {
         throw new Error(`Model does not support images: ${provider}/${modelId}`);
       }

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -82,18 +82,6 @@ export function buildTextToolResult(
   };
 }
 
-export function resolveModelFromRegistry(params: {
-  modelRegistry: { find: (provider: string, modelId: string) => unknown };
-  provider: string;
-  modelId: string;
-}): Model<Api> {
-  const model = params.modelRegistry.find(params.provider, params.modelId) as Model<Api> | null;
-  if (!model) {
-    throw new Error(`Unknown model: ${params.provider}/${params.modelId}`);
-  }
-  return model;
-}
-
 export async function resolveModelRuntimeApiKey(params: {
   model: Model<Api>;
   cfg: OpenClawConfig | undefined;

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-extract.js";
 import { resolveUserPath } from "../../utils.js";
 import { loadWebMediaRaw } from "../../web/media.js";
+import { resolveModelWithRegistry } from "../pi-embedded-runner/model.js";
 import {
   coerceImageModelConfig,
   type ImageModelConfig,
@@ -12,7 +13,6 @@ import {
 import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
-  resolveModelFromRegistry,
   resolveMediaToolLocalRoots,
   resolveModelRuntimeApiKey,
   resolvePromptAndModelOverride,
@@ -199,7 +199,15 @@ async function runPdfPrompt(params: {
     cfg: effectiveCfg,
     modelOverride: params.modelOverride,
     run: async (provider, modelId) => {
-      const model = resolveModelFromRegistry({ modelRegistry, provider, modelId });
+      const model = resolveModelWithRegistry({
+        modelRegistry,
+        provider,
+        modelId,
+        cfg: effectiveCfg,
+      });
+      if (!model) {
+        throw new Error(`Unknown model: ${provider}/${modelId}`);
+      }
       const apiKey = await resolveModelRuntimeApiKey({
         model,
         cfg: effectiveCfg,


### PR DESCRIPTION
## Problem

`image-tool` and `pdf-tool` were calling `resolveModelFromRegistry()` which returns the raw model from the registry without applying any config overrides. As a result, `models.provider` baseUrl configuration was silently ignored — requests always went to the default provider endpoint.

## Root Cause

`resolveModelFromRegistry()` in `media-tool-shared.ts` does a plain registry lookup with no awareness of `OpenClawConfig`. The main agent uses `resolveModelWithRegistry()` which calls `applyConfiguredProviderOverrides()` and sets `model.baseUrl = providerConfig.baseUrl` before passing the model to `complete()`. The media tools bypassed this entirely.

## Fix

- Replace `resolveModelFromRegistry()` calls in `image-tool.ts` and `pdf-tool.ts` with `resolveModelWithRegistry()`, passing `effectiveCfg` so provider overrides (including `baseUrl`) are applied.
- Remove the now-unused `resolveModelFromRegistry()` export from `media-tool-shared.ts`.

## Test

Configure `models.providers.<provider>.baseUrl` to a proxy and send an image-tool or pdf-tool request — traffic should now route through the configured baseUrl.
