### PR TITLE
refactor: remove redundant ?? undefined in Slack probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - macOS/onboarding: avoid self-restarting freshly bootstrapped launchd gateways and give new daemon installs longer to become healthy, so `openclaw onboard --install-daemon` no longer false-fails on slower Macs and fresh VM snapshots.
 - Agents/compaction: preserve safeguard compaction summary language continuity via default and configurable custom instructions so persona drift is reduced after auto-compaction. (#10456) Thanks @keepitmello.
 - Agents/tool warnings: distinguish gated core tools like `apply_patch` from plugin-only unknown entries in `tools.profile` warnings, so unavailable core tools now report current runtime/provider/model/config gating instead of suggesting a missing plugin.
+- Slack/probe: keep `auth.test()` bot and team metadata mapping stable while simplifying the probe result path. (#44775) Thanks @Cafexss.
 
 ## 2026.3.12
 

--- a/src/slack/probe.test.ts
+++ b/src/slack/probe.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authTestMock = vi.hoisted(() => vi.fn());
+const createSlackWebClientMock = vi.hoisted(() => vi.fn());
+const withTimeoutMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createSlackWebClient: createSlackWebClientMock,
+}));
+
+vi.mock("../utils/with-timeout.js", () => ({
+  withTimeout: withTimeoutMock,
+}));
+
+const { probeSlack } = await import("./probe.js");
+
+describe("probeSlack", () => {
+  beforeEach(() => {
+    authTestMock.mockReset();
+    createSlackWebClientMock.mockReset();
+    withTimeoutMock.mockReset();
+
+    createSlackWebClientMock.mockReturnValue({
+      auth: {
+        test: authTestMock,
+      },
+    });
+    withTimeoutMock.mockImplementation(async (promise: Promise<unknown>) => await promise);
+  });
+
+  it("maps Slack auth metadata on success", async () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(100).mockReturnValueOnce(145);
+    authTestMock.mockResolvedValue({
+      ok: true,
+      user_id: "U123",
+      user: "openclaw-bot",
+      team_id: "T123",
+      team: "OpenClaw",
+    });
+
+    await expect(probeSlack("xoxb-test", 2500)).resolves.toEqual({
+      ok: true,
+      status: 200,
+      elapsedMs: 45,
+      bot: { id: "U123", name: "openclaw-bot" },
+      team: { id: "T123", name: "OpenClaw" },
+    });
+    expect(createSlackWebClientMock).toHaveBeenCalledWith("xoxb-test");
+    expect(withTimeoutMock).toHaveBeenCalledWith(expect.any(Promise), 2500);
+  });
+
+  it("keeps optional auth metadata fields undefined when Slack omits them", async () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(200).mockReturnValueOnce(235);
+    authTestMock.mockResolvedValue({ ok: true });
+
+    const result = await probeSlack("xoxb-test");
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.elapsedMs).toBe(35);
+    expect(result.bot).toStrictEqual({ id: undefined, name: undefined });
+    expect(result.team).toStrictEqual({ id: undefined, name: undefined });
+  });
+});

--- a/src/slack/probe.ts
+++ b/src/slack/probe.ts
@@ -26,8 +26,8 @@ export async function probeSlack(token: string, timeoutMs = 2500): Promise<Slack
       ok: true,
       status: 200,
       elapsedMs: Date.now() - start,
-      bot: { id: result.user_id ?? undefined, name: result.user ?? undefined },
-      team: { id: result.team_id ?? undefined, name: result.team ?? undefined },
+      bot: { id: result.user_id, name: result.user },
+      team: { id: result.team_id, name: result.team },
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
 Remove redundant nullish coalescing with undefined (?? undefined) in Slack probe result handling. The properties from Slack auth.test() are already typed as string | undefined, so ?? undefined is a no-op.

  Summary

  - Problem: Code in src/slack/probe.ts uses redundant ?? undefined patterns
  - Why it matters: Redundant code reduces readability without providing any benefit
  - What changed: Removed ?? undefined from 4 property assignments (2 lines)
  - What did NOT change: No behavior change, same output

  Change Type

  - Refactor

  Scope

  - Integrations (Slack)

  User-visible / Behavior Changes

  None

  Security Impact

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Verification

  Code inspection: The ?? undefined is a no-op since the properties are already string | undefined typed by the Slack Web API.

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  Risks and Mitigations

  None - this is a no-op refactor.