### PR TITLE
fix(model): avoid ANTHROPIC_MODEL_ALIASES TDZ on Rollup bundle init

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -31,12 +31,17 @@ export type ModelAliasIndex = {
   byKey: Map<string, string[]>;
 };
 
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
-};
+// Defined as a function to avoid Rollup TDZ (temporal dead zone) errors when
+// this module is accessed before its own top-level bindings are initialized
+// due to chunk ordering (#44977, #45027).
+function getAnthropicModelAliases(): Record<string, string> {
+  return {
+    "opus-4.6": "claude-opus-4-6",
+    "opus-4.5": "claude-opus-4-5",
+    "sonnet-4.6": "claude-sonnet-4-6",
+    "sonnet-4.5": "claude-sonnet-4-5",
+  };
+}
 
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
@@ -151,7 +156,7 @@ function normalizeAnthropicModelId(model: string): string {
     return trimmed;
   }
   const lower = trimmed.toLowerCase();
-  return ANTHROPIC_MODEL_ALIASES[lower] ?? trimmed;
+  return getAnthropicModelAliases()[lower] ?? trimmed;
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {


### PR DESCRIPTION
Fixes a Temporal Dead Zone (TDZ) error that occurs when Rollup bundle chunk ordering causes `model-selection.ts` to be accessed before its top-level `const ANTHROPIC_MODEL_ALIASES` binding is initialized.

## Root cause

`ANTHROPIC_MODEL_ALIASES` was declared as a module-level `const`. When the Rollup bundler places the chunk that imports `model-selection.ts` before the chunk that evaluates it, the const binding is in the TDZ at first access, throwing a ReferenceError.

## Fix

Convert `ANTHROPIC_MODEL_ALIASES` to a function `getAnthropicModelAliases()` that returns the object inline. Functions are hoisted and do not suffer from TDZ, so this resolves the initialization ordering issue regardless of chunk order.

## Testing

- Existing model-selection tests pass (1 pre-existing failure unrelated to this change: `sanitizes control characters in providerless-model warnings` fails on `main` as well)
- Build passes cleanly with `pnpm build`
- Lint passes with `pnpm check`