### PR TITLE
 fix(browser): restore extension-relay color-scheme reset for attached pages

### DIFF
--- a/assets/chrome-extension/background-appearance.js
+++ b/assets/chrome-extension/background-appearance.js
@@ -1,0 +1,18 @@
+// Keep tab attachment visually transparent: attaching the debugger must not
+// leave media/theme emulation behind on the user's page.
+export async function clearDebuggerAppearanceOverrides(sendCommand, debuggee) {
+  try {
+    await sendCommand(debuggee, 'Emulation.setEmulatedMedia', {
+      media: '',
+      features: [],
+    })
+  } catch {
+    // Older Chromium builds or restricted targets may reject this.
+  }
+
+  try {
+    await sendCommand(debuggee, 'Emulation.setAutoDarkModeOverride', {})
+  } catch {
+    // Best-effort only; unsupported on some targets.
+  }
+}

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -5,6 +5,7 @@ import {
   isRetryableReconnectError,
   reconnectDelayMs,
 } from './background-utils.js'
+import { clearDebuggerAppearanceOverrides } from './background-appearance.js'
 
 const DEFAULT_PORT = 18792
 
@@ -510,6 +511,10 @@ function getTabByTargetId(targetId) {
 async function attachTab(tabId, opts = {}) {
   const debuggee = { tabId }
   await chrome.debugger.attach(debuggee, '1.3')
+  await clearDebuggerAppearanceOverrides(
+    (session, method, params) => chrome.debugger.sendCommand(session, method, params),
+    debuggee,
+  )
   await chrome.debugger.sendCommand(debuggee, 'Page.enable').catch(() => {})
 
   const info = /** @type {any} */ (await chrome.debugger.sendCommand(debuggee, 'Target.getTargetInfo'))

--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -252,7 +252,7 @@ describe("web monitor inbox", () => {
     });
   });
 
-  it("handles append messages by marking them read but skipping auto-reply", async () => {
+  it("handles stale append messages by marking them read but skipping auto-reply", async () => {
     const { onMessage, listener, sock } = await openInboxMonitor();
 
     const upsert = {
@@ -265,7 +265,7 @@ describe("web monitor inbox", () => {
             remoteJid: "999@s.whatsapp.net",
           },
           message: { conversation: "old message" },
-          messageTimestamp: nowSeconds(),
+          messageTimestamp: nowSeconds(-5 * 60_000),
           pushName: "History Sender",
         },
       ],

--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -254,6 +254,7 @@ describe("web monitor inbox", () => {
 
   it("handles stale append messages by marking them read but skipping auto-reply", async () => {
     const { onMessage, listener, sock } = await openInboxMonitor();
+    const staleTs = Math.floor(Date.now() / 1000) - 300;
 
     const upsert = {
       type: "append",
@@ -265,7 +266,7 @@ describe("web monitor inbox", () => {
             remoteJid: "999@s.whatsapp.net",
           },
           message: { conversation: "old message" },
-          messageTimestamp: nowSeconds(-5 * 60_000),
+          messageTimestamp: staleTs,
           pushName: "History Sender",
         },
       ],

--- a/src/browser/chrome-extension-background-appearance.test.ts
+++ b/src/browser/chrome-extension-background-appearance.test.ts
@@ -1,0 +1,61 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+type BackgroundAppearanceModule = {
+  clearDebuggerAppearanceOverrides: (
+    sendCommand: (
+      debuggee: { tabId: number },
+      method: string,
+      params?: Record<string, unknown>,
+    ) => Promise<unknown>,
+    debuggee: { tabId: number },
+  ) => Promise<void>;
+};
+
+const require = createRequire(import.meta.url);
+const BACKGROUND_APPEARANCE_MODULE = "../../assets/chrome-extension/background-appearance.js";
+
+async function loadBackgroundAppearance(): Promise<BackgroundAppearanceModule> {
+  try {
+    return require(BACKGROUND_APPEARANCE_MODULE) as BackgroundAppearanceModule;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Unexpected token 'export'")) {
+      throw error;
+    }
+    return (await import(BACKGROUND_APPEARANCE_MODULE)) as BackgroundAppearanceModule;
+  }
+}
+
+const { clearDebuggerAppearanceOverrides } = await loadBackgroundAppearance();
+
+describe("chrome extension background appearance", () => {
+  it("clears media and auto-dark overrides after attach", async () => {
+    const sendCommand = vi.fn(async () => ({}));
+
+    await clearDebuggerAppearanceOverrides(sendCommand, { tabId: 7 });
+
+    expect(sendCommand).toHaveBeenNthCalledWith(1, { tabId: 7 }, "Emulation.setEmulatedMedia", {
+      media: "",
+      features: [],
+    });
+    expect(sendCommand).toHaveBeenNthCalledWith(
+      2,
+      { tabId: 7 },
+      "Emulation.setAutoDarkModeOverride",
+      {},
+    );
+  });
+
+  it("keeps attach flow resilient when overrides are unsupported", async () => {
+    const sendCommand = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Emulation.setEmulatedMedia not supported"))
+      .mockRejectedValueOnce(new Error("Emulation.setAutoDarkModeOverride not supported"));
+
+    await expect(clearDebuggerAppearanceOverrides(sendCommand, { tabId: 9 })).resolves.toBe(
+      undefined,
+    );
+    expect(sendCommand).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
+++ b/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
@@ -223,7 +223,7 @@ describe("pw-session getPageForTargetId", () => {
     }
   });
 
-  it("bounds single-page relay neutralization when the selected page is stuck", async () => {
+  it("does not re-queue single-page relay neutralization while a timed-out attempt is still stuck", async () => {
     vi.useFakeTimers();
     extensionRelayMocks.getChromeExtensionRelayAuthHeaders.mockReturnValue({
       "x-openclaw-relay-token": "test-token",
@@ -240,12 +240,66 @@ describe("pw-session getPageForTargetId", () => {
       });
       await Promise.resolve();
       await Promise.resolve();
-      await vi.advanceTimersByTimeAsync(2_001);
+      await vi.advanceTimersByTimeAsync(1_001);
 
       await expect(pending).resolves.toBe(page);
-      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledTimes(2);
+      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledTimes(1);
       expect(pageEmulateMediaSpies[0]).toHaveBeenNthCalledWith(1, { colorScheme: null });
-      expect(pageEmulateMediaSpies[0]).toHaveBeenNthCalledWith(2, { colorScheme: null });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies a cooldown before retrying relay neutralization after a timeout", async () => {
+    vi.useFakeTimers();
+    extensionRelayMocks.getChromeExtensionRelayAuthHeaders.mockReturnValue({
+      "x-openclaw-relay-token": "test-token",
+    });
+    let callCount = 0;
+    const { pageEmulateMediaSpies, pages } = createExtensionFallbackBrowserHarness({
+      urls: ["https://alpha.example"],
+      emulateMediaImplementations: [
+        () => {
+          callCount += 1;
+          if (callCount === 1) {
+            return new Promise<void>((_resolve, reject) => {
+              setTimeout(() => reject(new Error("late failure")), 2_000);
+            });
+          }
+          return Promise.resolve();
+        },
+      ],
+    });
+    const [page] = pages;
+
+    try {
+      const first = getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:19999",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_001);
+
+      await expect(first).resolves.toBe(page);
+      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(
+        getPageForTargetId({
+          cdpUrl: "http://127.0.0.1:19999",
+        }),
+      ).resolves.toBe(page);
+      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(4_000);
+
+      await expect(
+        getPageForTargetId({
+          cdpUrl: "http://127.0.0.1:19999",
+        }),
+      ).resolves.toBe(page);
+      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
+++ b/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
@@ -223,6 +223,34 @@ describe("pw-session getPageForTargetId", () => {
     }
   });
 
+  it("bounds single-page relay neutralization when the selected page is stuck", async () => {
+    vi.useFakeTimers();
+    extensionRelayMocks.getChromeExtensionRelayAuthHeaders.mockReturnValue({
+      "x-openclaw-relay-token": "test-token",
+    });
+    const { pageEmulateMediaSpies, pages } = createExtensionFallbackBrowserHarness({
+      urls: ["https://alpha.example"],
+      emulateMediaImplementations: [() => new Promise(() => {})],
+    });
+    const [page] = pages;
+
+    try {
+      const pending = getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:19998",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(2_001);
+
+      await expect(pending).resolves.toBe(page);
+      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledTimes(2);
+      expect(pageEmulateMediaSpies[0]).toHaveBeenNthCalledWith(1, { colorScheme: null });
+      expect(pageEmulateMediaSpies[0]).toHaveBeenNthCalledWith(2, { colorScheme: null });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps relay appearance neutralization when relay probing transiently fails but auth hint exists", async () => {
     extensionRelayMocks.getChromeExtensionRelayAuthHeaders.mockReturnValue({
       "x-openclaw-relay-token": "test-token",

--- a/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
+++ b/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
@@ -1,20 +1,40 @@
-import { chromium } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import * as chromeModule from "./chrome.js";
-import { closePlaywrightBrowserConnection, getPageForTargetId } from "./pw-session.js";
+
+const extensionRelayMocks = vi.hoisted(() => ({
+  getChromeExtensionRelayAuthHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock("./extension-relay.js", () => extensionRelayMocks);
+
+const { chromium } = await import("playwright-core");
+const chromeModule = await import("./chrome.js");
+const { closePlaywrightBrowserConnection, getPageForTargetId } = await import("./pw-session.js");
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
 const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
 afterEach(async () => {
   connectOverCdpSpy.mockClear();
   getChromeWebSocketUrlSpy.mockClear();
+  extensionRelayMocks.getChromeExtensionRelayAuthHeaders.mockReset();
+  extensionRelayMocks.getChromeExtensionRelayAuthHeaders.mockReturnValue({});
   await closePlaywrightBrowserConnection().catch(() => {});
 });
 
 function createExtensionFallbackBrowserHarness(options?: {
   urls?: string[];
   newCDPSessionError?: string;
+  emulateMediaImplementations?: Array<() => Promise<void>>;
 }) {
   const pageOn = vi.fn();
   const contextOn = vi.fn();
@@ -30,14 +50,17 @@ function createExtensionFallbackBrowserHarness(options?: {
     newCDPSession,
   } as unknown as import("playwright-core").BrowserContext;
 
-  const pages = (options?.urls ?? [undefined]).map(
-    (url) =>
-      ({
-        on: pageOn,
-        context: () => context,
-        ...(url ? { url: () => url } : {}),
-      }) as unknown as import("playwright-core").Page,
-  );
+  const pageEmulateMediaSpies: Array<ReturnType<typeof vi.fn>> = [];
+  const pages = (options?.urls ?? [undefined]).map((url, index) => {
+    const emulateMedia = vi.fn(options?.emulateMediaImplementations?.[index] ?? (async () => {}));
+    pageEmulateMediaSpies.push(emulateMedia);
+    return {
+      on: pageOn,
+      context: () => context,
+      emulateMedia,
+      ...(url ? { url: () => url } : {}),
+    } as unknown as import("playwright-core").Page;
+  });
   (context as unknown as { pages: () => unknown[] }).pages = () => pages;
 
   const browser = {
@@ -48,10 +71,104 @@ function createExtensionFallbackBrowserHarness(options?: {
 
   connectOverCdpSpy.mockResolvedValue(browser);
   getChromeWebSocketUrlSpy.mockResolvedValue(null);
-  return { browserClose, newCDPSession, pages };
+  return { browserClose, newCDPSession, pageEmulateMediaSpies, pages };
 }
 
 describe("pw-session getPageForTargetId", () => {
+  it("retries when the browser disconnects before the initial relay setup finishes", async () => {
+    const pageOn = vi.fn();
+    const contextOn = vi.fn();
+    const firstBrowserOn = vi.fn();
+    const firstBrowserOff = vi.fn();
+    const secondBrowserOn = vi.fn();
+    const secondBrowserOff = vi.fn();
+    const firstBrowserClose = vi.fn(async () => {});
+    const secondBrowserClose = vi.fn(async () => {});
+    const deferredVersion = createDeferred<Response>();
+
+    const firstContext = {
+      pages: () => [],
+      on: contextOn,
+      newCDPSession: vi.fn(async () => {
+        throw new Error("Not allowed");
+      }),
+    } as unknown as import("playwright-core").BrowserContext;
+    const firstPageEmulateMedia = vi.fn(async () => {});
+    const firstPage = {
+      on: pageOn,
+      context: () => firstContext,
+      url: () => "https://alpha.example",
+      emulateMedia: firstPageEmulateMedia,
+    } as unknown as import("playwright-core").Page;
+    (firstContext as unknown as { pages: () => unknown[] }).pages = () => [firstPage];
+
+    const secondContext = {
+      pages: () => [],
+      on: contextOn,
+      newCDPSession: vi.fn(async () => {
+        throw new Error("Not allowed");
+      }),
+    } as unknown as import("playwright-core").BrowserContext;
+    const secondPageEmulateMedia = vi.fn(async () => {});
+    const secondPage = {
+      on: pageOn,
+      context: () => secondContext,
+      url: () => "https://beta.example",
+      emulateMedia: secondPageEmulateMedia,
+    } as unknown as import("playwright-core").Page;
+    (secondContext as unknown as { pages: () => unknown[] }).pages = () => [secondPage];
+
+    let firstDisconnectedHandler: (() => void) | undefined;
+    const firstBrowser = {
+      contexts: () => [firstContext],
+      on: firstBrowserOn.mockImplementation((event: string, handler: () => void) => {
+        if (event === "disconnected") {
+          firstDisconnectedHandler = handler;
+        }
+      }),
+      off: firstBrowserOff,
+      close: firstBrowserClose,
+    } as unknown as import("playwright-core").Browser;
+    const secondBrowser = {
+      contexts: () => [secondContext],
+      on: secondBrowserOn,
+      off: secondBrowserOff,
+      close: secondBrowserClose,
+    } as unknown as import("playwright-core").Browser;
+
+    connectOverCdpSpy.mockResolvedValueOnce(firstBrowser).mockResolvedValueOnce(secondBrowser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockReturnValueOnce(deferredVersion.promise).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ Browser: "OpenClaw/extension-relay" }),
+    } as Response);
+
+    const pending = getPageForTargetId({
+      cdpUrl: "http://127.0.0.1:19994",
+    });
+
+    await vi.waitFor(() => {
+      expect(firstBrowserOn).toHaveBeenCalledWith("disconnected", expect.any(Function));
+    });
+    firstDisconnectedHandler?.();
+    deferredVersion.resolve({
+      ok: true,
+      json: async () => ({ Browser: "OpenClaw/extension-relay" }),
+    } as Response);
+
+    try {
+      const resolved = await pending;
+      expect(resolved).toBe(secondPage);
+      expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
+      expect(firstBrowserOff).toHaveBeenCalledWith("disconnected", expect.any(Function));
+      expect(secondPageEmulateMedia).toHaveBeenCalledWith({ colorScheme: null });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("falls back to the only page when CDP session attachment is blocked (extension relays)", async () => {
     const { browserClose, pages } = createExtensionFallbackBrowserHarness();
     const [page] = pages;
@@ -64,6 +181,78 @@ describe("pw-session getPageForTargetId", () => {
 
     await closePlaywrightBrowserConnection();
     expect(browserClose).toHaveBeenCalled();
+  });
+
+  it("does not let one stuck page block initial relay setup for other attached pages", async () => {
+    vi.useFakeTimers();
+    const { pageEmulateMediaSpies, pages } = createExtensionFallbackBrowserHarness({
+      urls: ["https://alpha.example", "https://beta.example"],
+      emulateMediaImplementations: [() => new Promise(() => {}), async () => {}],
+    });
+    const [, pageB] = pages;
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ Browser: "OpenClaw/extension-relay" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: "TARGET_A", url: "https://alpha.example" },
+          { id: "TARGET_B", url: "https://beta.example" },
+        ],
+      } as Response);
+
+    try {
+      const pending = getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:19995",
+        targetId: "TARGET_B",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_001);
+
+      await expect(pending).resolves.toBe(pageB);
+      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledWith({ colorScheme: null });
+      expect(pageEmulateMediaSpies[1]).toHaveBeenCalledWith({ colorScheme: null });
+    } finally {
+      fetchSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps relay appearance neutralization when relay probing transiently fails but auth hint exists", async () => {
+    extensionRelayMocks.getChromeExtensionRelayAuthHeaders.mockReturnValue({
+      "x-openclaw-relay-token": "test-token",
+    });
+    const { newCDPSession, pageEmulateMediaSpies, pages } = createExtensionFallbackBrowserHarness({
+      urls: ["https://alpha.example", "https://beta.example"],
+      newCDPSessionError: "Target.attachToBrowserTarget: Not allowed",
+    });
+    const [, pageB] = pages;
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockRejectedValueOnce(new Error("timeout")).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: "TARGET_A", url: "https://alpha.example" },
+        { id: "TARGET_B", url: "https://beta.example" },
+      ],
+    } as Response);
+
+    try {
+      const resolved = await getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:19997",
+        targetId: "TARGET_B",
+      });
+      expect(resolved).toBe(pageB);
+      expect(newCDPSession).toHaveBeenCalled();
+      expect(pageEmulateMediaSpies[1]).toHaveBeenCalledWith({ colorScheme: null });
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("uses the shared HTTP-base normalization when falling back to /json/list for direct WebSocket CDP URLs", async () => {
@@ -95,7 +284,7 @@ describe("pw-session getPageForTargetId", () => {
   });
 
   it("resolves extension-relay pages from /json/list without probing page CDP sessions first", async () => {
-    const { newCDPSession, pages } = createExtensionFallbackBrowserHarness({
+    const { newCDPSession, pageEmulateMediaSpies, pages } = createExtensionFallbackBrowserHarness({
       urls: ["https://alpha.example", "https://beta.example"],
       newCDPSessionError: "Target.attachToBrowserTarget: Not allowed",
     });
@@ -122,6 +311,55 @@ describe("pw-session getPageForTargetId", () => {
       });
       expect(resolved).toBe(pageB);
       expect(newCDPSession).not.toHaveBeenCalled();
+      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledWith({ colorScheme: null });
+      expect(pageEmulateMediaSpies[1]).toHaveBeenCalledWith({ colorScheme: null });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("does not cache a relay browser after it was closed during initial setup", async () => {
+    const deferredNeutralization = createDeferred<void>();
+    const firstHarness = createExtensionFallbackBrowserHarness({
+      urls: ["https://alpha.example"],
+      emulateMediaImplementations: [() => deferredNeutralization.promise],
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ Browser: "OpenClaw/extension-relay" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ Browser: "OpenClaw/extension-relay" }),
+      } as Response);
+
+    try {
+      const pending = getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:19996",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      await closePlaywrightBrowserConnection({ cdpUrl: "http://127.0.0.1:19996" });
+      deferredNeutralization.resolve();
+
+      await expect(pending).rejects.toThrow("CDP browser connection closed during setup");
+      expect(firstHarness.browserClose).toHaveBeenCalledTimes(1);
+
+      const secondHarness = createExtensionFallbackBrowserHarness({
+        urls: ["https://beta.example"],
+      });
+      const [secondPage] = secondHarness.pages;
+
+      await expect(
+        getPageForTargetId({
+          cdpUrl: "http://127.0.0.1:19996",
+        }),
+      ).resolves.toBe(secondPage);
+      expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     } finally {
       fetchSpy.mockRestore();
     }

--- a/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
+++ b/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
@@ -8,7 +8,8 @@ vi.mock("./extension-relay.js", () => extensionRelayMocks);
 
 const { chromium } = await import("playwright-core");
 const chromeModule = await import("./chrome.js");
-const { closePlaywrightBrowserConnection, getPageForTargetId } = await import("./pw-session.js");
+const { closePlaywrightBrowserConnection, getPageForTargetId, listPagesViaPlaywright } =
+  await import("./pw-session.js");
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
 const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
@@ -247,6 +248,55 @@ describe("pw-session getPageForTargetId", () => {
       expect(pageEmulateMediaSpies[0]).toHaveBeenNthCalledWith(1, { colorScheme: null });
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("awaits in-flight relay neutralization for concurrent lookups of the same page", async () => {
+    extensionRelayMocks.getChromeExtensionRelayAuthHeaders.mockReturnValue({});
+    const deferredNeutralization = createDeferred<void>();
+    const { pageEmulateMediaSpies, pages } = createExtensionFallbackBrowserHarness({
+      urls: ["https://alpha.example"],
+      emulateMediaImplementations: [() => deferredNeutralization.promise],
+    });
+    const [page] = pages;
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("timeout"));
+    try {
+      await listPagesViaPlaywright({
+        cdpUrl: "http://127.0.0.1:20000",
+      });
+      extensionRelayMocks.getChromeExtensionRelayAuthHeaders.mockReturnValue({
+        "x-openclaw-relay-token": "test-token",
+      });
+
+      const first = getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:20000",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const second = getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:20000",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      let secondSettled = false;
+      void second.finally(() => {
+        secondSettled = true;
+      });
+
+      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledTimes(1);
+      await Promise.resolve();
+      expect(secondSettled).toBe(false);
+
+      deferredNeutralization.resolve();
+
+      await expect(first).resolves.toBe(page);
+      await expect(second).resolves.toBe(page);
+      expect(pageEmulateMediaSpies[0]).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchSpy.mockRestore();
     }
   });
 

--- a/src/browser/pw-session.page-cdp.test.ts
+++ b/src/browser/pw-session.page-cdp.test.ts
@@ -91,4 +91,57 @@ describe("pw-session page-scoped CDP client", () => {
 
     expect(cdpHelperMocks.fetchJson).toHaveBeenCalledTimes(1);
   });
+
+  it("does not cache transient detection failures as non-relay", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-13T00:00:00Z"));
+    cdpHelperMocks.fetchJson
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce({ Browser: "OpenClaw/extension-relay" });
+
+    try {
+      await expect(isExtensionRelayCdpEndpoint("http://127.0.0.1:29992")).resolves.toBe(false);
+      await expect(isExtensionRelayCdpEndpoint("http://127.0.0.1:29992")).resolves.toBe(false);
+      expect(cdpHelperMocks.fetchJson).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(4_999);
+      await expect(isExtensionRelayCdpEndpoint("http://127.0.0.1:29992")).resolves.toBe(false);
+      expect(cdpHelperMocks.fetchJson).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(2);
+
+      await expect(isExtensionRelayCdpEndpoint("http://127.0.0.1:29992")).resolves.toBe(true);
+      expect(cdpHelperMocks.fetchJson).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("backs off repeated detection failures to avoid repeated probe stalls", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-13T00:00:00Z"));
+    cdpHelperMocks.fetchJson
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce({ Browser: "OpenClaw/extension-relay" });
+
+    try {
+      await expect(isExtensionRelayCdpEndpoint("http://127.0.0.1:39992")).resolves.toBe(false);
+      expect(cdpHelperMocks.fetchJson).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(5_001);
+      await expect(isExtensionRelayCdpEndpoint("http://127.0.0.1:39992")).resolves.toBe(false);
+      expect(cdpHelperMocks.fetchJson).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(5_001);
+      await expect(isExtensionRelayCdpEndpoint("http://127.0.0.1:39992")).resolves.toBe(false);
+      expect(cdpHelperMocks.fetchJson).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(5_000);
+      await expect(isExtensionRelayCdpEndpoint("http://127.0.0.1:39992")).resolves.toBe(true);
+      expect(cdpHelperMocks.fetchJson).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/browser/pw-session.page-cdp.ts
+++ b/src/browser/pw-session.page-cdp.ts
@@ -8,18 +8,54 @@ import {
 import { getChromeWebSocketUrl } from "./chrome.js";
 
 const OPENCLAW_EXTENSION_RELAY_BROWSER = "OpenClaw/extension-relay";
+const EXTENSION_RELAY_PROBE_FAILURE_TTL_MS = 5_000;
+const EXTENSION_RELAY_PROBE_FAILURE_MAX_TTL_MS = 30_000;
 
 type PageCdpSend = (method: string, params?: Record<string, unknown>) => Promise<unknown>;
 
-const extensionRelayByCdpUrl = new Map<string, boolean>();
+type ExtensionRelayProbeCacheEntry = {
+  isRelay: boolean;
+  expiresAt?: number;
+  failureCount?: number;
+};
+
+const extensionRelayByCdpUrl = new Map<string, ExtensionRelayProbeCacheEntry>();
 
 function normalizeCdpUrl(raw: string) {
   return raw.replace(/\/$/, "");
 }
 
+function getCachedRelayProbeResult(normalized: string): boolean | undefined {
+  const cached = extensionRelayByCdpUrl.get(normalized);
+  if (!cached) {
+    return undefined;
+  }
+  if (cached.expiresAt !== undefined && cached.expiresAt <= Date.now()) {
+    extensionRelayByCdpUrl.delete(normalized);
+    return undefined;
+  }
+  return cached.isRelay;
+}
+
+function getCachedRelayProbeFailureCount(normalized: string): number {
+  const cached = extensionRelayByCdpUrl.get(normalized);
+  if (!cached || cached.isRelay || cached.expiresAt === undefined) {
+    return 0;
+  }
+  return cached.failureCount ?? 0;
+}
+
+function getRelayProbeFailureTtlMs(failureCount: number): number {
+  return Math.min(
+    EXTENSION_RELAY_PROBE_FAILURE_TTL_MS * 2 ** Math.max(0, failureCount - 1),
+    EXTENSION_RELAY_PROBE_FAILURE_MAX_TTL_MS,
+  );
+}
+
 export async function isExtensionRelayCdpEndpoint(cdpUrl: string): Promise<boolean> {
   const normalized = normalizeCdpUrl(cdpUrl);
-  const cached = extensionRelayByCdpUrl.get(normalized);
+  const previousFailureCount = getCachedRelayProbeFailureCount(normalized);
+  const cached = getCachedRelayProbeResult(normalized);
   if (cached !== undefined) {
     return cached;
   }
@@ -31,10 +67,15 @@ export async function isExtensionRelayCdpEndpoint(cdpUrl: string): Promise<boole
       2000,
     );
     const isRelay = String(version?.Browser ?? "").trim() === OPENCLAW_EXTENSION_RELAY_BROWSER;
-    extensionRelayByCdpUrl.set(normalized, isRelay);
+    extensionRelayByCdpUrl.set(normalized, { isRelay });
     return isRelay;
   } catch {
-    extensionRelayByCdpUrl.set(normalized, false);
+    const failureCount = previousFailureCount + 1;
+    extensionRelayByCdpUrl.set(normalized, {
+      isRelay: false,
+      expiresAt: Date.now() + getRelayProbeFailureTtlMs(failureCount),
+      failureCount,
+    });
     return false;
   }
 }

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -108,6 +108,8 @@ const contextStates = new WeakMap<BrowserContext, ContextState>();
 const observedContexts = new WeakSet<BrowserContext>();
 const observedPages = new WeakSet<Page>();
 const neutralizedExtensionRelayPages = new WeakSet<Page>();
+const inFlightExtensionRelayPageNeutralizations = new WeakMap<Page, Promise<void>>();
+const extensionRelayPageNeutralizationCooldownUntil = new WeakMap<Page, number>();
 
 // Best-effort cache to make role refs stable even if Playwright returns a different Page object
 // for the same CDP target across requests.
@@ -118,6 +120,7 @@ const MAX_CONSOLE_MESSAGES = 500;
 const MAX_PAGE_ERRORS = 200;
 const MAX_NETWORK_REQUESTS = 500;
 const EXTENSION_RELAY_PAGE_NEUTRALIZE_TIMEOUT_MS = 1_000;
+const EXTENSION_RELAY_PAGE_NEUTRALIZE_RETRY_COOLDOWN_MS = 5_000;
 
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
 const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
@@ -394,19 +397,58 @@ function hasKnownExtensionRelayAuthHint(cdpUrl: string): boolean {
   return Object.keys(getChromeExtensionRelayAuthHeaders(cdpUrl)).length > 0;
 }
 
+function isExtensionRelayPageNeutralizationCoolingDown(page: Page): boolean {
+  const cooldownUntil = extensionRelayPageNeutralizationCooldownUntil.get(page);
+  if (cooldownUntil === undefined) {
+    return false;
+  }
+  if (cooldownUntil <= Date.now()) {
+    extensionRelayPageNeutralizationCooldownUntil.delete(page);
+    return false;
+  }
+  return true;
+}
+
 async function neutralizeExtensionRelayPageMedia(page: Page, timeoutMs?: number): Promise<void> {
   if (neutralizedExtensionRelayPages.has(page)) {
     return;
   }
+  if (isExtensionRelayPageNeutralizationCoolingDown(page)) {
+    return;
+  }
+  if (inFlightExtensionRelayPageNeutralizations.has(page)) {
+    return;
+  }
+  const work = Promise.resolve().then(async () => {
+    await page.emulateMedia({ colorScheme: null });
+  });
+  inFlightExtensionRelayPageNeutralizations.set(page, work);
+  void work
+    .then(() => {
+      neutralizedExtensionRelayPages.add(page);
+      extensionRelayPageNeutralizationCooldownUntil.delete(page);
+    })
+    .catch(() => {
+      // Best-effort only; timeout callers may already have moved on.
+    })
+    .finally(() => {
+      if (inFlightExtensionRelayPageNeutralizations.get(page) === work) {
+        inFlightExtensionRelayPageNeutralizations.delete(page);
+      }
+    });
   try {
-    const work = page.emulateMedia({ colorScheme: null });
     if (typeof timeoutMs === "number" && timeoutMs > 0) {
       await withTimeout(work, timeoutMs, "Extension relay neutralization timed out");
     } else {
       await work;
     }
-    neutralizedExtensionRelayPages.add(page);
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.message === "Extension relay neutralization timed out") {
+      extensionRelayPageNeutralizationCooldownUntil.set(
+        page,
+        Date.now() + EXTENSION_RELAY_PAGE_NEUTRALIZE_RETRY_COOLDOWN_MS,
+      );
+    }
     // Best-effort only. If the page is mid-navigation or the target is gone,
     // the next request can retry.
   }

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -409,6 +409,17 @@ function isExtensionRelayPageNeutralizationCoolingDown(page: Page): boolean {
   return true;
 }
 
+async function awaitExtensionRelayPageNeutralization(
+  work: Promise<void>,
+  timeoutMs?: number,
+): Promise<void> {
+  if (typeof timeoutMs === "number" && timeoutMs > 0) {
+    await withTimeout(work, timeoutMs, "Extension relay neutralization timed out");
+    return;
+  }
+  await work;
+}
+
 async function neutralizeExtensionRelayPageMedia(page: Page, timeoutMs?: number): Promise<void> {
   if (neutralizedExtensionRelayPages.has(page)) {
     return;
@@ -416,7 +427,18 @@ async function neutralizeExtensionRelayPageMedia(page: Page, timeoutMs?: number)
   if (isExtensionRelayPageNeutralizationCoolingDown(page)) {
     return;
   }
-  if (inFlightExtensionRelayPageNeutralizations.has(page)) {
+  const existing = inFlightExtensionRelayPageNeutralizations.get(page);
+  if (existing) {
+    try {
+      await awaitExtensionRelayPageNeutralization(existing, timeoutMs);
+    } catch (error) {
+      if (error instanceof Error && error.message === "Extension relay neutralization timed out") {
+        extensionRelayPageNeutralizationCooldownUntil.set(
+          page,
+          Date.now() + EXTENSION_RELAY_PAGE_NEUTRALIZE_RETRY_COOLDOWN_MS,
+        );
+      }
+    }
     return;
   }
   const work = Promise.resolve().then(async () => {
@@ -437,11 +459,7 @@ async function neutralizeExtensionRelayPageMedia(page: Page, timeoutMs?: number)
       }
     });
   try {
-    if (typeof timeoutMs === "number" && timeoutMs > 0) {
-      await withTimeout(work, timeoutMs, "Extension relay neutralization timed out");
-    } else {
-      await work;
-    }
+    await awaitExtensionRelayPageNeutralization(work, timeoutMs);
   } catch (error) {
     if (error instanceof Error && error.message === "Extension relay neutralization timed out") {
       extensionRelayPageNeutralizationCooldownUntil.set(

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -122,6 +122,7 @@ const EXTENSION_RELAY_PAGE_NEUTRALIZE_TIMEOUT_MS = 1_000;
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
 const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
 const connectGenerationByCdpUrl = new Map<string, number>();
+const activeConnectCountByCdpUrl = new Map<string, number>();
 
 function normalizeCdpUrl(raw: string) {
   return raw.replace(/\/$/, "");
@@ -139,6 +140,34 @@ function bumpConnectGeneration(normalized: string): number {
 
 function hasConnectGenerationChanged(normalized: string, generation: number): boolean {
   return getConnectGeneration(normalized) !== generation;
+}
+
+function getActiveConnectCount(normalized: string): number {
+  return activeConnectCountByCdpUrl.get(normalized) ?? 0;
+}
+
+function beginActiveConnect(normalized: string): void {
+  activeConnectCountByCdpUrl.set(normalized, getActiveConnectCount(normalized) + 1);
+}
+
+function endActiveConnect(normalized: string): void {
+  const next = getActiveConnectCount(normalized) - 1;
+  if (next > 0) {
+    activeConnectCountByCdpUrl.set(normalized, next);
+    return;
+  }
+  activeConnectCountByCdpUrl.delete(normalized);
+}
+
+function pruneConnectGenerationIfIdle(normalized: string): void {
+  if (
+    cachedByCdpUrl.has(normalized) ||
+    connectingByCdpUrl.has(normalized) ||
+    getActiveConnectCount(normalized) > 0
+  ) {
+    return;
+  }
+  connectGenerationByCdpUrl.delete(normalized);
 }
 
 async function withTimeout<T>(work: Promise<T>, ms: number, timeoutMessage: string): Promise<T> {
@@ -437,6 +466,7 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
           if (current?.browser === browser) {
             cachedByCdpUrl.delete(normalized);
           }
+          pruneConnectGenerationIfIdle(normalized);
         };
         const connected: ConnectedBrowser = { browser, cdpUrl: normalized, onDisconnected };
         browser.on("disconnected", onDisconnected);
@@ -484,8 +514,11 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
     throw new Error(message);
   };
 
+  beginActiveConnect(normalized);
   const pending = connectWithRetry().finally(() => {
     connectingByCdpUrl.delete(normalized);
+    endActiveConnect(normalized);
+    pruneConnectGenerationIfIdle(normalized);
   });
   connectingByCdpUrl.set(normalized, pending);
 
@@ -621,7 +654,11 @@ export async function getPageForTargetId(opts: {
   }
   const first = pages[0];
   if (!opts.targetId) {
-    await maybeNeutralizeExtensionRelayPages({ cdpUrl: opts.cdpUrl, pages: [first] });
+    await maybeNeutralizeExtensionRelayPages({
+      cdpUrl: opts.cdpUrl,
+      pages: [first],
+      timeoutMs: EXTENSION_RELAY_PAGE_NEUTRALIZE_TIMEOUT_MS,
+    });
     return first;
   }
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
@@ -630,12 +667,20 @@ export async function getPageForTargetId(opts: {
     // which prevents us from resolving a page's targetId via newCDPSession(). If Playwright
     // only exposes a single Page, use it as a best-effort fallback.
     if (pages.length === 1) {
-      await maybeNeutralizeExtensionRelayPages({ cdpUrl: opts.cdpUrl, pages: [first] });
+      await maybeNeutralizeExtensionRelayPages({
+        cdpUrl: opts.cdpUrl,
+        pages: [first],
+        timeoutMs: EXTENSION_RELAY_PAGE_NEUTRALIZE_TIMEOUT_MS,
+      });
       return first;
     }
     throw new BrowserTabNotFoundError();
   }
-  await maybeNeutralizeExtensionRelayPages({ cdpUrl: opts.cdpUrl, pages: [found] });
+  await maybeNeutralizeExtensionRelayPages({
+    cdpUrl: opts.cdpUrl,
+    pages: [found],
+    timeoutMs: EXTENSION_RELAY_PAGE_NEUTRALIZE_TIMEOUT_MS,
+  });
   return found;
 }
 
@@ -682,24 +727,33 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
   const normalized = opts?.cdpUrl ? normalizeCdpUrl(opts.cdpUrl) : null;
 
   if (normalized) {
-    bumpConnectGeneration(normalized);
+    const hasCached = cachedByCdpUrl.has(normalized);
+    const hasConnecting = connectingByCdpUrl.has(normalized);
+    const hasActiveSetup = getActiveConnectCount(normalized) > 0;
+    if (hasCached || hasConnecting || hasActiveSetup) {
+      bumpConnectGeneration(normalized);
+    }
     const cur = cachedByCdpUrl.get(normalized);
     cachedByCdpUrl.delete(normalized);
     connectingByCdpUrl.delete(normalized);
     if (!cur) {
+      if (!hasActiveSetup) {
+        pruneConnectGenerationIfIdle(normalized);
+      }
       return;
     }
     if (cur.onDisconnected && typeof cur.browser.off === "function") {
       cur.browser.off("disconnected", cur.onDisconnected);
     }
     await cur.browser.close().catch(() => {});
+    pruneConnectGenerationIfIdle(normalized);
     return;
   }
 
   const generationsToBump = new Set([
     ...cachedByCdpUrl.keys(),
     ...connectingByCdpUrl.keys(),
-    ...connectGenerationByCdpUrl.keys(),
+    ...activeConnectCountByCdpUrl.keys(),
   ]);
   for (const key of generationsToBump) {
     bumpConnectGeneration(key);
@@ -712,6 +766,9 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
       cur.browser.off("disconnected", cur.onDisconnected);
     }
     await cur.browser.close().catch(() => {});
+  }
+  for (const key of Array.from(connectGenerationByCdpUrl.keys())) {
+    pruneConnectGenerationIfIdle(key);
   }
 }
 

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -20,6 +20,7 @@ import {
 import { normalizeCdpWsUrl } from "./cdp.js";
 import { getChromeWebSocketUrl } from "./chrome.js";
 import { BrowserTabNotFoundError } from "./errors.js";
+import { getChromeExtensionRelayAuthHeaders } from "./extension-relay.js";
 import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationRedirectChainAllowed,
@@ -106,6 +107,7 @@ const pageStates = new WeakMap<Page, PageState>();
 const contextStates = new WeakMap<BrowserContext, ContextState>();
 const observedContexts = new WeakSet<BrowserContext>();
 const observedPages = new WeakSet<Page>();
+const neutralizedExtensionRelayPages = new WeakSet<Page>();
 
 // Best-effort cache to make role refs stable even if Playwright returns a different Page object
 // for the same CDP target across requests.
@@ -115,12 +117,42 @@ const MAX_ROLE_REFS_CACHE = 50;
 const MAX_CONSOLE_MESSAGES = 500;
 const MAX_PAGE_ERRORS = 200;
 const MAX_NETWORK_REQUESTS = 500;
+const EXTENSION_RELAY_PAGE_NEUTRALIZE_TIMEOUT_MS = 1_000;
 
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
 const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
+const connectGenerationByCdpUrl = new Map<string, number>();
 
 function normalizeCdpUrl(raw: string) {
   return raw.replace(/\/$/, "");
+}
+
+function getConnectGeneration(normalized: string): number {
+  return connectGenerationByCdpUrl.get(normalized) ?? 0;
+}
+
+function bumpConnectGeneration(normalized: string): number {
+  const next = getConnectGeneration(normalized) + 1;
+  connectGenerationByCdpUrl.set(normalized, next);
+  return next;
+}
+
+function hasConnectGenerationChanged(normalized: string, generation: number): boolean {
+  return getConnectGeneration(normalized) !== generation;
+}
+
+async function withTimeout<T>(work: Promise<T>, ms: number, timeoutMessage: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(timeoutMessage)), ms);
+  });
+  try {
+    return await Promise.race([work, timeoutPromise]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 function findNetworkRequestById(state: PageState, id: string): BrowserNetworkRequest | undefined {
@@ -329,6 +361,44 @@ function observeBrowser(browser: Browser) {
   }
 }
 
+function hasKnownExtensionRelayAuthHint(cdpUrl: string): boolean {
+  return Object.keys(getChromeExtensionRelayAuthHeaders(cdpUrl)).length > 0;
+}
+
+async function neutralizeExtensionRelayPageMedia(page: Page, timeoutMs?: number): Promise<void> {
+  if (neutralizedExtensionRelayPages.has(page)) {
+    return;
+  }
+  try {
+    const work = page.emulateMedia({ colorScheme: null });
+    if (typeof timeoutMs === "number" && timeoutMs > 0) {
+      await withTimeout(work, timeoutMs, "Extension relay neutralization timed out");
+    } else {
+      await work;
+    }
+    neutralizedExtensionRelayPages.add(page);
+  } catch {
+    // Best-effort only. If the page is mid-navigation or the target is gone,
+    // the next request can retry.
+  }
+}
+
+async function maybeNeutralizeExtensionRelayPages(params: {
+  cdpUrl: string;
+  pages: Page[];
+  timeoutMs?: number;
+}): Promise<void> {
+  const isExtensionRelay =
+    hasKnownExtensionRelayAuthHint(params.cdpUrl) ||
+    (await isExtensionRelayCdpEndpoint(params.cdpUrl).catch(() => false));
+  if (!isExtensionRelay) {
+    return;
+  }
+  await Promise.allSettled(
+    params.pages.map((page) => neutralizeExtensionRelayPageMedia(page, params.timeoutMs)),
+  );
+}
+
 async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
   const normalized = normalizeCdpUrl(cdpUrl);
   const cached = cachedByCdpUrl.get(normalized);
@@ -339,10 +409,14 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
   if (connecting) {
     return await connecting;
   }
+  const generation = getConnectGeneration(normalized);
 
   const connectWithRetry = async (): Promise<ConnectedBrowser> => {
     let lastErr: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
+      if (hasConnectGenerationChanged(normalized, generation)) {
+        throw new Error("CDP browser connection closed during setup");
+      }
       try {
         const timeout = 5000 + attempt * 2000;
         const wsUrl = await getChromeWebSocketUrl(normalized, timeout).catch(() => null);
@@ -352,19 +426,48 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
         const browser = await withNoProxyForCdpUrl(endpoint, () =>
           chromium.connectOverCDP(endpoint, { timeout, headers }),
         );
+        if (hasConnectGenerationChanged(normalized, generation)) {
+          void browser.close().catch(() => {});
+          throw new Error("CDP browser connection closed during setup");
+        }
+        let disconnectedBeforeCache = false;
         const onDisconnected = () => {
+          disconnectedBeforeCache = true;
           const current = cachedByCdpUrl.get(normalized);
           if (current?.browser === browser) {
             cachedByCdpUrl.delete(normalized);
           }
         };
         const connected: ConnectedBrowser = { browser, cdpUrl: normalized, onDisconnected };
-        cachedByCdpUrl.set(normalized, connected);
         browser.on("disconnected", onDisconnected);
         observeBrowser(browser);
+        // Keep callers on connectingByCdpUrl until initial relay neutralization finishes so
+        // they do not observe a partially initialized cached browser connection.
+        await maybeNeutralizeExtensionRelayPages({
+          cdpUrl: normalized,
+          pages: await getAllPages(browser),
+          timeoutMs: EXTENSION_RELAY_PAGE_NEUTRALIZE_TIMEOUT_MS,
+        });
+        if (disconnectedBeforeCache) {
+          if (typeof browser.off === "function") {
+            browser.off("disconnected", onDisconnected);
+          }
+          throw new Error("CDP browser disconnected during initial setup");
+        }
+        if (hasConnectGenerationChanged(normalized, generation)) {
+          if (typeof browser.off === "function") {
+            browser.off("disconnected", onDisconnected);
+          }
+          void browser.close().catch(() => {});
+          throw new Error("CDP browser connection closed during setup");
+        }
+        cachedByCdpUrl.set(normalized, connected);
         return connected;
       } catch (err) {
         lastErr = err;
+        if (hasConnectGenerationChanged(normalized, generation)) {
+          break;
+        }
         // Don't retry rate-limit errors; retrying worsens the 429.
         const errMsg = err instanceof Error ? err.message : String(err);
         if (errMsg.includes("rate limit")) {
@@ -518,6 +621,7 @@ export async function getPageForTargetId(opts: {
   }
   const first = pages[0];
   if (!opts.targetId) {
+    await maybeNeutralizeExtensionRelayPages({ cdpUrl: opts.cdpUrl, pages: [first] });
     return first;
   }
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
@@ -526,10 +630,12 @@ export async function getPageForTargetId(opts: {
     // which prevents us from resolving a page's targetId via newCDPSession(). If Playwright
     // only exposes a single Page, use it as a best-effort fallback.
     if (pages.length === 1) {
+      await maybeNeutralizeExtensionRelayPages({ cdpUrl: opts.cdpUrl, pages: [first] });
       return first;
     }
     throw new BrowserTabNotFoundError();
   }
+  await maybeNeutralizeExtensionRelayPages({ cdpUrl: opts.cdpUrl, pages: [found] });
   return found;
 }
 
@@ -576,6 +682,7 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
   const normalized = opts?.cdpUrl ? normalizeCdpUrl(opts.cdpUrl) : null;
 
   if (normalized) {
+    bumpConnectGeneration(normalized);
     const cur = cachedByCdpUrl.get(normalized);
     cachedByCdpUrl.delete(normalized);
     connectingByCdpUrl.delete(normalized);
@@ -589,6 +696,14 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
     return;
   }
 
+  const generationsToBump = new Set([
+    ...cachedByCdpUrl.keys(),
+    ...connectingByCdpUrl.keys(),
+    ...connectGenerationByCdpUrl.keys(),
+  ]);
+  for (const key of generationsToBump) {
+    bumpConnectGeneration(key);
+  }
   const connections = Array.from(cachedByCdpUrl.values());
   cachedByCdpUrl.clear();
   connectingByCdpUrl.clear();


### PR DESCRIPTION
fix[Bug]: Browser Relay extension overrides page color scheme (dark → light) #40980
 ## Summary                                                                                                                                                             
                                                                                                                                                                         
  This PR fixes the browser relay color-scheme regression for extension-relay sessions.                                                                                  
                                                                                                                                                                         
  Changes included here are intentionally limited to the browser relay fix and its direct regression coverage:                                                           
                                                                                                                                                                         
  - preserve appearance neutralization for extension-relay attached pages                                                                                                
  - ensure target-id fallback flows still reset page media/color-scheme state correctly                                                                                  
  - retry extension-relay endpoint detection after transient `/json/version` probe failures instead of caching a false negative                                          
                                                                                                                                                                         
  ## Why                                                                                                                                                                 
                                                                                                                                                                         
  Attached tabs in extension-relay sessions could retain stale color-scheme overrides, which made the appearance reset unreliable across page lookups and reconnect      
  paths.                                                                                                                                                                 
                                                                                                                                                                         
  A follow-up issue also existed in relay detection: a single transient `/json/version` failure could be cached as "not a relay", causing later calls to skip            
  neutralization for the same CDP endpoint.                                                                                                                              
                                                                                                                                                                         
  ## Scope                                                                                                                                                               
                                                                                                                                                                         
  This clean PR includes only the browser relay behavior change and the browser tests that directly verify it.                                                           
                                                                                                                                                                         
  It intentionally excludes unrelated test-only stabilization work so the review stays focused on the actual relay fix.                                                  
                                                                                                                                                                         
  ## Testing                                                                                                                                                             
                                                                                                                                                                         
  - `pnpm vitest src/browser/chrome-extension-background-appearance.test.ts src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts src/browser/pw-      
  session.page-cdp.test.ts`