### PR TITLE
fix(ui): keep shared auth on insecure control-ui connects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ Docs: https://docs.openclaw.ai
 - Signal/config validation: add `channels.signal.groups` schema support so per-group `requireMention`, `tools`, and `toolsBySender` overrides no longer get rejected during config validation. (#27199) Thanks @unisone.
 - Config/discovery: accept `discovery.wideArea.domain` in strict config validation so unicast DNS-SD gateway configs no longer fail with an unrecognized-key error. (#35615) Thanks @ingyukoh.
 - Security/exec approvals: unwrap more `pnpm` runtime forms during approval binding, including `pnpm --reporter ... exec` and direct `pnpm node` file runs, with matching regression coverage and docs updates.
-
 - Security/exec approvals: fail closed for Perl `-M` and `-I` approval flows so preload and load-path module resolution stays outside approval-backed runtime execution unless the operator uses a broader explicit trust path.
+- Control UI/insecure auth: preserve explicit shared token and password auth on plain-HTTP Control UI connects so LAN and reverse-proxy sessions no longer drop shared auth before the first WebSocket handshake. (#45088) Thanks @velvet-shark.
 
 ## 2026.3.12
 

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -113,6 +113,12 @@ function getLatestWebSocket(): MockWebSocket {
   return ws;
 }
 
+function stubInsecureCrypto() {
+  vi.stubGlobal("crypto", {
+    randomUUID: () => "req-insecure",
+  });
+}
+
 describe("GatewayBrowserClient", () => {
   beforeEach(() => {
     const storage = createStorageMock();
@@ -174,6 +180,72 @@ describe("GatewayBrowserClient", () => {
     const signedPayload = signDevicePayloadMock.mock.calls[0]?.[1];
     expect(signedPayload).toContain("|shared-auth-token|nonce-1");
     expect(signedPayload).not.toContain("stored-device-token");
+  });
+
+  it("sends explicit shared token on insecure first connect without cached device fallback", async () => {
+    stubInsecureCrypto();
+    const client = new GatewayBrowserClient({
+      url: "ws://gateway.example:18789",
+      token: "shared-auth-token",
+    });
+
+    client.start();
+    const ws = getLatestWebSocket();
+    ws.emitOpen();
+    ws.emitMessage({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "nonce-1" },
+    });
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    const connectFrame = JSON.parse(ws.sent.at(-1) ?? "{}") as {
+      id?: string;
+      method?: string;
+      params?: { auth?: { token?: string; password?: string; deviceToken?: string } };
+    };
+    expect(connectFrame.id).toBe("req-insecure");
+    expect(connectFrame.method).toBe("connect");
+    expect(connectFrame.params?.auth).toEqual({
+      token: "shared-auth-token",
+      password: undefined,
+      deviceToken: undefined,
+    });
+    expect(loadOrCreateDeviceIdentityMock).not.toHaveBeenCalled();
+    expect(signDevicePayloadMock).not.toHaveBeenCalled();
+  });
+
+  it("sends explicit shared password on insecure first connect without cached device fallback", async () => {
+    stubInsecureCrypto();
+    const client = new GatewayBrowserClient({
+      url: "ws://gateway.example:18789",
+      password: "shared-password", // pragma: allowlist secret
+    });
+
+    client.start();
+    const ws = getLatestWebSocket();
+    ws.emitOpen();
+    ws.emitMessage({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "nonce-1" },
+    });
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    const connectFrame = JSON.parse(ws.sent.at(-1) ?? "{}") as {
+      id?: string;
+      method?: string;
+      params?: { auth?: { token?: string; password?: string; deviceToken?: string } };
+    };
+    expect(connectFrame.id).toBe("req-insecure");
+    expect(connectFrame.method).toBe("connect");
+    expect(connectFrame.params?.auth).toEqual({
+      token: undefined,
+      password: "shared-password", // pragma: allowlist secret
+      deviceToken: undefined,
+    });
+    expect(loadOrCreateDeviceIdentityMock).not.toHaveBeenCalled();
+    expect(signDevicePayloadMock).not.toHaveBeenCalled();
   });
 
   it("uses cached device tokens only when no explicit shared auth is provided", async () => {

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -244,8 +244,14 @@ export class GatewayBrowserClient {
 
     const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
     const role = "operator";
+    const explicitGatewayToken = this.opts.token?.trim() || undefined;
+    const explicitPassword = this.opts.password?.trim() || undefined;
     let deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null = null;
-    let selectedAuth: SelectedConnectAuth = { canFallbackToShared: false };
+    let selectedAuth: SelectedConnectAuth = {
+      authToken: explicitGatewayToken,
+      authPassword: explicitPassword,
+      canFallbackToShared: false,
+    };
 
     if (isSecureContext) {
       deviceIdentity = await loadOrCreateDeviceIdentity();
@@ -257,7 +263,6 @@ export class GatewayBrowserClient {
         this.pendingDeviceTokenRetry = false;
       }
     }
-    const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const authToken = selectedAuth.authToken;
     const deviceToken = selectedAuth.authDeviceToken ?? selectedAuth.resolvedDeviceToken;
     const auth =


### PR DESCRIPTION
## Summary

- Problem: plain-HTTP Control UI sessions behind LAN and reverse-proxy setups were dropping explicit shared token/password auth before the first WebSocket `connect` frame, so the gateway rejected them with `device identity required`.
- Why it matters: this broke the intended `allowInsecureAuth` + `dangerouslyDisableDeviceAuth` token flow for self-hosted HTTP deployments even though same-tab refresh/navigation had already been fixed separately.
- What changed: initialize Control UI connect auth from the explicit shared token/password before the secure-context device-auth branch, and add regression tests for insecure token/password connects.
- What did NOT change (scope boundary): cached device-token fallback is still limited to the existing trusted retry path, and this PR does not change the `#40892` sessionStorage same-tab behavior or add any cross-tab token sharing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44485
- Closes #44967
- Related #39611
- Related #40892
- Related #45070

## User-visible / Behavior Changes

- Control UI now preserves explicit shared token auth on insecure `http://` first-connect flows instead of dropping auth before the first WebSocket handshake.
- Control UI now preserves explicit shared password auth on the same insecure first-connect path.
- Cached device tokens are still not sent on the insecure first connect.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

This restores the explicit token/password that the operator already supplied to the existing first-connect frame on insecure Control UI sessions. It does not broaden cached device-token fallback, does not add storage, and keeps the trusted retry boundary unchanged.

## Repro + Verification

### Environment

- OS: macOS 15.7.4 (arm64)
- Runtime/container: Control UI Vitest projects + local runtime repro script
- Model/provider: N/A
- Integration/channel (if any): Control UI
- Relevant config (redacted): `gateway.auth.mode: "token"`, `gateway.controlUi.allowInsecureAuth: true`, `gateway.controlUi.dangerouslyDisableDeviceAuth: true`

### Steps

1. Open the Control UI over plain HTTP with an explicit shared token or password configured.
2. Let the browser receive the WebSocket `connect.challenge` event.
3. Inspect the first `connect` request payload.

### Expected

- The first `connect` frame includes the explicit shared token or password.
- No cached device token is sent on that insecure first connect.

### Actual

- Before this fix, insecure contexts built the first `connect` frame from an empty auth selection state, so `params.auth` was omitted entirely.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - insecure `http://` connect with explicit shared token now sends `auth.token`
  - insecure `http://` connect with explicit shared password now sends `auth.password`
  - existing trusted one-shot device-token retry tests still pass unchanged
  - existing same-tab navigation/refresh browser tests from `#40892` still pass
- Edge cases checked:
  - insecure first-connect still omits cached `deviceToken`
  - secure-context explicit shared auth still signs with the shared token rather than the cached device token
- What you did **not** verify:
  - a manual live repro against a remote VPS/reverse-proxy deployment

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `60abd798cffa99a9f03ac9936c47e8dc3f87deca`
- Files/config to restore: `ui/src/ui/gateway.ts` and `ui/src/ui/gateway.node.test.ts`
- Known bad symptoms reviewers should watch for: insecure HTTP Control UI connects still fail with `device identity required`, or cached device tokens start appearing on the first insecure connect

## Risks and Mitigations

- Risk: restoring explicit shared auth on insecure contexts could accidentally reintroduce cached device-token fallback on the same path.
  - Mitigation: the new tests assert token/password presence while also asserting `deviceToken` stays absent.
