### PR TITLE
fix(ui): tolerate malformed chat content blocks

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -46,7 +46,7 @@ describe("extractTextCached", () => {
   it("skips malformed content blocks when extracting text", () => {
     const message = {
       role: "assistant",
-      content: [null, undefined, { type: "text", text: "Hello there" }],
+      content: [null, undefined, ["nested"], { type: "text", text: "Hello there" }],
     };
 
     expect(extractText(message)).toBe("Hello there");
@@ -75,7 +75,7 @@ describe("extractThinkingCached", () => {
   it("skips malformed content blocks when extracting thinking", () => {
     const message = {
       role: "assistant",
-      content: [null, { type: "thinking", thinking: "Plan A" }, undefined],
+      content: [null, ["nested"], { type: "thinking", thinking: "Plan A" }, undefined],
     };
 
     expect(extractThinking(message)).toBe("Plan A");

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -42,6 +42,16 @@ describe("extractTextCached", () => {
     expect(extractText(message)).toBe("Final user answer");
     expect(extractTextCached(message)).toBe("Final user answer");
   });
+
+  it("skips malformed content blocks when extracting text", () => {
+    const message = {
+      role: "assistant",
+      content: [null, undefined, { type: "text", text: "Hello there" }],
+    };
+
+    expect(extractText(message)).toBe("Hello there");
+    expect(extractTextCached(message)).toBe("Hello there");
+  });
 });
 
 describe("extractThinkingCached", () => {
@@ -59,6 +69,16 @@ describe("extractThinkingCached", () => {
       content: [{ type: "thinking", thinking: "Plan A" }],
     };
     expect(extractThinkingCached(message)).toBe("Plan A");
+    expect(extractThinkingCached(message)).toBe("Plan A");
+  });
+
+  it("skips malformed content blocks when extracting thinking", () => {
+    const message = {
+      role: "assistant",
+      content: [null, { type: "thinking", thinking: "Plan A" }, undefined],
+    };
+
+    expect(extractThinking(message)).toBe("Plan A");
     expect(extractThinkingCached(message)).toBe("Plan A");
   });
 });

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -6,7 +6,9 @@ const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 function processMessageText(text: string, role: string): string {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -5,6 +5,10 @@ import { stripThinkingTags } from "../format.ts";
 const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
 function processMessageText(text: string, role: string): string {
   const shouldStripInboundMetadata = role.toLowerCase() === "user";
   if (role === "assistant") {
@@ -44,7 +48,10 @@ export function extractThinking(message: unknown): string | null {
   const parts: string[] = [];
   if (Array.isArray(content)) {
     for (const p of content) {
-      const item = p as Record<string, unknown>;
+      const item = asObjectRecord(p);
+      if (!item) {
+        continue;
+      }
       if (item.type === "thinking" && typeof item.thinking === "string") {
         const cleaned = item.thinking.trim();
         if (cleaned) {
@@ -91,7 +98,10 @@ export function extractRawText(message: unknown): string | null {
   if (Array.isArray(content)) {
     const parts = content
       .map((p) => {
-        const item = p as Record<string, unknown>;
+        const item = asObjectRecord(p);
+        if (!item) {
+          return null;
+        }
         if (item.type === "text" && typeof item.text === "string") {
           return item.text;
         }

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -62,7 +62,7 @@ describe("message-normalizer", () => {
     it("skips malformed content blocks without throwing", () => {
       const result = normalizeMessage({
         role: "assistant",
-        content: [null, undefined, { type: "text", text: "Recovered text" }],
+        content: [null, undefined, ["nested"], { type: "text", text: "Recovered text" }],
       });
 
       expect(result.role).toBe("assistant");

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -59,6 +59,23 @@ describe("message-normalizer", () => {
       });
     });
 
+    it("skips malformed content blocks without throwing", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: [null, undefined, { type: "text", text: "Recovered text" }],
+      });
+
+      expect(result.role).toBe("assistant");
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: "Recovered text",
+          name: undefined,
+          args: undefined,
+        },
+      ]);
+    });
+
     it("normalizes message with text field (alternative format)", () => {
       const result = normalizeMessage({
         role: "user",

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -5,6 +5,10 @@
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
 /**
  * Normalize a raw message object into a consistent structure.
  */
@@ -21,7 +25,10 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   const hasToolContent =
     Array.isArray(contentItems) &&
     contentItems.some((item) => {
-      const x = item as Record<string, unknown>;
+      const x = asObjectRecord(item);
+      if (!x) {
+        return false;
+      }
       const t = (typeof x.type === "string" ? x.type : "").toLowerCase();
       return t === "toolresult" || t === "tool_result";
     });
@@ -38,12 +45,20 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   if (typeof m.content === "string") {
     content = [{ type: "text", text: m.content }];
   } else if (Array.isArray(m.content)) {
-    content = m.content.map((item: Record<string, unknown>) => ({
-      type: (item.type as MessageContentItem["type"]) || "text",
-      text: item.text as string | undefined,
-      name: item.name as string | undefined,
-      args: item.args || item.arguments,
-    }));
+    content = m.content.flatMap((item) => {
+      const record = asObjectRecord(item);
+      if (!record) {
+        return [];
+      }
+      return [
+        {
+          type: (record.type as MessageContentItem["type"]) || "text",
+          text: record.text as string | undefined,
+          name: record.name as string | undefined,
+          args: record.args || record.arguments,
+        },
+      ];
+    });
   } else if (typeof m.text === "string") {
     content = [{ type: "text", text: m.text }];
   }

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -6,7 +6,9 @@ import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inb
 import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Dashboard chat rendering crashed when a historical message contained malformed `content` entries like `null` or `undefined`.
- Why it matters: A single legacy transcript entry could make an entire session unreadable in the dashboard, which matches the failure mode reported in #44791.
- What changed: Hardened the UI chat message normalizer and text/thinking extractors to skip malformed content blocks, and added regression tests for those shapes.
- What did NOT change (scope boundary): This PR does not change Telegram failed-media delivery, transcript persistence, or backend history sanitization.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44791
- Related #44758

## User-visible / Behavior Changes

Dashboard chat now ignores malformed historical `content` blocks instead of crashing the entire conversation view.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux 6.6.87.2-microsoft-standard-WSL2
- Runtime/container: local workspace, pnpm workspace install
- Model/provider: N/A
- Integration/channel (if any): Dashboard UI rendering of historical Telegram-linked sessions
- Relevant config (redacted): None

### Steps

1. Create or load a chat message whose `content` array contains malformed entries such as `null` or `undefined` alongside valid text/thinking blocks.
2. Open the session in the dashboard chat view or run the affected UI helpers against that message shape.
3. Observe whether the view renders or the helper throws.

### Expected

- The dashboard should ignore malformed blocks and continue rendering the message/session.

### Actual

- Before this change, the UI helper path threw when it read `item.type` from a malformed block.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added regression coverage for malformed `content` entries in `message-normalizer` and `message-extract`; reran targeted helper tests, root chat tests, and the full `test:ui` suite.
- Edge cases checked: `null` and `undefined` content blocks mixed with valid text and thinking blocks; existing normal message shapes remained green under the UI suite.
- What you did **not** verify: I did not reproduce against a real exported user session, and I did not change backend transcript sanitization.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `01482712f`.
- Files/config to restore: `ui/src/ui/chat/message-normalizer.ts` and `ui/src/ui/chat/message-extract.ts`
- Known bad symptoms reviewers should watch for: Unexpected omission of malformed content blocks from UI rendering.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Skipping malformed blocks could hide corrupted transcript content instead of surfacing it visibly.
  - Mitigation: The change only drops invalid blocks; valid text/thinking blocks are preserved, and the alternative today is a full chat-view crash.
