### PR TITLE
docs(web): escape dollar signs in Brave pricing text

### DIFF
--- a/docs/brave-search.md
+++ b/docs/brave-search.md
@@ -73,7 +73,7 @@ await web_search({
 ## Notes
 
 - OpenClaw uses the Brave **Search** plan. If you have a legacy subscription (e.g. the original Free plan with 2,000 queries/month), it remains valid but does not include newer features like LLM Context or higher rate limits.
-- Each Brave plan includes **$5/month in free credit** (renewing). The Search plan costs $5 per 1,000 requests, so the credit covers 1,000 queries/month. Set your usage limit in the Brave dashboard to avoid unexpected charges. See the [Brave API portal](https://brave.com/search/api/) for current plans.
+- Each Brave plan includes **\$5/month in free credit** (renewing). The Search plan costs \$5 per 1,000 requests, so the credit covers 1,000 queries/month. Set your usage limit in the Brave dashboard to avoid unexpected charges. See the [Brave API portal](https://brave.com/search/api/) for current plans.
 - The Search plan includes the LLM Context endpoint and AI inference rights. Storing results to train or tune models requires a plan with explicit storage rights. See the Brave [Terms of Service](https://api-dashboard.search.brave.com/terms-of-service).
 - Results are cached for 15 minutes by default (configurable via `cacheTtlMinutes`).
 

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -85,8 +85,8 @@ See [Memory](/concepts/memory).
 - **Kimi (Moonshot)**: `KIMI_API_KEY`, `MOONSHOT_API_KEY`, or `tools.web.search.kimi.apiKey`
 - **Perplexity Search API**: `PERPLEXITY_API_KEY`, `OPENROUTER_API_KEY`, or `tools.web.search.perplexity.apiKey`
 
-**Brave Search free credit:** Each Brave plan includes $5/month in renewing
-free credit. The Search plan costs $5 per 1,000 requests, so the credit covers
+**Brave Search free credit:** Each Brave plan includes \$5/month in renewing
+free credit. The Search plan costs \$5 per 1,000 requests, so the credit covers
 1,000 requests/month at no charge. Set your usage limit in the Brave dashboard
 to avoid unexpected charges.
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -65,8 +65,8 @@ Use `openclaw configure --section web` to set up your API key and choose a provi
 2. In the dashboard, choose the **Search** plan and generate an API key.
 3. Run `openclaw configure --section web` to store the key in config, or set `BRAVE_API_KEY` in your environment.
 
-Each Brave plan includes **$5/month in free credit** (renewing). The Search
-plan costs $5 per 1,000 requests, so the credit covers 1,000 queries/month. Set
+Each Brave plan includes **\$5/month in free credit** (renewing). The Search
+plan costs \$5 per 1,000 requests, so the credit covers 1,000 queries/month. Set
 your usage limit in the Brave dashboard to avoid unexpected charges. See the
 [Brave API portal](https://brave.com/search/api/) for current plans and
 pricing.


### PR DESCRIPTION
## Summary
Escape dollar signs in Brave pricing text to avoid MDX/math parsing glitches in docs rendering.

## Changes
- docs/reference/api-usage-costs.md
- docs/brave-search.md
- docs/tools/web.md

Replaced $5/month and $5 per 1,000 requests with escaped forms (\\$...) where needed.

## Why
This keeps the pricing text rendered as plain content and avoids formatting breakage reported in #44979.

Closes #44979
