### PR TITLE
feat(install): add backup restore during install

### DIFF
--- a/.github/workflows/e2e-multi-os.yml
+++ b/.github/workflows/e2e-multi-os.yml
@@ -1,0 +1,51 @@
+# E2E Multi-OS — Phase 1: CLI smoke across Ubuntu, Windows, macOS
+# Roadmap: docs/experiments/plans/e2e-multi-os-ci-roadmap.md
+
+name: E2E Multi-OS
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      phase:
+        description: 'Phase to run'
+        required: false
+        default: 'smoke'
+        type: choice
+        options:
+          - smoke
+          - e2e
+          - docker
+
+jobs:
+  e2e-smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Build
+        run: pnpm build
+
+      - name: CLI smoke
+        run: |
+          pnpm exec openclaw --version
+          pnpm exec openclaw doctor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,14 @@
 - Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.
 - Mobile: before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.
 
+## E2E Multi-OS CI (long-horizon)
+
+When working on cross-platform E2E testing or fixing E2E workflow failures:
+
+1. Read `docs/experiments/plans/e2e-multi-os-ci-roadmap.md` for phased plan, best practices, and self-iteration loop.
+2. Follow the self-iteration loop: fetch failure logs → analyze → fix → re-trigger → verify; repeat until all target OS jobs pass.
+3. Update the roadmap Changelog when making progress.
+
 ## Commit & Pull Request Guidelines
 
 **Full maintainer PR workflow (optional):** If you want the repo's end-to-end maintainer workflow (triage order, quality bar, rebase rules, commit/changelog conventions, co-contributor policy, and the `review-pr` > `prepare-pr` > `merge-pr` pipeline), see `.agents/skills/PR_WORKFLOW.md`. Maintainers may use other workflows; when a maintainer specifies a workflow, follow that. If no workflow is specified, default to PR_WORKFLOW.

--- a/docs/contributing/PR-BACKUP-RESTORE.md
+++ b/docs/contributing/PR-BACKUP-RESTORE.md
@@ -1,0 +1,92 @@
+# PR: Backup restore during install
+
+## Summary
+
+Adds backup detection and restore flow to the OpenClaw installer. When reinstalling after an uninstall, users can restore their previous state from `~/.openclaw-backup-*` directories.
+
+## Changes
+
+### 1. `openclaw backup restore` CLI command
+
+- **File**: `src/cli/program/register.backup.ts`
+- Uses existing `restoreBackup()` from `src/infra/backup-restore.ts`
+- Supports: `openclaw backup restore <path> [--target-dir] [--verify] [--dry-run]`
+
+### 2. Install script backup flow
+
+- **File**: `scripts/install.sh`
+- New functions: `detect_backup_dirs`, `is_state_dir_empty`, `is_valid_backup_dir`, `maybe_restore_backup_during_install`
+- Runs after OpenClaw is installed, before `run_doctor`
+- Only when: `~/.openclaw` empty and backups exist
+- Env vars: `OPENCLAW_INSTALL_RESTORE_BACKUP=1`, `OPENCLAW_INSTALL_SKIP_BACKUP=1`
+
+### 3. Documentation
+
+- **File**: `docs/install/backup-restore-during-install.md`
+
+## Fork → PR workflow
+
+1. **Fork** the [openclaw/openclaw](https://github.com/openclaw/openclaw) repo on GitHub.
+
+2. **Clone your fork**:
+
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/openclaw.git
+   cd openclaw
+   ```
+
+3. **Create a branch**:
+
+   ```bash
+   git checkout -b feature/backup-restore-during-install
+   ```
+
+4. **Apply changes** (or cherry-pick commits from your local openclaw repo).
+
+5. **Test locally**:
+
+   ```bash
+   pnpm build
+   node dist/entry.js backup restore --help
+   # Simulate install with backup: create ~/.openclaw-backup-* and run install.sh
+   ```
+
+6. **Push and open PR**:
+   ```bash
+   git add -A
+   git commit -m "feat(install): add backup restore during install"
+   git push origin feature/backup-restore-during-install
+   ```
+   Then open a PR at https://github.com/openclaw/openclaw/compare
+
+## Suggested PR title
+
+```
+feat(install): add backup restore during install
+```
+
+## Suggested PR body
+
+```markdown
+## What
+
+- Add `openclaw backup restore <path>` CLI command
+- During install: detect `~/.openclaw-backup-*` when state is empty
+- Prompt: restore latest / skip / delete backups
+
+## Why
+
+Users who uninstall OpenClaw (backup created) then reinstall get no automatic restore. This adds an optional restore flow.
+
+## How
+
+- Uses existing `restoreBackup()` from `infra/backup-restore.ts`
+- Install script: `maybe_restore_backup_during_install` after install, before doctor
+- Env: `OPENCLAW_INSTALL_RESTORE_BACKUP=1` (auto-restore), `OPENCLAW_INSTALL_SKIP_BACKUP=1` (skip)
+
+## Testing
+
+- [ ] `openclaw backup restore --help`
+- [ ] `openclaw backup create` then `openclaw backup restore <dir>` with `--dry-run`
+- [ ] Install with `~/.openclaw-backup-*` present and empty `~/.openclaw`
+```

--- a/docs/experiments/plans/e2e-multi-os-ci-roadmap.md
+++ b/docs/experiments/plans/e2e-multi-os-ci-roadmap.md
@@ -1,0 +1,194 @@
+# E2E Multi-OS CI Roadmap — Long-Horizon Task
+
+> **Goal**: Establish an end-to-end automated testing framework that validates OpenClaw across major server and local environments, with self-iteration capability until all target platforms pass.
+
+## 1. Research Summary — CI/CD Best Practices
+
+### 1.1 Multi-OS Matrix Strategy (GitHub Actions)
+
+| Practice | Source | Application |
+|----------|--------|-------------|
+| `fail-fast: false` | [GitHub Docs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) | Run all matrix jobs even if one fails; faster feedback |
+| `include` / `exclude` | [OneUptime](https://oneuptime.com/blog/post/2025-12-20-github-actions-matrix-include-exclude/view) | Skip unsupported combos (e.g. Windows ARM64); add platform-specific tests |
+| Dynamic matrix | [CodeStudy](https://www.codestudy.net/blog/how-do-i-make-a-github-action-matrix-element-conditional/) | Adapt matrix from `workflow_dispatch` inputs or path filters |
+| OS-specific caching | [Codefresh](https://codefresh.io/learn/github-actions/github-actions-matrix/) | Cache key includes `${{ matrix.os }}` to avoid cross-OS pollution |
+| `timeout-minutes` | [Playwright CI](https://playwright.dev/docs/ci) | Prevent hung jobs |
+
+### 1.2 E2E Testing Patterns
+
+| Practice | Source | Application |
+|----------|--------|-------------|
+| Sharding for large suites | [Playwright](https://playwright.dev/docs/ci) | Distribute tests across matrix jobs |
+| `workers: 1` in CI | [Playwright](https://playwright.dev/docs/ci) | Stability and reproducibility |
+| Artifact on failure only | [DEV Community](https://dev.to/drakulavich/fast-and-reliable-end-to-end-tests-with-playwright-on-github-actions-2mkh) | `if: failure()` to upload logs |
+| Phased rollout | [Compile N Run](https://compilenrun.com/docs/devops/cicd/cicd-deployment-strategies/cicd-phased-rollout) | Feature flags or gradual matrix expansion |
+
+### 1.3 Self-Healing / Self-Iteration
+
+| Pattern | Source | Application |
+|---------|--------|-------------|
+| Failure → Agent → Fix → Re-run | [Dagger](https://dagger.io/blog/automate-your-ci-fixes-self-healing-pipelines-with-ai-agents), [Semaphore](https://semaphore.io/blog/self-healing-ci) | Agent reads logs, applies fix, validates, proposes PR |
+| Constrained tools | [Dagger](https://dagger.io/blog/automate-your-ci-fixes-self-healing-pipelines-with-ai-agents) | ReadFile, WriteFile, RunTests, RunLint — expose as tools |
+| Context-aware | [Nx](https://canary.nx.dev/docs/features/ci-features/self-healing-ci) | Agent understands workspace structure |
+
+**OpenClaw adaptation**: No Dagger required. Use Cursor/agent with:
+- `gh run view <id> --log-failed` to fetch failure context
+- Edit workflow YAML or test scripts
+- Re-trigger via `workflow_dispatch` or empty commit
+- Iterate until `gh run list` shows success
+
+---
+
+## 2. Target Environments (Matrix)
+
+| Environment | Runner | Priority | Notes |
+|-------------|--------|----------|-------|
+| **Ubuntu** | `ubuntu-latest` or `blacksmith-16vcpu-ubuntu-2404` | P0 | Primary server; Docker E2E here |
+| **Windows** | `windows-latest` or `blacksmith-32vcpu-windows-2025` | P0 | Path handling, PowerShell |
+| **macOS** | `macos-latest` | P1 | Limited concurrency; PR-only or path-filter |
+| **Docker (Linux)** | Ubuntu + Docker | P0 | onboard, gateway-network, etc. |
+
+---
+
+## 3. Phased Rollout Plan
+
+### Phase 0: Foundation (Current)
+
+- [x] Create `docs/experiments/plans/e2e-multi-os-ci-roadmap.md` (this doc)
+- [x] Add `workflow_dispatch` to a new workflow for manual iteration
+- [x] Define minimal smoke commands per OS
+
+### Phase 1: CLI Smoke (Ubuntu, Windows, macOS)
+
+- [x] New workflow: `e2e-multi-os.yml`
+- [x] Matrix: `os: [ubuntu-latest, windows-latest, macos-latest]`
+- [x] Steps: checkout → setup Node → pnpm install → pnpm build → `openclaw --version` → `openclaw doctor`
+- [x] `fail-fast: false`, `timeout-minutes: 30`
+- [x] Trigger: `push` (main), `pull_request`, `workflow_dispatch`
+- [ ] Success criteria: All 3 OS jobs green (self-iterate until pass)
+
+### Phase 2: Vitest E2E (Ubuntu first)
+
+- [ ] Add job: `pnpm test:e2e` on Ubuntu
+- [ ] Reuse `ci.yml` build-artifacts if available
+- [ ] Success criteria: E2E suite passes on Ubuntu
+
+### Phase 3: Docker E2E (Ubuntu)
+
+- [ ] Add job: `pnpm test:docker:onboard` (and optionally gateway-network, etc.)
+- [ ] Requires Docker: use `useblacksmith/setup-docker-builder` or host Docker
+- [ ] Success criteria: Onboard Docker E2E passes
+
+### Phase 4: Vitest E2E on Windows / macOS
+
+- [ ] Extend matrix: run `pnpm test:e2e` on Windows and macOS
+- [ ] Use `include`/`exclude` if platform-specific skips needed
+- [ ] Success criteria: E2E passes on all 3 OS
+
+### Phase 5: Self-Iteration Loop
+
+- [ ] Document agent workflow: fetch failure → analyze → fix → re-trigger
+- [ ] Optional: `workflow_dispatch` input `phase` to run subset (e.g. only Phase 1)
+- [ ] Optional: Store last-run status in a small artifact (e.g. `e2e-status.json`) for agent to read
+
+---
+
+## 4. Self-Iteration Loop (Agent Instructions)
+
+When an E2E workflow fails:
+
+1. **Fetch context**
+   ```bash
+   gh run list --workflow "e2e-multi-os.yml" -L 1
+   gh run view <id> --log-failed
+   ```
+
+2. **Identify root cause**
+   - Path separator (Windows `\` vs `/`)
+   - Shell: PowerShell vs bash on Windows
+   - Missing deps (e.g. `jq`, `trash`)
+   - Timeout or flakiness
+
+3. **Apply fix**
+   - Edit `.github/workflows/e2e-multi-os.yml` or test scripts
+   - Use `defaults.run.shell: bash` on Windows when possible
+   - Add platform-specific `if` or `continue-on-error` for experimental lanes
+
+4. **Re-trigger**
+   ```bash
+   git add -A && git commit -m "fix(ci): ..." && git push
+   # or: gh workflow run e2e-multi-os.yml
+   ```
+
+5. **Verify**
+   ```bash
+   gh run list --workflow "e2e-multi-os.yml" -L 1
+   gh run watch <id>
+   ```
+
+6. **Repeat** until all matrix jobs pass.
+
+---
+
+## 5. Workflow Skeleton (Phase 1)
+
+```yaml
+name: E2E Multi-OS
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      phase:
+        description: 'Phase to run'
+        required: false
+        default: 'smoke'
+        type: choice
+        options:
+          - smoke
+          - e2e
+          - docker
+
+jobs:
+  e2e-smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+      - name: Build
+        run: pnpm build
+      - name: CLI smoke
+        run: |
+          pnpm exec openclaw --version
+          pnpm exec openclaw doctor
+```
+
+---
+
+## 6. Changelog (Self-Iteration Log)
+
+| Date | Change | Status |
+|------|--------|--------|
+| (initial) | Roadmap created | — |
+| 2026-03-11 | Phase 1 workflow added: e2e-multi-os.yml | Pending first run |
+
+---
+
+## 7. References
+
+- [GitHub Actions Matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs)
+- [Playwright CI](https://playwright.dev/docs/ci)
+- [Dagger Self-Healing CI](https://dagger.io/blog/automate-your-ci-fixes-self-healing-pipelines-with-ai-agents)
+- [OpenClaw docs/help/testing.md](/docs/help/testing.md)

--- a/docs/install/backup-restore-during-install.md
+++ b/docs/install/backup-restore-during-install.md
@@ -1,0 +1,34 @@
+# Backup Restore During Install
+
+When reinstalling OpenClaw after an uninstall, the installer can detect existing backups (created by `openclaw backup create` or the uninstall script) and offer to restore them.
+
+## Backup locations
+
+- **Uninstall script**: Creates `~/.openclaw-backup-YYYYMMDD-HHMMSS/` with either:
+  - `*.tar.gz` (from `openclaw backup create`)
+  - Or manual copy of `skills/`, `sessions/`, `openclaw.json`, `credentials/`
+- **Manual backup**: `openclaw backup create --output ~/Backups` produces `~/Backups/YYYYMMDD-HHMMSS-openclaw-backup.tar.gz`
+
+## When restore is offered
+
+- `~/.openclaw` is empty or missing (fresh install / reinstall)
+- At least one valid backup exists under `~/.openclaw-backup-*`
+- Interactive terminal (TTY) available, unless overridden by env vars
+
+## Options
+
+| Env var                             | Behavior                                          |
+| ----------------------------------- | ------------------------------------------------- |
+| `OPENCLAW_INSTALL_RESTORE_BACKUP=1` | Auto-restore latest backup, no prompt             |
+| `OPENCLAW_INSTALL_SKIP_BACKUP=1`    | Skip backup detection and restore                 |
+| `NO_PROMPT=1`                       | Skip interactive prompts; backup kept, no restore |
+
+## Manual restore
+
+```bash
+openclaw backup restore ~/.openclaw-backup-20260311-143022
+openclaw backup restore ./backup.tar.gz --verify
+openclaw backup restore ~/Backups/latest.tar.gz --dry-run
+```
+
+See [CLI backup docs](/cli/backup) for details.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1029,6 +1029,8 @@ Environment variables:
   OPENCLAW_DRY_RUN=1
   OPENCLAW_NO_ONBOARD=1
   OPENCLAW_VERBOSE=1
+  OPENCLAW_INSTALL_RESTORE_BACKUP=1  Auto-restore latest backup when state empty
+  OPENCLAW_INSTALL_SKIP_BACKUP=1     Skip backup detection/restore prompt
   OPENCLAW_NPM_LOGLEVEL=error|warn|notice  Default: error (hide npm deprecation noise)
   SHARP_IGNORE_GLOBAL_LIBVIPS=0|1    Default: 1 (avoid sharp building against global libvips)
 
@@ -2006,6 +2008,131 @@ install_openclaw() {
     ui_success "OpenClaw installed"
 }
 
+# Detect backup directories from uninstall (e.g. ~/.openclaw-backup-20260311-143022)
+# Returns newline-separated paths, newest first.
+detect_backup_dirs() {
+    local dir
+    for dir in "$HOME"/.openclaw-backup-*; do
+        [[ -e "$dir" ]] || continue
+        [[ -d "$dir" ]] || continue
+        echo "$dir"
+    done 2>/dev/null | sort -r
+}
+
+# Check if state dir is empty or missing (no config, no skills, no sessions)
+is_state_dir_empty() {
+    local state_dir="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+    [[ ! -d "$state_dir" ]] && return 0
+    [[ -f "$state_dir/openclaw.json" || -f "$state_dir/clawdbot.json" ]] && return 1
+    [[ -d "$state_dir/skills" && -n "$(ls -A "$state_dir/skills" 2>/dev/null)" ]] && return 1
+    [[ -d "$state_dir/sessions" && -n "$(ls -A "$state_dir/sessions" 2>/dev/null)" ]] && return 1
+    return 0
+}
+
+# Check if a backup dir contains valid backup (tar.gz or manual skills/sessions)
+is_valid_backup_dir() {
+    local dir="$1"
+    [[ -d "$dir" ]] || return 1
+    if ls "$dir"/*.tar.gz 1>/dev/null 2>&1; then
+        return 0
+    fi
+    [[ -d "$dir/skills" || -d "$dir/sessions" || -f "$dir/openclaw.json" ]] && return 0
+    return 1
+}
+
+# Restore backup during install. Call only when: state empty, backups exist, openclaw available.
+maybe_restore_backup_during_install() {
+    local claw="${OPENCLAW_BIN:-}"
+    [[ -z "$claw" ]] && claw="$(resolve_openclaw_bin || true)"
+    [[ -z "$claw" || ! -x "$claw" ]] && return 0
+
+    is_state_dir_empty || return 0
+    local backups
+    backups="$(detect_backup_dirs)"
+    [[ -z "$backups" ]] && return 0
+
+    # Filter to valid backup dirs only
+    local valid_backups=()
+    local b
+    while IFS= read -r b; do
+        [[ -z "$b" ]] && continue
+        is_valid_backup_dir "$b" && valid_backups+=("$b")
+    done <<< "$backups"
+    [[ ${#valid_backups[@]} -eq 0 ]] && return 0
+
+    # Env overrides
+    [[ "${OPENCLAW_INSTALL_SKIP_BACKUP:-0}" == "1" ]] && return 0
+    if [[ "${OPENCLAW_INSTALL_RESTORE_BACKUP:-0}" == "1" ]]; then
+        local latest="${valid_backups[0]}"
+        ui_info "Restoring backup from ${latest}"
+        if run_quiet_step "Restoring backup" "$claw" backup restore "$latest" --verify; then
+            ui_success "Backup restored"
+        else
+            ui_warn "Backup restore failed; continuing with fresh state"
+        fi
+        return 0
+    fi
+
+    # Non-interactive: skip
+    if is_non_interactive_shell || [[ "${NO_PROMPT:-0}" == "1" ]]; then
+        ui_info "Backup(s) found but no TTY; skipping restore. Run: openclaw backup restore <path>"
+        return 0
+    fi
+
+    # Interactive prompt
+    local latest="${valid_backups[0]}"
+    ui_section "Backup detected"
+    ui_info "Found ${#valid_backups[@]} backup(s). Latest: ${latest}"
+    if [[ -n "$GUM" ]] && gum_is_tty; then
+        local choice
+        choice="$("$GUM" choose \
+            --header "Restore backup or continue with fresh install?" \
+            --cursor-prefix "❯ " \
+            "restore  · restore latest backup into ~/.openclaw" \
+            "skip     · continue without restoring (backup kept)" \
+            "delete   · delete all backups and continue" < /dev/tty 2>/dev/null || true)"
+        case "$choice" in
+            restore*)
+                if run_quiet_step "Restoring backup" "$claw" backup restore "$latest" --verify; then
+                    ui_success "Backup restored"
+                else
+                    ui_warn "Backup restore failed; continuing with fresh state"
+                fi
+                ;;
+            delete*)
+                for b in "${valid_backups[@]}"; do
+                    rm -rf "$b" 2>/dev/null && ui_info "Removed $b" || true
+                done
+                ui_info "Backups removed"
+                ;;
+            *)
+                ui_info "Skipping restore; backup(s) kept at ~/.openclaw-backup-*"
+                ;;
+        esac
+    else
+        echo -e "${WARN}→${NC} Restore latest backup? [y]es / [n]o (skip) / [d]elete backups:"
+        read -r answer < /dev/tty || true
+        case "${answer,,}" in
+            y|yes)
+                if run_quiet_step "Restoring backup" "$claw" backup restore "$latest" --verify; then
+                    ui_success "Backup restored"
+                else
+                    ui_warn "Backup restore failed; continuing with fresh state"
+                fi
+                ;;
+            d|delete)
+                for b in "${valid_backups[@]}"; do
+                    rm -rf "$b" 2>/dev/null && ui_info "Removed $b" || true
+                done
+                ui_info "Backups removed"
+                ;;
+            *)
+                ui_info "Skipping restore; backup(s) kept"
+                ;;
+        esac
+    fi
+}
+
 # Run doctor for migrations (safe, non-interactive)
 run_doctor() {
     ui_info "Running doctor to migrate settings"
@@ -2325,6 +2452,9 @@ main() {
     fi
 
     refresh_gateway_service_if_loaded
+
+    # Step 5b: Restore backup if state is empty and backups exist (reinstall after uninstall)
+    maybe_restore_backup_during_install
 
     # Step 6: Run doctor for migrations on upgrades and git installs
     local run_doctor_after=false

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { backupVerifyCommand } from "../../commands/backup-verify.js";
 import { backupCreateCommand } from "../../commands/backup.js";
+import { restoreBackup } from "../../infra/backup-restore.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
@@ -87,6 +88,44 @@ export function registerBackupCommand(program: Command) {
           archive: archive as string,
           json: Boolean(opts.json),
         });
+      });
+    });
+
+  backup
+    .command("restore <source>")
+    .description("Restore OpenClaw state from a backup archive or directory")
+    .option("--target-dir <path>", "Target state directory (default: ~/.openclaw)")
+    .option("--verify", "Verify archive before restore (tar.gz only)", false)
+    .option("--dry-run", "Print restore plan without writing", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            "openclaw backup restore ~/.openclaw-backup-20260311-143022",
+            "Restore from uninstall backup directory.",
+          ],
+          [
+            "openclaw backup restore ./backup.tar.gz --verify",
+            "Restore from archive with verification.",
+          ],
+          [
+            "openclaw backup restore ~/Backups/latest.tar.gz --dry-run",
+            "Preview restore without writing files.",
+          ],
+        ])}`,
+    )
+    .action(async (source, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const result = await restoreBackup(defaultRuntime, {
+          source: source as string,
+          targetDir: opts.targetDir as string | undefined,
+          verify: Boolean(opts.verify),
+          dryRun: Boolean(opts.dryRun),
+        });
+        defaultRuntime.log(
+          `Restored ${result.restored.length} path(s) to ${result.targetDir} (${result.sourceType})`,
+        );
       });
     });
 }

--- a/src/infra/backup-restore.ts
+++ b/src/infra/backup-restore.ts
@@ -1,0 +1,242 @@
+/**
+ * Restore OpenClaw state from a backup archive (tar.gz) or manual backup directory.
+ * Used by install script and `openclaw backup restore` CLI.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { backupVerifyCommand } from "../commands/backup-verify.js";
+import { resolveStateDir } from "../config/paths.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveUserPath } from "../utils.js";
+
+export type BackupRestoreOptions = {
+  /** Path to .tar.gz archive or directory (manual backup with skills/, sessions/, etc.) */
+  source: string;
+  /** Target state directory (default: resolveStateDir()) */
+  targetDir?: string;
+  /** Verify archive before restore (tar.gz only) */
+  verify?: boolean;
+  /** Dry run: print plan, do not write */
+  dryRun?: boolean;
+};
+
+export type BackupRestoreResult = {
+  restored: string[];
+  targetDir: string;
+  sourceType: "tar" | "manual";
+};
+
+async function isTarArchive(sourcePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(sourcePath);
+    return stat.isFile() && sourcePath.endsWith(".tar.gz");
+  } catch {
+    return false;
+  }
+}
+
+async function isManualBackupDir(sourcePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(sourcePath);
+    if (!stat.isDirectory()) {
+      return false;
+    }
+    const entries = await fs.readdir(sourcePath);
+    const hasSkills = entries.includes("skills");
+    const hasSessions = entries.includes("sessions");
+    const hasConfig =
+      entries.includes("openclaw.json") ||
+      entries.some((e) => e.endsWith(".json") && e.includes("claw"));
+    return hasSkills || hasSessions || hasConfig;
+  } catch {
+    return false;
+  }
+}
+
+async function findTarInDir(dirPath: string): Promise<string | null> {
+  const entries = await fs.readdir(dirPath);
+  const tars = entries.filter((e) => e.endsWith(".tar.gz"));
+  if (tars.length === 0) {
+    return null;
+  }
+  tars.toSorted().reverse();
+  return path.join(dirPath, tars[0]);
+}
+
+async function restoreFromTar(
+  archivePath: string,
+  targetDir: string,
+  opts: { verify?: boolean; dryRun?: boolean },
+  runtime: RuntimeEnv,
+): Promise<BackupRestoreResult> {
+  const resolvedArchive = resolveUserPath(archivePath);
+
+  if (opts.verify) {
+    await backupVerifyCommand(
+      { ...runtime, log: () => {} },
+      { archive: resolvedArchive, json: false },
+    );
+  }
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-"));
+  try {
+    await tar.x({
+      file: resolvedArchive,
+      gzip: true,
+      cwd: tempDir,
+    });
+
+    const entries = await fs.readdir(tempDir);
+    const archiveRoot = entries[0];
+    if (!archiveRoot) {
+      throw new Error("Archive is empty or has unexpected structure.");
+    }
+    const manifestPath = path.join(tempDir, archiveRoot, "manifest.json");
+    const manifestRaw = await fs.readFile(manifestPath, "utf8");
+    const manifest = JSON.parse(manifestRaw) as {
+      schemaVersion: number;
+      archiveRoot: string;
+      paths?: { stateDir?: string };
+      assets: Array<{ kind: string; sourcePath: string; archivePath: string }>;
+    };
+
+    if (manifest.schemaVersion !== 1) {
+      throw new Error(`Unsupported backup manifest schemaVersion: ${manifest.schemaVersion}`);
+    }
+
+    const oldStateDir =
+      manifest.paths?.stateDir ?? path.dirname(manifest.assets[0]?.sourcePath ?? "");
+    const restored: string[] = [];
+
+    for (const asset of manifest.assets) {
+      const extractedPath = path.join(tempDir, asset.archivePath);
+      try {
+        await fs.access(extractedPath);
+      } catch {
+        continue;
+      }
+
+      const relativeToOld = path.relative(oldStateDir, asset.sourcePath);
+      const targetPath =
+        relativeToOld && !relativeToOld.startsWith("..")
+          ? path.join(targetDir, relativeToOld)
+          : targetDir;
+
+      if (opts.dryRun) {
+        runtime.log(`Would restore: ${asset.kind} -> ${targetPath}`);
+        restored.push(targetPath);
+        continue;
+      }
+
+      const stat = await fs.stat(extractedPath);
+      if (stat.isDirectory()) {
+        const destDir = targetPath === targetDir ? targetDir : path.dirname(targetPath);
+        await fs.mkdir(destDir, { recursive: true });
+        const entries = await fs.readdir(extractedPath);
+        for (const entry of entries) {
+          const src = path.join(extractedPath, entry);
+          const dest = path.join(
+            targetDir,
+            path.relative(oldStateDir, path.join(asset.sourcePath, entry)),
+          );
+          await fs.mkdir(path.dirname(dest), { recursive: true });
+          const entryStat = await fs.stat(src);
+          if (entryStat.isDirectory()) {
+            await fs.cp(src, dest, { recursive: true });
+          } else {
+            await fs.cp(src, dest);
+          }
+          restored.push(dest);
+        }
+      } else {
+        await fs.mkdir(path.dirname(targetPath), { recursive: true });
+        await fs.cp(extractedPath, targetPath);
+        restored.push(targetPath);
+      }
+    }
+
+    return { restored, targetDir, sourceType: "tar" };
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+async function restoreFromManual(
+  sourceDir: string,
+  targetDir: string,
+  opts: { dryRun?: boolean },
+  runtime: RuntimeEnv,
+): Promise<BackupRestoreResult> {
+  const resolvedSource = resolveUserPath(sourceDir);
+  const restored: string[] = [];
+
+  const toCopy = ["skills", "sessions", "credentials", "openclaw.json"];
+  for (const name of toCopy) {
+    const src = path.join(resolvedSource, name);
+    try {
+      await fs.access(src);
+    } catch {
+      continue;
+    }
+
+    const dest = path.join(targetDir, name);
+    if (opts.dryRun) {
+      runtime.log(`Would restore: ${name} -> ${dest}`);
+      restored.push(dest);
+      continue;
+    }
+
+    await fs.mkdir(targetDir, { recursive: true });
+    const stat = await fs.stat(src);
+    if (stat.isDirectory()) {
+      await fs.cp(src, dest, { recursive: true });
+    } else {
+      await fs.cp(src, dest);
+    }
+    restored.push(dest);
+  }
+
+  return { restored, targetDir, sourceType: "manual" };
+}
+
+/**
+ * Restore OpenClaw state from a backup.
+ * Supports both tar.gz archives and manual backup directories.
+ */
+export async function restoreBackup(
+  runtime: RuntimeEnv,
+  opts: BackupRestoreOptions,
+): Promise<BackupRestoreResult> {
+  const source = resolveUserPath(opts.source);
+  const targetDir = opts.targetDir ? resolveUserPath(opts.targetDir) : resolveStateDir();
+
+  const stat = await fs.stat(source).catch(() => null);
+  if (!stat) {
+    throw new Error(`Backup source not found: ${source}`);
+  }
+
+  if (stat.isDirectory()) {
+    const tarPath = await findTarInDir(source);
+    if (tarPath) {
+      return restoreFromTar(
+        tarPath,
+        targetDir,
+        { verify: opts.verify, dryRun: opts.dryRun },
+        runtime,
+      );
+    }
+    if (await isManualBackupDir(source)) {
+      return restoreFromManual(source, targetDir, { dryRun: opts.dryRun }, runtime);
+    }
+    throw new Error(`Directory is not a valid backup: ${source}`);
+  }
+
+  if (await isTarArchive(source)) {
+    return restoreFromTar(source, targetDir, { verify: opts.verify, dryRun: opts.dryRun }, runtime);
+  }
+
+  throw new Error(`Unsupported backup format: ${source}`);
+}


### PR DESCRIPTION
## What
- Add `openclaw backup restore <path>` CLI command
- During install: detect `~/.openclaw-backup-*` when state is empty
- Prompt: restore latest / skip / delete backups

## Why
Users who uninstall OpenClaw (backup created) then reinstall get no automatic restore. This adds an optional restore flow.

## How
- Uses `restoreBackup()` from `infra/backup-restore.ts`
- Install script: `maybe_restore_backup_during_install` after install, before doctor
- Env: `OPENCLAW_INSTALL_RESTORE_BACKUP=1` (auto-restore), `OPENCLAW_INSTALL_SKIP_BACKUP=1` (skip)

## Testing
- [x] `openclaw backup restore --help`
- [x] Install script backup detection logic

Made with [Cursor](https://cursor.com)