### PR TITLE
Preserve disk config during runtime snapshot writeback

### DIFF
--- a/src/config/io.runtime-snapshot-write.test.ts
+++ b/src/config/io.runtime-snapshot-write.test.ts
@@ -213,6 +213,40 @@ describe("runtime config snapshot writes", () => {
     });
   });
 
+  it("preserves disk-added session dmScope when writing from a stale runtime snapshot", async () => {
+    await withTempHome("openclaw-config-runtime-write-stale-session-", async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const sourceConfig = createSourceConfig();
+      const runtimeConfig = createRuntimeConfig();
+      const diskConfig: OpenClawConfig = {
+        ...sourceConfig,
+        session: { dmScope: "per-channel-peer" },
+      };
+
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, `${JSON.stringify(diskConfig, null, 2)}\n`, "utf8");
+
+      try {
+        setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+        await writeConfigFile(loadConfig());
+
+        const persisted = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+          session?: { dmScope?: unknown };
+          models?: { providers?: { openai?: { apiKey?: unknown } } };
+        };
+        expect(persisted.session?.dmScope).toBe("per-channel-peer");
+        expect(persisted.models?.providers?.openai?.apiKey).toEqual({
+          source: "env",
+          provider: "default",
+          id: "OPENAI_API_KEY",
+        });
+      } finally {
+        resetRuntimeConfigState();
+      }
+    });
+  });
+
   it("keeps the last-known-good runtime snapshot active while a specialized refresh is pending", async () => {
     await withTempHome("openclaw-config-runtime-refresh-pending-", async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1513,8 +1513,20 @@ export async function writeConfigFile(
   const hadRuntimeSnapshot = Boolean(runtimeConfigSnapshot);
   const hadBothSnapshots = Boolean(runtimeConfigSnapshot && runtimeConfigSourceSnapshot);
   if (hadBothSnapshots) {
+    let projectionBase = runtimeConfigSourceSnapshot!;
+    try {
+      const latestSnapshot = await io.readConfigFileSnapshot();
+      if (latestSnapshot.valid) {
+        // Prefer the latest on-disk source so write-back doesn't drop keys that were
+        // added after the active runtime snapshot was created.
+        projectionBase = latestSnapshot.resolved;
+      }
+    } catch {
+      // Fall back to the last-known runtime source snapshot when the current file
+      // cannot be read; the write path will surface the underlying I/O error later.
+    }
     const runtimePatch = createMergePatch(runtimeConfigSnapshot!, cfg);
-    nextCfg = coerceConfig(applyMergePatch(runtimeConfigSourceSnapshot!, runtimePatch));
+    nextCfg = coerceConfig(applyMergePatch(projectionBase, runtimePatch));
   }
   const sameConfigPath =
     options.expectedConfigPath === undefined || options.expectedConfigPath === io.configPath;

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1516,7 +1516,7 @@ export async function writeConfigFile(
     let projectionBase = runtimeConfigSourceSnapshot!;
     try {
       const latestSnapshot = await io.readConfigFileSnapshot();
-      if (latestSnapshot.valid) {
+      if (latestSnapshot.valid && latestSnapshot.exists) {
         // Prefer the latest on-disk source so write-back doesn't drop keys that were
         // added after the active runtime snapshot was created.
         projectionBase = latestSnapshot.resolved;


### PR DESCRIPTION
## Summary

This fixes a config writeback bug where `writeConfigFile(loadConfig())` could drop keys that were added on disk after the active runtime snapshot was created.

In practice that meant an explicit top-level `session.dmScope` could disappear during gateway-triggered writebacks, which matches the dmScope persistence bug reported in #15146.

## Root cause

`src/config/io.ts` projected runtime-derived configs back onto `runtimeConfigSourceSnapshot` before persisting them.
When that source snapshot was stale, any newer disk-only keys were missing from the projection base, so the follow-up write deleted them.

This PR now:

- prefers the latest valid on-disk snapshot as the projection base for runtime writeback
- falls back to the last runtime source snapshot only when the current file cannot be read
- adds a regression test that reproduces `session.dmScope` being stripped by a stale runtime snapshot

## Testing

- `corepack pnpm vitest src/config/io.runtime-snapshot-write.test.ts`
- `corepack pnpm vitest src/config/io.owner-display-secret.test.ts`
- `corepack pnpm vitest src/config/env-preserve-io.test.ts`

Fixes #15146.
