### PR TITLE
[WebUI] Fix missing styles and empty line layouts in Gateway Logs panel

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3733,6 +3733,58 @@
 }
 
 /* Bottom grid (event log + log tail) */
+
+.ov-event-log-list {
+  max-height: 400px;
+  overflow-y: auto;
+  margin-top: 12px;
+  padding-right: 8px;
+}
+
+.ov-event-log-entry {
+  display: flex;
+  gap: 8px;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.ov-event-log-entry:last-child {
+  border-bottom: none;
+}
+
+.ov-event-log-ts {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.ov-event-log-name {
+  font-weight: 500;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.ov-event-log-payload {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ov-log-tail-content {
+  margin: 12px 0 0 0;
+  padding: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--muted);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
 .ov-bottom-grid {
   display: grid;
   gap: 20px;

--- a/ui/src/ui/views/overview-log-tail.ts
+++ b/ui/src/ui/views/overview-log-tail.ts
@@ -20,7 +20,8 @@ export function renderOverviewLogTail(props: OverviewLogTailProps) {
 
   const displayLines = props.lines
     .slice(-50)
-    .map((line) => stripAnsi(line))
+    .map((line) => stripAnsi(line).trim())
+    .filter(Boolean)
     .join("\n");
 
   return html`

--- a/ui/src/ui/views/overview-log-tail.ts
+++ b/ui/src/ui/views/overview-log-tail.ts
@@ -20,8 +20,8 @@ export function renderOverviewLogTail(props: OverviewLogTailProps) {
 
   const displayLines = props.lines
     .slice(-50)
-    .map((line) => stripAnsi(line).trim())
-    .filter(Boolean)
+    .map((line) => stripAnsi(line))
+    .filter((line) => line.trim() !== "")
     .join("\n");
 
   return html`


### PR DESCRIPTION
The Gateway Logs view in the Overview tab occasionally renders a massive white gap above its text, pushing a single visible log line to the absolute bottom of the layout, looking completely broken.

This resolves two interlocking root causes:
1. **Missing CSS constraints**: The classes `.ov-event-log-list` and `.ov-log-tail-content` were used in TS but completely omitted from the stylesheets, causing them to lack `max-height`, `overflow-y`, and proper structural spacing.
2. **Invisible lines stretching layout**: The `logs.tail` output heavily features lines that become composed only of whitespace when `stripAnsi` returns empty sequences (e.g. from spinners or JSON newlines interacting). The array retained these blank lines, which mapped to 49 lines of literal `\n`, artificially shoving the actual text block to the floor of the `<details>` parent block.

Fixes: Added missing CSS layouts (`max-height: 400px; overflow-y: auto`), and explicitly `.filter(Boolean)` down the output of `stripAnsi` to ensure real content remains visible without silent spacing stretching layout.
