### PR TITLE
feat(web-search): add Tavily as search provider

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -22,7 +22,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as const;
+const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity", "tavily"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -333,6 +333,22 @@ type KimiConfig = {
   model?: string;
 };
 
+type TavilyConfig = {
+  apiKey?: string;
+  searchDepth?: string;
+};
+
+type TavilySearchResponse = {
+  results?: Array<{
+    title?: string;
+    url?: string;
+    content?: string;
+    score?: number;
+    raw_content?: string;
+  }>;
+  query?: string;
+};
+
 type GrokSearchResponse = {
   output?: Array<{
     type?: string;
@@ -593,6 +609,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "tavily") {
+    return {
+      error: "missing_tavily_api_key",
+      message:
+        "web_search (tavily) needs a Tavily API key. Set TAVILY_API_KEY in the Gateway environment, or configure tools.web.search.tavily.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_perplexity_api_key",
     message:
@@ -620,6 +644,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
   if (raw === "perplexity") {
     return "perplexity";
+  }
+  if (raw === "tavily") {
+    return "tavily";
   }
 
   // Auto-detect provider from available API keys (alphabetical order)
@@ -663,6 +690,14 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
         'web_search: no provider configured, auto-detected "perplexity" from available API keys',
       );
       return "perplexity";
+    }
+    // Tavily
+    const tavilyConfig = resolveTavilyConfig(search);
+    if (resolveTavilyApiKey(tavilyConfig)) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "tavily" from available API keys',
+      );
+      return "tavily";
     }
   }
 
@@ -889,6 +924,41 @@ function resolveKimiBaseUrl(kimi?: KimiConfig): string {
   return fromConfig || DEFAULT_KIMI_BASE_URL;
 }
 
+function resolveTavilyConfig(search?: WebSearchConfig): TavilyConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const tavily = "tavily" in search ? search.tavily : undefined;
+  if (!tavily || typeof tavily !== "object") {
+    return {};
+  }
+  return tavily as TavilyConfig;
+}
+
+function resolveTavilyApiKey(tavily?: TavilyConfig): string | undefined {
+  const fromConfig = normalizeApiKey(tavily?.apiKey);
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnv = normalizeApiKey(process.env.TAVILY_API_KEY);
+  return fromEnv || undefined;
+}
+
+function resolveTavilySearchDepth(tavily?: TavilyConfig, search?: unknown): string {
+  const fromTavily =
+    tavily && "searchDepth" in tavily && typeof tavily.searchDepth === "string"
+      ? tavily.searchDepth.trim()
+      : "";
+  const fromSearch =
+    search &&
+    typeof search === "object" &&
+    "searchDepth" in search &&
+    typeof (search as { searchDepth: unknown }).searchDepth === "string"
+      ? (search as { searchDepth: string }).searchDepth.trim()
+      : "";
+  return fromTavily || fromSearch || "basic";
+}
+
 function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
   if (!search || typeof search !== "object") {
     return {};
@@ -1017,6 +1087,65 @@ async function runGeminiSearch(params: {
       }
 
       return { content, citations };
+    },
+  );
+}
+
+async function runTavilySearch(params: {
+  query: string;
+  apiKey: string;
+  searchDepth: string;
+  timeoutSeconds: number;
+}): Promise<{ content: string; citations: Array<{ url: string; title?: string }> }> {
+  const endpoint = "https://api.tavily.com/search";
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: endpoint,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${params.apiKey}`,
+        },
+        body: JSON.stringify({
+          query: params.query,
+          search_depth: params.searchDepth,
+          include_raw_content: false,
+          include_images: false,
+          include_answer: false,
+        }),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+        const safeDetail = (detailResult.text || res.statusText).replace(
+          /tvly-[a-zA-Z0-9]+/g,
+          "tvly-***",
+        );
+        throw new Error(`Tavily API error (${res.status}): ${safeDetail}`);
+      }
+
+      let data: TavilySearchResponse;
+      try {
+        data = (await res.json()) as TavilySearchResponse;
+      } catch (err) {
+        throw new Error(`Tavily API returned invalid JSON`, { cause: err });
+      }
+
+      const results = data.results || [];
+      const content = results.map((r, i) => `[${i + 1}] ${r.title}\n${r.content}`).join("\n\n");
+
+      const citations = results
+        .map((r) => ({
+          url: r.url || "",
+          title: r.title || undefined,
+        }))
+        .filter((c) => c.url !== "");
+
+      return { content: content || "No response", citations };
     },
   );
 }
@@ -1603,6 +1732,7 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   braveMode?: "web" | "llm-context";
+  tavilySearchDepth?: string;
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
   const providerSpecificKey =
@@ -1769,6 +1899,32 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "tavily") {
+    const { content, citations } = await runTavilySearch({
+      query: params.query,
+      apiKey: params.apiKey,
+      searchDepth: params.tavilySearchDepth ?? "basic",
+      timeoutSeconds: params.timeoutSeconds,
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: citations.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      content: wrapWebContent(content, "web_search"),
+      citations,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -1909,23 +2065,26 @@ export function createWebSearchTool(options?: {
   const grokConfig = resolveGrokConfig(search);
   const geminiConfig = resolveGeminiConfig(search);
   const kimiConfig = resolveKimiConfig(search);
+  const tavilyConfig = resolveTavilyConfig(search);
   const braveConfig = resolveBraveConfig(search);
   const braveMode = resolveBraveMode(braveConfig);
 
   const description =
-    provider === "perplexity"
-      ? perplexitySchemaTransportHint === "chat_completions"
-        ? "Search the web using Perplexity Sonar via Perplexity/OpenRouter chat completions. Returns AI-synthesized answers with citations from web-grounded search."
-        : "Search the web using Perplexity. Runtime routing decides between native Search API and Sonar chat-completions compatibility. Structured filters are available on the native Search API path."
-      : provider === "grok"
-        ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
-        : provider === "kimi"
-          ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
-          : provider === "gemini"
-            ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : braveMode === "llm-context"
-              ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
-              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+    provider === "tavily"
+      ? "Search the web using Tavily Search API. Returns relevant search results with content snippets and URLs."
+      : provider === "perplexity"
+        ? perplexitySchemaTransportHint === "chat_completions"
+          ? "Search the web using Perplexity Sonar via Perplexity/OpenRouter chat completions. Returns AI-synthesized answers with citations from web-grounded search."
+          : "Search the web using Perplexity. Runtime routing decides between native Search API and Sonar chat-completions compatibility. Structured filters are available on the native Search API path."
+        : provider === "grok"
+          ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
+          : provider === "kimi"
+            ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
+            : provider === "gemini"
+              ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
+              : braveMode === "llm-context"
+                ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
+                : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -1949,7 +2108,9 @@ export function createWebSearchTool(options?: {
               ? resolveKimiApiKey(kimiConfig)
               : provider === "gemini"
                 ? resolveGeminiApiKey(geminiConfig)
-                : resolveSearchApiKey(search);
+                : provider === "tavily"
+                  ? resolveTavilyApiKey(tavilyConfig)
+                  : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
@@ -2186,6 +2347,7 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         braveMode,
+        tavilySearchDepth: resolveTavilySearchDepth(tavilyConfig, search),
       });
       return jsonResult(result);
     },

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -659,7 +659,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider":
-    'Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). Auto-detected from available API keys if omitted.',
+    'Search provider ("brave", "gemini", "grok", "kimi", "perplexity", or "tavily"). Auto-detected from available API keys if omitted.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -457,8 +457,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). */
-      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity";
+      /** Search provider ("brave", "gemini", "grok", "kimi", "perplexity", or "tavily"). */
+      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "tavily";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: SecretInput;
       /** Default search results count (1-10). */
@@ -505,6 +505,13 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
         model?: string;
+      };
+      /** Tavily-specific configuration (used when provider="tavily"). */
+      tavily?: {
+        /** Tavily API key (defaults to TAVILY_API_KEY env var). */
+        apiKey?: SecretInput;
+        /** Search depth: "basic" or "advanced" (default: "basic"). */
+        searchDepth?: string;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -269,6 +269,7 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.literal("tavily"),
       ])
       .optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
@@ -311,6 +312,13 @@ export const ToolsWebSearchSchema = z
     brave: z
       .object({
         mode: z.union([z.literal("web"), z.literal("llm-context")]).optional(),
+      })
+      .strict()
+      .optional(),
+    tavily: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        searchDepth: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -10,7 +10,7 @@ import {
   type SecretDefaults,
 } from "./runtime-shared.js";
 
-const WEB_SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as const;
+const WEB_SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity", "tavily"] as const;
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_KEY_PREFIXES = ["pplx-"];
@@ -328,6 +328,9 @@ function envVarsForProvider(provider: WebSearchProvider): string[] {
   }
   if (provider === "kimi") {
     return ["KIMI_API_KEY", "MOONSHOT_API_KEY"];
+  }
+  if (provider === "tavily") {
+    return ["TAVILY_API_KEY"];
   }
   return ["PERPLEXITY_API_KEY", "OPENROUTER_API_KEY"];
 }


### PR DESCRIPTION
## Summary

Add [Tavily](https://tavily.com) as the 6th web search provider alongside brave, gemini, grok, kimi, and perplexity.

- Full implementation of `runTavilySearch()` with Bearer token auth
- Configuration via `tools.web.search.tavily.apiKey` or `TAVILY_API_KEY` env var
- Supports `basic` and `advanced` search depth via `tavily.searchDepth`
- API key masking in error messages for security
- Integrated across all validation layers (TypeScript types, Zod schema, runtime secrets)

## Configuration

```json
{
  "tools": {
    "web": {
      "search": {
        "provider": "tavily",
        "tavily": {
          "apiKey": "tvly-...",
          "searchDepth": "basic"
        }
      }
    }
  }
}
```

Or simply set `TAVILY_API_KEY` environment variable.

## Files changed

- `src/agents/tools/web-search.ts` — Core implementation (types, config resolvers, search function, dispatch)
- `src/config/types.tools.ts` — TypeScript type definitions
- `src/config/zod-schema.agent-runtime.ts` — Zod validation schema
- `src/config/schema.help.ts` — Help text
- `src/secrets/runtime-web-tools.ts` — Runtime secret resolution

## Test plan

- [x] `pnpm build` passes
- [x] Gateway starts with `provider: "tavily"` without validation errors
- [x] Web search returns results via Tavily API
- [x] Auto-detection works when `TAVILY_API_KEY` is set