### PR TITLE
fix(ui): send token/password auth in Control UI insecure contexts

### DIFF
--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -374,6 +374,46 @@ describe("GatewayBrowserClient", () => {
     vi.useRealTimers();
   });
 
+  it("sends explicit token and password in insecure contexts without crypto.subtle", async () => {
+    // Simulate insecure context (plain HTTP) where crypto.subtle is unavailable
+    const origSubtle = crypto.subtle;
+    Object.defineProperty(crypto, "subtle", { value: undefined, configurable: true });
+
+    try {
+      const client = new GatewayBrowserClient({
+        url: "ws://192.168.1.100:18789",
+        token: "explicit-token",
+        password: "explicit-password",
+      });
+
+      client.start();
+      const ws = getLatestWebSocket();
+      ws.emitOpen();
+      ws.emitMessage({
+        type: "event",
+        event: "connect.challenge",
+        payload: { nonce: "nonce-1" },
+      });
+      await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+      const connectFrame = JSON.parse(ws.sent.at(-1) ?? "{}") as {
+        method?: string;
+        params?: {
+          auth?: { token?: string; password?: string; deviceToken?: string };
+          device?: unknown;
+        };
+      };
+      expect(connectFrame.method).toBe("connect");
+      expect(connectFrame.params?.auth?.token).toBe("explicit-token");
+      expect(connectFrame.params?.auth?.password).toBe("explicit-password");
+      // No device identity in insecure context
+      expect(connectFrame.params?.device).toBeUndefined();
+      expect(loadOrCreateDeviceIdentityMock).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(crypto, "subtle", { value: origSubtle, configurable: true });
+    }
+  });
+
   it("does not auto-reconnect on AUTH_TOKEN_MISSING", async () => {
     vi.useFakeTimers();
     localStorage.clear();

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -258,14 +258,18 @@ export class GatewayBrowserClient {
       }
     }
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
-    const authToken = selectedAuth.authToken;
+    const explicitPassword = this.opts.password?.trim() || undefined;
+    // In insecure contexts selectConnectAuth() is skipped (no WebCrypto),
+    // so fall back to the explicit token/password from the login form.
+    const authToken = selectedAuth.authToken ?? explicitGatewayToken;
     const deviceToken = selectedAuth.authDeviceToken ?? selectedAuth.resolvedDeviceToken;
+    const authPassword = selectedAuth.authPassword ?? explicitPassword;
     const auth =
-      authToken || selectedAuth.authPassword
+      authToken || authPassword
         ? {
             token: authToken,
             deviceToken,
-            password: selectedAuth.authPassword,
+            password: authPassword,
           }
         : undefined;
 


### PR DESCRIPTION
## Summary

- Problem: `GatewayBrowserClient.sendConnect()` only calls `selectConnectAuth()` inside `if (isSecureContext)`, so when the Control UI is accessed over plain HTTP (where `crypto.subtle` is unavailable), the explicit token and password from the login form are never included in the connect frame.
- Why it matters: The gateway sees no credentials, `sharedAuthOk` is false, and the connection is rejected with `CONTROL_UI_DEVICE_IDENTITY_REQUIRED` — even when `dangerouslyDisableDeviceAuth` is enabled. This makes the Control UI completely unusable over plain HTTP (common in LAN/Docker reverse-proxy setups).
- What changed: After the `isSecureContext` block, the explicit token (`this.opts.token`) and password (`this.opts.password`) are now used as fallbacks when `selectConnectAuth()` was skipped. One new test verifies the insecure context path.
- What did NOT change (scope boundary): Secure context behavior is unchanged — `selectConnectAuth()` still runs and its results take precedence via `??` fallback. Device identity flow, retry logic, and all existing auth paths are untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens
- [x] UI / DX

## Linked Issue/PR

- Closes #44864

## User-visible / Behavior Changes

Control UI now connects successfully over plain HTTP when a valid token or password is provided. Previously it always failed with "device identity required".

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — tokens were already available in `this.opts`, they just weren't being sent
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Debian 12, Docker)
- Runtime/container: Docker (OpenClaw v2026.3.12)
- Model/provider: N/A (gateway connection issue)
- Integration/channel: Control UI WebSocket
- Relevant config: `gateway.controlUi.dangerouslyDisableDeviceAuth: true`

### Steps

1. Run gateway on LAN host with `dangerouslyDisableDeviceAuth: true`
2. Reverse-proxy behind plain HTTP (no TLS)
3. Open Control UI via `http://host/gateway/#token=<valid-token>`

### Expected

- Control UI connects and shows dashboard

### Actual (before fix)

- Connection rejected: `CONTROL_UI_DEVICE_IDENTITY_REQUIRED`, close code 4008

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

New test `sends explicit token and password in insecure contexts without crypto.subtle` fails before the fix (connect frame has `auth: undefined`) and passes after (connect frame includes token and password).

Gateway logs before fix: `code=4008, reason="connect failed"`, detail `CONTROL_UI_DEVICE_IDENTITY_REQUIRED`
After fix: successful hello handshake, Control UI connected.

## Human Verification (required)

- Verified scenarios: Deployed to staging VM behind HTTP reverse proxy, Control UI connected successfully with token auth
- Edge cases checked: Verified secure context (HTTPS/localhost) behavior unchanged — existing tests all pass
- What you did **not** verify: Password-only auth in insecure context (tested token-only and token+password)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two-line change in `sendConnect()`
- Files/config to restore: `ui/src/ui/gateway.ts`
- Known bad symptoms reviewers should watch for: Auth regression in secure contexts (all existing tests cover this)

## Risks and Mitigations

- Risk: Explicit credentials could be sent when `selectConnectAuth()` already resolved different credentials
  - Mitigation: `??` operator ensures `selectConnectAuth()` results always take precedence; explicit values are only used when selectedAuth fields are undefined (i.e., when the function was skipped)

---

*Authored by Claude Code (Opus 4.6). Reviewed and tested by @asyncjason.*
