### PR TITLE
Config: prevent Anthropic alias TDZ during gateway startup

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -31,12 +31,7 @@ export type ModelAliasIndex = {
   byKey: Map<string, string[]>;
 };
 
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
-};
+const CLAUDE_46_MODEL_RE = /claude-(?:opus|sonnet)-4(?:\.|-)6(?:$|[-.])/i;
 
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
@@ -145,13 +140,30 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
   return Object.keys(backends).some((key) => normalizeProviderId(key) === normalized);
 }
 
+function resolveAnthropicModelAlias(modelLower: string): string | undefined {
+  // Keep alias resolution in a function declaration so parseModelRef stays safe
+  // during circular import evaluation before const bindings initialize.
+  switch (modelLower) {
+    case "opus-4.6":
+      return "claude-opus-4-6";
+    case "opus-4.5":
+      return "claude-opus-4-5";
+    case "sonnet-4.6":
+      return "claude-sonnet-4-6";
+    case "sonnet-4.5":
+      return "claude-sonnet-4-5";
+    default:
+      return undefined;
+  }
+}
+
 function normalizeAnthropicModelId(model: string): string {
   const trimmed = model.trim();
   if (!trimmed) {
     return trimmed;
   }
   const lower = trimmed.toLowerCase();
-  return ANTHROPIC_MODEL_ALIASES[lower] ?? trimmed;
+  return resolveAnthropicModelAlias(lower) ?? trimmed;
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {

--- a/src/config/config.pruning-defaults.test.ts
+++ b/src/config/config.pruning-defaults.test.ts
@@ -95,6 +95,9 @@ describe("config pruning defaults", () => {
       expect(cfg.agents?.defaults?.models?.["anthropic/sonnet-4.6"]?.params?.cacheRetention).toBe(
         "short",
       );
+      expect(
+        cfg.agents?.defaults?.models?.["anthropic/claude-sonnet-4-6"]?.params?.cacheRetention,
+      ).toBeUndefined();
     });
   });
 

--- a/src/config/config.pruning-defaults.test.ts
+++ b/src/config/config.pruning-defaults.test.ts
@@ -73,6 +73,31 @@ describe("config pruning defaults", () => {
     });
   });
 
+  it("loads Anthropic shorthand model refs without crashing", async () => {
+    await withTempHome(async (home) => {
+      await writeConfigForTest(home, {
+        auth: {
+          profiles: {
+            "anthropic:default": { provider: "anthropic", mode: "api_key" },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/sonnet-4.6": { alias: "sonnet" },
+            },
+          },
+        },
+      });
+
+      const cfg = loadConfig();
+
+      expect(cfg.agents?.defaults?.models?.["anthropic/sonnet-4.6"]?.params?.cacheRetention).toBe(
+        "short",
+      );
+    });
+  });
+
   it("adds default cacheRetention for Anthropic Claude models on Bedrock", async () => {
     await withTempHome(async (home) => {
       await writeConfigForTest(home, {


### PR DESCRIPTION
## Summary

- Problem: Gateway startup could crash with `ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization` when Anthropic config triggered `parseModelRef` during module initialization ordering.
- Why it matters: Any Anthropic provider/profile config could block gateway startup, including configs created by `openclaw configure`.
- What changed: Replaced Anthropic alias lookup from a top-level `const` map to a function-declaration switch lookup so `parseModelRef` no longer depends on a TDZ-prone binding during circular import evaluation.
- What did NOT change (scope boundary): No changes to model alias semantics, provider routing, or context-pruning policy defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44724
- Related #N/A

## User-visible / Behavior Changes

Gateway startup no longer crashes when Anthropic auth profiles/model refs are present, including shorthand refs like `anthropic/sonnet-4.6`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: Anthropic
- Integration/channel (if any): Gateway config load path
- Relevant config (redacted): Anthropic auth profile + Anthropic model refs (including shorthand alias ref)

### Steps

1. Configure Anthropic auth/profile and Anthropic model refs in config.
2. Trigger config load path (gateway startup / pruning defaults path).
3. Verify config load completes without TDZ exception.

### Expected

- Config load and gateway startup succeed with Anthropic configuration present.

### Actual

- After this patch, no `ANTHROPIC_MODEL_ALIASES` TDZ crash occurs.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run --config vitest.unit.config.ts src/config/config.pruning-defaults.test.ts` -> passed (`7 passed`).
  - `pnpm exec vitest run src/agents/model-selection.test.ts` -> passed (`47 passed`).
  - `pnpm build` -> passed.
- Edge cases checked:
  - Anthropic shorthand model ref `anthropic/sonnet-4.6` now loads through pruning-defaults path without crash (new regression test).
- What you did **not** verify:
  - End-to-end `openclaw gateway restart` on a globally installed npm package build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/agents/model-selection.ts`.
- Known bad symptoms reviewers should watch for: Anthropic shorthand aliases no longer resolving to canonical Claude IDs.

## Risks and Mitigations

- Risk: Alias resolution logic diverges from previous map behavior.
  - Mitigation: Switch cases preserve the same alias mappings; existing model-selection tests pass.
