### PR TITLE
fix(telegram): preserve media download transport fallback

### DIFF
--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -7,7 +7,6 @@ import {
   createPinnedDispatcher,
   resolvePinnedHostnameWithPolicy,
   type LookupFn,
-  type PinnedDispatcherPolicy,
   SsrFBlockedError,
   type SsrFPolicy,
 } from "./ssrf.js";
@@ -30,7 +29,6 @@ export type GuardedFetchOptions = {
   signal?: AbortSignal;
   policy?: SsrFPolicy;
   lookupFn?: LookupFn;
-  dispatcherPolicy?: PinnedDispatcherPolicy;
   mode?: GuardedFetchMode;
   pinDns?: boolean;
   /** @deprecated use `mode: "trusted_env_proxy"` for trusted/operator-controlled URLs. */
@@ -198,7 +196,7 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       if (canUseTrustedEnvProxy) {
         dispatcher = new EnvHttpProxyAgent();
       } else if (params.pinDns !== false) {
-        dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy);
+        dispatcher = createPinnedDispatcher(pinned);
       }
 
       const init: RequestInit & { dispatcher?: Dispatcher } = {

--- a/src/media/fetch.telegram-network.test.ts
+++ b/src/media/fetch.telegram-network.test.ts
@@ -35,6 +35,15 @@ vi.mock("undici", () => ({
   fetch: undiciFetch,
 }));
 
+function buildFetchFallbackError(code: string) {
+  const connectErr = Object.assign(new Error(`connect ${code} api.telegram.org:443`), {
+    code,
+  });
+  return Object.assign(new TypeError("fetch failed"), {
+    cause: connectErr,
+  });
+}
+
 describe("fetchRemoteMedia telegram network policy", () => {
   type LookupFn = NonNullable<Parameters<typeof fetchRemoteMedia>[0]["lookupFn"]>;
 
@@ -66,9 +75,9 @@ describe("fetchRemoteMedia telegram network policy", () => {
 
     await fetchRemoteMedia({
       url: "https://api.telegram.org/file/bottok/photos/1.jpg",
-      fetchImpl: telegramTransport.sourceFetch,
-      dispatcherPolicy: telegramTransport.pinnedDispatcherPolicy,
+      fetchImpl: telegramTransport.fetch,
       lookupFn,
+      pinDns: false,
       maxBytes: 1024,
       ssrfPolicy: {
         allowedHostnames: ["api.telegram.org"],
@@ -116,9 +125,9 @@ describe("fetchRemoteMedia telegram network policy", () => {
 
     await fetchRemoteMedia({
       url: "https://api.telegram.org/file/bottok/files/1.pdf",
-      fetchImpl: telegramTransport.sourceFetch,
-      dispatcherPolicy: telegramTransport.pinnedDispatcherPolicy,
+      fetchImpl: telegramTransport.fetch,
       lookupFn,
+      pinDns: false,
       maxBytes: 1024,
       ssrfPolicy: {
         allowedHostnames: ["api.telegram.org"],
@@ -138,5 +147,73 @@ describe("fetchRemoteMedia telegram network policy", () => {
 
     expect(init?.dispatcher?.options?.uri).toBe("http://127.0.0.1:7890");
     expect(ProxyAgentCtor).toHaveBeenCalled();
+  });
+
+  it("allows Telegram transport to arm sticky IPv4 fallback for file downloads", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "149.154.167.220", family: 4 },
+      { address: "2001:67c:4e8:f004::9", family: 6 },
+    ]) as unknown as LookupFn;
+    undiciFetch
+      .mockRejectedValueOnce(buildFetchFallbackError("EHOSTUNREACH"))
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([0xff, 0xd8, 0xff, 0x00]), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      );
+
+    const telegramTransport = resolveTelegramTransport(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await fetchRemoteMedia({
+      url: "https://api.telegram.org/file/bottok/photos/2.jpg",
+      fetchImpl: telegramTransport.fetch,
+      lookupFn,
+      pinDns: false,
+      maxBytes: 1024,
+      ssrfPolicy: {
+        allowedHostnames: ["api.telegram.org"],
+        allowRfc2544BenchmarkRange: true,
+      },
+    });
+
+    expect(undiciFetch).toHaveBeenCalledTimes(2);
+
+    const firstInit = undiciFetch.mock.calls[0]?.[1] as
+      | (RequestInit & {
+          dispatcher?: {
+            options?: {
+              connect?: Record<string, unknown>;
+            };
+          };
+        })
+      | undefined;
+    const secondInit = undiciFetch.mock.calls[1]?.[1] as
+      | (RequestInit & {
+          dispatcher?: {
+            options?: {
+              connect?: Record<string, unknown>;
+            };
+          };
+        })
+      | undefined;
+
+    expect(firstInit?.dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(secondInit?.dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
   });
 });

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fetchWithSsrFGuard, withStrictGuardedFetchMode } from "../infra/net/fetch-guard.js";
-import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import type { LookupFn, SsrFPolicy } from "../infra/net/ssrf.js";
 import { detectMime, extensionForMime } from "./mime.js";
 import { readResponseWithLimit } from "./read-response-with-limit.js";
 
@@ -37,7 +37,6 @@ type FetchMediaOptions = {
   pinDns?: boolean;
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
-  dispatcherPolicy?: PinnedDispatcherPolicy;
 };
 
 function stripQuotes(value: string): string {
@@ -96,7 +95,6 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     pinDns,
     ssrfPolicy,
     lookupFn,
-    dispatcherPolicy,
   } = options;
 
   let res: Response;
@@ -112,7 +110,6 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
         pinDns,
         policy: ssrfPolicy,
         lookupFn,
-        dispatcherPolicy,
       }),
     );
     res = result.response;

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -33,6 +33,8 @@ type FetchMediaOptions = {
   maxRedirects?: number;
   /** Abort if the response body stops yielding data for this long (ms). */
   readIdleTimeoutMs?: number;
+  /** Skip DNS pinning when the provided fetch owns dispatcher/network policy. */
+  pinDns?: boolean;
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
   dispatcherPolicy?: PinnedDispatcherPolicy;
@@ -91,6 +93,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     maxBytes,
     maxRedirects,
     readIdleTimeoutMs,
+    pinDns,
     ssrfPolicy,
     lookupFn,
     dispatcherPolicy,
@@ -106,6 +109,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
         fetchImpl,
         init: requestInit,
         maxRedirects,
+        pinDns,
         policy: ssrfPolicy,
         lookupFn,
         dispatcherPolicy,

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -302,8 +302,7 @@ describe("resolveMedia getFile retry", () => {
   it("uses caller-provided fetch impl for file downloads", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_42.pdf" });
     const callerFetch = vi.fn() as unknown as typeof fetch;
-    const sourceFetch = vi.fn() as unknown as typeof fetch;
-    const callerTransport = { fetch: callerFetch, sourceFetch };
+    const callerTransport = { fetch: callerFetch };
     fetchRemoteMedia.mockResolvedValueOnce({
       buffer: Buffer.from("pdf-data"),
       contentType: "application/pdf",
@@ -333,8 +332,7 @@ describe("resolveMedia getFile retry", () => {
   it("uses caller-provided fetch impl for sticker downloads", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "stickers/file_0.webp" });
     const callerFetch = vi.fn() as unknown as typeof fetch;
-    const sourceFetch = vi.fn() as unknown as typeof fetch;
-    const callerTransport = { fetch: callerFetch, sourceFetch };
+    const callerTransport = { fetch: callerFetch };
     fetchRemoteMedia.mockResolvedValueOnce({
       buffer: Buffer.from("sticker-data"),
       contentType: "image/webp",

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -150,6 +150,7 @@ async function expectTransientGetFileRetrySuccess() {
   expect(fetchRemoteMedia).toHaveBeenCalledWith(
     expect.objectContaining({
       url: `https://api.telegram.org/file/bot${BOT_TOKEN}/voice/file_0.oga`,
+      pinDns: false,
       ssrfPolicy: {
         allowRfc2544BenchmarkRange: true,
         allowedHostnames: ["api.telegram.org"],
@@ -301,7 +302,8 @@ describe("resolveMedia getFile retry", () => {
   it("uses caller-provided fetch impl for file downloads", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_42.pdf" });
     const callerFetch = vi.fn() as unknown as typeof fetch;
-    const callerTransport = { fetch: callerFetch, sourceFetch: callerFetch };
+    const sourceFetch = vi.fn() as unknown as typeof fetch;
+    const callerTransport = { fetch: callerFetch, sourceFetch };
     fetchRemoteMedia.mockResolvedValueOnce({
       buffer: Buffer.from("pdf-data"),
       contentType: "application/pdf",
@@ -323,6 +325,7 @@ describe("resolveMedia getFile retry", () => {
     expect(fetchRemoteMedia).toHaveBeenCalledWith(
       expect.objectContaining({
         fetchImpl: callerFetch,
+        pinDns: false,
       }),
     );
   });
@@ -330,7 +333,8 @@ describe("resolveMedia getFile retry", () => {
   it("uses caller-provided fetch impl for sticker downloads", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "stickers/file_0.webp" });
     const callerFetch = vi.fn() as unknown as typeof fetch;
-    const callerTransport = { fetch: callerFetch, sourceFetch: callerFetch };
+    const sourceFetch = vi.fn() as unknown as typeof fetch;
+    const callerTransport = { fetch: callerFetch, sourceFetch };
     fetchRemoteMedia.mockResolvedValueOnce({
       buffer: Buffer.from("sticker-data"),
       contentType: "image/webp",
@@ -352,6 +356,7 @@ describe("resolveMedia getFile retry", () => {
     expect(fetchRemoteMedia).toHaveBeenCalledWith(
       expect.objectContaining({
         fetchImpl: callerFetch,
+        pinDns: false,
       }),
     );
   });

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -103,7 +103,6 @@ function resolveRequiredTelegramTransport(transport?: TelegramTransport): Telegr
   }
   return {
     fetch: resolvedFetch,
-    sourceFetch: resolvedFetch,
   };
 }
 

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -128,11 +128,12 @@ async function downloadAndSaveTelegramFile(params: {
   const url = `https://api.telegram.org/file/bot${params.token}/${params.filePath}`;
   const fetched = await fetchRemoteMedia({
     url,
-    fetchImpl: params.transport.sourceFetch,
-    dispatcherPolicy: params.transport.pinnedDispatcherPolicy,
+    // Keep Telegram's resolver-owned retry/proxy logic in control for media downloads.
+    fetchImpl: params.transport.fetch,
     filePathHint: params.filePath,
     maxBytes: params.maxBytes,
     readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
+    pinDns: false,
     ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
   });
   const originalName = params.telegramFileName ?? fetched.fileName ?? params.filePath;

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -339,11 +339,6 @@ describe("resolveTelegramFetch", () => {
         autoSelectFamily: false,
       }),
     );
-    expect(transport.pinnedDispatcherPolicy).toEqual(
-      expect.objectContaining({
-        mode: "direct",
-      }),
-    );
   });
 
   it("arms sticky IPv4 fallback when env proxy init falls back to direct Agent", async () => {

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -231,7 +231,6 @@ function resolveTelegramDispatcherPolicy(params: {
 function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
   dispatcher: TelegramDispatcher;
   mode: TelegramDispatcherMode;
-  effectivePolicy: PinnedDispatcherPolicy;
 } {
   if (policy.mode === "explicit-proxy") {
     const proxyOptions = policy.proxyTls
@@ -244,7 +243,6 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
       return {
         dispatcher: new ProxyAgent(proxyOptions),
         mode: "explicit-proxy",
-        effectivePolicy: policy,
       };
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
@@ -266,7 +264,6 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
       return {
         dispatcher: new EnvHttpProxyAgent(proxyOptions),
         mode: "env-proxy",
-        effectivePolicy: policy,
       };
     } catch (err) {
       log.warn(
@@ -287,7 +284,6 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
             : undefined,
         ),
         mode: "direct",
-        effectivePolicy: directPolicy,
       };
     }
   }
@@ -301,7 +297,6 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
         : undefined,
     ),
     mode: "direct",
-    effectivePolicy: policy,
   };
 }
 
@@ -392,8 +387,6 @@ function shouldRetryWithIpv4Fallback(err: unknown): boolean {
 // Prefer wrapped fetch when available to normalize AbortSignal across runtimes.
 export type TelegramTransport = {
   fetch: typeof fetch;
-  sourceFetch: typeof fetch;
-  pinnedDispatcherPolicy?: PinnedDispatcherPolicy;
 };
 
 export function resolveTelegramTransport(
@@ -421,7 +414,7 @@ export function resolveTelegramTransport(
   const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
   // Preserve fully caller-owned custom fetch implementations.
   if (proxyFetch && !explicitProxyUrl) {
-    return { fetch: sourceFetch, sourceFetch };
+    return { fetch: sourceFetch };
   }
 
   const useEnvProxy = !explicitProxyUrl && hasEnvHttpProxyForTelegramApi();
@@ -489,11 +482,7 @@ export function resolveTelegramTransport(
     }
   }) as typeof fetch;
 
-  return {
-    fetch: resolvedFetch,
-    sourceFetch,
-    pinnedDispatcherPolicy: defaultDispatcher.effectivePolicy,
-  };
+  return { fetch: resolvedFetch };
 }
 
 export function resolveTelegramFetch(


### PR DESCRIPTION
## Summary

Fix Telegram media download regressions introduced after the transport refactor.

Telegram file downloads were still going through a static pinned dispatcher path, which bypassed the resolver-owned IPv4/proxy fallback logic. On affected networks this caused media downloads to fail with `TypeError: fetch failed`, even though normal Telegram API calls and `curl` still worked.

## What Changed

- switch Telegram media downloads to use `transport.fetch`
- propagate `pinDns` through `fetchRemoteMedia`
- disable DNS pinning for Telegram media downloads so the resolver-owned transport policy stays in control
- add regression coverage for:
  - normal Telegram transport policy on media downloads
  - explicit proxy routing
  - sticky IPv4 fallback arming on media download failures
  - Telegram delivery path using the caller transport fetch

## Verification

- `pnpm exec vitest run --config vitest.unit.config.ts src/media/fetch.telegram-network.test.ts`
- `pnpm exec vitest run --config vitest.channels.config.ts src/telegram/bot/delivery.resolve-media-retry.test.ts --maxWorkers=1`

Fixes #44708
