### PR TITLE
AI-assisted: Onboarding: avoid plugin-registry reload for built-in QuickStart channels

### DIFF
--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -259,26 +259,6 @@ describe("setupChannels", () => {
       );
     });
     expect(sawHardStop).toBe(false);
-    expect(reloadOnboardingPluginRegistry).not.toHaveBeenCalled();
-  });
-
-  it("reloads built-in plugins for configured Telegram when registry is empty", async () => {
-    setActivePluginRegistry(createEmptyPluginRegistry());
-
-    const select = createQuickstartTelegramSelect({
-      configuredAction: "skip",
-      strictUnexpected: true,
-    });
-    const { prompter } = createUnexpectedQuickstartPrompter(
-      select as unknown as WizardPrompter["select"],
-    );
-
-    await runSetupChannels(createTelegramCfg("token"), prompter, {
-      quickstartDefaults: true,
-      allowDisable: true,
-    });
-
-    expect(reloadOnboardingPluginRegistry).toHaveBeenCalledTimes(1);
   });
 
   it("shows explicit dmScope config command in channel primer", async () => {

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   setDefaultChannelPluginRegistryForTests,
 } from "./channel-test-helpers.js";
 import { setupChannels } from "./onboard-channels.js";
+import { reloadOnboardingPluginRegistry } from "./onboarding/plugin-install.js";
 import { createExitThrowingRuntime, createWizardPrompter } from "./test-wizard-helpers.js";
 
 function createPrompter(overrides: Partial<WizardPrompter>): WizardPrompter {
@@ -190,6 +191,7 @@ vi.mock("./onboarding/plugin-install.js", async (importOriginal) => {
 describe("setupChannels", () => {
   beforeEach(() => {
     setDefaultChannelPluginRegistryForTests();
+    vi.mocked(reloadOnboardingPluginRegistry).mockClear();
   });
   it("QuickStart uses single-select (no multiselect) and doesn't prompt for Telegram token when WhatsApp is chosen", async () => {
     const select = vi.fn(async () => "whatsapp");
@@ -257,6 +259,26 @@ describe("setupChannels", () => {
       );
     });
     expect(sawHardStop).toBe(false);
+    expect(reloadOnboardingPluginRegistry).not.toHaveBeenCalled();
+  });
+
+  it("reloads built-in plugins for configured Telegram when registry is empty", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const select = createQuickstartTelegramSelect({
+      configuredAction: "skip",
+      strictUnexpected: true,
+    });
+    const { prompter } = createUnexpectedQuickstartPrompter(
+      select as unknown as WizardPrompter["select"],
+    );
+
+    await runSetupChannels(createTelegramCfg("token"), prompter, {
+      quickstartDefaults: true,
+      allowDisable: true,
+    });
+
+    expect(reloadOnboardingPluginRegistry).toHaveBeenCalledTimes(1);
   });
 
   it("shows explicit dmScope config command in channel primer", async () => {

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -348,7 +348,6 @@ export async function setupChannels(
 
   const quickstartDefault =
     options?.initialSelection?.[0] ?? resolveQuickstartDefault(statusByChannel);
-  const builtInChannelIds = coreIds;
 
   const shouldPromptAccountIds = options?.promptAccountIds === true;
   const accountIdsByChannel = new Map<ChannelChoice, string>();
@@ -464,11 +463,6 @@ export async function setupChannels(
       return false;
     }
     const adapter = getChannelOnboardingAdapter(channel);
-    const configured = statusByChannel.get(channel)?.configured === true;
-    if (adapter && builtInChannelIds.has(channel) && !configured) {
-      await refreshStatus(channel);
-      return true;
-    }
     const workspaceDir = resolveAgentWorkspaceDir(next, resolveDefaultAgentId(next));
     reloadOnboardingPluginRegistry({
       cfg: next,

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -348,6 +348,7 @@ export async function setupChannels(
 
   const quickstartDefault =
     options?.initialSelection?.[0] ?? resolveQuickstartDefault(statusByChannel);
+  const builtInChannelIds = coreIds;
 
   const shouldPromptAccountIds = options?.promptAccountIds === true;
   const accountIdsByChannel = new Map<ChannelChoice, string>();
@@ -462,6 +463,12 @@ export async function setupChannels(
       );
       return false;
     }
+    const adapter = getChannelOnboardingAdapter(channel);
+    const configured = statusByChannel.get(channel)?.configured === true;
+    if (adapter && builtInChannelIds.has(channel) && !configured) {
+      await refreshStatus(channel);
+      return true;
+    }
     const workspaceDir = resolveAgentWorkspaceDir(next, resolveDefaultAgentId(next));
     reloadOnboardingPluginRegistry({
       cfg: next,
@@ -469,10 +476,9 @@ export async function setupChannels(
       workspaceDir,
     });
     if (!getChannelPlugin(channel)) {
-      // Some installs/environments can fail to populate the plugin registry during onboarding,
-      // even for built-in channels. If the channel supports onboarding, proceed with config
-      // so setup isn't blocked; the gateway can still load plugins on startup.
-      const adapter = getChannelOnboardingAdapter(channel);
+      // Some installs/environments can fail to populate the plugin registry during onboarding.
+      // If the channel supports onboarding, proceed with config so setup isn't blocked;
+      // the gateway can still load plugins on startup.
       if (adapter) {
         await prompter.note(
           `${channel} plugin not available (continuing with onboarding). If the channel still doesn't work after setup, run \`${formatCliCommand(


### PR DESCRIPTION
## Summary

- Problem: on low-memory hosts (~2 GB), `openclaw onboard` OOMs after selecting a built-in channel (e.g. Telegram) in QuickStart.
- Why it matters: blocks first-run onboarding on small VPS setups.
- What changed: built-in channels with onboarding adapters now skip `reloadOnboardingPluginRegistry()` after `enablePluginInConfig()`, avoiding a full plugin-runtime reload.
- What did NOT change (scope boundary): extension/plugin channel flows still reload the registry; no auth/token semantics changed.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

On low-memory machines, `QuickStart -> Telegram` (and other built-in channels) now proceeds to the bot-token prompt instead of OOMing.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04, ~2 GB RAM
- Runtime/container: Node v22.22.1
- Integration/channel: Telegram onboarding in QuickStart

### Steps

1. `openclaw onboard --install-daemon --auth-choice skip`
2. Accept security prompt → choose `QuickStart`
3. Select `Telegram`

### Expected

Onboarding continues into the Telegram token flow.

### Actual (before fix)

Process OOMs during `reloadOnboardingPluginRegistry()`:

```
◇  Select channel (QuickStart)
│  Telegram (Bot API)

<--- Last few GCs --->
[12030:0x8f62000]   379468 ms: Scavenge (interleaved) 961.7 (984.1) -> 961.2 (988.9) MB
[12030:0x8f62000]   380733 ms: Mark-Compact (reduce) 964.5 (988.9) -> 964.0 (985.1) MB

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

### After fix

Same steps on same machine — onboarding reaches the bot-token prompt without OOM:

```
◇  Select channel (QuickStart)
│  Telegram (Bot API)
│
◇  Telegram bot token ──────────────────────────────────────────────╮
│  1) Open Telegram and chat with @BotFather                        │
│  2) Run /newbot (or /mybots)                                      │
│  3) Copy the token (looks like 123456:ABC...)                     │
├───────────────────────────────────────────────────────────────────╯
│
◆  How do you want to provide this Telegram bot token?
```

## Evidence

- [x] Failing test/log before + passing after (see above)
- [x] Trace/log snippets (see above)

### Root Cause

`ensureBundledPluginEnabled()` unconditionally called `reloadOnboardingPluginRegistry()` after `enablePluginInConfig()`. This triggers `clearPluginDiscoveryCache()` + `loadOpenClawPlugins({ cache: false })` — a full disk scan that spikes memory. Built-in channels already have onboarding adapters via `src/commands/onboarding/registry.ts` and don't need this reload to continue.

### Code Change

- `src/commands/onboard-channels.ts`: if the channel is built-in and has an onboarding adapter, `refreshStatus()` and return immediately — skip `reloadOnboardingPluginRegistry()`.
- `src/commands/onboard-channels.e2e.test.ts`: regression test asserting Telegram onboarding continues with an empty plugin registry and does not call `reloadOnboardingPluginRegistry()`.

## Human Verification

- Verified scenarios:
  - `pnpm build` succeeds
  - `pnpm test` passes (7417 tests, 3 skipped)
  - targeted e2e test passes (10/10)
  - `npm pack` → deploy to 2 GB Ubuntu VPS → `npm i -g` → `openclaw onboard` reaches bot-token prompt without OOM
- Edge cases checked:
  - empty plugin registry fallback for built-in Telegram onboarding
  - full end-to-end onboarding with a real Telegram bot token — bot is functional

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- How to disable/revert: revert the commit and rebuild.
- Known bad symptoms: built-in channels failing to continue onboarding after enable.

## Risks and Mitigations

- Risk: extension/plugin channels still do the full reload; they may still OOM on very low-memory machines.
  - Mitigation: this is a targeted fix for the QuickStart path (built-in channels only). A broader fix (incremental/lazy plugin loading) is a separate effort.
- Risk: built-in channel status could become stale if future logic depends on a freshly reloaded registry.
  - Mitigation: guarded by `adapter && builtInChannelIds.has(channel)`; regression test locks the intended behavior.

## AI Assistance Disclosure

- AI-assisted: Yes
- Testing level: fully verified — automated tests + packaged deployment on 2 GB VPS
- I understand what the code does
