### PR TITLE
fix(telegram): allow catch-all mention patterns to match media-only group messages

### DIFF
--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -415,6 +415,24 @@ describe("mention helpers", () => {
     expect(matchesMentionPatterns("OPENCLAW: hi", regexes)).toBe(true);
   });
 
+  it("catch-all pattern matches empty text for media-only messages", () => {
+    const regexes = buildMentionRegexes({
+      messages: { groupChat: { mentionPatterns: [".*"] } },
+    });
+    // A photo-only message in a Telegram group has no caption text.
+    // With mentionPatterns: [".*"], the bot should still respond.
+    expect(matchesMentionPatterns("", regexes)).toBe(true);
+    expect(matchesMentionPatterns("hello", regexes)).toBe(true);
+  });
+
+  it("specific pattern does not match empty text", () => {
+    const regexes = buildMentionRegexes({
+      messages: { groupChat: { mentionPatterns: ["\\bbot\\b"] } },
+    });
+    expect(matchesMentionPatterns("", regexes)).toBe(false);
+    expect(matchesMentionPatterns("hey bot", regexes)).toBe(true);
+  });
+
   it("uses per-agent mention patterns when configured", () => {
     const regexes = buildMentionRegexes(
       {

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -90,9 +90,9 @@ export function matchesMentionPatterns(text: string, mentionRegexes: RegExp[]): 
     return false;
   }
   const cleaned = normalizeMentionText(text ?? "");
-  if (!cleaned) {
-    return false;
-  }
+  // Allow regex patterns to decide whether empty text matches.
+  // Catch-all patterns like ".*" should match media-only messages
+  // that have no caption text (e.g. photos in Telegram groups).
   return mentionRegexes.some((re) => re.test(cleaned));
 }
 
@@ -119,9 +119,6 @@ export function matchesMentionWithExplicit(params: {
 
   if (hasAnyMention && explicitAvailable) {
     return explicit || params.mentionRegexes.some((re) => re.test(textToCheck));
-  }
-  if (!textToCheck) {
-    return explicit;
   }
   return explicit || params.mentionRegexes.some((re) => re.test(textToCheck));
 }


### PR DESCRIPTION
Closes #44833

## Problem

Photo-only messages sent in Telegram groups are silently dropped when `requireMention` is active. The same photo works fine in DMs. Adding any caption (even `.`) makes it work in groups too.

## Root cause

`matchesMentionPatterns` has an early return that bails out when the input text is empty:

```ts
const cleaned = normalizeMentionText(text ?? "");
if (!cleaned) {
  return false;  // blocks catch-all patterns from matching
}
```

A photo-only message has no caption text, so `cleaned` is always empty. This means even `mentionPatterns: [".*"]` (which the reporter configured) never gets tested against the input, and the mention gate drops the message.

The same early return exists in `matchesMentionWithExplicit`, where empty text short-circuits to only checking explicit @-mentions.

## Fix

Remove the empty-text guards and let the regex patterns decide. `/.*/.test("")` returns `true`, which is the correct behavior for a catch-all config. Specific patterns like `/\bbot\b/` naturally return `false` for empty strings, so those groups remain unaffected.

## Testing

- Added two tests: catch-all pattern matches empty text, specific pattern does not
- All 39 existing mention tests pass
- 3 pre-existing failures in `bot.create-telegram-bot.test.ts` are unrelated (getFile mock issue on main)