### PR TITLE
feat: MCP server config support in openclaw.json (#43509)

### DIFF
--- a/src/config/config.mcp-servers.test.ts
+++ b/src/config/config.mcp-servers.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("mcp servers config schema", () => {
+  it("accepts a valid mcp.servers block", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          qmd: {
+            command: "/usr/local/bin/qmd",
+            args: ["mcp"],
+            description: "QMD hybrid search over markdown files",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts a server entry with only command (args and description optional)", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          "my-tool": {
+            command: "my-mcp-server",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts multiple server entries", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          search: { command: "/usr/bin/search-mcp", args: ["--serve"] },
+          files: { command: "/usr/bin/files-mcp" },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts mcp with no servers key (fully optional)", () => {
+    const res = OpenClawSchema.safeParse({ mcp: {} });
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts config without mcp key at all", () => {
+    const res = OpenClawSchema.safeParse({});
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects a server entry missing command", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          broken: {
+            args: ["mcp"],
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+    if (res.success) {
+      return;
+    }
+
+    const paths = res.error.issues.map((i) => i.path.join("."));
+    expect(paths.some((p) => p.includes("mcp"))).toBe(true);
+  });
+
+  it("rejects an empty string command", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          bad: { command: "" },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects unrecognized fields under a server entry (strict schema)", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          rogue: {
+            command: "/bin/thing",
+            unknownField: true,
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+    if (res.success) {
+      return;
+    }
+
+    expect(
+      res.error.issues.some((issue) => issue.message.toLowerCase().includes("unrecognized")),
+    ).toBe(true);
+  });
+
+  it("rejects unrecognized fields on the mcp object itself", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {},
+        bogus: true,
+      },
+    });
+
+    expect(res.success).toBe(false);
+    if (res.success) {
+      return;
+    }
+
+    expect(
+      res.error.issues.some((issue) => issue.message.toLowerCase().includes("unrecognized")),
+    ).toBe(true);
+  });
+});

--- a/src/config/config.mcp-servers.test.ts
+++ b/src/config/config.mcp-servers.test.ts
@@ -55,11 +55,11 @@ describe("mcp servers config schema", () => {
     expect(res.success).toBe(true);
   });
 
-  it("rejects a server name with invalid characters", () => {
+  it("rejects a server name containing a space", () => {
     const res = OpenClawSchema.safeParse({
       mcp: {
         servers: {
-          "my__server name!": {
+          "my server": {
             command: "/usr/bin/thing",
           },
         },
@@ -72,7 +72,27 @@ describe("mcp servers config schema", () => {
     }
 
     const paths = res.error.issues.map((i) => i.path.join("."));
-    expect(paths.some((p) => p.includes("my__server name!"))).toBe(true);
+    expect(paths.some((p) => p.includes("my server"))).toBe(true);
+  });
+
+  it("rejects a server name containing a special character", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          "bad!": {
+            command: "/usr/bin/thing",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+    if (res.success) {
+      return;
+    }
+
+    const paths = res.error.issues.map((i) => i.path.join("."));
+    expect(paths.some((p) => p.includes("bad!"))).toBe(true);
   });
 
   it("rejects a server entry missing command", () => {

--- a/src/config/config.mcp-servers.test.ts
+++ b/src/config/config.mcp-servers.test.ts
@@ -112,7 +112,7 @@ describe("mcp servers config schema", () => {
     }
 
     const paths = res.error.issues.map((i) => i.path.join("."));
-    expect(paths.some((p) => p.includes("mcp"))).toBe(true);
+    expect(paths.some((p) => p.endsWith("command"))).toBe(true);
   });
 
   it("rejects an empty string command", () => {

--- a/src/config/config.mcp-servers.test.ts
+++ b/src/config/config.mcp-servers.test.ts
@@ -166,4 +166,25 @@ describe("mcp servers config schema", () => {
       res.error.issues.some((issue) => issue.message.toLowerCase().includes("unrecognized")),
     ).toBe(true);
   });
+
+  it("rejects empty strings in the args array", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          bad_args: {
+            command: "/usr/bin/thing",
+            args: ["--flag", ""],
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+    if (res.success) {
+      return;
+    }
+
+    const paths = res.error.issues.map((i) => i.path.join("."));
+    expect(paths.some((p) => p.includes("args"))).toBe(true);
+  });
 });

--- a/src/config/config.mcp-servers.test.ts
+++ b/src/config/config.mcp-servers.test.ts
@@ -55,6 +55,26 @@ describe("mcp servers config schema", () => {
     expect(res.success).toBe(true);
   });
 
+  it("rejects a server name with invalid characters", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          "my__server name!": {
+            command: "/usr/bin/thing",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+    if (res.success) {
+      return;
+    }
+
+    const paths = res.error.issues.map((i) => i.path.join("."));
+    expect(paths.some((p) => p.includes("my__server name!"))).toBe(true);
+  });
+
   it("rejects a server entry missing command", () => {
     const res = OpenClawSchema.safeParse({
       mcp: {

--- a/src/config/config.mcp-servers.test.ts
+++ b/src/config/config.mcp-servers.test.ts
@@ -167,6 +167,27 @@ describe("mcp servers config schema", () => {
     ).toBe(true);
   });
 
+  it("rejects an empty string description", () => {
+    const res = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          bad_desc: {
+            command: "/usr/bin/thing",
+            description: "",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+    if (res.success) {
+      return;
+    }
+
+    const paths = res.error.issues.map((i) => i.path.join("."));
+    expect(paths.some((p) => p.includes("description"))).toBe(true);
+  });
+
   it("rejects empty strings in the args array", () => {
     const res = OpenClawSchema.safeParse({
       mcp: {

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -36,6 +36,7 @@ const ROOT_SECTIONS = [
   "gateway",
   "memory",
   "plugins",
+  "mcp",
 ] as const;
 
 const TARGET_KEYS = [
@@ -389,6 +390,11 @@ const TARGET_KEYS = [
   "agents.defaults.compaction.memoryFlush.softThresholdTokens",
   "agents.defaults.compaction.memoryFlush.prompt",
   "agents.defaults.compaction.memoryFlush.systemPrompt",
+  "mcp",
+  "mcp.servers",
+  "mcp.servers.*.command",
+  "mcp.servers.*.args",
+  "mcp.servers.*.description",
 ] as const;
 
 const ENUM_EXPECTATIONS: Record<string, string[]> = {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1598,4 +1598,13 @@ export const FIELD_HELP: Record<string, string> = {
     'Direct message access control ("pairing" recommended). "open" requires channels.slack.allowFrom=["*"] (legacy: channels.slack.dm.allowFrom).',
   "channels.slack.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.slack.allowFrom=["*"].',
+  mcp: "MCP (Model Context Protocol) server declarations keyed by a user-defined server name. Use this section to wire external MCP-compatible binaries so their tools are available to agents without manual shell-out workarounds.",
+  "mcp.servers":
+    "Named map of MCP servers this gateway can start and expose as agent tools. Keep entries stable because server names are used as tool-name prefixes (mcp__<name>__<tool>). Remove unused entries to avoid stale process launches.",
+  "mcp.servers.*.command":
+    "Executable path or binary name for the MCP server process. Use an absolute path or ensure the binary is on PATH; relative paths resolve from the gateway working directory.",
+  "mcp.servers.*.args":
+    'Optional arguments passed to the MCP server command on startup. Use this for mode flags (for example ["mcp"]) or config pointers required by the server.',
+  "mcp.servers.*.description":
+    "Optional human-readable summary of what this MCP server provides. Use this to help operators identify server purpose at a glance in diagnostics and the control UI.",
 };

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -864,4 +864,9 @@ export const FIELD_LABELS: Record<string, string> = {
   "plugins.installs.*.shasum": "Plugin Resolved Shasum",
   "plugins.installs.*.resolvedAt": "Plugin Resolution Time",
   "plugins.installs.*.installedAt": "Plugin Install Time",
+  mcp: "MCP Servers",
+  "mcp.servers": "MCP Server Map",
+  "mcp.servers.*.command": "MCP Server Command",
+  "mcp.servers.*.args": "MCP Server Args",
+  "mcp.servers.*.description": "MCP Server Description",
 };

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -44,7 +44,7 @@ export type McpServerEntryConfig = {
 export type McpServerName = string & { readonly __brand: "McpServerName" };
 
 export type McpConfig = {
-  /** MCP servers keyed by an arbitrary user-defined server name. */
+  /** MCP servers keyed by a user-defined server name (must match /^[a-zA-Z0-9_-]+$/). */
   servers?: Record<McpServerName, McpServerEntryConfig>;
 };
 

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -37,9 +37,15 @@ export type McpServerEntryConfig = {
   description?: string;
 };
 
+/**
+ * Server names must match /^[a-zA-Z0-9_-]+$/ to be safely embedded
+ * in mcp__<name>__<tool> tool definitions later.
+ */
+export type McpServerName = string & { readonly __brand: "McpServerName" };
+
 export type McpConfig = {
   /** MCP servers keyed by an arbitrary user-defined server name. */
-  servers?: Record<string, McpServerEntryConfig>;
+  servers?: Record<McpServerName, McpServerEntryConfig>;
 };
 
 export type OpenClawConfig = {

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -28,6 +28,20 @@ import type { SecretsConfig } from "./types.secrets.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
+export type McpServerEntryConfig = {
+  /** Executable path or binary name for the MCP server process. */
+  command: string;
+  /** Optional arguments passed to the MCP server command on startup. */
+  args?: string[];
+  /** Optional human-readable description of what this server provides. */
+  description?: string;
+};
+
+export type McpConfig = {
+  /** MCP servers keyed by an arbitrary user-defined server name. */
+  servers?: Record<string, McpServerEntryConfig>;
+};
+
 export type OpenClawConfig = {
   meta?: {
     /** Last OpenClaw version that wrote this config. */
@@ -120,6 +134,7 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  mcp?: McpConfig;
 };
 
 export type ConfigValidationIssue = {

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -37,15 +37,9 @@ export type McpServerEntryConfig = {
   description?: string;
 };
 
-/**
- * Server names must match /^[a-zA-Z0-9_-]+$/ to be safely embedded
- * in mcp__<name>__<tool> tool definitions later.
- */
-export type McpServerName = string & { readonly __brand: "McpServerName" };
-
 export type McpConfig = {
   /** MCP servers keyed by a user-defined server name (must match /^[a-zA-Z0-9_-]+$/). */
-  servers?: Record<McpServerName, McpServerEntryConfig>;
+  servers?: Record<string, McpServerEntryConfig>;
 };
 
 export type OpenClawConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -90,7 +90,7 @@ const MemoryQmdMcporterSchema = z
 const McpServerEntrySchema = z
   .object({
     command: z.string().min(1),
-    args: z.array(z.string()).optional(),
+    args: z.array(z.string().min(1)).optional(),
     description: z.string().optional(),
   })
   .strict();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -110,8 +110,7 @@ const McpSchema = z
       )
       .optional(),
   })
-  .strict()
-  .optional();
+  .strict();
 
 const LoggingLevelSchema = z.union([
   z.literal("silent"),
@@ -918,7 +917,7 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
-    mcp: McpSchema,
+    mcp: McpSchema.optional(),
   })
   .strict()
   .superRefine((cfg, ctx) => {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -87,6 +87,21 @@ const MemoryQmdMcporterSchema = z
   })
   .strict();
 
+const McpServerEntrySchema = z
+  .object({
+    command: z.string().min(1),
+    args: z.array(z.string()).optional(),
+    description: z.string().optional(),
+  })
+  .strict();
+
+const McpSchema = z
+  .object({
+    servers: z.record(z.string().min(1), McpServerEntrySchema).optional(),
+  })
+  .strict()
+  .optional();
+
 const LoggingLevelSchema = z.union([
   z.literal("silent"),
   z.literal("fatal"),
@@ -892,6 +907,7 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    mcp: McpSchema,
   })
   .strict()
   .superRefine((cfg, ctx) => {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -91,7 +91,7 @@ const McpServerEntrySchema = z
   .object({
     command: z.string().min(1),
     args: z.array(z.string().min(1)).optional(),
-    description: z.string().optional(),
+    description: z.string().min(1).optional(),
   })
   .strict();
 

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -97,7 +97,18 @@ const McpServerEntrySchema = z
 
 const McpSchema = z
   .object({
-    servers: z.record(z.string().min(1), McpServerEntrySchema).optional(),
+    servers: z
+      .record(
+        z
+          .string()
+          .min(1)
+          .regex(
+            /^[a-zA-Z0-9_-]+$/,
+            "Server names can only contain alphanumeric characters, hyphens, and underscores",
+          ),
+        McpServerEntrySchema,
+      )
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
### Summary

Adds a top-level `mcp` config block to `openclaw.json`. This lays the
configuration foundation for allowing users to declare external MCP servers
(which will ultimately be registered as native tools available to all
agents, avoiding the need to shell out via `exec`).

### Config shape
```json
{
  "mcp": {
    "servers": {
      "qmd": {
        "command": "/path/to/qmd",
        "args": ["mcp"],
        "description": "QMD hybrid search over markdown files and session transcripts"
      }
    }
  }
}
```

### Changes

- `types.openclaw.ts`: Added `McpServerEntryConfig`, `McpConfig`, and
  extended `OpenClawConfig` with an optional `mcp` field. Types are
  declared in dependency order to avoid forward references.
- `zod-schema.ts`: Added strict `McpServerEntrySchema` and `McpSchema`
  validators.
- `schema.labels.ts` & `schema.help.ts`: Added labels and operational
  guidance help text for the `mcp.servers` block.
- Tests: Added `config.mcp-servers.test.ts` and updated help quality
  tests to ensure operational guidance coverage.

### Out of scope (intentional)

**Runtime wiring is deferred.** This PR implements the static
configuration layer only. The actual logic to spawn these servers and
expose them as tools (`mcp__<name>__<tool>`) is a planned follow-up.

**`env` support is deferred.** Many MCP servers require API keys injected
as environment variables. The config shape is already extensible — adding
`env?: Record<string, string>` to `McpServerEntryConfig` is a one-field
addition when that lands.

### Test notes

52 pre-existing import failures (`Cannot find package
'@mariozechner/pi-ai/oauth'`) appear in the test run but are completely
unrelated to this change. All 324 actual test cases pass.

Closes #43509