### PR TITLE
docs: fix changelog credit for xhigh help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ Docs: https://docs.openclaw.ai
 - ACP/client final-message delivery: preserve terminal assistant text snapshots before resolving `end_turn`, so ACP clients no longer drop the last visible reply when the gateway sends the final message body on the terminal chat event. (#17615) Thanks @pjeby.
 - Telegram/Discord status reactions: show a temporary compacting reaction during auto-compaction pauses and restore thinking afterward so the bot no longer appears frozen while context is being compacted. (#35474) thanks @Cypherm.
 - Delivery/dedupe: trim completed direct-cron delivery cache correctly and keep mirrored transcript dedupe active even when transcript files contain malformed lines. (#44666) thanks @frankekn.
-- CLI/thinking help: add the missing `xhigh` level hints to `openclaw cron add`, `openclaw cron edit`, and `openclaw agent` so the help text matches the levels already accepted at runtime. (#44819) Thanks @frankekn.
+- CLI/thinking help: add the missing `xhigh` level hints to `openclaw cron add`, `openclaw cron edit`, and `openclaw agent` so the help text matches the levels already accepted at runtime. (#44819) Thanks @kiki830621.
 
 ## 2026.3.11
 


### PR DESCRIPTION
## Summary

- fix the `CHANGELOG.md` attribution for the xhigh help-text entry
- credit the original contributor `@kiki830621` instead of the maintainer replacement branch author

Follow-up to #44819.

## Test plan

- [x] inspected the single-line `CHANGELOG.md` diff
