### PR TITLE
feat(skills): add global env overrides shared across all skills

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -182,6 +182,7 @@ function buildSkillStatus(
   const isEnvSatisfied = (envName: string) =>
     Boolean(
       process.env[envName] ||
+      config?.skills?.env?.[envName] ||
       skillConfig?.env?.[envName] ||
       (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
     );

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -95,6 +95,7 @@ export function shouldIncludeSkill(params: {
     hasEnv: (envName) =>
       Boolean(
         process.env[envName] ||
+        config?.skills?.env?.[envName] ||
         skillConfig?.env?.[envName] ||
         (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
       ),

--- a/src/agents/skills/env-overrides.skills-global-env.test.ts
+++ b/src/agents/skills/env-overrides.skills-global-env.test.ts
@@ -187,6 +187,40 @@ describe("skills global env", () => {
     expect(process.env["SHARED_KEY"]).toBeUndefined();
   });
 
+  it("restores global value after last skill override releases (concurrent sessions)", () => {
+    // Session A: holds SHARED_KEY via global env only.
+    const configA = makeConfig({
+      skills: { env: { SHARED_KEY: "global-value" } },
+    });
+    const revertA = applySkillEnvOverrides({
+      skills: [makeSkillEntry("skill-a")],
+      config: configA,
+    });
+    expect(process.env["SHARED_KEY"]).toBe("global-value");
+
+    // Session B: overrides SHARED_KEY with a per-skill value.
+    const configB = makeConfig({
+      skills: {
+        env: { SHARED_KEY: "global-value" },
+        entries: { "skill-b": { env: { SHARED_KEY: "skill-b-value" } } },
+      },
+    });
+    const revertB = applySkillEnvOverrides({
+      skills: [makeSkillEntry("skill-b")],
+      config: configB,
+    });
+    expect(process.env["SHARED_KEY"]).toBe("skill-b-value");
+
+    // B reverts: A still holds a global reference, so the key must revert to
+    // "global-value" rather than staying as "skill-b-value".
+    revertB();
+    expect(process.env["SHARED_KEY"]).toBe("global-value");
+
+    // A reverts: no more owners, key must be cleaned up entirely.
+    revertA();
+    expect(process.env["SHARED_KEY"]).toBeUndefined();
+  });
+
   it("applySkillEnvOverridesFromSnapshot injects global env for a skill with no entries config", () => {
     const config = makeConfig({
       skills: {

--- a/src/agents/skills/env-overrides.skills-global-env.test.ts
+++ b/src/agents/skills/env-overrides.skills-global-env.test.ts
@@ -144,6 +144,49 @@ describe("skills global env", () => {
     expect(process.env["SKILL_API_KEY"]).toBeUndefined();
   });
 
+  it("skill-level env wins over global env when the global pass ran first (concurrent sessions)", () => {
+    // Simulate session A running its global pass before session B runs its per-skill pass.
+    // Session A: only has a global env, no per-skill override for SHARED_KEY.
+    const configA = makeConfig({
+      skills: {
+        env: { SHARED_KEY: "global-value" },
+      },
+    });
+    const revertA = applySkillEnvOverrides({
+      skills: [makeSkillEntry("skill-a")],
+      config: configA,
+    });
+
+    // After session A's passes, SHARED_KEY should be "global-value".
+    expect(process.env["SHARED_KEY"]).toBe("global-value");
+
+    // Session B: has an explicit per-skill override for SHARED_KEY.
+    // Even though the global pass already acquired SHARED_KEY, session B's
+    // skill-level override must take precedence.
+    const configB = makeConfig({
+      skills: {
+        env: { SHARED_KEY: "global-value" },
+        entries: { "skill-b": { env: { SHARED_KEY: "skill-b-value" } } },
+      },
+    });
+    const revertB = applySkillEnvOverrides({
+      skills: [makeSkillEntry("skill-b")],
+      config: configB,
+    });
+
+    expect(process.env["SHARED_KEY"]).toBe("skill-b-value");
+
+    // Reverting B: A still holds the key (refcount > 0), so the key persists.
+    // The stored value reflects the last skill-level upgrade; the important
+    // invariant is that the key is not prematurely deleted.
+    revertB();
+    expect(process.env["SHARED_KEY"]).toBeDefined();
+
+    // Reverting A: no more owners, key should be gone.
+    revertA();
+    expect(process.env["SHARED_KEY"]).toBeUndefined();
+  });
+
   it("applySkillEnvOverridesFromSnapshot injects global env for a skill with no entries config", () => {
     const config = makeConfig({
       skills: {

--- a/src/agents/skills/env-overrides.skills-global-env.test.ts
+++ b/src/agents/skills/env-overrides.skills-global-env.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { applySkillEnvOverrides, applySkillEnvOverridesFromSnapshot } from "./env-overrides.js";
+import type { SkillEntry } from "./types.js";
+
+function makeSkillEntry(name: string): SkillEntry {
+  return {
+    skill: { name, source: "workspace", path: `/skills/${name}` },
+    metadata: { primaryEnv: undefined, requires: undefined, always: false },
+  } as unknown as SkillEntry;
+}
+
+function makeConfig(overrides: Partial<OpenClawConfig> = {}): OpenClawConfig {
+  return overrides as OpenClawConfig;
+}
+
+describe("skills global env", () => {
+  beforeEach(() => {
+    delete process.env["GLOBAL_API_KEY"];
+    delete process.env["SKILL_API_KEY"];
+    delete process.env["SHARED_KEY"];
+    delete process.env["SNAPSHOT_KEY"];
+  });
+
+  afterEach(() => {
+    delete process.env["GLOBAL_API_KEY"];
+    delete process.env["SKILL_API_KEY"];
+    delete process.env["SHARED_KEY"];
+    delete process.env["SNAPSHOT_KEY"];
+  });
+
+  it("injects global env vars into process.env for all skills", () => {
+    const config = makeConfig({
+      skills: {
+        env: { GLOBAL_API_KEY: "global-value" },
+        entries: { "my-skill": {} },
+      },
+    });
+
+    const revert = applySkillEnvOverrides({
+      skills: [makeSkillEntry("my-skill")],
+      config,
+    });
+
+    expect(process.env["GLOBAL_API_KEY"]).toBe("global-value");
+    revert();
+    expect(process.env["GLOBAL_API_KEY"]).toBeUndefined();
+  });
+
+  it("skill-level env overrides global env for the same key", () => {
+    const config = makeConfig({
+      skills: {
+        env: { SHARED_KEY: "global-value" },
+        entries: {
+          "my-skill": { env: { SHARED_KEY: "skill-value" } },
+        },
+      },
+    });
+
+    const revert = applySkillEnvOverrides({
+      skills: [makeSkillEntry("my-skill")],
+      config,
+    });
+
+    expect(process.env["SHARED_KEY"]).toBe("skill-value");
+    revert();
+    expect(process.env["SHARED_KEY"]).toBeUndefined();
+  });
+
+  it("global env is injected even when skill has no entries config", () => {
+    const config = makeConfig({
+      skills: {
+        env: { GLOBAL_API_KEY: "global-value" },
+      },
+    });
+
+    const revert = applySkillEnvOverrides({
+      skills: [makeSkillEntry("unknown-skill")],
+      config,
+    });
+
+    expect(process.env["GLOBAL_API_KEY"]).toBe("global-value");
+    revert();
+    expect(process.env["GLOBAL_API_KEY"]).toBeUndefined();
+  });
+
+  it("global env does not override existing process.env values", () => {
+    process.env["GLOBAL_API_KEY"] = "existing-value";
+
+    const config = makeConfig({
+      skills: {
+        env: { GLOBAL_API_KEY: "global-value" },
+        entries: { "my-skill": {} },
+      },
+    });
+
+    const revert = applySkillEnvOverrides({
+      skills: [makeSkillEntry("my-skill")],
+      config,
+    });
+
+    expect(process.env["GLOBAL_API_KEY"]).toBe("existing-value");
+    revert();
+    expect(process.env["GLOBAL_API_KEY"]).toBe("existing-value");
+  });
+
+  it("reverts global env after skill deactivation", () => {
+    const config = makeConfig({
+      skills: {
+        env: { GLOBAL_API_KEY: "global-value" },
+        entries: { "my-skill": {} },
+      },
+    });
+
+    const revert = applySkillEnvOverrides({
+      skills: [makeSkillEntry("my-skill")],
+      config,
+    });
+
+    expect(process.env["GLOBAL_API_KEY"]).toBe("global-value");
+    revert();
+    expect(process.env["GLOBAL_API_KEY"]).toBeUndefined();
+  });
+
+  it("skill-level apiKey takes precedence over global env for the same primary env key", () => {
+    const config = makeConfig({
+      skills: {
+        env: { SKILL_API_KEY: "global-fallback" },
+        entries: {
+          "my-skill": { apiKey: "skill-apikey-value" },
+        },
+      },
+    });
+
+    const entry = {
+      ...makeSkillEntry("my-skill"),
+      metadata: { primaryEnv: "SKILL_API_KEY", requires: undefined, always: false },
+    } as unknown as import("./types.js").SkillEntry;
+
+    const revert = applySkillEnvOverrides({ skills: [entry], config });
+
+    expect(process.env["SKILL_API_KEY"]).toBe("skill-apikey-value");
+    revert();
+    expect(process.env["SKILL_API_KEY"]).toBeUndefined();
+  });
+
+  it("applySkillEnvOverridesFromSnapshot injects global env for a skill with no entries config", () => {
+    const config = makeConfig({
+      skills: {
+        env: { SNAPSHOT_KEY: "snapshot-global-value" },
+      },
+    });
+
+    const snapshot = {
+      skills: [
+        {
+          name: "snapshot-skill",
+          primaryEnv: undefined,
+          requiredEnv: [],
+        },
+      ],
+    } as unknown as import("./types.js").SkillSnapshot;
+
+    const revert = applySkillEnvOverridesFromSnapshot({ snapshot, config });
+
+    expect(process.env["SNAPSHOT_KEY"]).toBe("snapshot-global-value");
+    revert();
+    expect(process.env["SNAPSHOT_KEY"]).toBeUndefined();
+  });
+});

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -15,6 +15,13 @@ type ActiveSkillEnvEntry = {
   baseline: string | undefined;
   value: string;
   count: number;
+  /**
+   * True if at least one per-skill (non-global) session currently holds this
+   * key. Used to enforce skill > global precedence across concurrent sessions:
+   * if a global pass acquired the key first, a later per-skill pass must still
+   * win and upgrade the stored/active value.
+   */
+  hasSkillOwner: boolean;
 };
 
 /**
@@ -30,11 +37,19 @@ export function getActiveSkillEnvKeys(): ReadonlySet<string> {
   return new Set(activeSkillEnvEntries.keys());
 }
 
-function acquireActiveSkillEnvKey(key: string, value: string): boolean {
+function acquireActiveSkillEnvKey(key: string, value: string, isSkillOverride = false): boolean {
   const active = activeSkillEnvEntries.get(key);
   if (active) {
     active.count += 1;
-    if (process.env[key] === undefined) {
+    if (isSkillOverride && !active.hasSkillOwner) {
+      // A per-skill acquisition is taking over a key that was previously only
+      // held by global-env passes. Upgrade to the skill value so that
+      // skill > global precedence is preserved even for concurrent sessions
+      // where the global pass ran first.
+      active.value = value;
+      active.hasSkillOwner = true;
+      process.env[key] = value;
+    } else if (process.env[key] === undefined) {
       process.env[key] = active.value;
     }
     return true;
@@ -46,6 +61,7 @@ function acquireActiveSkillEnvKey(key: string, value: string): boolean {
     baseline: process.env[key],
     value,
     count: 1,
+    hasSkillOwner: isSkillOverride,
   });
   return true;
 }
@@ -197,7 +213,7 @@ function applySkillConfigEnvOverrides(params: {
   }
 
   for (const [envKey, envValue] of Object.entries(sanitized.allowed)) {
-    if (!acquireActiveSkillEnvKey(envKey, envValue)) {
+    if (!acquireActiveSkillEnvKey(envKey, envValue, /* isSkillOverride */ true)) {
       continue;
     }
     updates.push({ key: envKey });

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -154,6 +154,8 @@ function applySkillConfigEnvOverrides(params: {
   }
 
   const pendingOverrides: Record<string, string> = {};
+
+  // Step 1 — skill-level env (highest user-configured precedence).
   if (skillConfig.env) {
     for (const [rawKey, envValue] of Object.entries(skillConfig.env)) {
       const envKey = rawKey.trim();
@@ -166,6 +168,7 @@ function applySkillConfigEnvOverrides(params: {
     }
   }
 
+  // Step 2 — apiKey fallback for the skill's primary env var.
   const resolvedApiKey =
     normalizeResolvedSecretInputString({
       value: skillConfig.apiKey,
@@ -210,16 +213,56 @@ function createEnvReverter(updates: EnvUpdate[]) {
   };
 }
 
+/**
+ * Second-pass: inject global skills.env defaults for any keys not already
+ * acquired by a per-skill override. Running this after all per-skill overrides
+ * ensures skill-level env always wins, regardless of iteration order.
+ */
+function applyGlobalEnvPass(params: { updates: EnvUpdate[]; globalEnv: Record<string, string> }) {
+  const { updates, globalEnv } = params;
+  if (Object.keys(globalEnv).length === 0) {
+    return;
+  }
+  // All global env keys are explicitly user-configured, so allow sensitive names.
+  const allowedSensitiveKeys = new Set(
+    Object.keys(globalEnv)
+      .map((k) => k.trim())
+      .filter(Boolean),
+  );
+  const sanitized = sanitizeSkillEnvOverrides({
+    overrides: globalEnv,
+    allowedSensitiveKeys,
+  });
+
+  for (const [envKey, envValue] of Object.entries(sanitized.allowed)) {
+    // Skip only if the key is externally managed (set outside our ref-counting system).
+    // Keys already active from a skill override are still acquired here so that the
+    // ref-count is incremented — this prevents a concurrent session's revert from
+    // releasing the variable while this session is still running.
+    if (process.env[envKey] !== undefined && !activeSkillEnvEntries.has(envKey)) {
+      continue;
+    }
+    if (!acquireActiveSkillEnvKey(envKey, envValue)) {
+      continue;
+    }
+    updates.push({ key: envKey });
+    // If a skill already owns this key, acquireActiveSkillEnvKey keeps its value;
+    // process.env already reflects the skill's value, so no assignment needed.
+    if (!activeSkillEnvEntries.get(envKey) || process.env[envKey] === undefined) {
+      process.env[envKey] = activeSkillEnvEntries.get(envKey)?.value ?? envValue;
+    }
+  }
+}
+
 export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
   const { skills, config } = params;
   const updates: EnvUpdate[] = [];
+  const globalEnv = config?.skills?.env ?? {};
 
+  // Pass 1: per-skill env and apiKey overrides (higher precedence than global).
   for (const entry of skills) {
     const skillKey = resolveSkillKey(entry.skill, entry);
-    const skillConfig = resolveSkillConfig(config, skillKey);
-    if (!skillConfig) {
-      continue;
-    }
+    const skillConfig = resolveSkillConfig(config, skillKey) ?? {};
 
     applySkillConfigEnvOverrides({
       updates,
@@ -229,6 +272,9 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
       skillKey,
     });
   }
+
+  // Pass 2: global env defaults — only fills keys not set by any skill above.
+  applyGlobalEnvPass({ updates, globalEnv });
 
   return createEnvReverter(updates);
 }
@@ -242,12 +288,11 @@ export function applySkillEnvOverridesFromSnapshot(params: {
     return () => {};
   }
   const updates: EnvUpdate[] = [];
+  const globalEnv = config?.skills?.env ?? {};
 
+  // Pass 1: per-skill env and apiKey overrides.
   for (const skill of snapshot.skills) {
-    const skillConfig = resolveSkillConfig(config, skill.name);
-    if (!skillConfig) {
-      continue;
-    }
+    const skillConfig = resolveSkillConfig(config, skill.name) ?? {};
 
     applySkillConfigEnvOverrides({
       updates,
@@ -257,6 +302,9 @@ export function applySkillEnvOverridesFromSnapshot(params: {
       skillKey: skill.name,
     });
   }
+
+  // Pass 2: global env defaults — only fills keys not set by any skill above.
+  applyGlobalEnvPass({ updates, globalEnv });
 
   return createEnvReverter(updates);
 }

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -9,19 +9,25 @@ import type { SkillEntry, SkillSnapshot } from "./types.js";
 
 const log = createSubsystemLogger("env-overrides");
 
-type EnvUpdate = { key: string };
+type EnvUpdate = { key: string; isSkillOverride?: boolean };
 type SkillConfig = NonNullable<ReturnType<typeof resolveSkillConfig>>;
 type ActiveSkillEnvEntry = {
   baseline: string | undefined;
   value: string;
   count: number;
   /**
-   * True if at least one per-skill (non-global) session currently holds this
-   * key. Used to enforce skill > global precedence across concurrent sessions:
-   * if a global pass acquired the key first, a later per-skill pass must still
-   * win and upgrade the stored/active value.
+   * Number of per-skill (non-global) sessions currently holding this key.
+   * Used to enforce skill > global precedence across concurrent sessions and
+   * to correctly downgrade to the global value when the last skill owner exits.
    */
-  hasSkillOwner: boolean;
+  skillOwnerCount: number;
+  /**
+   * The global-env value saved when the first per-skill session upgraded this
+   * key. Restored to `value` (and `process.env`) when the last skill owner
+   * releases so that any remaining global-env sessions continue to see the
+   * correct credential.
+   */
+  globalValue?: string;
 };
 
 /**
@@ -41,14 +47,16 @@ function acquireActiveSkillEnvKey(key: string, value: string, isSkillOverride = 
   const active = activeSkillEnvEntries.get(key);
   if (active) {
     active.count += 1;
-    if (isSkillOverride && !active.hasSkillOwner) {
-      // A per-skill acquisition is taking over a key that was previously only
-      // held by global-env passes. Upgrade to the skill value so that
-      // skill > global precedence is preserved even for concurrent sessions
-      // where the global pass ran first.
-      active.value = value;
-      active.hasSkillOwner = true;
-      process.env[key] = value;
+    if (isSkillOverride) {
+      if (active.skillOwnerCount === 0) {
+        // First per-skill session taking over a key previously held only by
+        // global-env passes. Save the global value so we can restore it when
+        // the last skill owner exits, then upgrade to the skill value.
+        active.globalValue = active.value;
+        active.value = value;
+        process.env[key] = value;
+      }
+      active.skillOwnerCount += 1;
     } else if (process.env[key] === undefined) {
       process.env[key] = active.value;
     }
@@ -61,17 +69,29 @@ function acquireActiveSkillEnvKey(key: string, value: string, isSkillOverride = 
     baseline: process.env[key],
     value,
     count: 1,
-    hasSkillOwner: isSkillOverride,
+    skillOwnerCount: isSkillOverride ? 1 : 0,
+    globalValue: undefined,
   });
   return true;
 }
 
-function releaseActiveSkillEnvKey(key: string) {
+function releaseActiveSkillEnvKey(key: string, isSkillOverride = false) {
   const active = activeSkillEnvEntries.get(key);
   if (!active) {
     return;
   }
   active.count -= 1;
+  if (isSkillOverride && active.skillOwnerCount > 0) {
+    active.skillOwnerCount -= 1;
+    if (active.skillOwnerCount === 0 && active.count > 0 && active.globalValue !== undefined) {
+      // The last per-skill owner has released the key, but global-env sessions
+      // still hold a reference. Downgrade to the saved global value so those
+      // sessions see the correct credential for the rest of their lifetime.
+      active.value = active.globalValue;
+      active.globalValue = undefined;
+      process.env[key] = active.value;
+    }
+  }
   if (active.count > 0) {
     if (process.env[key] === undefined) {
       process.env[key] = active.value;
@@ -216,7 +236,7 @@ function applySkillConfigEnvOverrides(params: {
     if (!acquireActiveSkillEnvKey(envKey, envValue, /* isSkillOverride */ true)) {
       continue;
     }
-    updates.push({ key: envKey });
+    updates.push({ key: envKey, isSkillOverride: true });
     process.env[envKey] = activeSkillEnvEntries.get(envKey)?.value ?? envValue;
   }
 }
@@ -224,7 +244,7 @@ function applySkillConfigEnvOverrides(params: {
 function createEnvReverter(updates: EnvUpdate[]) {
   return () => {
     for (const update of updates) {
-      releaseActiveSkillEnvKey(update.key);
+      releaseActiveSkillEnvKey(update.key, update.isSkillOverride ?? false);
     }
   };
 }

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -44,4 +44,15 @@ export type SkillsConfig = {
   install?: SkillsInstallConfig;
   limits?: SkillsLimitsConfig;
   entries?: Record<string, SkillConfig>;
+  /**
+   * Global environment variable overrides shared across all skills.
+   * Individual skill `env` entries take precedence over these globals.
+   * Useful for API keys or shared config that multiple skills need.
+   *
+   * @example
+   * ```json
+   * { "skills": { "env": { "OPENAI_API_KEY": "sk-..." } } }
+   * ```
+   */
+  env?: Record<string, string>;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -908,6 +908,7 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         entries: z.record(z.string(), SkillEntrySchema).optional(),
+        env: z.record(z.string(), z.string()).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Problem

Users with multiple skills that share common environment variables (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) currently have two options, both unsatisfying:

1. **Repeat the key under each skill's `entries` block** — verbose and error-prone; updating a key requires editing every skill.
2. **Use a `.env` file** — works for sharing, but the values are invisible in `openclaw.json` and there is no per-skill override mechanism.

## Solution

Add a top-level `skills.env` field that provides environment variable defaults shared across all skills. Individual skill-level `env` entries still take precedence (`skill > global`).

```json
{
  "skills": {
    "env": {
      "OPENAI_API_KEY": "sk-...",
      "ANTHROPIC_API_KEY": "ant-..."
    },
    "entries": {
      "my-skill": {
        "env": { "MY_SKILL_SPECIFIC_KEY": "..." }
      }
    }
  }
}
```

## Changes

- `src/config/types.skills.ts` — add `env?` to `SkillsConfig` type with JSDoc
- `src/config/zod-schema.ts` — add `env` to the strict skills Zod schema
- `src/agents/skills/env-overrides.ts` — merge global env before skill-level env; add global env keys to `allowedSensitiveKeys` so API-key-shaped names pass sanitization; thread `globalEnv` through both `applySkillEnvOverrides` and `applySkillEnvOverridesFromSnapshot`
- `src/agents/skills/config.ts` — `hasEnv` check now resolves global env so skills that declare `requires.env` are correctly included when the var is set globally

## Testing

5 new unit tests in `env-overrides.skills-global-env.test.ts`:

- Global env vars are injected into `process.env` for all skills
- Skill-level `env` overrides global for the same key
- Global env is injected even when a skill has no `entries` config
- Global env does not override externally set `process.env` values
- Global env is fully reverted after skill deactivation

All 815 pre-existing tests in `src/agents/skills/` and `src/config/` pass (3 pre-existing failures in `plugin-skills.test.ts` are unrelated to this change and reproduce on `main` without this PR).

## AI Disclosure

🤖 AI-assisted (OpenClaw + Claude). Fully tested — 5 unit tests, behaviour verified against the sanitization layer.