### PR TITLE
fix(cli): add windowsHide to restart script spawn to suppress console windows (#44693)

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -302,6 +302,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -317,6 +318,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", `"${scriptPath}"`], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
     });
   });

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -287,6 +287,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("/bin/sh", [scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: false,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -169,6 +169,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    ...(isWindows ? { windowsHide: true } : {}),
   });
   child.unref();
 }

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -169,7 +169,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
-    ...(isWindows ? { windowsHide: true } : {}),
+    windowsHide: isWindows,
   });
   child.unref();
 }


### PR DESCRIPTION
## Summary

- **Problem:** On Windows, when the OpenClaw gateway starts or restarts, multiple visible command prompt windows briefly appear during the port-checking loop.
- **Why it matters:** Affects all Windows users; causes visual distraction on every gateway start/restart.
- **What changed:** Added `windowsHide: true` to the `spawn()` options in `runRestartScript()` when running on Windows.
- **What did NOT change:** Linux/macOS behavior unchanged.

## Change Type
- [x] Bug fix

## Linked Issue/PR
- Closes #44693

## Evidence
- Unit tests updated in `restart-helper.test.ts` to assert `windowsHide: true` in spawn options on Windows.
