### PR TITLE
docs: redirect /zh-CN root to localized index

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -56,6 +56,14 @@
       "destination": "/concepts/context"
     },
     {
+      "source": "/zh-CN",
+      "destination": "/zh-CN/index"
+    },
+    {
+      "source": "/zh-CN/",
+      "destination": "/zh-CN/index"
+    },
+    {
       "source": "/compaction",
       "destination": "/concepts/compaction"
     },


### PR DESCRIPTION
## Summary
Add explicit redirects so `/zh-CN` and `/zh-CN/` resolve to the Chinese docs index page.

## Why
Accessing the locale root path should consistently land on the docs index. Without explicit redirects, `/zh-CN` can fail to resolve in some routes/deploy contexts.

## Changes
Updated `docs/docs.json` redirects:
- `/zh-CN` → `/zh-CN/index`
- `/zh-CN/` → `/zh-CN/index`

## How to test
1. Build/serve docs locally.
2. Visit:
   - `/zh-CN`
   - `/zh-CN/`
3. Confirm both routes load the Chinese index page (`/zh-CN/index`).

Closes #43598
