### PR TITLE
fix(telegram/acp): preserve bound ACP session keys in DM topics

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -311,7 +311,7 @@ export const registerTelegramHandlers = ({
     const dmThreadId = !params.isGroup ? params.messageThreadId : undefined;
     const topicThreadId = resolvedThreadId ?? dmThreadId;
     const { topicConfig } = resolveTelegramGroupConfig(params.chatId, topicThreadId);
-    const { route } = resolveTelegramConversationRoute({
+    const { route, skipDmThreadSuffix } = resolveTelegramConversationRoute({
       cfg,
       accountId,
       chatId: params.chatId,
@@ -323,7 +323,7 @@ export const registerTelegramHandlers = ({
     });
     const baseSessionKey = route.sessionKey;
     const threadKeys =
-      dmThreadId != null
+      dmThreadId != null && !skipDmThreadSuffix
         ? resolveThreadSessionKeys({ baseSessionKey, threadId: `${params.chatId}:${dmThreadId}` })
         : null;
     const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;

--- a/src/telegram/bot-message-context.thread-binding.test.ts
+++ b/src/telegram/bot-message-context.thread-binding.test.ts
@@ -113,4 +113,31 @@ describe("buildTelegramMessageContext bound conversation override", () => {
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:codex-acp:session-dm");
     expect(hoisted.touchMock).toHaveBeenCalledWith("default:1234", undefined);
   });
+
+  it("routes dm topic messages to the bound session without adding a thread suffix", async () => {
+    hoisted.resolveByConversationMock.mockReturnValue({
+      bindingId: "default:1234:topic:42",
+      targetSessionKey: "agent:codex-acp:session-dm-topic",
+    });
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1,
+        chat: { id: 1234, type: "private" },
+        message_thread_id: 42,
+        date: 1_700_000_000,
+        text: "hello",
+        from: { id: 42, first_name: "Alice" },
+      },
+    });
+
+    expect(hoisted.resolveByConversationMock).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "1234:topic:42",
+    });
+    expect(ctx?.ctxPayload?.MessageThreadId).toBe(42);
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:codex-acp:session-dm-topic");
+    expect(hoisted.touchMock).toHaveBeenCalledWith("default:1234:topic:42", undefined);
+  });
 });

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -81,7 +81,12 @@ export const buildTelegramMessageContext = async ({
       : dmPolicy;
   // Fresh config for bindings lookup; other routing inputs are payload-derived.
   const freshCfg = loadConfig();
-  let { route, configuredBinding, configuredBindingSessionKey } = resolveTelegramConversationRoute({
+  let {
+    route,
+    configuredBinding,
+    configuredBindingSessionKey,
+    skipDmThreadSuffix,
+  } = resolveTelegramConversationRoute({
     cfg: freshCfg,
     accountId: account.accountId,
     chatId,
@@ -242,7 +247,7 @@ export const buildTelegramMessageContext = async ({
     : route.sessionKey;
   // DMs: use thread suffix for session isolation (works regardless of dmScope)
   const threadKeys =
-    dmThreadId != null
+    dmThreadId != null && !skipDmThreadSuffix
       ? resolveThreadSessionKeys({ baseSessionKey, threadId: `${chatId}:${dmThreadId}` })
       : null;
   const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -81,21 +81,17 @@ export const buildTelegramMessageContext = async ({
       : dmPolicy;
   // Fresh config for bindings lookup; other routing inputs are payload-derived.
   const freshCfg = loadConfig();
-  let {
-    route,
-    configuredBinding,
-    configuredBindingSessionKey,
-    skipDmThreadSuffix,
-  } = resolveTelegramConversationRoute({
-    cfg: freshCfg,
-    accountId: account.accountId,
-    chatId,
-    isGroup,
-    resolvedThreadId,
-    replyThreadId,
-    senderId,
-    topicAgentId: topicConfig?.agentId,
-  });
+  let { route, configuredBinding, configuredBindingSessionKey, skipDmThreadSuffix } =
+    resolveTelegramConversationRoute({
+      cfg: freshCfg,
+      accountId: account.accountId,
+      chatId,
+      isGroup,
+      resolvedThreadId,
+      replyThreadId,
+      senderId,
+      topicAgentId: topicConfig?.agentId,
+    });
   const requiresExplicitAccountBinding = (
     candidate: ReturnType<typeof resolveTelegramConversationRoute>["route"],
   ): boolean => candidate.accountId !== DEFAULT_ACCOUNT_ID && candidate.matchedBy === "default";

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -140,6 +140,19 @@ function buildStatusTopicCommandContext() {
   };
 }
 
+function buildStatusDmTopicCommandContext() {
+  return {
+    match: "",
+    message: {
+      message_id: 3,
+      date: Math.floor(Date.now() / 1000),
+      chat: { id: 100, type: "private" as const },
+      message_thread_id: 42,
+      from: { id: 200, username: "bob" },
+    },
+  };
+}
+
 function registerAndResolveStatusHandler(params: {
   cfg: OpenClawConfig;
   allowFrom?: string[];
@@ -483,6 +496,35 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       "default:-1001234567890:topic:42",
       undefined,
     );
+  });
+
+  it("routes Telegram native commands through bound DM topic sessions without a thread suffix", async () => {
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "default:100:topic:42",
+      targetSessionKey: "agent:codex-acp:session-dm-topic",
+    });
+
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {},
+      allowFrom: ["200"],
+      groupAllowFrom: ["200"],
+    });
+    await handler(buildStatusDmTopicCommandContext());
+
+    expect(sessionBindingMocks.resolveByConversation).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "100:topic:42",
+    });
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [{ ctx?: { CommandTargetSessionKey?: string } }]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(
+      "agent:codex-acp:session-dm-topic",
+    );
+    expect(sessionBindingMocks.touch).toHaveBeenCalledWith("default:100:topic:42", undefined);
   });
 
   it("aborts native command dispatch when configured ACP topic binding cannot initialize", async () => {

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -521,9 +521,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
         [{ ctx?: { CommandTargetSessionKey?: string } }]
       >
     )[0]?.[0];
-    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(
-      "agent:codex-acp:session-dm-topic",
-    );
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe("agent:codex-acp:session-dm-topic");
     expect(sessionBindingMocks.touch).toHaveBeenCalledWith("default:100:topic:42", undefined);
   });
 

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -462,6 +462,7 @@ export const registerTelegramNativeCommands = ({
     chatId: number;
     threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
     route: ReturnType<typeof resolveTelegramConversationRoute>["route"];
+    skipDmThreadSuffix: boolean;
     mediaLocalRoots: readonly string[] | undefined;
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: ReturnType<typeof resolveChunkMode>;
@@ -513,7 +514,15 @@ export const registerTelegramNativeCommands = ({
       accountId: route.accountId,
     });
     const chunkMode = resolveChunkMode(cfg, "telegram", route.accountId);
-    return { chatId, threadSpec, route, mediaLocalRoots, tableMode, chunkMode };
+    return {
+      chatId,
+      threadSpec,
+      route,
+      skipDmThreadSuffix,
+      mediaLocalRoots,
+      tableMode,
+      chunkMode,
+    };
   };
   const buildCommandDeliveryBaseOptions = (params: {
     chatId: string | number;
@@ -595,7 +604,14 @@ export const registerTelegramNativeCommands = ({
           if (!runtimeContext) {
             return;
           }
-          const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
+          const {
+            threadSpec,
+            route,
+            skipDmThreadSuffix,
+            mediaLocalRoots,
+            tableMode,
+            chunkMode,
+          } = runtimeContext;
           const threadParams = buildTelegramThreadParams(threadSpec) ?? {};
 
           const commandDefinition = findCommandByNativeName(command.name, "telegram");

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -474,7 +474,7 @@ export const registerTelegramNativeCommands = ({
       isForum,
       messageThreadId,
     });
-    let { route, configuredBinding } = resolveTelegramConversationRoute({
+    let { route, configuredBinding, skipDmThreadSuffix } = resolveTelegramConversationRoute({
       cfg,
       accountId,
       chatId,
@@ -652,7 +652,7 @@ export const registerTelegramNativeCommands = ({
           // DMs: use raw messageThreadId for thread sessions (not resolvedThreadId which is for forums)
           const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
           const threadKeys =
-            dmThreadId != null
+            dmThreadId != null && !skipDmThreadSuffix
               ? resolveThreadSessionKeys({
                   baseSessionKey,
                   threadId: `${chatId}:${dmThreadId}`,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -604,14 +604,8 @@ export const registerTelegramNativeCommands = ({
           if (!runtimeContext) {
             return;
           }
-          const {
-            threadSpec,
-            route,
-            skipDmThreadSuffix,
-            mediaLocalRoots,
-            tableMode,
-            chunkMode,
-          } = runtimeContext;
+          const { threadSpec, route, skipDmThreadSuffix, mediaLocalRoots, tableMode, chunkMode } =
+            runtimeContext;
           const threadParams = buildTelegramThreadParams(threadSpec) ?? {};
 
           const commandDefinition = findCommandByNativeName(command.name, "telegram");

--- a/src/telegram/conversation-route.ts
+++ b/src/telegram/conversation-route.ts
@@ -28,6 +28,7 @@ export function resolveTelegramConversationRoute(params: {
   route: ReturnType<typeof resolveAgentRoute>;
   configuredBinding: ReturnType<typeof resolveConfiguredAcpRoute>["configuredBinding"];
   configuredBindingSessionKey: string;
+  skipDmThreadSuffix: boolean;
 } {
   const peerId = params.isGroup
     ? buildTelegramGroupPeerId(params.chatId, params.resolvedThreadId)
@@ -97,6 +98,7 @@ export function resolveTelegramConversationRoute(params: {
   });
   let configuredBinding = configuredRoute.configuredBinding;
   let configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
+  let skipDmThreadSuffix = Boolean(configuredRoute.boundSessionKey);
   route = configuredRoute.route;
 
   const threadBindingConversationId =
@@ -125,6 +127,7 @@ export function resolveTelegramConversationRoute(params: {
       };
       configuredBinding = null;
       configuredBindingSessionKey = "";
+      skipDmThreadSuffix = true;
       getSessionBindingService().touch(threadBinding.bindingId);
       logVerbose(
         `telegram: routed via bound conversation ${threadBindingConversationId} -> ${boundSessionKey}`,
@@ -136,5 +139,6 @@ export function resolveTelegramConversationRoute(params: {
     route,
     configuredBinding,
     configuredBindingSessionKey,
+    skipDmThreadSuffix,
   };
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram ACP-bound DM topic follow-ups append a DM-thread suffix to an already bound ACP session key, so later ACP dispatch looks up metadata under the wrong key and fails with `ACP metadata is missing`.
- Why it matters: `/acp spawn codex --thread here` can successfully bind a DM topic, but the next normal message in that same DM topic fails to continue the ACP session.
- What changed: `resolveTelegramConversationRoute()` now marks when a Telegram route already resolved to a final bound conversation session key, and DM-topic thread suffixing is skipped in Telegram inbound/native-command/session-resolution paths for those bound routes.
- What did NOT change (scope boundary): unbound DM topic isolation is preserved; plain DMs, forum topics, and non-topic group behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #34873
- Related #40347
- Related #41466
- Related #31968

## User-visible / Behavior Changes

- Telegram DM topics that are already bound to an ACP session now keep using that exact bound ACP session key for follow-up messages and native commands.
- `/acp spawn ... --thread here` in a Telegram DM topic no longer leads to later `ACP metadata is missing for ...:thread:<chatId>:<topicId>` failures caused by a mismatched follow-up session key.

## Security Impact (required)

- New permissions/capabilities? (`No`) No
- Secrets/tokens handling changed? (`No`) No
- New/changed network calls? (`No`) No
- Command/tool execution surface changed? (`No`) No
- Data access scope changed? (`No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Nimbus engineering lane worktree (`/Users/Nimbus/work/repos/openclaw-pr-telegram-acp-dm-topic`)
- Model/provider: ACP / ACPX
- Integration/channel (if any): Telegram DM topics
- Relevant config (redacted): Telegram thread bindings enabled; ACP enabled; DM topic bound with `/acp spawn ... --thread here`

### Steps

1. In a Telegram DM topic, run `/acp spawn codex --mode persistent --thread here`.
2. Observe a successful bind response (`Bound this conversation to ...`).
3. Send a normal follow-up message in the same DM topic.

### Expected

- The follow-up message reuses the same bound ACP session and continues normally.

### Actual

- Before this fix, Telegram follow-up routing appended a DM-topic thread suffix to the already bound ACP session key, and ACP metadata lookup failed under that derived key.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression coverage for:

- bound DM topic inbound message keeps the bound session key unchanged
- bound DM topic native command keeps the bound ACP target session key unchanged

Validated on Nimbus engineering lane:

- `pnpm exec vitest run --config vitest.channels.config.ts src/telegram/bot-message-context.thread-binding.test.ts src/telegram/bot-native-commands.session-meta.test.ts`
- `pnpm build`
- `pnpm check`

Observed failing runtime symptom before fix:

- `ACP error (ACP_SESSION_INIT_FAILED): ACP metadata is missing for agent:codex:acp:...:thread:<chatId>:<topicId>`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reviewed Telegram conversation binding flow after #34873 and confirmed bound routes already carry the final ACP session key.
  - Added regression coverage for bound DM-topic message routing and bound DM-topic native command targeting.
  - Confirmed unbound DM-topic routing still keeps thread isolation.
  - Ran the targeted Telegram regression suite, `pnpm build`, and `pnpm check` in a Nimbus engineering-lane worktree on the PR branch.
- Edge cases checked:
  - plain DM bound conversation behavior unchanged
  - forum-topic bound conversation behavior unchanged
  - only bound DM-topic routes skip the extra thread suffix
- What you did **not** verify:
  - Live Telegram end-to-end against a real bot token in this PR branch
  - Full repo-wide `pnpm test`
  - Live deployment to the Nimbus runtime lane

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`) Yes
- Config/env changes? (`No`) No
- Migration needed? (`No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore:
  - `src/telegram/conversation-route.ts`
  - `src/telegram/bot-message-context.ts`
  - `src/telegram/bot-native-commands.ts`
  - `src/telegram/bot-handlers.ts`
- Known bad symptoms reviewers should watch for:
  - bound Telegram DM topics still failing ACP follow-ups with `ACP metadata is missing`
  - unbound DM topics losing their isolated `:thread:<chatId>:<topicId>` session behavior

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the new `skipDmThreadSuffix` flag could suppress DM-topic isolation too broadly if set for non-bound routes.
  - Mitigation: it is only set when the Telegram route already resolves to a final configured or active bound session key, and regression tests cover both bound and unbound DM-topic cases.
