### PR TITLE
fix(agent): restore command execution for legacy local onboarding profiles

### DIFF
--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -315,6 +315,54 @@ describe("Agent-specific tool filtering", () => {
     expect(toolNames).toEqual(["session_status"]);
   });
 
+  it("restores exec for legacy local onboarding messaging profiles", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-profile-"));
+    const outputPath = path.join(workspaceDir, "legacy-local-profile.txt");
+    try {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          mode: "local",
+        },
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        tools: {
+          profile: "messaging",
+        },
+      };
+
+      const tools = createOpenClawCodingTools({
+        config: cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+        agentDir: "/tmp/agent-legacy-profile",
+      });
+
+      const toolNames = tools.map((tool) => tool.name);
+      expect(toolNames).toContain("exec");
+
+      const execTool = tools.find((tool) => tool.name === "exec");
+      expect(execTool).toBeDefined();
+
+      const result = await execTool!.execute("call-legacy-local-profile", {
+        command: `printf legacy-local-profile > ${JSON.stringify(outputPath)}`,
+        timeout: 5,
+      });
+
+      const details = result?.details as { status?: string } | undefined;
+      expect(details?.status).toBe("completed");
+      expect(await fs.readFile(outputPath, "utf8")).toBe("legacy-local-profile");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("should allow different tool policies for different agents", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -218,6 +218,43 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
 });
 
 describe("resolveEffectiveToolPolicy", () => {
+  it("treats legacy local onboarding messaging profile as coding", () => {
+    const cfg = {
+      gateway: {
+        mode: "local",
+      },
+      agents: {
+        defaults: {
+          workspace: "/tmp/workspace",
+        },
+      },
+      tools: {
+        profile: "messaging",
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profile).toBe("coding");
+  });
+
+  it("keeps explicit messaging profiles when other tool policy is configured", () => {
+    const cfg = {
+      gateway: {
+        mode: "local",
+      },
+      agents: {
+        defaults: {
+          workspace: "/tmp/workspace",
+        },
+      },
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["web_search"],
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profile).toBe("messaging");
+  });
+
   it("implicitly re-exposes exec and process when tools.exec is configured", () => {
     const cfg = {
       tools: {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -2,6 +2,7 @@ import { getChannelDock } from "../channels/dock.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveChannelGroupToolsPolicy } from "../config/group-policy.js";
+import { resolveLegacyLocalOnboardingToolsProfile } from "../config/legacy-local-tools-profile.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveThreadParentSessionKey } from "../sessions/session-key-utils.js";
@@ -284,7 +285,9 @@ export function resolveEffectiveToolPolicy(params: {
   const agentTools = agentConfig?.tools;
   const globalTools = params.config?.tools;
 
-  const profile = agentTools?.profile ?? globalTools?.profile;
+  const profile =
+    agentTools?.profile ??
+    resolveLegacyLocalOnboardingToolsProfile(params.config, globalTools?.profile);
   const providerPolicy = resolveProviderToolPolicy({
     byProvider: globalTools?.byProvider,
     modelProvider: params.modelProvider,

--- a/src/config/legacy-local-tools-profile.ts
+++ b/src/config/legacy-local-tools-profile.ts
@@ -1,0 +1,47 @@
+import type { OpenClawConfig } from "./config.js";
+import type { ToolProfileId } from "./types.tools.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOnlyProfileKey(tools: unknown): boolean {
+  if (!isRecord(tools)) {
+    return false;
+  }
+  const keys = Object.keys(tools).filter((key) => !key.startsWith("__"));
+  return keys.length === 1 && keys[0] === "profile";
+}
+
+/**
+ * v2026.3.x local onboarding accidentally persisted `tools.profile="messaging"`
+ * for coding-oriented local workspace installs. Preserve intentional messaging
+ * profiles, but reinterpret the old pure-onboarding signature as `coding`.
+ */
+export function resolveLegacyLocalOnboardingToolsProfile(
+  config: Pick<OpenClawConfig, "agents" | "gateway" | "tools"> | Record<string, unknown> | null,
+  profile?: string,
+): ToolProfileId | undefined {
+  if (profile !== "messaging" || !isRecord(config)) {
+    return profile;
+  }
+
+  const gateway = config.gateway;
+  if (!isRecord(gateway) || gateway.mode !== "local") {
+    return profile;
+  }
+
+  const agents = config.agents;
+  const defaults = isRecord(agents) ? agents.defaults : undefined;
+  const workspace =
+    isRecord(defaults) && typeof defaults.workspace === "string" ? defaults.workspace.trim() : "";
+  if (!workspace) {
+    return profile;
+  }
+
+  if (!hasOnlyProfileKey(config.tools)) {
+    return profile;
+  }
+
+  return "coding";
+}

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -236,6 +236,49 @@ describe("legacy migrate heartbeat config", () => {
   });
 });
 
+describe("legacy migrate local onboarding tools.profile", () => {
+  it('rewrites legacy local tools.profile "messaging" to "coding"', () => {
+    const res = migrateLegacyConfig({
+      gateway: {
+        mode: "local",
+      },
+      agents: {
+        defaults: {
+          workspace: "/tmp/workspace",
+        },
+      },
+      tools: {
+        profile: "messaging",
+      },
+    });
+
+    expect(res.changes).toContain(
+      'Updated tools.profile "messaging" → "coding" for legacy local onboarding installs.',
+    );
+    expect(res.config?.tools?.profile).toBe("coding");
+  });
+
+  it("does not rewrite explicit messaging tool configs", () => {
+    const res = migrateLegacyConfig({
+      gateway: {
+        mode: "local",
+      },
+      agents: {
+        defaults: {
+          workspace: "/tmp/workspace",
+        },
+      },
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["web_search"],
+      },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+});
+
 describe("legacy migrate controlUi.allowedOrigins seed (issue #29385)", () => {
   it("seeds allowedOrigins for bind=lan with no existing controlUi config", () => {
     const res = migrateLegacyConfig({

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -4,6 +4,7 @@ import {
   isGatewayNonLoopbackBindMode,
   resolveGatewayPortWithDefault,
 } from "./gateway-control-ui-origins.js";
+import { resolveLegacyLocalOnboardingToolsProfile } from "./legacy-local-tools-profile.js";
 import {
   ensureAgentEntry,
   ensureRecord,
@@ -97,6 +98,25 @@ function mergeLegacyIntoDefaults(params: {
 // tools.alsoAllow legacy migration intentionally omitted (field not shipped in prod).
 
 export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
+  {
+    id: "tools.profile.messaging->coding.local-onboarding",
+    describe: "Restore coding tools.profile for legacy local onboarding installs",
+    apply: (raw, changes) => {
+      const tools = getRecord(raw.tools);
+      if (!tools || tools.profile !== "messaging") {
+        return;
+      }
+      const resolvedProfile = resolveLegacyLocalOnboardingToolsProfile(raw, tools.profile);
+      if (resolvedProfile !== "coding") {
+        return;
+      }
+      tools.profile = "coding";
+      raw.tools = tools;
+      changes.push(
+        'Updated tools.profile "messaging" → "coding" for legacy local onboarding installs.',
+      );
+    },
+  },
   {
     // v2026.2.26 added a startup guard requiring gateway.controlUi.allowedOrigins (or the
     // host-header fallback flag) for any non-loopback bind. The onboarding wizard was updated


### PR DESCRIPTION
## Summary

Fixes a regression where agents in legacy local onboarding setups could no longer run commands because persisted `tools.profile: "messaging"` disabled coding tools like `exec`.

## Root cause

Older local onboarding configs persisted `tools.profile: "messaging"`.
At runtime, `resolveEffectiveToolPolicy` treated that as an intentional messaging profile, which excluded `exec` and related coding tools from the tool catalog. As a result, the agent could describe commands but never enter the real execution path.

## What changed

- added a narrow compatibility helper for legacy local onboarding configs
- reinterpret legacy local-only `tools.profile: "messaging"` as `coding`
- added a matching legacy migration so persisted configs get repaired
- added regression tests for:
  - migration behavior
  - runtime tool policy resolution
  - real exec-path restoration

## Safety

This does **not** weaken explicit messaging-only configurations.
The compatibility logic only applies to the legacy local onboarding signature:

- `gateway.mode === "local"`
- `agents.defaults.workspace` is set
- `tools` only contains `profile: "messaging"`

## Tests

```bash
pnpm test -- src/config/legacy-migrate.test.ts src/agents/pi-tools.policy.test.ts src/agents/pi-tools-agent-config.test.ts