### PR TITLE
docs: use secret-scanner-safe credential placeholders

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -30,8 +30,8 @@ Status: production-ready for DMs + channels via Slack app integrations. Default 
         In Slack app settings:
 
         - enable **Socket Mode**
-        - create **App Token** (`xapp-...`) with `connections:write`
-        - install app and copy **Bot Token** (`xoxb-...`)
+        - create **App Token** (`slack-app-token-example`) with `connections:write`
+        - install app and copy **Bot Token** (`slack-bot-token-example`)
       </Step>
 
       <Step title="Configure OpenClaw">
@@ -42,8 +42,8 @@ Status: production-ready for DMs + channels via Slack app integrations. Default 
     slack: {
       enabled: true,
       mode: "socket",
-      appToken: "xapp-...",
-      botToken: "xoxb-...",
+      appToken: "slack-app-token-example",
+      botToken: "slack-bot-token-example",
     },
   },
 }
@@ -52,8 +52,8 @@ Status: production-ready for DMs + channels via Slack app integrations. Default 
         Env fallback (default account only):
 
 ```bash
-SLACK_APP_TOKEN=xapp-...
-SLACK_BOT_TOKEN=xoxb-...
+SLACK_APP_TOKEN=slack-app-token-example
+SLACK_BOT_TOKEN=slack-bot-token-example
 ```
 
       </Step>
@@ -100,7 +100,7 @@ openclaw gateway
     slack: {
       enabled: true,
       mode: "http",
-      botToken: "xoxb-...",
+      botToken: "slack-bot-token-example",
       signingSecret: "your-signing-secret",
       webhookPath: "/slack/events",
     },
@@ -126,7 +126,7 @@ openclaw gateway
 - HTTP mode requires `botToken` + `signingSecret`.
 - Config tokens override env fallback.
 - `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` env fallback applies only to the default account.
-- `userToken` (`xoxp-...`) is config-only (no env fallback) and defaults to read-only behavior (`userTokenReadOnly: true`).
+- `userToken` (`slack-user-token-example`) is config-only (no env fallback) and defaults to read-only behavior (`userTokenReadOnly: true`).
 - Optional: add `chat:write.customize` if you want outgoing messages to use the active agent identity (custom `username` and icon). `icon_emoji` uses `:emoji_name:` syntax.
 
 <Tip>

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -97,14 +97,14 @@ primary_region = "iad"
 fly secrets set OPENCLAW_GATEWAY_TOKEN=$(openssl rand -hex 32)
 
 # Model provider API keys
-fly secrets set ANTHROPIC_API_KEY=sk-ant-...
+fly secrets set ANTHROPIC_API_KEY=example-anthropic-key-not-real
 
 # Optional: Other providers
-fly secrets set OPENAI_API_KEY=sk-...
+fly secrets set OPENAI_API_KEY=example-openai-key-not-real
 fly secrets set GOOGLE_API_KEY=...
 
 # Channel tokens
-fly secrets set DISCORD_BOT_TOKEN=MTQ...
+fly secrets set DISCORD_BOT_TOKEN=example-discord-bot-token
 ```
 
 **Notes:**

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -30,7 +30,7 @@ openclaw onboard --anthropic-api-key "$ANTHROPIC_API_KEY"
 
 ```json5
 {
-  env: { ANTHROPIC_API_KEY: "sk-ant-..." },
+  env: { ANTHROPIC_API_KEY: "example-anthropic-key-not-real" },
   agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6" } } },
 }
 ```

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -56,7 +56,7 @@ Notes:
 1. Ensure AWS credentials are available on the **gateway host**:
 
 ```bash
-export AWS_ACCESS_KEY_ID="AKIA..."
+export AWS_ACCESS_KEY_ID="EXAMPLE_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="..."
 export AWS_REGION="us-east-1"
 # Optional:

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -29,7 +29,7 @@ openclaw onboard --openai-api-key "$OPENAI_API_KEY"
 
 ```json5
 {
-  env: { OPENAI_API_KEY: "sk-..." },
+  env: { OPENAI_API_KEY: "example-openai-key-not-real" },
   agents: { defaults: { model: { primary: "openai/gpt-5.4" } } },
 }
 ```

--- a/docs/reference/secret-placeholder-conventions.md
+++ b/docs/reference/secret-placeholder-conventions.md
@@ -1,0 +1,33 @@
+---
+summary: "Secret-scanner-safe placeholder conventions for docs and examples"
+read_when:
+  - Writing docs that include tokens, API keys, or credential snippets
+  - Updating examples that may be scanned by secret-detection tooling
+title: "Secret Placeholder Conventions"
+---
+
+# Secret placeholder conventions
+
+Use placeholders that are human-readable but do not resemble real secrets.
+
+## Recommended style
+
+- Prefer descriptive values like `example-openai-key-not-real` or `example-discord-bot-token`.
+- For shell snippets, prefer `${OPENAI_API_KEY}` over inline token-like strings.
+- Keep examples obviously fake and scoped to purpose (provider, channel, auth type).
+
+## Avoid these patterns in docs
+
+- Private key sentinels such as `-----BEGIN PRIVATE KEY-----`.
+- Prefixes that resemble live credentials, for example `sk-...`, `xoxb-...`, `AKIA...`.
+- Realistic-looking bearer tokens copied from runtime logs.
+
+## Example
+
+```bash
+# Good
+export OPENAI_API_KEY="example-openai-key-not-real"
+
+# Better (when the doc is about env wiring)
+export OPENAI_API_KEY="${OPENAI_API_KEY}"
+```

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -25,6 +25,10 @@ OpenClaw assembles its own system prompt on every run. It includes:
 
 See the full breakdown in [System Prompt](/concepts/system-prompt).
 
+When documenting credentials or auth snippets, use the
+[Secret Placeholder Conventions](/reference/secret-placeholder-conventions) to
+avoid secret-scanner false positives in docs-only changes.
+
 ## What counts in the context window
 
 Everything the model receives counts toward the context limit:


### PR DESCRIPTION
## Summary
Fixes #44298.

This PR reduces secret-scanner false positives in docs by replacing token-like examples with explicit non-secret placeholders and documenting a repo-wide placeholder convention.

## Changes
- Replaced risky credential examples in key docs pages:
  - `docs/providers/openai.md`
  - `docs/providers/anthropic.md`
  - `docs/providers/bedrock.md`
  - `docs/channels/slack.md`
  - `docs/install/fly.md`
- Added `docs/reference/secret-placeholder-conventions.md` with guidance for safe examples.
- Linked the new convention doc from `docs/reference/token-use.md`.

## Notes
- This keeps examples readable while avoiding sentinel formats that look like live credentials (`sk-*`, `xoxb-*`, `AKIA*`, PEM-style blocks).
