### PR TITLE
fix(cron): correctly handle delivery status for all modes (none/announce/webhook)

### DIFF
--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -151,14 +151,17 @@ describe("CronService persists delivered status", () => {
     expect(updated?.state.lastDeliveryError).toBeUndefined();
   });
 
-  it("persists lastDelivered=false when isolated job explicitly reports not delivered", async () => {
+  it("persists not-requested when delivery.mode=none and runner reports delivered=false", async () => {
+    // When delivery was never requested (mode: "none"), delivered=false from
+    // the runner should resolve to "not-requested", not "not-delivered".
+    // See: https://github.com/openclaw/openclaw/issues/44533
     const updated = await runIsolatedJobAndReadState({
       job: buildIsolatedAgentTurnJob("delivered-false"),
       delivered: false,
     });
     expectSuccessfulCronRun(updated);
     expect(updated?.state.lastDelivered).toBe(false);
-    expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
     expect(updated?.state.lastDeliveryError).toBeUndefined();
   });
 
@@ -167,6 +170,34 @@ describe("CronService persists delivered status", () => {
       job: buildIsolatedAgentTurnJob("no-delivery"),
     });
     expectDeliveryNotRequested(updated);
+  });
+
+  it("persists not-delivered when delivery.mode=announce and runner reports delivered=false", async () => {
+    const updated = await runIsolatedJobAndReadState({
+      job: {
+        ...buildIsolatedAgentTurnJob("announce-delivered-false"),
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      },
+      delivered: false,
+    });
+    expectSuccessfulCronRun(updated);
+    expect(updated?.state.lastDelivered).toBe(false);
+    expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(updated?.state.lastDeliveryError).toBeUndefined();
+  });
+
+  it("persists not-delivered when delivery.mode=webhook and runner reports delivered=false", async () => {
+    const updated = await runIsolatedJobAndReadState({
+      job: {
+        ...buildIsolatedAgentTurnJob("webhook-delivered-false"),
+        delivery: { mode: "webhook", to: "https://example.com/webhook" },
+      },
+      delivered: false,
+    });
+    expectSuccessfulCronRun(updated);
+    expect(updated?.state.lastDelivered).toBe(false);
+    expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(updated?.state.lastDeliveryError).toBeUndefined();
   });
 
   it("persists unknown delivery state when delivery is requested but the runner omits delivered", async () => {

--- a/src/cron/service/delivery-status.test.ts
+++ b/src/cron/service/delivery-status.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import { resolveDeliveryStatus } from "./timer.js";
+
+function makeJob(delivery?: { mode?: string }): CronJob {
+  return {
+    id: "test-job",
+    name: "test",
+    schedule: { kind: "every", everyMs: 60_000 },
+    payload: { kind: "agentTurn", message: "hello" },
+    sessionTarget: "isolated",
+    enabled: true,
+    state: {},
+    ...(delivery ? { delivery } : {}),
+  } as CronJob;
+}
+
+describe("resolveDeliveryStatus", () => {
+  // mode="none" tests
+  it('returns "not-requested" when delivery.mode is "none" and delivered is false', () => {
+    const job = makeJob({ mode: "none" });
+    expect(resolveDeliveryStatus({ job, delivered: false })).toBe("not-requested");
+  });
+
+  it('returns "not-requested" when delivery.mode is "none" and delivered is undefined', () => {
+    const job = makeJob({ mode: "none" });
+    expect(resolveDeliveryStatus({ job })).toBe("not-requested");
+  });
+
+  it('returns "delivered" when delivery.mode is "none" but delivered is true', () => {
+    // Even when cron doesn't configure delivery, manual delivery via messaging tools is possible
+    const job = makeJob({ mode: "none" });
+    expect(resolveDeliveryStatus({ job, delivered: true })).toBe("delivered");
+  });
+
+  // mode="announce" tests
+  it('returns "delivered" when delivery.mode is "announce" and delivered is true', () => {
+    const job = makeJob({ mode: "announce" });
+    expect(resolveDeliveryStatus({ job, delivered: true })).toBe("delivered");
+  });
+
+  it('returns "not-delivered" when delivery.mode is "announce" and delivered is false', () => {
+    const job = makeJob({ mode: "announce" });
+    expect(resolveDeliveryStatus({ job, delivered: false })).toBe("not-delivered");
+  });
+
+  it('returns "unknown" when delivery.mode is "announce" and delivered is undefined', () => {
+    const job = makeJob({ mode: "announce" });
+    expect(resolveDeliveryStatus({ job })).toBe("unknown");
+  });
+
+  // mode="webhook" tests - critical fix: webhook should return not-delivered, not not-requested
+  it('returns "delivered" when delivery.mode is "webhook" and delivered is true', () => {
+    const job = makeJob({ mode: "webhook" });
+    expect(resolveDeliveryStatus({ job, delivered: true })).toBe("delivered");
+  });
+
+  it('returns "not-delivered" when delivery.mode is "webhook" and delivered is false', () => {
+    const job = makeJob({ mode: "webhook" });
+    expect(resolveDeliveryStatus({ job, delivered: false })).toBe("not-delivered");
+  });
+
+  it('returns "unknown" when delivery.mode is "webhook" and delivered is undefined', () => {
+    const job = makeJob({ mode: "webhook" });
+    expect(resolveDeliveryStatus({ job })).toBe("unknown");
+  });
+
+  // Edge case tests
+  it("handles legacy deliver=true field", () => {
+    const job = {
+      ...makeJob(),
+      payload: { kind: "agentTurn", message: "hello", deliver: true },
+    } as CronJob;
+    // legacy deliver=true should be treated as announce mode
+    expect(resolveDeliveryStatus({ job, delivered: false })).toBe("not-delivered");
+  });
+
+  it("handles legacy deliver=false field", () => {
+    const job = {
+      ...makeJob(),
+      payload: { kind: "agentTurn", message: "hello", deliver: false },
+    } as CronJob;
+    // legacy deliver=false should be treated as none mode
+    expect(resolveDeliveryStatus({ job, delivered: false })).toBe("not-requested");
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -161,14 +161,27 @@ function resolveRetryConfig(cronConfig?: CronConfig) {
   };
 }
 
-function resolveDeliveryStatus(params: { job: CronJob; delivered?: boolean }): CronDeliveryStatus {
+export function resolveDeliveryStatus(params: {
+  job: CronJob;
+  delivered?: boolean;
+}): CronDeliveryStatus {
   if (params.delivered === true) {
     return "delivered";
   }
+
+  const deliveryPlan = resolveCronDeliveryPlan(params.job);
+
+  // mode="none" means delivery was never requested
+  // Note: webhook mode also has requested=false, but it's a requested delivery
+  if (deliveryPlan.mode === "none") {
+    return "not-requested";
+  }
+
   if (params.delivered === false) {
     return "not-delivered";
   }
-  return resolveCronDeliveryPlan(params.job).requested ? "unknown" : "not-requested";
+
+  return "unknown";
 }
 
 function normalizeCronMessageChannel(input: unknown): CronMessageChannel | undefined {


### PR DESCRIPTION
Fixes #44533

## Summary

This PR fixes the delivery status reporting for cron jobs with `delivery.mode = "none"` and correctly handles all delivery modes (`none`, `announce`, `webhook`).

### Problem
When `delivery.mode = "none"` is set in a cron job config, the system incorrectly reports `lastDeliveryStatus: "not-delivered"` instead of `"not-requested"`.

### Root Cause Analysis
After analyzing all existing PRs (#44594, #44665, #44698, #44788), I found a critical issue:

1. **All existing PRs use `!plan.requested` as the condition**
2. **But `resolveCronDeliveryPlan` sets `requested: resolvedMode === "announce"`**
3. **This means `mode="webhook"` also has `requested: false`**
4. **Using `!requested` would incorrectly report webhook failures as `"not-requested"`**

### Solution
Check `deliveryPlan.mode === "none"` instead of `!deliveryPlan.requested` to correctly distinguish between:
- `mode="none"` (delivery never requested) → `"not-requested"`
- `mode="announce"` or `mode="webhook"` (delivery requested but failed) → `"not-delivered"`

### Changes

1. **`src/cron/service/timer.ts`**:
   - Fixed `resolveDeliveryStatus` to check `deliveryPlan.mode === "none"`
   - Added `export` keyword for testability
   - Added detailed comments explaining the logic

2. **`src/cron/service/delivery-status.test.ts`** (new):
   - Comprehensive unit tests covering all combinations:
     - `mode="none"` with `delivered=false/true/undefined`
     - `mode="announce"` with `delivered=false/true/undefined`
     - `mode="webhook"` with `delivered=false/true/undefined`
     - Legacy `deliver=true/false` fields

3. **`src/cron/service.persists-delivered-status.test.ts`**:
   - Updated existing test to expect `"not-requested"` for `mode="none"`
   - Added new tests for `mode="announce"` and `mode="webhook"` with `delivered=false`

### Testing
- All new unit tests pass
- Existing integration tests updated and pass
- Correctly handles edge cases (e.g., `mode="none"` but `delivered=true` from manual messaging)

### Comparison with Existing PRs
This PR fixes the **webhook regression** present in all other PRs while maintaining the correct behavior for all delivery modes.