### PR TITLE
fix(gateway): bridge plugin registry across jiti VM realm boundaries

### DIFF
--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "../server-methods/types.js";
 import { makeMockHttpResponse } from "../test-http-response.js";

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -87,6 +87,10 @@ async function createSubagentRuntime(): Promise<PluginRuntime["subagent"]> {
 }
 
 describe("createGatewayPluginRequestHandler", () => {
+  beforeEach(() => {
+    (process as unknown as { __openclawPluginRegistry?: unknown }).__openclawPluginRegistry =
+      undefined;
+  });
   it("caps unauthenticated plugin routes to non-admin subagent scopes", async () => {
     loadOpenClawPlugins.mockReset();
     handleGatewayRequest.mockReset();

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -64,6 +64,12 @@ export function createGatewayPluginRequestHandler(params: {
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
   const { registry, log } = params;
+  // Share the authoritative registry via process so it is reachable across
+  // jiti VM realm boundaries.  Plugin loading through jiti may create
+  // separate VM contexts where the registry object identity differs; this
+  // ensures findMatchingPluginHttpRoutes always sees the real routes.
+  (process as unknown as { __openclawPluginRegistry?: PluginRegistry }).__openclawPluginRegistry =
+    registry;
   return async (req, res, providedPathContext, dispatchContext) => {
     const routes = registry.httpRoutes ?? [];
     if (routes.length === 0) {

--- a/src/gateway/server/plugins-http/route-match.ts
+++ b/src/gateway/server/plugins-http/route-match.ts
@@ -23,7 +23,20 @@ export function findMatchingPluginHttpRoutes(
   registry: PluginRegistry,
   context: PluginRoutePathContext,
 ): PluginHttpRouteEntry[] {
-  const routes = registry.httpRoutes ?? [];
+  // When plugins are loaded through jiti, the registry passed here may come
+  // from a different VM realm than the one that owns the HTTP routes.  Fall
+  // back to the authoritative registry stored on process by
+  // createGatewayPluginRequestHandler.
+  const liveRegistry = (process as unknown as { __openclawPluginRegistry?: PluginRegistry })
+    .__openclawPluginRegistry;
+  const ownRoutes = registry.httpRoutes ?? [];
+  const liveRoutes =
+    liveRegistry && liveRegistry !== registry ? (liveRegistry.httpRoutes ?? []) : [];
+  // NOTE: liveRoutes is only non-empty when registry is a jiti-realm stub
+  // with an empty httpRoutes array.  If ownRoutes is also non-empty, both
+  // sets are merged; callers must not register routes in both realms for the
+  // same path, or they will be dispatched twice.
+  const routes = liveRoutes.length > 0 ? [...ownRoutes, ...liveRoutes] : ownRoutes;
   if (routes.length === 0) {
     return [];
   }


### PR DESCRIPTION
## Summary

Fix inbound webhooks (e.g. BlueBubbles, Telegram) returning 404 after upgrading to 2026.3.12 by bridging the plugin registry across jiti VM realm boundaries.

## Problem

The provider-plugin refactor in 2026.3.12 moved Ollama/vLLM/SGLang onto jiti-based plugin loading. jiti creates separate VM contexts, so the `PluginRegistry` instance captured by `createGatewayPluginRequestHandler()` lives in the main realm, but `findMatchingPluginHttpRoutes()` may receive a registry from a different jiti realm with an empty `httpRoutes` array -- causing all inbound webhooks to 404.

## Fix

1. In `createGatewayPluginRequestHandler()`, store the authoritative registry on `process` (shared across all VM contexts)
2. In `findMatchingPluginHttpRoutes()`, check for the cross-realm registry and merge its routes when the local registry instance differs

This is a minimal, targeted fix. A more comprehensive solution would be to ensure jiti plugin loading shares the same registry instance, but that's a larger refactor of the plugin architecture.

## Testing

- Verified BlueBubbles webhook routes resolve correctly after the fix in a Docker from-source build of 2026.3.12
- No behavior change when running without jiti (single-realm -- the fallback is never used)

Fixes #45007