### PR TITLE
Sessions: normalize mirrored media names

### DIFF
--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveMirroredTranscriptText } from "./transcript.js";
+
+describe("resolveMirroredTranscriptText", () => {
+  it("strips Windows-style path segments from encoded media URLs", () => {
+    const result = resolveMirroredTranscriptText({
+      mediaUrls: ["https://example.com/uploads/..%5Csecret.txt?sig=123"],
+    });
+
+    expect(result).toBe("secret.txt");
+  });
+
+  it("strips Windows-style path segments from raw media hints", () => {
+    const result = resolveMirroredTranscriptText({
+      mediaUrls: ["..\\private\\voice-note.m4a#fragment"],
+    });
+
+    expect(result).toBe("voice-note.m4a");
+  });
+});

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -18,6 +18,10 @@ function stripQuery(value: string): string {
   return noHash.split("?")[0] ?? noHash;
 }
 
+function safeBaseName(value: string): string {
+  return path.win32.basename(path.posix.basename(value));
+}
+
 function extractFileNameFromMediaUrl(value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -26,17 +30,17 @@ function extractFileNameFromMediaUrl(value: string): string | null {
   const cleaned = stripQuery(trimmed);
   try {
     const parsed = new URL(cleaned);
-    const base = path.basename(parsed.pathname);
+    const base = safeBaseName(parsed.pathname);
     if (!base) {
       return null;
     }
     try {
-      return decodeURIComponent(base);
+      return safeBaseName(decodeURIComponent(base));
     } catch {
       return base;
     }
   } catch {
-    const base = path.basename(cleaned);
+    const base = safeBaseName(cleaned);
     if (!base || base === "/" || base === ".") {
       return null;
     }


### PR DESCRIPTION
## Summary
- normalize mirrored media file names through a separator-agnostic basename helper
- strip Windows-style path segments out of transcript media URL mirrors on non-Windows hosts
- add regression coverage for encoded and raw backslash path segments

## Testing
- pnpm test src/config/sessions/transcript.test.ts
- pnpm check
- pnpm build
