### PR TITLE
feat(compaction): add language-preservation default instructions

### DIFF
--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -82,6 +82,7 @@ export function buildEmbeddedExtensionFactories(params: {
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
       contextWindowTokens: contextWindowInfo.tokens,
+      customInstructions: compactionCfg?.customInstructions,
       identifierPolicy: compactionCfg?.identifierPolicy,
       identifierInstructions: compactionCfg?.identifierInstructions,
       qualityGuardEnabled: qualityGuardCfg?.enabled ?? false,

--- a/src/agents/pi-extensions/compaction-instructions.test.ts
+++ b/src/agents/pi-extensions/compaction-instructions.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_COMPACTION_INSTRUCTIONS,
+  resolveCompactionInstructions,
+  composeSplitTurnInstructions,
+} from "./compaction-instructions.js";
+
+describe("DEFAULT_COMPACTION_INSTRUCTIONS", () => {
+  it("is a non-empty string", () => {
+    expect(typeof DEFAULT_COMPACTION_INSTRUCTIONS).toBe("string");
+    expect(DEFAULT_COMPACTION_INSTRUCTIONS.trim().length).toBeGreaterThan(0);
+  });
+
+  it("contains language preservation directive", () => {
+    expect(DEFAULT_COMPACTION_INSTRUCTIONS).toContain("primary language");
+  });
+
+  it("contains factual content directive", () => {
+    expect(DEFAULT_COMPACTION_INSTRUCTIONS).toContain("factual content");
+  });
+
+  it("does not exceed MAX_INSTRUCTION_LENGTH (800 chars)", () => {
+    expect(DEFAULT_COMPACTION_INSTRUCTIONS.length).toBeLessThanOrEqual(800);
+  });
+});
+
+describe("resolveCompactionInstructions", () => {
+  describe("null / undefined handling", () => {
+    it("returns DEFAULT when both args are undefined", () => {
+      expect(resolveCompactionInstructions(undefined, undefined)).toBe(
+        DEFAULT_COMPACTION_INSTRUCTIONS,
+      );
+    });
+
+    it("returns DEFAULT when both args are explicitly null (untyped JS caller)", () => {
+      expect(
+        resolveCompactionInstructions(null as unknown as undefined, null as unknown as undefined),
+      ).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+    });
+  });
+
+  describe("empty and whitespace normalization", () => {
+    it("treats empty-string event as absent -- runtime wins", () => {
+      const result = resolveCompactionInstructions("", "runtime value");
+      expect(result).toBe("runtime value");
+    });
+
+    it("treats whitespace-only event as absent -- runtime wins", () => {
+      const result = resolveCompactionInstructions("   ", "runtime value");
+      expect(result).toBe("runtime value");
+    });
+
+    it("treats tab/newline-only event as absent -- runtime wins", () => {
+      const result = resolveCompactionInstructions("\t\n\r", "runtime value");
+      expect(result).toBe("runtime value");
+    });
+
+    it("treats empty-string runtime as absent -- DEFAULT wins", () => {
+      const result = resolveCompactionInstructions(undefined, "");
+      expect(result).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+    });
+
+    it("treats whitespace-only runtime as absent -- DEFAULT wins", () => {
+      const result = resolveCompactionInstructions(undefined, "   \n  ");
+      expect(result).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+    });
+
+    it("falls through both empty to DEFAULT", () => {
+      const result = resolveCompactionInstructions("", "");
+      expect(result).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+    });
+  });
+
+  describe("precedence", () => {
+    it("event takes priority over runtime", () => {
+      const result = resolveCompactionInstructions("event text", "runtime text");
+      expect(result).toBe("event text");
+    });
+
+    it("runtime wins when event is undefined", () => {
+      const result = resolveCompactionInstructions(undefined, "runtime text");
+      expect(result).toBe("runtime text");
+    });
+  });
+
+  describe("truncation", () => {
+    it("truncates to 800 code-points", () => {
+      const long = "x".repeat(1000);
+      const result = resolveCompactionInstructions(long, undefined);
+      expect(Array.from(result).length).toBe(800);
+    });
+
+    it("handles multi-byte unicode without splitting surrogates", () => {
+      const emoji = "🎉".repeat(1000); // 1000 code points, 2000 UTF-16 code units
+      const result = resolveCompactionInstructions(emoji, undefined);
+      expect(Array.from(result).length).toBe(800);
+      // Every char should be a valid emoji, no broken surrogates
+      for (const c of result) {
+        expect(c).toBe("🎉");
+      }
+    });
+  });
+});
+
+describe("composeSplitTurnInstructions", () => {
+  it("joins prefix + additional requirements + resolved instructions", () => {
+    const result = composeSplitTurnInstructions("Turn prefix here", "Keep language consistent");
+    expect(result).toBe("Turn prefix here\n\nAdditional requirements:\n\nKeep language consistent");
+  });
+});

--- a/src/agents/pi-extensions/compaction-instructions.ts
+++ b/src/agents/pi-extensions/compaction-instructions.ts
@@ -1,0 +1,68 @@
+/**
+ * Compaction instruction utilities.
+ *
+ * Provides default language-preservation instructions and a precedence-based
+ * resolver for customInstructions used during context compaction summaries.
+ */
+
+/**
+ * Default instructions injected into every safeguard-mode compaction summary.
+ * Preserves conversation language and persona while keeping the SDK's required
+ * summary structure intact.
+ */
+export const DEFAULT_COMPACTION_INSTRUCTIONS =
+  "Write the summary body in the primary language used in the conversation.\n" +
+  "Focus on factual content: what was discussed, decisions made, and current state.\n" +
+  "Keep the required summary structure and section headers unchanged.\n" +
+  "Do not translate or alter code, file paths, identifiers, or error messages.";
+
+/**
+ * Upper bound on custom instruction length to prevent prompt bloat.
+ * ~800 chars ≈ ~200 tokens — keeps summarization quality stable.
+ */
+const MAX_INSTRUCTION_LENGTH = 800;
+
+function truncateUnicodeSafe(s: string, maxCodePoints: number): string {
+  const chars = Array.from(s);
+  if (chars.length <= maxCodePoints) {
+    return s;
+  }
+  return chars.slice(0, maxCodePoints).join("");
+}
+
+function normalize(s: string | undefined): string | undefined {
+  if (s == null) {
+    return undefined;
+  }
+  const trimmed = s.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Resolve compaction instructions with precedence:
+ *   event (SDK) → runtime (config) → DEFAULT constant.
+ *
+ * Each input is normalized first (trim + empty→undefined) so that blank
+ * strings don't short-circuit the fallback chain.
+ */
+export function resolveCompactionInstructions(
+  eventInstructions: string | undefined,
+  runtimeInstructions: string | undefined,
+): string {
+  const resolved =
+    normalize(eventInstructions) ??
+    normalize(runtimeInstructions) ??
+    DEFAULT_COMPACTION_INSTRUCTIONS;
+  return truncateUnicodeSafe(resolved, MAX_INSTRUCTION_LENGTH);
+}
+
+/**
+ * Compose split-turn instructions by combining the SDK's turn-prefix
+ * instructions with the resolved compaction instructions.
+ */
+export function composeSplitTurnInstructions(
+  turnPrefixInstructions: string,
+  resolvedInstructions: string,
+): string {
+  return [turnPrefixInstructions, "Additional requirements:", resolvedInstructions].join("\n\n");
+}

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -5,6 +5,7 @@ import { createSessionManagerRuntimeRegistry } from "./session-manager-runtime-r
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
   contextWindowTokens?: number;
+  customInstructions?: string;
   identifierPolicy?: AgentCompactionIdentifierPolicy;
   identifierInstructions?: string;
   /**

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -23,6 +23,7 @@ import { collectTextContentBlocks } from "../content-blocks.js";
 import { wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
+import { resolveCompactionInstructions } from "./compaction-instructions.js";
 import { getCompactionSafeguardRuntime } from "./compaction-safeguard-runtime.js";
 
 const log = createSubsystemLogger("compaction-safeguard");
@@ -751,8 +752,12 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const recentTurnsPreserve = resolveRecentTurnsPreserve(runtime?.recentTurnsPreserve);
       const qualityGuardEnabled = runtime?.qualityGuardEnabled ?? false;
       const qualityGuardMaxRetries = resolveQualityGuardMaxRetries(runtime?.qualityGuardMaxRetries);
-      const structuredInstructions = buildCompactionStructureInstructions(
+      const resolvedInstructions = resolveCompactionInstructions(
         customInstructions,
+        runtime?.customInstructions,
+      );
+      const structuredInstructions = buildCompactionStructureInstructions(
+        resolvedInstructions,
         summarizationInstructions,
       );
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -313,6 +313,8 @@ export type AgentCompactionConfig = {
   identifierPolicy?: AgentCompactionIdentifierPolicy;
   /** Custom identifier-preservation instructions used when identifierPolicy is "custom". */
   identifierInstructions?: string;
+  /** Custom instructions for compaction summaries (e.g. language preservation). Falls back to built-in language-preservation defaults when unset. */
+  customInstructions?: string;
   /** Optional quality-audit retries for safeguard compaction summaries. */
   qualityGuard?: AgentCompactionQualityGuardConfig;
   /** Post-compaction session memory index sync mode. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -95,6 +95,8 @@ export const AgentDefaultsSchema = z
           .union([z.literal("strict"), z.literal("off"), z.literal("custom")])
           .optional(),
         identifierInstructions: z.string().optional(),
+        /** Custom instructions for compaction summaries (e.g. language preservation). Falls back to built-in language-preservation defaults. */
+        customInstructions: z.string().optional(),
         recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
         qualityGuard: z
           .object({


### PR DESCRIPTION
## Problem

Compaction summaries currently default to the model's preferred language (English), regardless of the original conversation language. For non-English users (e.g., Chinese, Japanese, Korean), this creates a jarring experience where native-language conversations produce English summaries after compaction.

## Solution

Add a default language-preservation instruction that directs the compaction summarizer to use the conversation's primary language, while keeping required section headers and structure intact.

### Changes

- **New file: `compaction-instructions.ts`**
  - `DEFAULT_COMPACTION_INSTRUCTIONS`: built-in instructions that preserve conversation language
  - `resolveCompactionInstructions(event, runtime)`: precedence resolver (event → runtime config → default)
  - `composeSplitTurnInstructions()`: helper for split-turn instruction composition
  - Unicode-safe truncation at 800 code points

- **Config support: `compaction.customInstructions`**
  - Added to `AgentCompactionConfig` type and Zod schema
  - Threaded through runtime registry → safeguard extension
  - When unset, the built-in language-preservation default kicks in automatically

- **17 unit tests** covering normalization, precedence, truncation, and unicode safety

### Default Instructions

```
Write the summary body in the primary language used in the conversation.
Focus on factual content: what was discussed, decisions made, and current state.
Keep the required summary structure and section headers unchanged.
Do not translate or alter code, file paths, identifiers, or error messages.
```

### Config Example

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "customInstructions": "用中文写摘要，保持技术术语原文"
      }
    }
  }
}
```

When `customInstructions` is not set, the default language-preservation instructions apply automatically — no configuration needed for most users.

## Motivation

This was discovered in production use with Chinese conversations. After context compaction, the resumption summary was written in English, causing the agent to briefly respond in English before correcting itself. The language mismatch also affected persona consistency and cultural context.