### PR TITLE
feat: skip install when local version matches target in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -995,6 +995,7 @@ SHARP_IGNORE_GLOBAL_LIBVIPS="${SHARP_IGNORE_GLOBAL_LIBVIPS:-1}"
 NPM_LOGLEVEL="${OPENCLAW_NPM_LOGLEVEL:-error}"
 NPM_SILENT_FLAG="--silent"
 VERBOSE="${OPENCLAW_VERBOSE:-0}"
+FORCE_INSTALL=${OPENCLAW_FORCE_INSTALL:-0}
 OPENCLAW_BIN=""
 PNPM_CMD=()
 HELP=0
@@ -1018,6 +1019,7 @@ Options:
   --no-prompt                           Disable prompts (required in CI/automation)
   --dry-run                             Print what would happen (no changes)
   --verbose                             Print debug output (set -x, npm verbose)
+  --force, -f                            Force reinstall even if already up to date
   --help, -h                            Show this help
 
 Environment variables:
@@ -1029,6 +1031,7 @@ Environment variables:
   OPENCLAW_NO_PROMPT=1
   OPENCLAW_DRY_RUN=1
   OPENCLAW_NO_ONBOARD=1
+  OPENCLAW_FORCE_INSTALL=0|1
   OPENCLAW_VERBOSE=1
   OPENCLAW_NPM_LOGLEVEL=error|warn|notice  Default: error (hide npm deprecation noise)
   SHARP_IGNORE_GLOBAL_LIBVIPS=0|1    Default: 1 (avoid sharp building against global libvips)
@@ -1093,6 +1096,10 @@ parse_args() {
                 ;;
             --no-git-update)
                 GIT_UPDATE=0
+                shift
+                ;;
+            --force|-f)
+                FORCE_INSTALL=1
                 shift
                 ;;
             *)
@@ -1976,6 +1983,19 @@ install_openclaw() {
 
     local resolved_version=""
     resolved_version="$(npm view "${package_name}@${OPENCLAW_VERSION}" version 2>/dev/null || true)"
+    # Skip install if already up to date (unless --force)
+    if [[ -n "$resolved_version" && "$FORCE_INSTALL" != "1" ]]; then
+        local current_version=""
+        current_version="$(resolve_openclaw_version)"
+        if semver_equal "$current_version" "$resolved_version"; then
+            # Still ensure bin link is intact (may have been broken by interrupted install)
+            ensure_openclaw_bin_link || true
+            ui_success "OpenClaw is already up to date (v${resolved_version}). Use --force to reinstall."
+            INSTALL_SKIPPED=1
+            return 0
+        fi
+    fi
+
     if [[ -n "$resolved_version" ]]; then
         ui_info "Installing OpenClaw v${resolved_version}"
     else
@@ -2143,6 +2163,12 @@ resolve_openclaw_version() {
     echo "$version"
 }
 
+semver_equal() {
+    local a="${1:-}"
+    local b="${2:-}"
+    [[ -n "$a" && -n "$b" && "$a" == "$b" ]]
+}
+
 is_gateway_daemon_loaded() {
     local claw="$1"
     if [[ -z "$claw" ]]; then
@@ -2307,6 +2333,9 @@ main() {
 
         # Step 5: OpenClaw
         install_openclaw
+        if [[ "${INSTALL_SKIPPED:-0}" == "1" ]]; then
+            return 0
+        fi
     fi
 
     ui_stage "Finalizing setup"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1990,6 +1990,10 @@ install_openclaw() {
         if semver_equal "$current_version" "$resolved_version"; then
             # Still ensure bin link is intact (may have been broken by interrupted install)
             ensure_openclaw_bin_link || true
+            # Warn if npm global bin dir is missing from PATH (skip doesn't mean PATH is fine)
+            local npm_bin=""
+            npm_bin="$(npm_global_bin_dir || true)"
+            warn_shell_path_missing_dir "$npm_bin" "npm global bin dir"
             ui_success "OpenClaw is already up to date (v${resolved_version}). Use --force to reinstall."
             INSTALL_SKIPPED=1
             return 0


### PR DESCRIPTION
  ## Summary
  - Add version check to `scripts/install.sh` that compares the locally installed version with the target version before running npm install
  - If versions match, skip the install and print a message; supports `--force` / `OPENCLAW_FORCE_INSTALL=1` to override
  - Only affects the npm install path; git installs are unchanged

  Closes #44700

  ## Test plan
  - [x] Run `bash scripts/install.sh` when already up to date — should print "already up to date" and skip
  - [x] Run `bash scripts/install.sh --force` — should perform full install
  - [x] Run `OPENCLAW_FORCE_INSTALL=1 bash scripts/install.sh` — should perform full install
  - [x] Run `bash scripts/install.sh` on a fresh machine (no openclaw) — should install normally
  - [x] Run `bash scripts/install.sh --version <different>` — should install if version differs