### PR TITLE
fix(ui): prevent new-messages scroll button icon from stretching

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -101,7 +101,8 @@
 }
 
 /* New messages indicator - floating pill above compose */
-.chat-new-messages {
+.chat-new-messages,
+.agent-chat__scroll-pill {
   align-self: center;
   display: inline-flex;
   align-items: center;
@@ -122,12 +123,14 @@
     border-color 150ms ease-out;
 }
 
-.chat-new-messages:hover {
+.chat-new-messages:hover,
+.agent-chat__scroll-pill:hover {
   background: var(--panel);
   border-color: var(--accent);
 }
 
-.chat-new-messages svg {
+.chat-new-messages svg,
+.agent-chat__scroll-pill svg {
   width: 16px;
   height: 16px;
   stroke: currentColor;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2226,7 +2226,8 @@
 }
 
 /* New messages indicator */
-.chat-new-messages {
+.chat-new-messages,
+.agent-chat__scroll-pill {
   align-self: center;
   margin: 8px auto 0;
   border-radius: 999px;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1169,7 +1169,7 @@ export function renderChat(props: ChatProps) {
         props.showNewMessages
           ? html`
             <button
-              class="agent-chat__scroll-pill"
+              class="chat-new-messages"
               type="button"
               @click=${props.onScrollToBottom}
             >


### PR DESCRIPTION
## Summary
- Fix class mismatch in chat template by using `.chat-new-messages` for the scroll pill button.
- Add backward-compatible CSS selectors for `.agent-chat__scroll-pill`.
- Ensure the SVG icon inside the button is constrained to 16x16.

## Testing
- `pnpm -C /home/ltx/projects/openclaw test:ui` *(fails locally because dependencies are not installed in this environment: missing `node_modules` / `typescript`)*

Closes #44728