### PR TITLE
feat(cron): inject output history into isolated agent prompts

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -418,6 +418,48 @@ describe("cron tool", () => {
     expect(params?.sessionTarget).toBe("isolated");
   });
 
+  it("preserves outputHistory in agentTurn payload", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool({ agentSessionKey: "agent:main:discord:dm:buddy" });
+    await tool.execute("call-dedup", {
+      action: "add",
+      job: {
+        name: "daily-briefing",
+        schedule: { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "Send daily briefing", outputHistory: true },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | { payload?: { kind?: string; message?: string; outputHistory?: boolean } }
+      | undefined;
+    expect(params?.payload?.kind).toBe("agentTurn");
+    expect(params?.payload?.outputHistory).toBe(true);
+  });
+
+  it("recovers outputHistory in flat add params", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool();
+    await tool.execute("call-flat-oh", {
+      action: "add",
+      name: "flat-oh-job",
+      schedule: { kind: "at", at: new Date(123).toISOString() },
+      sessionTarget: "isolated",
+      message: "do stuff",
+      outputHistory: true,
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | { payload?: { outputHistory?: boolean; message?: string } }
+      | undefined;
+    expect(params?.payload?.outputHistory).toBe(true);
+    expect(params?.payload?.message).toBe("do stuff");
+  });
+
   it("does not recover flat params when no meaningful job field is present", async () => {
     const tool = createCronTool();
     await expect(
@@ -545,5 +587,22 @@ describe("cron tool", () => {
     expect(params?.id).toBe("job-2");
     expect(params?.patch?.sessionTarget).toBe("main");
     expect(params?.patch?.failureAlert).toEqual({ after: 3, cooldownMs: 60_000 });
+  });
+
+  it("recovers outputHistory in flat patch params for update action", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool();
+    await tool.execute("call-update-flat-oh", {
+      action: "update",
+      jobId: "job-oh",
+      outputHistory: true,
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | { id?: string; patch?: { payload?: { outputHistory?: boolean } } }
+      | undefined;
+    expect(params?.id).toBe("job-oh");
+    expect(params?.patch?.payload?.outputHistory).toBe(true);
   });
 });

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -260,7 +260,8 @@ PAYLOAD TYPES (payload.kind):
 - "systemEvent": Injects text as system event into session
   { "kind": "systemEvent", "text": "<message>" }
 - "agentTurn": Runs agent with message (isolated sessions only)
-  { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional, 0 means no timeout> }
+  { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional, 0 means no timeout>, "outputHistory": <optional-bool> }
+  - outputHistory: set true to include recent delivery outputs as context for the agent. Useful for any recurring task where seeing previous outputs helps — avoiding repetition, tracking changes, building on prior results, etc. Default: false.
 
 DELIVERY (top-level):
   { "mode": "none|announce|webhook", "channel": "<optional>", "to": "<optional>", "bestEffort": <optional-bool> }
@@ -331,6 +332,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               "thinking",
               "timeoutSeconds",
               "allowUnsafeExternalContent",
+              "outputHistory",
             ]);
             const synthetic: Record<string, unknown> = {};
             let found = false;
@@ -340,6 +342,10 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
                 found = true;
               }
             }
+            // outputHistory is a payload-level agentTurn field.  For add,
+            // leave it at the top level so normalizeCronJobCreate can first
+            // auto-create the payload from `message`, then
+            // copyTopLevelAgentTurnFields copies outputHistory in.
             // Only use the synthetic job if at least one meaningful field is present
             // (schedule, payload, message, or text are the minimum signals that the
             // LLM intended to create a job).
@@ -474,6 +480,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               "wakeMode",
               "failureAlert",
               "allowUnsafeExternalContent",
+              "outputHistory",
             ]);
             const synthetic: Record<string, unknown> = {};
             let found = false;
@@ -482,6 +489,29 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
                 synthetic[key] = params[key];
                 found = true;
               }
+            }
+            // outputHistory is a payload-level field; move it into payload
+            // so normalization and applyCronJobPatch see it in the right place.
+            // Skip when systemEvent signals are present to avoid forcing the wrong kind.
+            if (typeof synthetic.outputHistory === "boolean") {
+              const existingPayload =
+                synthetic.payload && typeof synthetic.payload === "object"
+                  ? (synthetic.payload as Record<string, unknown>)
+                  : null;
+              const rawKind =
+                typeof existingPayload?.kind === "string"
+                  ? existingPayload.kind.trim().toLowerCase()
+                  : "";
+              const isSystemEvent = rawKind === "systemevent";
+              if (!isSystemEvent) {
+                const payload = existingPayload ?? {};
+                payload.outputHistory = synthetic.outputHistory;
+                if (!payload.kind) {
+                  payload.kind = "agentTurn";
+                }
+                synthetic.payload = payload;
+              }
+              delete synthetic.outputHistory;
             }
             if (found) {
               params.patch = synthetic;

--- a/src/cron/isolated-agent/output-history.test.ts
+++ b/src/cron/isolated-agent/output-history.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import { buildOutputHistoryBlock, truncateOutputForHistory } from "./output-history.js";
+
+function makeJob(overrides?: {
+  outputHistory?: boolean;
+  recentOutputs?: Array<{ text: string; timestamp: number }>;
+  tz?: string;
+}): CronJob {
+  return {
+    id: "job-1",
+    name: "test-job",
+    description: "",
+    enabled: true,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    schedule: {
+      kind: "cron",
+      expr: "0 8 * * *",
+      ...(overrides?.tz ? { tz: overrides.tz } : {}),
+    },
+    payload: {
+      kind: "agentTurn",
+      message: "test",
+      ...(overrides?.outputHistory ? { outputHistory: true } : {}),
+    },
+    delivery: { mode: "none" },
+    state: overrides?.recentOutputs ? { recentOutputs: overrides.recentOutputs } : {},
+  } as CronJob;
+}
+
+describe("buildOutputHistoryBlock", () => {
+  it("returns undefined when outputHistory is not enabled", () => {
+    const job = makeJob({ recentOutputs: [{ text: "hello", timestamp: 1000 }] });
+    expect(buildOutputHistoryBlock(job)).toBeUndefined();
+  });
+
+  it("returns undefined when outputHistory is enabled but no outputs exist", () => {
+    const job = makeJob({ outputHistory: true });
+    expect(buildOutputHistoryBlock(job)).toBeUndefined();
+  });
+
+  it("returns undefined when recentOutputs is empty array", () => {
+    const job = makeJob({ outputHistory: true, recentOutputs: [] });
+    expect(buildOutputHistoryBlock(job)).toBeUndefined();
+  });
+
+  it("returns undefined for non-agentTurn payload", () => {
+    const job = makeJob({ outputHistory: true, recentOutputs: [{ text: "hi", timestamp: 1000 }] });
+    (job.payload as { kind: string }).kind = "systemEvent";
+    expect(buildOutputHistoryBlock(job)).toBeUndefined();
+  });
+
+  it("builds context block with formatted outputs", () => {
+    const job = makeJob({
+      outputHistory: true,
+      recentOutputs: [
+        { text: "First output", timestamp: 1710230400000 },
+        { text: "Second output", timestamp: 1710316800000 },
+      ],
+    });
+    const result = buildOutputHistoryBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("[Your previous outputs for this scheduled task");
+    expect(result).toContain("First output");
+    expect(result).toContain("Second output");
+    const firstIdx = result!.indexOf("First output");
+    const secondIdx = result!.indexOf("Second output");
+    expect(secondIdx).toBeGreaterThan(firstIdx);
+  });
+
+  it("uses job timezone for formatting when available", () => {
+    const job = makeJob({
+      outputHistory: true,
+      tz: "Asia/Shanghai",
+      recentOutputs: [{ text: "output", timestamp: 1710230400000 }],
+    });
+    const result = buildOutputHistoryBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("output");
+  });
+
+  it("falls back to default formatting for invalid timezone", () => {
+    const job = makeJob({
+      outputHistory: true,
+      tz: "Invalid/Timezone",
+      recentOutputs: [{ text: "output", timestamp: 1710230400000 }],
+    });
+    const result = buildOutputHistoryBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("output");
+  });
+
+  it("works with every-schedule jobs (no tz field)", () => {
+    const job = makeJob({
+      outputHistory: true,
+      recentOutputs: [{ text: "output", timestamp: 1710230400000 }],
+    });
+    job.schedule = { kind: "every", everyMs: 60_000 };
+    const result = buildOutputHistoryBlock(job);
+    expect(result).toBeDefined();
+    expect(result).toContain("output");
+  });
+});
+
+describe("truncateOutputForHistory", () => {
+  it("returns short text unchanged", () => {
+    expect(truncateOutputForHistory("hello")).toBe("hello");
+  });
+
+  it("returns text at exactly the limit unchanged", () => {
+    const text = "x".repeat(600);
+    expect(truncateOutputForHistory(text)).toBe(text);
+  });
+
+  it("truncates long text keeping head and tail within limit", () => {
+    const head = "H".repeat(400);
+    const middle = "M".repeat(200);
+    const tail = "T".repeat(400);
+    const result = truncateOutputForHistory(`${head}${middle}${tail}`);
+    expect(result).toContain("H".repeat(298));
+    expect(result).toContain("T".repeat(298));
+    expect(result).toContain("…");
+    // partLen = floor((600 - 3) / 2) = 298; total = 298 + " … " + 298 = 599
+    expect(result.length).toBeLessThanOrEqual(600);
+  });
+
+  it("does not expand text in the 601-602 char range", () => {
+    const text = "A".repeat(601);
+    const result = truncateOutputForHistory(text);
+    expect(result.length).toBeLessThanOrEqual(600);
+    expect(result).toContain("…");
+  });
+});

--- a/src/cron/isolated-agent/output-history.ts
+++ b/src/cron/isolated-agent/output-history.ts
@@ -1,0 +1,52 @@
+import type { CronJob } from "../types.js";
+
+export const OUTPUT_HISTORY_MAX_ENTRIES = 5;
+/** Max characters to keep from each end when truncating long outputs. */
+export const OUTPUT_HISTORY_HEAD_TAIL_CHARS = 300;
+
+/** Truncate output text keeping the first and last N characters. */
+export function truncateOutputForHistory(text: string): string {
+  const sep = " … ";
+  const limit = OUTPUT_HISTORY_HEAD_TAIL_CHARS * 2;
+  if (text.length <= limit) {
+    return text;
+  }
+  const partLen = Math.floor((limit - sep.length) / 2);
+  const head = text.slice(0, partLen);
+  const tail = text.slice(-partLen);
+  return `${head}${sep}${tail}`;
+}
+
+export function buildOutputHistoryBlock(job: CronJob): string | undefined {
+  if (job.payload.kind !== "agentTurn" || !job.payload.outputHistory) {
+    return undefined;
+  }
+  const raw = job.state.recentOutputs;
+  if (!raw || raw.length === 0) {
+    return undefined;
+  }
+
+  // Defense-in-depth: cap entries and text length at consumption to prevent
+  // prompt blow-ups even if state was patched directly bypassing runtime guards.
+  const outputs = raw.slice(-OUTPUT_HISTORY_MAX_ENTRIES);
+
+  const rawTz = job.schedule.kind === "cron" ? job.schedule.tz?.trim() : undefined;
+  const lines = outputs.map((o) => {
+    const text = truncateOutputForHistory(o.text);
+    const date = new Date(o.timestamp);
+    let formatted: string;
+    try {
+      formatted = rawTz
+        ? date.toLocaleString("en-US", { timeZone: rawTz, dateStyle: "short", timeStyle: "short" })
+        : date.toLocaleString("en-US", { dateStyle: "short", timeStyle: "short" });
+    } catch {
+      formatted = date.toLocaleString("en-US", { dateStyle: "short", timeStyle: "short" });
+    }
+    return `- ${formatted}: ${text}`;
+  });
+
+  return [
+    "[Your previous outputs for this scheduled task — use them as context for your next response:]",
+    ...lines,
+  ].join("\n");
+}

--- a/src/cron/isolated-agent/run.output-history.test.ts
+++ b/src/cron/isolated-agent/run.output-history.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentTurnJob,
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+/**
+ * Intercept the prompt that runCronIsolatedAgentTurn assembles and passes
+ * through the real code path: runWithModelFallback → runEmbeddedPiAgent.
+ */
+function interceptPrompt(): { get(): string } {
+  let captured = "";
+  runWithModelFallbackMock.mockImplementationOnce(async (opts: { run: Function }) => {
+    await opts.run("openai", "gpt-4", {});
+    return {
+      result: {
+        payloads: [{ text: "test output" }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    };
+  });
+  runEmbeddedPiAgentMock.mockImplementationOnce(async (opts: { prompt: string }) => {
+    captured = opts.prompt;
+    return {
+      payloads: [{ text: "test output" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    };
+  });
+  return { get: () => captured };
+}
+
+describe("runCronIsolatedAgentTurn — output history injection", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("includes output history block when outputHistory is enabled and outputs exist", async () => {
+    const prompt = interceptPrompt();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: { kind: "agentTurn", message: "Send daily briefing", outputHistory: true },
+          state: {
+            recentOutputs: [
+              { text: "Yesterday's briefing: Stock market rose 2%", timestamp: 1710230400000 },
+              { text: "Markets closed flat today", timestamp: 1710316800000 },
+            ],
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(prompt.get()).toContain(
+      "[Your previous outputs for this scheduled task — use them as context for your next response:]",
+    );
+    expect(prompt.get()).toContain("Yesterday's briefing: Stock market rose 2%");
+    expect(prompt.get()).toContain("Markets closed flat today");
+  });
+
+  it("does not include output history block when outputHistory is disabled", async () => {
+    const prompt = interceptPrompt();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: { kind: "agentTurn", message: "Send daily briefing" },
+          state: {
+            recentOutputs: [{ text: "Old output", timestamp: 1710230400000 }],
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(prompt.get()).not.toContain("[Your previous outputs for this scheduled task");
+  });
+
+  it("does not include output history block on first run (no previous outputs)", async () => {
+    const prompt = interceptPrompt();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: { kind: "agentTurn", message: "Send daily briefing", outputHistory: true },
+          state: {},
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(prompt.get()).not.toContain("[Your previous outputs for this scheduled task");
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -62,6 +62,7 @@ import {
   resolveHeartbeatAckMaxChars,
 } from "./helpers.js";
 import { resolveCronModelSelection } from "./model-selection.js";
+import { buildOutputHistoryBlock } from "./output-history.js";
 import { buildCronAgentDefaultsConfig } from "./run-config.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";
@@ -360,11 +361,16 @@ export async function runCronIsolatedAgentTurn(params: {
     }
   }
 
+  const outputHistoryBlock = buildOutputHistoryBlock(params.job);
+
   if (shouldWrapExternal) {
-    // Wrap external content with security boundaries
+    // Wrap external content (and any output history) with security boundaries
     const hookType = mapHookExternalContentSource(hookExternalContentSource ?? "webhook");
+    const contentToWrap = outputHistoryBlock
+      ? `${params.message}\n\n${outputHistoryBlock}`
+      : params.message;
     const safeContent = buildSafeExternalPrompt({
-      content: params.message,
+      content: contentToWrap,
       source: hookType,
       jobName: params.job.name,
       jobId: params.job.id,
@@ -375,7 +381,11 @@ export async function runCronIsolatedAgentTurn(params: {
   } else {
     // Internal/trusted source - use original format
     commandBody = `${base}\n${timeLine}`.trim();
+    if (outputHistoryBlock) {
+      commandBody = `${commandBody}\n\n${outputHistoryBlock}`;
+    }
   }
+
   commandBody = appendCronDeliveryInstruction({ commandBody, deliveryRequested });
 
   const existingSkillsSnapshot = cronSession.sessionEntry.skillsSnapshot;

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -101,7 +101,8 @@ function coercePayload(payload: UnknownRecord) {
       typeof next.model === "string" ||
       typeof next.thinking === "string" ||
       typeof next.timeoutSeconds === "number" ||
-      typeof next.allowUnsafeExternalContent === "boolean";
+      typeof next.allowUnsafeExternalContent === "boolean" ||
+      typeof next.outputHistory === "boolean";
     if (hasMessage) {
       next.kind = "agentTurn";
     } else if (hasText) {
@@ -268,6 +269,9 @@ function copyTopLevelAgentTurnFields(next: UnknownRecord, payload: UnknownRecord
   ) {
     payload.allowUnsafeExternalContent = next.allowUnsafeExternalContent;
   }
+  if (typeof payload.outputHistory !== "boolean" && typeof next.outputHistory === "boolean") {
+    payload.outputHistory = next.outputHistory;
+  }
 }
 
 function copyTopLevelLegacyDeliveryFields(next: UnknownRecord, payload: UnknownRecord) {
@@ -311,6 +315,7 @@ function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.to;
   delete next.bestEffortDeliver;
   delete next.provider;
+  delete next.outputHistory;
 }
 
 export function normalizeCronJobInput(

--- a/src/cron/service.output-history-recording.test.ts
+++ b/src/cron/service.output-history-recording.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createFinishedBarrier,
+  createCronStoreHarness,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+type CronAddInput = Parameters<CronService["add"]>[0];
+
+function buildOutputHistoryJob(name: string): CronAddInput {
+  return {
+    name,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "test", outputHistory: true },
+    delivery: { mode: "none" },
+  };
+}
+
+describe("CronService output history recording", () => {
+  it("records outputText in recentOutputs when outputHistory is enabled and run succeeds", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: "Today's celebrity news: Actor X did Y",
+        delivered: true,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildOutputHistoryJob("history-record"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toBeDefined();
+      expect(updated?.state.recentOutputs).toHaveLength(1);
+      expect(updated?.state.recentOutputs![0].text).toBe("Today's celebrity news: Actor X did Y");
+      expect(updated?.state.recentOutputs![0].timestamp).toBeGreaterThan(0);
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("does not record when outputHistory is not enabled", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: "some output",
+        delivered: true,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add({
+        ...buildOutputHistoryJob("no-history"),
+        payload: { kind: "agentTurn", message: "test" },
+      });
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toBeUndefined();
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("does not record when run fails", async () => {
+    const store = await makeStorePath();
+    let finishedResolve: () => void;
+    const finishedPromise = new Promise<void>((r) => {
+      finishedResolve = r;
+    });
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "error" as const,
+        error: "something went wrong",
+        outputText: "partial output",
+      })),
+      onEvent: (evt) => {
+        if (evt.action === "finished") {
+          finishedResolve();
+        }
+      },
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildOutputHistoryJob("error-run"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finishedPromise;
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toBeUndefined();
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("caps recentOutputs at 5 entries (FIFO)", async () => {
+    const store = await makeStorePath();
+    let runCount = 0;
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        runCount++;
+        return {
+          status: "ok" as const,
+          summary: "done",
+          outputText: `output-${runCount}`,
+          delivered: true,
+        };
+      }),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildOutputHistoryJob("cap-test"));
+
+      // Run 6 times
+      for (let i = 0; i < 6; i++) {
+        vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+        await vi.runOnlyPendingTimersAsync();
+        await finished.waitForOk(job.id);
+        // Re-read job state for next iteration's nextRunAtMs
+        const jobs = await cron.list({ includeDisabled: true });
+        const updated = jobs.find((j) => j.id === job.id)!;
+        Object.assign(job.state, updated.state);
+      }
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      expect(updated?.state.recentOutputs).toHaveLength(5);
+      // Oldest (output-1) should be dropped, newest 5 remain
+      expect(updated?.state.recentOutputs![0].text).toBe("output-2");
+      expect(updated?.state.recentOutputs![4].text).toBe("output-6");
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("truncates long output keeping head and tail", async () => {
+    const store = await makeStorePath();
+    const finished = createFinishedBarrier();
+    const head = "H".repeat(400);
+    const tail = "T".repeat(400);
+    const longText = `${head}${"x".repeat(200)}${tail}`;
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        outputText: longText,
+        delivered: true,
+      })),
+      onEvent: (evt) => finished.onEvent(evt),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildOutputHistoryJob("truncate-test"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const updated = jobs.find((j) => j.id === job.id);
+      const stored = updated?.state.recentOutputs![0].text;
+      // Should contain head and tail with ellipsis separator, within the 600 char limit
+      expect(stored).toContain("H".repeat(298));
+      expect(stored).toContain("T".repeat(298));
+      expect(stored).toContain("…");
+      expect(stored!.length).toBeLessThanOrEqual(600);
+    } finally {
+      cron.stop();
+    }
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -704,6 +704,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.bestEffortDeliver === "boolean") {
     next.bestEffortDeliver = patch.bestEffortDeliver;
   }
+  if (typeof patch.outputHistory === "boolean") {
+    next.outputHistory = patch.outputHistory;
+  }
   return next;
 }
 
@@ -772,6 +775,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     channel: patch.channel,
     to: patch.to,
     bestEffortDeliver: patch.bestEffortDeliver,
+    outputHistory: patch.outputHistory,
   };
 }
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -487,9 +487,7 @@ async function finishPreparedManualRun(
       state,
       job,
       {
-        status: coreResult.status,
-        error: coreResult.error,
-        delivered: coreResult.delivered,
+        ...coreResult,
         startedAt,
         endedAt,
       },

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -3,6 +3,10 @@ import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
+import {
+  OUTPUT_HISTORY_MAX_ENTRIES,
+  truncateOutputForHistory,
+} from "../isolated-agent/output-history.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
 import type {
   CronDeliveryStatus,
@@ -48,6 +52,7 @@ type TimedCronRunOutcome = CronRunOutcome &
     jobId: string;
     delivered?: boolean;
     deliveryAttempted?: boolean;
+    outputText?: string;
     startedAt: number;
     endedAt: number;
   };
@@ -299,6 +304,7 @@ export function applyJobResult(
     status: CronRunStatus;
     error?: string;
     delivered?: boolean;
+    outputText?: string;
     startedAt: number;
     endedAt: number;
   },
@@ -333,6 +339,27 @@ export function applyJobResult(
   job.state.lastDeliveryError =
     deliveryStatus === "not-delivered" && result.error ? result.error : undefined;
   job.updatedAtMs = result.endedAt;
+
+  // Record output for history on successful runs. Delivery outcome is irrelevant —
+  // the agent should remember what it produced regardless of whether it reached the
+  // user, otherwise it will repeat itself when delivery recovers.
+  const outputText = result.outputText?.trim();
+  const shouldRecordHistory =
+    result.status === "ok" &&
+    outputText &&
+    job.payload.kind === "agentTurn" &&
+    job.payload.outputHistory;
+  if (shouldRecordHistory) {
+    const outputs = job.state.recentOutputs ?? [];
+    outputs.push({
+      text: truncateOutputForHistory(outputText),
+      timestamp: result.endedAt,
+    });
+    if (outputs.length > OUTPUT_HISTORY_MAX_ENTRIES) {
+      outputs.splice(0, outputs.length - OUTPUT_HISTORY_MAX_ENTRIES);
+    }
+    job.state.recentOutputs = outputs;
+  }
 
   // Track consecutive errors for backoff / auto-disable.
   if (result.status === "error") {
@@ -492,6 +519,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     status: result.status,
     error: result.error,
     delivered: result.delivered,
+    outputText: result.outputText,
     startedAt: result.startedAt,
     endedAt: result.endedAt,
   });
@@ -929,20 +957,7 @@ async function runStartupCatchupCandidate(
   emit(state, { jobId: candidate.job.id, action: "started", runAtMs: startedAt });
   try {
     const result = await executeJobCoreWithTimeout(state, candidate.job);
-    return {
-      jobId: candidate.jobId,
-      status: result.status,
-      error: result.error,
-      summary: result.summary,
-      delivered: result.delivered,
-      sessionId: result.sessionId,
-      sessionKey: result.sessionKey,
-      model: result.model,
-      provider: result.provider,
-      usage: result.usage,
-      startedAt,
-      endedAt: state.deps.nowMs(),
-    };
+    return { jobId: candidate.jobId, ...result, startedAt, endedAt: state.deps.nowMs() };
   } catch (err) {
     return {
       jobId: candidate.jobId,
@@ -1009,7 +1024,8 @@ export async function executeJobCore(
   job: CronJob,
   abortSignal?: AbortSignal,
 ): Promise<
-  CronRunOutcome & CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean }
+  CronRunOutcome &
+    CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean; outputText?: string }
 > {
   const resolveAbortError = () => ({
     status: "error" as const,
@@ -1148,6 +1164,7 @@ export async function executeJobCore(
     summary: res.summary,
     delivered: res.delivered,
     deliveryAttempted: res.deliveryAttempted,
+    outputText: res.outputText,
     sessionId: res.sessionId,
     sessionKey: res.sessionKey,
     model: res.model,
@@ -1177,6 +1194,7 @@ export async function executeJob(
   let coreResult: {
     status: CronRunStatus;
     delivered?: boolean;
+    outputText?: string;
   } & CronRunOutcome &
     CronRunTelemetry;
   try {
@@ -1190,6 +1208,7 @@ export async function executeJob(
     status: coreResult.status,
     error: coreResult.error,
     delivered: coreResult.delivered,
+    outputText: coreResult.outputText,
     startedAt,
     endedAt,
   });

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -100,6 +100,11 @@ type CronAgentTurnPayloadFields = {
   channel?: CronMessageChannel;
   to?: string;
   bestEffortDeliver?: boolean;
+  /**
+   * When true, inject recent delivered outputs into the agent's system prompt
+   * as context for the next run. Default: false.
+   */
+  outputHistory?: boolean;
 };
 
 type CronAgentTurnPayload = {
@@ -133,6 +138,17 @@ export type CronJobState = {
   lastDeliveryError?: string;
   /** Whether the last run's output was delivered to the target channel. */
   lastDelivered?: boolean;
+  /**
+   * Recent delivered outputs for output history injection.
+   * Capped at 5 entries, FIFO.
+   * Only populated when `payload.outputHistory` is enabled.
+   */
+  recentOutputs?: Array<{
+    /** Delivered text, truncated to ≤600 characters (head + tail with separator). */
+    text: string;
+    /** Timestamp (ms since epoch) when the output was delivered. */
+    timestamp: number;
+  }>;
 };
 
 export type CronJob = CronJobBase<

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -107,6 +107,27 @@ describe("cron protocol validators", () => {
     expect(validateCronRunsParams({ id: "job-1", offset: -1 })).toBe(false);
   });
 
+  it("accepts agentTurn add params with outputHistory", () => {
+    expect(
+      validateCronAddParams({
+        name: "daily-briefing",
+        schedule: { kind: "cron", expr: "0 8 * * *" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "Send briefing", outputHistory: true },
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts update params with outputHistory in payload patch", () => {
+    expect(
+      validateCronUpdateParams({
+        id: "job-1",
+        patch: { payload: { kind: "agentTurn", message: "updated", outputHistory: true } },
+      }),
+    ).toBe(true);
+  });
+
   it("accepts all-scope runs with multi-select filters", () => {
     expect(
       validateCronRunsParams({

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -16,6 +16,7 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
       channel: Type.Optional(Type.String()),
       to: Type.Optional(Type.String()),
       bestEffortDeliver: Type.Optional(Type.Boolean()),
+      outputHistory: Type.Optional(Type.Boolean()),
     },
     { additionalProperties: false },
   );
@@ -240,6 +241,17 @@ export const CronJobStateSchema = Type.Object(
     lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
     lastDeliveryError: Type.Optional(Type.String()),
     lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    recentOutputs: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            text: Type.String(),
+            timestamp: Type.Integer({ minimum: 0 }),
+          },
+          { additionalProperties: false },
+        ),
+      ),
+    ),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
## Problem

Isolated cron sessions start fresh each run (`forceNew: true`), so the agent has zero memory of previous outputs. This causes:

- **Repetitive content**: daily briefings repeat the same news/updates
- **No change tracking**: monitoring jobs can't compare current vs previous state
- **No iterative analysis**: each run starts from scratch, unable to build on prior findings
- **No variety**: content scheduling produces duplicate outputs

## Solution

Add a per-job `outputHistory` flag. When enabled:

1. After successful delivery, the output text is recorded in `job.state.recentOutputs` (capped at 5 entries, FIFO)
2. On subsequent runs, recent outputs are injected into the agent's system prompt as context
3. Outputs are truncated to ≤600 characters (head + tail with separator) to keep prompt size bounded

## Use cases

- **Daily briefings**: agent sees what it reported yesterday, avoids repetition
- **Monitoring**: agent compares current metrics against previous readings
- **Iterative analysis**: agent builds on prior findings across runs
- **Content scheduling**: agent maintains variety by seeing recent outputs

## Changes

- Add `outputHistory` field to `CronAgentTurnPayloadFields` and `recentOutputs` to `CronJobState`
- New `output-history.ts`: `buildOutputHistoryBlock` + `truncateOutputForHistory`
- Inject history block into agent prompt in `run.ts`
- Record delivered output in `timer.ts` `applyJobResult`
- Support `outputHistory` in `mergeCronPayload` / `buildPayloadFromPatch`
- Guard against invalid timezone in output formatting
- Update gateway protocol schema and cron tool description

## Test plan

- [x] Unit tests: `buildOutputHistoryBlock` guard conditions, formatting, timezone fallback, truncation bounds
- [x] Integration tests: recording, FIFO cap, no-record when disabled/failed, truncation
- [x] E2E tests: prompt injection through real `runCronIsolatedAgentTurn` code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)