### PR TITLE
feat(gh-issues): Include type definitions in agent dispatch prompts

### DIFF
--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -326,6 +326,63 @@ For each confirmed issue, spawn a sub-agent using sessions_spawn. Launch up to 8
 
 **Write claims:** After spawning each sub-agent, read the claims file, add `{SOURCE_REPO}#{N}` with the current ISO timestamp, and write it back (same procedure as cron mode above). This covers interactive usage where watch mode might overlap with cron runs.
 
+### Type Definitions Discovery
+
+Before constructing the sub-agent prompt, gather type definitions from the target repository to prevent type system incompatibilities.
+
+**For each issue to be processed:**
+
+1. **Detect type definitions directory:**
+   Check for common type definition locations in the repository (in order of preference):
+
+   ```bash
+   # Try src/types/ first
+   if curl -s -o /dev/null -w "%{http_code}" \
+     -H "Authorization: Bearer $GH_TOKEN" \
+     "https://api.github.com/repos/{SOURCE_REPO}/contents/src/types?ref={BASE_BRANCH}" | grep -q "200"; then
+     TYPES_DIR="src/types"
+   # Then try types/
+   elif curl -s -o /dev/null -w "%{http_code}" \
+     -H "Authorization: Bearer $GH_TOKEN" \
+     "https://api.github.com/repos/{SOURCE_REPO}/contents/types?ref={BASE_BRANCH}" | grep -q "200"; then
+     TYPES_DIR="types"
+   else
+     TYPES_DIR=""
+   fi
+   ```
+
+2. **Fetch type definition files (if TYPES_DIR is set):**
+
+   ```bash
+   if [ -n "$TYPES_DIR" ]; then
+     # Get list of files in the types directory
+     TYPE_FILES=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+       -H "Accept: application/vnd.github+json" \
+       "https://api.github.com/repos/{SOURCE_REPO}/contents/$TYPES_DIR?ref={BASE_BRANCH}" \
+       | jq -r '.[] | select(.type == "file" and (.name | endswith(".ts") or endswith(".d.ts"))) | .name')
+
+     # Fetch content of each type file
+     TYPE_DEFINITIONS=""
+     for file in $TYPE_FILES; do
+       CONTENT=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+         -H "Accept: application/vnd.github.raw" \
+         "https://api.github.com/repos/{SOURCE_REPO}/contents/$TYPES_DIR/$file?ref={BASE_BRANCH}")
+       TYPE_DEFINITIONS="$TYPE_DEFINITIONS
+
+## $TYPES_DIR/$file
+
+\`\`\`typescript
+$CONTENT
+\`\`\`
+"
+     done
+   else
+     TYPE_DEFINITIONS="(No centralized types directory found. Agent may define types as needed.)"
+   fi
+   ```
+
+3. **Store TYPE_DEFINITIONS** for inclusion in the sub-agent prompt template.
+
 ### Sub-agent Task Prompt
 
 For each issue, construct the following prompt and pass it to sessions_spawn. Variables to inject into the template:
@@ -337,8 +394,9 @@ For each issue, construct the following prompt and pass it to sessions_spawn. Va
 - {number}, {title}, {url}, {labels}, {body} — from the issue
 - {BASE_BRANCH} — from Phase 4
 - {notify_channel} — Telegram channel ID for notifications (empty if not set). Replace {notify_channel} in the template below with the value of `--notify-channel` flag (or leave as empty string if not provided).
+- {TYPE_DEFINITIONS} — Type definitions gathered from the repository (from Type Definitions Discovery above)
 
-When constructing the task, replace all template variables including {notify_channel} with actual values.
+When constructing the task, replace all template variables including {notify_channel} and {TYPE_DEFINITIONS} with actual values.
 
 ```
 You are a focused code-fix agent. Your task is to fix a single GitHub issue and open a PR.
@@ -368,6 +426,12 @@ URL: {url}
 Labels: {labels}
 Body: {body}
 </issue>
+
+<types>
+The repository uses the following type definitions. Use ONLY these types in your implementation. Do NOT create new type names unless the issue specifically requires new types to be added.
+
+{TYPE_DEFINITIONS}
+</types>
 
 <instructions>
 Follow these steps in order. If any step fails, report the failure and stop.
@@ -409,6 +473,8 @@ git checkout -b fix/issue-{number} {BASE_BRANCH}
 
 4. IMPLEMENT — Make the minimal, focused fix:
 - Follow existing code style and conventions
+- Use ONLY the type definitions provided in the <types> section above — do NOT create new type names
+- If you need a type that doesn't exist, use the closest existing type or propose it in your PR description
 - Change only what is necessary to fix the issue
 - Do not add unrelated changes or new dependencies without justification
 
@@ -706,6 +772,8 @@ If `--yes` is NOT set and this is not a subsequent watch poll: ask the user to c
 
 For each PR with actionable comments, spawn a sub-agent. Launch up to 8 concurrently.
 
+**Before spawning each review fix sub-agent,** gather type definitions from the repository using the same Type Definitions Discovery procedure from Phase 5 (check for `src/types/` or `types/`, fetch all `.ts` and `.d.ts` files, build TYPE_DEFINITIONS variable).
+
 **Review fix sub-agent prompt:**
 
 ```
@@ -739,6 +807,12 @@ Each comment has:
 - source: where the comment came from (review, inline, pr_body, greptile, etc.)
 </review_comments>
 
+<types>
+The repository uses the following type definitions. Use ONLY these types when implementing review feedback. Do NOT create new type names unless a review comment specifically asks for it.
+
+{TYPE_DEFINITIONS}
+</types>
+
 <instructions>
 Follow these steps in order:
 
@@ -760,6 +834,7 @@ git pull {PUSH_REMOTE} {branch_name}
 3. IMPLEMENT — For each comment, make the requested change:
 - Read the file and locate the relevant code
 - Make the change the reviewer requested
+- Use ONLY the type definitions provided in the <types> section — do NOT create new type names
 - If the comment is vague or you disagree, still attempt a reasonable fix but note your concern
 - If the comment asks for something impossible or contradictory, skip it and explain why in your reply
 


### PR DESCRIPTION
## Summary

This PR implements issue #59 by auto-detecting and including type definitions from the target repository when spawning sub-agents in the gh-issues skill.

## Changes

- Added **Type Definitions Discovery** section in Phase 5 that:
  - Detects `src/types/` or `types/` directory via GitHub API
  - Fetches all `.ts` and `.d.ts` files from the types directory  
  - Builds a TYPE_DEFINITIONS variable with all type file contents

- Enhanced **Sub-agent Task Prompt** to:
  - Include a new `<types>` section with all repository type definitions
  - Add explicit instruction: 'Use ONLY these types — do NOT create new type names'
  - Add {TYPE_DEFINITIONS} variable to template

- Applied same enhancement to **Review Fix Sub-agent** prompts in Phase 6

- Updated IMPLEMENT instructions in both prompts to reinforce type constraint

## Testing

- Manual review of SKILL.md changes
- Verified bash snippets use GitHub API (no gh CLI dependency)
- Confirmed TYPE_DEFINITIONS variable is properly injected

## Impact

Prevents type system incompatibilities when agents create implementations. Sub-agents will now see and use existing types (like FilterRule, ScannerDefinition) instead of creating new names (ScannerRule, FilterNode, etc.).

Closes #59
