### PR TITLE
security(docker): prevent gateway token leak in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,11 @@
 .git
 .worktrees
+
+# Sensitive files – docker-setup.sh writes .env with OPENCLAW_GATEWAY_TOKEN
+# into the project root; keep it out of the build context.
+.env
+.env.*
+
 .bun-cache
 .bun
 .tmp


### PR DESCRIPTION
docker-setup.sh writes OPENCLAW_GATEWAY_TOKEN into .env. While .gitignore excludes it, .dockerignore does not, so docker build copies the secret into the build context. Adds .env and .env.* to .dockerignore.