### PR TITLE
fix(daemon): try direct systemctl --user before --machine fallback

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -694,13 +694,16 @@ describe("systemd service control", () => {
   });
 
   it("targets the sudo caller's user scope when SUDO_USER is set", async () => {
+    // After fix: try direct --user scope first (works when XDG_RUNTIME_DIR is set),
+    // only fall back to --machine if direct fails. Since direct succeeds for status,
+    // restart also uses direct --user scope.
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertMachineUserSystemctlArgs(args, "debian", "status");
-        cb(null, "", "");
+        expect(args).toEqual(["--user", "status"]);
+        cb(null, "", ""); // Direct method succeeds
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertMachineRestartArgs(args);
+        expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
         cb(null, "", "");
       });
     await assertRestartSuccess({ SUDO_USER: "debian" });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -390,21 +390,15 @@ async function execSystemctlUser(
   args: string[],
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const machineUser = resolveSystemctlMachineScopeUser(env);
-  const sudoUser = env.SUDO_USER?.trim();
 
-  // Under sudo, prefer the invoking non-root user's scope directly.
-  if (sudoUser && sudoUser !== "root" && machineUser) {
-    const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
-    if (machineScopeArgs.length > 0) {
-      return await execSystemctl([...machineScopeArgs, ...args]);
-    }
-  }
-
+  // Try direct user scope first using XDG_RUNTIME_DIR. This works for both
+  // direct sessions and sudo -u <user> when XDG_RUNTIME_DIR is set.
   const directResult = await execSystemctl([...resolveSystemctlDirectUserScopeArgs(), ...args]);
   if (directResult.code === 0) {
     return directResult;
   }
 
+  // Direct method failed; check if we should fall back to --machine scope.
   const detail = `${directResult.stderr} ${directResult.stdout}`.trim();
   if (!machineUser || !shouldFallbackToMachineUserScope(detail)) {
     return directResult;

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -52,9 +52,9 @@ vi.mock("undici", () => ({
 }));
 
 import {
+  PROXY_FETCH_PROXY_URL,
   getProxyUrlFromFetch,
   makeProxyFetch,
-  PROXY_FETCH_PROXY_URL,
   resolveProxyFetchFromEnv,
 } from "./proxy-fetch.js";
 
@@ -116,13 +116,10 @@ describe("getProxyUrlFromFetch", () => {
 
   it("returns undefined for plain fetch functions or blank metadata", () => {
     const plainFetch = vi.fn() as unknown as typeof fetch;
-    const blankMetadataFetch = vi.fn() as unknown as typeof fetch;
-    Object.defineProperty(blankMetadataFetch, PROXY_FETCH_PROXY_URL, {
-      value: "   ",
-      enumerable: false,
-      configurable: true,
-      writable: true,
-    });
+    const blankMetadataFetch = vi.fn() as unknown as typeof fetch & {
+      [PROXY_FETCH_PROXY_URL]?: string;
+    };
+    blankMetadataFetch[PROXY_FETCH_PROXY_URL] = "   ";
 
     expect(getProxyUrlFromFetch(plainFetch)).toBeUndefined();
     expect(getProxyUrlFromFetch(blankMetadataFetch)).toBeUndefined();


### PR DESCRIPTION
Fixes #44417 - systemctl --user detection fails during `sudo -u` due to SUDO_USER fallback

## Root Cause

When `SUDO_USER` is set (e.g., `sudo -u jarvis bash`), OpenClaw's `execSystemctlUser` function bypassed the direct `systemctl --user` check and immediately tried `systemctl --machine admin@.host --user`. This caused detection to fail or hang.

## Fix

Remove the early `SUDO_USER` check. Instead:
1. **Always try direct method first** using `XDG_RUNTIME_DIR`
2. Only fall back to `--machine` scope if direct method fails
3. This works for both direct sessions AND `sudo -u <user>` when `XDG_RUNTIME_DIR` is set

## Test Plan

- [x] Direct user session — `systemctl --user status` works
- [x] sudo session with `XDG_RUNTIME_DIR` set — direct method works
- [x] `openclaw gateway install` succeeds in sudo environment