### PR TITLE
fix(cron): correct delivery status for mode=none to not-requested

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -165,10 +165,16 @@ function resolveDeliveryStatus(params: { job: CronJob; delivered?: boolean }): C
   if (params.delivered === true) {
     return "delivered";
   }
+  
+  const deliveryPlan = resolveCronDeliveryPlan(params.job);
+  if (!deliveryPlan.requested) {
+    return "not-requested";
+  }
+  
   if (params.delivered === false) {
     return "not-delivered";
   }
-  return resolveCronDeliveryPlan(params.job).requested ? "unknown" : "not-requested";
+  return "unknown";
 }
 
 function normalizeCronMessageChannel(input: unknown): CronMessageChannel | undefined {


### PR DESCRIPTION
Fixes #44533

### Summary
When `delivery.mode = "none"` is set in a cron job config, the system incorrectly reports `lastDeliveryStatus: "not-delivered"` instead of `"not-requested"`.

### Changes
- Modified `resolveDeliveryStatus` function in `src/cron/service/timer.ts`
- Now checks `deliveryPlan.requested` before returning `"not-delivered"`
- When `mode = "none"`, returns `"not-requested"` instead of `"not-delivered"`

### Testing
- Manual verification with cron jobs configured with `delivery: { mode: "none" }`
- Existing cron tests should continue to pass