### PR TITLE
[WebUI] Fix infinite logo loading screen on chat.history RPC timeouts

### DIFF
--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -97,9 +97,13 @@ export async function loadChatHistory(state: ChatState) {
         if (
           hasTimedOut &&
           state.sessionKey === targetSession &&
-          currentFreshness === _chatHistoryFreshnessToken
+          currentFreshness === _chatHistoryFreshnessToken &&
+          state.chatMessages.length === _originalMessageCount
         ) {
-          state.lastError = null;
+          // Only clear the timeout error, not unrelated errors
+          if (state.lastError && state.lastError.includes("timed out")) {
+            state.lastError = null;
+          }
           const messages = Array.isArray(res.messages) ? res.messages : [];
           state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
           state.chatThinkingLevel = res.thinkingLevel ?? null;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -7,334 +7,360 @@ import { generateUUID } from "../uuid.ts";
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 
 function isSilentReplyStream(text: string): boolean {
-  return SILENT_REPLY_PATTERN.test(text);
+	return SILENT_REPLY_PATTERN.test(text);
 }
 /** Client-side defense-in-depth: detect assistant messages whose text is purely NO_REPLY. */
 function isAssistantSilentReply(message: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const entry = message as Record<string, unknown>;
-  const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
-  if (role !== "assistant") {
-    return false;
-  }
-  // entry.text takes precedence — matches gateway extractAssistantTextForSilentCheck
-  if (typeof entry.text === "string") {
-    return isSilentReplyStream(entry.text);
-  }
-  const text = extractText(message);
-  return typeof text === "string" && isSilentReplyStream(text);
+	if (!message || typeof message !== "object") {
+		return false;
+	}
+	const entry = message as Record<string, unknown>;
+	const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
+	if (role !== "assistant") {
+		return false;
+	}
+	// entry.text takes precedence — matches gateway extractAssistantTextForSilentCheck
+	if (typeof entry.text === "string") {
+		return isSilentReplyStream(entry.text);
+	}
+	const text = extractText(message);
+	return typeof text === "string" && isSilentReplyStream(text);
 }
 
 export type ChatState = {
-  client: GatewayBrowserClient | null;
-  connected: boolean;
-  sessionKey: string;
-  chatLoading: boolean;
-  chatMessages: unknown[];
-  chatThinkingLevel: string | null;
-  chatSending: boolean;
-  chatMessage: string;
-  chatAttachments: ChatAttachment[];
-  chatRunId: string | null;
-  chatStream: string | null;
-  chatStreamStartedAt: number | null;
-  lastError: string | null;
+	client: GatewayBrowserClient | null;
+	connected: boolean;
+	sessionKey: string;
+	chatLoading: boolean;
+	chatMessages: unknown[];
+	chatThinkingLevel: string | null;
+	chatSending: boolean;
+	chatMessage: string;
+	chatAttachments: ChatAttachment[];
+	chatRunId: string | null;
+	chatStream: string | null;
+	chatStreamStartedAt: number | null;
+	lastError: string | null;
 };
 
 export type ChatEventPayload = {
-  runId: string;
-  sessionKey: string;
-  state: "delta" | "final" | "aborted" | "error";
-  message?: unknown;
-  errorMessage?: string;
+	runId: string;
+	sessionKey: string;
+	state: "delta" | "final" | "aborted" | "error";
+	message?: unknown;
+	errorMessage?: string;
 };
 
 function maybeResetToolStream(state: ChatState) {
-  const toolHost = state as ChatState & Partial<Parameters<typeof resetToolStream>[0]>;
-  if (
-    toolHost.toolStreamById instanceof Map &&
-    Array.isArray(toolHost.toolStreamOrder) &&
-    Array.isArray(toolHost.chatToolMessages) &&
-    Array.isArray(toolHost.chatStreamSegments)
-  ) {
-    resetToolStream(toolHost as Parameters<typeof resetToolStream>[0]);
-  }
+	const toolHost = state as ChatState &
+		Partial<Parameters<typeof resetToolStream>[0]>;
+	if (
+		toolHost.toolStreamById instanceof Map &&
+		Array.isArray(toolHost.toolStreamOrder) &&
+		Array.isArray(toolHost.chatToolMessages) &&
+		Array.isArray(toolHost.chatStreamSegments)
+	) {
+		resetToolStream(toolHost as Parameters<typeof resetToolStream>[0]);
+	}
 }
 
 export async function loadChatHistory(state: ChatState) {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  state.chatLoading = true;
-  state.lastError = null;
-  try {
-    const requestPromise = state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
-      "chat.history",
-      {
-        sessionKey: state.sessionKey,
-        limit: 200,
-      },
-    );
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new Error("chat.history request timed out after 10000ms")), 10000);
-    });
-    const res = await Promise.race([requestPromise, timeoutPromise]);
-    const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
-    state.chatThinkingLevel = res.thinkingLevel ?? null;
-    // Clear all streaming state — history includes tool results and text
-    // inline, so keeping streaming artifacts would cause duplicates.
-    maybeResetToolStream(state);
-    state.chatStream = null;
-    state.chatStreamStartedAt = null;
-  } catch (err) {
-    state.lastError = String(err);
-  } finally {
-    state.chatLoading = false;
-  }
+	if (!state.client || !state.connected) {
+		return;
+	}
+	state.chatLoading = true;
+	state.lastError = null;
+	try {
+		const requestPromise = state.client.request<{
+			messages?: Array<unknown>;
+			thinkingLevel?: string;
+		}>("chat.history", {
+			sessionKey: state.sessionKey,
+			limit: 200,
+		});
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			setTimeout(
+				() => reject(new Error("chat.history request timed out after 10000ms")),
+				10000,
+			);
+		});
+		const res = await Promise.race([requestPromise, timeoutPromise]);
+		const messages = Array.isArray(res.messages) ? res.messages : [];
+		state.chatMessages = messages.filter(
+			(message) => !isAssistantSilentReply(message),
+		);
+		state.chatThinkingLevel = res.thinkingLevel ?? null;
+		// Clear all streaming state — history includes tool results and text
+		// inline, so keeping streaming artifacts would cause duplicates.
+		maybeResetToolStream(state);
+		state.chatStream = null;
+		state.chatStreamStartedAt = null;
+	} catch (err) {
+		state.lastError = String(err);
+	} finally {
+		state.chatLoading = false;
+	}
 }
 
-function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string } | null {
-  const match = /^data:([^;]+);base64,(.+)$/.exec(dataUrl);
-  if (!match) {
-    return null;
-  }
-  return { mimeType: match[1], content: match[2] };
+function dataUrlToBase64(
+	dataUrl: string,
+): { content: string; mimeType: string } | null {
+	const match = /^data:([^;]+);base64,(.+)$/.exec(dataUrl);
+	if (!match) {
+		return null;
+	}
+	return { mimeType: match[1], content: match[2] };
 }
 
 type AssistantMessageNormalizationOptions = {
-  roleRequirement: "required" | "optional";
-  roleCaseSensitive?: boolean;
-  requireContentArray?: boolean;
-  allowTextField?: boolean;
+	roleRequirement: "required" | "optional";
+	roleCaseSensitive?: boolean;
+	requireContentArray?: boolean;
+	allowTextField?: boolean;
 };
 
 function normalizeAssistantMessage(
-  message: unknown,
-  options: AssistantMessageNormalizationOptions,
+	message: unknown,
+	options: AssistantMessageNormalizationOptions,
 ): Record<string, unknown> | null {
-  if (!message || typeof message !== "object") {
-    return null;
-  }
-  const candidate = message as Record<string, unknown>;
-  const roleValue = candidate.role;
-  if (typeof roleValue === "string") {
-    const role = options.roleCaseSensitive ? roleValue : roleValue.toLowerCase();
-    if (role !== "assistant") {
-      return null;
-    }
-  } else if (options.roleRequirement === "required") {
-    return null;
-  }
+	if (!message || typeof message !== "object") {
+		return null;
+	}
+	const candidate = message as Record<string, unknown>;
+	const roleValue = candidate.role;
+	if (typeof roleValue === "string") {
+		const role = options.roleCaseSensitive
+			? roleValue
+			: roleValue.toLowerCase();
+		if (role !== "assistant") {
+			return null;
+		}
+	} else if (options.roleRequirement === "required") {
+		return null;
+	}
 
-  if (options.requireContentArray) {
-    return Array.isArray(candidate.content) ? candidate : null;
-  }
-  if (!("content" in candidate) && !(options.allowTextField && "text" in candidate)) {
-    return null;
-  }
-  return candidate;
+	if (options.requireContentArray) {
+		return Array.isArray(candidate.content) ? candidate : null;
+	}
+	if (
+		!("content" in candidate) &&
+		!(options.allowTextField && "text" in candidate)
+	) {
+		return null;
+	}
+	return candidate;
 }
 
-function normalizeAbortedAssistantMessage(message: unknown): Record<string, unknown> | null {
-  return normalizeAssistantMessage(message, {
-    roleRequirement: "required",
-    roleCaseSensitive: true,
-    requireContentArray: true,
-  });
+function normalizeAbortedAssistantMessage(
+	message: unknown,
+): Record<string, unknown> | null {
+	return normalizeAssistantMessage(message, {
+		roleRequirement: "required",
+		roleCaseSensitive: true,
+		requireContentArray: true,
+	});
 }
 
-function normalizeFinalAssistantMessage(message: unknown): Record<string, unknown> | null {
-  return normalizeAssistantMessage(message, {
-    roleRequirement: "optional",
-    allowTextField: true,
-  });
+function normalizeFinalAssistantMessage(
+	message: unknown,
+): Record<string, unknown> | null {
+	return normalizeAssistantMessage(message, {
+		roleRequirement: "optional",
+		allowTextField: true,
+	});
 }
 
 export async function sendChatMessage(
-  state: ChatState,
-  message: string,
-  attachments?: ChatAttachment[],
+	state: ChatState,
+	message: string,
+	attachments?: ChatAttachment[],
 ): Promise<string | null> {
-  if (!state.client || !state.connected) {
-    return null;
-  }
-  const msg = message.trim();
-  const hasAttachments = attachments && attachments.length > 0;
-  if (!msg && !hasAttachments) {
-    return null;
-  }
+	if (!state.client || !state.connected) {
+		return null;
+	}
+	const msg = message.trim();
+	const hasAttachments = attachments && attachments.length > 0;
+	if (!msg && !hasAttachments) {
+		return null;
+	}
 
-  const now = Date.now();
+	const now = Date.now();
 
-  // Build user message content blocks
-  const contentBlocks: Array<{ type: string; text?: string; source?: unknown }> = [];
-  if (msg) {
-    contentBlocks.push({ type: "text", text: msg });
-  }
-  // Add image previews to the message for display
-  if (hasAttachments) {
-    for (const att of attachments) {
-      contentBlocks.push({
-        type: "image",
-        source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
-      });
-    }
-  }
+	// Build user message content blocks
+	const contentBlocks: Array<{
+		type: string;
+		text?: string;
+		source?: unknown;
+	}> = [];
+	if (msg) {
+		contentBlocks.push({ type: "text", text: msg });
+	}
+	// Add image previews to the message for display
+	if (hasAttachments) {
+		for (const att of attachments) {
+			contentBlocks.push({
+				type: "image",
+				source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
+			});
+		}
+	}
 
-  state.chatMessages = [
-    ...state.chatMessages,
-    {
-      role: "user",
-      content: contentBlocks,
-      timestamp: now,
-    },
-  ];
+	state.chatMessages = [
+		...state.chatMessages,
+		{
+			role: "user",
+			content: contentBlocks,
+			timestamp: now,
+		},
+	];
 
-  state.chatSending = true;
-  state.lastError = null;
-  const runId = generateUUID();
-  state.chatRunId = runId;
-  state.chatStream = "";
-  state.chatStreamStartedAt = now;
+	state.chatSending = true;
+	state.lastError = null;
+	const runId = generateUUID();
+	state.chatRunId = runId;
+	state.chatStream = "";
+	state.chatStreamStartedAt = now;
 
-  // Convert attachments to API format
-  const apiAttachments = hasAttachments
-    ? attachments
-        .map((att) => {
-          const parsed = dataUrlToBase64(att.dataUrl);
-          if (!parsed) {
-            return null;
-          }
-          return {
-            type: "image",
-            mimeType: parsed.mimeType,
-            content: parsed.content,
-          };
-        })
-        .filter((a): a is NonNullable<typeof a> => a !== null)
-    : undefined;
+	// Convert attachments to API format
+	const apiAttachments = hasAttachments
+		? attachments
+				.map((att) => {
+					const parsed = dataUrlToBase64(att.dataUrl);
+					if (!parsed) {
+						return null;
+					}
+					return {
+						type: "image",
+						mimeType: parsed.mimeType,
+						content: parsed.content,
+					};
+				})
+				.filter((a): a is NonNullable<typeof a> => a !== null)
+		: undefined;
 
-  try {
-    await state.client.request("chat.send", {
-      sessionKey: state.sessionKey,
-      message: msg,
-      deliver: false,
-      idempotencyKey: runId,
-      attachments: apiAttachments,
-    });
-    return runId;
-  } catch (err) {
-    const error = String(err);
-    state.chatRunId = null;
-    state.chatStream = null;
-    state.chatStreamStartedAt = null;
-    state.lastError = error;
-    state.chatMessages = [
-      ...state.chatMessages,
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Error: " + error }],
-        timestamp: Date.now(),
-      },
-    ];
-    return null;
-  } finally {
-    state.chatSending = false;
-  }
+	try {
+		await state.client.request("chat.send", {
+			sessionKey: state.sessionKey,
+			message: msg,
+			deliver: false,
+			idempotencyKey: runId,
+			attachments: apiAttachments,
+		});
+		return runId;
+	} catch (err) {
+		const error = String(err);
+		state.chatRunId = null;
+		state.chatStream = null;
+		state.chatStreamStartedAt = null;
+		state.lastError = error;
+		state.chatMessages = [
+			...state.chatMessages,
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Error: " + error }],
+				timestamp: Date.now(),
+			},
+		];
+		return null;
+	} finally {
+		state.chatSending = false;
+	}
 }
 
 export async function abortChatRun(state: ChatState): Promise<boolean> {
-  if (!state.client || !state.connected) {
-    return false;
-  }
-  const runId = state.chatRunId;
-  try {
-    await state.client.request(
-      "chat.abort",
-      runId ? { sessionKey: state.sessionKey, runId } : { sessionKey: state.sessionKey },
-    );
-    return true;
-  } catch (err) {
-    state.lastError = String(err);
-    return false;
-  }
+	if (!state.client || !state.connected) {
+		return false;
+	}
+	const runId = state.chatRunId;
+	try {
+		await state.client.request(
+			"chat.abort",
+			runId
+				? { sessionKey: state.sessionKey, runId }
+				: { sessionKey: state.sessionKey },
+		);
+		return true;
+	} catch (err) {
+		state.lastError = String(err);
+		return false;
+	}
 }
 
 export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
-  if (!payload) {
-    return null;
-  }
-  if (payload.sessionKey !== state.sessionKey) {
-    return null;
-  }
+	if (!payload) {
+		return null;
+	}
+	if (payload.sessionKey !== state.sessionKey) {
+		return null;
+	}
 
-  // Final from another run (e.g. sub-agent announce): refresh history to show new message.
-  // See https://github.com/openclaw/openclaw/issues/1909
-  if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
-    if (payload.state === "final") {
-      const finalMessage = normalizeFinalAssistantMessage(payload.message);
-      if (finalMessage && !isAssistantSilentReply(finalMessage)) {
-        state.chatMessages = [...state.chatMessages, finalMessage];
-        return null;
-      }
-      return "final";
-    }
-    return null;
-  }
+	// Final from another run (e.g. sub-agent announce): refresh history to show new message.
+	// See https://github.com/openclaw/openclaw/issues/1909
+	if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
+		if (payload.state === "final") {
+			const finalMessage = normalizeFinalAssistantMessage(payload.message);
+			if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+				state.chatMessages = [...state.chatMessages, finalMessage];
+				return null;
+			}
+			return "final";
+		}
+		return null;
+	}
 
-  if (payload.state === "delta") {
-    const next = extractText(payload.message);
-    if (typeof next === "string" && !isSilentReplyStream(next)) {
-      const current = state.chatStream ?? "";
-      if (!current || next.length >= current.length) {
-        state.chatStream = next;
-      }
-    }
-  } else if (payload.state === "final") {
-    const finalMessage = normalizeFinalAssistantMessage(payload.message);
-    if (finalMessage && !isAssistantSilentReply(finalMessage)) {
-      state.chatMessages = [...state.chatMessages, finalMessage];
-    } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
-      state.chatMessages = [
-        ...state.chatMessages,
-        {
-          role: "assistant",
-          content: [{ type: "text", text: state.chatStream }],
-          timestamp: Date.now(),
-        },
-      ];
-    }
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
-  } else if (payload.state === "aborted") {
-    const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
-    if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
-      state.chatMessages = [...state.chatMessages, normalizedMessage];
-    } else {
-      const streamedText = state.chatStream ?? "";
-      if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
-        state.chatMessages = [
-          ...state.chatMessages,
-          {
-            role: "assistant",
-            content: [{ type: "text", text: streamedText }],
-            timestamp: Date.now(),
-          },
-        ];
-      }
-    }
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
-  } else if (payload.state === "error") {
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
-    state.lastError = payload.errorMessage ?? "chat error";
-  }
-  return payload.state;
+	if (payload.state === "delta") {
+		const next = extractText(payload.message);
+		if (typeof next === "string" && !isSilentReplyStream(next)) {
+			const current = state.chatStream ?? "";
+			if (!current || next.length >= current.length) {
+				state.chatStream = next;
+			}
+		}
+	} else if (payload.state === "final") {
+		const finalMessage = normalizeFinalAssistantMessage(payload.message);
+		if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+			state.chatMessages = [...state.chatMessages, finalMessage];
+		} else if (
+			state.chatStream?.trim() &&
+			!isSilentReplyStream(state.chatStream)
+		) {
+			state.chatMessages = [
+				...state.chatMessages,
+				{
+					role: "assistant",
+					content: [{ type: "text", text: state.chatStream }],
+					timestamp: Date.now(),
+				},
+			];
+		}
+		state.chatStream = null;
+		state.chatRunId = null;
+		state.chatStreamStartedAt = null;
+	} else if (payload.state === "aborted") {
+		const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
+		if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
+			state.chatMessages = [...state.chatMessages, normalizedMessage];
+		} else {
+			const streamedText = state.chatStream ?? "";
+			if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
+				state.chatMessages = [
+					...state.chatMessages,
+					{
+						role: "assistant",
+						content: [{ type: "text", text: streamedText }],
+						timestamp: Date.now(),
+					},
+				];
+			}
+		}
+		state.chatStream = null;
+		state.chatRunId = null;
+		state.chatStreamStartedAt = null;
+	} else if (payload.state === "error") {
+		state.chatStream = null;
+		state.chatRunId = null;
+		state.chatStreamStartedAt = null;
+		state.lastError = payload.errorMessage ?? "chat error";
+	}
+	return payload.state;
 }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -63,7 +63,10 @@ function maybeResetToolStream(state: ChatState) {
   }
 }
 
+let _chatHistoryFreshnessToken = 0;
+
 export async function loadChatHistory(state: ChatState) {
+  const currentFreshness = ++_chatHistoryFreshnessToken;
   if (!state.client || !state.connected) {
     return;
   }
@@ -90,7 +93,11 @@ export async function loadChatHistory(state: ChatState) {
     // Auto-apply late successfully resolved history to recover from transient timeouts
     void requestPromise
       .then((res) => {
-        if (hasTimedOut && state.sessionKey === targetSession) {
+        if (
+          hasTimedOut &&
+          state.sessionKey === targetSession &&
+          currentFreshness === _chatHistoryFreshnessToken
+        ) {
           state.lastError = null;
           const messages = Array.isArray(res.messages) ? res.messages : [];
           state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
@@ -193,6 +200,8 @@ export async function sendChatMessage(
   if (!msg && !hasAttachments) {
     return null;
   }
+
+  _chatHistoryFreshnessToken++; // bust history cache on interaction
 
   const now = Date.now();
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -74,6 +74,7 @@ export async function loadChatHistory(state: ChatState) {
   state.lastError = null;
   try {
     const targetSession = state.sessionKey;
+    const _originalMessageCount = state.chatMessages.length;
     const requestPromise = state.client.request<{
       messages?: Array<unknown>;
       thinkingLevel?: string;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -98,7 +98,8 @@ export async function loadChatHistory(state: ChatState) {
           hasTimedOut &&
           state.sessionKey === targetSession &&
           currentFreshness === _chatHistoryFreshnessToken &&
-          state.chatMessages.length === _originalMessageCount
+          state.chatMessages.length === _originalMessageCount &&
+          state.chatStream === null
         ) {
           // Only clear the timeout error, not unrelated errors
           if (state.lastError && state.lastError.includes("timed out")) {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -70,6 +70,7 @@ export async function loadChatHistory(state: ChatState) {
   state.chatLoading = true;
   state.lastError = null;
   try {
+    const targetSession = state.sessionKey;
     const requestPromise = state.client.request<{
       messages?: Array<unknown>;
       thinkingLevel?: string;
@@ -89,7 +90,7 @@ export async function loadChatHistory(state: ChatState) {
     // Auto-apply late successfully resolved history to recover from transient timeouts
     void requestPromise
       .then((res) => {
-        if (hasTimedOut) {
+        if (hasTimedOut && state.sessionKey === targetSession) {
           state.lastError = null;
           const messages = Array.isArray(res.messages) ? res.messages : [];
           state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -7,360 +7,344 @@ import { generateUUID } from "../uuid.ts";
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 
 function isSilentReplyStream(text: string): boolean {
-	return SILENT_REPLY_PATTERN.test(text);
+  return SILENT_REPLY_PATTERN.test(text);
 }
 /** Client-side defense-in-depth: detect assistant messages whose text is purely NO_REPLY. */
 function isAssistantSilentReply(message: unknown): boolean {
-	if (!message || typeof message !== "object") {
-		return false;
-	}
-	const entry = message as Record<string, unknown>;
-	const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
-	if (role !== "assistant") {
-		return false;
-	}
-	// entry.text takes precedence — matches gateway extractAssistantTextForSilentCheck
-	if (typeof entry.text === "string") {
-		return isSilentReplyStream(entry.text);
-	}
-	const text = extractText(message);
-	return typeof text === "string" && isSilentReplyStream(text);
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
+  if (role !== "assistant") {
+    return false;
+  }
+  // entry.text takes precedence — matches gateway extractAssistantTextForSilentCheck
+  if (typeof entry.text === "string") {
+    return isSilentReplyStream(entry.text);
+  }
+  const text = extractText(message);
+  return typeof text === "string" && isSilentReplyStream(text);
 }
 
 export type ChatState = {
-	client: GatewayBrowserClient | null;
-	connected: boolean;
-	sessionKey: string;
-	chatLoading: boolean;
-	chatMessages: unknown[];
-	chatThinkingLevel: string | null;
-	chatSending: boolean;
-	chatMessage: string;
-	chatAttachments: ChatAttachment[];
-	chatRunId: string | null;
-	chatStream: string | null;
-	chatStreamStartedAt: number | null;
-	lastError: string | null;
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  sessionKey: string;
+  chatLoading: boolean;
+  chatMessages: unknown[];
+  chatThinkingLevel: string | null;
+  chatSending: boolean;
+  chatMessage: string;
+  chatAttachments: ChatAttachment[];
+  chatRunId: string | null;
+  chatStream: string | null;
+  chatStreamStartedAt: number | null;
+  lastError: string | null;
 };
 
 export type ChatEventPayload = {
-	runId: string;
-	sessionKey: string;
-	state: "delta" | "final" | "aborted" | "error";
-	message?: unknown;
-	errorMessage?: string;
+  runId: string;
+  sessionKey: string;
+  state: "delta" | "final" | "aborted" | "error";
+  message?: unknown;
+  errorMessage?: string;
 };
 
 function maybeResetToolStream(state: ChatState) {
-	const toolHost = state as ChatState &
-		Partial<Parameters<typeof resetToolStream>[0]>;
-	if (
-		toolHost.toolStreamById instanceof Map &&
-		Array.isArray(toolHost.toolStreamOrder) &&
-		Array.isArray(toolHost.chatToolMessages) &&
-		Array.isArray(toolHost.chatStreamSegments)
-	) {
-		resetToolStream(toolHost as Parameters<typeof resetToolStream>[0]);
-	}
+  const toolHost = state as ChatState & Partial<Parameters<typeof resetToolStream>[0]>;
+  if (
+    toolHost.toolStreamById instanceof Map &&
+    Array.isArray(toolHost.toolStreamOrder) &&
+    Array.isArray(toolHost.chatToolMessages) &&
+    Array.isArray(toolHost.chatStreamSegments)
+  ) {
+    resetToolStream(toolHost as Parameters<typeof resetToolStream>[0]);
+  }
 }
 
 export async function loadChatHistory(state: ChatState) {
-	if (!state.client || !state.connected) {
-		return;
-	}
-	state.chatLoading = true;
-	state.lastError = null;
-	try {
-		const requestPromise = state.client.request<{
-			messages?: Array<unknown>;
-			thinkingLevel?: string;
-		}>("chat.history", {
-			sessionKey: state.sessionKey,
-			limit: 200,
-		});
-		const timeoutPromise = new Promise<never>((_, reject) => {
-			setTimeout(
-				() => reject(new Error("chat.history request timed out after 10000ms")),
-				10000,
-			);
-		});
-		const res = await Promise.race([requestPromise, timeoutPromise]);
-		const messages = Array.isArray(res.messages) ? res.messages : [];
-		state.chatMessages = messages.filter(
-			(message) => !isAssistantSilentReply(message),
-		);
-		state.chatThinkingLevel = res.thinkingLevel ?? null;
-		// Clear all streaming state — history includes tool results and text
-		// inline, so keeping streaming artifacts would cause duplicates.
-		maybeResetToolStream(state);
-		state.chatStream = null;
-		state.chatStreamStartedAt = null;
-	} catch (err) {
-		state.lastError = String(err);
-	} finally {
-		state.chatLoading = false;
-	}
+  if (!state.client || !state.connected) {
+    return;
+  }
+  state.chatLoading = true;
+  state.lastError = null;
+  try {
+    const requestPromise = state.client.request<{
+      messages?: Array<unknown>;
+      thinkingLevel?: string;
+    }>("chat.history", {
+      sessionKey: state.sessionKey,
+      limit: 200,
+    });
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error("chat.history request timed out after 10000ms")),
+        10000,
+      );
+    });
+    const res = await Promise.race([requestPromise, timeoutPromise]).finally(() => {
+      clearTimeout(timeoutId);
+    });
+    const messages = Array.isArray(res.messages) ? res.messages : [];
+    state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
+    state.chatThinkingLevel = res.thinkingLevel ?? null;
+    // Clear all streaming state — history includes tool results and text
+    // inline, so keeping streaming artifacts would cause duplicates.
+    maybeResetToolStream(state);
+    state.chatStream = null;
+    state.chatStreamStartedAt = null;
+  } catch (err) {
+    state.lastError = String(err);
+  } finally {
+    state.chatLoading = false;
+  }
 }
 
-function dataUrlToBase64(
-	dataUrl: string,
-): { content: string; mimeType: string } | null {
-	const match = /^data:([^;]+);base64,(.+)$/.exec(dataUrl);
-	if (!match) {
-		return null;
-	}
-	return { mimeType: match[1], content: match[2] };
+function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string } | null {
+  const match = /^data:([^;]+);base64,(.+)$/.exec(dataUrl);
+  if (!match) {
+    return null;
+  }
+  return { mimeType: match[1], content: match[2] };
 }
 
 type AssistantMessageNormalizationOptions = {
-	roleRequirement: "required" | "optional";
-	roleCaseSensitive?: boolean;
-	requireContentArray?: boolean;
-	allowTextField?: boolean;
+  roleRequirement: "required" | "optional";
+  roleCaseSensitive?: boolean;
+  requireContentArray?: boolean;
+  allowTextField?: boolean;
 };
 
 function normalizeAssistantMessage(
-	message: unknown,
-	options: AssistantMessageNormalizationOptions,
+  message: unknown,
+  options: AssistantMessageNormalizationOptions,
 ): Record<string, unknown> | null {
-	if (!message || typeof message !== "object") {
-		return null;
-	}
-	const candidate = message as Record<string, unknown>;
-	const roleValue = candidate.role;
-	if (typeof roleValue === "string") {
-		const role = options.roleCaseSensitive
-			? roleValue
-			: roleValue.toLowerCase();
-		if (role !== "assistant") {
-			return null;
-		}
-	} else if (options.roleRequirement === "required") {
-		return null;
-	}
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  const candidate = message as Record<string, unknown>;
+  const roleValue = candidate.role;
+  if (typeof roleValue === "string") {
+    const role = options.roleCaseSensitive ? roleValue : roleValue.toLowerCase();
+    if (role !== "assistant") {
+      return null;
+    }
+  } else if (options.roleRequirement === "required") {
+    return null;
+  }
 
-	if (options.requireContentArray) {
-		return Array.isArray(candidate.content) ? candidate : null;
-	}
-	if (
-		!("content" in candidate) &&
-		!(options.allowTextField && "text" in candidate)
-	) {
-		return null;
-	}
-	return candidate;
+  if (options.requireContentArray) {
+    return Array.isArray(candidate.content) ? candidate : null;
+  }
+  if (!("content" in candidate) && !(options.allowTextField && "text" in candidate)) {
+    return null;
+  }
+  return candidate;
 }
 
-function normalizeAbortedAssistantMessage(
-	message: unknown,
-): Record<string, unknown> | null {
-	return normalizeAssistantMessage(message, {
-		roleRequirement: "required",
-		roleCaseSensitive: true,
-		requireContentArray: true,
-	});
+function normalizeAbortedAssistantMessage(message: unknown): Record<string, unknown> | null {
+  return normalizeAssistantMessage(message, {
+    roleRequirement: "required",
+    roleCaseSensitive: true,
+    requireContentArray: true,
+  });
 }
 
-function normalizeFinalAssistantMessage(
-	message: unknown,
-): Record<string, unknown> | null {
-	return normalizeAssistantMessage(message, {
-		roleRequirement: "optional",
-		allowTextField: true,
-	});
+function normalizeFinalAssistantMessage(message: unknown): Record<string, unknown> | null {
+  return normalizeAssistantMessage(message, {
+    roleRequirement: "optional",
+    allowTextField: true,
+  });
 }
 
 export async function sendChatMessage(
-	state: ChatState,
-	message: string,
-	attachments?: ChatAttachment[],
+  state: ChatState,
+  message: string,
+  attachments?: ChatAttachment[],
 ): Promise<string | null> {
-	if (!state.client || !state.connected) {
-		return null;
-	}
-	const msg = message.trim();
-	const hasAttachments = attachments && attachments.length > 0;
-	if (!msg && !hasAttachments) {
-		return null;
-	}
+  if (!state.client || !state.connected) {
+    return null;
+  }
+  const msg = message.trim();
+  const hasAttachments = attachments && attachments.length > 0;
+  if (!msg && !hasAttachments) {
+    return null;
+  }
 
-	const now = Date.now();
+  const now = Date.now();
 
-	// Build user message content blocks
-	const contentBlocks: Array<{
-		type: string;
-		text?: string;
-		source?: unknown;
-	}> = [];
-	if (msg) {
-		contentBlocks.push({ type: "text", text: msg });
-	}
-	// Add image previews to the message for display
-	if (hasAttachments) {
-		for (const att of attachments) {
-			contentBlocks.push({
-				type: "image",
-				source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
-			});
-		}
-	}
+  // Build user message content blocks
+  const contentBlocks: Array<{
+    type: string;
+    text?: string;
+    source?: unknown;
+  }> = [];
+  if (msg) {
+    contentBlocks.push({ type: "text", text: msg });
+  }
+  // Add image previews to the message for display
+  if (hasAttachments) {
+    for (const att of attachments) {
+      contentBlocks.push({
+        type: "image",
+        source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
+      });
+    }
+  }
 
-	state.chatMessages = [
-		...state.chatMessages,
-		{
-			role: "user",
-			content: contentBlocks,
-			timestamp: now,
-		},
-	];
+  state.chatMessages = [
+    ...state.chatMessages,
+    {
+      role: "user",
+      content: contentBlocks,
+      timestamp: now,
+    },
+  ];
 
-	state.chatSending = true;
-	state.lastError = null;
-	const runId = generateUUID();
-	state.chatRunId = runId;
-	state.chatStream = "";
-	state.chatStreamStartedAt = now;
+  state.chatSending = true;
+  state.lastError = null;
+  const runId = generateUUID();
+  state.chatRunId = runId;
+  state.chatStream = "";
+  state.chatStreamStartedAt = now;
 
-	// Convert attachments to API format
-	const apiAttachments = hasAttachments
-		? attachments
-				.map((att) => {
-					const parsed = dataUrlToBase64(att.dataUrl);
-					if (!parsed) {
-						return null;
-					}
-					return {
-						type: "image",
-						mimeType: parsed.mimeType,
-						content: parsed.content,
-					};
-				})
-				.filter((a): a is NonNullable<typeof a> => a !== null)
-		: undefined;
+  // Convert attachments to API format
+  const apiAttachments = hasAttachments
+    ? attachments
+        .map((att) => {
+          const parsed = dataUrlToBase64(att.dataUrl);
+          if (!parsed) {
+            return null;
+          }
+          return {
+            type: "image",
+            mimeType: parsed.mimeType,
+            content: parsed.content,
+          };
+        })
+        .filter((a): a is NonNullable<typeof a> => a !== null)
+    : undefined;
 
-	try {
-		await state.client.request("chat.send", {
-			sessionKey: state.sessionKey,
-			message: msg,
-			deliver: false,
-			idempotencyKey: runId,
-			attachments: apiAttachments,
-		});
-		return runId;
-	} catch (err) {
-		const error = String(err);
-		state.chatRunId = null;
-		state.chatStream = null;
-		state.chatStreamStartedAt = null;
-		state.lastError = error;
-		state.chatMessages = [
-			...state.chatMessages,
-			{
-				role: "assistant",
-				content: [{ type: "text", text: "Error: " + error }],
-				timestamp: Date.now(),
-			},
-		];
-		return null;
-	} finally {
-		state.chatSending = false;
-	}
+  try {
+    await state.client.request("chat.send", {
+      sessionKey: state.sessionKey,
+      message: msg,
+      deliver: false,
+      idempotencyKey: runId,
+      attachments: apiAttachments,
+    });
+    return runId;
+  } catch (err) {
+    const error = String(err);
+    state.chatRunId = null;
+    state.chatStream = null;
+    state.chatStreamStartedAt = null;
+    state.lastError = error;
+    state.chatMessages = [
+      ...state.chatMessages,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Error: " + error }],
+        timestamp: Date.now(),
+      },
+    ];
+    return null;
+  } finally {
+    state.chatSending = false;
+  }
 }
 
 export async function abortChatRun(state: ChatState): Promise<boolean> {
-	if (!state.client || !state.connected) {
-		return false;
-	}
-	const runId = state.chatRunId;
-	try {
-		await state.client.request(
-			"chat.abort",
-			runId
-				? { sessionKey: state.sessionKey, runId }
-				: { sessionKey: state.sessionKey },
-		);
-		return true;
-	} catch (err) {
-		state.lastError = String(err);
-		return false;
-	}
+  if (!state.client || !state.connected) {
+    return false;
+  }
+  const runId = state.chatRunId;
+  try {
+    await state.client.request(
+      "chat.abort",
+      runId ? { sessionKey: state.sessionKey, runId } : { sessionKey: state.sessionKey },
+    );
+    return true;
+  } catch (err) {
+    state.lastError = String(err);
+    return false;
+  }
 }
 
 export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
-	if (!payload) {
-		return null;
-	}
-	if (payload.sessionKey !== state.sessionKey) {
-		return null;
-	}
+  if (!payload) {
+    return null;
+  }
+  if (payload.sessionKey !== state.sessionKey) {
+    return null;
+  }
 
-	// Final from another run (e.g. sub-agent announce): refresh history to show new message.
-	// See https://github.com/openclaw/openclaw/issues/1909
-	if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
-		if (payload.state === "final") {
-			const finalMessage = normalizeFinalAssistantMessage(payload.message);
-			if (finalMessage && !isAssistantSilentReply(finalMessage)) {
-				state.chatMessages = [...state.chatMessages, finalMessage];
-				return null;
-			}
-			return "final";
-		}
-		return null;
-	}
+  // Final from another run (e.g. sub-agent announce): refresh history to show new message.
+  // See https://github.com/openclaw/openclaw/issues/1909
+  if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
+    if (payload.state === "final") {
+      const finalMessage = normalizeFinalAssistantMessage(payload.message);
+      if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+        state.chatMessages = [...state.chatMessages, finalMessage];
+        return null;
+      }
+      return "final";
+    }
+    return null;
+  }
 
-	if (payload.state === "delta") {
-		const next = extractText(payload.message);
-		if (typeof next === "string" && !isSilentReplyStream(next)) {
-			const current = state.chatStream ?? "";
-			if (!current || next.length >= current.length) {
-				state.chatStream = next;
-			}
-		}
-	} else if (payload.state === "final") {
-		const finalMessage = normalizeFinalAssistantMessage(payload.message);
-		if (finalMessage && !isAssistantSilentReply(finalMessage)) {
-			state.chatMessages = [...state.chatMessages, finalMessage];
-		} else if (
-			state.chatStream?.trim() &&
-			!isSilentReplyStream(state.chatStream)
-		) {
-			state.chatMessages = [
-				...state.chatMessages,
-				{
-					role: "assistant",
-					content: [{ type: "text", text: state.chatStream }],
-					timestamp: Date.now(),
-				},
-			];
-		}
-		state.chatStream = null;
-		state.chatRunId = null;
-		state.chatStreamStartedAt = null;
-	} else if (payload.state === "aborted") {
-		const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
-		if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
-			state.chatMessages = [...state.chatMessages, normalizedMessage];
-		} else {
-			const streamedText = state.chatStream ?? "";
-			if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
-				state.chatMessages = [
-					...state.chatMessages,
-					{
-						role: "assistant",
-						content: [{ type: "text", text: streamedText }],
-						timestamp: Date.now(),
-					},
-				];
-			}
-		}
-		state.chatStream = null;
-		state.chatRunId = null;
-		state.chatStreamStartedAt = null;
-	} else if (payload.state === "error") {
-		state.chatStream = null;
-		state.chatRunId = null;
-		state.chatStreamStartedAt = null;
-		state.lastError = payload.errorMessage ?? "chat error";
-	}
-	return payload.state;
+  if (payload.state === "delta") {
+    const next = extractText(payload.message);
+    if (typeof next === "string" && !isSilentReplyStream(next)) {
+      const current = state.chatStream ?? "";
+      if (!current || next.length >= current.length) {
+        state.chatStream = next;
+      }
+    }
+  } else if (payload.state === "final") {
+    const finalMessage = normalizeFinalAssistantMessage(payload.message);
+    if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+      state.chatMessages = [...state.chatMessages, finalMessage];
+    } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
+      state.chatMessages = [
+        ...state.chatMessages,
+        {
+          role: "assistant",
+          content: [{ type: "text", text: state.chatStream }],
+          timestamp: Date.now(),
+        },
+      ];
+    }
+    state.chatStream = null;
+    state.chatRunId = null;
+    state.chatStreamStartedAt = null;
+  } else if (payload.state === "aborted") {
+    const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
+    if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
+      state.chatMessages = [...state.chatMessages, normalizedMessage];
+    } else {
+      const streamedText = state.chatStream ?? "";
+      if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
+        state.chatMessages = [
+          ...state.chatMessages,
+          {
+            role: "assistant",
+            content: [{ type: "text", text: streamedText }],
+            timestamp: Date.now(),
+          },
+        ];
+      }
+    }
+    state.chatStream = null;
+    state.chatRunId = null;
+    state.chatStreamStartedAt = null;
+  } else if (payload.state === "error") {
+    state.chatStream = null;
+    state.chatRunId = null;
+    state.chatStreamStartedAt = null;
+    state.lastError = payload.errorMessage ?? "chat error";
+  }
+  return payload.state;
 }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -78,12 +78,32 @@ export async function loadChatHistory(state: ChatState) {
       limit: 200,
     });
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let hasTimedOut = false;
     const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(
-        () => reject(new Error("chat.history request timed out after 10000ms")),
-        10000,
-      );
+      timeoutId = setTimeout(() => {
+        hasTimedOut = true;
+        reject(new Error("chat.history request timed out after 10000ms"));
+      }, 10000);
     });
+
+    // Auto-apply late successfully resolved history to recover from transient timeouts
+    void requestPromise
+      .then((res) => {
+        if (hasTimedOut) {
+          state.lastError = null;
+          const messages = Array.isArray(res.messages) ? res.messages : [];
+          state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
+          state.chatThinkingLevel = res.thinkingLevel ?? null;
+          maybeResetToolStream(state);
+          state.chatStream = null;
+          state.chatStreamStartedAt = null;
+          if (typeof (state as unknown as Record<string, Function>).requestUpdate === "function") {
+            (state as unknown as { requestUpdate: () => void }).requestUpdate();
+          }
+        }
+      })
+      .catch(() => {});
+
     const res = await Promise.race([requestPromise, timeoutPromise]).finally(() => {
       clearTimeout(timeoutId);
     });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -70,13 +70,17 @@ export async function loadChatHistory(state: ChatState) {
   state.chatLoading = true;
   state.lastError = null;
   try {
-    const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
+    const requestPromise = state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
       "chat.history",
       {
         sessionKey: state.sessionKey,
         limit: 200,
       },
     );
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("chat.history request timed out after 10000ms")), 10000);
+    });
+    const res = await Promise.race([requestPromise, timeoutPromise]);
     const messages = Array.isArray(res.messages) ? res.messages : [];
     state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
     state.chatThinkingLevel = res.thinkingLevel ?? null;


### PR DESCRIPTION
When the Gateway's event loop is momentarily blocked (e.g., during heavy image resizing or large embedded `exec` tasks), the payload for the initial `chat.history` RPC is delayed. The frontend React Client awaits `this.client.request('chat.history')` indefinitely without a timeout mechanism, leaving the UI stuck on the loading logo forever, even if the gateway recovers.

By injecting a 10s `Promise.race` timeout mechanism into `loadChatHistory`, the frontend will gracefully escape the `pending` phase avoiding infinite logo hangings.
