### PR TITLE
fix(gateway): emit response.incomplete for OpenResponses tool-call SSE responses

### DIFF
--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -299,6 +299,11 @@ export const ResponseCompletedEventSchema = z.object({
   response: ResponseResourceSchema,
 });
 
+export const ResponseIncompleteEventSchema = z.object({
+  type: z.literal("response.incomplete"),
+  response: ResponseResourceSchema,
+});
+
 export const ResponseFailedEventSchema = z.object({
   type: z.literal("response.failed"),
   response: ResponseResourceSchema,

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -4,7 +4,7 @@
  * Zod schemas for the OpenResponses `/v1/responses` endpoint.
  * This module is isolated from gateway imports to enable future codegen and prevent drift.
  *
- * @see https://www.open-responses.com/
+ * @see https://www.openresponses.org/
  */
 
 import { z } from "zod";

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -357,6 +357,7 @@ export type StreamingEvent =
   | z.infer<typeof ResponseCreatedEventSchema>
   | z.infer<typeof ResponseInProgressEventSchema>
   | z.infer<typeof ResponseCompletedEventSchema>
+  | z.infer<typeof ResponseIncompleteEventSchema>
   | z.infer<typeof ResponseFailedEventSchema>
   | z.infer<typeof OutputItemAddedEventSchema>
   | z.infer<typeof OutputItemDoneEventSchema>

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -557,6 +557,52 @@ describe("OpenResponses HTTP API (e2e)", () => {
 
       agentCommand.mockClear();
       agentCommand.mockResolvedValueOnce({
+        payloads: [],
+        meta: {
+          stopReason: "tool_calls",
+          pendingToolCalls: [
+            {
+              id: "call_123",
+              name: "get_weather",
+              arguments: '{"city":"Paris"}',
+            },
+          ],
+        },
+      } as never);
+
+      const resIncomplete = await postResponses(port, {
+        stream: true,
+        model: "openclaw",
+        input: "hi",
+      });
+      expect(resIncomplete.status).toBe(200);
+
+      const incompleteText = await resIncomplete.text();
+      const incompleteEvents = parseSseEvents(incompleteText);
+      const incompleteEventTypes = incompleteEvents.map((e) => e.event).filter(Boolean);
+      expect(incompleteEventTypes).toContain("response.incomplete");
+      expect(incompleteEventTypes).not.toContain("response.completed");
+
+      const incompleteEvent = incompleteEvents.find((e) => e.event === "response.incomplete");
+      expect(incompleteEvent).toBeDefined();
+      const incompleteJson = JSON.parse(incompleteEvent?.data ?? "{}") as {
+        response?: {
+          status?: string;
+          output?: Array<Record<string, unknown>>;
+        };
+      };
+      expect(incompleteJson.response?.status).toBe("incomplete");
+      const incompleteOutput = incompleteJson.response?.output ?? [];
+      expect(incompleteOutput).toHaveLength(2);
+      expect(incompleteOutput[0]?.type).toBe("message");
+      expect(incompleteOutput[1]?.type).toBe("function_call");
+      expect(incompleteOutput[1]?.call_id).toBe("call_123");
+      expect(incompleteOutput[1]?.name).toBe("get_weather");
+      expect(incompleteOutput[1]?.arguments).toBe('{"city":"Paris"}');
+      expect(incompleteEvents.some((e) => e.data === "[DONE]")).toBe(true);
+
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({
         payloads: [{ text: "hello" }],
       } as never);
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -3,7 +3,7 @@
  *
  * Implements the OpenResponses `/v1/responses` endpoint for OpenClaw Gateway.
  *
- * @see https://www.open-responses.com/
+ * @see https://www.openresponses.org/
  */
 
 import { randomUUID } from "node:crypto";

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -783,7 +783,7 @@ export async function handleOpenResponsesHttpRequest(
           });
           closed = true;
           unsubscribe();
-          writeSseEvent(res, { type: "response.incompleted", response: incompleteResponse });
+          writeSseEvent(res, { type: "response.incomplete", response: incompleteResponse });
           writeDone(res);
           res.end();
           return;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -783,7 +783,7 @@ export async function handleOpenResponsesHttpRequest(
           });
           closed = true;
           unsubscribe();
-          writeSseEvent(res, { type: "response.completed", response: incompleteResponse });
+          writeSseEvent(res, { type: "response.incompleted", response: incompleteResponse });
           writeDone(res);
           res.end();
           return;


### PR DESCRIPTION

## Summary

- Fix an incorrect OpenResponses docs page URL.
- Fix the OpenResponses SSE terminal event for tool-call responses.
- Emit `response.incomplete` when the agent stops with pending tool calls.
- Add a test in `streams OpenResponses SSE events` for the incomplete path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

OpenResponses SSE tool-call responses now end with `response.incomplete`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Vitest
- Model/provider: mocked agent command
- Integration/channel (if any): OpenResponses HTTP SSE
- Relevant config (redacted): `gateway.http.endpoints.responses.enabled=true`

### Steps

1. Send `POST /v1/responses` with `stream: true`.
2. Return an agent result with `meta.stopReason = "tool_calls"` and one pending tool call.
3. Read the SSE stream and inspect the terminal response event.

### Expected

- The stream ends with `response.incomplete` and `[DONE]`.

### Actual

- The tool-call path now emits `response.incomplete`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added coverage for the tool-call incomplete SSE path in `src/gateway/openresponses-http.test.ts`.
- Edge cases checked: normal text SSE path still completes normally.
- What you did **not** verify: full test suite.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the `src/gateway/openresponses-http.ts` change.
- Files/config to restore: `src/gateway/openresponses-http.ts`, `src/gateway/openresponses-http.test.ts`
- Known bad symptoms reviewers should watch for: tool-call SSE streams ending with `response.completed`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: clients may already be compensating for the old behavior.
- Mitigation: the change matches the schema and adds a regression test.
