### PR TITLE
feat(acp): support ACP bindings on any channel (plugin channels)

### DIFF
--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -139,6 +139,13 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
           accountId: "default",
           sessionKey: "agent:main:test:dm:peer",
         })) as unknown as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
+        resolveConfiguredAcpRoute: vi.fn((params: any) => ({
+          configuredBinding: null,
+          route: params.route,
+        })) as unknown as PluginRuntime["channel"]["routing"]["resolveConfiguredAcpRoute"],
+        ensureConfiguredAcpRouteReady: vi.fn().mockResolvedValue({
+          ok: true,
+        }) as unknown as PluginRuntime["channel"]["routing"]["ensureConfiguredAcpRouteReady"],
       },
       pairing: {
         buildPairingReply: vi.fn(

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -52,9 +52,11 @@ function parseConfiguredBindingSessionKey(params: {
     return null;
   }
   const tokens = rest.split(":");
-  if (tokens.length < 5 || tokens[0] !== "acp" || tokens[1] !== "binding") {
+  if (tokens.length !== 5 || tokens[0] !== "acp" || tokens[1] !== "binding") {
     return null;
   }
+  // Channel names have colons replaced with underscores in the key;
+  // the original channel name is recovered during binding resolution.
   const channel = normalizeBindingChannel(tokens[2]);
   if (!channel) {
     return null;

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -21,10 +21,10 @@ import {
 
 function normalizeBindingChannel(value: string | undefined): ConfiguredAcpBindingChannel | null {
   const normalized = (value ?? "").trim().toLowerCase();
-  if (normalized === "discord" || normalized === "telegram") {
-    return normalized;
+  if (!normalized) {
+    return null;
   }
-  return null;
+  return normalized;
 }
 
 function resolveAccountMatchPriority(match: string | undefined, actual: string): 0 | 1 | 2 {
@@ -52,7 +52,7 @@ function parseConfiguredBindingSessionKey(params: {
     return null;
   }
   const tokens = rest.split(":");
-  if (tokens.length !== 5 || tokens[0] !== "acp" || tokens[1] !== "binding") {
+  if (tokens.length < 5 || tokens[0] !== "acp" || tokens[1] !== "binding") {
     return null;
   }
   const channel = normalizeBindingChannel(tokens[2]);
@@ -164,26 +164,47 @@ export function resolveConfiguredAcpBindingSpecBySessionKey(params: {
       }
       continue;
     }
-    const parsedTopic = parseTelegramTopicConversation({
-      conversationId: targetConversationId,
-    });
-    if (!parsedTopic || !parsedTopic.chatId.startsWith("-")) {
+    if (channel === "telegram") {
+      const parsedTopic = parseTelegramTopicConversation({
+        conversationId: targetConversationId,
+      });
+      if (!parsedTopic || !parsedTopic.chatId.startsWith("-")) {
+        continue;
+      }
+      const spec = toConfiguredBindingSpec({
+        cfg: params.cfg,
+        channel: "telegram",
+        accountId: parsedSessionKey.accountId,
+        conversationId: parsedTopic.canonicalConversationId,
+        parentConversationId: parsedTopic.chatId,
+        binding,
+      });
+      if (buildConfiguredAcpSessionKey(spec) === sessionKey) {
+        if (accountMatchPriority === 2) {
+          return spec;
+        }
+        if (!wildcardMatch) {
+          wildcardMatch = spec;
+        }
+      }
       continue;
     }
-    const spec = toConfiguredBindingSpec({
-      cfg: params.cfg,
-      channel: "telegram",
-      accountId: parsedSessionKey.accountId,
-      conversationId: parsedTopic.canonicalConversationId,
-      parentConversationId: parsedTopic.chatId,
-      binding,
-    });
-    if (buildConfiguredAcpSessionKey(spec) === sessionKey) {
-      if (accountMatchPriority === 2) {
-        return spec;
-      }
-      if (!wildcardMatch) {
-        wildcardMatch = spec;
+    // Generic plugin channel: flat conversation ID matching
+    {
+      const spec = toConfiguredBindingSpec({
+        cfg: params.cfg,
+        channel,
+        accountId: parsedSessionKey.accountId,
+        conversationId: targetConversationId,
+        binding,
+      });
+      if (buildConfiguredAcpSessionKey(spec) === sessionKey) {
+        if (accountMatchPriority === 2) {
+          return spec;
+        }
+        if (!wildcardMatch) {
+          wildcardMatch = spec;
+        }
       }
     }
   }
@@ -335,6 +356,55 @@ export function resolveConfiguredAcpBindingRecord(params: {
       };
     }
     return null;
+  }
+
+  // Generic plugin channel: flat conversation ID matching (no thread inheritance,
+  // no topic parsing). This enables ACP bindings on any channel (Bridge, Matrix, etc.)
+  {
+    let wildcardMatch: AgentAcpBinding | null = null;
+    for (const binding of listAcpBindings(params.cfg)) {
+      const bindingChannel = normalizeBindingChannel(binding.match.channel);
+      if (!bindingChannel || bindingChannel !== channel) {
+        continue;
+      }
+      const accountMatchPriority = resolveAccountMatchPriority(binding.match.accountId, accountId);
+      if (accountMatchPriority === 0) {
+        continue;
+      }
+      const bindingConversationId = resolveBindingConversationId(binding);
+      if (!bindingConversationId || bindingConversationId !== conversationId) {
+        continue;
+      }
+      if (accountMatchPriority === 2) {
+        const spec = toConfiguredBindingSpec({
+          cfg: params.cfg,
+          channel,
+          accountId,
+          conversationId,
+          binding,
+        });
+        return {
+          spec,
+          record: toConfiguredAcpBindingRecord(spec),
+        };
+      }
+      if (!wildcardMatch) {
+        wildcardMatch = binding;
+      }
+    }
+    if (wildcardMatch) {
+      const spec = toConfiguredBindingSpec({
+        cfg: params.cfg,
+        channel,
+        accountId,
+        conversationId,
+        binding: wildcardMatch,
+      });
+      return {
+        spec,
+        record: toConfiguredAcpBindingRecord(spec),
+      };
+    }
   }
 
   return null;

--- a/src/acp/persistent-bindings.route.ts
+++ b/src/acp/persistent-bindings.route.ts
@@ -5,14 +5,13 @@ import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
   ensureConfiguredAcpBindingSession,
   resolveConfiguredAcpBindingRecord,
-  type ConfiguredAcpBindingChannel,
   type ResolvedConfiguredAcpBinding,
 } from "./persistent-bindings.js";
 
 export function resolveConfiguredAcpRoute(params: {
   cfg: OpenClawConfig;
   route: ResolvedAgentRoute;
-  channel: ConfiguredAcpBindingChannel;
+  channel: string;
   accountId: string;
   conversationId: string;
   parentConversationId?: string;

--- a/src/acp/persistent-bindings.types.ts
+++ b/src/acp/persistent-bindings.types.ts
@@ -70,13 +70,21 @@ function buildBindingHash(params: {
     .slice(0, 16);
 }
 
+/**
+ * Encode a channel name for use in session keys.
+ * Replaces `:` with `_` to avoid breaking the colon-delimited key format.
+ */
+function encodeChannelForKey(channel: string): string {
+  return channel.replace(/:/g, "_");
+}
+
 export function buildConfiguredAcpSessionKey(spec: ConfiguredAcpBindingSpec): string {
   const hash = buildBindingHash({
     channel: spec.channel,
     accountId: spec.accountId,
     conversationId: spec.conversationId,
   });
-  return `agent:${sanitizeAgentId(spec.agentId)}:acp:binding:${spec.channel}:${spec.accountId}:${hash}`;
+  return `agent:${sanitizeAgentId(spec.agentId)}:acp:binding:${encodeChannelForKey(spec.channel)}:${spec.accountId}:${hash}`;
 }
 
 export function toConfiguredAcpBindingRecord(spec: ConfiguredAcpBindingSpec): SessionBindingRecord {

--- a/src/acp/persistent-bindings.types.ts
+++ b/src/acp/persistent-bindings.types.ts
@@ -3,7 +3,7 @@ import type { SessionBindingRecord } from "../infra/outbound/session-binding-ser
 import { sanitizeAgentId } from "../routing/session-key.js";
 import type { AcpRuntimeSessionMode } from "./runtime/types.js";
 
-export type ConfiguredAcpBindingChannel = "discord" | "telegram";
+export type ConfiguredAcpBindingChannel = "discord" | "telegram" | (string & {});
 
 export type ConfiguredAcpBindingSpec = {
   channel: ConfiguredAcpBindingChannel;
@@ -60,7 +60,7 @@ export function normalizeBindingConfig(raw: unknown): AcpBindingConfigShape {
 }
 
 function buildBindingHash(params: {
-  channel: ConfiguredAcpBindingChannel;
+  channel: string;
   accountId: string;
   conversationId: string;
 }): string {

--- a/src/config/config.acp-binding-cutover.test.ts
+++ b/src/config/config.acp-binding-cutover.test.ts
@@ -109,7 +109,7 @@ describe("ACP binding cutover schema", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("rejects ACP bindings on unsupported channels", () => {
+  it("accepts ACP bindings on any channel (plugin channels)", () => {
     const parsed = OpenClawSchema.safeParse({
       bindings: [
         {
@@ -117,6 +117,24 @@ describe("ACP binding cutover schema", () => {
           agentId: "codex",
           match: {
             channel: "slack",
+            accountId: "default",
+            peer: { kind: "channel", id: "C123456" },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects ACP bindings with empty channel", () => {
+    const parsed = OpenClawSchema.safeParse({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "  ",
             accountId: "default",
             peer: { kind: "channel", id: "C123456" },
           },

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -71,6 +71,14 @@ const AcpBindingSchema = z
       return;
     }
     const channel = value.match.channel.trim().toLowerCase();
+    if (!channel) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["match", "channel"],
+        message: "ACP bindings require a non-empty match.channel.",
+      });
+      return;
+    }
     if (channel === "telegram" && !/^-\d+:topic:\d+$/.test(peerId)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -71,14 +71,6 @@ const AcpBindingSchema = z
       return;
     }
     const channel = value.match.channel.trim().toLowerCase();
-    if (channel !== "discord" && channel !== "telegram") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["match", "channel"],
-        message: 'ACP bindings currently support only "discord" and "telegram" channels.',
-      });
-      return;
-    }
     if (channel === "telegram" && !/^-\d+:topic:\d+$/.test(peerId)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/plugins/runtime/runtime-channel.ts
+++ b/src/plugins/runtime/runtime-channel.ts
@@ -1,3 +1,7 @@
+import {
+  resolveConfiguredAcpRoute,
+  ensureConfiguredAcpRouteReady,
+} from "../../acp/persistent-bindings.route.js";
 import { resolveEffectiveMessagesConfig, resolveHumanDelayConfig } from "../../agents/identity.js";
 import { handleSlackAction } from "../../agents/tools/slack-actions.js";
 import {
@@ -146,6 +150,8 @@ export function createRuntimeChannel(): PluginRuntime["channel"] {
     routing: {
       buildAgentSessionKey,
       resolveAgentRoute,
+      resolveConfiguredAcpRoute,
+      ensureConfiguredAcpRouteReady,
     },
     pairing: {
       buildPairingReply,

--- a/src/plugins/runtime/types-channel.ts
+++ b/src/plugins/runtime/types-channel.ts
@@ -42,6 +42,8 @@ export type PluginRuntimeChannel = {
   routing: {
     buildAgentSessionKey: typeof import("../../routing/resolve-route.js").buildAgentSessionKey;
     resolveAgentRoute: typeof import("../../routing/resolve-route.js").resolveAgentRoute;
+    resolveConfiguredAcpRoute: typeof import("../../acp/persistent-bindings.route.js").resolveConfiguredAcpRoute;
+    ensureConfiguredAcpRouteReady: typeof import("../../acp/persistent-bindings.route.js").ensureConfiguredAcpRouteReady;
   };
   pairing: {
     buildPairingReply: typeof import("../../pairing/pairing-messages.js").buildPairingReply;


### PR DESCRIPTION
## Summary

Extends ACP persistent bindings to work with **any channel**, not just Discord and Telegram. This enables plugin channels (or any custom channel integration) to use ACP bindings for auto-spawning agent sessions.

## Problem

ACP bindings were hardcoded to only support Discord and Telegram across multiple layers:
1. **Type definition** — `ConfiguredAcpBindingChannel = "discord" | "telegram"`
2. **Zod validator** — rejected any other channel string
3. **Resolution logic** — `normalizeBindingChannel()` returned null for anything else
4. **Plugin SDK** — `resolveConfiguredAcpRoute` and `ensureConfiguredAcpRouteReady` were not exposed to plugin channels
5. **No generic resolution path** — only Discord thread inheritance and Telegram topic parsing existed

This prevented anyone building a channel plugin from using ACP bindings.

## Solution

Added a generic resolution path for plugin channels alongside the existing Discord and Telegram specific paths:

- **Widened `ConfiguredAcpBindingChannel`** to accept any string (preserving Discord/Telegram as named literals)
- **Relaxed zod validator** — removed channel restriction, added non-empty validation
- **Added generic fallback** in `resolveConfiguredAcpBindingRecord()` and `resolveConfiguredAcpBindingSpecBySessionKey()` — flat conversation ID matching (channel + accountId + conversationId)
- **Exposed `resolveConfiguredAcpRoute` and `ensureConfiguredAcpRouteReady`** to the plugin SDK via `PluginRuntimeChannel.routing`
- **Handled colons in channel names** — encoded in session key construction to avoid parser issues
- **Updated tests** — existing test now validates any-channel support; added empty-channel rejection test; added plugin runtime mock implementations

The generic path is intentionally simpler than Discord/Telegram: plugin channels have flat conversation models (no thread inheritance, no topic parsing).

## Example Config

```json
{
  "bindings": [
    {
      "type": "acp",
      "agentId": "my-agent",
      "match": { "channel": "my-plugin", "peer": { "kind": "group", "id": "agent-tasks" } },
      "acp": { "mode": "persistent", "backend": "acpx" }
    }
  ]
}
```

When a message arrives on the `agent-tasks` channel via the plugin, it auto-spawns an ACP session for that agent.

## Plugin Usage

Plugin channel adapters can now resolve and initialize ACP bindings:

```ts
const { resolveConfiguredAcpRoute, ensureConfiguredAcpRouteReady } = runtime.channel.routing;

// Resolve binding
const acpResult = resolveConfiguredAcpRoute({ cfg, route, channel, accountId, conversationId });

// Initialize session if binding matched
if (acpResult.configuredBinding) {
  await ensureConfiguredAcpRouteReady({ cfg, configuredBinding: acpResult.configuredBinding });
}
```

## Files Changed (8 files, +141 -29)

| File | Change |
|------|--------|
| `src/acp/persistent-bindings.types.ts` | Widened channel type, added colon encoding for session keys |
| `src/config/zod-schema.agents.ts` | Removed channel restriction, added non-empty check |
| `src/acp/persistent-bindings.resolve.ts` | Added generic resolution fallback for both resolve functions |
| `src/acp/persistent-bindings.route.ts` | Accept any channel string |
| `src/plugins/runtime/types-channel.ts` | Exposed ACP routing functions in plugin SDK types |
| `src/plugins/runtime/runtime-channel.ts` | Wired up the exports |
| `src/config/config.acp-binding-cutover.test.ts` | Updated + added tests |
| `extensions/test-utils/plugin-runtime-mock.ts` | Added mock implementations |

## Testing

- ✅ TypeScript compiles cleanly
- ✅ Existing Discord/Telegram paths unchanged
- ✅ Generic path only activates for non-discord/telegram channels
- ✅ End-to-end verified with a real plugin channel (message → ACP binding match → session spawn → agent response)
- ✅ Empty channel names rejected at config validation

Resolves #41988