### PR TITLE
fix(skills): downgrade escaped skill path log from warn to debug

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -190,7 +190,7 @@ function warnEscapedSkillPath(params: {
   candidatePath: string;
   candidateRealPath: string;
 }) {
-  skillsLogger.warn("Skipping skill path that resolves outside its configured root.", {
+  skillsLogger.debug("Skipping skill path that resolves outside its configured root.", {
     source: params.source,
     rootDir: params.rootDir,
     path: params.candidatePath,


### PR DESCRIPTION
1-line fix: warn -> debug for skill paths that resolve outside their root. On flat layouts this produces 75+ warnings that bury useful output.