### PR TITLE
fix(devices): fallback when gateway closes with 1000/no reason

### DIFF
--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -251,6 +251,23 @@ describe("devices cli local fallback", () => {
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
   });
 
+  it("falls back to local pairing list when gateway closes with no reason on loopback", async () => {
+    callGateway.mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-2", deviceId: "device-2", publicKey: "pk", ts: 2 }],
+      paired: [],
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesCommand(["list"]);
+
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "device.pair.list" }),
+    );
+    expect(listDevicePairing).toHaveBeenCalledTimes(1);
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
+  });
+
   it("falls back to local approve when gateway returns pairing required on loopback", async () => {
     callGateway
       .mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"))

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -99,7 +99,11 @@ function normalizeErrorMessage(error: unknown): string {
 
 function shouldUseLocalPairingFallback(opts: DevicesRpcOpts, error: unknown): boolean {
   const message = normalizeErrorMessage(error).toLowerCase();
-  if (!message.includes("pairing required")) {
+  const pairingRequired = message.includes("pairing required");
+  const normalClosureWithoutReason =
+    message.includes("gateway closed (1000") &&
+    (message.includes("normal closure") || message.includes("no close reason"));
+  if (!pairingRequired && !normalClosureWithoutReason) {
     return false;
   }
   if (typeof opts.url === "string" && opts.url.trim().length > 0) {


### PR DESCRIPTION
## Summary
- Extend devices local fallback detection to cover normal-close failures like: gateway closed (1000 normal closure): no close reason.
- Keep existing safeguards: only fallback on local loopback target; never fallback when explicit --url is provided.
- Add regression test for the normal-close/no-reason path.

## Testing
- pnpm -C /home/ltx/projects/openclaw exec vitest run src/cli/devices-cli.test.ts

Closes #44760