### PR TITLE
fix(session): preserve mid-turn messages on gateway restart

### DIFF
--- a/scripts/verify-session-init-fix.sh
+++ b/scripts/verify-session-init-fix.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Reproduces the gateway restart session data loss scenario and verifies the fix.
+# Usage: bash scripts/verify-session-init-fix.sh
+
+set -euo pipefail
+
+SESSION_DIR=$(mktemp -d)
+SESSION_FILE="$SESSION_DIR/test-session.jsonl"
+
+echo "=== Simulating gateway restart mid-turn scenario ==="
+echo "Creating session file with header + user message (no assistant yet)..."
+
+# Simulate: header + user message but no assistant (gateway restart mid-turn state)
+cat > "$SESSION_FILE" <<'EOF'
+{"type":"session","version":3,"id":"test-id","timestamp":"2026-03-13T00:00:00.000Z","cwd":"/tmp"}
+{"type":"message","id":"msg-001","parentId":null,"timestamp":"2026-03-13T00:01:00.000Z","message":{"role":"user","content":"还是不对，再试试"}}
+EOF
+
+echo "=== Before: $(wc -l < "$SESSION_FILE") lines ==="
+cat "$SESSION_FILE"
+echo ""
+
+echo "=== Running unit tests ==="
+pnpm vitest run src/agents/pi-embedded-runner/session-manager-init.test.ts
+
+echo ""
+echo "=== Verification complete ==="
+echo "If the test 'should NOT reset when user message exists but no assistant' passes,"
+echo "then the fix correctly preserves session data during gateway restarts."
+
+rm -rf "$SESSION_DIR"

--- a/scripts/verify-session-init-fix.sh
+++ b/scripts/verify-session-init-fix.sh
@@ -1,31 +1,18 @@
 #!/usr/bin/env bash
-# Reproduces the gateway restart session data loss scenario and verifies the fix.
+# Verifies the session data loss fix by running unit tests.
+# The tests cover the gateway restart mid-turn scenario where a session file
+# contains [header, user_msg] but no assistant message yet.
 # Usage: bash scripts/verify-session-init-fix.sh
 
 set -euo pipefail
 
-SESSION_DIR=$(mktemp -d)
-SESSION_FILE="$SESSION_DIR/test-session.jsonl"
-
-echo "=== Simulating gateway restart mid-turn scenario ==="
-echo "Creating session file with header + user message (no assistant yet)..."
-
-# Simulate: header + user message but no assistant (gateway restart mid-turn state)
-cat > "$SESSION_FILE" <<'EOF'
-{"type":"session","version":3,"id":"test-id","timestamp":"2026-03-13T00:00:00.000Z","cwd":"/tmp"}
-{"type":"message","id":"msg-001","parentId":null,"timestamp":"2026-03-13T00:01:00.000Z","message":{"role":"user","content":"还是不对，再试试"}}
-EOF
-
-echo "=== Before: $(wc -l < "$SESSION_FILE") lines ==="
-cat "$SESSION_FILE"
+echo "=== Running session-manager-init tests ==="
+echo "Testing scenario: gateway restart mid-turn (user message present, no assistant)"
 echo ""
 
-echo "=== Running unit tests ==="
 pnpm vitest run src/agents/pi-embedded-runner/session-manager-init.test.ts
 
 echo ""
 echo "=== Verification complete ==="
 echo "If the test 'should NOT reset when user message exists but no assistant' passes,"
 echo "then the fix correctly preserves session data during gateway restarts."
-
-rm -rf "$SESSION_DIR"

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { prepareSessionManagerForRun } from "./session-manager-init.js";
+
+describe("prepareSessionManagerForRun", () => {
+  let tmpDir: string;
+  let sessionFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp("/tmp/session-init-test-");
+    sessionFile = `${tmpDir}/test-session.jsonl`;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should update header id/cwd for new files without clearing", async () => {
+    const sm = {
+      sessionId: "old-id",
+      flushed: false,
+      fileEntries: [{ type: "session", id: "old-id", cwd: "/old" }],
+    };
+
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: false,
+      sessionId: "new-id",
+      cwd: "/new",
+    });
+
+    expect(sm.fileEntries[0]).toEqual({ type: "session", id: "new-id", cwd: "/new" });
+    expect(sm.sessionId).toBe("new-id");
+  });
+
+  it("should reset header-only files (pre-created session scenario)", async () => {
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({ type: "session", id: "test-id", cwd: "/tmp" }) + "\n",
+      "utf-8",
+    );
+
+    const sm = {
+      sessionId: "test-id",
+      flushed: true,
+      fileEntries: [{ type: "session", id: "test-id", cwd: "/tmp" }],
+      byId: new Map(),
+      labelsById: new Map(),
+      leafId: "some-leaf",
+    };
+
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "test-id",
+      cwd: "/tmp",
+    });
+
+    const content = await fs.readFile(sessionFile, "utf-8");
+    expect(content).toBe("");
+    expect(sm.fileEntries).toEqual([{ type: "session", id: "test-id", cwd: "/tmp" }]);
+    expect(sm.flushed).toBe(false);
+    expect(sm.byId.size).toBe(0);
+    expect(sm.labelsById.size).toBe(0);
+    expect(sm.leafId).toBe(null);
+
+    // Verify archive was created
+    const files = await fs.readdir(tmpDir);
+    const archiveFile = files.find((f) => f.includes(".reset."));
+    expect(archiveFile).toBeDefined();
+  });
+
+  it("should NOT reset when user message exists but no assistant (gateway restart mid-turn)", async () => {
+    // This is the critical regression test for the bug fix.
+    // Scenario: user sent a message, AI is processing, gateway restarts before assistant reply.
+    const initialContent =
+      JSON.stringify({ type: "session", id: "test-id", cwd: "/tmp" }) +
+      "\n" +
+      JSON.stringify({
+        type: "message",
+        id: "msg-001",
+        parentId: null,
+        timestamp: "2026-03-13T00:01:00.000Z",
+        message: { role: "user", content: "还是不对，再试试" },
+      }) +
+      "\n";
+
+    await fs.writeFile(sessionFile, initialContent, "utf-8");
+
+    const sm = {
+      sessionId: "test-id",
+      flushed: true,
+      fileEntries: [
+        { type: "session", id: "test-id", cwd: "/tmp" },
+        {
+          type: "message",
+          id: "msg-001",
+          message: { role: "user", content: "还是不对，再试试" },
+        },
+      ],
+      byId: new Map([["msg-001", {}]]),
+      labelsById: new Map(),
+      leafId: "msg-001",
+    };
+
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "test-id",
+      cwd: "/tmp",
+    });
+
+    // File should NOT be cleared
+    const content = await fs.readFile(sessionFile, "utf-8");
+    expect(content).toBe(initialContent);
+
+    // Session manager state should be unchanged
+    expect(sm.fileEntries.length).toBe(2);
+    expect(sm.flushed).toBe(true);
+    expect(sm.byId.size).toBe(1);
+    expect(sm.leafId).toBe("msg-001");
+
+    // No archive should be created
+    const files = await fs.readdir(tmpDir);
+    expect(files.filter((f) => f.includes(".reset."))).toHaveLength(0);
+  });
+
+  it("should NOT reset when both user and assistant messages exist", async () => {
+    const initialContent =
+      JSON.stringify({ type: "session", id: "test-id", cwd: "/tmp" }) +
+      "\n" +
+      JSON.stringify({
+        type: "message",
+        id: "msg-001",
+        message: { role: "user", content: "Hello" },
+      }) +
+      "\n" +
+      JSON.stringify({
+        type: "message",
+        id: "msg-002",
+        message: { role: "assistant", content: "Hi there!" },
+      }) +
+      "\n";
+
+    await fs.writeFile(sessionFile, initialContent, "utf-8");
+
+    const sm = {
+      sessionId: "test-id",
+      flushed: true,
+      fileEntries: [
+        { type: "session", id: "test-id", cwd: "/tmp" },
+        { type: "message", id: "msg-001", message: { role: "user", content: "Hello" } },
+        { type: "message", id: "msg-002", message: { role: "assistant", content: "Hi there!" } },
+      ],
+      byId: new Map([
+        ["msg-001", {}],
+        ["msg-002", {}],
+      ]),
+      labelsById: new Map(),
+      leafId: "msg-002",
+    };
+
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "test-id",
+      cwd: "/tmp",
+    });
+
+    // File should NOT be cleared
+    const content = await fs.readFile(sessionFile, "utf-8");
+    expect(content).toBe(initialContent);
+
+    // Session manager state should be unchanged
+    expect(sm.fileEntries.length).toBe(3);
+    expect(sm.flushed).toBe(true);
+    expect(sm.byId.size).toBe(2);
+    expect(sm.leafId).toBe("msg-002");
+
+    // No archive should be created
+    const files = await fs.readdir(tmpDir);
+    expect(files.filter((f) => f.includes(".reset."))).toHaveLength(0);
+  });
+});

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { archiveFileOnDisk } from "../../gateway/session-utils.fs.js";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
@@ -12,6 +13,10 @@ type SessionMessageEntry = { type: "message"; message?: { role?: string } };
  *
  * This normalizes the file/session state so the first user prompt is persisted before the first
  * assistant entry, even for pre-created session files.
+ *
+ * CRITICAL: We only reset header-only files (no messages at all). If there's a user message
+ * but no assistant message, that means the gateway restarted mid-turn — we must preserve
+ * the existing messages, not clear them.
  */
 export async function prepareSessionManagerForRun(params: {
   sessionManager: unknown;
@@ -30,9 +35,7 @@ export async function prepareSessionManagerForRun(params: {
   };
 
   const header = sm.fileEntries.find((e): e is SessionHeaderEntry => e.type === "session");
-  const hasAssistant = sm.fileEntries.some(
-    (e) => e.type === "message" && (e as SessionMessageEntry).message?.role === "assistant",
-  );
+  const hasAnyMessage = sm.fileEntries.some((e) => e.type === "message");
 
   if (!params.hadSessionFile && header) {
     header.id = params.sessionId;
@@ -41,8 +44,15 @@ export async function prepareSessionManagerForRun(params: {
     return;
   }
 
-  if (params.hadSessionFile && header && !hasAssistant) {
-    // Reset file so the first assistant flush includes header+user+assistant in order.
+  if (params.hadSessionFile && header && !hasAnyMessage) {
+    // Only reset header-only files (pre-created session files with no messages).
+    // If there's a user message but no assistant, that's a gateway restart mid-turn —
+    // we must preserve the existing messages, not clear them.
+    try {
+      archiveFileOnDisk(params.sessionFile, "reset");
+    } catch {
+      // best-effort backup
+    }
     await fs.writeFile(params.sessionFile, "", "utf-8");
     sm.fileEntries = [header];
     sm.byId?.clear?.();


### PR DESCRIPTION
## Problem

Session data loss occurs when the gateway restarts mid-turn (after user message but before assistant reply). The entire session file gets cleared, losing all conversation history.

**Timeline from user report (2026-03-12)**:
- 22:25:21 — User sends message "还是不对，再试试", AI starts processing
- 22:25:33 — Gateway receives restart request
- 22:25:35 — SIGUSR1 signal, process restarts
- After restart — Entire session file lost (including previously persisted history)

**Evidence**:
- Reset marker file found: `6ec0a2d5-...jsonl.reset.2026-03-13T02-17-23.309Z`
- Old session file last modified Feb 22, 3 weeks of conversations lost

## Root Cause

**File**: `src/agents/pi-embedded-runner/session-manager-init.ts:44`

The condition `!hasAssistant` was too broad, matching two different states:

| State | File Content | Original Intent | Actual Behavior |
|-------|--------------|-----------------|-----------------|
| Pre-created file | `[header]` only | ✅ Should reset | Resets |
| Gateway restart mid-turn | `[header, user_msg]` | ❌ Should NOT reset | Also resets! |

**Trigger chain**:
1. User sends message, AI thinking (file has header + user message)
2. Gateway restarts
3. `SessionManager.setSessionFile()` loads file, sets `flushed = true`
4. `prepareSessionManagerForRun` detects `!hasAssistant` → clears file
5. All history lost

## Fix

Changed `!hasAssistant` to `!hasAnyMessage` to only reset header-only files (no messages at all).

**Key changes**:
- Only reset when file is header-only (pre-created file scenario)
- If user message exists but no assistant, that's a gateway restart mid-turn — preserve messages
- Added defensive archival before clearing (best-effort backup)
- Updated comments to explain the logic

## Testing

Added comprehensive unit tests in `src/agents/pi-embedded-runner/session-manager-init.test.ts`:

1. ✅ New file scenario: only updates header id/cwd
2. ✅ Header-only file: triggers reset (original pre-created file scenario)
3. ✅ **User message but no assistant**: does NOT reset (critical regression test for the bug)
4. ✅ User + assistant messages: does NOT reset

Also added verification script: `scripts/verify-session-init-fix.sh`

## Verification

```bash
pnpm vitest run src/agents/pi-embedded-runner/session-manager-init.test.ts
pnpm build
```

All tests pass, build succeeds.