### PR TITLE
Telegram: fix media download behind HTTP proxy

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -36,6 +36,12 @@ type FetchMediaOptions = {
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
   dispatcherPolicy?: PinnedDispatcherPolicy;
+  /**
+   * Whether to enable DNS pinning at the SSRF guard layer.
+   * Defaults to true; set to false when the caller already applies
+   * its own dispatcher/proxy and only needs hostname-level SSRF checks.
+   */
+  pinDns?: boolean;
 };
 
 function stripQuotes(value: string): string {
@@ -94,6 +100,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     ssrfPolicy,
     lookupFn,
     dispatcherPolicy,
+    pinDns,
   } = options;
 
   let res: Response;
@@ -109,6 +116,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
         policy: ssrfPolicy,
         lookupFn,
         dispatcherPolicy,
+        ...(pinDns === false ? { pinDns: false } : {}),
       }),
     );
     res = result.response;

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -128,12 +128,18 @@ async function downloadAndSaveTelegramFile(params: {
   const url = `https://api.telegram.org/file/bot${params.token}/${params.filePath}`;
   const fetched = await fetchRemoteMedia({
     url,
-    fetchImpl: params.transport.sourceFetch,
-    dispatcherPolicy: params.transport.pinnedDispatcherPolicy,
+    // Use the transport's fully configured fetch so we preserve
+    // Telegram's proxy/dispatcher decisions (explicit proxy, env proxy,
+    // IPv4 fallback, etc.) instead of bypassing them.
+    fetchImpl: params.transport.fetch,
     filePathHint: params.filePath,
     maxBytes: params.maxBytes,
     readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
     ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
+    // Telegram already applies resolver-scoped dispatchers and proxy routing
+    // via resolveTelegramFetch. Disable DNS pinning at the SSRF layer so we
+    // don't override Telegram's dispatcher decisions or bypass HTTP proxies.
+    pinDns: false,
   });
   const originalName = params.telegramFileName ?? fetched.fileName ?? params.filePath;
   return saveMediaBuffer(


### PR DESCRIPTION
## Summary

- Fix Telegram media downloads when running behind an HTTP proxy.
- Keep SSRF protections for Telegram media while avoiding proxy bypass caused by DNS pinning.
- Change is scoped to Telegram media fetch + shared media fetch helper; no behavior change for other providers.

## Problem

When running behind an HTTP proxy, Telegram media downloads go through `fetchRemoteMedia` with SSRF DNS pinning enabled. The SSRF layer resolves and pins IPs itself, which can:
- Bypass the HTTP proxy route selected by `resolveTelegramFetch` / `EnvHttpProxyAgent` / `ProxyAgent`.
- Break fake-IP / internal-range proxy setups (common in Asia), triggering SSRF checks and causing media downloads to fail, even though normal Bot API calls work.

## What Changed

- `src/media/fetch.ts`:
  - Add an optional `pinDns?: boolean` option to `fetchRemoteMedia`.
  - Pass `pinDns: false` through to `fetchWithSsrFGuard` when requested, so the SSRF guard:
    - Still applies hostname-level policy (`SsrFPolicy`),
    - But does **not** create its own pinned dispatcher, letting caller-controlled dispatchers/proxies take effect.
- `src/telegram/bot/delivery.resolve-media.ts`:
  - For Telegram media downloads, call `fetchRemoteMedia` with:
    - `ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY` (whitelists `api.telegram.org`, allows RFC 2544 range),
    - `pinDns: false`, so DNS pinning is not re-applied on top of `resolveTelegramFetch`.
  - This keeps SSRF hostname checks but defers routing (proxy vs direct, IPv4 fallback, etc.) entirely to the Telegram network resolver.

## What Did NOT Change

- Telegram Bot API call path and retry logic for `getFile` are unchanged.
- SSRF policy for Telegram media still enforces hostname allowlist and internal-range rules via `TELEGRAM_MEDIA_SSRF_POLICY`.
- No changes to other providers (Slack/Discord/Web) or to the global SSRF behavior outside of the new `pinDns` opt-out flag.

## Testing

- Static reasoning:
  - Verified `fetchRemoteMedia` continues to use `fetchWithSsrFGuard` for all callers, with `pinDns` defaulting to the previous behavior (DNS pinning enabled).
  - Confirmed Telegram media path now passes `pinDns: false` while still providing a strict `ssrfPolicy`, so only Telegram media fetches opt out of guard-level DNS pinning.
- Unit tests:
  - Existing `src/media/fetch.test.ts` SSRF tests remain valid (private IP literals still blocked before fetch).
  - Existing Telegram media tests continue to cover the “prefer proxyFetch over global fetch” behavior; the new flag only affects how the SSRF guard wires dispatchers, not the URL or headers under test.
- Manual reasoning:
  - In proxy environments, media downloads now use the same dispatcher/proxy decisions as other Telegram calls (`resolveTelegramFetch`), avoiding proxy bypass while keeping SSRF protections.

Closes #44732.
Closes #44769. 