### PR TITLE
feat(cron): inject output history into isolated agent prompts

### DIFF
--- a/docs/superpowers/plans/2026-03-12-bot-history-pending-flush.md
+++ b/docs/superpowers/plans/2026-03-12-bot-history-pending-flush.md
@@ -1,0 +1,886 @@
+# Bot History Pending Flush Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the bot sends proactive cron messages to a chat, persist those messages and flush them into the session transcript on the next inbound message so the LLM has full context.
+
+**Architecture:** A JSON file store (`~/.openclaw/bot-history/pending.json`) buffers bot messages at delivery time. On inbound, matching entries are flushed to the session transcript via the existing `appendAssistantMessageToSessionTranscript` infrastructure.
+
+**Tech Stack:** TypeScript (ESM), Node.js fs, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-03-12-bot-history-pending-flush-design.md`
+
+---
+
+## File Structure
+
+| File                                           | Responsibility                                                                                 |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `src/auto-reply/reply/bot-history.ts`          | **New** — Pending store (load/save/append/read/remove/compact) + `flushBotHistoryToTranscript` |
+| `src/auto-reply/reply/bot-history.test.ts`     | **New** — Unit tests for all store operations and flush logic                                  |
+| `src/cron/isolated-agent/delivery-dispatch.ts` | **Modify** — Add recording call inside `deliverViaDirect` closure                              |
+| `src/auto-reply/reply/get-reply.ts`            | **Modify** — Add flush call after `initSessionState()` destructuring                           |
+
+---
+
+## Chunk 1: Core Store + Tests
+
+### Task 1: Pending Bot History Store — Types and Load/Save
+
+**Files:**
+
+- Create: `src/auto-reply/reply/bot-history.ts`
+- Test: `src/auto-reply/reply/bot-history.test.ts`
+
+- [ ] **Step 1: Write test scaffolding and first failing test (load empty store)**
+
+Create `src/auto-reply/reply/bot-history.test.ts`:
+
+```typescript
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Will be imported once implemented
+// import { appendBotHistoryEntry, readBotHistoryEntries, removeBotHistoryEntries, compactBotHistoryStore } from "./bot-history.js";
+
+let fixtureRoot = "";
+let caseId = 0;
+
+beforeAll(async () => {
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bot-history-"));
+});
+
+afterAll(async () => {
+  if (fixtureRoot) {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+function makeStorePath(): string {
+  return path.join(fixtureRoot, `case-${caseId++}`, "bot-history", "pending.json");
+}
+
+describe("bot-history store", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("readBotHistoryEntries returns [] when store does not exist", async () => {
+    const storePath = makeStorePath();
+    const { readBotHistoryEntries } = await import("./bot-history.js");
+    const entries = await readBotHistoryEntries(
+      { channel: "telegram", to: "telegram:-100123" },
+      { storePath },
+    );
+    expect(entries).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/auto-reply/reply/bot-history.test.ts`
+Expected: FAIL — module `./bot-history.js` does not exist
+
+- [ ] **Step 3: Create bot-history.ts with types, load/save, and readBotHistoryEntries**
+
+Create `src/auto-reply/reply/bot-history.ts`:
+
+```typescript
+import { randomBytes, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { CONFIG_DIR } from "../../utils.js";
+
+// ── Types ──
+
+export type BotHistoryEntry = {
+  id: string;
+  channel: string;
+  to: string;
+  accountId?: string;
+  threadId?: string;
+  text: string;
+  timestamp: number;
+  source?: string;
+};
+
+type BotHistoryStore = {
+  version: 1;
+  entries: BotHistoryEntry[];
+};
+
+// ── Constants ──
+
+const DEFAULT_BOT_HISTORY_DIR = path.join(CONFIG_DIR, "bot-history");
+const DEFAULT_STORE_PATH = path.join(DEFAULT_BOT_HISTORY_DIR, "pending.json");
+const MAX_ENTRIES = 500;
+const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const COMPACTION_THRESHOLD = 400;
+
+// ── In-memory cache (same pattern as cron store's serializedStoreCache) ──
+
+const serializedStoreCache = new Map<string, string>();
+
+// ── Internal helpers ──
+
+function resolveStorePath(override?: string): string {
+  return override ?? DEFAULT_STORE_PATH;
+}
+
+async function loadStore(storePath: string): Promise<BotHistoryStore> {
+  try {
+    const raw = await fs.promises.readFile(storePath, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const record = parsed as Record<string, unknown>;
+      const entries = Array.isArray(record.entries) ? (record.entries as BotHistoryEntry[]) : [];
+      const store: BotHistoryStore = { version: 1, entries };
+      serializedStoreCache.set(storePath, JSON.stringify(store));
+      return store;
+    }
+    return { version: 1, entries: [] };
+  } catch (err) {
+    if ((err as { code?: string })?.code === "ENOENT") {
+      serializedStoreCache.delete(storePath);
+      return { version: 1, entries: [] };
+    }
+    throw err;
+  }
+}
+
+async function saveStore(storePath: string, store: BotHistoryStore): Promise<void> {
+  const storeDir = path.dirname(storePath);
+  await fs.promises.mkdir(storeDir, { recursive: true, mode: 0o700 });
+  await fs.promises.chmod(storeDir, 0o700).catch(() => undefined);
+  const json = JSON.stringify(store);
+  const cached = serializedStoreCache.get(storePath);
+  if (cached === json) {
+    return;
+  }
+  const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
+  await fs.promises.chmod(tmp, 0o600).catch(() => undefined);
+  await renameWithRetry(tmp, storePath);
+  await fs.promises.chmod(storePath, 0o600).catch(() => undefined);
+  serializedStoreCache.set(storePath, json);
+}
+
+const RENAME_MAX_RETRIES = 3;
+const RENAME_BASE_DELAY_MS = 50;
+
+async function renameWithRetry(src: string, dest: string): Promise<void> {
+  for (let attempt = 0; attempt <= RENAME_MAX_RETRIES; attempt++) {
+    try {
+      await fs.promises.rename(src, dest);
+      return;
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === "EBUSY" && attempt < RENAME_MAX_RETRIES) {
+        await new Promise((resolve) => setTimeout(resolve, RENAME_BASE_DELAY_MS * 2 ** attempt));
+        continue;
+      }
+      if (code === "EPERM" || code === "EEXIST") {
+        await fs.promises.copyFile(src, dest);
+        await fs.promises.unlink(src).catch(() => {});
+        return;
+      }
+      throw err;
+    }
+  }
+}
+
+// ── Exported functions ──
+
+type StoreOptions = { storePath?: string };
+
+export async function readBotHistoryEntries(
+  query: { channel: string; to: string; accountId?: string; threadId?: string },
+  opts?: StoreOptions,
+): Promise<BotHistoryEntry[]> {
+  const storePath = resolveStorePath(opts?.storePath);
+  const store = await loadStore(storePath);
+  return store.entries.filter(
+    (e) =>
+      e.channel === query.channel &&
+      e.to === query.to &&
+      e.accountId === query.accountId &&
+      e.threadId === query.threadId,
+  );
+}
+
+export async function appendBotHistoryEntry(
+  entry: Omit<BotHistoryEntry, "id">,
+  opts?: StoreOptions,
+): Promise<void> {
+  const storePath = resolveStorePath(opts?.storePath);
+  const store = await loadStore(storePath);
+
+  // Lazy compaction when threshold exceeded
+  if (store.entries.length >= COMPACTION_THRESHOLD) {
+    compactEntries(store);
+  }
+
+  // Enforce max entries — drop oldest if at capacity
+  if (store.entries.length >= MAX_ENTRIES) {
+    store.entries.sort((a, b) => a.timestamp - b.timestamp);
+    store.entries.splice(0, store.entries.length - MAX_ENTRIES + 1);
+  }
+
+  store.entries.push({ ...entry, id: randomUUID() });
+  await saveStore(storePath, store);
+}
+
+export async function removeBotHistoryEntries(ids: string[], opts?: StoreOptions): Promise<void> {
+  if (ids.length === 0) return;
+  const storePath = resolveStorePath(opts?.storePath);
+  const store = await loadStore(storePath);
+  const idSet = new Set(ids);
+  store.entries = store.entries.filter((e) => !idSet.has(e.id));
+  await saveStore(storePath, store);
+}
+
+export async function compactBotHistoryStore(opts?: StoreOptions): Promise<number> {
+  const storePath = resolveStorePath(opts?.storePath);
+  const store = await loadStore(storePath);
+  const before = store.entries.length;
+  compactEntries(store);
+  if (store.entries.length !== before) {
+    await saveStore(storePath, store);
+  }
+  return before - store.entries.length;
+}
+
+function compactEntries(store: BotHistoryStore): void {
+  const cutoff = Date.now() - TTL_MS;
+  store.entries = store.entries.filter((e) => e.timestamp > cutoff);
+}
+
+// For tests: reset the in-memory cache
+export function _resetBotHistoryCache(): void {
+  serializedStoreCache.clear();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/auto-reply/reply/bot-history.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+scripts/committer "feat(bot-history): add pending store with load/save/read/append/remove/compact" \
+  src/auto-reply/reply/bot-history.ts \
+  src/auto-reply/reply/bot-history.test.ts
+```
+
+---
+
+### Task 2: Comprehensive Unit Tests for Store Operations
+
+**Files:**
+
+- Modify: `src/auto-reply/reply/bot-history.test.ts`
+
+- [ ] **Step 1: Add tests for append, read with matching, remove, compaction, and max entries**
+
+Expand `src/auto-reply/reply/bot-history.test.ts` — add the following test cases inside the `describe("bot-history store")` block, after the existing test. Each test uses a fresh `storePath` and imports the module with `resetModules` to isolate cache state.
+
+```typescript
+it("appendBotHistoryEntry writes and readBotHistoryEntries retrieves", async () => {
+  const storePath = makeStorePath();
+  const { appendBotHistoryEntry, readBotHistoryEntries, _resetBotHistoryCache } =
+    await import("./bot-history.js");
+  _resetBotHistoryCache();
+
+  await appendBotHistoryEntry(
+    {
+      channel: "telegram",
+      to: "telegram:-100123",
+      text: "hello from cron",
+      timestamp: Date.now(),
+      source: "cron",
+    },
+    { storePath },
+  );
+
+  const entries = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123" },
+    { storePath },
+  );
+  expect(entries).toHaveLength(1);
+  expect(entries[0].text).toBe("hello from cron");
+  expect(entries[0].id).toBeTruthy();
+  expect(entries[0].source).toBe("cron");
+});
+
+it("readBotHistoryEntries filters by channel + to", async () => {
+  const storePath = makeStorePath();
+  const { appendBotHistoryEntry, readBotHistoryEntries, _resetBotHistoryCache } =
+    await import("./bot-history.js");
+  _resetBotHistoryCache();
+
+  await appendBotHistoryEntry(
+    { channel: "telegram", to: "telegram:-100123", text: "msg1", timestamp: 1000 },
+    { storePath },
+  );
+  await appendBotHistoryEntry(
+    { channel: "telegram", to: "telegram:-100999", text: "msg2", timestamp: 2000 },
+    { storePath },
+  );
+  await appendBotHistoryEntry(
+    { channel: "discord", to: "discord:456", text: "msg3", timestamp: 3000 },
+    { storePath },
+  );
+
+  const results = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123" },
+    { storePath },
+  );
+  expect(results).toHaveLength(1);
+  expect(results[0].text).toBe("msg1");
+});
+
+it("readBotHistoryEntries uses strict equality for accountId and threadId", async () => {
+  const storePath = makeStorePath();
+  const { appendBotHistoryEntry, readBotHistoryEntries, _resetBotHistoryCache } =
+    await import("./bot-history.js");
+  _resetBotHistoryCache();
+
+  await appendBotHistoryEntry(
+    {
+      channel: "telegram",
+      to: "telegram:-100123",
+      accountId: "acct-A",
+      threadId: "42",
+      text: "acct-A thread-42",
+      timestamp: 1000,
+    },
+    { storePath },
+  );
+  await appendBotHistoryEntry(
+    {
+      channel: "telegram",
+      to: "telegram:-100123",
+      accountId: "acct-B",
+      text: "acct-B no thread",
+      timestamp: 2000,
+    },
+    { storePath },
+  );
+
+  // Match acct-A + thread 42
+  const matchA = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123", accountId: "acct-A", threadId: "42" },
+    { storePath },
+  );
+  expect(matchA).toHaveLength(1);
+  expect(matchA[0].text).toBe("acct-A thread-42");
+
+  // Wrong accountId — no match
+  const noMatch = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123", accountId: "acct-C" },
+    { storePath },
+  );
+  expect(noMatch).toHaveLength(0);
+
+  // Both undefined — matches entry with no accountId/threadId? No, acct-B has accountId set.
+  const undefinedMatch = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123" },
+    { storePath },
+  );
+  expect(undefinedMatch).toHaveLength(0); // Both entries have accountId set
+});
+
+it("removeBotHistoryEntries removes specific entries by id", async () => {
+  const storePath = makeStorePath();
+  const {
+    appendBotHistoryEntry,
+    readBotHistoryEntries,
+    removeBotHistoryEntries,
+    _resetBotHistoryCache,
+  } = await import("./bot-history.js");
+  _resetBotHistoryCache();
+
+  await appendBotHistoryEntry(
+    { channel: "telegram", to: "telegram:-100123", text: "keep", timestamp: 1000 },
+    { storePath },
+  );
+  await appendBotHistoryEntry(
+    { channel: "telegram", to: "telegram:-100123", text: "remove", timestamp: 2000 },
+    { storePath },
+  );
+
+  const all = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123" },
+    { storePath },
+  );
+  expect(all).toHaveLength(2);
+  const toRemove = all.find((e) => e.text === "remove")!;
+
+  await removeBotHistoryEntries([toRemove.id], { storePath });
+
+  const remaining = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123" },
+    { storePath },
+  );
+  expect(remaining).toHaveLength(1);
+  expect(remaining[0].text).toBe("keep");
+});
+
+it("compactBotHistoryStore removes entries older than TTL", async () => {
+  const storePath = makeStorePath();
+  const {
+    appendBotHistoryEntry,
+    compactBotHistoryStore,
+    readBotHistoryEntries,
+    _resetBotHistoryCache,
+  } = await import("./bot-history.js");
+  _resetBotHistoryCache();
+
+  const now = Date.now();
+  const oldTimestamp = now - 25 * 60 * 60 * 1000; // 25 hours ago
+
+  await appendBotHistoryEntry(
+    { channel: "telegram", to: "telegram:-100123", text: "old", timestamp: oldTimestamp },
+    { storePath },
+  );
+  await appendBotHistoryEntry(
+    { channel: "telegram", to: "telegram:-100123", text: "fresh", timestamp: now },
+    { storePath },
+  );
+
+  const removed = await compactBotHistoryStore({ storePath });
+  expect(removed).toBe(1);
+
+  const remaining = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123" },
+    { storePath },
+  );
+  expect(remaining).toHaveLength(1);
+  expect(remaining[0].text).toBe("fresh");
+});
+
+it("appendBotHistoryEntry enforces max 500 entries", async () => {
+  const storePath = makeStorePath();
+  const { appendBotHistoryEntry, _resetBotHistoryCache } = await import("./bot-history.js");
+  _resetBotHistoryCache();
+
+  // Write 500 entries
+  for (let i = 0; i < 500; i++) {
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "telegram:-100123", text: `msg-${i}`, timestamp: 1000 + i },
+      { storePath },
+    );
+  }
+
+  // Write one more — oldest should be evicted
+  await appendBotHistoryEntry(
+    { channel: "telegram", to: "telegram:-100123", text: "msg-500", timestamp: 2000 },
+    { storePath },
+  );
+
+  const { readBotHistoryEntries } = await import("./bot-history.js");
+  const all = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123" },
+    { storePath },
+  );
+  expect(all.length).toBeLessThanOrEqual(500);
+  // The very first entry (msg-0) should have been evicted
+  expect(all.find((e) => e.text === "msg-0")).toBeUndefined();
+  expect(all.find((e) => e.text === "msg-500")).toBeTruthy();
+});
+
+it("store persists to disk and survives cache reset", async () => {
+  const storePath = makeStorePath();
+  const { appendBotHistoryEntry, readBotHistoryEntries, _resetBotHistoryCache } =
+    await import("./bot-history.js");
+  _resetBotHistoryCache();
+
+  await appendBotHistoryEntry(
+    { channel: "telegram", to: "telegram:-100123", text: "persisted", timestamp: Date.now() },
+    { storePath },
+  );
+
+  // Reset cache to force re-read from disk
+  _resetBotHistoryCache();
+
+  const entries = await readBotHistoryEntries(
+    { channel: "telegram", to: "telegram:-100123" },
+    { storePath },
+  );
+  expect(entries).toHaveLength(1);
+  expect(entries[0].text).toBe("persisted");
+});
+```
+
+- [ ] **Step 2: Run all tests to verify they pass**
+
+Run: `pnpm vitest run src/auto-reply/reply/bot-history.test.ts`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+scripts/committer "test(bot-history): add comprehensive unit tests for store operations" \
+  src/auto-reply/reply/bot-history.test.ts
+```
+
+---
+
+### Task 3: flushBotHistoryToTranscript Function
+
+**Files:**
+
+- Modify: `src/auto-reply/reply/bot-history.ts`
+- Modify: `src/auto-reply/reply/bot-history.test.ts`
+
+- [ ] **Step 1: Write failing test for flushBotHistoryToTranscript**
+
+Add to `src/auto-reply/reply/bot-history.test.ts`:
+
+Add the `vi.mock` call at the **top of the file** (after existing imports, before `let fixtureRoot`). Vitest hoists `vi.mock` calls, so it applies module-wide. This does NOT affect Task 2 store-only tests since they never call `flushBotHistoryToTranscript`.
+
+```typescript
+// Add this at the top of the file, after imports:
+vi.mock("../../config/sessions/transcript.js", () => ({
+  appendAssistantMessageToSessionTranscript: vi.fn(),
+}));
+```
+
+Then add a new `describe` block after the existing `describe("bot-history store")` block:
+
+```typescript
+describe("flushBotHistoryToTranscript", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("flushes matching entries to session transcript and removes them", async () => {
+    const storePath = makeStorePath();
+    const {
+      appendBotHistoryEntry,
+      flushBotHistoryToTranscript,
+      readBotHistoryEntries,
+      _resetBotHistoryCache,
+    } = await import("./bot-history.js");
+    const { appendAssistantMessageToSessionTranscript } =
+      await import("../../config/sessions/transcript.js");
+    _resetBotHistoryCache();
+
+    const mockAppend = vi.mocked(appendAssistantMessageToSessionTranscript);
+    mockAppend.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "telegram:-100123", text: "cron msg 1", timestamp: 1000 },
+      { storePath },
+    );
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "telegram:-100123", text: "cron msg 2", timestamp: 2000 },
+      { storePath },
+    );
+
+    const flushed = await flushBotHistoryToTranscript({
+      channel: "telegram",
+      to: "telegram:-100123",
+      sessionKey: "test-session",
+      agentId: "test-agent",
+      storePath,
+    });
+
+    expect(flushed).toBe(2);
+    expect(mockAppend).toHaveBeenCalledTimes(2);
+    // Flushed in chronological order
+    expect(mockAppend).toHaveBeenNthCalledWith(1, {
+      agentId: "test-agent",
+      sessionKey: "test-session",
+      text: "cron msg 1",
+    });
+    expect(mockAppend).toHaveBeenNthCalledWith(2, {
+      agentId: "test-agent",
+      sessionKey: "test-session",
+      text: "cron msg 2",
+    });
+
+    // Entries should be removed after flush
+    const remaining = await readBotHistoryEntries(
+      { channel: "telegram", to: "telegram:-100123" },
+      { storePath },
+    );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("returns 0 when no matching entries exist", async () => {
+    const storePath = makeStorePath();
+    const { flushBotHistoryToTranscript, _resetBotHistoryCache } = await import("./bot-history.js");
+    _resetBotHistoryCache();
+
+    const flushed = await flushBotHistoryToTranscript({
+      channel: "telegram",
+      to: "telegram:-100123",
+      sessionKey: "test-session",
+      agentId: "test-agent",
+      storePath,
+    });
+    expect(flushed).toBe(0);
+  });
+
+  it("keeps entries that fail to flush", async () => {
+    const storePath = makeStorePath();
+    const {
+      appendBotHistoryEntry,
+      flushBotHistoryToTranscript,
+      readBotHistoryEntries,
+      _resetBotHistoryCache,
+    } = await import("./bot-history.js");
+    const { appendAssistantMessageToSessionTranscript } =
+      await import("../../config/sessions/transcript.js");
+    _resetBotHistoryCache();
+
+    const mockAppend = vi.mocked(appendAssistantMessageToSessionTranscript);
+    // First succeeds, second fails
+    mockAppend
+      .mockResolvedValueOnce({ ok: true, sessionFile: "/tmp/test.jsonl" })
+      .mockResolvedValueOnce({ ok: false, reason: "unknown sessionKey" });
+
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "telegram:-100123", text: "will flush", timestamp: 1000 },
+      { storePath },
+    );
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "telegram:-100123", text: "will fail", timestamp: 2000 },
+      { storePath },
+    );
+
+    const flushed = await flushBotHistoryToTranscript({
+      channel: "telegram",
+      to: "telegram:-100123",
+      sessionKey: "test-session",
+      agentId: "test-agent",
+      storePath,
+    });
+
+    expect(flushed).toBe(1);
+
+    // The failed entry should remain
+    const remaining = await readBotHistoryEntries(
+      { channel: "telegram", to: "telegram:-100123" },
+      { storePath },
+    );
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].text).toBe("will fail");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/auto-reply/reply/bot-history.test.ts`
+Expected: FAIL — `flushBotHistoryToTranscript` is not exported
+
+- [ ] **Step 3: Implement flushBotHistoryToTranscript**
+
+Add to the end of `src/auto-reply/reply/bot-history.ts` (before `_resetBotHistoryCache`):
+
+```typescript
+import { appendAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.js";
+
+export async function flushBotHistoryToTranscript(params: {
+  channel: string;
+  to: string;
+  accountId?: string;
+  threadId?: string;
+  sessionKey: string;
+  agentId: string;
+  storePath?: string;
+}): Promise<number> {
+  const entries = await readBotHistoryEntries(
+    {
+      channel: params.channel,
+      to: params.to,
+      accountId: params.accountId,
+      threadId: params.threadId,
+    },
+    { storePath: params.storePath },
+  );
+  if (entries.length === 0) return 0;
+
+  entries.sort((a, b) => a.timestamp - b.timestamp);
+
+  // Flush each entry individually. Only remove entries that succeed —
+  // failed entries stay for the next flush attempt.
+  const flushedIds: string[] = [];
+  for (const entry of entries) {
+    const result = await appendAssistantMessageToSessionTranscript({
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      text: entry.text,
+    });
+    if (result.ok) {
+      flushedIds.push(entry.id);
+    }
+  }
+
+  if (flushedIds.length > 0) {
+    await removeBotHistoryEntries(flushedIds, { storePath: params.storePath });
+  }
+  return flushedIds.length;
+}
+```
+
+**Important:** Add the `import { appendAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.js"` line to the **existing import block at the top of `bot-history.ts`** (after the `import { CONFIG_DIR }` line). Do NOT include it inline in the function code block above — it is shown there only for context.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/auto-reply/reply/bot-history.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+scripts/committer "feat(bot-history): add flushBotHistoryToTranscript with partial-failure safety" \
+  src/auto-reply/reply/bot-history.ts \
+  src/auto-reply/reply/bot-history.test.ts
+```
+
+---
+
+## Chunk 2: Integration Points
+
+### Task 4: Recording Point in delivery-dispatch.ts
+
+**Files:**
+
+- Modify: `src/cron/isolated-agent/delivery-dispatch.ts:275`
+
+- [ ] **Step 1: Add the recording call inside `deliverViaDirect`**
+
+In `src/cron/isolated-agent/delivery-dispatch.ts`, add an import at the top:
+
+```typescript
+import { appendBotHistoryEntry } from "../../auto-reply/reply/bot-history.js";
+```
+
+Then modify the `deliverViaDirect` closure. Find line 275 (`delivered = deliveryResults.length > 0;`) and replace:
+
+```typescript
+delivered = deliveryResults.length > 0;
+return null;
+```
+
+with:
+
+```typescript
+delivered = deliveryResults.length > 0;
+// Record delivered bot message for later flush into the target chat's
+// session transcript. Other proactive outbound paths that bypass the
+// `mirror` parameter should add their own appendBotHistoryEntry call.
+if (delivered && synthesizedText?.trim()) {
+  appendBotHistoryEntry({
+    channel: delivery.channel,
+    to: delivery.to,
+    accountId: delivery.accountId,
+    threadId: delivery.threadId != null ? String(delivery.threadId) : undefined,
+    text: synthesizedText.trim(),
+    timestamp: Date.now(),
+    source: "cron",
+  }).catch(() => {}); // best-effort, don't block delivery
+}
+return null;
+```
+
+- [ ] **Step 2: Run type check**
+
+Run: `pnpm tsgo`
+Expected: No new errors
+
+- [ ] **Step 3: Run existing delivery-dispatch tests to verify no regressions**
+
+Run: `pnpm vitest run src/cron/isolated-agent/delivery-dispatch`
+Expected: All existing tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+scripts/committer "feat(bot-history): record cron delivery to pending store" \
+  src/cron/isolated-agent/delivery-dispatch.ts
+```
+
+---
+
+### Task 5: Flush Point in get-reply.ts
+
+**Files:**
+
+- Modify: `src/auto-reply/reply/get-reply.ts:174`
+
+- [ ] **Step 1: Add the flush call after initSessionState destructuring**
+
+In `src/auto-reply/reply/get-reply.ts`, add an import at the top:
+
+```typescript
+import { flushBotHistoryToTranscript } from "./bot-history.js";
+```
+
+Then find line 174 (`} = sessionState;`) and insert after it:
+
+```typescript
+// Flush pending bot messages (e.g. cron deliveries) into the current
+// session transcript so the LLM sees them as prior assistant messages.
+// OriginatingChannel and OriginatingTo are optional on MsgContext;
+// skip flush when either is missing (e.g. internal/non-channel messages).
+if (finalized.OriginatingChannel && finalized.OriginatingTo) {
+  await flushBotHistoryToTranscript({
+    channel: finalized.OriginatingChannel,
+    to: finalized.OriginatingTo,
+    accountId: finalized.AccountId,
+    threadId: finalized.MessageThreadId != null ? String(finalized.MessageThreadId) : undefined,
+    sessionKey,
+    agentId,
+  }).catch(() => {}); // best-effort
+}
+```
+
+- [ ] **Step 2: Run type check**
+
+Run: `pnpm tsgo`
+Expected: No new errors. The `if` guard narrows `OriginatingChannel` and `OriginatingTo` from optional to required, satisfying `flushBotHistoryToTranscript`'s `channel: string` / `to: string` parameter types.
+
+- [ ] **Step 3: Run existing get-reply tests to verify no regressions**
+
+Run: `pnpm vitest run src/auto-reply/reply/get-reply`
+Expected: All existing tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+scripts/committer "feat(bot-history): flush pending entries on inbound message" \
+  src/auto-reply/reply/get-reply.ts
+```
+
+---
+
+### Task 6: Final Verification
+
+- [ ] **Step 1: Run full type check**
+
+Run: `pnpm tsgo`
+Expected: No errors
+
+- [ ] **Step 2: Run lint/format check**
+
+Run: `pnpm check`
+Expected: No errors. If formatting issues, run `pnpm format:fix` and commit.
+
+- [ ] **Step 3: Run full test suite for affected areas**
+
+Run: `pnpm vitest run src/auto-reply/reply/bot-history.test.ts src/cron/isolated-agent/ src/auto-reply/reply/get-reply`
+Expected: All PASS
+
+- [ ] **Step 4: Run broader test suite**
+
+Run: `pnpm test`
+Expected: All PASS, no regressions

--- a/docs/superpowers/plans/2026-03-13-cron-dedup-context.md
+++ b/docs/superpowers/plans/2026-03-13-cron-dedup-context.md
@@ -1,0 +1,734 @@
+# Cron Dedup Context Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Inject previous delivery outputs into isolated cron agent prompts so they can avoid repeating themselves.
+
+**Architecture:** Store recent outputs in `CronJobState.recentOutputs` (capped FIFO array). Thread `outputText` through the timer result chain to `applyJobResult` for recording. Inject a dedup context block into `commandBody` before the agent turn when `payload.dedupContext` is enabled.
+
+**Tech Stack:** TypeScript, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-03-13-cron-dedup-context-design.md`
+
+---
+
+## File Structure
+
+| File                                               | Responsibility                                        | Action                                                                   |
+| -------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------ |
+| `src/cron/types.ts`                                | Type definitions for cron jobs                        | Modify: add `recentOutputs` to `CronJobState`, `dedupContext` to payload |
+| `src/cron/isolated-agent/run.ts`                   | Isolated agent turn orchestration                     | Modify: inject dedup block into `commandBody`                            |
+| `src/cron/service/timer.ts`                        | Job execution and state management                    | Modify: thread `outputText`, record in `applyJobResult`                  |
+| `src/cron/isolated-agent/dedup-context.ts`         | Pure helper for building dedup prompt block           | Create                                                                   |
+| `src/cron/isolated-agent/dedup-context.test.ts`    | Tests for dedup context builder                       | Create                                                                   |
+| `src/cron/service.dedup-context-recording.test.ts` | Integration test for output recording via CronService | Create                                                                   |
+
+---
+
+## Chunk 1: All Tasks
+
+### Task 1: Data Model — Add types
+
+**Files:**
+
+- Modify: `src/cron/types.ts:85-100` (CronAgentTurnPayloadFields)
+- Modify: `src/cron/types.ts:109-133` (CronJobState)
+
+- [ ] **Step 1: Add `dedupContext` to `CronAgentTurnPayloadFields`**
+
+In `src/cron/types.ts`, add after the `bestEffortDeliver` field (line ~100):
+
+```typescript
+  /**
+   * When true, inject recent delivered outputs into the agent's system prompt
+   * so it can avoid repeating the same content. Default: false.
+   */
+  dedupContext?: boolean;
+```
+
+- [ ] **Step 2: Add `recentOutputs` to `CronJobState`**
+
+In `src/cron/types.ts`, add after the `lastDelivered` field (line ~132):
+
+```typescript
+  /**
+   * Recent delivered outputs for dedup context injection.
+   * Capped at {@link DEDUP_MAX_OUTPUTS} entries, FIFO.
+   * Only populated when `payload.dedupContext` is enabled.
+   */
+  recentOutputs?: Array<{
+    /** Delivered text, truncated to {@link DEDUP_MAX_CHARS_PER_OUTPUT} characters. */
+    text: string;
+    /** Timestamp (ms since epoch) when the output was delivered. */
+    timestamp: number;
+  }>;
+```
+
+- [ ] **Step 3: Verify types compile**
+
+Run: `pnpm tsgo`
+Expected: No new errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+scripts/committer "feat(cron): add dedupContext and recentOutputs type definitions" src/cron/types.ts
+```
+
+---
+
+### Task 2: Dedup Context Builder — Pure helper with tests
+
+**Files:**
+
+- Create: `src/cron/isolated-agent/dedup-context.ts`
+- Create: `src/cron/isolated-agent/dedup-context.test.ts`
+
+- [ ] **Step 1: Write failing tests for `buildDedupContextBlock`**
+
+Create `src/cron/isolated-agent/dedup-context.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { buildDedupContextBlock } from "./dedup-context.js";
+import type { CronJob } from "../types.js";
+
+function makeJob(overrides?: {
+  dedupContext?: boolean;
+  recentOutputs?: Array<{ text: string; timestamp: number }>;
+  tz?: string;
+}): CronJob {
+  return {
+    id: "job-1",
+    name: "test-job",
+    description: "",
+    enabled: true,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    schedule: {
+      kind: "cron",
+      expr: "0 8 * * *",
+      ...(overrides?.tz ? { tz: overrides.tz } : {}),
+    },
+    payload: {
+      kind: "agentTurn",
+      message: "test",
+      ...(overrides?.dedupContext ? { dedupContext: true } : {}),
+    },
+    delivery: { mode: "none" },
+    state: {
+      ...(overrides?.recentOutputs ? { recentOutputs: overrides.recentOutputs } : {}),
+    },
+  } as CronJob;
+}
+
+describe("buildDedupContextBlock", () => {
+  it("returns undefined when dedupContext is not enabled", () => {
+    const job = makeJob({ recentOutputs: [{ text: "hello", timestamp: 1000 }] });
+    expect(buildDedupContextBlock(job)).toBeUndefined();
+  });
+
+  it("returns undefined when dedupContext is enabled but no outputs exist", () => {
+    const job = makeJob({ dedupContext: true });
+    expect(buildDedupContextBlock(job)).toBeUndefined();
+  });
+
+  it("returns undefined when recentOutputs is empty array", () => {
+    const job = makeJob({ dedupContext: true, recentOutputs: [] });
+    expect(buildDedupContextBlock(job)).toBeUndefined();
+  });
+
+  it("returns undefined for non-agentTurn payload", () => {
+    const job = makeJob({ dedupContext: true, recentOutputs: [{ text: "hi", timestamp: 1000 }] });
+    (job.payload as { kind: string }).kind = "systemEvent";
+    expect(buildDedupContextBlock(job)).toBeUndefined();
+  });
+
+  it("builds context block with formatted outputs", () => {
+    const job = makeJob({
+      dedupContext: true,
+      recentOutputs: [
+        { text: "First output", timestamp: 1710230400000 },
+        { text: "Second output", timestamp: 1710316800000 },
+      ],
+    });
+    const result = buildDedupContextBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("[Your previous outputs for this scheduled task");
+    expect(result).toContain("First output");
+    expect(result).toContain("Second output");
+    // Second output should appear after first (chronological order preserved)
+    const firstIdx = result!.indexOf("First output");
+    const secondIdx = result!.indexOf("Second output");
+    expect(secondIdx).toBeGreaterThan(firstIdx);
+  });
+
+  it("uses job timezone for formatting when available", () => {
+    const job = makeJob({
+      dedupContext: true,
+      tz: "Asia/Shanghai",
+      recentOutputs: [{ text: "output", timestamp: 1710230400000 }],
+    });
+    const result = buildDedupContextBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("output");
+  });
+
+  it("works with every-schedule jobs (no tz field)", () => {
+    const job = makeJob({
+      dedupContext: true,
+      recentOutputs: [{ text: "output", timestamp: 1710230400000 }],
+    });
+    job.schedule = { kind: "every", everyMs: 60_000 };
+    const result = buildDedupContextBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("output");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test src/cron/isolated-agent/dedup-context.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `buildDedupContextBlock`**
+
+Create `src/cron/isolated-agent/dedup-context.ts`:
+
+```typescript
+import type { CronJob } from "../types.js";
+
+export const DEDUP_MAX_OUTPUTS = 5;
+export const DEDUP_MAX_CHARS_PER_OUTPUT = 500;
+
+export function buildDedupContextBlock(job: CronJob): string | undefined {
+  if (job.payload.kind !== "agentTurn" || !job.payload.dedupContext) {
+    return undefined;
+  }
+  const outputs = job.state.recentOutputs;
+  if (!outputs || outputs.length === 0) {
+    return undefined;
+  }
+
+  const tz = job.schedule.kind === "cron" ? job.schedule.tz : undefined;
+  const lines = outputs.map((o) => {
+    const date = new Date(o.timestamp);
+    const formatted = tz
+      ? date.toLocaleString("en-US", { timeZone: tz, dateStyle: "short", timeStyle: "short" })
+      : date.toLocaleString("en-US", { dateStyle: "short", timeStyle: "short" });
+    return `- ${formatted}: ${o.text}`;
+  });
+
+  return [
+    "[Your previous outputs for this scheduled task — avoid repeating the same content:]",
+    ...lines,
+  ].join("\n");
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test src/cron/isolated-agent/dedup-context.test.ts`
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+scripts/committer "feat(cron): add buildDedupContextBlock helper with tests" src/cron/isolated-agent/dedup-context.ts src/cron/isolated-agent/dedup-context.test.ts
+```
+
+---
+
+### Task 3: Injection Point — Append dedup block to commandBody
+
+**Files:**
+
+- Modify: `src/cron/isolated-agent/run.ts:480` (after `appendCronDeliveryInstruction`)
+
+- [ ] **Step 1: Add import**
+
+At the top of `src/cron/isolated-agent/run.ts`, add:
+
+```typescript
+import { buildDedupContextBlock } from "./dedup-context.js";
+```
+
+- [ ] **Step 2: Inject dedup block after commandBody finalization**
+
+Find this line in `run.ts` (line ~480):
+
+```typescript
+commandBody = appendCronDeliveryInstruction({ commandBody, deliveryRequested });
+```
+
+Immediately after it, add:
+
+```typescript
+const dedupBlock = buildDedupContextBlock(params.job);
+if (dedupBlock) {
+  commandBody = `${commandBody}\n\n${dedupBlock}`;
+}
+```
+
+- [ ] **Step 3: Verify types compile**
+
+Run: `pnpm tsgo`
+Expected: No new errors
+
+- [ ] **Step 4: Run existing cron tests to check for regressions**
+
+Run: `pnpm test src/cron/isolated-agent/`
+Expected: All existing tests PASS (dedup block is only injected when `dedupContext=true`, which no existing test sets)
+
+- [ ] **Step 5: Commit**
+
+```bash
+scripts/committer "feat(cron): inject dedup context block into agent prompt" src/cron/isolated-agent/run.ts
+```
+
+---
+
+### Task 4: Thread outputText through timer result chain
+
+**Files:**
+
+- Modify: `src/cron/service/timer.ts:46-53` (TimedCronRunOutcome)
+- Modify: `src/cron/service/timer.ts:1143-1154` (executeJobCore return)
+- Modify: `src/cron/service/timer.ts:493-498` (applyOutcomeToStoredJob)
+- Modify: `src/cron/service/timer.ts:1187-1192` (executeJob)
+
+- [ ] **Step 1: Add `outputText` to `TimedCronRunOutcome`**
+
+In `src/cron/service/timer.ts`, find (line ~46):
+
+```typescript
+type TimedCronRunOutcome = CronRunOutcome &
+  CronRunTelemetry & {
+    jobId: string;
+    delivered?: boolean;
+    deliveryAttempted?: boolean;
+    startedAt: number;
+    endedAt: number;
+  };
+```
+
+Add `outputText?: string;` after `deliveryAttempted`:
+
+```typescript
+type TimedCronRunOutcome = CronRunOutcome &
+  CronRunTelemetry & {
+    jobId: string;
+    delivered?: boolean;
+    deliveryAttempted?: boolean;
+    outputText?: string;
+    startedAt: number;
+    endedAt: number;
+  };
+```
+
+- [ ] **Step 2: Include `outputText` in `executeJobCore` return**
+
+In `src/cron/service/timer.ts`, find the return statement in `executeJobCore` after the `runIsolatedAgentJob` call (line ~1143). The current code explicitly lists fields from `res`. Add `outputText`:
+
+```typescript
+return {
+  status: res.status,
+  error: res.error,
+  summary: res.summary,
+  delivered: res.delivered,
+  deliveryAttempted: res.deliveryAttempted,
+  outputText: res.outputText,
+  sessionId: res.sessionId,
+  sessionKey: res.sessionKey,
+  model: res.model,
+  provider: res.provider,
+  usage: res.usage,
+};
+```
+
+- [ ] **Step 3: Pass `outputText` in `applyOutcomeToStoredJob`**
+
+In `src/cron/service/timer.ts`, find `applyOutcomeToStoredJob` (line ~493). The call to `applyJobResult` currently passes:
+
+```typescript
+const shouldDelete = applyJobResult(state, job, {
+  status: result.status,
+  error: result.error,
+  delivered: result.delivered,
+  startedAt: result.startedAt,
+  endedAt: result.endedAt,
+});
+```
+
+Add `outputText`:
+
+```typescript
+const shouldDelete = applyJobResult(state, job, {
+  status: result.status,
+  error: result.error,
+  delivered: result.delivered,
+  outputText: result.outputText,
+  startedAt: result.startedAt,
+  endedAt: result.endedAt,
+});
+```
+
+- [ ] **Step 4: Add `outputText` to `coreResult` inline type and pass it in `executeJob`**
+
+In `src/cron/service/timer.ts`, find `executeJob` (line ~1161). The `coreResult` variable has an explicit inline type annotation (line ~1175):
+
+```typescript
+let coreResult: {
+  status: CronRunStatus;
+  delivered?: boolean;
+} & CronRunOutcome &
+  CronRunTelemetry;
+```
+
+Add `outputText?: string;` to the inline type:
+
+```typescript
+let coreResult: {
+  status: CronRunStatus;
+  delivered?: boolean;
+  outputText?: string;
+} & CronRunOutcome &
+  CronRunTelemetry;
+```
+
+Then find the `applyJobResult` call in the same function (line ~1187). Add `outputText`:
+
+```typescript
+const shouldDelete = applyJobResult(state, job, {
+  status: coreResult.status,
+  error: coreResult.error,
+  delivered: coreResult.delivered,
+  outputText: coreResult.outputText,
+  startedAt,
+  endedAt,
+});
+```
+
+- [ ] **Step 5: Verify types compile**
+
+Run: `pnpm tsgo`
+Expected: No new errors
+
+- [ ] **Step 6: Run existing service tests for regressions**
+
+Run: `pnpm test src/cron/service.persists-delivered-status.test.ts`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+scripts/committer "feat(cron): thread outputText through timer result chain" src/cron/service/timer.ts
+```
+
+---
+
+### Task 5: Recording — Store output in `applyJobResult`
+
+**Files:**
+
+- Modify: `src/cron/service/timer.ts:295-335` (applyJobResult)
+- Create: `src/cron/service.dedup-context-recording.test.ts`
+
+- [ ] **Step 1: Write failing integration test**
+
+Create `src/cron/service.dedup-context-recording.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createFinishedBarrier,
+  createCronStoreHarness,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+type CronAddInput = Parameters<CronService["add"]>[0];
+
+function buildDedupJob(name: string): CronAddInput {
+  return {
+    name,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "test", dedupContext: true },
+    delivery: { mode: "none" },
+  };
+}
+
+describe("CronService dedup context recording", () => {
+  it("records outputText in recentOutputs when dedupContext is enabled and delivered", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: "Today's celebrity news: Actor X did Y",
+        delivered: true,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildDedupJob("dedup-record"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toBeDefined();
+      expect(updated?.state.recentOutputs).toHaveLength(1);
+      expect(updated?.state.recentOutputs![0].text).toBe("Today's celebrity news: Actor X did Y");
+      expect(updated?.state.recentOutputs![0].timestamp).toBeGreaterThan(0);
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("does not record when dedupContext is not enabled", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: "some output",
+        delivered: true,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add({
+        ...buildDedupJob("no-dedup"),
+        payload: { kind: "agentTurn", message: "test" },
+      });
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toBeUndefined();
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("does not record when delivery fails", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: "some output",
+        delivered: false,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildDedupJob("no-delivery"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toBeUndefined();
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("caps recentOutputs at 5 entries (FIFO)", async () => {
+    const store = await makeStorePath();
+    let runCount = 0;
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        runCount++;
+        return {
+          status: "ok" as const,
+          summary: "done",
+          outputText: `output-${runCount}`,
+          delivered: true,
+        };
+      }),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildDedupJob("cap-test"));
+
+      // Run 6 times — waitForOk clears the internal resolver after resolution,
+      // so calling it again re-registers for the next finished event.
+      for (let i = 0; i < 6; i++) {
+        vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+        await vi.runOnlyPendingTimersAsync();
+        await finished.waitForOk(job.id);
+        // Re-read job state for next iteration's nextRunAtMs
+        const jobs = await cron.list({ includeDisabled: true });
+        const updated = jobs.find((j) => j.id === job.id)!;
+        Object.assign(job.state, updated.state);
+      }
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toHaveLength(5);
+      // Oldest (output-1) should be dropped, newest 5 remain
+      expect(updated?.state.recentOutputs![0].text).toBe("output-2");
+      expect(updated?.state.recentOutputs![4].text).toBe("output-6");
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("truncates output text at 500 characters", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const longText = "x".repeat(600);
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: longText,
+        delivered: true,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildDedupJob("truncate-test"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs![0].text).toHaveLength(500);
+    } finally {
+      cron.stop();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test src/cron/service.dedup-context-recording.test.ts`
+Expected: FAIL — `recentOutputs` is undefined (recording logic not yet implemented)
+
+- [ ] **Step 3: Add `outputText` to `applyJobResult` parameter type and recording logic**
+
+In `src/cron/service/timer.ts`, find `applyJobResult` (line 295). Add import at the top of the file:
+
+```typescript
+import { DEDUP_MAX_OUTPUTS, DEDUP_MAX_CHARS_PER_OUTPUT } from "../isolated-agent/dedup-context.js";
+```
+
+Extend the `result` parameter type to include `outputText`:
+
+```typescript
+export function applyJobResult(
+  state: CronServiceState,
+  job: CronJob,
+  result: {
+    status: CronRunStatus;
+    error?: string;
+    delivered?: boolean;
+    outputText?: string;
+    startedAt: number;
+    endedAt: number;
+  },
+  // ...
+```
+
+After the existing `job.updatedAtMs = result.endedAt;` line (line ~335), add:
+
+```typescript
+// Record delivered output for dedup context (only when enabled and delivered).
+if (
+  result.delivered &&
+  result.outputText?.trim() &&
+  job.payload.kind === "agentTurn" &&
+  job.payload.dedupContext
+) {
+  const outputs = job.state.recentOutputs ?? [];
+  outputs.push({
+    text: result.outputText.slice(0, DEDUP_MAX_CHARS_PER_OUTPUT),
+    timestamp: result.endedAt,
+  });
+  if (outputs.length > DEDUP_MAX_OUTPUTS) {
+    outputs.splice(0, outputs.length - DEDUP_MAX_OUTPUTS);
+  }
+  job.state.recentOutputs = outputs;
+}
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `pnpm test src/cron/service.dedup-context-recording.test.ts`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Run full cron test suite for regressions**
+
+Run: `pnpm test src/cron/`
+Expected: All PASS
+
+- [ ] **Step 6: Verify types compile**
+
+Run: `pnpm tsgo`
+Expected: No new errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+scripts/committer "feat(cron): record delivered output for dedup context" src/cron/service/timer.ts src/cron/service.dedup-context-recording.test.ts
+```

--- a/docs/superpowers/specs/2026-03-12-bot-history-pending-flush-design.md
+++ b/docs/superpowers/specs/2026-03-12-bot-history-pending-flush-design.md
@@ -1,0 +1,266 @@
+# Bot History: Pending Flush to Session Transcript
+
+## Problem
+
+When the bot sends proactive messages (cron jobs, scheduled tasks) to a Telegram chat, these messages are not included in the LLM's conversation context. When a user asks about those messages, the LLM denies having sent them.
+
+### Root Cause
+
+- Cron delivery calls `deliverOutboundPayloads` **without** the `mirror` parameter
+- Without `mirror`, the delivered text is never written to any session transcript
+- The Telegram inbound handler's `groupHistories` only records **user** messages, not bot outbound messages
+- The cron agent's session is isolated from the Telegram chat's session — they use different session keys
+
+### Example
+
+1. Cron sends "抢到红包！金额: 3 USDC" to a Telegram group
+2. User replies "真的么？"
+3. Bot says "我没说过..." (denies its own message)
+
+## Solution: Pending Buffer + Flush at Inbound
+
+A two-phase approach that bridges cron delivery and session transcripts without coupling the delivery layer to session management.
+
+**Phase 1 (Delivery time):** Record the delivered text to a lightweight JSON store keyed by `channel + to + threadId`.
+
+**Phase 2 (Inbound time):** When a user message arrives, flush pending entries into the correct session transcript using the existing `appendAssistantMessageToSessionTranscript` infrastructure.
+
+### Why This Approach
+
+- **Reuses existing infrastructure**: `appendAssistantMessageToSessionTranscript` is already production-ready (used by the `mirror` flow in `deliver.ts`)
+- **No cross-layer coupling**: Delivery layer writes to a simple buffer; session key resolution stays in the inbound handler where it naturally belongs
+- **Persistent**: JSON file survives restarts (unlike in-memory-only approaches)
+- **Channel-agnostic**: Works for any channel, not just Telegram
+
+## Components
+
+### 1. Pending Bot History Store
+
+**File**: `src/auto-reply/reply/bot-history.ts`
+
+Follows the cron store pattern (`src/cron/store.ts`): JSON file + atomic write (tmp + rename) + in-memory cache.
+
+**Store path**: `~/.openclaw/bot-history/pending.json`
+
+```typescript
+type BotHistoryEntry = {
+  id: string; // unique identifier (crypto.randomUUID())
+  channel: string; // "telegram", "discord", etc.
+  to: string; // delivery target in codebase format (e.g., "telegram:-100123456")
+  accountId?: string; // optional account discriminator
+  threadId?: string; // optional thread/topic ID (Telegram forum topics)
+  text: string; // delivered text content
+  timestamp: number; // Date.now()
+  source?: string; // origin: "cron" | "heartbeat" | "manual" (for debugging)
+};
+
+type BotHistoryStore = {
+  version: 1;
+  entries: BotHistoryEntry[];
+};
+```
+
+**Exported functions:**
+
+- `appendBotHistoryEntry(entry: Omit<BotHistoryEntry, 'id'>)` — Append an entry to the store (delivery time). Generates `id` via `crypto.randomUUID()` internally. Also triggers compaction when entry count exceeds threshold.
+- `readBotHistoryEntries({ channel, to, accountId?, threadId? })` — Read matching entries without removing them. Matching uses strict equality: `entry.accountId === query.accountId` and `entry.threadId === query.threadId` (both `undefined` = match; different values = no match). This ensures cron delivery to account-A is only flushed when inbound is also from account-A.
+- `removeBotHistoryEntries(ids: string[])` — Remove specific entries by `id` (after successful flush)
+- `flushBotHistoryToTranscript({ channel, to, accountId?, threadId?, sessionKey, agentId })` — Read matching entries, write each to session transcript, remove only successfully flushed entries
+- `compactBotHistoryStore()` — Remove entries older than TTL. Called lazily: on first store load, and when entry count exceeds threshold during `appendBotHistoryEntry`. No dedicated startup hook needed — the first read or write triggers compaction if stale entries exist.
+
+**Constraints:**
+
+- Max 500 entries total (prevents unbounded growth)
+- 24-hour TTL (entries older than this are discarded on compaction)
+- Atomic write with tmp + rename (crash-safe)
+- In-memory cache to avoid unnecessary file I/O (same pattern as `serializedStoreCache` in cron store)
+
+### 2. Recording Point
+
+**File**: `src/cron/isolated-agent/delivery-dispatch.ts`
+
+**Location**: Inside the `deliverViaDirect` closure, immediately after `delivered = deliveryResults.length > 0` (line 275). This is the single point where actual channel delivery happens — it captures both the direct delivery path (line 454) and the `finalizeTextDelivery` path (line 411). Early returns before this point (active subagent runs, interim message suppression, silent reply) never reach actual delivery, so no recording is needed for those.
+
+```typescript
+delivered = deliveryResults.length > 0;
+if (delivered && synthesizedText?.trim()) {
+  appendBotHistoryEntry({
+    channel: delivery.channel,
+    to: delivery.to,
+    accountId: delivery.accountId,
+    threadId: delivery.threadId != null ? String(delivery.threadId) : undefined,
+    text: synthesizedText.trim(),
+    timestamp: Date.now(),
+    source: "cron",
+  }).catch(() => {}); // best-effort, don't block delivery
+}
+return null;
+```
+
+**Why inside `deliverViaDirect` (not at function end or in `deliver.ts`):**
+
+- `dispatchCronDelivery` has 8+ early return paths; placing at function end would miss deliveries that exit early
+- `deliverViaDirect` is the single funnel — ALL successful cron channel sends go through it
+- Closure captures `synthesizedText` from outer scope — no parameter threading needed
+- `delivery` parameter is already typed as `SuccessfulDeliveryTarget` — no `.ok` guard needed
+- More targeted than `deliver.ts` — only records cron deliveries, which are the actual problem
+- Other non-mirror, non-cron outbound paths (heartbeat, webhook-triggered push, etc.) can add their own recording at the source with the appropriate `source` tag
+
+> **Note for implementers:** Add a code comment at the recording site explaining that other proactive outbound paths should add their own `appendBotHistoryEntry` call if they also bypass the `mirror` parameter.
+
+### 3. Flush Point
+
+**File**: `src/auto-reply/reply/get-reply.ts`
+
+**Location**: In `getReplyFromConfig()`, after `initSessionState()` and before `runPreparedReply()`.
+
+```typescript
+// existing code:
+const sessionState = await initSessionState({ ctx: finalized, cfg, commandAuthorized });
+let { sessionKey /* ...other destructured fields... */ } = sessionState;
+
+// ──── INSERT HERE ────
+// Flush pending bot messages into the current session transcript
+await flushBotHistoryToTranscript({
+  channel: finalized.OriginatingChannel,
+  to: finalized.OriginatingTo,
+  accountId: finalized.AccountId,
+  threadId: finalized.MessageThreadId != null ? String(finalized.MessageThreadId) : undefined,
+  sessionKey,
+  agentId,
+}).catch(() => {}); // best-effort
+```
+
+**Why here:**
+
+- `getReplyFromConfig` is the unified entry point for all channels (channel-agnostic)
+- After `initSessionState()` + destructuring: `sessionKey` is available and session is guaranteed to exist
+- Before agent execution: transcript will include flushed messages when loaded
+- `finalized` (the inbound context) already carries `OriginatingChannel`, `OriginatingTo`, `AccountId`, and `MessageThreadId` (verified in `src/auto-reply/templating.ts:49,149`) — no new parameters needed
+
+> **Note:** Some fast-abort paths in `dispatch-from-config.ts` short-circuit before reaching `getReplyFromConfig`. Those paths produce non-agent replies and won't trigger a flush. Pending entries will be flushed on the next full agent reply turn. This is acceptable since fast-abort replies don't involve LLM context.
+
+### `flushBotHistoryToTranscript` Implementation
+
+```typescript
+export async function flushBotHistoryToTranscript(params: {
+  channel: string;
+  to: string;
+  accountId?: string;
+  threadId?: string;
+  sessionKey: string;
+  agentId: string;
+}): Promise<number> {
+  const entries = await readBotHistoryEntries({
+    channel: params.channel,
+    to: params.to,
+    accountId: params.accountId,
+    threadId: params.threadId,
+  });
+  if (entries.length === 0) return 0;
+
+  entries.sort((a, b) => a.timestamp - b.timestamp);
+
+  // Flush each entry to the session transcript individually.
+  // Only remove entries that were successfully written — if a write fails,
+  // the entry stays in the pending store for the next flush attempt.
+  const flushedIds: string[] = [];
+  for (const entry of entries) {
+    const result = await appendAssistantMessageToSessionTranscript({
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      text: entry.text,
+    });
+    if (result.ok) {
+      flushedIds.push(entry.id);
+    }
+  }
+
+  if (flushedIds.length > 0) {
+    await removeBotHistoryEntries(flushedIds);
+  }
+  return flushedIds.length;
+}
+```
+
+**Key detail:** Entries are read without removal, then only successfully flushed entries are removed. This prevents data loss if `appendAssistantMessageToSessionTranscript` fails partway through a batch.
+
+## Data Flow
+
+```
+Cron Agent Turn
+  │
+  ▼
+  synthesizedText = "🧧 抢到红包！金额: 3 USDC"
+  │
+  ▼
+  deliverOutboundPayloads() → Telegram API sends message
+  │
+  ▼
+  appendBotHistoryEntry()
+  → ~/.openclaw/bot-history/pending.json
+    { id:"a1b2c3...", channel:"telegram", to:"telegram:-100xxx",
+      text:"🧧 抢到红包！...", timestamp:1741795200000, source:"cron" }
+
+                ⏳ User sees the message...
+
+Telegram Inbound: "真的么？"
+  │
+  ▼
+  getReplyFromConfig(ctx)
+  │
+  ▼
+  initSessionState() → session exists
+  │
+  ▼
+  flushBotHistoryToTranscript()
+  → reads pending.json, finds matching channel+to+threadId entries
+  → appendAssistantMessageToSessionTranscript() writes to session transcript
+  → removes only successfully flushed entries from pending.json
+  │
+  ▼
+  runPreparedReply() → agent loads transcript
+  │
+  ▼
+  LLM sees:
+    [assistant] 🧧 抢到红包！金额: 3 USDC
+    [user] 真的么？
+  │
+  ▼
+  LLM replies: "是的，你抢到了 3 USDC"
+```
+
+## Edge Cases
+
+| Scenario                                                  | Behavior                                                                                                                                                                                                                                                                   |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Session doesn't exist yet (first message in chat)         | `initSessionState()` creates the session before flush runs                                                                                                                                                                                                                 |
+| No pending entries                                        | Flush reads cache, finds nothing, returns immediately (negligible overhead)                                                                                                                                                                                                |
+| Cron sends multiple messages before user replies          | All entries accumulate, flushed in chronological order on next inbound                                                                                                                                                                                                     |
+| Process restarts between cron delivery and user message   | Entries persisted to JSON file, restored on startup                                                                                                                                                                                                                        |
+| Entries older than 24h                                    | Removed by `compactBotHistoryStore()` on startup                                                                                                                                                                                                                           |
+| Multiple users ask about the same cron message in a group | First user's message triggers flush to transcript; subsequent messages in the same session see it in the transcript                                                                                                                                                        |
+| DM cron delivery                                          | Same flow — channel + to matching works for both DM and group                                                                                                                                                                                                              |
+| Telegram forum topics                                     | `threadId` is captured at recording and matched at flush; different topics in the same group map to different session keys, so entries go to the correct transcript                                                                                                        |
+| Multi-account setup                                       | `accountId` matching prevents cross-account pollution (cron delivery from account-A won't be flushed into account-B's session)                                                                                                                                             |
+| Partial flush failure                                     | Only successfully written entries are removed from pending store; failed entries remain for retry on the next inbound message                                                                                                                                              |
+| Concurrent cron delivery + inbound message                | Node.js single-threaded event loop; atomic file writes ensure consistency                                                                                                                                                                                                  |
+| Concurrent flush from two users in same group             | Both handlers may read the same pending entries between await points; worst case is a duplicate assistant message in the transcript, which is harmless for LLM context quality. Accepted trade-off for v1 — a per-key flush lock can be added if this becomes a real issue |
+
+## Changes Summary
+
+| File                                           | Change                                    | Estimated Lines |
+| ---------------------------------------------- | ----------------------------------------- | --------------- |
+| `src/auto-reply/reply/bot-history.ts`          | **New** — pending store + flush functions | ~120            |
+| `src/cron/isolated-agent/delivery-dispatch.ts` | Record entry after successful delivery    | +8              |
+| `src/auto-reply/reply/get-reply.ts`            | Flush after `initSessionState()`          | +6              |
+| `src/auto-reply/reply/bot-history.test.ts`     | **New** — unit tests                      | ~150            |
+
+Total: ~300 lines of new code, 2 small insertion points. No changes to existing interfaces or types.
+
+## Testing Strategy
+
+- **Unit: `bot-history.test.ts`** — append, flush, compact, TTL expiry, max entries limit, atomic write safety
+- **Unit: `delivery-dispatch`** — mock `appendBotHistoryEntry`, verify called when `delivered && synthesizedText`
+- **Unit: `get-reply`** — mock `flushBotHistoryToTranscript`, verify called after `initSessionState` with correct sessionKey
+- **Integration** — cron delivery → pending entry exists → inbound message → session transcript contains bot message → LLM context includes it

--- a/docs/superpowers/specs/2026-03-13-cron-dedup-context-design.md
+++ b/docs/superpowers/specs/2026-03-13-cron-dedup-context-design.md
@@ -1,0 +1,234 @@
+# Cron Dedup Context: Inject Previous Outputs Into Isolated Agent Turns
+
+## Problem
+
+Isolated cron sessions (`sessionTarget: "isolated"`) create a fresh transcript per run. The agent cannot see what it previously delivered, leading to repetitive outputs.
+
+### Example
+
+A cron job configured to send a daily celebrity briefing:
+
+1. Run 1: "Today's celebrity news: Actor X attended Y event..."
+2. Run 2: "Today's celebrity news: Actor X attended Y event..." (nearly identical)
+3. Run 3: same pattern
+
+The agent has no memory of prior outputs, so it cannot avoid repetition.
+
+### Root Cause
+
+- `forceNew: true` in `resolveCronSession()` creates a new session ID and empty transcript every run
+- `CronJobState` only tracks `lastDelivered` (boolean), not the actual output text
+- No mechanism exists to pass previous outputs to the cron agent
+
+## Solution: Per-Job Output History in CronJobState
+
+Store recent delivered outputs in `job.state.recentOutputs` and inject them into the agent's system prompt when the job opts in via `dedupContext: true`.
+
+### Why This Approach
+
+- **Simplest**: no new store, no new file I/O — reuses the existing cron store persistence
+- **Lifecycle match**: output history belongs to the job; delete job = delete history
+- **Already on the hot path**: cron store is loaded/saved every run cycle
+- **Minimal overhead**: ~2.5KB per job worst case (5 entries x 500 chars)
+
+## Components
+
+### 1. Data Model Changes
+
+**File**: `src/cron/types.ts`
+
+Add to `CronJobState` (after line 133):
+
+```typescript
+export type CronJobState = {
+  // ... existing fields ...
+
+  /**
+   * Recent delivered outputs for dedup context injection.
+   * Capped at 5 entries, FIFO. Only populated when `payload.dedupContext` is enabled.
+   */
+  recentOutputs?: Array<{
+    /** Delivered text, truncated to 500 characters. */
+    text: string;
+    /** Timestamp (ms since epoch) when the output was delivered. */
+    timestamp: number;
+  }>;
+};
+```
+
+Add to `CronAgentTurnPayloadFields` (after line 100):
+
+```typescript
+export type CronAgentTurnPayloadFields = {
+  // ... existing fields ...
+
+  /**
+   * When true, inject recent delivered outputs into the agent's system prompt
+   * so it can avoid repeating the same content. Default: false.
+   */
+  dedupContext?: boolean;
+};
+```
+
+**Constants** (in the implementation file, not the type file):
+
+```typescript
+const DEDUP_MAX_OUTPUTS = 5;
+const DEDUP_MAX_CHARS_PER_OUTPUT = 500;
+```
+
+### 2. Recording Point
+
+**Strategy:** Reuse the existing `outputText` field on `RunCronAgentTurnResult` rather than adding a new field. `outputText` already represents the last non-empty agent text output, flows through the result chain, and reflects subagent final replies when applicable.
+
+The result chain is: `dispatchCronDelivery()` → `runCronIsolatedAgentTurn()` → `runIsolatedAgentJob()` → `executeJobCore()` → `applyJobResult()`.
+
+Currently `outputText` is available on `RunCronAgentTurnResult` and `runIsolatedAgentJob`'s return type, but is dropped by `executeJobCore()` which maps to a narrower `TimedCronRunOutcome`. We need to thread it through.
+
+**File**: `src/cron/service/timer.ts`
+
+1. Add `outputText?: string` to `TimedCronRunOutcome` (line ~46).
+
+2. In `executeJobCore()` (line ~1143), include `outputText` in the returned object from the `runIsolatedAgentJob` result.
+
+3. In `applyOutcomeToStoredJob()` (line ~491), pass `outputText` through to `applyJobResult`.
+
+4. In `applyJobResult()` (line 295), extend the `result` parameter type and add recording logic:
+
+```typescript
+export function applyJobResult(
+  state: CronServiceState,
+  job: CronJob,
+  result: {
+    // ... existing fields ...
+    outputText?: string;
+  },
+  // ...
+): boolean {
+```
+
+After the existing state updates (after line 335), add:
+
+```typescript
+// Record delivered output for dedup context (only when enabled and delivered).
+if (
+  result.delivered &&
+  result.outputText?.trim() &&
+  job.payload.kind === "agentTurn" &&
+  job.payload.dedupContext
+) {
+  const outputs = job.state.recentOutputs ?? [];
+  outputs.push({
+    text: result.outputText.slice(0, DEDUP_MAX_CHARS_PER_OUTPUT),
+    timestamp: result.endedAt,
+  });
+  if (outputs.length > DEDUP_MAX_OUTPUTS) {
+    outputs.splice(0, outputs.length - DEDUP_MAX_OUTPUTS);
+  }
+  job.state.recentOutputs = outputs;
+}
+```
+
+5. The `executeJob()` forced-execution path (line ~1161) also calls `applyJobResult` — ensure `outputText` is threaded through this path as well.
+
+### 3. Injection Point
+
+**File**: `src/cron/isolated-agent/run.ts`
+
+The system prompt assembly in `run.ts` (lines 441-480) builds a `base` string, then branches into external-hook vs. internal paths, and finally calls `appendCronDeliveryInstruction()` at line 480 to produce `commandBody`. The dedup block should be appended **after** `commandBody` is finalized (after line 480), so it doesn't get overwritten by the branching logic:
+
+```typescript
+commandBody = appendCronDeliveryInstruction({ commandBody, deliveryRequested });
+
+// ──── INSERT HERE ────
+const dedupBlock = buildDedupContextBlock(params.job);
+if (dedupBlock) {
+  commandBody = `${commandBody}\n\n${dedupBlock}`;
+}
+```
+
+**Helper function** (new, in the same file or a small helper):
+
+```typescript
+function buildDedupContextBlock(job: CronJob): string | undefined {
+  if (job.payload.kind !== "agentTurn" || !job.payload.dedupContext) {
+    return undefined;
+  }
+  const outputs = job.state.recentOutputs;
+  if (!outputs || outputs.length === 0) {
+    return undefined;
+  }
+
+  const tz = job.schedule.kind === "cron" ? job.schedule.tz : undefined;
+  const lines = outputs.map((o) => {
+    const date = new Date(o.timestamp);
+    const formatted = tz
+      ? date.toLocaleString("en-US", { timeZone: tz, dateStyle: "short", timeStyle: "short" })
+      : date.toLocaleString("en-US", { dateStyle: "short", timeStyle: "short" });
+    return `- ${formatted}: ${o.text}`;
+  });
+
+  return [
+    "[Your previous outputs for this scheduled task — avoid repeating the same content:]",
+    ...lines,
+  ].join("\n");
+}
+```
+
+## Data Flow
+
+```
+Cron Job Run (isolated session)
+  │
+  ▼
+  buildDedupContextBlock(job)
+  → reads job.state.recentOutputs
+  → appends to agent system prompt (if dedupContext=true and outputs exist)
+  │
+  ▼
+  Agent turn executes with dedup context
+  → produces new, non-repetitive output
+  │
+  ▼
+  dispatchCronDelivery()
+  → delivers to channel
+  → outputText reflects final delivered text (including subagent replacements)
+  │
+  ▼
+  runCronIsolatedAgentTurn() → runIsolatedAgentJob() → executeJobCore()
+  → outputText threaded through result chain
+  │
+  ▼
+  applyJobResult()
+  → pushes { text: outputText, timestamp } to job.state.recentOutputs (capped at 5)
+  → saves cron store
+  │
+  ▼
+  Next run reads updated recentOutputs
+```
+
+## Edge Cases
+
+| Scenario                         | Behavior                                                                                                                                     |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dedupContext` not set (default) | No recording, no injection. Zero overhead.                                                                                                   |
+| First run (no previous outputs)  | No dedup block injected. Agent runs normally.                                                                                                |
+| Job delivery fails               | `result.delivered` is false; output NOT recorded (no false history).                                                                         |
+| Output exceeds 500 chars         | Truncated at 500 chars before storage.                                                                                                       |
+| 6th output arrives               | Oldest entry dropped (FIFO).                                                                                                                 |
+| Job disabled then re-enabled     | `recentOutputs` persists in job state; history survives.                                                                                     |
+| Job deleted                      | State deleted with job. No orphan cleanup.                                                                                                   |
+| Non-agentTurn payload            | Guard: `job.payload.kind === "agentTurn"` skips non-agent payloads.                                                                          |
+| Subagent orchestration           | `outputText` is updated to the subagent final reply (lines 366-377 in dispatch); that final text is what gets recorded via the result chain. |
+
+## Changes Summary
+
+| File                                                 | Change                                                                                                                                       | Estimated Lines |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `src/cron/types.ts`                                  | Add `recentOutputs` to state, `dedupContext` to payload                                                                                      | +12             |
+| `src/cron/isolated-agent/run.ts`                     | Inject dedup block after `commandBody`, add `buildDedupContextBlock` helper                                                                  | +30             |
+| `src/cron/service/timer.ts`                          | Thread `outputText` through `TimedCronRunOutcome`, `executeJobCore`, `executeJob`, `applyOutcomeToStoredJob`, and record in `applyJobResult` | +25             |
+| `src/cron/isolated-agent/run.test.ts` (or colocated) | Unit tests for `buildDedupContextBlock`                                                                                                      | +40             |
+| `src/cron/service/timer.test.ts` (or colocated)      | Unit tests for recording in `applyJobResult`                                                                                                 | +30             |
+
+Total: ~140 lines of new code across 3 existing files. No new files needed.

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -418,6 +418,28 @@ describe("cron tool", () => {
     expect(params?.sessionTarget).toBe("isolated");
   });
 
+  it("preserves outputHistory in agentTurn payload", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool({ agentSessionKey: "agent:main:discord:dm:buddy" });
+    await tool.execute("call-dedup", {
+      action: "add",
+      job: {
+        name: "daily-briefing",
+        schedule: { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "Send daily briefing", outputHistory: true },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | { payload?: { kind?: string; message?: string; outputHistory?: boolean } }
+      | undefined;
+    expect(params?.payload?.kind).toBe("agentTurn");
+    expect(params?.payload?.outputHistory).toBe(true);
+  });
+
   it("does not recover flat params when no meaningful job field is present", async () => {
     const tool = createCronTool();
     await expect(

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -249,7 +249,8 @@ PAYLOAD TYPES (payload.kind):
 - "systemEvent": Injects text as system event into session
   { "kind": "systemEvent", "text": "<message>" }
 - "agentTurn": Runs agent with message (isolated sessions only)
-  { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional, 0 means no timeout> }
+  { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional, 0 means no timeout>, "outputHistory": <optional-bool> }
+  - outputHistory: set true to include recent delivery outputs as context for the agent. Useful for any recurring task where seeing previous outputs helps — avoiding repetition, tracking changes, building on prior results, etc. Default: false.
 
 DELIVERY (top-level):
   { "mode": "none|announce|webhook", "channel": "<optional>", "to": "<optional>", "bestEffort": <optional-bool> }

--- a/src/auto-reply/reply/bot-history.test.ts
+++ b/src/auto-reply/reply/bot-history.test.ts
@@ -1,0 +1,364 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/sessions/transcript.js", () => ({
+  appendAssistantMessageToSessionTranscript: vi.fn(),
+}));
+
+let fixtureRoot: string;
+let storeCounter = 0;
+
+function makeStorePath(): string {
+  storeCounter += 1;
+  return path.join(fixtureRoot, `pending-${storeCounter}.json`);
+}
+
+beforeAll(async () => {
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "bot-history-test-"));
+});
+
+afterAll(async () => {
+  await fs.rm(fixtureRoot, { recursive: true, force: true });
+});
+
+describe("bot-history store", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("readBotHistoryEntries returns [] when store does not exist", async () => {
+    const { _resetBotHistoryCache, readBotHistoryEntries } = await import("./bot-history.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    const result = await readBotHistoryEntries({ channel: "telegram", to: "user1" }, { storePath });
+    expect(result).toEqual([]);
+  });
+
+  it("appendBotHistoryEntry writes and readBotHistoryEntries retrieves", async () => {
+    const { _resetBotHistoryCache, appendBotHistoryEntry, readBotHistoryEntries } =
+      await import("./bot-history.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    await appendBotHistoryEntry(
+      {
+        channel: "telegram",
+        to: "user1",
+        text: "hello",
+        timestamp: Date.now(),
+      },
+      { storePath },
+    );
+    const entries = await readBotHistoryEntries(
+      { channel: "telegram", to: "user1" },
+      { storePath },
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.text).toBe("hello");
+    expect(entries[0]?.id).toBeDefined();
+  });
+
+  it("readBotHistoryEntries filters by channel + to", async () => {
+    const { _resetBotHistoryCache, appendBotHistoryEntry, readBotHistoryEntries } =
+      await import("./bot-history.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    const now = Date.now();
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "msg-a", timestamp: now },
+      { storePath },
+    );
+    await appendBotHistoryEntry(
+      { channel: "discord", to: "user1", text: "msg-b", timestamp: now },
+      { storePath },
+    );
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user2", text: "msg-c", timestamp: now },
+      { storePath },
+    );
+
+    const results = await readBotHistoryEntries(
+      { channel: "telegram", to: "user1" },
+      { storePath },
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0]?.text).toBe("msg-a");
+  });
+
+  it("readBotHistoryEntries uses strict equality for accountId and threadId", async () => {
+    const { _resetBotHistoryCache, appendBotHistoryEntry, readBotHistoryEntries } =
+      await import("./bot-history.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    const now = Date.now();
+
+    // Entry with accountId + threadId
+    await appendBotHistoryEntry(
+      {
+        channel: "telegram",
+        to: "user1",
+        accountId: "acct-A",
+        threadId: "thread-42",
+        text: "targeted",
+        timestamp: now,
+      },
+      { storePath },
+    );
+    // Entry with different accountId
+    await appendBotHistoryEntry(
+      {
+        channel: "telegram",
+        to: "user1",
+        accountId: "acct-C",
+        threadId: "thread-42",
+        text: "other-acct",
+        timestamp: now,
+      },
+      { storePath },
+    );
+
+    // Exact match
+    const exact = await readBotHistoryEntries(
+      { channel: "telegram", to: "user1", accountId: "acct-A", threadId: "thread-42" },
+      { storePath },
+    );
+    expect(exact).toHaveLength(1);
+    expect(exact[0]?.text).toBe("targeted");
+
+    // Different accountId — should not match
+    const wrongAcct = await readBotHistoryEntries(
+      { channel: "telegram", to: "user1", accountId: "acct-C", threadId: "thread-42" },
+      { storePath },
+    );
+    expect(wrongAcct).toHaveLength(1);
+    expect(wrongAcct[0]?.text).toBe("other-acct");
+
+    // Undefined accountId query — should not match entries that have accountId set
+    const noAcct = await readBotHistoryEntries({ channel: "telegram", to: "user1" }, { storePath });
+    expect(noAcct).toHaveLength(0);
+  });
+
+  it("removeBotHistoryEntries removes specific entries by id", async () => {
+    const {
+      _resetBotHistoryCache,
+      appendBotHistoryEntry,
+      readBotHistoryEntries,
+      removeBotHistoryEntries,
+    } = await import("./bot-history.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    const now = Date.now();
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "keep", timestamp: now },
+      { storePath },
+    );
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "remove-me", timestamp: now + 1 },
+      { storePath },
+    );
+
+    const before = await readBotHistoryEntries({ channel: "telegram", to: "user1" }, { storePath });
+    expect(before).toHaveLength(2);
+
+    const removeId = before.find((e) => e.text === "remove-me")?.id;
+    expect(removeId).toBeDefined();
+    await removeBotHistoryEntries([removeId!], { storePath });
+
+    const after = await readBotHistoryEntries({ channel: "telegram", to: "user1" }, { storePath });
+    expect(after).toHaveLength(1);
+    expect(after[0]?.text).toBe("keep");
+  });
+
+  it("compactBotHistoryStore removes entries older than TTL", async () => {
+    const { _resetBotHistoryCache, appendBotHistoryEntry, compactBotHistoryStore } =
+      await import("./bot-history.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    const OLD_MS = 25 * 60 * 60 * 1000; // 25 hours ago — older than 24-hour TTL
+    const now = Date.now();
+
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "old", timestamp: now - OLD_MS },
+      { storePath },
+    );
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "fresh", timestamp: now },
+      { storePath },
+    );
+
+    const removed = await compactBotHistoryStore({ storePath });
+    expect(removed).toBe(1);
+
+    // Verify fresh entry still present via raw file read
+    const raw = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      entries: Array<{ text: string }>;
+    };
+    expect(raw.entries).toHaveLength(1);
+    expect(raw.entries[0]?.text).toBe("fresh");
+  });
+
+  it("appendBotHistoryEntry enforces max 500 entries", async () => {
+    const { _resetBotHistoryCache, appendBotHistoryEntry, readBotHistoryEntries } =
+      await import("./bot-history.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    const now = Date.now();
+
+    // Write 500 entries
+    for (let i = 0; i < 500; i++) {
+      await appendBotHistoryEntry(
+        { channel: "telegram", to: "user1", text: `msg-${i}`, timestamp: now + i },
+        { storePath },
+      );
+    }
+
+    // One more — should push out the oldest
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "msg-500", timestamp: now + 500 },
+      { storePath },
+    );
+
+    const entries = await readBotHistoryEntries(
+      { channel: "telegram", to: "user1" },
+      { storePath },
+    );
+    expect(entries.length).toBeLessThanOrEqual(500);
+    expect(entries.some((e) => e.text === "msg-0")).toBe(false);
+    expect(entries.some((e) => e.text === "msg-500")).toBe(true);
+  }, 30_000);
+
+  it("store persists to disk and survives cache reset", async () => {
+    const { _resetBotHistoryCache, appendBotHistoryEntry, readBotHistoryEntries } =
+      await import("./bot-history.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "persisted", timestamp: Date.now() },
+      { storePath },
+    );
+
+    // Reset the in-memory cache to force a disk read
+    _resetBotHistoryCache();
+
+    const entries = await readBotHistoryEntries(
+      { channel: "telegram", to: "user1" },
+      { storePath },
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.text).toBe("persisted");
+  });
+});
+
+describe("flushBotHistoryToTranscript", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("flushes matching entries to session transcript and removes them", async () => {
+    const { _resetBotHistoryCache, appendBotHistoryEntry, flushBotHistoryToTranscript } =
+      await import("./bot-history.js");
+    const { appendAssistantMessageToSessionTranscript } =
+      await import("../../config/sessions/transcript.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    const now = Date.now();
+
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "first", timestamp: now },
+      { storePath },
+    );
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "second", timestamp: now + 1 },
+      { storePath },
+    );
+
+    vi.mocked(appendAssistantMessageToSessionTranscript).mockResolvedValue({
+      ok: true,
+      sessionFile: "/tmp/test.jsonl",
+    });
+
+    const count = await flushBotHistoryToTranscript({
+      channel: "telegram",
+      to: "user1",
+      sessionKey: "sk-test",
+      agentId: "agent-1",
+      storePath,
+    });
+
+    expect(count).toBe(2);
+    expect(appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(2);
+
+    // Entries should be removed after successful flush
+    const { readBotHistoryEntries } = await import("./bot-history.js");
+    const remaining = await readBotHistoryEntries(
+      { channel: "telegram", to: "user1" },
+      { storePath },
+    );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("returns 0 when no matching entries exist", async () => {
+    const { _resetBotHistoryCache, flushBotHistoryToTranscript } = await import("./bot-history.js");
+    const { appendAssistantMessageToSessionTranscript } =
+      await import("../../config/sessions/transcript.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+
+    const count = await flushBotHistoryToTranscript({
+      channel: "telegram",
+      to: "no-such-user",
+      sessionKey: "sk-test",
+      agentId: "agent-1",
+      storePath,
+    });
+
+    expect(count).toBe(0);
+    expect(appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
+  });
+
+  it("keeps entries that fail to flush", async () => {
+    const {
+      _resetBotHistoryCache,
+      appendBotHistoryEntry,
+      flushBotHistoryToTranscript,
+      readBotHistoryEntries,
+    } = await import("./bot-history.js");
+    const { appendAssistantMessageToSessionTranscript } =
+      await import("../../config/sessions/transcript.js");
+    _resetBotHistoryCache();
+    const storePath = makeStorePath();
+    const now = Date.now();
+
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "ok-entry", timestamp: now },
+      { storePath },
+    );
+    await appendBotHistoryEntry(
+      { channel: "telegram", to: "user1", text: "fail-entry", timestamp: now + 1 },
+      { storePath },
+    );
+
+    // First call succeeds, second fails
+    vi.mocked(appendAssistantMessageToSessionTranscript)
+      .mockResolvedValueOnce({ ok: true, sessionFile: "/tmp/test.jsonl" })
+      .mockResolvedValueOnce({ ok: false, reason: "unknown sessionKey" });
+
+    const count = await flushBotHistoryToTranscript({
+      channel: "telegram",
+      to: "user1",
+      sessionKey: "sk-test",
+      agentId: "agent-1",
+      storePath,
+    });
+
+    expect(count).toBe(1);
+
+    // Failed entry should remain in the store
+    const remaining = await readBotHistoryEntries(
+      { channel: "telegram", to: "user1" },
+      { storePath },
+    );
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.text).toBe("fail-entry");
+  });
+});

--- a/src/auto-reply/reply/bot-history.ts
+++ b/src/auto-reply/reply/bot-history.ts
@@ -1,0 +1,235 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { appendAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.js";
+import { CONFIG_DIR } from "../../utils.js";
+
+// ── Types ──
+
+export type BotHistoryEntry = {
+  id: string;
+  channel: string;
+  to: string;
+  accountId?: string;
+  threadId?: string;
+  text: string;
+  timestamp: number;
+  source?: string;
+};
+
+type BotHistoryStore = {
+  version: 1;
+  entries: BotHistoryEntry[];
+};
+
+// ── Constants ──
+
+const DEFAULT_BOT_HISTORY_DIR = path.join(CONFIG_DIR, "bot-history");
+const DEFAULT_STORE_PATH = path.join(DEFAULT_BOT_HISTORY_DIR, "pending.json");
+const MAX_ENTRIES = 500;
+const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const COMPACTION_THRESHOLD = 400;
+
+// ── In-memory cache (same pattern as cron store's serializedStoreCache) ──
+
+const serializedStoreCache = new Map<string, string>();
+
+// ── Internal helpers ──
+
+function resolveStorePath(override?: string): string {
+  return override ?? DEFAULT_STORE_PATH;
+}
+
+async function loadStore(storePath: string): Promise<BotHistoryStore> {
+  try {
+    const raw = await fs.promises.readFile(storePath, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const record = parsed as Record<string, unknown>;
+      const entries = Array.isArray(record.entries) ? (record.entries as BotHistoryEntry[]) : [];
+      const store: BotHistoryStore = { version: 1, entries };
+      serializedStoreCache.set(storePath, JSON.stringify(store));
+      return store;
+    }
+    return { version: 1, entries: [] };
+  } catch (err) {
+    if ((err as { code?: string })?.code === "ENOENT") {
+      serializedStoreCache.delete(storePath);
+      return { version: 1, entries: [] };
+    }
+    throw err;
+  }
+}
+
+async function saveStore(storePath: string, store: BotHistoryStore): Promise<void> {
+  const storeDir = path.dirname(storePath);
+  await fs.promises.mkdir(storeDir, { recursive: true, mode: 0o700 });
+  await fs.promises.chmod(storeDir, 0o700).catch(() => undefined);
+  const json = JSON.stringify(store);
+  const cached = serializedStoreCache.get(storePath);
+  if (cached === json) {
+    return;
+  }
+  const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
+  await fs.promises.chmod(tmp, 0o600).catch(() => undefined);
+  await renameWithRetry(tmp, storePath);
+  await fs.promises.chmod(storePath, 0o600).catch(() => undefined);
+  serializedStoreCache.set(storePath, json);
+}
+
+const RENAME_MAX_RETRIES = 3;
+const RENAME_BASE_DELAY_MS = 50;
+
+async function renameWithRetry(src: string, dest: string): Promise<void> {
+  for (let attempt = 0; attempt <= RENAME_MAX_RETRIES; attempt++) {
+    try {
+      await fs.promises.rename(src, dest);
+      return;
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === "EBUSY" && attempt < RENAME_MAX_RETRIES) {
+        await new Promise((resolve) => setTimeout(resolve, RENAME_BASE_DELAY_MS * 2 ** attempt));
+        continue;
+      }
+      if (code === "EPERM" || code === "EEXIST") {
+        await fs.promises.copyFile(src, dest);
+        await fs.promises.unlink(src).catch(() => {});
+        return;
+      }
+      throw err;
+    }
+  }
+}
+
+// ── Exported functions ──
+
+type StoreOptions = { storePath?: string };
+
+/**
+ * Normalize `to` to match the OriginatingTo format used by each channel's
+ * inbound handler. This ensures recording and flushing use the same key.
+ *
+ * Telegram: OriginatingTo is always "telegram:{chatId}", but cron delivery.to
+ *   may be a bare chatId when set explicitly by the job config.
+ * Other channels: delivery.to already matches OriginatingTo format.
+ */
+export function normalizeToForBotHistory(channel: string, to: string): string {
+  if (channel === "telegram" && !to.startsWith("telegram:")) {
+    return `telegram:${to}`;
+  }
+  return to;
+}
+
+export async function readBotHistoryEntries(
+  query: { channel: string; to: string; accountId?: string; threadId?: string },
+  opts?: StoreOptions,
+): Promise<BotHistoryEntry[]> {
+  const storePath = resolveStorePath(opts?.storePath);
+  const store = await loadStore(storePath);
+  return store.entries.filter(
+    (e) =>
+      e.channel === query.channel &&
+      e.to === query.to &&
+      e.accountId === query.accountId &&
+      e.threadId === query.threadId,
+  );
+}
+
+export async function appendBotHistoryEntry(
+  entry: Omit<BotHistoryEntry, "id">,
+  opts?: StoreOptions,
+): Promise<void> {
+  const storePath = resolveStorePath(opts?.storePath);
+  const store = await loadStore(storePath);
+
+  // Lazy compaction when threshold exceeded
+  if (store.entries.length >= COMPACTION_THRESHOLD) {
+    compactEntries(store);
+  }
+
+  // Enforce max entries — drop oldest if at capacity
+  if (store.entries.length >= MAX_ENTRIES) {
+    store.entries.sort((a, b) => a.timestamp - b.timestamp);
+    store.entries.splice(0, store.entries.length - MAX_ENTRIES + 1);
+  }
+
+  store.entries.push({ ...entry, id: randomUUID() });
+  await saveStore(storePath, store);
+}
+
+export async function removeBotHistoryEntries(ids: string[], opts?: StoreOptions): Promise<void> {
+  if (ids.length === 0) {
+    return;
+  }
+  const storePath = resolveStorePath(opts?.storePath);
+  const store = await loadStore(storePath);
+  const idSet = new Set(ids);
+  store.entries = store.entries.filter((e) => !idSet.has(e.id));
+  await saveStore(storePath, store);
+}
+
+export async function compactBotHistoryStore(opts?: StoreOptions): Promise<number> {
+  const storePath = resolveStorePath(opts?.storePath);
+  const store = await loadStore(storePath);
+  const before = store.entries.length;
+  compactEntries(store);
+  if (store.entries.length !== before) {
+    await saveStore(storePath, store);
+  }
+  return before - store.entries.length;
+}
+
+function compactEntries(store: BotHistoryStore): void {
+  const cutoff = Date.now() - TTL_MS;
+  store.entries = store.entries.filter((e) => e.timestamp > cutoff);
+}
+
+export async function flushBotHistoryToTranscript(params: {
+  channel: string;
+  to: string;
+  accountId?: string;
+  threadId?: string;
+  sessionKey: string;
+  agentId: string;
+  storePath?: string;
+}): Promise<number> {
+  const entries = await readBotHistoryEntries(
+    {
+      channel: params.channel,
+      to: params.to,
+      accountId: params.accountId,
+      threadId: params.threadId,
+    },
+    { storePath: params.storePath },
+  );
+  if (entries.length === 0) {
+    return 0;
+  }
+
+  entries.sort((a, b) => a.timestamp - b.timestamp);
+
+  // Flush each entry individually. Only remove entries that succeed —
+  // failed entries stay for the next flush attempt.
+  const flushedIds: string[] = [];
+  for (const entry of entries) {
+    const result = await appendAssistantMessageToSessionTranscript({
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      text: `[Sent via scheduled task (${entry.source ?? "cron"})]\n${entry.text}`,
+    });
+    if (result.ok) {
+      flushedIds.push(entry.id);
+    }
+  }
+
+  if (flushedIds.length > 0) {
+    await removeBotHistoryEntries(flushedIds, { storePath: params.storePath });
+  }
+  return flushedIds.length;
+}
+
+// For tests: reset the in-memory cache
+export function _resetBotHistoryCache(): void {
+  serializedStoreCache.clear();
+}

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -17,6 +17,7 @@ import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { flushBotHistoryToTranscript } from "./bot-history.js";
 import { emitResetCommandHooks, type ResetCommandAction } from "./commands-core.js";
 import { resolveDefaultModel } from "./directive-handling.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
@@ -172,6 +173,26 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
     bodyStripped,
   } = sessionState;
+
+  // Flush pending bot messages (e.g. cron deliveries) into the current
+  // session transcript so the LLM sees them as prior assistant messages.
+  // Only for group chats — DM cron runs share the main session, so the
+  // agent turn already writes to the same transcript.
+  if (
+    cfg.session?.cronHistoryFlush &&
+    isGroup &&
+    finalized.OriginatingChannel &&
+    finalized.OriginatingTo
+  ) {
+    await flushBotHistoryToTranscript({
+      channel: finalized.OriginatingChannel,
+      to: finalized.OriginatingTo,
+      accountId: finalized.AccountId,
+      threadId: finalized.MessageThreadId != null ? String(finalized.MessageThreadId) : undefined,
+      sessionKey,
+      agentId,
+    }).catch(() => {}); // best-effort
+  }
 
   await applyResetModelOverride({
     cfg,

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -131,6 +131,11 @@ export type SessionConfig = {
   };
   /** Shared defaults for thread-bound session routing across channels/providers. */
   threadBindings?: SessionThreadBindingsConfig;
+  /**
+   * Flush cron-delivered bot messages into the chat session transcript so the
+   * LLM can recall what it previously sent via scheduled tasks. Default: false.
+   */
+  cronHistoryFlush?: boolean;
   /** Automatic session store maintenance (pruning, capping, file rotation). */
   maintenance?: SessionMaintenanceConfig;
 };

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,4 +1,8 @@
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
+import {
+  appendBotHistoryEntry,
+  normalizeToForBotHistory,
+} from "../../auto-reply/reply/bot-history.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
@@ -373,6 +377,20 @@ export async function dispatchCronDelivery(
       delivered = deliveryResults.length > 0;
       if (delivered) {
         rememberCompletedDirectCronDelivery(deliveryIdempotencyKey, deliveryResults);
+      }
+      // Record delivered bot message for later flush into the target chat's
+      // session transcript. Other proactive outbound paths that bypass the
+      // `mirror` parameter should add their own appendBotHistoryEntry call.
+      if (delivered && synthesizedText?.trim() && params.cfg.session?.cronHistoryFlush) {
+        appendBotHistoryEntry({
+          channel: delivery.channel,
+          to: normalizeToForBotHistory(delivery.channel, delivery.to),
+          accountId: delivery.accountId,
+          threadId: delivery.threadId != null ? String(delivery.threadId) : undefined,
+          text: synthesizedText.trim(),
+          timestamp: Date.now(),
+          source: "cron",
+        }).catch(() => {}); // best-effort, don't block delivery
       }
       return null;
     } catch (err) {

--- a/src/cron/isolated-agent/output-history.test.ts
+++ b/src/cron/isolated-agent/output-history.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import { buildOutputHistoryBlock, truncateOutputForHistory } from "./output-history.js";
+
+function makeJob(overrides?: {
+  outputHistory?: boolean;
+  recentOutputs?: Array<{ text: string; timestamp: number }>;
+  tz?: string;
+}): CronJob {
+  return {
+    id: "job-1",
+    name: "test-job",
+    description: "",
+    enabled: true,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    schedule: {
+      kind: "cron",
+      expr: "0 8 * * *",
+      ...(overrides?.tz ? { tz: overrides.tz } : {}),
+    },
+    payload: {
+      kind: "agentTurn",
+      message: "test",
+      ...(overrides?.outputHistory ? { outputHistory: true } : {}),
+    },
+    delivery: { mode: "none" },
+    state: overrides?.recentOutputs ? { recentOutputs: overrides.recentOutputs } : {},
+  } as CronJob;
+}
+
+describe("buildOutputHistoryBlock", () => {
+  it("returns undefined when outputHistory is not enabled", () => {
+    const job = makeJob({ recentOutputs: [{ text: "hello", timestamp: 1000 }] });
+    expect(buildOutputHistoryBlock(job)).toBeUndefined();
+  });
+
+  it("returns undefined when outputHistory is enabled but no outputs exist", () => {
+    const job = makeJob({ outputHistory: true });
+    expect(buildOutputHistoryBlock(job)).toBeUndefined();
+  });
+
+  it("returns undefined when recentOutputs is empty array", () => {
+    const job = makeJob({ outputHistory: true, recentOutputs: [] });
+    expect(buildOutputHistoryBlock(job)).toBeUndefined();
+  });
+
+  it("returns undefined for non-agentTurn payload", () => {
+    const job = makeJob({ outputHistory: true, recentOutputs: [{ text: "hi", timestamp: 1000 }] });
+    (job.payload as { kind: string }).kind = "systemEvent";
+    expect(buildOutputHistoryBlock(job)).toBeUndefined();
+  });
+
+  it("builds context block with formatted outputs", () => {
+    const job = makeJob({
+      outputHistory: true,
+      recentOutputs: [
+        { text: "First output", timestamp: 1710230400000 },
+        { text: "Second output", timestamp: 1710316800000 },
+      ],
+    });
+    const result = buildOutputHistoryBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("[Your previous outputs for this scheduled task");
+    expect(result).toContain("First output");
+    expect(result).toContain("Second output");
+    const firstIdx = result!.indexOf("First output");
+    const secondIdx = result!.indexOf("Second output");
+    expect(secondIdx).toBeGreaterThan(firstIdx);
+  });
+
+  it("uses job timezone for formatting when available", () => {
+    const job = makeJob({
+      outputHistory: true,
+      tz: "Asia/Shanghai",
+      recentOutputs: [{ text: "output", timestamp: 1710230400000 }],
+    });
+    const result = buildOutputHistoryBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("output");
+  });
+
+  it("works with every-schedule jobs (no tz field)", () => {
+    const job = makeJob({
+      outputHistory: true,
+      recentOutputs: [{ text: "output", timestamp: 1710230400000 }],
+    });
+    job.schedule = { kind: "every", everyMs: 60_000 };
+    const result = buildOutputHistoryBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("output");
+  });
+});
+
+describe("truncateOutputForHistory", () => {
+  it("returns short text unchanged", () => {
+    expect(truncateOutputForHistory("hello")).toBe("hello");
+  });
+
+  it("returns text at exactly the limit unchanged", () => {
+    const text = "x".repeat(600);
+    expect(truncateOutputForHistory(text)).toBe(text);
+  });
+
+  it("truncates long text keeping head and tail", () => {
+    const head = "H".repeat(400);
+    const middle = "M".repeat(200);
+    const tail = "T".repeat(400);
+    const result = truncateOutputForHistory(`${head}${middle}${tail}`);
+    expect(result).toContain("H".repeat(300));
+    expect(result).toContain("T".repeat(300));
+    expect(result).toContain("…");
+    expect(result.length).toBeLessThanOrEqual(603); // 300 + " … " + 300
+  });
+});

--- a/src/cron/isolated-agent/output-history.test.ts
+++ b/src/cron/isolated-agent/output-history.test.ts
@@ -104,14 +104,22 @@ describe("truncateOutputForHistory", () => {
     expect(truncateOutputForHistory(text)).toBe(text);
   });
 
-  it("truncates long text keeping head and tail", () => {
+  it("truncates long text keeping head and tail within limit", () => {
     const head = "H".repeat(400);
     const middle = "M".repeat(200);
     const tail = "T".repeat(400);
     const result = truncateOutputForHistory(`${head}${middle}${tail}`);
-    expect(result).toContain("H".repeat(300));
-    expect(result).toContain("T".repeat(300));
+    expect(result).toContain("H".repeat(298));
+    expect(result).toContain("T".repeat(298));
     expect(result).toContain("…");
-    expect(result.length).toBeLessThanOrEqual(603); // 300 + " … " + 300
+    // partLen = floor((600 - 3) / 2) = 298; total = 298 + " … " + 298 = 599
+    expect(result.length).toBeLessThanOrEqual(600);
+  });
+
+  it("does not expand text in the 601-602 char range", () => {
+    const text = "A".repeat(601);
+    const result = truncateOutputForHistory(text);
+    expect(result.length).toBeLessThanOrEqual(600);
+    expect(result).toContain("…");
   });
 });

--- a/src/cron/isolated-agent/output-history.ts
+++ b/src/cron/isolated-agent/output-history.ts
@@ -1,0 +1,40 @@
+import type { CronJob } from "../types.js";
+
+export const OUTPUT_HISTORY_MAX_ENTRIES = 5;
+/** Max characters to keep from each end when truncating long outputs. */
+export const OUTPUT_HISTORY_HEAD_TAIL_CHARS = 300;
+
+/** Truncate output text keeping the first and last N characters. */
+export function truncateOutputForHistory(text: string): string {
+  const limit = OUTPUT_HISTORY_HEAD_TAIL_CHARS * 2;
+  if (text.length <= limit) {
+    return text;
+  }
+  const head = text.slice(0, OUTPUT_HISTORY_HEAD_TAIL_CHARS);
+  const tail = text.slice(-OUTPUT_HISTORY_HEAD_TAIL_CHARS);
+  return `${head} … ${tail}`;
+}
+
+export function buildOutputHistoryBlock(job: CronJob): string | undefined {
+  if (job.payload.kind !== "agentTurn" || !job.payload.outputHistory) {
+    return undefined;
+  }
+  const outputs = job.state.recentOutputs;
+  if (!outputs || outputs.length === 0) {
+    return undefined;
+  }
+
+  const tz = job.schedule.kind === "cron" ? job.schedule.tz : undefined;
+  const lines = outputs.map((o) => {
+    const date = new Date(o.timestamp);
+    const formatted = tz
+      ? date.toLocaleString("en-US", { timeZone: tz, dateStyle: "short", timeStyle: "short" })
+      : date.toLocaleString("en-US", { dateStyle: "short", timeStyle: "short" });
+    return `- ${formatted}: ${o.text}`;
+  });
+
+  return [
+    "[Your previous outputs for this scheduled task — use them as context for your next response:]",
+    ...lines,
+  ].join("\n");
+}

--- a/src/cron/isolated-agent/output-history.ts
+++ b/src/cron/isolated-agent/output-history.ts
@@ -6,13 +6,15 @@ export const OUTPUT_HISTORY_HEAD_TAIL_CHARS = 300;
 
 /** Truncate output text keeping the first and last N characters. */
 export function truncateOutputForHistory(text: string): string {
+  const sep = " … ";
   const limit = OUTPUT_HISTORY_HEAD_TAIL_CHARS * 2;
   if (text.length <= limit) {
     return text;
   }
-  const head = text.slice(0, OUTPUT_HISTORY_HEAD_TAIL_CHARS);
-  const tail = text.slice(-OUTPUT_HISTORY_HEAD_TAIL_CHARS);
-  return `${head} … ${tail}`;
+  const partLen = Math.floor((limit - sep.length) / 2);
+  const head = text.slice(0, partLen);
+  const tail = text.slice(-partLen);
+  return `${head}${sep}${tail}`;
 }
 
 export function buildOutputHistoryBlock(job: CronJob): string | undefined {

--- a/src/cron/isolated-agent/run.output-history.test.ts
+++ b/src/cron/isolated-agent/run.output-history.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentTurnJob,
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+/**
+ * Intercept the prompt that runCronIsolatedAgentTurn assembles and passes
+ * through the real code path: runWithModelFallback → runEmbeddedPiAgent.
+ */
+function interceptPrompt(): { get(): string } {
+  let captured = "";
+  runWithModelFallbackMock.mockImplementationOnce(async (opts: { run: Function }) => {
+    await opts.run("openai", "gpt-4", {});
+    return {
+      result: {
+        payloads: [{ text: "test output" }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    };
+  });
+  runEmbeddedPiAgentMock.mockImplementationOnce(async (opts: { prompt: string }) => {
+    captured = opts.prompt;
+    return {
+      payloads: [{ text: "test output" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    };
+  });
+  return { get: () => captured };
+}
+
+describe("runCronIsolatedAgentTurn — output history injection", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("includes output history block when outputHistory is enabled and outputs exist", async () => {
+    const prompt = interceptPrompt();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: { kind: "agentTurn", message: "Send daily briefing", outputHistory: true },
+          state: {
+            recentOutputs: [
+              { text: "Yesterday's briefing: Stock market rose 2%", timestamp: 1710230400000 },
+              { text: "Markets closed flat today", timestamp: 1710316800000 },
+            ],
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(prompt.get()).toContain(
+      "[Your previous outputs for this scheduled task — use them as context for your next response:]",
+    );
+    expect(prompt.get()).toContain("Yesterday's briefing: Stock market rose 2%");
+    expect(prompt.get()).toContain("Markets closed flat today");
+  });
+
+  it("does not include output history block when outputHistory is disabled", async () => {
+    const prompt = interceptPrompt();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: { kind: "agentTurn", message: "Send daily briefing" },
+          state: {
+            recentOutputs: [{ text: "Old output", timestamp: 1710230400000 }],
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(prompt.get()).not.toContain("[Your previous outputs for this scheduled task");
+  });
+
+  it("does not include output history block on first run (no previous outputs)", async () => {
+    const prompt = interceptPrompt();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: { kind: "agentTurn", message: "Send daily briefing", outputHistory: true },
+          state: {},
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(prompt.get()).not.toContain("[Your previous outputs for this scheduled task");
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -71,6 +71,7 @@ import {
   pickSummaryFromPayloads,
   resolveHeartbeatAckMaxChars,
 } from "./helpers.js";
+import { buildOutputHistoryBlock } from "./output-history.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";
 import { resolveCronSkillsSnapshot } from "./skills-snapshot.js";
@@ -479,6 +480,11 @@ export async function runCronIsolatedAgentTurn(params: {
     commandBody = `${base}\n${timeLine}`.trim();
   }
   commandBody = appendCronDeliveryInstruction({ commandBody, deliveryRequested });
+
+  const outputHistoryBlock = buildOutputHistoryBlock(params.job);
+  if (outputHistoryBlock) {
+    commandBody = `${commandBody}\n\n${outputHistoryBlock}`;
+  }
 
   const existingSkillsSnapshot = cronSession.sessionEntry.skillsSnapshot;
   const skillsSnapshot = resolveCronSkillsSnapshot({

--- a/src/cron/service.output-history-recording.test.ts
+++ b/src/cron/service.output-history-recording.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createFinishedBarrier,
+  createCronStoreHarness,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+type CronAddInput = Parameters<CronService["add"]>[0];
+
+function buildOutputHistoryJob(name: string): CronAddInput {
+  return {
+    name,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "test", outputHistory: true },
+    delivery: { mode: "none" },
+  };
+}
+
+describe("CronService output history recording", () => {
+  it("records outputText in recentOutputs when outputHistory is enabled and delivered", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: "Today's celebrity news: Actor X did Y",
+        delivered: true,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildOutputHistoryJob("history-record"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toBeDefined();
+      expect(updated?.state.recentOutputs).toHaveLength(1);
+      expect(updated?.state.recentOutputs![0].text).toBe("Today's celebrity news: Actor X did Y");
+      expect(updated?.state.recentOutputs![0].timestamp).toBeGreaterThan(0);
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("does not record when outputHistory is not enabled", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: "some output",
+        delivered: true,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add({
+        ...buildOutputHistoryJob("no-history"),
+        payload: { kind: "agentTurn", message: "test" },
+      });
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toBeUndefined();
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("does not record when delivery fails", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: "some output",
+        delivered: false,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildOutputHistoryJob("no-delivery"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toBeUndefined();
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("caps recentOutputs at 5 entries (FIFO)", async () => {
+    const store = await makeStorePath();
+    let runCount = 0;
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        runCount++;
+        return {
+          status: "ok" as const,
+          summary: "done",
+          outputText: `output-${runCount}`,
+          delivered: true,
+        };
+      }),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildOutputHistoryJob("cap-test"));
+
+      // Run 6 times
+      for (let i = 0; i < 6; i++) {
+        vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+        await vi.runOnlyPendingTimersAsync();
+        await finished.waitForOk(job.id);
+        // Re-read job state for next iteration's nextRunAtMs
+        const jobs = await cron.list({ includeDisabled: true });
+        const updated = jobs.find((j) => j.id === job.id)!;
+        Object.assign(job.state, updated.state);
+      }
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toHaveLength(5);
+      // Oldest (output-1) should be dropped, newest 5 remain
+      expect(updated?.state.recentOutputs![0].text).toBe("output-2");
+      expect(updated?.state.recentOutputs![4].text).toBe("output-6");
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("truncates long output keeping head and tail", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const head = "H".repeat(400);
+    const tail = "T".repeat(400);
+    const longText = `${head}${"x".repeat(200)}${tail}`;
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: longText,
+        delivered: true,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildOutputHistoryJob("truncate-test"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      const stored = updated?.state.recentOutputs![0].text;
+      // Should contain head and tail with ellipsis separator
+      expect(stored).toContain("H".repeat(300));
+      expect(stored).toContain("T".repeat(300));
+      expect(stored).toContain("…");
+      expect(stored!.length).toBeLessThanOrEqual(603); // 300 + 3 + 300
+    } finally {
+      cron.stop();
+    }
+  });
+});

--- a/src/cron/service.output-history-recording.test.ts
+++ b/src/cron/service.output-history-recording.test.ts
@@ -210,11 +210,11 @@ describe("CronService output history recording", () => {
       const jobs = await cron.list({ includeDisabled: true });
       const updated = jobs.find((j) => j.id === job.id);
       const stored = updated?.state.recentOutputs![0].text;
-      // Should contain head and tail with ellipsis separator
-      expect(stored).toContain("H".repeat(300));
-      expect(stored).toContain("T".repeat(300));
+      // Should contain head and tail with ellipsis separator, within the 600 char limit
+      expect(stored).toContain("H".repeat(298));
+      expect(stored).toContain("T".repeat(298));
       expect(stored).toContain("…");
-      expect(stored!.length).toBeLessThanOrEqual(603); // 300 + 3 + 300
+      expect(stored!.length).toBeLessThanOrEqual(600);
     } finally {
       cron.stop();
     }

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -695,6 +695,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.bestEffortDeliver === "boolean") {
     next.bestEffortDeliver = patch.bestEffortDeliver;
   }
+  if (typeof patch.outputHistory === "boolean") {
+    next.outputHistory = patch.outputHistory;
+  }
   return next;
 }
 
@@ -763,6 +766,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     channel: patch.channel,
     to: patch.to,
     bestEffortDeliver: patch.bestEffortDeliver,
+    outputHistory: patch.outputHistory,
   };
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -3,6 +3,10 @@ import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
+import {
+  OUTPUT_HISTORY_MAX_ENTRIES,
+  truncateOutputForHistory,
+} from "../isolated-agent/output-history.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
 import type {
   CronDeliveryStatus,
@@ -48,6 +52,7 @@ type TimedCronRunOutcome = CronRunOutcome &
     jobId: string;
     delivered?: boolean;
     deliveryAttempted?: boolean;
+    outputText?: string;
     startedAt: number;
     endedAt: number;
   };
@@ -299,6 +304,7 @@ export function applyJobResult(
     status: CronRunStatus;
     error?: string;
     delivered?: boolean;
+    outputText?: string;
     startedAt: number;
     endedAt: number;
   },
@@ -333,6 +339,24 @@ export function applyJobResult(
   job.state.lastDeliveryError =
     deliveryStatus === "not-delivered" && result.error ? result.error : undefined;
   job.updatedAtMs = result.endedAt;
+
+  // Record delivered output for output history (only when enabled and delivered).
+  if (
+    result.delivered &&
+    result.outputText?.trim() &&
+    job.payload.kind === "agentTurn" &&
+    job.payload.outputHistory
+  ) {
+    const outputs = job.state.recentOutputs ?? [];
+    outputs.push({
+      text: truncateOutputForHistory(result.outputText.trim()),
+      timestamp: result.endedAt,
+    });
+    if (outputs.length > OUTPUT_HISTORY_MAX_ENTRIES) {
+      outputs.splice(0, outputs.length - OUTPUT_HISTORY_MAX_ENTRIES);
+    }
+    job.state.recentOutputs = outputs;
+  }
 
   // Track consecutive errors for backoff / auto-disable.
   if (result.status === "error") {
@@ -492,6 +516,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     status: result.status,
     error: result.error,
     delivered: result.delivered,
+    outputText: result.outputText,
     startedAt: result.startedAt,
     endedAt: result.endedAt,
   });
@@ -1007,7 +1032,8 @@ export async function executeJobCore(
   job: CronJob,
   abortSignal?: AbortSignal,
 ): Promise<
-  CronRunOutcome & CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean }
+  CronRunOutcome &
+    CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean; outputText?: string }
 > {
   const resolveAbortError = () => ({
     status: "error" as const,
@@ -1146,6 +1172,7 @@ export async function executeJobCore(
     summary: res.summary,
     delivered: res.delivered,
     deliveryAttempted: res.deliveryAttempted,
+    outputText: res.outputText,
     sessionId: res.sessionId,
     sessionKey: res.sessionKey,
     model: res.model,
@@ -1175,6 +1202,7 @@ export async function executeJob(
   let coreResult: {
     status: CronRunStatus;
     delivered?: boolean;
+    outputText?: string;
   } & CronRunOutcome &
     CronRunTelemetry;
   try {
@@ -1188,6 +1216,7 @@ export async function executeJob(
     status: coreResult.status,
     error: coreResult.error,
     delivered: coreResult.delivered,
+    outputText: coreResult.outputText,
     startedAt,
     endedAt,
   });

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -97,6 +97,11 @@ type CronAgentTurnPayloadFields = {
   channel?: CronMessageChannel;
   to?: string;
   bestEffortDeliver?: boolean;
+  /**
+   * When true, inject recent delivered outputs into the agent's system prompt
+   * as context for the next run. Default: false.
+   */
+  outputHistory?: boolean;
 };
 
 type CronAgentTurnPayload = {
@@ -130,6 +135,17 @@ export type CronJobState = {
   lastDeliveryError?: string;
   /** Whether the last run's output was delivered to the target channel. */
   lastDelivered?: boolean;
+  /**
+   * Recent delivered outputs for output history injection.
+   * Capped at 5 entries, FIFO.
+   * Only populated when `payload.outputHistory` is enabled.
+   */
+  recentOutputs?: Array<{
+    /** Delivered text, truncated to ~600 characters (first 300 + last 300). */
+    text: string;
+    /** Timestamp (ms since epoch) when the output was delivered. */
+    timestamp: number;
+  }>;
 };
 
 export type CronJob = CronJobBase<

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -141,7 +141,7 @@ export type CronJobState = {
    * Only populated when `payload.outputHistory` is enabled.
    */
   recentOutputs?: Array<{
-    /** Delivered text, truncated to ~600 characters (first 300 + last 300). */
+    /** Delivered text, truncated to ≤600 characters (head + tail with separator). */
     text: string;
     /** Timestamp (ms since epoch) when the output was delivered. */
     timestamp: number;

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -84,6 +84,18 @@ describe("cron protocol validators", () => {
     expect(validateCronRunsParams({ id: "job-1", offset: -1 })).toBe(false);
   });
 
+  it("accepts agentTurn add params with outputHistory", () => {
+    expect(
+      validateCronAddParams({
+        name: "daily-briefing",
+        schedule: { kind: "cron", expr: "0 8 * * *" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "Send briefing", outputHistory: true },
+      }),
+    ).toBe(true);
+  });
+
   it("accepts all-scope runs with multi-select filters", () => {
     expect(
       validateCronRunsParams({

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -16,6 +16,7 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
       channel: Type.Optional(Type.String()),
       to: Type.Optional(Type.String()),
       bestEffortDeliver: Type.Optional(Type.Boolean()),
+      outputHistory: Type.Optional(Type.Boolean()),
     },
     { additionalProperties: false },
   );
@@ -235,6 +236,17 @@ export const CronJobStateSchema = Type.Object(
     lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
     lastDeliveryError: Type.Optional(Type.String()),
     lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    recentOutputs: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            text: Type.String(),
+            timestamp: Type.Integer({ minimum: 0 }),
+          },
+          { additionalProperties: false },
+        ),
+      ),
+    ),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
## Problem

Isolated cron sessions (`sessionTarget: "isolated"`) create a fresh transcript per run. The agent starts with zero context about what it previously produced, which degrades quality for recurring tasks.

### Concrete scenarios this fixes

**Daily briefings/newsletters** — A cron job sends a celebrity news briefing every morning. Without history, the agent picks the same trending topics and produces nearly identical output each day. With `outputHistory`, it sees what it already covered and selects fresh angles.

**Monitoring & change tracking** — A cron job checks server status every hour. Without history, each report is a standalone snapshot. With `outputHistory`, the agent can say "CPU usage increased from 45% (last run) to 78%" instead of just "CPU usage is 78%".

**Iterative analysis** — A weekly market summary cron. Without history, it cannot reference prior weeks. With `outputHistory`, it can identify trends: "This is the third consecutive week of growth, up from $X last week."

**Content scheduling** — A cron that posts social media content. Without history, it may suggest the same topics repeatedly. With `outputHistory`, it naturally rotates through different themes.

### Root cause

- `forceNew: true` in `resolveCronSession()` creates a new session ID and empty transcript every run
- `CronJobState` only tracked `lastDelivered` (boolean), not the actual output text
- No mechanism existed to pass previous outputs to the cron agent

## Solution

Add `outputHistory: true` option to agentTurn payloads. When enabled:

1. **Record**: After each successful delivery, store the output text in `job.state.recentOutputs` (capped at 5 entries, FIFO)
2. **Inject**: On the next run, append the history block to the agent's system prompt
3. **Truncate**: Long outputs keep first 300 + last 300 characters to preserve both ends

The creating agent (LLM) decides per-job whether to enable it based on task nature — a simple weather push doesn't need it, a daily briefing does.

Also includes **bot-history pending flush**: cron deliveries are recorded and flushed into session transcripts so the agent doesn't deny its own messages in group chats.

## Key changes

- `src/cron/types.ts` — add `outputHistory` to payload, `recentOutputs` to state
- `src/cron/isolated-agent/output-history.ts` — builder + truncation (head 300 + tail 300)
- `src/cron/isolated-agent/run.ts` — inject history block into prompt
- `src/cron/service/timer.ts` — thread `outputText` through result chain, record on delivery
- `src/gateway/protocol/schema/cron.ts` — schema validation
- `src/agents/tools/cron-tool.ts` — tool description for LLM discoverability

## Test plan

- [x] Unit tests: `buildOutputHistoryBlock` (7) + `truncateOutputForHistory` (3)
- [x] Integration: real CronService recording, FIFO cap, truncation (5)
- [x] E2E: real `runCronIsolatedAgentTurn` prompt injection verification (3)
- [x] Gateway schema + cron tool passthrough (2)
- [x] Full cron suite: 69 files / 566 tests passing
- [x] `pnpm tsgo` clean, `pnpm check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)