### PR TITLE
fix(doctor): avoid false cron payload-kind normalization warnings

### DIFF
--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -215,6 +215,59 @@ describe("maybeRepairLegacyCronStore", () => {
     );
   });
 
+  it("does not warn for already-normalized payload kinds", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "normalized-job",
+              name: "Normalized job",
+              enabled: true,
+              createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+              schedule: { kind: "cron", expr: "0 7 * * *", tz: "UTC" },
+              sessionTarget: "isolated",
+              wakeMode: "now",
+              payload: {
+                kind: "agentTurn",
+                message: "already normalized",
+              },
+              delivery: { mode: "none" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    const prompter = makePrompter(true);
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: {
+          store: storePath,
+        },
+      },
+      options: { nonInteractive: true },
+      prompter,
+    });
+
+    expect(prompter.confirm).not.toHaveBeenCalled();
+    expect(noteSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("needs payload kind normalization"),
+      "Cron",
+    );
+  });
+
   it("migrates notify fallback none delivery jobs to cron.webhook", async () => {
     const storePath = await makeTempStorePath();
     await fs.mkdir(path.dirname(storePath), { recursive: true });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,14 +28,21 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
+  const original = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  const raw = original.toLowerCase();
   if (raw === "agentturn") {
-    payload.kind = "agentTurn";
-    return true;
+    if (original !== "agentTurn") {
+      payload.kind = "agentTurn";
+      return true;
+    }
+    return false;
   }
   if (raw === "systemevent") {
-    payload.kind = "systemEvent";
-    return true;
+    if (original !== "systemEvent") {
+      payload.kind = "systemEvent";
+      return true;
+    }
+    return false;
   }
   return false;
 }


### PR DESCRIPTION
## Problem

Doctor can continue to report cron payload-kind normalization warnings even when the cron store already uses canonical payload kinds like:

- `agentTurn`
- `systemEvent`

The detector lowercased `payload.kind` and returned `true` for `agentturn` / `systemevent` even when the stored value was already canonical, producing a false-positive warning loop.

## Fix

Only treat payload-kind normalization as needed when the stored value is actually mutated.

## Tests

Added regression coverage verifying that already-normalized cron payload kinds do not trigger doctor warnings or repair prompts.

Closes #44674
