### PR TITLE
fix(session): preserve `lastAccountId ` and `lastThreadId` on session reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/media downloads: thread the same direct or proxy transport policy into SSRF-guarded file fetches so inbound attachments keep working when Telegram falls back between env-proxy and direct networking. (#44639) Thanks @obviyus.
 - Agents/compaction: compare post-compaction token sanity checks against full-session pre-compaction totals and skip the check when token estimation fails, so sessions with large bootstrap context keep real token counts instead of falling back to unknown. (#28347) thanks @efe-arv.
 - Discord/gateway startup: treat plain-text and transient `/gateway/bot` metadata fetch failures as transient startup errors so Discord gateway boot no longer crashes on unhandled rejections. (#44397) Thanks @jalehman.
+- Gateway/session reset: preserve `lastAccountId` and `lastThreadId` across gateway session resets so replies keep routing back to the same account and thread after `/reset`. (#44773) Thanks @Lanfei.
 
 ## 2026.3.12
 

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -266,6 +266,7 @@ describe("gateway server sessions", () => {
           lastChannel: "whatsapp",
           lastTo: "+1555",
           lastAccountId: "work",
+          lastThreadId: "1737500000.123456",
         },
         "discord:group:dev": {
           sessionId: "sess-group",
@@ -336,6 +337,7 @@ describe("gateway server sessions", () => {
       channel: "whatsapp",
       to: "+1555",
       accountId: "work",
+      threadId: "1737500000.123456",
     });
 
     const active = await rpcReq<{
@@ -545,13 +547,27 @@ describe("gateway server sessions", () => {
     const reset = await rpcReq<{
       ok: true;
       key: string;
-      entry: { sessionId: string; modelProvider?: string; model?: string };
+      entry: {
+        sessionId: string;
+        modelProvider?: string;
+        model?: string;
+        lastAccountId?: string;
+        lastThreadId?: string | number;
+      };
     }>(ws, "sessions.reset", { key: "agent:main:main" });
     expect(reset.ok).toBe(true);
     expect(reset.payload?.key).toBe("agent:main:main");
     expect(reset.payload?.entry.sessionId).not.toBe("sess-main");
     expect(reset.payload?.entry.modelProvider).toBe("openai");
     expect(reset.payload?.entry.model).toBe("gpt-test-a");
+    expect(reset.payload?.entry.lastAccountId).toBe("work");
+    expect(reset.payload?.entry.lastThreadId).toBe("1737500000.123456");
+    const storeAfterReset = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      { lastAccountId?: string; lastThreadId?: string | number }
+    >;
+    expect(storeAfterReset["agent:main:main"]?.lastAccountId).toBe("work");
+    expect(storeAfterReset["agent:main:main"]?.lastThreadId).toBe("1737500000.123456");
     const filesAfterReset = await fs.readdir(dir);
     expect(filesAfterReset.some((f) => f.startsWith("sess-main.jsonl.reset."))).toBe(true);
 

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -338,6 +338,8 @@ export async function performGatewaySessionReset(params: {
       origin: snapshotSessionOrigin(currentEntry),
       lastChannel: currentEntry?.lastChannel,
       lastTo: currentEntry?.lastTo,
+      lastAccountId: currentEntry?.lastAccountId,
+      lastThreadId: currentEntry?.lastThreadId,
       skillsSnapshot: currentEntry?.skillsSnapshot,
       inputTokens: 0,
       outputTokens: 0,


### PR DESCRIPTION
## Summary

- **Problem:** `performGatewaySessionReset` omitted `lastAccountId` and `lastThreadId` when constructing `nextEntry`, causing both fields to be lost after a session reset.
- **Why it matters:** These fields identify the source account and thread for message routing; losing them after reset can cause replies to fail to route back to the original conversation.
- **What changed:** Added `lastAccountId` and `lastThreadId` to the `nextEntry` construction in `session-reset-service.ts`, consistent with how `lastChannel` and `lastTo` are already handled.
- **What did NOT change:** No other fields, reset flow steps, or ACP cleanup behavior are affected.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #

## User-visible / Behavior Changes

After a session reset, `lastAccountId` and `lastThreadId` are now correctly preserved, restoring proper message routing behavior.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. Establish an active session with `lastAccountId` / `lastThreadId` set (e.g. via a Discord thread message)
2. Trigger a session reset (`/reset` or equivalent)
3. Send a new message

### Expected

- Reply is routed back to the original account/thread

### Actual (before fix)

- `lastAccountId` / `lastThreadId` were cleared on reset, causing routing failure or lost replies

## Evidence

- [ ] Code diff directly shows the omitted fields

## Human Verification

- Verified scenarios: code review confirmed fields were missing from `nextEntry`
- Edge cases checked: `currentEntry` being `undefined` is handled safely via optional chaining
- What you did **not** verify: end-to-end Discord/Telegram thread reset flow

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: `git revert` this commit
- Files/config to restore: `src/gateway/session-reset-service.ts`
- Known bad symptoms reviewers should watch for: None

## Risks and Mitigations

None
