### PR TITLE
fix(gateway-status): avoid false SecretRef errors when gateway is healthy

### DIFF
--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -201,13 +201,54 @@ describe("gateway-status command", () => {
     expect(targets[0]?.summary).toBeTruthy();
   });
 
-  it("surfaces unresolved SecretRef auth diagnostics in warnings", async () => {
+  it("suppresses unresolved SecretRef auth diagnostics when target probe succeeds", async () => {
     const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
     await withEnvAsync({ MISSING_GATEWAY_TOKEN: undefined }, async () => {
       mockLocalTokenEnvRefConfig();
 
       await runGatewayStatus(runtime, { timeout: "1000", json: true });
     });
+
+    expect(runtimeErrors).toHaveLength(0);
+    const parsed = JSON.parse(runtimeLogs.join("\n")) as {
+      warnings?: Array<{ code?: string; message?: string; targetIds?: string[] }>;
+    };
+    const unresolvedWarning = parsed.warnings?.find(
+      (warning) =>
+        warning.code === "auth_secretref_unresolved" &&
+        warning.message?.includes("gateway.auth.token SecretRef is unresolved"),
+    );
+    expect(unresolvedWarning).toBeUndefined();
+  });
+
+  it("keeps unresolved SecretRef auth diagnostics when target probe fails", async () => {
+    const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
+    const previousProbeImpl = probeGateway.getMockImplementation();
+    probeGateway.mockImplementationOnce(async (opts: { url: string }) => ({
+      ok: false,
+      url: opts.url,
+      connectLatencyMs: 15,
+      error: "connect failed: unauthorized",
+      close: null,
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    }));
+    try {
+      await withEnvAsync({ MISSING_GATEWAY_TOKEN: undefined }, async () => {
+        mockLocalTokenEnvRefConfig();
+        await expect(runGatewayStatus(runtime, { timeout: "1000", json: true })).rejects.toThrow(
+          "__exit__:1",
+        );
+      });
+    } finally {
+      if (previousProbeImpl) {
+        probeGateway.mockImplementation(previousProbeImpl);
+      } else {
+        probeGateway.mockReset();
+      }
+    }
 
     expect(runtimeErrors).toHaveLength(0);
     const parsed = JSON.parse(runtimeLogs.join("\n")) as {

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -225,7 +225,7 @@ export async function gatewayStatusCommand(
     });
   }
   for (const result of probed) {
-    if (result.authDiagnostics.length === 0) {
+    if (result.authDiagnostics.length === 0 || result.probe.ok) {
       continue;
     }
     for (const diagnostic of result.authDiagnostics) {


### PR DESCRIPTION
## Summary
- stop surfacing `auth_secretref_unresolved` warnings for targets that probe successfully
- keep unresolved SecretRef diagnostics for failed probes so real auth/connectivity failures remain visible
- add regression coverage for both healthy and failed probe paths

## Testing
- `pnpm vitest run src/commands/gateway-status.test.ts`

Closes #44754
