### PR TITLE
feat(LanceDB-context): support LanceDB based context engine

### DIFF
--- a/extensions/context-lancedb/index.ts
+++ b/extensions/context-lancedb/index.ts
@@ -1,0 +1,22 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/compat";
+import { createLanceDbContextEngine } from "./src/engine.js";
+
+const lancedbContextPlugin = {
+  id: "lancedb-context",
+  name: "Context Engine (LanceDB)",
+  description: "LanceDB-backed context engine with same-session-key history recall",
+  kind: "context-engine" as const,
+
+  register(api: OpenClawPluginApi) {
+    const engine = createLanceDbContextEngine({
+      config: api.config,
+      pluginConfig: api.pluginConfig,
+      logger: api.logger,
+      resolvePath: api.resolvePath,
+    });
+
+    api.registerContextEngine("lancedb-context", () => engine);
+  },
+};
+
+export default lancedbContextPlugin;

--- a/extensions/context-lancedb/openclaw.plugin.json
+++ b/extensions/context-lancedb/openclaw.plugin.json
@@ -1,0 +1,178 @@
+{
+  "id": "lancedb-context",
+  "name": "Context Engine (LanceDB)",
+  "description": "LanceDB-backed context engine with same-session-key history recall.",
+  "kind": "context-engine",
+  "uiHints": {
+    "dbPath": {
+      "label": "Database Path",
+      "placeholder": "~/.openclaw/context/lancedb",
+      "advanced": true
+    },
+    "embedding.provider": {
+      "label": "Embedding Provider",
+      "help": "Embedding provider used for message, summary, and query vectors."
+    },
+    "embedding.fallback": {
+      "label": "Embedding Fallback",
+      "help": "Fallback provider when the primary provider is unavailable.",
+      "advanced": true
+    },
+    "embedding.model": {
+      "label": "Embedding Model",
+      "help": "Embedding model id passed to the selected provider."
+    },
+    "embedding.dimensions": {
+      "label": "Embedding Dimensions",
+      "help": "Required vector size for LanceDB schemas."
+    },
+    "embedding.baseUrl": {
+      "label": "Embedding Base URL",
+      "advanced": true
+    },
+    "embedding.apiKey": {
+      "label": "Embedding API Key",
+      "sensitive": true,
+      "advanced": true
+    },
+    "assembly.recentTailTokens": {
+      "label": "Recent Tail Tokens",
+      "advanced": true
+    },
+    "assembly.retrievalTopK": {
+      "label": "Retrieval Top K",
+      "advanced": true
+    },
+    "assembly.retrievalMinScore": {
+      "label": "Retrieval Min Score",
+      "advanced": true
+    },
+    "assembly.maxRetrievedChars": {
+      "label": "Max Retrieved Chars",
+      "advanced": true
+    },
+    "assembly.crossSessionScope": {
+      "label": "Cross Session Scope",
+      "advanced": true
+    },
+    "assembly.crossSessionRecallMode": {
+      "label": "Cross Session Recall Mode",
+      "advanced": true
+    },
+    "maintenance.optimizeIntervalMinutes": {
+      "label": "Optimize Interval Minutes",
+      "advanced": true
+    },
+    "limits.maxMessageCharsForEmbedding": {
+      "label": "Max Message Chars For Embedding",
+      "advanced": true
+    },
+    "limits.skipLargeToolResultChars": {
+      "label": "Skip Large Tool Result Chars",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "dbPath": {
+        "type": "string"
+      },
+      "embedding": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": ["auto", "openai", "gemini", "voyage", "mistral", "ollama", "local"]
+          },
+          "fallback": {
+            "type": "string",
+            "enum": ["none", "openai", "gemini", "voyage", "mistral", "ollama", "local"]
+          },
+          "model": {
+            "type": "string"
+          },
+          "dimensions": {
+            "type": "number",
+            "minimum": 1
+          },
+          "baseUrl": {
+            "type": "string"
+          },
+          "apiKey": {
+            "type": "string"
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "localModelPath": {
+            "type": "string"
+          },
+          "localModelCacheDir": {
+            "type": "string"
+          }
+        }
+      },
+      "assembly": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "recentTailTokens": {
+            "type": "number",
+            "minimum": 1
+          },
+          "retrievalTopK": {
+            "type": "number",
+            "minimum": 1
+          },
+          "retrievalMinScore": {
+            "type": "number",
+            "minimum": -1,
+            "maximum": 1
+          },
+          "maxRetrievedChars": {
+            "type": "number",
+            "minimum": 1
+          },
+          "crossSessionScope": {
+            "type": "string",
+            "enum": ["session_key"]
+          },
+          "crossSessionRecallMode": {
+            "type": "string",
+            "enum": ["summary-first"]
+          }
+        }
+      },
+      "maintenance": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "optimizeIntervalMinutes": {
+            "type": "number",
+            "minimum": 1
+          }
+        }
+      },
+      "limits": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "maxMessageCharsForEmbedding": {
+            "type": "number",
+            "minimum": 1
+          },
+          "skipLargeToolResultChars": {
+            "type": "number",
+            "minimum": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/context-lancedb/package.json
+++ b/extensions/context-lancedb/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/context-lancedb",
+  "version": "2026.3.13",
+  "private": true,
+  "description": "OpenClaw LanceDB-backed context engine with same-session-key recall",
+  "type": "module",
+  "dependencies": {
+    "@lancedb/lancedb": "^0.26.2"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/context-lancedb/src/config.ts
+++ b/extensions/context-lancedb/src/config.ts
@@ -1,0 +1,164 @@
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import type {
+  EmbeddingProviderFallback,
+  EmbeddingProviderRequest,
+} from "../../../src/memory/embeddings.js";
+import { resolveUserPath } from "../../../src/utils.js";
+
+export type LanceDbContextPluginConfig = {
+  dbPath?: string;
+  embedding?: {
+    provider?: EmbeddingProviderRequest;
+    fallback?: EmbeddingProviderFallback;
+    model?: string;
+    dimensions?: number;
+    baseUrl?: string;
+    apiKey?: string;
+    headers?: Record<string, string>;
+    localModelPath?: string;
+    localModelCacheDir?: string;
+  };
+  assembly?: {
+    recentTailTokens?: number;
+    retrievalTopK?: number;
+    retrievalMinScore?: number;
+    maxRetrievedChars?: number;
+    crossSessionScope?: "session_key";
+    crossSessionRecallMode?: "summary-first";
+  };
+  maintenance?: {
+    optimizeIntervalMinutes?: number;
+  };
+  limits?: {
+    maxMessageCharsForEmbedding?: number;
+    skipLargeToolResultChars?: number;
+  };
+};
+
+export type ResolvedLanceDbContextConfig = {
+  openclawConfig: OpenClawConfig;
+  dbPath: string;
+  embedding: {
+    provider: EmbeddingProviderRequest;
+    fallback: EmbeddingProviderFallback;
+    model: string;
+    dimensions: number;
+    remote?: {
+      baseUrl?: string;
+      apiKey?: string;
+      headers?: Record<string, string>;
+    };
+    local?: {
+      modelPath?: string;
+      modelCacheDir?: string;
+    };
+  };
+  assembly: {
+    recentTailTokens: number;
+    retrievalTopK: number;
+    retrievalMinScore: number;
+    maxRetrievedChars: number;
+    crossSessionScope: "session_key";
+    crossSessionRecallMode: "summary-first";
+  };
+  maintenance: {
+    optimizeIntervalMinutes: number;
+  };
+  limits: {
+    maxMessageCharsForEmbedding: number;
+    skipLargeToolResultChars: number;
+  };
+};
+
+const DEFAULT_DB_PATH = "~/.openclaw/context/lancedb";
+const DEFAULT_MODEL = "text-embedding-3-small";
+const DEFAULT_DIMS_BY_MODEL: Record<string, number> = {
+  "text-embedding-3-small": 1536,
+  "text-embedding-3-large": 3072,
+  "text-embedding-ada-002": 1536,
+};
+
+function resolveEnvVars(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => process.env[envVar] ?? "");
+}
+
+function resolvePositiveInt(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  return fallback;
+}
+
+function resolveClampedNumber(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.min(max, Math.max(min, value));
+  }
+  return fallback;
+}
+
+function resolveDimensions(model: string, value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  const fallback = DEFAULT_DIMS_BY_MODEL[model];
+  if (!fallback) {
+    throw new Error(`lancedb-context: embedding.dimensions is required for model "${model}"`);
+  }
+  return fallback;
+}
+
+export function resolveLanceDbContextConfig(params: {
+  config: OpenClawConfig;
+  pluginConfig?: Record<string, unknown>;
+  resolvePath: (input: string) => string;
+}): ResolvedLanceDbContextConfig {
+  const raw = (params.pluginConfig ?? {}) as LanceDbContextPluginConfig;
+  const embedding = raw.embedding ?? {};
+  const model = (embedding.model?.trim() || DEFAULT_MODEL).trim();
+  const dimensions = resolveDimensions(model, embedding.dimensions);
+  const dbPath = params.resolvePath(raw.dbPath?.trim() || DEFAULT_DB_PATH);
+
+  return {
+    openclawConfig: params.config,
+    dbPath: resolveUserPath(dbPath),
+    embedding: {
+      provider: embedding.provider ?? "auto",
+      fallback: embedding.fallback ?? "none",
+      model,
+      dimensions,
+      remote:
+        embedding.baseUrl || embedding.apiKey || embedding.headers
+          ? {
+              baseUrl: embedding.baseUrl ? resolveEnvVars(embedding.baseUrl) : undefined,
+              apiKey: embedding.apiKey ? resolveEnvVars(embedding.apiKey) : undefined,
+              headers: embedding.headers,
+            }
+          : undefined,
+      local:
+        embedding.localModelPath || embedding.localModelCacheDir
+          ? {
+              modelPath: embedding.localModelPath,
+              modelCacheDir: embedding.localModelCacheDir,
+            }
+          : undefined,
+    },
+    assembly: {
+      recentTailTokens: resolvePositiveInt(raw.assembly?.recentTailTokens, 12_000),
+      retrievalTopK: resolvePositiveInt(raw.assembly?.retrievalTopK, 8),
+      retrievalMinScore: resolveClampedNumber(raw.assembly?.retrievalMinScore, 0.2, -1, 1),
+      maxRetrievedChars: resolvePositiveInt(raw.assembly?.maxRetrievedChars, 6_000),
+      crossSessionScope: "session_key",
+      crossSessionRecallMode: "summary-first",
+    },
+    maintenance: {
+      optimizeIntervalMinutes: resolvePositiveInt(raw.maintenance?.optimizeIntervalMinutes, 30),
+    },
+    limits: {
+      maxMessageCharsForEmbedding: resolvePositiveInt(
+        raw.limits?.maxMessageCharsForEmbedding,
+        4_000,
+      ),
+      skipLargeToolResultChars: resolvePositiveInt(raw.limits?.skipLargeToolResultChars, 8_000),
+    },
+  };
+}

--- a/extensions/context-lancedb/src/engine.test.ts
+++ b/extensions/context-lancedb/src/engine.test.ts
@@ -1,0 +1,782 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import type { EmbeddingProvider, EmbeddingProviderResult } from "../../../src/memory/embeddings.js";
+import { createLanceDbContextEngine } from "./engine.js";
+
+const compactEmbeddedPiSessionDirect = vi.fn(async () => ({
+  ok: true,
+  compacted: true,
+  reason: "legacy",
+  result: {
+    summary: "legacy summary",
+    firstKeptEntryId: "entry-1",
+    tokensBefore: 120,
+    tokensAfter: 60,
+    details: { source: "mock" },
+  },
+}));
+
+vi.mock("../../../src/agents/pi-embedded-runner/compact.runtime.js", () => ({
+  compactEmbeddedPiSessionDirect,
+}));
+
+class FakeField {
+  constructor(
+    readonly name: string,
+    readonly type: unknown,
+    readonly nullable: boolean,
+  ) {}
+}
+
+class FakeSchema {
+  constructor(readonly fields: unknown[]) {}
+}
+
+class FakeUtf8 {}
+class FakeInt32 {}
+class FakeFloat32 {}
+class FakeFloat64 {}
+
+type FakeRow = Record<string, unknown>;
+
+function dotProduct(left: number[], right: number[]): number {
+  if (left.length === 0 || left.length !== right.length) {
+    return -1;
+  }
+  let total = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    total += left[index]! * right[index]!;
+  }
+  return total;
+}
+
+function decodeSqlString(value: string): string {
+  return value.replace(/''/g, "'");
+}
+
+function matchesClause(row: FakeRow, clause: string): boolean {
+  const trimmed = clause.trim();
+  if (!trimmed) {
+    return true;
+  }
+
+  let match = trimmed.match(/^([a-z_]+)\s+IS\s+NOT\s+NULL$/i);
+  if (match) {
+    return row[match[1]!] != null;
+  }
+
+  match = trimmed.match(/^([a-z_]+)\s*!=\s*'(.*)'$/i);
+  if (match) {
+    return String(row[match[1]!] ?? "") !== decodeSqlString(match[2]!);
+  }
+
+  match = trimmed.match(/^([a-z_]+)\s*=\s*'(.*)'$/i);
+  if (match) {
+    return String(row[match[1]!] ?? "") === decodeSqlString(match[2]!);
+  }
+
+  match = trimmed.match(/^([a-z_]+)\s*>\s*(-?\d+(?:\.\d+)?)$/i);
+  if (match) {
+    return Number(row[match[1]!] ?? 0) > Number(match[2]!);
+  }
+
+  throw new Error(`Unsupported fake LanceDB filter clause: ${trimmed}`);
+}
+
+function matchesFilter(row: FakeRow, filter?: string): boolean {
+  if (!filter) {
+    return true;
+  }
+  return filter.split(/\s+AND\s+/).every((clause) => matchesClause(row, clause));
+}
+
+class FakeQuery {
+  protected whereClause = "";
+  protected rowLimit = Number.POSITIVE_INFINITY;
+
+  constructor(protected readonly rows: FakeRow[]) {}
+
+  where(clause: string): this {
+    this.whereClause = clause;
+    return this;
+  }
+
+  limit(count: number): this {
+    this.rowLimit = count;
+    return this;
+  }
+
+  async toArray(): Promise<FakeRow[]> {
+    return this.rows
+      .filter((row) => matchesFilter(row, this.whereClause))
+      .slice(0, this.rowLimit)
+      .map((row) => ({ ...row }));
+  }
+}
+
+class FakeVectorQuery extends FakeQuery {
+  constructor(
+    rows: FakeRow[],
+    private readonly queryVector: number[],
+  ) {
+    super(rows);
+  }
+
+  override async toArray(): Promise<FakeRow[]> {
+    return this.rows
+      .filter((row) => matchesFilter(row, this.whereClause))
+      .map((row) => ({
+        row,
+        score: Array.isArray(row.embedding)
+          ? dotProduct(this.queryVector, row.embedding as number[])
+          : -1,
+      }))
+      .sort((left, right) => right.score - left.score)
+      .slice(0, this.rowLimit)
+      .map((item) => ({ ...item.row }));
+  }
+}
+
+class FakeTable {
+  readonly rows: FakeRow[] = [];
+
+  constructor(readonly name: string) {}
+
+  mergeInsert(key: string) {
+    const builder = {
+      whenMatchedUpdateAll: () => builder,
+      whenNotMatchedInsertAll: () => builder,
+      execute: async (rows: FakeRow[]) => {
+        for (const row of rows) {
+          const value = row[key];
+          const index = this.rows.findIndex((candidate) => candidate[key] === value);
+          if (index >= 0) {
+            this.rows[index] = { ...this.rows[index]!, ...row };
+          } else {
+            this.rows.push({ ...row });
+          }
+        }
+      },
+    };
+    return builder;
+  }
+
+  query(): FakeQuery {
+    return new FakeQuery(this.rows);
+  }
+
+  vectorSearch(vector: number[]): FakeVectorQuery {
+    return new FakeVectorQuery(this.rows, vector);
+  }
+
+  async delete(predicate: string): Promise<void> {
+    const kept = this.rows.filter((row) => !matchesFilter(row, predicate));
+    this.rows.splice(0, this.rows.length, ...kept);
+  }
+
+  async createIndex(_column: string): Promise<void> {}
+
+  async optimize(): Promise<void> {}
+}
+
+class FakeConnection {
+  private readonly tables = new Map<string, FakeTable>();
+
+  async tableNames(): Promise<string[]> {
+    return [...this.tables.keys()];
+  }
+
+  async openTable(name: string): Promise<FakeTable> {
+    const table = this.tables.get(name);
+    if (!table) {
+      throw new Error(`Missing fake table: ${name}`);
+    }
+    return table;
+  }
+
+  async createEmptyTable(name: string, _schema: unknown): Promise<FakeTable> {
+    const table = new FakeTable(name);
+    this.tables.set(name, table);
+    return table;
+  }
+
+  async createTable(name: string, data: FakeRow[]): Promise<FakeTable> {
+    const table = new FakeTable(name);
+    table.rows.push(...data.map((row) => ({ ...row })));
+    this.tables.set(name, table);
+    return table;
+  }
+}
+
+function createFakeLanceDbModule() {
+  const connections = new Map<string, FakeConnection>();
+  return {
+    Field: FakeField,
+    Float32: FakeFloat32,
+    Float64: FakeFloat64,
+    Int32: FakeInt32,
+    Schema: FakeSchema,
+    Utf8: FakeUtf8,
+    newVectorType: (dimensions: number, inner: unknown) => ({ dimensions, inner }),
+    connect: async (uri: string) => {
+      let connection = connections.get(uri);
+      if (!connection) {
+        connection = new FakeConnection();
+        connections.set(uri, connection);
+      }
+      return connection;
+    },
+  };
+}
+
+function createEmbeddingProvider(): EmbeddingProvider {
+  const vocabulary = [
+    "auth",
+    "token",
+    "lancedb",
+    "summary",
+    "context",
+    "history",
+    "session",
+    "reset",
+  ];
+
+  const embed = (text: string): number[] => {
+    const lower = text.toLowerCase();
+    const vector = vocabulary.map((token) => {
+      const matches = lower.match(new RegExp(token, "g"));
+      return matches?.length ?? 0;
+    });
+    const magnitude = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+    return magnitude > 0 ? vector.map((value) => value / magnitude) : vector;
+  };
+
+  return {
+    id: "test",
+    model: "test-model",
+    embedQuery: async (text) => embed(text),
+    embedBatch: async (texts) => texts.map((text) => embed(text)),
+  };
+}
+
+function createEmbeddingProviderResult(): Promise<EmbeddingProviderResult> {
+  return Promise.resolve({
+    provider: createEmbeddingProvider(),
+    requestedProvider: "openai",
+  });
+}
+
+function createLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+function createMessage(params: {
+  id: string;
+  parentId: string | null;
+  role: "user" | "assistant" | "tool";
+  content: string;
+}) {
+  return {
+    type: "message",
+    id: params.id,
+    parentId: params.parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: params.role,
+      content: params.content,
+      timestamp: Date.now(),
+    },
+  };
+}
+
+function createCompaction(params: {
+  id: string;
+  parentId: string | null;
+  summary: string;
+  firstKeptEntryId: string;
+}) {
+  return {
+    type: "compaction",
+    id: params.id,
+    parentId: params.parentId,
+    timestamp: new Date().toISOString(),
+    summary: params.summary,
+    firstKeptEntryId: params.firstKeptEntryId,
+    tokensBefore: 100,
+  };
+}
+
+async function writeTranscript(file: string, entries: unknown[]): Promise<void> {
+  const header = {
+    type: "session",
+    version: 3,
+    id: path.basename(file, ".jsonl"),
+    timestamp: new Date().toISOString(),
+    cwd: process.cwd(),
+  };
+  const content = [header, ...entries].map((entry) => JSON.stringify(entry)).join("\n");
+  await fs.writeFile(file, `${content}\n`, "utf-8");
+}
+
+async function writeSessionStore(
+  dir: string,
+  entries: Record<string, { sessionId: string; updatedAt: number }>,
+): Promise<void> {
+  await fs.writeFile(path.join(dir, "sessions.json"), JSON.stringify(entries, null, 2), "utf-8");
+}
+
+function createEngine(params: {
+  dbPath: string;
+  logger?: ReturnType<typeof createLogger>;
+  loadLanceDb?: () => Promise<typeof import("@lancedb/lancedb")>;
+  embeddingProviderFactory?: (params: {
+    config: OpenClawConfig;
+    resolved: {
+      embedding: { dimensions: number };
+    };
+    agentDir?: string;
+  }) => Promise<EmbeddingProviderResult>;
+}) {
+  return createLanceDbContextEngine({
+    config: {} as OpenClawConfig,
+    pluginConfig: {
+      dbPath: params.dbPath,
+      embedding: {
+        provider: "openai",
+        model: "text-embedding-3-small",
+        dimensions: 8,
+      },
+      assembly: {
+        recentTailTokens: 2_000,
+        retrievalTopK: 4,
+        retrievalMinScore: 0.15,
+        maxRetrievedChars: 4_000,
+        crossSessionScope: "session_key",
+        crossSessionRecallMode: "summary-first",
+      },
+      maintenance: {
+        optimizeIntervalMinutes: 30,
+      },
+      limits: {
+        maxMessageCharsForEmbedding: 1_000,
+        skipLargeToolResultChars: 2_000,
+      },
+    },
+    logger: params.logger ?? createLogger(),
+    resolvePath: (input) => input,
+    deps: {
+      loadLanceDb: params.loadLanceDb ?? (async () => createFakeLanceDbModule() as never),
+      embeddingProviderFactory: params.embeddingProviderFactory ?? createEmbeddingProviderResult,
+    },
+  });
+}
+
+function runtimeMessages(query: string): AgentMessage[] {
+  return [
+    {
+      role: "user",
+      content: query,
+      timestamp: Date.now(),
+    } as AgentMessage,
+  ];
+}
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  compactEmbeddedPiSessionDirect.mockClear();
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("context-lancedb engine", () => {
+  it("bootstrap indexes transcript and resolves session_key from sessions.json", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lancedb-context-"));
+    tempRoots.push(root);
+
+    const sessionFile = path.join(root, "current-1.jsonl");
+    await writeTranscript(sessionFile, [
+      createMessage({ id: "m1", parentId: null, role: "user", content: "We store auth tokens." }),
+      createMessage({
+        id: "m2",
+        parentId: "m1",
+        role: "assistant",
+        content: "We keep a compact session summary in LanceDB.",
+      }),
+      createCompaction({
+        id: "c1",
+        parentId: "m2",
+        summary: "Current session summary keeps LanceDB auth token context.",
+        firstKeptEntryId: "m2",
+      }),
+    ]);
+    await writeSessionStore(root, {
+      "family-key": {
+        sessionId: "current-1",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const engine = createEngine({
+      dbPath: path.join(root, "db"),
+    });
+
+    expect(engine.bootstrap).toBeDefined();
+    const bootstrap = await engine.bootstrap!({
+      sessionId: "current-1",
+      sessionFile,
+    });
+    expect(bootstrap.bootstrapped).toBe(true);
+    expect(bootstrap.importedMessages).toBe(2);
+
+    const assembled = await engine.assemble({
+      sessionId: "current-1",
+      messages: runtimeMessages("Why do we keep auth token context in LanceDB summaries?"),
+      tokenBudget: 4_000,
+    });
+
+    expect(assembled.systemPromptAddition).toContain("Current session summary");
+    expect(assembled.systemPromptAddition).toContain(
+      "Current session summary keeps LanceDB auth token context.",
+    );
+  });
+
+  it("assembles current summary plus same-session_key historical summaries and messages", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lancedb-context-"));
+    tempRoots.push(root);
+
+    const oldSummaryFile = path.join(root, "old-summary.jsonl");
+    const oldMessagesFile = path.join(root, "old-messages.jsonl");
+    const currentFile = path.join(root, "current.jsonl");
+    const otherFamilyFile = path.join(root, "other-family.jsonl");
+
+    await writeTranscript(oldSummaryFile, [
+      createMessage({
+        id: "os1",
+        parentId: null,
+        role: "user",
+        content: "We need durable auth token context.",
+      }),
+      createMessage({
+        id: "os2",
+        parentId: "os1",
+        role: "assistant",
+        content: "Use LanceDB summaries so reset sessions can recall auth token context.",
+      }),
+      createMessage({
+        id: "os3",
+        parentId: "os2",
+        role: "user",
+        content: "Make sure reset still recalls the auth context.",
+      }),
+      createCompaction({
+        id: "osc1",
+        parentId: "os3",
+        summary: "Historical decision: LanceDB summaries preserve auth token context across reset.",
+        firstKeptEntryId: "os3",
+      }),
+    ]);
+
+    await writeTranscript(oldMessagesFile, [
+      createMessage({
+        id: "om1",
+        parentId: null,
+        role: "user",
+        content:
+          "When there is no summary yet, keep the raw auth token context message searchable.",
+      }),
+      createMessage({
+        id: "om2",
+        parentId: "om1",
+        role: "assistant",
+        content: "LanceDB message recall supplements historical sessions without summaries.",
+      }),
+    ]);
+
+    await writeTranscript(currentFile, [
+      createMessage({
+        id: "cu1",
+        parentId: null,
+        role: "user",
+        content: "We are refining the current session context engine.",
+      }),
+      createMessage({
+        id: "cu2",
+        parentId: "cu1",
+        role: "assistant",
+        content: "Current session summary tracks the context-engine changes.",
+      }),
+      createCompaction({
+        id: "cuc1",
+        parentId: "cu2",
+        summary: "Current session summary: implementing LanceDB context-engine projection.",
+        firstKeptEntryId: "cu2",
+      }),
+    ]);
+
+    await writeTranscript(otherFamilyFile, [
+      createMessage({
+        id: "of1",
+        parentId: null,
+        role: "user",
+        content: "Other family also mentions auth token context and LanceDB.",
+      }),
+      createCompaction({
+        id: "ofc1",
+        parentId: "of1",
+        summary: "This summary belongs to another session family and must not be recalled.",
+        firstKeptEntryId: "of1",
+      }),
+    ]);
+
+    const engine = createEngine({
+      dbPath: path.join(root, "db"),
+    });
+
+    expect(engine.afterTurn).toBeDefined();
+    await engine.afterTurn!({
+      sessionId: "old-summary",
+      sessionFile: oldSummaryFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      runtimeContext: { sessionKey: "family-key", agentDir: root },
+    });
+    await engine.afterTurn!({
+      sessionId: "old-messages",
+      sessionFile: oldMessagesFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      runtimeContext: { sessionKey: "family-key", agentDir: root },
+    });
+    await engine.afterTurn!({
+      sessionId: "current",
+      sessionFile: currentFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      runtimeContext: { sessionKey: "family-key", agentDir: root },
+    });
+    await engine.afterTurn!({
+      sessionId: "other-family",
+      sessionFile: otherFamilyFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      runtimeContext: { sessionKey: "other-key", agentDir: root },
+    });
+
+    const assembled = await engine.assemble({
+      sessionId: "current",
+      messages: runtimeMessages(
+        "Why do we use LanceDB to preserve auth token context after reset?",
+      ),
+      tokenBudget: 4_000,
+    });
+
+    expect(assembled.systemPromptAddition).toContain(
+      "Current session summary: implementing LanceDB context-engine projection.",
+    );
+    expect(assembled.systemPromptAddition).toContain(
+      "Historical decision: LanceDB summaries preserve auth token context across reset.",
+    );
+    expect(assembled.systemPromptAddition).toContain(
+      "LanceDB message recall supplements historical sessions without summaries.",
+    );
+    expect(assembled.systemPromptAddition).not.toContain(
+      "This summary belongs to another session family and must not be recalled.",
+    );
+
+    const summaryIndex = assembled.systemPromptAddition?.indexOf(
+      "Relevant history from earlier sessions in this conversation family",
+    );
+    const messageIndex = assembled.systemPromptAddition?.indexOf("Relevant prior messages");
+    expect(summaryIndex).toBeTypeOf("number");
+    expect(messageIndex).toBeTypeOf("number");
+    expect(summaryIndex!).toBeLessThan(messageIndex!);
+  });
+
+  it("delegates compact() to the legacy compaction runtime", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lancedb-context-"));
+    tempRoots.push(root);
+
+    const engine = createEngine({
+      dbPath: path.join(root, "db"),
+    });
+
+    const result = await engine.compact({
+      sessionId: "current",
+      sessionFile: path.join(root, "session.jsonl"),
+      tokenBudget: 2_000,
+      force: true,
+      runtimeContext: {
+        sessionKey: "family-key",
+        workspaceDir: root,
+      },
+    });
+
+    expect(compactEmbeddedPiSessionDirect).toHaveBeenCalledTimes(1);
+    expect(compactEmbeddedPiSessionDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "current",
+        sessionFile: path.join(root, "session.jsonl"),
+        tokenBudget: 2_000,
+        force: true,
+        sessionKey: "family-key",
+        workspaceDir: root,
+      }),
+    );
+    expect(result).toEqual({
+      ok: true,
+      compacted: true,
+      reason: "legacy",
+      result: {
+        summary: "legacy summary",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 120,
+        tokensAfter: 60,
+        details: { source: "mock" },
+      },
+    });
+  });
+
+  it("caches embedding providers per agentDir and reuses the session agent for assemble", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lancedb-context-"));
+    tempRoots.push(root);
+
+    const alphaSessionsDir = path.join(root, "agents", "alpha", "sessions");
+    const betaSessionsDir = path.join(root, "agents", "beta", "sessions");
+    await fs.mkdir(alphaSessionsDir, { recursive: true });
+    await fs.mkdir(betaSessionsDir, { recursive: true });
+
+    const alphaAgentDir = path.join(root, "agents", "alpha", "agent");
+    const betaAgentDir = path.join(root, "agents", "beta", "agent");
+
+    const alphaFile = path.join(alphaSessionsDir, "alpha.jsonl");
+    const betaOldFile = path.join(betaSessionsDir, "beta-old.jsonl");
+    const betaCurrentFile = path.join(betaSessionsDir, "beta-current.jsonl");
+
+    await writeTranscript(alphaFile, [
+      createMessage({
+        id: "a1",
+        parentId: null,
+        role: "user",
+        content: "Alpha session uses a different embedding provider.",
+      }),
+    ]);
+
+    await writeTranscript(betaOldFile, [
+      createMessage({
+        id: "b1",
+        parentId: null,
+        role: "user",
+        content: "Beta history must be recalled for auth token context.",
+      }),
+      createCompaction({
+        id: "bc1",
+        parentId: "b1",
+        summary: "Beta historical summary should only recall with the beta embedding provider.",
+        firstKeptEntryId: "b1",
+      }),
+    ]);
+
+    await writeTranscript(betaCurrentFile, [
+      createMessage({
+        id: "b2",
+        parentId: null,
+        role: "user",
+        content: "Current beta session is asking about auth token context.",
+      }),
+      createCompaction({
+        id: "bc2",
+        parentId: "b2",
+        summary: "Current beta summary.",
+        firstKeptEntryId: "b2",
+      }),
+    ]);
+
+    const embeddingProviderFactory = vi.fn(
+      async (params: {
+        config: OpenClawConfig;
+        resolved: { embedding: { dimensions: number } };
+        agentDir?: string;
+      }): Promise<EmbeddingProviderResult> => {
+        const vector = Array.from({ length: params.resolved.embedding.dimensions }, (_, index) => {
+          if (params.agentDir === alphaAgentDir) {
+            return index === 0 ? 1 : 0;
+          }
+          if (params.agentDir === betaAgentDir) {
+            return index === 1 ? 1 : 0;
+          }
+          return index === 2 ? 1 : 0;
+        });
+
+        return {
+          provider: {
+            id: params.agentDir ?? "default",
+            model: "test-model",
+            embedQuery: async () => vector,
+            embedBatch: async (texts) => texts.map(() => vector),
+          },
+          requestedProvider: "openai",
+        };
+      },
+    );
+
+    const engine = createEngine({
+      dbPath: path.join(root, "db"),
+      embeddingProviderFactory,
+    });
+
+    await engine.afterTurn!({
+      sessionId: "alpha",
+      sessionFile: alphaFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      runtimeContext: { sessionKey: "alpha-key", agentDir: alphaAgentDir },
+    });
+    await engine.afterTurn!({
+      sessionId: "beta-old",
+      sessionFile: betaOldFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      runtimeContext: { sessionKey: "beta-key", agentDir: betaAgentDir },
+    });
+    await engine.afterTurn!({
+      sessionId: "beta-current",
+      sessionFile: betaCurrentFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      runtimeContext: { sessionKey: "beta-key", agentDir: betaAgentDir },
+    });
+
+    const assembled = await engine.assemble({
+      sessionId: "beta-current",
+      messages: runtimeMessages("Which historical auth token context should beta sessions recall?"),
+      tokenBudget: 4_000,
+    });
+
+    expect(assembled.systemPromptAddition).toContain(
+      "Beta historical summary should only recall with the beta embedding provider.",
+    );
+    expect(embeddingProviderFactory).toHaveBeenCalledTimes(2);
+    expect(embeddingProviderFactory).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ agentDir: alphaAgentDir }),
+    );
+    expect(embeddingProviderFactory).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ agentDir: betaAgentDir }),
+    );
+  });
+});

--- a/extensions/context-lancedb/src/engine.ts
+++ b/extensions/context-lancedb/src/engine.ts
@@ -1,0 +1,1575 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type * as LanceDb from "@lancedb/lancedb";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type {
+  CompactionEntry,
+  CustomMessageEntry,
+  FileEntry,
+  SessionMessageEntry,
+} from "@mariozechner/pi-coding-agent";
+import type {
+  AssembleResult,
+  BootstrapResult,
+  CompactResult,
+  ContextEngine,
+  ContextEngineInfo,
+  IngestResult,
+} from "openclaw/plugin-sdk/compat";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import { resolveDefaultSessionStorePath } from "../../../src/config/sessions/paths.js";
+import { loadSessionStore, normalizeStoreSessionKey } from "../../../src/config/sessions/store.js";
+import type { SessionEntry } from "../../../src/config/sessions/types.js";
+import {
+  createEmbeddingProvider,
+  type EmbeddingProvider,
+  type EmbeddingProviderResult,
+} from "../../../src/memory/embeddings.js";
+import type { PluginLogger } from "../../../src/plugins/types.js";
+import { extractTextFromChatContent } from "../../../src/shared/chat-content.js";
+import { resolveLanceDbContextConfig, type ResolvedLanceDbContextConfig } from "./config.js";
+
+const SESSIONS_TABLE = "ce_sessions";
+const MESSAGES_TABLE = "ce_messages";
+const SUMMARIES_TABLE = "ce_summaries";
+const SYNC_STATE_TABLE = "ce_sync_state";
+
+type TableName =
+  | typeof SESSIONS_TABLE
+  | typeof MESSAGES_TABLE
+  | typeof SUMMARIES_TABLE
+  | typeof SYNC_STATE_TABLE;
+
+type SessionRow = {
+  session_id: string;
+  session_key: string;
+  active_summary_id: string | null;
+  latest_message_seq: number;
+  summary_covered_until_seq: number;
+  updated_at: number;
+};
+
+type MessageRole = "user" | "assistant" | "tool" | "toolResult" | "other";
+
+type MessageRow = {
+  message_id: string;
+  session_id: string;
+  session_key: string;
+  message_seq: number;
+  turn_seq: number;
+  role: MessageRole;
+  text: string;
+  embedding: number[] | null;
+};
+
+type SummaryRow = {
+  summary_id: string;
+  session_id: string;
+  session_key: string;
+  end_seq: number;
+  text: string;
+  embedding: number[] | null;
+};
+
+type SyncStateRow = {
+  session_id: string;
+  session_file: string;
+  last_ingested_line: number;
+  last_optimized_at: number | null;
+};
+
+type ContextEngineRuntimeContext = Record<string, unknown>;
+
+type EmbeddingTask = {
+  kind: "message" | "summary";
+  id: string;
+  text: string;
+};
+
+type HistoricalTurn = {
+  sessionId: string;
+  turnSeq: number;
+  score: number;
+  text: string;
+};
+
+type SearchResult<T> = {
+  row: T;
+  score: number;
+};
+
+type EngineDeps = {
+  loadLanceDb?: () => Promise<typeof import("@lancedb/lancedb")>;
+  embeddingProviderFactory?: (params: {
+    config: OpenClawConfig;
+    resolved: ResolvedLanceDbContextConfig;
+    agentDir?: string;
+  }) => Promise<EmbeddingProviderResult>;
+};
+
+let lancedbImportPromise: Promise<typeof import("@lancedb/lancedb")> | null = null;
+const maintenanceJobs = new Map<string, Promise<void>>();
+
+const loadLanceDb = async (): Promise<typeof import("@lancedb/lancedb")> => {
+  if (!lancedbImportPromise) {
+    lancedbImportPromise = import("@lancedb/lancedb");
+  }
+  try {
+    return await lancedbImportPromise;
+  } catch (err) {
+    throw new Error(`lancedb-context: failed to load LanceDB. ${String(err)}`, { cause: err });
+  }
+};
+
+function quoteSql(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function normalizeSessionKey(value: string | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return "";
+  }
+  return normalizeStoreSessionKey(trimmed);
+}
+
+function normalizeTextFingerprint(value: string): string {
+  return value.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  const clipped = text.slice(0, Math.max(0, maxChars - 3)).trimEnd();
+  return `${clipped}...`;
+}
+
+function coerceNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+function coerceString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function coerceNullableString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function coerceVector(value: unknown): number[] | null {
+  if (Array.isArray(value)) {
+    const vector = value.map((item) => Number(item)).filter((item) => Number.isFinite(item));
+    return vector.length > 0 ? vector : null;
+  }
+  if (value instanceof Float32Array || value instanceof Float64Array) {
+    const vector = Array.from(value).filter((item) => Number.isFinite(item));
+    return vector.length > 0 ? vector : null;
+  }
+  return null;
+}
+
+function coerceSessionRow(row: Record<string, unknown>): SessionRow {
+  return {
+    session_id: coerceString(row.session_id),
+    session_key: coerceString(row.session_key),
+    active_summary_id: coerceNullableString(row.active_summary_id),
+    latest_message_seq: coerceNumber(row.latest_message_seq),
+    summary_covered_until_seq: coerceNumber(row.summary_covered_until_seq),
+    updated_at: coerceNumber(row.updated_at),
+  };
+}
+
+function coerceMessageRow(row: Record<string, unknown>): MessageRow {
+  return {
+    message_id: coerceString(row.message_id),
+    session_id: coerceString(row.session_id),
+    session_key: coerceString(row.session_key),
+    message_seq: coerceNumber(row.message_seq),
+    turn_seq: coerceNumber(row.turn_seq),
+    role: normalizeRole(row.role),
+    text: coerceString(row.text),
+    embedding: coerceVector(row.embedding),
+  };
+}
+
+function coerceSummaryRow(row: Record<string, unknown>): SummaryRow {
+  return {
+    summary_id: coerceString(row.summary_id),
+    session_id: coerceString(row.session_id),
+    session_key: coerceString(row.session_key),
+    end_seq: coerceNumber(row.end_seq),
+    text: coerceString(row.text),
+    embedding: coerceVector(row.embedding),
+  };
+}
+
+function coerceSyncStateRow(row: Record<string, unknown>): SyncStateRow {
+  return {
+    session_id: coerceString(row.session_id),
+    session_file: coerceString(row.session_file),
+    last_ingested_line: coerceNumber(row.last_ingested_line),
+    last_optimized_at:
+      typeof row.last_optimized_at === "number" && Number.isFinite(row.last_optimized_at)
+        ? row.last_optimized_at
+        : null,
+  };
+}
+
+function estimateTextTokens(text: string): number {
+  if (!text.trim()) {
+    return 0;
+  }
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function estimateMessageTokens(message: AgentMessage): number {
+  const text = extractTextFromChatContent((message as { content?: unknown }).content) ?? "";
+  return estimateTextTokens(text);
+}
+
+function dotProduct(left: number[], right: number[]): number {
+  if (left.length === 0 || right.length === 0 || left.length !== right.length) {
+    return -1;
+  }
+  let sum = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    sum += left[index]! * right[index]!;
+  }
+  return sum;
+}
+
+function normalizeRole(role: unknown): MessageRole {
+  const value = typeof role === "string" ? role.trim().toLowerCase() : "";
+  if (value === "user" || value === "assistant") {
+    return value;
+  }
+  if (value === "tool" || value === "tool_use" || value === "toolcall" || value === "tool_call") {
+    return "tool";
+  }
+  if (value === "toolresult" || value === "tool_result" || value === "tool_result_error") {
+    return "toolResult";
+  }
+  return "other";
+}
+
+function isToolLikeRole(role: MessageRole): boolean {
+  return role === "tool" || role === "toolResult";
+}
+
+function extractMessageText(content: unknown): string {
+  return (
+    extractTextFromChatContent(content, {
+      joinWith: "\n",
+      normalizeText: (text) => text.replace(/\s+/g, " ").trim(),
+    }) ?? ""
+  );
+}
+
+function groupMessagesIntoTurns(messages: AgentMessage[]): AgentMessage[][] {
+  const turns: AgentMessage[][] = [];
+  let current: AgentMessage[] = [];
+
+  for (const message of messages) {
+    const role = normalizeRole((message as { role?: unknown }).role);
+    if (role === "user" && current.length > 0) {
+      turns.push(current);
+      current = [message];
+      continue;
+    }
+    current.push(message);
+  }
+
+  if (current.length > 0) {
+    turns.push(current);
+  }
+
+  return turns;
+}
+
+function formatCurrentSummary(text: string): string {
+  return text.trim();
+}
+
+function formatHistoricalSummary(row: SummaryRow): string {
+  return `Session ${row.session_id} summary:\n${row.text.trim()}`;
+}
+
+function formatHistoricalTurn(turn: HistoricalTurn): string {
+  return `Session ${turn.sessionId} turn ${turn.turnSeq}:\n${turn.text.trim()}`;
+}
+
+function buildPromptSections(
+  sections: Array<{ title: string; blocks: string[] }>,
+): string | undefined {
+  const rendered = sections
+    .filter((section) => section.blocks.length > 0)
+    .map((section) => `${section.title}:\n${section.blocks.join("\n\n")}`)
+    .join("\n\n");
+  return rendered.trim() ? rendered : undefined;
+}
+
+function selectRecentTail(
+  messages: AgentMessage[],
+  tailBudget: number,
+): {
+  messages: AgentMessage[];
+  tokens: number;
+  textFingerprints: Set<string>;
+} {
+  const turns = groupMessagesIntoTurns(messages);
+  const kept: AgentMessage[][] = [];
+  let usedTokens = 0;
+
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const turn = turns[index] ?? [];
+    const turnTokens = turn.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
+    if (kept.length > 0 && usedTokens + turnTokens > tailBudget) {
+      break;
+    }
+    kept.unshift(turn);
+    usedTokens += turnTokens;
+  }
+
+  const flat = kept.flat();
+  const textFingerprints = new Set(
+    flat
+      .map((message) =>
+        normalizeTextFingerprint(
+          extractTextFromChatContent((message as { content?: unknown }).content) ?? "",
+        ),
+      )
+      .filter(Boolean),
+  );
+
+  return {
+    messages: flat,
+    tokens: usedTokens,
+    textFingerprints,
+  };
+}
+
+function shouldScheduleMaintenance(params: {
+  syncState: SyncStateRow | null;
+  importedRows: number;
+  optimizeIntervalMinutes: number;
+  nowMs: number;
+}): boolean {
+  if (params.importedRows === 0) {
+    return false;
+  }
+  if (params.importedRows >= 100) {
+    return true;
+  }
+  const lastOptimizedAt = params.syncState?.last_optimized_at;
+  if (lastOptimizedAt == null) {
+    return true;
+  }
+  return params.nowMs - lastOptimizedAt >= params.optimizeIntervalMinutes * 60_000;
+}
+
+function extractAgentIdFromSessionFile(sessionFile: string): string | undefined {
+  const parts = path.resolve(sessionFile).split(path.sep).filter(Boolean);
+  const sessionsIndex = parts.lastIndexOf("sessions");
+  if (sessionsIndex < 2 || parts[sessionsIndex - 2] !== "agents") {
+    return undefined;
+  }
+  return parts[sessionsIndex - 1] || undefined;
+}
+
+function extractAgentDirFromSessionFile(sessionFile: string): string | undefined {
+  const resolved = path.resolve(sessionFile);
+  const parts = resolved.split(path.sep).filter(Boolean);
+  const sessionsIndex = parts.lastIndexOf("sessions");
+  if (sessionsIndex < 2 || parts[sessionsIndex - 2] !== "agents") {
+    return undefined;
+  }
+
+  const agentRoot = path.join(path.sep, ...parts.slice(0, sessionsIndex));
+  return path.join(agentRoot, "agent");
+}
+
+function parseTranscriptEntries(content: string): {
+  entries: Array<{ line: number; entry: FileEntry }>;
+  totalLines: number;
+} {
+  const lines = content.split(/\r?\n/);
+  const entries: Array<{ line: number; entry: FileEntry }> = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line?.trim()) {
+      continue;
+    }
+    try {
+      entries.push({
+        line: index + 1,
+        entry: JSON.parse(line) as FileEntry,
+      });
+    } catch {
+      // Ignore malformed transcript lines and continue indexing the rest.
+    }
+  }
+
+  return {
+    entries,
+    totalLines: lines.length,
+  };
+}
+
+class LanceDbContextEngineImpl implements ContextEngine {
+  readonly info: ContextEngineInfo = {
+    id: "lancedb-context",
+    name: "LanceDB Context Engine",
+    version: "1.0.0",
+    ownsCompaction: false,
+  };
+
+  private db: LanceDb.Connection | null = null;
+  private tables: Partial<Record<TableName, LanceDb.Table>> = {};
+  private initPromise: Promise<void> | null = null;
+  private embeddingProviderPromises = new Map<string, Promise<EmbeddingProviderResult>>();
+
+  constructor(
+    private readonly resolved: ResolvedLanceDbContextConfig,
+    private readonly logger: PluginLogger,
+    private readonly deps: Required<EngineDeps>,
+  ) {}
+
+  async bootstrap(params: { sessionId: string; sessionFile: string }): Promise<BootstrapResult> {
+    const importedMessages = await this.syncSession({
+      sessionId: params.sessionId,
+      sessionFile: params.sessionFile,
+      reason: "bootstrap",
+    });
+    return {
+      bootstrapped: true,
+      importedMessages,
+    };
+  }
+
+  async ingest(_params: {
+    sessionId: string;
+    message: AgentMessage;
+    isHeartbeat?: boolean;
+  }): Promise<IngestResult> {
+    return { ingested: false };
+  }
+
+  async afterTurn(params: {
+    sessionId: string;
+    sessionFile: string;
+    messages: AgentMessage[];
+    prePromptMessageCount: number;
+    autoCompactionSummary?: string;
+    isHeartbeat?: boolean;
+    tokenBudget?: number;
+    runtimeContext?: ContextEngineRuntimeContext;
+  }): Promise<void> {
+    const sessionKey = normalizeSessionKey(
+      typeof params.runtimeContext?.sessionKey === "string"
+        ? params.runtimeContext.sessionKey
+        : undefined,
+    );
+    const agentDir =
+      typeof params.runtimeContext?.agentDir === "string"
+        ? params.runtimeContext.agentDir
+        : undefined;
+    await this.syncSession({
+      sessionId: params.sessionId,
+      sessionFile: params.sessionFile,
+      sessionKey,
+      agentDir,
+      reason: "afterTurn",
+    });
+  }
+
+  async assemble(params: {
+    sessionId: string;
+    messages: AgentMessage[];
+    tokenBudget?: number;
+  }): Promise<AssembleResult> {
+    await this.ensureInitialized();
+
+    const sessionRow = await this.getSessionRow(params.sessionId);
+    if (!sessionRow) {
+      return {
+        messages: params.messages,
+        estimatedTokens: 0,
+      };
+    }
+
+    const currentSummary =
+      sessionRow.active_summary_id != null
+        ? await this.getSummaryRow(sessionRow.active_summary_id)
+        : null;
+    const currentSessionKey = await this.ensureSessionKey(sessionRow);
+    const syncState = await this.getSyncStateRow(params.sessionId);
+    const agentDir = syncState?.session_file
+      ? extractAgentDirFromSessionFile(syncState.session_file)
+      : undefined;
+
+    const effectiveTokenBudget =
+      params.tokenBudget && params.tokenBudget > 0 ? params.tokenBudget : 0;
+    const tailBudget =
+      effectiveTokenBudget > 0
+        ? Math.max(
+            1_024,
+            Math.min(
+              this.resolved.assembly.recentTailTokens,
+              Math.floor(effectiveTokenBudget * 0.55),
+            ),
+          )
+        : this.resolved.assembly.recentTailTokens;
+    const recentTail = selectRecentTail(params.messages, tailBudget);
+
+    const queryText = this.extractQueryText(params.messages);
+    const provider = await this.getActiveEmbeddingProvider(agentDir);
+    let queryEmbedding: number[] | null = null;
+    if (provider && queryText) {
+      try {
+        queryEmbedding = await provider.embedQuery(queryText);
+      } catch (err) {
+        this.logger.warn(`lancedb-context: query embedding failed: ${String(err)}`);
+      }
+    }
+
+    const historicalSummaries =
+      currentSessionKey && queryEmbedding
+        ? await this.searchHistoricalSummaries({
+            currentSessionId: params.sessionId,
+            sessionKey: currentSessionKey,
+            queryEmbedding,
+          })
+        : [];
+    const summarySessionIds = new Set(historicalSummaries.map((row) => row.session_id));
+
+    const historicalTurns =
+      currentSessionKey && queryEmbedding
+        ? await this.searchHistoricalTurns({
+            currentSessionId: params.sessionId,
+            sessionKey: currentSessionKey,
+            queryEmbedding,
+            excludedSessionIds: summarySessionIds,
+          })
+        : [];
+
+    const currentSessionTurns = queryEmbedding
+      ? await this.searchCurrentSessionTurns({
+          sessionId: params.sessionId,
+          summaryCoveredUntilSeq: sessionRow.summary_covered_until_seq,
+          queryEmbedding,
+          recentTailFingerprints: recentTail.textFingerprints,
+        })
+      : [];
+
+    const maxExtraChars =
+      effectiveTokenBudget > 0
+        ? Math.min(
+            this.resolved.assembly.maxRetrievedChars,
+            Math.max(1_200, Math.floor((effectiveTokenBudget - recentTail.tokens) * 4)),
+          )
+        : this.resolved.assembly.maxRetrievedChars;
+
+    const currentSummaryBlock = currentSummary?.text
+      ? truncateText(currentSummary.text, Math.max(400, Math.floor(maxExtraChars * 0.4)))
+      : "";
+    const historicalSummaryBlocks = historicalSummaries
+      .slice(0, this.resolved.assembly.retrievalTopK)
+      .map((row) =>
+        formatHistoricalSummary({
+          ...row,
+          text: truncateText(row.text, Math.max(300, Math.floor(maxExtraChars * 0.25))),
+        }),
+      );
+    const historicalMessageBlocks = [...historicalTurns, ...currentSessionTurns]
+      .slice(0, this.resolved.assembly.retrievalTopK)
+      .map((turn) =>
+        formatHistoricalTurn({
+          ...turn,
+          text: truncateText(turn.text, Math.max(250, Math.floor(maxExtraChars * 0.2))),
+        }),
+      );
+
+    const systemPromptAddition = buildPromptSections([
+      {
+        title: "Current session summary",
+        blocks: currentSummaryBlock ? [formatCurrentSummary(currentSummaryBlock)] : [],
+      },
+      {
+        title: "Relevant history from earlier sessions in this conversation family",
+        blocks: historicalSummaryBlocks,
+      },
+      {
+        title: "Relevant prior messages",
+        blocks: historicalMessageBlocks,
+      },
+    ]);
+
+    return {
+      messages: recentTail.messages,
+      estimatedTokens: recentTail.tokens + estimateTextTokens(systemPromptAddition ?? ""),
+      systemPromptAddition,
+    };
+  }
+
+  async compact(params: {
+    sessionId: string;
+    sessionFile: string;
+    tokenBudget?: number;
+    force?: boolean;
+    currentTokenCount?: number;
+    compactionTarget?: "budget" | "threshold";
+    customInstructions?: string;
+    runtimeContext?: ContextEngineRuntimeContext;
+  }): Promise<CompactResult> {
+    const { compactEmbeddedPiSessionDirect } =
+      await import("../../../src/agents/pi-embedded-runner/compact.runtime.js");
+
+    const runtimeContext = params.runtimeContext ?? {};
+    const result = await compactEmbeddedPiSessionDirect({
+      ...runtimeContext,
+      sessionId: params.sessionId,
+      sessionFile: params.sessionFile,
+      tokenBudget: params.tokenBudget,
+      force: params.force,
+      customInstructions: params.customInstructions,
+      workspaceDir: (runtimeContext.workspaceDir as string) ?? process.cwd(),
+    } as Parameters<typeof compactEmbeddedPiSessionDirect>[0]);
+
+    return {
+      ok: result.ok,
+      compacted: result.compacted,
+      reason: result.reason,
+      result: result.result
+        ? {
+            summary: result.result.summary,
+            firstKeptEntryId: result.result.firstKeptEntryId,
+            tokensBefore: result.result.tokensBefore,
+            tokensAfter: result.result.tokensAfter,
+            details: result.result.details,
+          }
+        : undefined,
+    };
+  }
+
+  async dispose(): Promise<void> {
+    // Keep the DB handle warm for the process lifetime.
+  }
+
+  private async syncSession(params: {
+    sessionId: string;
+    sessionFile: string;
+    sessionKey?: string;
+    agentDir?: string;
+    reason: "bootstrap" | "afterTurn";
+  }): Promise<number> {
+    await this.ensureInitialized();
+
+    const [existingSession, existingSyncState, existingMessages, existingSummaries] =
+      await Promise.all([
+        this.getSessionRow(params.sessionId),
+        this.getSyncStateRow(params.sessionId),
+        this.listMessagesForSession(params.sessionId),
+        this.listSummariesForSession(params.sessionId),
+      ]);
+
+    const resolvedSessionKey =
+      normalizeSessionKey(params.sessionKey) ||
+      existingSession?.session_key ||
+      (await this.resolveSessionKeyFromStore(params.sessionId, params.sessionFile));
+    const resolvedAgentDir = params.agentDir ?? extractAgentDirFromSessionFile(params.sessionFile);
+
+    const transcript = await fs.readFile(params.sessionFile, "utf-8").catch((err) => {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    });
+
+    const nowMs = Date.now();
+    const parsed = transcript ? parseTranscriptEntries(transcript) : { entries: [], totalLines: 0 };
+    const lastIngestedLine = existingSyncState?.last_ingested_line ?? 0;
+    const startLine = lastIngestedLine > parsed.totalLines ? 0 : lastIngestedLine;
+    const fullReplay = startLine === 0;
+
+    const existingMessagesById = new Map(existingMessages.map((row) => [row.message_id, row]));
+    const existingSummariesById = new Map(existingSummaries.map((row) => [row.summary_id, row]));
+    const messageSeqById = new Map(
+      existingMessages.map((row) => [row.message_id, row.message_seq]),
+    );
+
+    let latestMessageSeq = fullReplay
+      ? 0
+      : Math.max(
+          existingSession?.latest_message_seq ?? 0,
+          ...existingMessages.map((row) => row.message_seq),
+          0,
+        );
+    let turnSeq = fullReplay ? 0 : Math.max(...existingMessages.map((row) => row.turn_seq), 0);
+    let activeSummaryId = fullReplay ? null : (existingSession?.active_summary_id ?? null);
+    let summaryCoveredUntilSeq = fullReplay ? 0 : (existingSession?.summary_covered_until_seq ?? 0);
+
+    const importedMessageRows: MessageRow[] = [];
+    const importedSummaryRows: SummaryRow[] = [];
+    const embeddingTasks: EmbeddingTask[] = [];
+
+    for (const item of parsed.entries) {
+      if (item.line <= startLine) {
+        const entry = item.entry;
+        if (this.isMessageEntry(entry)) {
+          const existingRow = existingMessagesById.get(entry.id);
+          if (existingRow) {
+            latestMessageSeq = Math.max(latestMessageSeq, existingRow.message_seq);
+            turnSeq = Math.max(turnSeq, existingRow.turn_seq);
+          }
+        } else if (this.isCompactionEntry(entry)) {
+          const existingSummary = existingSummariesById.get(entry.id);
+          if (existingSummary) {
+            activeSummaryId = existingSummary.summary_id;
+            summaryCoveredUntilSeq = Math.max(summaryCoveredUntilSeq, existingSummary.end_seq);
+          }
+        }
+        continue;
+      }
+
+      const entry = item.entry;
+      if (this.isMessageEntry(entry)) {
+        const existingRow = existingMessagesById.get(entry.id);
+        const projected = this.projectMessageRow({
+          entry,
+          sessionId: params.sessionId,
+          sessionKey: resolvedSessionKey,
+          latestMessageSeq,
+          turnSeq,
+          existingRow,
+        });
+
+        latestMessageSeq = projected.row.message_seq;
+        turnSeq = projected.row.turn_seq;
+        messageSeqById.set(projected.row.message_id, projected.row.message_seq);
+        existingMessagesById.set(projected.row.message_id, projected.row);
+
+        importedMessageRows.push(projected.row);
+        if (projected.shouldEmbed) {
+          embeddingTasks.push({
+            kind: "message",
+            id: projected.row.message_id,
+            text: projected.row.text,
+          });
+        }
+        continue;
+      }
+
+      if (this.isCompactionEntry(entry)) {
+        const existingSummary = existingSummariesById.get(entry.id);
+        const endSeq = this.resolveCompactionEndSeq({
+          compaction: entry,
+          messageSeqById,
+          latestMessageSeq,
+        });
+        const summaryRow: SummaryRow = {
+          summary_id: entry.id,
+          session_id: params.sessionId,
+          session_key: resolvedSessionKey,
+          end_seq: existingSummary?.end_seq ?? endSeq,
+          text: entry.summary,
+          embedding: existingSummary?.embedding ?? null,
+        };
+
+        if (existingSummary?.text !== summaryRow.text) {
+          summaryRow.embedding = null;
+        }
+
+        importedSummaryRows.push(summaryRow);
+        existingSummariesById.set(summaryRow.summary_id, summaryRow);
+        activeSummaryId = summaryRow.summary_id;
+        summaryCoveredUntilSeq = Math.max(summaryCoveredUntilSeq, summaryRow.end_seq);
+
+        if (summaryRow.text.trim() && summaryRow.embedding == null) {
+          embeddingTasks.push({
+            kind: "summary",
+            id: summaryRow.summary_id,
+            text: truncateText(summaryRow.text, this.resolved.limits.maxMessageCharsForEmbedding),
+          });
+        }
+      }
+    }
+
+    if (fullReplay && importedMessageRows.length === 0 && existingMessages.length > 0) {
+      latestMessageSeq = Math.max(...existingMessages.map((row) => row.message_seq), 0);
+      turnSeq = Math.max(...existingMessages.map((row) => row.turn_seq), 0);
+    }
+
+    await this.applyEmbeddings({
+      messageRows: importedMessageRows,
+      summaryRows: importedSummaryRows,
+      tasks: embeddingTasks,
+      agentDir: resolvedAgentDir,
+    });
+
+    if (resolvedSessionKey && resolvedSessionKey !== existingSession?.session_key) {
+      await this.backfillSessionKey(params.sessionId, resolvedSessionKey);
+    }
+
+    if (importedMessageRows.length > 0) {
+      await this.upsertRows(MESSAGES_TABLE, "message_id", importedMessageRows);
+    }
+    if (importedSummaryRows.length > 0) {
+      await this.upsertRows(SUMMARIES_TABLE, "summary_id", importedSummaryRows);
+    }
+
+    const nextSessionRow: SessionRow = {
+      session_id: params.sessionId,
+      session_key: resolvedSessionKey,
+      active_summary_id: activeSummaryId,
+      latest_message_seq: latestMessageSeq,
+      summary_covered_until_seq: summaryCoveredUntilSeq,
+      updated_at: nowMs,
+    };
+    const nextSyncState: SyncStateRow = {
+      session_id: params.sessionId,
+      session_file: params.sessionFile,
+      last_ingested_line: transcript ? parsed.totalLines : lastIngestedLine,
+      last_optimized_at: existingSyncState?.last_optimized_at ?? null,
+    };
+
+    await this.upsertRows(SESSIONS_TABLE, "session_id", [nextSessionRow]);
+    await this.upsertRows(SYNC_STATE_TABLE, "session_id", [nextSyncState]);
+
+    const importedRowCount = importedMessageRows.length + importedSummaryRows.length;
+    if (
+      shouldScheduleMaintenance({
+        syncState: existingSyncState,
+        importedRows: importedRowCount,
+        optimizeIntervalMinutes: this.resolved.maintenance.optimizeIntervalMinutes,
+        nowMs,
+      })
+    ) {
+      this.scheduleMaintenance(params.sessionId);
+    }
+
+    return importedMessageRows.length;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.db) {
+      return;
+    }
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+    this.initPromise = this.doInitialize();
+    return this.initPromise;
+  }
+
+  private async doInitialize(): Promise<void> {
+    const lancedb = await this.deps.loadLanceDb();
+    this.db = await lancedb.connect(this.resolved.dbPath);
+    const existingTables = new Set(await this.db.tableNames());
+
+    this.tables[SESSIONS_TABLE] = existingTables.has(SESSIONS_TABLE)
+      ? await this.db.openTable(SESSIONS_TABLE)
+      : await this.createTableWithSentinel(SESSIONS_TABLE, this.createSessionSentinelRow());
+    this.tables[MESSAGES_TABLE] = existingTables.has(MESSAGES_TABLE)
+      ? await this.db.openTable(MESSAGES_TABLE)
+      : await this.createTableWithSentinel(MESSAGES_TABLE, this.createMessageSentinelRow());
+    this.tables[SUMMARIES_TABLE] = existingTables.has(SUMMARIES_TABLE)
+      ? await this.db.openTable(SUMMARIES_TABLE)
+      : await this.createTableWithSentinel(SUMMARIES_TABLE, this.createSummarySentinelRow());
+    this.tables[SYNC_STATE_TABLE] = existingTables.has(SYNC_STATE_TABLE)
+      ? await this.db.openTable(SYNC_STATE_TABLE)
+      : await this.createTableWithSentinel(SYNC_STATE_TABLE, this.createSyncStateSentinelRow());
+  }
+
+  private async createTableWithSentinel(
+    name: TableName,
+    sentinelRow: Record<string, unknown>,
+  ): Promise<LanceDb.Table> {
+    if (!this.db) {
+      throw new Error("lancedb-context: database is not initialized");
+    }
+    const table = await this.db.createTable(name, [sentinelRow]);
+    const key = Object.keys(sentinelRow)[0];
+    if (typeof key === "string" && typeof sentinelRow[key] === "string") {
+      await table.delete(`${key} = ${quoteSql(String(sentinelRow[key]))}`);
+    }
+    return table;
+  }
+
+  private createSessionSentinelRow(): SessionRow {
+    return {
+      session_id: "__schema__",
+      session_key: "",
+      active_summary_id: null,
+      latest_message_seq: 0,
+      summary_covered_until_seq: 0,
+      updated_at: 0,
+    };
+  }
+
+  private createMessageSentinelRow(): MessageRow {
+    return {
+      message_id: "__schema__",
+      session_id: "",
+      session_key: "",
+      message_seq: 0,
+      turn_seq: 0,
+      role: "other",
+      text: "",
+      embedding: Array.from({ length: this.resolved.embedding.dimensions }, () => 0),
+    };
+  }
+
+  private createSummarySentinelRow(): SummaryRow {
+    return {
+      summary_id: "__schema__",
+      session_id: "",
+      session_key: "",
+      end_seq: 0,
+      text: "",
+      embedding: Array.from({ length: this.resolved.embedding.dimensions }, () => 0),
+    };
+  }
+
+  private createSyncStateSentinelRow(): SyncStateRow {
+    return {
+      session_id: "__schema__",
+      session_file: "",
+      last_ingested_line: 0,
+      last_optimized_at: null,
+    };
+  }
+
+  private async getTable(name: TableName): Promise<LanceDb.Table> {
+    await this.ensureInitialized();
+    const table = this.tables[name];
+    if (!table) {
+      throw new Error(`lancedb-context: table ${name} not initialized`);
+    }
+    return table;
+  }
+
+  private async upsertRows<T extends Record<string, unknown>>(
+    tableName: TableName,
+    key: keyof T & string,
+    rows: T[],
+  ): Promise<void> {
+    if (rows.length === 0) {
+      return;
+    }
+    const table = await this.getTable(tableName);
+    await table.mergeInsert(key).whenMatchedUpdateAll().whenNotMatchedInsertAll().execute(rows);
+  }
+
+  private async queryRows(
+    tableName: TableName,
+    filter?: string,
+  ): Promise<Array<Record<string, unknown>>> {
+    const table = await this.getTable(tableName);
+    const query = filter ? table.query().where(filter) : table.query();
+    return (await query.toArray()) as Array<Record<string, unknown>>;
+  }
+
+  private async getSessionRow(sessionId: string): Promise<SessionRow | null> {
+    const rows = await this.queryRows(SESSIONS_TABLE, `session_id = ${quoteSql(sessionId)}`);
+    const first = rows[0];
+    return first ? coerceSessionRow(first) : null;
+  }
+
+  private async getSyncStateRow(sessionId: string): Promise<SyncStateRow | null> {
+    const rows = await this.queryRows(SYNC_STATE_TABLE, `session_id = ${quoteSql(sessionId)}`);
+    const first = rows[0];
+    return first ? coerceSyncStateRow(first) : null;
+  }
+
+  private async getSummaryRow(summaryId: string): Promise<SummaryRow | null> {
+    const rows = await this.queryRows(SUMMARIES_TABLE, `summary_id = ${quoteSql(summaryId)}`);
+    const first = rows[0];
+    return first ? coerceSummaryRow(first) : null;
+  }
+
+  private async listSessionsByKey(sessionKey: string): Promise<SessionRow[]> {
+    const rows = await this.queryRows(SESSIONS_TABLE, `session_key = ${quoteSql(sessionKey)}`);
+    return rows
+      .map((row) => coerceSessionRow(row))
+      .sort((left, right) => right.updated_at - left.updated_at);
+  }
+
+  private async listMessagesForSession(sessionId: string): Promise<MessageRow[]> {
+    const rows = await this.queryRows(MESSAGES_TABLE, `session_id = ${quoteSql(sessionId)}`);
+    return rows
+      .map((row) => coerceMessageRow(row))
+      .sort((left, right) => left.message_seq - right.message_seq);
+  }
+
+  private async listSummariesForSession(sessionId: string): Promise<SummaryRow[]> {
+    const rows = await this.queryRows(SUMMARIES_TABLE, `session_id = ${quoteSql(sessionId)}`);
+    return rows
+      .map((row) => coerceSummaryRow(row))
+      .sort((left, right) => left.end_seq - right.end_seq);
+  }
+
+  private async resolveSessionKeyFromStore(
+    sessionId: string,
+    sessionFile: string,
+  ): Promise<string> {
+    const candidates = [path.join(path.dirname(path.resolve(sessionFile)), "sessions.json")];
+    const agentId = extractAgentIdFromSessionFile(sessionFile);
+    if (agentId) {
+      candidates.push(resolveDefaultSessionStorePath(agentId));
+    }
+
+    for (const candidate of new Set(candidates)) {
+      try {
+        const store = loadSessionStore(candidate);
+        let bestKey = "";
+        let bestUpdatedAt = -1;
+        for (const [sessionKey, entry] of Object.entries(store)) {
+          const typed = entry as SessionEntry | undefined;
+          if (!typed || typed.sessionId !== sessionId) {
+            continue;
+          }
+          const updatedAt = typed.updatedAt ?? 0;
+          if (updatedAt >= bestUpdatedAt) {
+            bestKey = normalizeSessionKey(sessionKey);
+            bestUpdatedAt = updatedAt;
+          }
+        }
+        if (bestKey) {
+          return bestKey;
+        }
+      } catch {
+        // Best-effort lookup only.
+      }
+    }
+
+    return "";
+  }
+
+  private async ensureSessionKey(sessionRow: SessionRow): Promise<string> {
+    if (sessionRow.session_key) {
+      return sessionRow.session_key;
+    }
+    const syncState = await this.getSyncStateRow(sessionRow.session_id);
+    if (!syncState?.session_file) {
+      return "";
+    }
+    const resolved = await this.resolveSessionKeyFromStore(
+      sessionRow.session_id,
+      syncState.session_file,
+    );
+    if (!resolved) {
+      return "";
+    }
+    await this.backfillSessionKey(sessionRow.session_id, resolved);
+    await this.upsertRows(SESSIONS_TABLE, "session_id", [
+      {
+        ...sessionRow,
+        session_key: resolved,
+      },
+    ]);
+    return resolved;
+  }
+
+  private async backfillSessionKey(sessionId: string, sessionKey: string): Promise<void> {
+    const normalized = normalizeSessionKey(sessionKey);
+    if (!normalized) {
+      return;
+    }
+
+    const [messages, summaries] = await Promise.all([
+      this.listMessagesForSession(sessionId),
+      this.listSummariesForSession(sessionId),
+    ]);
+
+    const messageUpdates = messages
+      .filter((row) => row.session_key !== normalized)
+      .map((row) => ({ ...row, session_key: normalized }));
+    const summaryUpdates = summaries
+      .filter((row) => row.session_key !== normalized)
+      .map((row) => ({ ...row, session_key: normalized }));
+
+    await Promise.all([
+      messageUpdates.length > 0
+        ? this.upsertRows(MESSAGES_TABLE, "message_id", messageUpdates)
+        : Promise.resolve(),
+      summaryUpdates.length > 0
+        ? this.upsertRows(SUMMARIES_TABLE, "summary_id", summaryUpdates)
+        : Promise.resolve(),
+    ]);
+  }
+
+  private isMessageEntry(entry: FileEntry): entry is SessionMessageEntry | CustomMessageEntry {
+    return entry.type === "message" || entry.type === "custom_message";
+  }
+
+  private isCompactionEntry(entry: FileEntry): entry is CompactionEntry {
+    return entry.type === "compaction";
+  }
+
+  private projectMessageRow(params: {
+    entry: SessionMessageEntry | CustomMessageEntry;
+    sessionId: string;
+    sessionKey: string;
+    latestMessageSeq: number;
+    turnSeq: number;
+    existingRow?: MessageRow;
+  }): {
+    row: MessageRow;
+    shouldEmbed: boolean;
+  } {
+    const role =
+      params.entry.type === "message"
+        ? normalizeRole((params.entry.message as { role?: unknown }).role)
+        : "other";
+    const rawText =
+      params.entry.type === "message"
+        ? extractMessageText((params.entry.message as { content?: unknown }).content)
+        : extractMessageText(params.entry.content);
+
+    const nextMessageSeq = params.existingRow?.message_seq ?? params.latestMessageSeq + 1;
+    const nextTurnSeq =
+      params.existingRow?.turn_seq ??
+      (role === "user" || params.turnSeq === 0 ? params.turnSeq + 1 : params.turnSeq);
+
+    const text = truncateText(rawText, this.resolved.limits.maxMessageCharsForEmbedding);
+    const shouldEmbed =
+      text.trim().length > 0 &&
+      (!isToolLikeRole(role) || rawText.length <= this.resolved.limits.skipLargeToolResultChars);
+    const textChanged = params.existingRow ? params.existingRow.text !== text : true;
+
+    return {
+      row: {
+        message_id: params.entry.id || `${params.sessionId}:${nextMessageSeq}`,
+        session_id: params.sessionId,
+        session_key: params.sessionKey,
+        message_seq: nextMessageSeq,
+        turn_seq: nextTurnSeq,
+        role,
+        text,
+        embedding: textChanged ? null : (params.existingRow?.embedding ?? null),
+      },
+      shouldEmbed: shouldEmbed && textChanged,
+    };
+  }
+
+  private resolveCompactionEndSeq(params: {
+    compaction: CompactionEntry;
+    messageSeqById: Map<string, number>;
+    latestMessageSeq: number;
+  }): number {
+    const firstKeptEntryId = params.compaction.firstKeptEntryId?.trim();
+    if (!firstKeptEntryId) {
+      return params.latestMessageSeq;
+    }
+    const firstKeptSeq = params.messageSeqById.get(firstKeptEntryId);
+    if (typeof firstKeptSeq === "number") {
+      return Math.max(0, firstKeptSeq - 1);
+    }
+    return params.latestMessageSeq;
+  }
+
+  private async getEmbeddingProvider(agentDir?: string): Promise<EmbeddingProviderResult> {
+    const cacheKey = agentDir ? path.resolve(agentDir) : "__default__";
+    const existing = this.embeddingProviderPromises.get(cacheKey);
+    if (existing) {
+      return existing;
+    }
+
+    const created = this.deps
+      .embeddingProviderFactory({
+        config: this.resolved.openclawConfig,
+        resolved: this.resolved,
+        agentDir,
+      })
+      .catch((err) => {
+        this.embeddingProviderPromises.delete(cacheKey);
+        throw err;
+      });
+    this.embeddingProviderPromises.set(cacheKey, created);
+    return created;
+  }
+
+  private async getActiveEmbeddingProvider(agentDir?: string): Promise<EmbeddingProvider | null> {
+    const result = await this.getEmbeddingProvider(agentDir);
+    return result.provider;
+  }
+
+  private async applyEmbeddings(params: {
+    messageRows: MessageRow[];
+    summaryRows: SummaryRow[];
+    tasks: EmbeddingTask[];
+    agentDir?: string;
+  }): Promise<void> {
+    if (params.tasks.length === 0) {
+      return;
+    }
+
+    const providerResult = await this.getEmbeddingProvider(params.agentDir);
+    if (!providerResult.provider) {
+      if (providerResult.providerUnavailableReason) {
+        this.logger.warn(
+          `lancedb-context: embeddings unavailable; continuing without vectors: ${providerResult.providerUnavailableReason}`,
+        );
+      }
+      return;
+    }
+
+    const vectors = await this.embedTexts(
+      providerResult.provider,
+      params.tasks.map((task) => task.text),
+    );
+    const byKey = new Map<string, number[]>();
+    params.tasks.forEach((task, index) => {
+      const vector = vectors[index];
+      if (Array.isArray(vector) && vector.length === this.resolved.embedding.dimensions) {
+        byKey.set(`${task.kind}:${task.id}`, vector);
+      }
+    });
+
+    for (const row of params.messageRows) {
+      row.embedding = byKey.get(`message:${row.message_id}`) ?? row.embedding;
+    }
+    for (const row of params.summaryRows) {
+      row.embedding = byKey.get(`summary:${row.summary_id}`) ?? row.embedding;
+    }
+  }
+
+  private async embedTexts(
+    provider: EmbeddingProvider,
+    texts: string[],
+  ): Promise<Array<number[] | null>> {
+    try {
+      const batch = await provider.embedBatch(texts);
+      return batch.map((vector) =>
+        vector.length === this.resolved.embedding.dimensions ? vector : null,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `lancedb-context: batch embeddings failed, retrying individually: ${String(err)}`,
+      );
+      const results: Array<number[] | null> = [];
+      for (const text of texts) {
+        try {
+          const vector = await provider.embedQuery(text);
+          results.push(vector.length === this.resolved.embedding.dimensions ? vector : null);
+        } catch (itemErr) {
+          this.logger.warn(`lancedb-context: embedding skipped: ${String(itemErr)}`);
+          results.push(null);
+        }
+      }
+      return results;
+    }
+  }
+
+  private extractQueryText(messages: AgentMessage[]): string {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (normalizeRole((message as { role?: unknown }).role) !== "user") {
+        continue;
+      }
+      const text = extractTextFromChatContent((message as { content?: unknown }).content) ?? "";
+      if (text) {
+        return text;
+      }
+    }
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const text =
+        extractTextFromChatContent((messages[index] as { content?: unknown }).content) ?? "";
+      if (text) {
+        return text;
+      }
+    }
+    return "";
+  }
+
+  private async searchHistoricalSummaries(params: {
+    currentSessionId: string;
+    sessionKey: string;
+    queryEmbedding: number[];
+  }): Promise<SummaryRow[]> {
+    const sameKeySessions = (await this.listSessionsByKey(params.sessionKey)).filter(
+      (row) => row.session_id !== params.currentSessionId,
+    );
+    const activeSummaryIds = new Set(
+      sameKeySessions
+        .map((row) => row.active_summary_id)
+        .filter((value): value is string => typeof value === "string" && value.length > 0),
+    );
+    if (activeSummaryIds.size === 0) {
+      return [];
+    }
+
+    const rows = await this.vectorSearchRows(
+      SUMMARIES_TABLE,
+      params.queryEmbedding,
+      [
+        `session_key = ${quoteSql(params.sessionKey)}`,
+        `session_id != ${quoteSql(params.currentSessionId)}`,
+        "embedding IS NOT NULL",
+      ],
+      this.resolved.assembly.retrievalTopK * 6,
+      coerceSummaryRow,
+    );
+
+    const maxUpdatedAt = Math.max(...sameKeySessions.map((row) => row.updated_at), 1);
+    const updatedAtBySession = new Map(
+      sameKeySessions.map((row) => [row.session_id, row.updated_at]),
+    );
+
+    return rows
+      .filter((row) => activeSummaryIds.has(row.summary_id))
+      .map((row) => ({
+        row,
+        score:
+          (row.embedding ? dotProduct(params.queryEmbedding, row.embedding) : -1) +
+          this.recencyBoost(updatedAtBySession.get(row.session_id), maxUpdatedAt),
+      }))
+      .filter((item) => item.score >= this.resolved.assembly.retrievalMinScore)
+      .sort((left, right) => right.score - left.score)
+      .slice(0, this.resolved.assembly.retrievalTopK)
+      .map((item) => item.row);
+  }
+
+  private async searchHistoricalTurns(params: {
+    currentSessionId: string;
+    sessionKey: string;
+    queryEmbedding: number[];
+    excludedSessionIds: Set<string>;
+  }): Promise<HistoricalTurn[]> {
+    const filterParts = [
+      `session_key = ${quoteSql(params.sessionKey)}`,
+      `session_id != ${quoteSql(params.currentSessionId)}`,
+      "embedding IS NOT NULL",
+    ];
+    for (const sessionId of params.excludedSessionIds) {
+      filterParts.push(`session_id != ${quoteSql(sessionId)}`);
+    }
+
+    const rows = await this.searchMessageRows({
+      queryEmbedding: params.queryEmbedding,
+      filter: filterParts.join(" AND "),
+      limit: this.resolved.assembly.retrievalTopK * 8,
+    });
+
+    return this.groupTurns(rows);
+  }
+
+  private async searchCurrentSessionTurns(params: {
+    sessionId: string;
+    summaryCoveredUntilSeq: number;
+    queryEmbedding: number[];
+    recentTailFingerprints: Set<string>;
+  }): Promise<HistoricalTurn[]> {
+    const filter = [
+      `session_id = ${quoteSql(params.sessionId)}`,
+      `message_seq > ${Math.max(0, Math.floor(params.summaryCoveredUntilSeq))}`,
+      "embedding IS NOT NULL",
+    ].join(" AND ");
+
+    const rows = await this.searchMessageRows({
+      queryEmbedding: params.queryEmbedding,
+      filter,
+      limit: this.resolved.assembly.retrievalTopK * 6,
+    });
+
+    return this.groupTurns(rows).filter(
+      (turn) => !params.recentTailFingerprints.has(normalizeTextFingerprint(turn.text)),
+    );
+  }
+
+  private async searchMessageRows(params: {
+    queryEmbedding: number[];
+    filter: string;
+    limit: number;
+  }): Promise<Array<SearchResult<MessageRow>>> {
+    const rows = await this.vectorSearchRows(
+      MESSAGES_TABLE,
+      params.queryEmbedding,
+      [params.filter],
+      params.limit,
+      coerceMessageRow,
+    );
+
+    return rows
+      .map((row) => ({
+        row,
+        score: row.embedding ? dotProduct(params.queryEmbedding, row.embedding) : -1,
+      }))
+      .filter((item) => item.score >= this.resolved.assembly.retrievalMinScore);
+  }
+
+  private async vectorSearchRows<T>(
+    tableName: TableName,
+    queryEmbedding: number[],
+    filters: string[],
+    limit: number,
+    coerce: (row: Record<string, unknown>) => T,
+  ): Promise<T[]> {
+    const table = await this.getTable(tableName);
+    const filter = filters.filter(Boolean).join(" AND ");
+    const query = table.vectorSearch(queryEmbedding);
+    const filtered = filter ? query.where(filter) : query;
+    const rows = (await filtered.limit(limit).toArray()) as Array<Record<string, unknown>>;
+    return rows.map((row) => coerce(row));
+  }
+
+  private groupTurns(rows: Array<SearchResult<MessageRow>>): HistoricalTurn[] {
+    const groups = new Map<string, HistoricalTurn & { rows: MessageRow[] }>();
+
+    for (const item of rows) {
+      const key = `${item.row.session_id}:${item.row.turn_seq}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.rows.push(item.row);
+        existing.score = Math.max(existing.score, item.score);
+        continue;
+      }
+      groups.set(key, {
+        sessionId: item.row.session_id,
+        turnSeq: item.row.turn_seq,
+        score: item.score,
+        text: "",
+        rows: [item.row],
+      });
+    }
+
+    return [...groups.values()]
+      .map((group) => ({
+        sessionId: group.sessionId,
+        turnSeq: group.turnSeq,
+        score: group.score,
+        text: group.rows
+          .sort((left, right) => left.message_seq - right.message_seq)
+          .map((row) => `${row.role}: ${row.text}`)
+          .join("\n"),
+      }))
+      .filter((turn) => turn.text.trim().length > 0)
+      .sort((left, right) => right.score - left.score)
+      .slice(0, this.resolved.assembly.retrievalTopK);
+  }
+
+  private recencyBoost(updatedAt: number | undefined, maxUpdatedAt: number): number {
+    if (!updatedAt || maxUpdatedAt <= 0) {
+      return 0;
+    }
+    return Math.min(0.05, (updatedAt / maxUpdatedAt) * 0.05);
+  }
+
+  private scheduleMaintenance(sessionId: string): void {
+    const existing = maintenanceJobs.get(this.resolved.dbPath);
+    if (existing) {
+      return;
+    }
+
+    const job = Promise.resolve()
+      .then(async () => {
+        await this.runMaintenance(sessionId);
+      })
+      .catch((err) => {
+        this.logger.warn(`lancedb-context: maintenance failed: ${String(err)}`);
+      })
+      .finally(() => {
+        maintenanceJobs.delete(this.resolved.dbPath);
+      });
+    maintenanceJobs.set(this.resolved.dbPath, job);
+  }
+
+  private async runMaintenance(sessionId: string): Promise<void> {
+    const [sessions, messages, summaries, syncStates, syncState] = await Promise.all([
+      this.getTable(SESSIONS_TABLE),
+      this.getTable(MESSAGES_TABLE),
+      this.getTable(SUMMARIES_TABLE),
+      this.getTable(SYNC_STATE_TABLE),
+      this.getSyncStateRow(sessionId),
+    ]);
+
+    const createIndexIfPossible = async (table: LanceDb.Table, column: string) => {
+      try {
+        await table.createIndex(column);
+      } catch {
+        // Best-effort maintenance only.
+      }
+    };
+
+    await Promise.all([
+      createIndexIfPossible(sessions, "session_id"),
+      createIndexIfPossible(sessions, "session_key"),
+      createIndexIfPossible(messages, "session_id"),
+      createIndexIfPossible(messages, "session_key"),
+      createIndexIfPossible(messages, "message_seq"),
+      createIndexIfPossible(messages, "turn_seq"),
+      createIndexIfPossible(messages, "embedding"),
+      createIndexIfPossible(summaries, "session_id"),
+      createIndexIfPossible(summaries, "session_key"),
+      createIndexIfPossible(summaries, "end_seq"),
+      createIndexIfPossible(summaries, "embedding"),
+      createIndexIfPossible(syncStates, "session_id"),
+    ]);
+
+    await Promise.all(
+      [sessions, messages, summaries, syncStates].map(async (table) => {
+        try {
+          await table.optimize();
+        } catch {
+          // Best-effort maintenance only.
+        }
+      }),
+    );
+
+    if (!syncState) {
+      return;
+    }
+    await this.upsertRows(SYNC_STATE_TABLE, "session_id", [
+      {
+        ...syncState,
+        last_optimized_at: Date.now(),
+      },
+    ]);
+  }
+}
+
+function createDefaultEmbeddingProviderFactory(deps?: EngineDeps["embeddingProviderFactory"]) {
+  if (deps) {
+    return deps;
+  }
+  return async (params: {
+    config: OpenClawConfig;
+    resolved: ResolvedLanceDbContextConfig;
+    agentDir?: string;
+  }) =>
+    await createEmbeddingProvider({
+      config: params.config,
+      agentDir: params.agentDir,
+      provider: params.resolved.embedding.provider,
+      fallback: params.resolved.embedding.fallback,
+      model: params.resolved.embedding.model,
+      remote: params.resolved.embedding.remote,
+      local: params.resolved.embedding.local,
+    });
+}
+
+export function createLanceDbContextEngine(params: {
+  config: OpenClawConfig;
+  pluginConfig?: Record<string, unknown>;
+  logger: PluginLogger;
+  resolvePath: (input: string) => string;
+  deps?: EngineDeps;
+}): ContextEngine {
+  const resolved = resolveLanceDbContextConfig({
+    config: params.config,
+    pluginConfig: params.pluginConfig,
+    resolvePath: params.resolvePath,
+  });
+
+  return new LanceDbContextEngineImpl(resolved, params.logger, {
+    loadLanceDb: params.deps?.loadLanceDb ?? loadLanceDb,
+    embeddingProviderFactory: createDefaultEmbeddingProviderFactory(
+      params.deps?.embeddingProviderFactory,
+    ),
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,12 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  extensions/context-lancedb:
+    dependencies:
+      '@lancedb/lancedb':
+        specifier: ^0.26.2
+        version: 0.26.2(apache-arrow@18.1.0)
+
   extensions/copilot-proxy: {}
 
   extensions/diagnostics-otel:

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { registerLegacyContextEngine, resolveContextEngine } from "../context-engine/index.js";
 import { withEnv } from "../test-utils/env.js";
 async function importFreshPluginTestModules() {
   vi.resetModules();
@@ -975,6 +976,41 @@ describe("loadOpenClawPlugins", () => {
     const b = registry.plugins.find((entry) => entry.id === "memory-b");
     expect(b?.status).toBe("loaded");
     expect(a?.status).toBe("disabled");
+  });
+
+  it("supports configuring memory and contextEngine slots together", async () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    registerLegacyContextEngine();
+    const memoryA = writePlugin({
+      id: "memory-a",
+      body: `module.exports = { id: "memory-a", kind: "memory", register() {} };`,
+    });
+    const memoryB = writePlugin({
+      id: "memory-b",
+      body: `module.exports = { id: "memory-b", kind: "memory", register() {} };`,
+    });
+    const config = {
+      plugins: {
+        load: { paths: [memoryA.file, memoryB.file] },
+        slots: {
+          memory: "memory-b",
+          contextEngine: "legacy",
+        },
+      },
+    };
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config,
+    });
+
+    const a = registry.plugins.find((entry) => entry.id === "memory-a");
+    const b = registry.plugins.find((entry) => entry.id === "memory-b");
+    expect(b?.status).toBe("loaded");
+    expect(a?.status).toBe("disabled");
+
+    const engine = await resolveContextEngine(config);
+    expect(engine.info.id).toBe("legacy");
   });
 
   it("skips importing bundled memory plugins that are disabled by memory slot", () => {


### PR DESCRIPTION
**PR Summary**

This PR introduces a new `lancedb-context` ContextEngine that adds LanceDB-backed context indexing and retrieval to improve long-running conversation continuity and historical context reuse in OpenClaw.

**Design Highlights**

1. The implementation defines four minimal LanceDB tables:
- `ce_sessions(session_id, session_key, active_summary_id, latest_message_seq, summary_covered_until_seq, updated_at)`
  - Purpose: stores the session identity and the minimal state needed directly by `assemble()`, including the active summary pointer, message boundary, and freshness timestamp
- `ce_messages(message_id, session_id, session_key, message_seq, turn_seq, role, text, embedding)`
  - Purpose: stores message-level semantic indexes for current-session retrieval, same-`session_key` historical message recall, and turn-based context reconstruction
- `ce_summaries(summary_id, session_id, session_key, end_seq, text, embedding)`
  - Purpose: stores projected compaction summaries from the transcript for current-session active summary injection and same-`session_key` historical summary-first recall
- `ce_sync_state(session_id, session_file, last_ingested_line, last_optimized_at)`
  - Purpose: stores internal sync control state rather than business data; used for transcript incremental ingestion and background index optimization cadence

2. The following `ContextEngine` APIs are implemented:
- `bootstrap({ sessionId, sessionFile })`
  - Initializes LanceDB projection for a session by scanning the full transcript, writing message/summary rows, and seeding session and sync state
- `afterTurn({ sessionId, sessionFile, runtimeContext, ... })`
  - Synchronously ingests transcript deltas after each turn, generates embeddings, writes LanceDB rows, and updates the active summary pointer and sync cursor
- `assemble({ sessionId, messages, tokenBudget })`
  - Builds context from the current session plus historical sessions under the same `session_key`; keeps the recent tail, injects the current active summary, and performs cross-session recall with a `summary-first, messages-as-supplement` policy
- `compact({ sessionId, sessionFile, ... })`
  - Does not manage compaction itself; instead directly delegates to OpenClaw’s existing legacy compaction flow for full behavioral compatibility
- `ingest(...)`
  - Currently implemented as a no-op; v1 uses transcript projection as the canonical ingestion path

**Impact**

- Allows a session to recall historical context from the same logical conversation family after reset / rollover
- Reduces prompt noise by preferring summary-based long-term context over replaying raw old messages
- Preserves existing session / transcript / compaction semantics, keeping integration risk low
- Upgrades context assembly from “recent messages only” to “current context + historical semantic memory”