### PR TITLE
fix(docker): exclude .env from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,11 @@
 .git
 .worktrees
+
+# Sensitive files – docker-setup.sh writes .env with OPENCLAW_GATEWAY_TOKEN
+# into the project root; keep it out of the build context.
+.env
+.env.*
+
 .bun-cache
 .bun
 .tmp


### PR DESCRIPTION
## Problem

`docker-setup.sh` creates a `.env` file in the project root containing `OPENCLAW_GATEWAY_TOKEN` (a 64-character random hex secret).  While `.gitignore` already excludes `.env`, the `.dockerignore` does **not**.

When a user runs `docker build .`, the `.env` file — including the gateway token — is sent to the Docker daemon as part of the build context.  This means the secret could end up cached in an image layer or exposed in build logs.

## Fix

Add `.env` and `.env.*` patterns to `.dockerignore`, right next to the other dotfile exclusions.

## Changes

- `.dockerignore`: add `.env` and `.env.*` exclusion with explanatory comment

## Testing

```bash
# Verify .env is now excluded from the build context
echo 'OPENCLAW_GATEWAY_TOKEN=test_secret' > .env
docker build --no-cache -f /dev/null . 2>&1 | grep -c '.env'  # should be 0
```

## Related

- `.gitignore` line 3 already excludes `.env`
- `docker-setup.sh` lines 357-401 create/update `.env` with the gateway token
