### PR TITLE
fix: normalize baseUrl for custom Google Generative AI providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Runtime/build: stabilize long-lived lazy `dist` runtime entry paths and harden bundled plugin npm staging so local rebuilds stop breaking on missing hashed chunks or broken shell `npm` shims. (#53855) Thanks @vincentkoc.
 - Slack/runtime defaults: trim Slack DM reply overhead, restore Codex auto transport, and tighten Slack/web-search runtime defaults around DM preview threading, cache scoping, warning dedupe, and explicit web-search opt-in. (#53957) Thanks @vincentkoc.
 - Discord/timeouts: send a visible timeout reply when the inbound Discord worker times out before a final reply starts, including created auto-thread targets and queued-run ordering. (#53823) Thanks @Kimbo7870.
+- Models/google: normalize bare Google Generative AI API roots for custom provider names, and keep built-in Google model-id rewrites working when `api` is declared only on individual models, so custom Google lanes and older configs stop missing `/v1beta` or preview-id normalization. (#44969) Thanks @Kathie-yu.
 
 ## 2026.3.23
 

--- a/src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts
+++ b/src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts
@@ -20,11 +20,19 @@ function createGoogleModelsConfig(models: ModelDefinitionConfig[]): OpenClawConf
   };
 }
 
-async function expectGeneratedGoogleModelIds(ids: string[]) {
+async function readGeneratedProvider(providerKey: string) {
   const parsed = await readGeneratedModelsJson<{
-    providers: Record<string, { models: Array<{ id: string }> }>;
+    providers: Record<string, { baseUrl?: string; models: Array<{ id: string }> }>;
   }>();
-  expect(parsed.providers.google?.models?.map((model) => model.id)).toEqual(ids);
+  return parsed.providers[providerKey];
+}
+
+async function expectGeneratedProvider(providerKey: string, params: { ids: string[]; baseUrl?: string }) {
+  const provider = await readGeneratedProvider(providerKey);
+  expect(provider?.models?.map((model) => model.id)).toEqual(params.ids);
+  if (params.baseUrl !== undefined) {
+    expect(provider?.baseUrl).toBe(params.baseUrl);
+  }
 }
 
 describe("models-config", () => {
@@ -56,7 +64,9 @@ describe("models-config", () => {
       ]);
 
       await ensureOpenClawModelsJson(cfg);
-      await expectGeneratedGoogleModelIds(["gemini-3-pro-preview", "gemini-3-flash-preview"]);
+      await expectGeneratedProvider("google", {
+        ids: ["gemini-3-pro-preview", "gemini-3-flash-preview"],
+      });
     });
   });
 
@@ -76,7 +86,76 @@ describe("models-config", () => {
       ]);
 
       await ensureOpenClawModelsJson(cfg);
-      await expectGeneratedGoogleModelIds(["gemini-3-flash-preview"]);
+      await expectGeneratedProvider("google", {
+        ids: ["gemini-3-flash-preview"],
+      });
+    });
+  });
+
+  it("normalizes custom Google Generative AI providers by api instead of provider name", async () => {
+    await withModelsTempHome(async () => {
+      const cfg = {
+        models: {
+          providers: {
+            "google-paid": {
+              baseUrl: "https://generativelanguage.googleapis.com",
+              apiKey: "GEMINI_KEY", // pragma: allowlist secret
+              api: "google-generative-ai",
+              models: [
+                {
+                  id: "gemini-3-pro",
+                  name: "Gemini 3 Pro",
+                  api: "google-generative-ai",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1048576,
+                  maxTokens: 65536,
+                },
+              ],
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+
+      await ensureOpenClawModelsJson(cfg);
+      await expectGeneratedProvider("google-paid", {
+        ids: ["gemini-3-pro-preview"],
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      });
+    });
+  });
+
+  it("keeps built-in google normalization when api is only defined on models", async () => {
+    await withModelsTempHome(async () => {
+      const cfg = {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com",
+              apiKey: "GEMINI_KEY", // pragma: allowlist secret
+              models: [
+                {
+                  id: "gemini-3-flash",
+                  name: "Gemini 3 Flash",
+                  api: "google-generative-ai",
+                  reasoning: false,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1048576,
+                  maxTokens: 65536,
+                },
+              ],
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+
+      await ensureOpenClawModelsJson(cfg);
+      await expectGeneratedProvider("google", {
+        ids: ["gemini-3-flash-preview"],
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      });
     });
   });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -17,6 +17,7 @@ import {
 } from "../plugin-sdk/provider-catalog.js";
 import { isRecord } from "../utils.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
+import { normalizeGoogleApiBaseUrl } from "../infra/google-api-base-url.js";
 import { hasAnthropicVertexAvailableAuth } from "./anthropic-vertex-provider.js";
 import { ensureAuthProfileStore, listProfilesForProvider } from "./auth-profiles.js";
 import { discoverBedrockModels } from "./bedrock-discovery.js";
@@ -330,8 +331,25 @@ function normalizeProviderModels(
   return mutated ? { ...provider, models } : provider;
 }
 
+function shouldNormalizeGoogleProvider(providerKey: string, provider: ProviderConfig): boolean {
+  if (providerKey === "google" || providerKey === "google-vertex") {
+    return true;
+  }
+  if (provider.api === "google-generative-ai") {
+    return true;
+  }
+  return provider.models.some((model) => model.api === "google-generative-ai");
+}
+
 function normalizeGoogleProvider(provider: ProviderConfig): ProviderConfig {
-  return normalizeProviderModels(provider, normalizeGoogleModelId);
+  const modelNormalized = normalizeProviderModels(provider, normalizeGoogleModelId);
+  const normalizedBaseUrl = modelNormalized.baseUrl
+    ? normalizeGoogleApiBaseUrl(modelNormalized.baseUrl)
+    : modelNormalized.baseUrl;
+  if (normalizedBaseUrl !== modelNormalized.baseUrl) {
+    return { ...modelNormalized, baseUrl: normalizedBaseUrl ?? modelNormalized.baseUrl };
+  }
+  return modelNormalized;
 }
 
 function normalizeAntigravityProvider(provider: ProviderConfig): ProviderConfig {
@@ -608,7 +626,7 @@ export function normalizeProviders(params: {
       }
     }
 
-    if (normalizedKey === "google" || normalizedKey === "google-vertex") {
+    if (shouldNormalizeGoogleProvider(normalizedKey, normalizedProvider)) {
       const googleNormalized = normalizeGoogleProvider(normalizedProvider);
       if (googleNormalized !== normalizedProvider) {
         mutated = true;

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -177,6 +177,25 @@ describe("buildInlineProviderModels", () => {
     });
   });
 
+  it("normalizes bare Google API hosts for custom Google Generative AI providers", () => {
+    const providers: Parameters<typeof buildInlineProviderModels>[0] = {
+      "google-paid ": {
+        baseUrl: "https://generativelanguage.googleapis.com",
+        api: "google-generative-ai",
+        models: [makeModel("gemini-2.5-pro")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      provider: "google-paid",
+      api: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    });
+  });
+
   it("merges provider-level headers into inline models", () => {
     const providers: Parameters<typeof buildInlineProviderModels>[0] = {
       proxy: {
@@ -282,6 +301,54 @@ describe("resolveModel", () => {
     expect(result.model?.baseUrl).toBe("http://localhost:9000");
     expect(result.model?.provider).toBe("custom");
     expect(result.model?.id).toBe("missing-model");
+  });
+
+  it("normalizes Google fallback baseUrls for custom providers", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "google-paid": {
+            baseUrl: "https://generativelanguage.googleapis.com",
+            api: "google-generative-ai",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModelForTest("google-paid", "missing-model", "/tmp/agent", cfg);
+
+    expect(result.model?.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta");
+  });
+
+  it("normalizes configured Google override baseUrls when provider api is omitted", () => {
+    mockDiscoveredModel({
+      provider: "google",
+      modelId: "gemini-2.5-pro",
+      templateModel: {
+        ...makeModel("gemini-2.5-pro"),
+        provider: "google",
+        api: "google-generative-ai",
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            baseUrl: "https://generativelanguage.googleapis.com",
+            models: [{ id: "gemini-2.5-pro", name: "gemini-2.5-pro" }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModelForTest("google", "gemini-2.5-pro", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.api).toBe("google-generative-ai");
+    expect(result.model?.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta");
   });
 
   it("includes provider headers in provider fallback model", () => {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -19,7 +19,12 @@ import {
   shouldSuppressBuiltInModel,
 } from "../model-suppression.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
+import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
 import { normalizeResolvedProviderModel } from "./model.provider-normalization.js";
+
+function normalizeGoogleGenerativeAiBaseUrl(baseUrl: string | undefined): string | undefined {
+  return baseUrl ? normalizeGoogleApiBaseUrl(baseUrl) : baseUrl;
+}
 
 type InlineModelEntry = ModelDefinitionConfig & {
   provider: string;
@@ -175,10 +180,15 @@ function applyConfiguredProviderOverrides(params: {
       ? resolvedInput.filter((item) => item === "text" || item === "image")
       : (["text"] as Array<"text" | "image">);
 
+  const resolvedApi = configuredModel?.api ?? providerConfig.api ?? discoveredModel.api;
+  let resolvedBaseUrl = providerConfig.baseUrl ?? discoveredModel.baseUrl;
+  if (resolvedApi === "google-generative-ai") {
+    resolvedBaseUrl = normalizeGoogleGenerativeAiBaseUrl(resolvedBaseUrl) ?? resolvedBaseUrl;
+  }
   return {
     ...discoveredModel,
-    api: configuredModel?.api ?? providerConfig.api ?? discoveredModel.api,
-    baseUrl: providerConfig.baseUrl ?? discoveredModel.baseUrl,
+    api: resolvedApi,
+    baseUrl: resolvedBaseUrl,
     reasoning: configuredModel?.reasoning ?? discoveredModel.reasoning,
     input: normalizedInput,
     cost: configuredModel?.cost ?? discoveredModel.cost,
@@ -207,24 +217,31 @@ export function buildInlineProviderModels(
     const providerHeaders = sanitizeModelHeaders(entry?.headers, {
       stripSecretRefMarkers: true,
     });
-    return (entry?.models ?? []).map((model) => ({
-      ...model,
-      provider: trimmed,
-      baseUrl: entry?.baseUrl,
-      api: model.api ?? entry?.api,
-      headers: (() => {
-        const modelHeaders = sanitizeModelHeaders((model as InlineModelEntry).headers, {
-          stripSecretRefMarkers: true,
-        });
-        if (!providerHeaders && !modelHeaders) {
-          return undefined;
-        }
-        return {
-          ...providerHeaders,
-          ...modelHeaders,
-        };
-      })(),
-    }));
+    return (entry?.models ?? []).map((model) => {
+      const modelApi = model.api ?? entry?.api;
+      let baseUrl = entry?.baseUrl;
+      if (modelApi === "google-generative-ai") {
+        baseUrl = normalizeGoogleGenerativeAiBaseUrl(baseUrl) ?? baseUrl;
+      }
+      return {
+        ...model,
+        provider: trimmed,
+        baseUrl,
+        api: modelApi,
+        headers: (() => {
+          const modelHeaders = sanitizeModelHeaders((model as InlineModelEntry).headers, {
+            stripSecretRefMarkers: true,
+          });
+          if (!providerHeaders && !modelHeaders) {
+            return undefined;
+          }
+          return {
+            ...providerHeaders,
+            ...modelHeaders,
+          };
+        })(),
+      };
+    });
   });
 }
 
@@ -358,6 +375,11 @@ function resolveConfiguredFallbackModel(params: {
   if (!providerConfig && !modelId.startsWith("mock-")) {
     return undefined;
   }
+  const fallbackApi = providerConfig?.api ?? "openai-responses";
+  let fallbackBaseUrl = providerConfig?.baseUrl;
+  if (fallbackApi === "google-generative-ai") {
+    fallbackBaseUrl = normalizeGoogleGenerativeAiBaseUrl(fallbackBaseUrl) ?? fallbackBaseUrl;
+  }
   return normalizeResolvedModel({
     provider,
     cfg,
@@ -365,9 +387,9 @@ function resolveConfiguredFallbackModel(params: {
     model: {
       id: modelId,
       name: modelId,
-      api: providerConfig?.api ?? "openai-responses",
+      api: fallbackApi,
       provider,
-      baseUrl: providerConfig?.baseUrl,
+      baseUrl: fallbackBaseUrl,
       reasoning: configuredModel?.reasoning ?? false,
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },


### PR DESCRIPTION
## Summary

- **Problem:** Provider normalization in `models-config.providers.ts` is gated on `normalizedKey === "google"`, so any custom-named provider using `api: "google-generative-ai"` (e.g. for separate API keys, billing, or rate-limit isolation) skips Google-specific model ID and base URL normalization. Additionally, the base URL for `generativelanguage.googleapis.com` may lack the required `/v1beta` path segment at runtime.
- **Why it matters:** Users who create custom Google Generative AI provider lanes see the model in the picker but get HTTP 404 at runtime — a confusing silent failure.
- **What changed:** Two files, both gated on the semantic `api === "google-generative-ai"` field instead of provider name strings — ensuring any provider using this transport gets correct normalization regardless of its name.
- **What did NOT change:** Name-only call sites (`model-selection`, `live-model-filter`, `model-forward-compat`) are untouched. Broadening their provider-name checks would incorrectly capture unrelated providers like `google-antigravity`.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## User-visible / Behavior Changes

Custom providers with `api: "google-generative-ai"` now work at runtime. No config changes required — existing configurations that were silently failing will start working.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same Google API endpoints, just with correct URL path
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 22.04
- Runtime: Node.js (OpenClaw 2026.3.11)
- Model/provider: custom provider with `api: "google-generative-ai"`

### Steps

1. Configure a custom provider in `openclaw.json`:
   ```json
   "my-google": {
     "baseUrl": "https://generativelanguage.googleapis.com",
     "api": "google-generative-ai",
     "models": [{ "id": "gemini-3.1-pro-preview", ... }]
   }
   ```
2. Select the model in the picker — it appears correctly
3. Send a message

### Expected

Normal model response.

### Actual (before fix)

HTTP 404 — base URL sent without `/v1beta`, provider-specific normalization skipped.

## Evidence

- [x] Trace/log snippets

Verified via `openclaw agent --local`:
```
"provider": "google-paid",
"model": "gemini-3.1-pro-preview",
"text": "Hi"    # successful response, no 404
```

Built-in `google/` provider confirmed unaffected.

## Human Verification (required)

- Verified scenarios: custom Google provider returns successful responses through the gateway; built-in `google/` provider unaffected
- Edge cases checked: base URL with trailing slash, with `/v1beta` already present, without `/v1beta`, non-Google base URLs pass through unchanged
- What I did **not** verify: `google-antigravity` provider (no test credentials), but its code paths are unchanged

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit
- Files to restore: `src/agents/models-config.providers.ts`, `src/agents/pi-embedded-runner/model.ts`
- Known bad symptoms: built-in `google/` provider stops normalizing model IDs or base URLs

## Risks and Mitigations

- Risk: `normalizeGoogleBaseUrl` regex is too narrow and misses a valid Google API base URL variant
  - Mitigation: The regex only activates for `generativelanguage.googleapis.com`; all other base URLs pass through unchanged. Non-matching URLs degrade to the previous behavior (no normalization), not a new failure mode.