### PR TITLE
fix(gateway): always resolve device token for fallback auth during SPA navigation

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -354,11 +354,17 @@ describe("GatewayClient connect auth payload", () => {
     );
   }
 
-  it("uses explicit shared token and does not inject stored device token", () => {
+  it("sends stored device token alongside explicit shared token for fallback auth", () => {
     loadDeviceAuthTokenMock.mockReturnValue({ token: "stored-device-token" });
+    const identity: DeviceIdentity = {
+      deviceId: "dev-fallback-1",
+      privateKeyPem: "private-key", // pragma: allowlist secret
+      publicKeyPem: "public-key",
+    };
     const client = new GatewayClient({
       url: "ws://127.0.0.1:18789",
       token: "shared-token",
+      deviceIdentity: identity,
     });
 
     client.start();
@@ -368,16 +374,22 @@ describe("GatewayClient connect auth payload", () => {
 
     expect(connectFrameFrom(ws)).toMatchObject({
       token: "shared-token",
+      deviceToken: "stored-device-token",
     });
-    expect(connectFrameFrom(ws).deviceToken).toBeUndefined();
     client.stop();
   });
 
-  it("uses explicit shared password and does not inject stored device token", () => {
+  it("sends stored device token alongside explicit shared password for fallback auth", () => {
     loadDeviceAuthTokenMock.mockReturnValue({ token: "stored-device-token" });
+    const identity: DeviceIdentity = {
+      deviceId: "dev-fallback-2",
+      privateKeyPem: "private-key", // pragma: allowlist secret
+      publicKeyPem: "public-key",
+    };
     const client = new GatewayClient({
       url: "ws://127.0.0.1:18789",
       password: "shared-password", // pragma: allowlist secret
+      deviceIdentity: identity,
     });
 
     client.start();
@@ -387,9 +399,11 @@ describe("GatewayClient connect auth payload", () => {
 
     expect(connectFrameFrom(ws)).toMatchObject({
       password: "shared-password", // pragma: allowlist secret
+      deviceToken: "stored-device-token",
     });
-    expect(connectFrameFrom(ws).token).toBeUndefined();
-    expect(connectFrameFrom(ws).deviceToken).toBeUndefined();
+    // When password is the primary credential, auth.token falls back to
+    // the resolved device token for legacy compatibility.
+    expect(connectFrameFrom(ws).token).toBe("stored-device-token");
     client.stop();
   });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -508,10 +508,17 @@ export class GatewayClient {
       Boolean(explicitGatewayToken) &&
       Boolean(storedToken) &&
       this.isTrustedDeviceRetryEndpoint();
+    // Always resolve the device token independently of shared credentials.
+    // The gateway server supports deviceToken fallback when the shared
+    // token/password is absent or invalid (see server auth matrix test
+    // "uses explicit auth.deviceToken fallback when shared token is wrong").
+    // Suppressing the stored token when a shared credential was present
+    // caused Control-UI reconnects to fail with "device identity required"
+    // after SPA navigation dropped the shared token from the URL hash
+    // (#39611, #39667, #44485).
     const resolvedDeviceToken =
       explicitDeviceToken ??
-      (shouldUseDeviceRetryToken ||
-      (!(explicitGatewayToken || authPassword) && (!explicitBootstrapToken || Boolean(storedToken)))
+      (shouldUseDeviceRetryToken || !explicitBootstrapToken || Boolean(storedToken)
         ? (storedToken ?? undefined)
         : undefined);
     // Legacy compatibility: keep `auth.token` populated for device-token auth when

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -146,7 +146,7 @@ describe("GatewayBrowserClient", () => {
     vi.unstubAllGlobals();
   });
 
-  it("prefers explicit shared auth over cached device tokens", async () => {
+  it("sends stored device token alongside explicit shared auth for fallback", async () => {
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",
       token: "shared-auth-token",
@@ -165,13 +165,18 @@ describe("GatewayBrowserClient", () => {
     const connectFrame = JSON.parse(ws.sent.at(-1) ?? "{}") as {
       id?: string;
       method?: string;
-      params?: { auth?: { token?: string } };
+      params?: { auth?: { token?: string; deviceToken?: string } };
     };
     expect(typeof connectFrame.id).toBe("string");
     expect(connectFrame.method).toBe("connect");
+    // Shared token takes priority for auth.token; device token is sent
+    // alongside for gateway-side fallback (#39611, #39667, #44485).
     expect(connectFrame.params?.auth?.token).toBe("shared-auth-token");
+    expect(connectFrame.params?.auth?.deviceToken).toBe("stored-device-token");
     expect(signDevicePayloadMock).toHaveBeenCalledWith("private-key", expect.any(String));
     const signedPayload = signDevicePayloadMock.mock.calls[0]?.[1];
+    // The signed payload still uses the shared token (authToken), not the
+    // stored device token, because explicitGatewayToken takes precedence.
     expect(signedPayload).toContain("|shared-auth-token|nonce-1");
     expect(signedPayload).not.toContain("stored-device-token");
   });

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -261,7 +261,7 @@ export class GatewayBrowserClient {
     const authToken = selectedAuth.authToken;
     const deviceToken = selectedAuth.authDeviceToken ?? selectedAuth.resolvedDeviceToken;
     const auth =
-      authToken || selectedAuth.authPassword
+      authToken || selectedAuth.authPassword || deviceToken
         ? {
             token: authToken,
             deviceToken,
@@ -447,9 +447,13 @@ export class GatewayBrowserClient {
       Boolean(explicitGatewayToken) &&
       Boolean(storedToken) &&
       isTrustedRetryEndpoint(this.opts.url);
-    const resolvedDeviceToken = !(explicitGatewayToken || authPassword)
-      ? (storedToken ?? undefined)
-      : undefined;
+    // Always resolve the device token independently of shared credentials.
+    // The gateway server supports deviceToken fallback when the shared
+    // token/password is absent or invalid.  Suppressing the stored token
+    // caused reconnects to fail with "device identity required" after SPA
+    // navigation dropped the shared token from the URL hash (#39611,
+    // #39667, #44485).
+    const resolvedDeviceToken = storedToken ?? undefined;
     const authToken = explicitGatewayToken ?? resolvedDeviceToken;
     return {
       authToken,


### PR DESCRIPTION
## Summary

The gateway connect-auth logic suppresses the stored device token whenever an explicit shared token or password is present. This means the `auth.deviceToken` field in the WebSocket connect frame is empty when the user connects via a dashboard token URL.

After SPA navigation or a page refresh strips the shared token from the URL hash, the next reconnect attempt has **neither** a shared token **nor** a device token, causing the gateway to reject with `device identity required` (close code 1008).

This PR fixes the root cause by resolving the stored device token **independently** of shared credentials, so `auth.deviceToken` is always populated when a device identity exists. The gateway server already supports `deviceToken` fallback when the shared token is absent or invalid (see the server auth matrix test *"uses explicit auth.deviceToken fallback when shared token is wrong"*).

## What changed

### Production code (2 files)

| File | Change |
|------|--------|
| `src/gateway/client.ts` | Remove the `!(explicitGatewayToken \|\| authPassword)` guard from `resolvedDeviceToken` computation so the stored token is always resolved |
| `ui/src/ui/gateway.ts` | Same fix for the browser client; also include `deviceToken` in the `auth` object construction guard so the payload is built even when only a device token is available |

### Test code (2 files)

| File | Change |
|------|--------|
| `src/gateway/client.test.ts` | Update two tests to verify `deviceToken` is sent alongside shared token/password; add `deviceIdentity` to test fixtures (fixes the missing config gap flagged during review of #39639) |
| `ui/src/ui/gateway.node.test.ts` | Update browser-client test to verify `deviceToken` is sent alongside explicit shared auth |

## Root cause analysis

The issue was first reported in #39611 and traced to three interacting bugs by @NetZlash:

1. **Bug 1** — `resolvedDeviceToken` guard in `selectConnectAuth()` discards the stored device token when any shared credential is present
2. **Bug 2** — The browser client's `auth` object omits `deviceToken` when only a device token (no shared token/password) is available
3. **Bug 3** — SPA navigation drops the URL hash token on same-tab reload

PR #40892 addressed Bug 3 via `sessionStorage` persistence, but Bugs 1 and 2 remain unfixed on `main`. This is confirmed by:

- Users still reporting "device identity required" on v2026.3.12 (#39611 comments from @YIwanT, @ricardopera)
- #39667 (device signature invalid) remaining **open**
- #44485 (`dangerouslyDisableDeviceAuth` ignored in v2026.3.11) opened today
- #44967 (LAN token-only access rejected on v2026.3.12) opened today

This PR fixes Bugs 1 and 2 at the gateway layer, complementing the UI-layer fix in #40892.

## How to test

1. Start gateway with token auth: `openclaw dashboard --no-open`
2. Open the token URL in browser — Control UI connects
3. Navigate to Sessions → click a session → **should stay connected** (previously disconnected with 1008)
4. Refresh the page → **should reconnect** using the device token fallback
5. Open a new tab with the base URL (no token hash) → should still connect if device was previously paired

## Related issues

- Fixes #39667
- Refs #39611, #44485, #44967
- Supersedes #39639 (my earlier PR, closed as superseded by #40892 — this PR is scoped to the remaining gateway-layer bugs)