### PR TITLE
fix(discord,telegram): suppress NO_REPLY token before API call

### DIFF
--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -138,7 +138,12 @@ export async function sendMessageDiscord(
 ): Promise<DiscordSendResult> {
   // Suppress NO_REPLY and other silent tokens before hitting the Discord API (parity with Slack)
   const trimmed = text?.trim() ?? "";
-  if (isSilentReplyText(trimmed) && !opts.mediaUrl && !opts.components && !opts.embeds) {
+  if (
+    isSilentReplyText(trimmed) &&
+    !opts.mediaUrl &&
+    !opts.components?.length &&
+    !opts.embeds?.length
+  ) {
     logVerbose("discord send: suppressed NO_REPLY token before API call");
     return { messageId: "suppressed", channelId: "" };
   }

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 import { serializePayload, type MessagePayloadObject, type RequestClient } from "@buape/carbon";
 import { ChannelType, Routes } from "discord-api-types/v10";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
+import { logVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
 import type { RetryConfig } from "../infra/retry.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -134,6 +136,13 @@ export async function sendMessageDiscord(
   text: string,
   opts: DiscordSendOpts = {},
 ): Promise<DiscordSendResult> {
+  // Suppress NO_REPLY and other silent tokens before hitting the Discord API (parity with Slack)
+  const trimmed = text?.trim() ?? "";
+  if (isSilentReplyText(trimmed) && !opts.mediaUrl) {
+    logVerbose("discord send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", channelId: "" };
+  }
+
   const cfg = opts.cfg ?? loadConfig();
   const accountInfo = resolveDiscordAccount({
     cfg,

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -138,7 +138,7 @@ export async function sendMessageDiscord(
 ): Promise<DiscordSendResult> {
   // Suppress NO_REPLY and other silent tokens before hitting the Discord API (parity with Slack)
   const trimmed = text?.trim() ?? "";
-  if (isSilentReplyText(trimmed) && !opts.mediaUrl) {
+  if (isSilentReplyText(trimmed) && !opts.mediaUrl && !opts.components && !opts.embeds) {
     logVerbose("discord send: suppressed NO_REPLY token before API call");
     return { messageId: "suppressed", channelId: "" };
   }

--- a/src/discord/send.sends-basic-channel-messages.test.ts
+++ b/src/discord/send.sends-basic-channel-messages.test.ts
@@ -70,6 +70,38 @@ describe("sendMessageDiscord", () => {
     __resetDiscordDirectoryCacheForTest();
   });
 
+  it("suppresses NO_REPLY token without hitting the API", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const res = await sendMessageDiscord("channel:789", "NO_REPLY", {
+      rest,
+      token: "t",
+    });
+    expect(res).toEqual({ messageId: "suppressed", channelId: "" });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("suppresses NO_REPLY with surrounding whitespace", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const res = await sendMessageDiscord("channel:789", "  NO_REPLY  \n", {
+      rest,
+      token: "t",
+    });
+    expect(res).toEqual({ messageId: "suppressed", channelId: "" });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress NO_REPLY when mediaUrl is present", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    const res = await sendMessageDiscord("channel:789", "NO_REPLY", {
+      rest,
+      token: "t",
+      mediaUrl: "https://example.com/image.png",
+    });
+    expect(res.messageId).not.toBe("suppressed");
+  });
+
   it("sends basic channel messages", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();
     // Channel type lookup returns a normal text channel (not a forum).

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -172,6 +172,18 @@ describe("buildInlineKeyboard", () => {
 });
 
 describe("sendMessageTelegram", () => {
+  it("suppresses NO_REPLY token without hitting the API", async () => {
+    const res = await sendMessageTelegram("123", "NO_REPLY", { token: "tok" });
+    expect(res).toEqual({ messageId: "suppressed", chatId: "" });
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("suppresses NO_REPLY with surrounding whitespace", async () => {
+    const res = await sendMessageTelegram("123", "  NO_REPLY  \n", { token: "tok" });
+    expect(res).toEqual({ messageId: "suppressed", chatId: "" });
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("sends typing to the resolved chat and topic", async () => {
     loadConfig.mockReturnValue({
       channels: {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,6 +5,7 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -590,6 +591,13 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts = {},
 ): Promise<TelegramSendResult> {
+  // Suppress NO_REPLY and other silent tokens before hitting the Telegram API (parity with Slack)
+  const trimmed = text?.trim() ?? "";
+  if (isSilentReplyText(trimmed) && !opts.mediaUrl) {
+    logVerbose("telegram send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", chatId: "" };
+  }
+
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -593,7 +593,7 @@ export async function sendMessageTelegram(
 ): Promise<TelegramSendResult> {
   // Suppress NO_REPLY and other silent tokens before hitting the Telegram API (parity with Slack)
   const trimmed = text?.trim() ?? "";
-  if (isSilentReplyText(trimmed) && !opts.mediaUrl && !opts.buttons) {
+  if (isSilentReplyText(trimmed) && !opts.mediaUrl && !opts.buttons?.length) {
     logVerbose("telegram send: suppressed NO_REPLY token before API call");
     return { messageId: "suppressed", chatId: "" };
   }

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -593,7 +593,7 @@ export async function sendMessageTelegram(
 ): Promise<TelegramSendResult> {
   // Suppress NO_REPLY and other silent tokens before hitting the Telegram API (parity with Slack)
   const trimmed = text?.trim() ?? "";
-  if (isSilentReplyText(trimmed) && !opts.mediaUrl) {
+  if (isSilentReplyText(trimmed) && !opts.mediaUrl && !opts.buttons) {
     logVerbose("telegram send: suppressed NO_REPLY token before API call");
     return { messageId: "suppressed", chatId: "" };
   }


### PR DESCRIPTION
## Summary

- Problem: Discord and Telegram channels leak internal `NO_REPLY` tokens (and other silent reply markers) to end-users, while Slack correctly suppresses them.
- Why it matters: Internal orchestration artifacts (`NO_REPLY`, `to=functions.*`, `commentary`) reaching end-users is a privacy/UX issue.
- What changed: Added `isSilentReplyText` guard at the top of `sendMessageDiscord` and `sendMessageTelegram`, matching the existing Slack pattern at `src/slack/send.ts:258`.
- What did NOT change (scope boundary): No changes to shared sanitization layers, normalize pipelines, or other channels. This is a targeted send-level guard only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44905
- Closes #38603
- Closes #37727
- Related #43679
- Related #38232
- Related #31060

## User-visible / Behavior Changes

Discord and Telegram channels will no longer deliver messages whose entire content is `NO_REPLY` (the internal silent reply token). Previously these leaked as visible chat messages.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+
- Integration/channel (if any): Discord, Telegram

### Steps

1. Configure a Discord or Telegram channel
2. Trigger an LLM response that produces `NO_REPLY` (e.g., a cron heartbeat with no actionable content)
3. Observe the channel

### Expected

- `NO_REPLY` token is silently suppressed; no message delivered to the channel

### Actual (before fix)

- `NO_REPLY` appears as a visible message in Discord/Telegram

## Evidence

- [x] Failing test/log before + passing after
  - New tests: `src/discord/send.sends-basic-channel-messages.test.ts` (3 tests), `src/telegram/send.test.ts` (2 tests)
  - All verify `NO_REPLY` returns `{messageId: "suppressed"}` without hitting the API
  - Media/UI-payload bypass verified: suppression skipped when `mediaUrl`, `components`, `embeds`, or `buttons` present

## Human Verification (required)

- Verified scenarios: `pnpm build` succeeds, all new guard tests pass, existing Discord send tests (29/29) pass
- Edge cases checked: NO_REPLY with whitespace, NO_REPLY with media (not suppressed), NO_REPLY with components/embeds/buttons (not suppressed)
- What you did **not** verify: live Discord/Telegram channel test (no bot credentials available locally)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two guard blocks (4 lines each) in `src/discord/send.outbound.ts` and `src/telegram/send.ts`
- Known bad symptoms reviewers should watch for: legitimate messages containing only `NO_REPLY` being silently dropped (extremely unlikely in practice; same risk profile as existing Slack guard)

## Risks and Mitigations

- Risk: A message whose entire content is literally `NO_REPLY` would be silently suppressed
  - Mitigation: `isSilentReplyText` only matches exact full-message matches (with whitespace tolerance), not substrings. Guard also bypasses when media, components, embeds, or buttons are present (parity with Slack's `!opts.blocks` check). This pattern has been running in production on Slack without issue.

---

AI-assisted (Claude Code). Codex review run against `origin/main`; P3 feedback addressed (added UI-payload bypass conditions).