### PR TITLE
feat(gateway): add netbird bind mode with auto-TLS (#32725)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/netbird bind mode: add `gateway.bind: "netbird"` to auto-detect NetBird wt\* interfaces and auto-enable TLS, so Control UI device identity works over VPN without manual TLS setup. (#32725)
 - Android/chat settings: redesign the chat settings sheet with grouped device and media sections, refresh the Connect and Voice tabs, and tighten the chat composer/session header for a denser mobile layout. (#44894) Thanks @obviyus.
 
 ### Fixes

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -67,12 +67,16 @@ export function pickProbeHostForBind(
   bindMode: string,
   tailnetIPv4: string | undefined,
   customBindHost?: string,
+  netbirdIPv4?: string,
 ) {
   if (bindMode === "custom" && customBindHost?.trim()) {
     return customBindHost.trim();
   }
   if (bindMode === "tailnet") {
     return tailnetIPv4 ?? "127.0.0.1";
+  }
+  if (bindMode === "netbird") {
+    return netbirdIPv4 ?? "127.0.0.1";
   }
   if (bindMode === "lan") {
     // Same as call.ts: self-connections should always target loopback.

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -19,6 +19,7 @@ import { resolveGatewayService } from "../../daemon/service.js";
 import { trimToUndefined } from "../../gateway/credentials.js";
 import { resolveGatewayBindHost } from "../../gateway/net.js";
 import { resolveGatewayProbeAuthWithSecretInputs } from "../../gateway/probe-auth.js";
+import { pickPrimaryNetbirdIPv4 } from "../../infra/netbird.js";
 import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
 import {
   formatPortDiagnostics,
@@ -193,9 +194,11 @@ async function resolveGatewayStatusSummary(params: {
   const customBindHost = params.daemonCfg.gateway?.customBindHost;
   const bindHost = await resolveGatewayBindHost(bindMode, customBindHost);
   const tailnetIPv4 = pickPrimaryTailnetIPv4();
-  const probeHost = pickProbeHostForBind(bindMode, tailnetIPv4, customBindHost);
+  const netbirdIPv4 = pickPrimaryNetbirdIPv4();
+  const probeHost = pickProbeHostForBind(bindMode, tailnetIPv4, customBindHost, netbirdIPv4);
   const probeUrlOverride = trimToUndefined(params.rpcUrlOverride) ?? null;
-  const scheme = params.daemonCfg.gateway?.tls?.enabled === true ? "wss" : "ws";
+  const tlsEnabled = params.daemonCfg.gateway?.tls?.enabled === true || bindMode === "netbird";
+  const scheme = tlsEnabled ? "wss" : "ws";
   const probeUrl = probeUrlOverride ?? `${scheme}://${probeHost}:${daemonPort}`;
   const probeNote =
     !probeUrlOverride && bindMode === "lan"

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -215,11 +215,14 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     bindRaw === "lan" ||
     bindRaw === "auto" ||
     bindRaw === "custom" ||
-    bindRaw === "tailnet"
+    bindRaw === "tailnet" ||
+    bindRaw === "netbird"
       ? bindRaw
       : null;
   if (!bind) {
-    defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", or "custom")');
+    defaultRuntime.error(
+      'Invalid --bind (use "loopback", "lan", "tailnet", "netbird", "auto", or "custom")',
+    );
     defaultRuntime.exit(1);
     return;
   }
@@ -462,7 +465,7 @@ export function addGatewayRunCommand(cmd: Command): Command {
     .option("--port <port>", "Port for the gateway WebSocket")
     .option(
       "--bind <mode>",
-      'Bind mode ("loopback"|"lan"|"tailnet"|"auto"|"custom"). Defaults to config gateway.bind (or loopback).',
+      'Bind mode ("loopback"|"lan"|"tailnet"|"netbird"|"auto"|"custom"). Defaults to config gateway.bind (or loopback).',
     )
     .option(
       "--token <token>",

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -70,7 +70,7 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
 
   const gatewayBind = (cfg.gateway?.bind ?? "loopback") as string;
   const customBindHost = cfg.gateway?.customBindHost?.trim();
-  const bindModes: GatewayBindMode[] = ["auto", "lan", "loopback", "custom", "tailnet"];
+  const bindModes: GatewayBindMode[] = ["auto", "lan", "loopback", "custom", "tailnet", "netbird"];
   const bindMode = bindModes.includes(gatewayBind as GatewayBindMode)
     ? (gatewayBind as GatewayBindMode)
     : undefined;

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -12,6 +12,7 @@ import { callGateway } from "../gateway/call.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
 import { pickPrimaryLanIPv4, isValidIPv4 } from "../gateway/net.js";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
+import { pickPrimaryNetbirdIPv4 } from "../infra/netbird.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { isWSL } from "../infra/wsl.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -458,7 +459,7 @@ export const DEFAULT_WORKSPACE = DEFAULT_AGENT_WORKSPACE_DIR;
 
 export function resolveControlUiLinks(params: {
   port: number;
-  bind?: "auto" | "lan" | "loopback" | "custom" | "tailnet";
+  bind?: import("../config/config.js").GatewayBindMode;
   customBindHost?: string;
   basePath?: string;
 }): { httpUrl: string; wsUrl: string } {
@@ -466,6 +467,7 @@ export function resolveControlUiLinks(params: {
   const bind = params.bind ?? "loopback";
   const customBindHost = params.customBindHost?.trim();
   const tailnetIPv4 = pickPrimaryTailnetIPv4();
+  const netbirdIPv4 = pickPrimaryNetbirdIPv4();
   const host = (() => {
     if (bind === "custom" && customBindHost && isValidIPv4(customBindHost)) {
       return customBindHost;
@@ -473,16 +475,20 @@ export function resolveControlUiLinks(params: {
     if (bind === "tailnet" && tailnetIPv4) {
       return tailnetIPv4 ?? "127.0.0.1";
     }
+    if (bind === "netbird" && netbirdIPv4) {
+      return netbirdIPv4 ?? "127.0.0.1";
+    }
     if (bind === "lan") {
       return pickPrimaryLanIPv4() ?? "127.0.0.1";
     }
     return "127.0.0.1";
   })();
+  const useTls = bind === "netbird";
   const basePath = normalizeControlUiBasePath(params.basePath);
   const uiPath = basePath ? `${basePath}/` : "/";
   const wsPath = basePath ? basePath : "";
   return {
-    httpUrl: `http://${host}:${port}${uiPath}`,
-    wsUrl: `ws://${host}:${port}${wsPath}`,
+    httpUrl: `${useTls ? "https" : "http"}://${host}:${port}${uiPath}`,
+    wsUrl: `${useTls ? "wss" : "ws"}://${host}:${port}${wsPath}`,
   };
 }

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -476,7 +476,7 @@ export function resolveControlUiLinks(params: {
       return tailnetIPv4 ?? "127.0.0.1";
     }
     if (bind === "netbird" && netbirdIPv4) {
-      return netbirdIPv4 ?? "127.0.0.1";
+      return netbirdIPv4;
     }
     if (bind === "lan") {
       return pickPrimaryLanIPv4() ?? "127.0.0.1";

--- a/src/config/gateway-control-ui-origins.ts
+++ b/src/config/gateway-control-ui-origins.ts
@@ -32,9 +32,10 @@ export function buildDefaultControlUiAllowedOrigins(params: {
   bind: unknown;
   customBindHost?: string;
 }): string[] {
+  const scheme = params.bind === "netbird" ? "https" : "http";
   const origins = new Set<string>([
-    `http://localhost:${params.port}`,
-    `http://127.0.0.1:${params.port}`,
+    `${scheme}://localhost:${params.port}`,
+    `${scheme}://127.0.0.1:${params.port}`,
   ]);
   const customBindHost = params.customBindHost?.trim();
   if (params.bind === "custom" && customBindHost) {

--- a/src/config/gateway-control-ui-origins.ts
+++ b/src/config/gateway-control-ui-origins.ts
@@ -1,10 +1,10 @@
 import type { OpenClawConfig } from "./config.js";
 import { DEFAULT_GATEWAY_PORT } from "./paths.js";
 
-export type GatewayNonLoopbackBindMode = "lan" | "tailnet" | "custom";
+export type GatewayNonLoopbackBindMode = "lan" | "tailnet" | "netbird" | "custom";
 
 export function isGatewayNonLoopbackBindMode(bind: unknown): bind is GatewayNonLoopbackBindMode {
-  return bind === "lan" || bind === "tailnet" || bind === "custom";
+  return bind === "lan" || bind === "tailnet" || bind === "netbird" || bind === "custom";
 }
 
 export function hasConfiguredControlUiAllowedOrigins(params: {

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -417,7 +417,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "messages.queue.drop": ['"old"', '"new"', '"summarize"'],
   "channels.defaults.groupPolicy": ['"open"', '"disabled"', '"allowlist"'],
   "gateway.mode": ['"local"', '"remote"'],
-  "gateway.bind": ['"auto"', '"lan"', '"loopback"', '"custom"', '"tailnet"'],
+  "gateway.bind": ['"auto"', '"lan"', '"loopback"', '"custom"', '"tailnet"', '"netbird"'],
   "gateway.auth.mode": ['"none"', '"token"', '"password"', '"trusted-proxy"'],
   "gateway.tailscale.mode": ['"off"', '"serve"', '"funnel"'],
   "browser.profiles.*.driver": ['"openclaw"', '"clawd"', '"extension"'],
@@ -757,6 +757,7 @@ describe("config help copy quality", () => {
     const bind = FIELD_HELP["gateway.bind"];
     expect(bind.includes('"loopback"')).toBe(true);
     expect(bind.includes('"tailnet"')).toBe(true);
+    expect(bind.includes('"netbird"')).toBe(true);
 
     const reconnect = FIELD_HELP["web.reconnect.maxAttempts"];
     expect(/0 means no retries|no retries/i.test(reconnect)).toBe(true);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -73,7 +73,7 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.mode":
     'Gateway operation mode: "local" runs channels and agent runtime on this host, while "remote" connects through remote transport. Keep "local" unless you intentionally run a split remote gateway topology.',
   "gateway.bind":
-    'Network bind profile: "auto", "lan", "loopback", "custom", or "tailnet" to control interface exposure. Keep "loopback" or "auto" for safest local operation unless external clients must connect.',
+    'Network bind profile: "auto", "lan", "loopback", "custom", "tailnet", or "netbird" to control interface exposure. Keep "loopback" or "auto" for safest local operation unless external clients must connect.',
   "gateway.customBindHost":
     "Explicit bind host/IP used when gateway.bind is set to custom for manual interface targeting. Use a precise address and avoid wildcard binds unless external exposure is required.",
   "gateway.controlUi":

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -1,6 +1,6 @@
 import type { SecretInput } from "./types.secrets.js";
 
-export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet";
+export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet" | "netbird";
 
 export type GatewayTlsConfig = {
   /** Enable TLS for the gateway server. */
@@ -397,6 +397,7 @@ export type GatewayConfig = {
    * - lan: 0.0.0.0 (all interfaces, no fallback)
    * - loopback: 127.0.0.1 (local-only)
    * - tailnet: Tailnet IPv4 if available (100.64.0.0/10), else loopback
+   * - netbird: Netbird wt* interface IPv4 if available, else loopback (auto-enables TLS)
    * - custom: User-specified IP, fallback to 0.0.0.0 if unavailable (requires customBindHost)
    * Default: loopback (127.0.0.1).
    */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -629,6 +629,7 @@ export const OpenClawSchema = z
             z.literal("loopback"),
             z.literal("custom"),
             z.literal("tailnet"),
+            z.literal("netbird"),
           ])
           .optional(),
         customBindHost: z.string().optional(),

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -169,6 +169,20 @@ describe("callGateway url resolution", () => {
       lanIp: undefined,
       expectedUrl: "ws://127.0.0.1:18800",
     },
+    {
+      label: "netbird auto-enables TLS",
+      gateway: { mode: "local", bind: "netbird" },
+      tailnetIp: undefined,
+      lanIp: undefined,
+      expectedUrl: "wss://127.0.0.1:18800",
+    },
+    {
+      label: "netbird with explicit TLS",
+      gateway: { mode: "local", bind: "netbird", tls: { enabled: true } },
+      tailnetIp: undefined,
+      lanIp: undefined,
+      expectedUrl: "wss://127.0.0.1:18800",
+    },
   ])("uses loopback for $label", async ({ gateway, tailnetIp, lanIp, expectedUrl }) => {
     loadConfig.mockReturnValue({ gateway });
     resolveGatewayPort.mockReturnValue(18800);

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -4,6 +4,7 @@ import { captureEnv } from "../test-utils/env.js";
 import {
   loadConfigMock as loadConfig,
   pickPrimaryLanIPv4Mock as pickPrimaryLanIPv4,
+  pickPrimaryNetbirdIPv4Mock as pickPrimaryNetbirdIPv4,
   pickPrimaryTailnetIPv4Mock as pickPrimaryTailnetIPv4,
   resolveGatewayPortMock as resolveGatewayPort,
 } from "./gateway-connection.test-mocks.js";
@@ -181,12 +182,22 @@ describe("callGateway url resolution", () => {
       gateway: { mode: "local", bind: "netbird", tls: { enabled: true } },
       tailnetIp: undefined,
       lanIp: undefined,
+      netbirdIp: undefined,
       expectedUrl: "wss://127.0.0.1:18800",
     },
-  ])("uses loopback for $label", async ({ gateway, tailnetIp, lanIp, expectedUrl }) => {
+    {
+      label: "netbird with IP still uses loopback with TLS",
+      gateway: { mode: "local", bind: "netbird" },
+      tailnetIp: undefined,
+      lanIp: undefined,
+      netbirdIp: "100.119.0.5",
+      expectedUrl: "wss://127.0.0.1:18800",
+    },
+  ])("uses loopback for $label", async ({ gateway, tailnetIp, lanIp, netbirdIp, expectedUrl }) => {
     loadConfig.mockReturnValue({ gateway });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue(tailnetIp);
+    pickPrimaryNetbirdIPv4.mockReturnValue(netbirdIp);
     pickPrimaryLanIPv4.mockReturnValue(lanIp);
 
     await callGateway({ method: "health" });

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -147,9 +147,9 @@ export function buildGatewayConnectionDetails(
     options.configPath ?? resolveConfigPath(process.env, resolveStateDir(process.env));
   const isRemoteMode = config.gateway?.mode === "remote";
   const remote = isRemoteMode ? config.gateway?.remote : undefined;
-  const tlsEnabled = config.gateway?.tls?.enabled === true;
   const localPort = resolveGatewayPort(config);
   const bindMode = config.gateway?.bind ?? "loopback";
+  const tlsEnabled = config.gateway?.tls?.enabled === true || bindMode === "netbird";
   const scheme = tlsEnabled ? "wss" : "ws";
   // Self-connections should always target loopback; bind mode only controls listener exposure.
   const localUrl = `${scheme}://127.0.0.1:${localPort}`;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -705,14 +705,17 @@ async function resolveGatewayTlsFingerprint(params: {
   url: string;
 }): Promise<string | undefined> {
   const { opts, context, url } = params;
+  const bindMode = context.config.gateway?.bind ?? "loopback";
   const useLocalTls =
-    context.config.gateway?.tls?.enabled === true &&
+    (context.config.gateway?.tls?.enabled === true || bindMode === "netbird") &&
     !context.urlOverrideSource &&
     !context.remoteUrl &&
     url.startsWith("wss://");
-  const tlsRuntime = useLocalTls
-    ? await loadGatewayTlsRuntime(context.config.gateway?.tls)
-    : undefined;
+  const effectiveTlsCfg =
+    useLocalTls && bindMode === "netbird" && context.config.gateway?.tls?.enabled !== true
+      ? { ...context.config.gateway?.tls, enabled: true as const, autoGenerate: true }
+      : context.config.gateway?.tls;
+  const tlsRuntime = useLocalTls ? await loadGatewayTlsRuntime(effectiveTlsCfg) : undefined;
   const overrideTlsFingerprint = trimToUndefined(opts.tlsFingerprint);
   const remoteTlsFingerprint =
     // Env overrides may still inherit configured remote TLS pinning for private cert deployments.

--- a/src/gateway/gateway-connection.test-mocks.ts
+++ b/src/gateway/gateway-connection.test-mocks.ts
@@ -5,6 +5,7 @@ type TestMock = ReturnType<typeof vi.fn>;
 export const loadConfigMock: TestMock = vi.fn();
 export const resolveGatewayPortMock: TestMock = vi.fn();
 export const pickPrimaryTailnetIPv4Mock: TestMock = vi.fn();
+export const pickPrimaryNetbirdIPv4Mock: TestMock = vi.fn();
 export const pickPrimaryLanIPv4Mock: TestMock = vi.fn();
 
 vi.mock("../config/config.js", async (importOriginal) => {
@@ -18,6 +19,10 @@ vi.mock("../config/config.js", async (importOriginal) => {
 
 vi.mock("../infra/tailnet.js", () => ({
   pickPrimaryTailnetIPv4: pickPrimaryTailnetIPv4Mock,
+}));
+
+vi.mock("../infra/netbird.js", () => ({
+  pickPrimaryNetbirdIPv4: pickPrimaryNetbirdIPv4Mock,
 }));
 
 vi.mock("./net.js", async (importOriginal) => {

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from "node:http";
 import net from "node:net";
 import os from "node:os";
+import { pickPrimaryNetbirdIPv4, pickPrimaryNetbirdIPv6 } from "../infra/netbird.js";
 import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
 import {
   isCanonicalDottedDecimalIPv4,
@@ -225,6 +226,14 @@ export function isLocalGatewayAddress(ip: string | undefined): boolean {
   if (tailnetIPv6 && ip.trim().toLowerCase() === tailnetIPv6.toLowerCase()) {
     return true;
   }
+  const netbirdIPv4 = pickPrimaryNetbirdIPv4();
+  if (netbirdIPv4 && normalized === netbirdIPv4.toLowerCase()) {
+    return true;
+  }
+  const netbirdIPv6 = pickPrimaryNetbirdIPv6();
+  if (netbirdIPv6 && ip.trim().toLowerCase() === netbirdIPv6.toLowerCase()) {
+    return true;
+  }
   return false;
 }
 
@@ -235,6 +244,7 @@ export function isLocalGatewayAddress(ip: string | undefined): boolean {
  * - loopback: 127.0.0.1 (rarely fails, but handled gracefully)
  * - lan: always 0.0.0.0 (no fallback)
  * - tailnet: Tailnet IPv4 if available, else loopback
+ * - netbird: Netbird wt* interface IPv4 if available, else loopback (auto-TLS)
  * - auto: Loopback if available, else 0.0.0.0
  * - custom: User-specified IP, fallback to 0.0.0.0 if unavailable
  *
@@ -258,6 +268,17 @@ export async function resolveGatewayBindHost(
     const tailnetIP = pickPrimaryTailnetIPv4();
     if (tailnetIP && (await canBindToHost(tailnetIP))) {
       return tailnetIP;
+    }
+    if (await canBindToHost("127.0.0.1")) {
+      return "127.0.0.1";
+    }
+    return "0.0.0.0";
+  }
+
+  if (mode === "netbird") {
+    const netbirdIP = pickPrimaryNetbirdIPv4();
+    if (netbirdIP && (await canBindToHost(netbirdIP))) {
+      return netbirdIP;
     }
     if (await canBindToHost("127.0.0.1")) {
       return "127.0.0.1";

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from "node:http";
 import net from "node:net";
 import os from "node:os";
-import { pickPrimaryNetbirdIPv4, pickPrimaryNetbirdIPv6 } from "../infra/netbird.js";
+import { listNetbirdAddresses, pickPrimaryNetbirdIPv4 } from "../infra/netbird.js";
 import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
 import {
   isCanonicalDottedDecimalIPv4,
@@ -226,12 +226,11 @@ export function isLocalGatewayAddress(ip: string | undefined): boolean {
   if (tailnetIPv6 && ip.trim().toLowerCase() === tailnetIPv6.toLowerCase()) {
     return true;
   }
-  const netbirdIPv4 = pickPrimaryNetbirdIPv4();
-  if (netbirdIPv4 && normalized === netbirdIPv4.toLowerCase()) {
+  const { ipv4: netbirdV4List, ipv6: netbirdV6List } = listNetbirdAddresses();
+  if (netbirdV4List[0] && normalized === netbirdV4List[0].toLowerCase()) {
     return true;
   }
-  const netbirdIPv6 = pickPrimaryNetbirdIPv6();
-  if (netbirdIPv6 && ip.trim().toLowerCase() === netbirdIPv6.toLowerCase()) {
+  if (netbirdV6List[0] && ip.trim().toLowerCase() === netbirdV6List[0].toLowerCase()) {
     return true;
   }
   return false;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -566,8 +566,13 @@ export async function startGatewayServer(
 
   const deps = createDefaultDeps();
   let canvasHostServer: CanvasHostServer | null = null;
-  const gatewayTls = await loadGatewayTlsRuntime(cfgAtStart.gateway?.tls, log.child("tls"));
-  if (cfgAtStart.gateway?.tls?.enabled && !gatewayTls.enabled) {
+  const effectiveBindMode = opts.bind ?? cfgAtStart.gateway?.bind ?? "loopback";
+  const effectiveTlsCfg =
+    effectiveBindMode === "netbird" && cfgAtStart.gateway?.tls?.enabled !== true
+      ? { ...cfgAtStart.gateway?.tls, enabled: true as const, autoGenerate: true }
+      : cfgAtStart.gateway?.tls;
+  const gatewayTls = await loadGatewayTlsRuntime(effectiveTlsCfg, log.child("tls"));
+  if (effectiveTlsCfg?.enabled && !gatewayTls.enabled) {
     throw new Error(gatewayTls.error ?? "gateway tls: failed to enable");
   }
   const serverStartedAt = Date.now();

--- a/src/infra/netbird.ts
+++ b/src/infra/netbird.ts
@@ -1,0 +1,44 @@
+import os from "node:os";
+
+export type NetbirdAddresses = {
+  ipv4: string[];
+  ipv6: string[];
+};
+
+const NETBIRD_INTERFACE_PREFIX = "wt";
+
+export function listNetbirdAddresses(): NetbirdAddresses {
+  const ipv4: string[] = [];
+  const ipv6: string[] = [];
+
+  const ifaces = os.networkInterfaces();
+  for (const [name, entries] of Object.entries(ifaces)) {
+    if (!name.startsWith(NETBIRD_INTERFACE_PREFIX) || !entries) {
+      continue;
+    }
+    for (const e of entries) {
+      if (!e || e.internal) {
+        continue;
+      }
+      const address = e.address?.trim();
+      if (!address) {
+        continue;
+      }
+      if (e.family === "IPv4") {
+        ipv4.push(address);
+      } else if (e.family === "IPv6") {
+        ipv6.push(address);
+      }
+    }
+  }
+
+  return { ipv4: [...new Set(ipv4)], ipv6: [...new Set(ipv6)] };
+}
+
+export function pickPrimaryNetbirdIPv4(): string | undefined {
+  return listNetbirdAddresses().ipv4[0];
+}
+
+export function pickPrimaryNetbirdIPv6(): string | undefined {
+  return listNetbirdAddresses().ipv6[0];
+}

--- a/src/wizard/onboarding.gateway-config.ts
+++ b/src/wizard/onboarding.gateway-config.ts
@@ -78,6 +78,7 @@ export async function configureGatewayForOnboarding(
             { value: "loopback", label: "Loopback (127.0.0.1)" },
             { value: "lan", label: "LAN (0.0.0.0)" },
             { value: "tailnet", label: "Tailnet (Tailscale IP)" },
+            { value: "netbird", label: "Netbird (WireGuard VPN IP, auto-TLS)" },
             { value: "auto", label: "Auto (Loopback → LAN)" },
             { value: "custom", label: "Custom IP" },
           ],

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -227,7 +227,7 @@ export async function runOnboardingWizard(
   })();
 
   if (flow === "quickstart") {
-    const formatBind = (value: "loopback" | "lan" | "auto" | "custom" | "tailnet") => {
+    const formatBind = (value: "loopback" | "lan" | "auto" | "custom" | "tailnet" | "netbird") => {
       if (value === "loopback") {
         return "Loopback (127.0.0.1)";
       }
@@ -239,6 +239,9 @@ export async function runOnboardingWizard(
       }
       if (value === "tailnet") {
         return "Tailnet (Tailscale IP)";
+      }
+      if (value === "netbird") {
+        return "Netbird (WireGuard VPN IP, auto-TLS)";
       }
       return "Auto";
     };

--- a/src/wizard/onboarding.types.ts
+++ b/src/wizard/onboarding.types.ts
@@ -6,7 +6,7 @@ export type WizardFlow = "quickstart" | "advanced";
 export type QuickstartGatewayDefaults = {
   hasExisting: boolean;
   port: number;
-  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet";
+  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet" | "netbird";
   authMode: GatewayAuthChoice;
   tailscaleMode: "off" | "serve" | "funnel";
   token?: SecretInput;
@@ -17,7 +17,7 @@ export type QuickstartGatewayDefaults = {
 
 export type GatewayWizardSettings = {
   port: number;
-  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet";
+  bind: "loopback" | "lan" | "auto" | "custom" | "tailnet" | "netbird";
   customBindHost?: string;
   authMode: GatewayAuthChoice;
   gatewayToken?: string;


### PR DESCRIPTION
## Summary

- **Problem:** NetBird VPN users cannot access the Control UI over VPN because `SubtleCrypto` (device identity) requires HTTPS, but no bind mode auto-enables TLS. The existing `tailnet` bind mode uses CIDR matching (`100.64.0.0/10`) which NetBird IPs also fall into.
- **Why it matters:** NetBird is a growing WireGuard-based VPN (issue #32725). Users must currently combine `bind: "lan"` + manual `tls.enabled: true` + `allowedOrigins` to make it work — error-prone and undocumented.
- **What changed:** Added `gateway.bind: "netbird"` that (1) detects `wt*` network interfaces, (2) auto-enables self-signed TLS, (3) follows the same fallback chain as `tailnet`.
- **What did NOT change:** No changes to existing bind modes. Tailscale behavior is untouched. No new dependencies.

## Change Type

- [x] Feature

## Scope

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #32725
- Related #3667

## User-visible / Behavior Changes

- New config option: `gateway.bind: "netbird"` — binds to the NetBird wt* interface IP with auto-TLS
- New onboarding wizard option: "Netbird (WireGuard VPN IP, auto-TLS)"
- Dashboard links use `https://` when bind is netbird

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same bind pattern as tailnet
- Command/tool execution surface changed? No
- Data access scope changed? No
- Auto-TLS generates a self-signed cert at `~/.openclaw/gateway/tls/` using the existing `generateSelfSignedCert()` — same mechanism as manual `tls.enabled: true`

## Repro + Verification

### Environment
- OS: Ubuntu 24.04 (Hetzner VPS) + macOS 15
- Runtime: Node 24
- Integration: NetBird VPN (self-hosted management)
- Config: `gateway.bind: "netbird"`, token auth

### Steps
1. Install NetBird, connect to management server
2. Set `gateway.bind: "netbird"` in openclaw config
3. Restart gateway

### Expected
- Gateway binds to wt0 interface IP
- Self-signed TLS cert auto-generated
- Control UI accessible at `https://<netbird-ip>:18789`

### Actual
- Works as expected, device identity check passes

## Evidence

- [x] Failing test/log before + passing after
- [x] All 138 relevant tests pass (call.test.ts, net.test.ts, schema.help.quality.test.ts, onboard-helpers.test.ts)
- [x] TypeScript compiles with zero errors in src/

## Human Verification

- Verified: Gateway binds to NetBird IP on real server (mainframe, Ubuntu 24.04)
- Verified: TLS auto-generated, Control UI accessible over HTTPS
- Verified: Fallback to loopback when NetBird not running
- Edge cases: netbird + tailscale serve/funnel conflict (covered by existing validation)
- Not verified: macOS NetBird interface naming (assumed wt* based on NetBird docs)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — new enum value, no existing config changes
- Config/env changes? New optional value for `gateway.bind`
- Migration needed? No

## Failure Recovery

- Revert: remove "netbird" from GatewayBindMode union (single revert commit)
- Users with `bind: "netbird"` would get a Zod validation error on startup (clear error message)
- No data loss or state corruption possible

## Risks and Mitigations

- Risk: NetBird interface prefix changes in future versions
  - Mitigation: `wt` prefix is stable across NetBird versions; documented in their codebase
- Risk: Other WireGuard tools also use wt* prefix
  - Mitigation: Users of other WireGuard tools can use `bind: "custom"` + manual TLS. The netbird mode is explicitly for NetBird.

---
Built with Claude Code (AI-assisted). Fully tested on real NetBird deployment.