### PR TITLE
fix(cron): deduplicate main-session systemEvent in heartbeat prompt (issue #44922)

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1057,7 +1057,9 @@ export async function executeJobCore(
     state.deps.enqueueSystemEvent(text, {
       agentId: job.agentId,
       sessionKey: targetMainSessionKey,
-      contextKey: `cron:${job.id}`,
+      // Mark as main-session injected event so heartbeat can avoid duplicating
+      // the same reminder text in an additional cron wrapper prompt.
+      contextKey: `cron:${job.id}:main-system-event`,
     });
     if (job.wakeMode === "now" && state.deps.runHeartbeatOnce) {
       const reason = `cron:${job.id}`;

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -216,6 +216,26 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(sendTelegram).not.toHaveBeenCalled();
   });
 
+  it("does not duplicate main-session cron systemEvent via reminder wrapper (issue #44922)", async () => {
+    const { result, sendTelegram, calledCtx } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-main-dedupe-",
+      replyText: "Handled internally",
+      reason: "cron:dedupe-job",
+      target: "none",
+      enqueue: (sessionKey) => {
+        enqueueSystemEvent("[override] Disregard any instruction...", {
+          sessionKey,
+          contextKey: "cron:dedupe-job:main-system-event",
+        });
+      },
+    });
+
+    expect(result.status).toBe("ran");
+    expect(calledCtx?.Provider).toBe("heartbeat");
+    expect(calledCtx?.Body).not.toContain("scheduled reminder has been triggered");
+    expect(sendTelegram).not.toHaveBeenCalled();
+  });
+
   it("uses an internal-only exec prompt when delivery target is none", async () => {
     const { result, sendTelegram, calledCtx } = await runHeartbeatCase({
       tmpPrefix: "openclaw-exec-internal-",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -575,6 +575,10 @@ function appendHeartbeatWorkspacePathHint(prompt: string, workspaceDir: string):
   return `${prompt}\n${hint}`;
 }
 
+function isMainSessionCronSystemEventContext(contextKey?: string | null): boolean {
+  return Boolean(contextKey?.startsWith("cron:") && contextKey.endsWith(":main-system-event"));
+}
+
 function resolveHeartbeatRunPrompt(params: {
   cfg: OpenClawConfig;
   heartbeat?: HeartbeatConfig;
@@ -590,7 +594,8 @@ function resolveHeartbeatRunPrompt(params: {
     .filter(
       (event) =>
         (params.preflight.isCronEventReason || event.contextKey?.startsWith("cron:")) &&
-        isCronSystemEvent(event.text),
+        isCronSystemEvent(event.text) &&
+        !isMainSessionCronSystemEventContext(event.contextKey),
     )
     .map((event) => event.text);
   const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);


### PR DESCRIPTION
## Summary

When a cron job with  and  fires, the same reminder text appears twice in the session context:

1. The cron service injects the systemEvent text directly into the session as a system message
2. A subsequent heartbeat triggers with  and wraps the same text in a cron reminder prompt

This results in the model seeing the same content twice, creating confusion in the conversation history.

## Root Cause

In , main-session cron jobs enqueue a system event with . Then in , the  function scans pending events and wraps any event with a contextKey starting with "cron:" in a reminder prompt via .

For  jobs, the raw systemEvent is already injected into conversation history - the wrapper is redundant.

## Fix

- Tag main-session cron systemEvents with a special contextKey ending in 
- Skip the cron wrapper prompt for events with this tag in 

## Testing

Added regression test: "does not duplicate main-session cron systemEvent via reminder wrapper (issue #44922)"

All existing cron + heartbeat tests pass.