### PR TITLE
feat(backup): add --no-include-browser option to exclude browser profile data

### DIFF
--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -53,6 +53,7 @@ describe("registerBackupCommand", () => {
         verify: false,
         onlyConfig: false,
         includeWorkspace: true,
+        includeBrowser: true,
       }),
     );
   });
@@ -75,6 +76,17 @@ describe("registerBackupCommand", () => {
       runtime,
       expect.objectContaining({
         verify: true,
+      }),
+    );
+  });
+
+  it("honors --no-include-browser", async () => {
+    await runCli(["backup", "create", "--no-include-browser"]);
+
+    expect(backupCreateCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        includeBrowser: false,
       }),
     );
   });

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -26,6 +26,7 @@ export function registerBackupCommand(program: Command) {
     .option("--verify", "Verify the archive after writing it", false)
     .option("--only-config", "Back up only the active JSON config file", false)
     .option("--no-include-workspace", "Exclude workspace directories from the backup")
+    .option("--no-include-browser", "Exclude browser profile data from the backup")
     .addHelpText(
       "after",
       () =>
@@ -48,6 +49,10 @@ export function registerBackupCommand(program: Command) {
             "Back up state/config without agent workspace files.",
           ],
           ["openclaw backup create --only-config", "Back up only the active JSON config file."],
+          [
+            "openclaw backup create --no-include-browser",
+            "Back up without browser profile data (saves ~1.6GB).",
+          ],
         ])}`,
     )
     .action(async (opts) => {
@@ -59,6 +64,7 @@ export function registerBackupCommand(program: Command) {
           verify: Boolean(opts.verify),
           onlyConfig: Boolean(opts.onlyConfig),
           includeWorkspace: opts.includeWorkspace as boolean,
+          includeBrowser: opts.includeBrowser as boolean,
         });
       });
     });

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -11,7 +11,7 @@ import { pathExists, shortenHomePath } from "../utils.js";
 import { buildCleanupPlan, isPathWithin } from "./cleanup-utils.js";
 
 export type BackupAssetKind = "state" | "config" | "credentials" | "workspace";
-export type BackupSkipReason = "covered" | "missing";
+export type BackupSkipReason = "covered" | "missing" | "excluded";
 
 export type BackupAsset = {
   kind: BackupAssetKind;
@@ -106,11 +106,13 @@ async function canonicalizeExistingPath(targetPath: string): Promise<string> {
 export async function resolveBackupPlanFromDisk(
   params: {
     includeWorkspace?: boolean;
+    includeBrowser?: boolean;
     onlyConfig?: boolean;
     nowMs?: number;
   } = {},
 ): Promise<BackupPlan> {
   const includeWorkspace = params.includeWorkspace ?? true;
+  const includeBrowser = params.includeBrowser ?? true;
   const onlyConfig = params.onlyConfig ?? false;
   const stateDir = resolveStateDir();
   const configPath = resolveConfigPath();
@@ -241,6 +243,20 @@ export async function resolveBackupPlanFromDisk(
       displayPath: shortenHomePath(candidate.canonicalPath),
       archivePath: buildBackupArchivePath(archiveRoot, candidate.canonicalPath),
     });
+  }
+
+  if (!includeBrowser) {
+    for (const asset of included) {
+      if (asset.kind === "state") {
+        const browserDir = path.join(asset.sourcePath, "browser");
+        skipped.push({
+          kind: "state",
+          sourcePath: browserDir,
+          displayPath: shortenHomePath(browserDir),
+          reason: "excluded",
+        });
+      }
+    }
   }
 
   return {

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -20,6 +20,7 @@ type BackupManifest = {
   nodeVersion: string;
   options?: {
     includeWorkspace?: boolean;
+    includeBrowser?: boolean;
   };
   paths?: {
     stateDir?: string;
@@ -150,7 +151,10 @@ function parseManifest(raw: string): BackupManifest {
     platform: typeof parsed.platform === "string" ? parsed.platform : "unknown",
     nodeVersion: typeof parsed.nodeVersion === "string" ? parsed.nodeVersion : "unknown",
     options: isRecord(parsed.options)
-      ? { includeWorkspace: parsed.options.includeWorkspace as boolean | undefined }
+      ? {
+          includeWorkspace: parsed.options.includeWorkspace as boolean | undefined,
+          includeBrowser: parsed.options.includeBrowser as boolean | undefined,
+        }
       : undefined,
     paths: isRecord(parsed.paths)
       ? {

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -431,4 +431,139 @@ describe("backup commands", () => {
       delete process.env.OPENCLAW_CONFIG_PATH;
     }
   });
+
+  it("excludes browser directory from backup when --no-include-browser is used", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+    await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+    await fs.mkdir(path.join(stateDir, "browser", "Default"), { recursive: true });
+    await fs.writeFile(
+      path.join(stateDir, "browser", "Default", "Cookies"),
+      "browser-data\n",
+      "utf8",
+    );
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    const result = await backupCreateCommand(runtime, {
+      dryRun: true,
+      includeBrowser: false,
+    });
+
+    expect(result.includeBrowser).toBe(false);
+    expect(result.skipped).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ reason: "excluded", sourcePath: expect.stringContaining("browser") }),
+      ]),
+    );
+  });
+
+  it("creates an archive excluding browser directory contents", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-browser-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+      await fs.mkdir(path.join(stateDir, "browser", "Default"), { recursive: true });
+      await fs.writeFile(
+        path.join(stateDir, "browser", "Default", "Cookies"),
+        "browser-data\n",
+        "utf8",
+      );
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      const nowMs = Date.UTC(2026, 2, 9, 3, 0, 0);
+      const result = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        includeBrowser: false,
+        nowMs,
+      });
+
+      const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-extract-"));
+      try {
+        await tar.x({ file: result.archivePath, cwd: extractDir, gzip: true });
+        const archiveRoot = path.join(extractDir, buildBackupArchiveRoot(nowMs));
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(archiveRoot, "manifest.json"), "utf8"),
+        ) as {
+          options: { includeBrowser?: boolean };
+        };
+
+        expect(manifest.options.includeBrowser).toBe(false);
+
+        // Verify state.txt is present but browser data is not
+        const stateAsset = result.assets.find((asset) => asset.kind === "state");
+        expect(stateAsset).toBeDefined();
+        const encodedStatePath = path.join(
+          archiveRoot,
+          "payload",
+          encodeAbsolutePathForBackupArchive(stateAsset!.sourcePath),
+        );
+        expect(await fs.readFile(path.join(encodedStatePath, "state.txt"), "utf8")).toBe(
+          "state\n",
+        );
+
+        // browser directory should not exist in the archive
+        const browserPath = path.join(encodedStatePath, "browser");
+        await expect(fs.access(browserPath)).rejects.toThrow();
+      } finally {
+        await fs.rm(extractDir, { recursive: true, force: true });
+      }
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
+  it("includes browser directory by default", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-browser-default-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.mkdir(path.join(stateDir, "browser"), { recursive: true });
+      await fs.writeFile(path.join(stateDir, "browser", "data.txt"), "browser\n", "utf8");
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      const nowMs = Date.UTC(2026, 2, 9, 4, 0, 0);
+      const result = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        nowMs,
+      });
+
+      expect(result.includeBrowser).toBe(true);
+
+      const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-extract-"));
+      try {
+        await tar.x({ file: result.archivePath, cwd: extractDir, gzip: true });
+        const archiveRoot = path.join(extractDir, buildBackupArchiveRoot(nowMs));
+        const stateAsset = result.assets.find((asset) => asset.kind === "state");
+        const encodedStatePath = path.join(
+          archiveRoot,
+          "payload",
+          encodeAbsolutePathForBackupArchive(stateAsset!.sourcePath),
+        );
+        // browser data should be present
+        expect(await fs.readFile(path.join(encodedStatePath, "browser", "data.txt"), "utf8")).toBe(
+          "browser\n",
+        );
+      } finally {
+        await fs.rm(extractDir, { recursive: true, force: true });
+      }
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -457,7 +457,10 @@ describe("backup commands", () => {
     expect(result.includeBrowser).toBe(false);
     expect(result.skipped).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ reason: "excluded", sourcePath: expect.stringContaining("browser") }),
+        expect.objectContaining({
+          reason: "excluded",
+          sourcePath: expect.stringContaining("browser"),
+        }),
       ]),
     );
   });
@@ -508,9 +511,7 @@ describe("backup commands", () => {
           "payload",
           encodeAbsolutePathForBackupArchive(stateAsset!.sourcePath),
         );
-        expect(await fs.readFile(path.join(encodedStatePath, "state.txt"), "utf8")).toBe(
-          "state\n",
-        );
+        expect(await fs.readFile(path.join(encodedStatePath, "state.txt"), "utf8")).toBe("state\n");
 
         // browser directory should not exist in the archive
         const browserPath = path.join(encodedStatePath, "browser");

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -282,7 +282,12 @@ export async function createBackupArchive(
   const onlyConfig = Boolean(opts.onlyConfig);
   const includeWorkspace = onlyConfig ? false : (opts.includeWorkspace ?? true);
   const includeBrowser = onlyConfig ? true : (opts.includeBrowser ?? true);
-  const plan = await resolveBackupPlanFromDisk({ includeWorkspace, includeBrowser, onlyConfig, nowMs });
+  const plan = await resolveBackupPlanFromDisk({
+    includeWorkspace,
+    includeBrowser,
+    onlyConfig,
+    nowMs,
+  });
   const outputPath = await resolveOutputPath({
     output: opts.output,
     nowMs,

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -19,6 +19,7 @@ export type BackupCreateOptions = {
   output?: string;
   dryRun?: boolean;
   includeWorkspace?: boolean;
+  includeBrowser?: boolean;
   onlyConfig?: boolean;
   verify?: boolean;
   json?: boolean;
@@ -40,6 +41,7 @@ type BackupManifest = {
   nodeVersion: string;
   options: {
     includeWorkspace: boolean;
+    includeBrowser?: boolean;
     onlyConfig?: boolean;
   };
   paths: {
@@ -63,6 +65,7 @@ export type BackupCreateResult = {
   archivePath: string;
   dryRun: boolean;
   includeWorkspace: boolean;
+  includeBrowser: boolean;
   onlyConfig: boolean;
   verified: boolean;
   assets: BackupAsset[];
@@ -191,6 +194,7 @@ function buildManifest(params: {
   createdAt: string;
   archiveRoot: string;
   includeWorkspace: boolean;
+  includeBrowser: boolean;
   onlyConfig: boolean;
   assets: BackupAsset[];
   skipped: BackupCreateResult["skipped"];
@@ -208,6 +212,7 @@ function buildManifest(params: {
     nodeVersion: process.version,
     options: {
       includeWorkspace: params.includeWorkspace,
+      includeBrowser: params.includeBrowser,
       onlyConfig: params.onlyConfig,
     },
     paths: {
@@ -276,7 +281,8 @@ export async function createBackupArchive(
   const archiveRoot = buildBackupArchiveRoot(nowMs);
   const onlyConfig = Boolean(opts.onlyConfig);
   const includeWorkspace = onlyConfig ? false : (opts.includeWorkspace ?? true);
-  const plan = await resolveBackupPlanFromDisk({ includeWorkspace, onlyConfig, nowMs });
+  const includeBrowser = onlyConfig ? true : (opts.includeBrowser ?? true);
+  const plan = await resolveBackupPlanFromDisk({ includeWorkspace, includeBrowser, onlyConfig, nowMs });
   const outputPath = await resolveOutputPath({
     output: opts.output,
     nowMs,
@@ -313,6 +319,7 @@ export async function createBackupArchive(
     archivePath: outputPath,
     dryRun: Boolean(opts.dryRun),
     includeWorkspace,
+    includeBrowser,
     onlyConfig,
     verified: false,
     assets: plan.included,
@@ -332,6 +339,7 @@ export async function createBackupArchive(
       createdAt,
       archiveRoot,
       includeWorkspace,
+      includeBrowser,
       onlyConfig,
       assets: result.assets,
       skipped: result.skipped,
@@ -342,12 +350,27 @@ export async function createBackupArchive(
     });
     await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 
+    const browserExcludePaths = !includeBrowser
+      ? result.assets
+          .filter((asset) => asset.kind === "state")
+          .map((asset) => path.join(asset.sourcePath, "browser"))
+      : [];
+
     await tar.c(
       {
         file: tempArchivePath,
         gzip: true,
         portable: true,
         preservePaths: true,
+        filter: (entryPath) => {
+          if (browserExcludePaths.length === 0) {
+            return true;
+          }
+          const resolved = path.resolve(entryPath);
+          return !browserExcludePaths.some(
+            (excludePath) => resolved === excludePath || isPathWithin(resolved, excludePath),
+          );
+        },
         onWriteEntry: (entry) => {
           entry.path = remapArchiveEntryPath({
             entryPath: entry.path,


### PR DESCRIPTION
## Summary

Adds a `--no-include-browser` option to `openclaw backup create`, allowing users to exclude the `browser/` directory from backup archives. Browser profile data (Chrome/Chromium user data, CDP caches) can easily reach 1–2 GB, making routine backups unnecessarily large when browser state is not needed.

### Motivation

On a typical macOS install, `~/.openclaw/browser/` holds ~1.6 GB of Chromium profile data. The existing `--no-include-workspace` excludes workspace files, and `--only-config` narrows to just the config file, but there was no way to keep sessions/config/workspace while dropping browser data.

### Changes

- **`src/cli/program/register.backup.ts`**: Register `--no-include-browser` option with help example
- **`src/infra/backup-create.ts`**: Add `includeBrowser` to options/manifest/result types; apply tar `filter` to exclude `browser/` subtree when disabled
- **`src/commands/backup-shared.ts`**: Accept `includeBrowser` in `resolveBackupPlanFromDisk`; record excluded browser dir in `skipped` list with reason `"excluded"`
- **`src/commands/backup-verify.ts`**: Parse `includeBrowser` from manifest for forward compatibility
- **Tests**: 4 new tests covering CLI forwarding, dry-run skip recording, archive content exclusion, and default inclusion

### Design decisions

- Naming follows the established `--no-include-workspace` / `includeWorkspace` pattern
- Uses tar `filter` callback rather than splitting the state asset, since `browser/` is a subdirectory of the state dir
- `--only-config` forces `includeBrowser: true` (browser exclusion is meaningless when only backing up config)
- Fully backward compatible: defaults to `true`, manifest field is optional

### Usage

```bash
# Full backup minus browser data (~300 MB instead of ~1.9 GB)
openclaw backup create --no-include-browser

# Combine with other options
openclaw backup create --no-include-browser --verify

# Preview what would be excluded
openclaw backup create --no-include-browser --dry-run
```