### PR TITLE
[AI-assisted] Matrix: harden user-id DM routing for heartbeats

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -181,6 +181,8 @@ Notes:
 
 - Replies always go back to Matrix.
 - DMs share the agent's main session; rooms map to group sessions.
+- Outbound Matrix targets can use a room ID, room alias, or full Matrix user ID. For DM-style sends such as heartbeats, keep `to` as `@user:server` unless you explicitly need a room override.
+- When a Matrix target is a user ID, OpenClaw ranks the joined DM candidates for that account using `m.direct`, SDK DM state, membership flags, and unnamed 2-member fallback rooms, then refreshes `m.direct` after a successful send.
 
 ## Access control (DMs)
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -297,7 +297,7 @@ When validation fails:
     ```
 
     - `every`: duration string (`30m`, `2h`). Set `0m` to disable.
-    - `target`: `last` | `whatsapp` | `telegram` | `discord` | `none`
+    - `target`: `last` | `whatsapp` | `telegram` | `discord` | `matrix` | `none`
     - `directPolicy`: `allow` (default) or `block` for DM-style heartbeat targets
     - See [Heartbeat](/gateway/heartbeat) for the full guide.
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -218,12 +218,12 @@ Use `accountId` to target a specific account on multi-account channels like Tele
   - Session key formats: see [Sessions](/concepts/session) and [Groups](/channels/groups).
 - `target`:
   - `last`: deliver to the last used external channel.
-  - explicit channel: `whatsapp` / `telegram` / `discord` / `googlechat` / `slack` / `msteams` / `signal` / `imessage`.
+  - explicit channel: `whatsapp` / `telegram` / `discord` / `googlechat` / `matrix` / `msteams` / `signal` / `slack` / `imessage`.
   - `none` (default): run the heartbeat but **do not deliver** externally.
 - `directPolicy`: controls direct/DM delivery behavior:
   - `allow` (default): allow direct/DM heartbeat delivery.
   - `block`: suppress direct/DM delivery (`reason=dm-blocked`).
-- `to`: optional recipient override (channel-specific id, e.g. E.164 for WhatsApp or a Telegram chat id). For Telegram topics/threads, use `<chatId>:topic:<messageThreadId>`.
+- `to`: optional recipient override (channel-specific id, e.g. E.164 for WhatsApp, a Telegram chat id, or a full Matrix user ID like `@owner:example.org`). For Telegram topics/threads, use `<chatId>:topic:<messageThreadId>`.
 - `accountId`: optional account id for multi-account channels. When `target: "last"`, the account id applies to the resolved last channel if it supports accounts; otherwise it is ignored. If the account id does not match a configured account for the resolved channel, delivery is skipped.
 - `prompt`: overrides the default prompt body (not merged).
 - `ackMaxChars`: max chars allowed after `HEARTBEAT_OK` before delivery.
@@ -243,6 +243,7 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 - `session` only affects the run context; delivery is controlled by `target` and `to`.
 - To deliver to a specific channel/recipient, set `target` + `to`. With
   `target: "last"`, delivery uses the last external channel for that session.
+- For Matrix DM heartbeats, set `target: "matrix"` and keep `to` as the full Matrix user ID. OpenClaw resolves the best joined DM for that account and updates `m.direct` after successful sends, so you usually do not need the raw `!roomId:server`.
 - Heartbeat deliveries allow direct/DM targets by default. Set `directPolicy: "block"` to suppress direct-target sends while still running the heartbeat turn.
 - If the main queue is busy, the heartbeat is skipped and retried later.
 - If `target` resolves to no external destination, the run still happens but no

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -2,6 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { setMatrixRuntime } from "../runtime.js";
 
+const resolveMatrixClientMock = vi.hoisted(() => vi.fn());
+const matrixLogWarnMock = vi.hoisted(() => vi.fn());
 vi.mock("music-metadata", () => ({
   // `resolveMediaDurationMs` lazily imports `music-metadata`; in tests we don't
   // need real duration parsing and the real module is expensive to load.
@@ -18,6 +20,11 @@ vi.mock("@vector-im/matrix-bot-sdk", () => ({
   },
   LogService: {
     setLogger: vi.fn(),
+    warn: matrixLogWarnMock,
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
   },
   MatrixClient: vi.fn(),
   SimpleFsStorageProvider: vi.fn(),
@@ -27,6 +34,15 @@ vi.mock("@vector-im/matrix-bot-sdk", () => ({
 vi.mock("./send-queue.js", () => ({
   enqueueSend: async <T>(_roomId: string, fn: () => Promise<T>) => await fn(),
 }));
+
+vi.mock("./send/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./send/client.js")>();
+  return {
+    ...actual,
+    resolveMatrixClient: (...args: Parameters<typeof actual.resolveMatrixClient>) =>
+      resolveMatrixClientMock(...args),
+  };
+});
 
 const loadWebMediaMock = vi.fn().mockResolvedValue({
   buffer: Buffer.from("media"),
@@ -79,6 +95,57 @@ const makeClient = () => {
   return { client, sendMessage, uploadContent };
 };
 
+const makeMatrixSendError = (message: string, statusCode: number, errcode: string) => {
+  const err = new Error(message) as Error & {
+    statusCode?: number;
+    errcode?: string;
+  };
+  err.statusCode = statusCode;
+  err.errcode = errcode;
+  return err;
+};
+
+const makeUserTargetClient = (opts?: {
+  directContent?: Record<string, string[] | undefined>;
+  joinedRooms?: string[];
+  membersByRoom?: Record<string, string[]>;
+  roomStateEvents?: Record<string, Record<string, unknown>>;
+  sendMessage?: ReturnType<typeof vi.fn>;
+}) => {
+  const sendMessage = opts?.sendMessage ?? vi.fn().mockResolvedValue("evt1");
+  const client = {
+    sendMessage,
+    uploadContent: vi.fn().mockResolvedValue("mxc://example/file"),
+    getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    getAccountData: vi.fn().mockResolvedValue(opts?.directContent ?? {}),
+    getJoinedRooms: vi.fn().mockResolvedValue(opts?.joinedRooms ?? []),
+    getJoinedRoomMembers: vi
+      .fn()
+      .mockImplementation(async (roomId: string) => opts?.membersByRoom?.[roomId] ?? []),
+    getRoomStateEvent: vi
+      .fn()
+      .mockImplementation(async (roomId: string, eventType: string, stateKey: string) => {
+        const key = `${roomId}|${eventType}|${stateKey}`;
+        const event = opts?.roomStateEvents?.[key];
+        if (event === undefined) {
+          const err = new Error(`missing state ${key}`) as Error & {
+            errcode?: string;
+            statusCode?: number;
+          };
+          err.errcode = "M_NOT_FOUND";
+          err.statusCode = 404;
+          throw err;
+        }
+        return event;
+      }),
+    dms: {
+      update: vi.fn().mockResolvedValue(undefined),
+      isDm: vi.fn().mockImplementation(() => false),
+    },
+  } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+  return { client, sendMessage };
+};
+
 beforeAll(async () => {
   setMatrixRuntime(runtimeStub);
   ({ sendMessageMatrix } = await import("./send.js"));
@@ -88,6 +155,13 @@ beforeAll(async () => {
 describe("sendMessageMatrix media", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    matrixLogWarnMock.mockReset();
+    resolveMatrixClientMock.mockImplementation(async (opts) => {
+      if (!opts.client) {
+        throw new Error("test expected a Matrix client");
+      }
+      return { client: opts.client, stopOnDone: false };
+    });
     runtimeLoadConfigMock.mockReset();
     runtimeLoadConfigMock.mockReturnValue({});
     mediaKindFromMimeMock.mockReturnValue("image");
@@ -213,6 +287,127 @@ describe("sendMessageMatrix media", () => {
     expect(mediaContent.msgtype).toBe("m.audio");
     expect(mediaContent.body).toBe("voice caption");
     expect(mediaContent["org.matrix.msc3245.voice"]).toBeUndefined();
+  });
+
+  it("re-resolves Matrix user targets once after a stale cached room send fails", async () => {
+    const userId = "@user:example.org";
+    const staleRoom = "!stale:example.org";
+    const activeRoom = "!active:example.org";
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(makeMatrixSendError("stale room send failed", 404, "M_NOT_FOUND"))
+      .mockResolvedValueOnce("evt2");
+    const { client } = makeUserTargetClient({
+      directContent: {
+        [userId]: [staleRoom],
+      },
+      joinedRooms: [staleRoom],
+      membersByRoom: {
+        [staleRoom]: ["@bot:example.org", userId],
+        [activeRoom]: ["@bot:example.org", userId],
+      },
+      roomStateEvents: {
+        [`${staleRoom}|m.room.member|${userId}`]: {},
+        [`${staleRoom}|m.room.member|@bot:example.org`]: {},
+        [`${staleRoom}|m.room.name|`]: { name: "Old named room" },
+        [`${activeRoom}|m.room.member|${userId}`]: { is_direct: true },
+        [`${activeRoom}|m.room.member|@bot:example.org`]: {},
+      },
+      sendMessage,
+    });
+
+    const { resolveMatrixRoomId } = await import("./send/targets.js");
+    await resolveMatrixRoomId(client, userId);
+    vi.mocked(client.getAccountData).mockResolvedValue({
+      [userId]: [staleRoom, activeRoom],
+    });
+    vi.mocked(client.getJoinedRooms).mockResolvedValue([staleRoom, activeRoom]);
+
+    const result = await sendMessageMatrix(userId, "hello", { client });
+
+    expect(result.roomId).toBe(activeRoom);
+    expect(sendMessage.mock.calls[0]?.[0]).toBe(staleRoom);
+    expect(sendMessage.mock.calls[1]?.[0]).toBe(activeRoom);
+    expect(matrixLogWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("does not retry generic Matrix user-target send failures", async () => {
+    const userId = "@user:example.org";
+    const activeRoom = "!active:example.org";
+    const sendMessage = vi.fn().mockRejectedValueOnce(new Error("network down"));
+    const { client } = makeUserTargetClient({
+      directContent: {
+        [userId]: [activeRoom],
+      },
+      joinedRooms: [activeRoom],
+      membersByRoom: {
+        [activeRoom]: ["@bot:example.org", userId],
+      },
+      roomStateEvents: {
+        [`${activeRoom}|m.room.member|${userId}`]: { is_direct: true },
+        [`${activeRoom}|m.room.member|@bot:example.org`]: {},
+      },
+      sendMessage,
+    });
+
+    await expect(sendMessageMatrix(userId, "hello", { client })).rejects.toThrow("network down");
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[0]).toBe(activeRoom);
+    expect(matrixLogWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("logs and clears cache again when self-heal still fails, then re-resolves on the next invocation", async () => {
+    const userId = "@user:example.org";
+    const staleRoom = "!stale:example.org";
+    const failingFreshRoom = "!failing:example.org";
+    const recoveredRoom = "!recovered:example.org";
+    const directContent: Record<string, string[] | undefined> = {
+      [userId]: [staleRoom, failingFreshRoom],
+    };
+    const joinedRooms = [staleRoom, failingFreshRoom];
+    const membersByRoom: Record<string, string[]> = {
+      [staleRoom]: ["@bot:example.org", userId],
+      [failingFreshRoom]: ["@bot:example.org", userId],
+      [recoveredRoom]: ["@bot:example.org", userId],
+    };
+    const roomStateEvents: Record<string, Record<string, unknown>> = {
+      [`${staleRoom}|m.room.member|${userId}`]: {},
+      [`${staleRoom}|m.room.member|@bot:example.org`]: {},
+      [`${staleRoom}|m.room.name|`]: { name: "Old named room" },
+      [`${failingFreshRoom}|m.room.member|${userId}`]: { is_direct: true },
+      [`${failingFreshRoom}|m.room.member|@bot:example.org`]: {},
+      [`${recoveredRoom}|m.room.member|${userId}`]: { is_direct: true },
+      [`${recoveredRoom}|m.room.member|@bot:example.org`]: {},
+    };
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(makeMatrixSendError("stale room send failed", 404, "M_NOT_FOUND"))
+      .mockRejectedValueOnce(makeMatrixSendError("fresh room send failed", 404, "M_NOT_FOUND"))
+      .mockResolvedValueOnce("evt4");
+    const { client } = makeUserTargetClient({
+      directContent,
+      joinedRooms: [staleRoom],
+      membersByRoom,
+      roomStateEvents,
+      sendMessage,
+    });
+
+    const { resolveMatrixRoomId } = await import("./send/targets.js");
+    await resolveMatrixRoomId(client, userId);
+    vi.mocked(client.getJoinedRooms).mockResolvedValue(joinedRooms);
+
+    await expect(sendMessageMatrix(userId, "hello", { client })).rejects.toThrow(
+      "fresh room send failed",
+    );
+
+    directContent[userId] = [staleRoom, recoveredRoom];
+    joinedRooms.splice(0, joinedRooms.length, staleRoom, recoveredRoom);
+
+    const recovered = await sendMessageMatrix(userId, "hello", { client });
+
+    expect(recovered.roomId).toBe(recoveredRoom);
+    expect(sendMessage.mock.calls[2]?.[0]).toBe(recoveredRoom);
   });
 });
 

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -448,6 +448,55 @@ describe("sendMessageMatrix media", () => {
     expect(sendMessage.mock.calls[2]?.[0]).toBe(recoveredRoom);
   });
 
+  it("keeps the refreshed DM cache when a retry already sent content before failing", async () => {
+    const userId = "@user:example.org";
+    const staleRoom = "!stale:example.org";
+    const refreshedRoom = "!fresh:example.org";
+    const directContent: Record<string, string[] | undefined> = {
+      [userId]: [staleRoom, refreshedRoom],
+    };
+    const joinedRooms = [staleRoom, refreshedRoom];
+    const membersByRoom: Record<string, string[]> = {
+      [staleRoom]: ["@bot:example.org", userId],
+      [refreshedRoom]: ["@bot:example.org", userId],
+    };
+    const roomStateEvents: Record<string, Record<string, unknown>> = {
+      [`${staleRoom}|m.room.member|${userId}`]: {},
+      [`${staleRoom}|m.room.member|@bot:example.org`]: {},
+      [`${staleRoom}|m.room.name|`]: { name: "Old named room" },
+      [`${refreshedRoom}|m.room.member|${userId}`]: { is_direct: true },
+      [`${refreshedRoom}|m.room.member|@bot:example.org`]: {},
+    };
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(makeMatrixSendError("stale room send failed", 404, "M_NOT_FOUND"))
+      .mockResolvedValueOnce("evt1")
+      .mockRejectedValueOnce(new Error("later chunk failed"))
+      .mockResolvedValueOnce("evt2");
+    const { client } = makeUserTargetClient({
+      directContent,
+      joinedRooms,
+      membersByRoom,
+      roomStateEvents,
+      sendMessage,
+    });
+
+    runtimeStub.channel.text.chunkMarkdownTextWithMode = () => ["hello", "again"];
+
+    await expect(sendMessageMatrix(userId, "hello again", { client })).rejects.toThrow(
+      "later chunk failed",
+    );
+
+    directContent[userId] = [staleRoom];
+    joinedRooms.splice(0, joinedRooms.length, staleRoom);
+    runtimeStub.channel.text.chunkMarkdownTextWithMode = (text: string) => (text ? [text] : []);
+
+    const retried = await sendMessageMatrix(userId, "hello", { client });
+
+    expect(retried.roomId).toBe(refreshedRoom);
+    expect(sendMessage.mock.calls[3]?.[0]).toBe(refreshedRoom);
+  });
+
   afterEach(() => {
     runtimeStub.channel.text.chunkMarkdownTextWithMode = (text: string) => (text ? [text] : []);
   });

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -111,11 +111,13 @@ const makeUserTargetClient = (opts?: {
   membersByRoom?: Record<string, string[]>;
   roomStateEvents?: Record<string, Record<string, unknown>>;
   sendMessage?: ReturnType<typeof vi.fn>;
+  uploadContent?: ReturnType<typeof vi.fn>;
 }) => {
   const sendMessage = opts?.sendMessage ?? vi.fn().mockResolvedValue("evt1");
+  const uploadContent = opts?.uploadContent ?? vi.fn().mockResolvedValue("mxc://example/file");
   const client = {
     sendMessage,
-    uploadContent: vi.fn().mockResolvedValue("mxc://example/file"),
+    uploadContent,
     getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
     getAccountData: vi.fn().mockResolvedValue(opts?.directContent ?? {}),
     getJoinedRooms: vi.fn().mockResolvedValue(opts?.joinedRooms ?? []),
@@ -143,7 +145,7 @@ const makeUserTargetClient = (opts?: {
       isDm: vi.fn().mockImplementation(() => false),
     },
   } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
-  return { client, sendMessage };
+  return { client, sendMessage, uploadContent };
 };
 
 beforeAll(async () => {
@@ -354,6 +356,40 @@ describe("sendMessageMatrix media", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage.mock.calls[0]?.[0]).toBe(activeRoom);
+    expect(matrixLogWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("does not self-heal retry pre-send media upload failures", async () => {
+    const userId = "@user:example.org";
+    const staleRoom = "!stale:example.org";
+    const freshRoom = "!fresh:example.org";
+    const uploadContent = vi
+      .fn()
+      .mockRejectedValueOnce(makeMatrixSendError("upload failed", 404, "M_NOT_FOUND"));
+    const { client, sendMessage } = makeUserTargetClient({
+      directContent: {
+        [userId]: [staleRoom, freshRoom],
+      },
+      joinedRooms: [staleRoom, freshRoom],
+      membersByRoom: {
+        [staleRoom]: ["@bot:example.org", userId],
+        [freshRoom]: ["@bot:example.org", userId],
+      },
+      roomStateEvents: {
+        [`${staleRoom}|m.room.member|${userId}`]: { is_direct: true },
+        [`${staleRoom}|m.room.member|@bot:example.org`]: {},
+        [`${freshRoom}|m.room.member|${userId}`]: { is_direct: true },
+        [`${freshRoom}|m.room.member|@bot:example.org`]: {},
+      },
+      uploadContent,
+    });
+
+    await expect(
+      sendMessageMatrix(userId, "caption", { client, mediaUrl: "file:///tmp/photo.png" }),
+    ).rejects.toThrow("upload failed");
+
+    expect(uploadContent).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
     expect(matrixLogWarnMock).not.toHaveBeenCalled();
   });
 

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -1,5 +1,5 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { setMatrixRuntime } from "../runtime.js";
 
 const resolveMatrixClientMock = vi.hoisted(() => vi.fn());
@@ -357,6 +357,44 @@ describe("sendMessageMatrix media", () => {
     expect(matrixLogWarnMock).not.toHaveBeenCalled();
   });
 
+  it("does not replay already-sent chunks when a later Matrix user-target send fails", async () => {
+    const userId = "@user:example.org";
+    const staleRoom = "!stale:example.org";
+    const activeRoom = "!active:example.org";
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce("evt1")
+      .mockRejectedValueOnce(makeMatrixSendError("second chunk failed", 404, "M_NOT_FOUND"));
+    const { client } = makeUserTargetClient({
+      directContent: {
+        [userId]: [staleRoom],
+      },
+      joinedRooms: [staleRoom],
+      membersByRoom: {
+        [staleRoom]: ["@bot:example.org", userId],
+        [activeRoom]: ["@bot:example.org", userId],
+      },
+      roomStateEvents: {
+        [`${staleRoom}|m.room.member|${userId}`]: { is_direct: true },
+        [`${staleRoom}|m.room.member|@bot:example.org`]: {},
+        [`${activeRoom}|m.room.member|${userId}`]: { is_direct: true },
+        [`${activeRoom}|m.room.member|@bot:example.org`]: {},
+      },
+      sendMessage,
+    });
+
+    runtimeStub.channel.text.chunkMarkdownTextWithMode = () => ["hello", "again"];
+
+    await expect(sendMessageMatrix(userId, "hello again", { client })).rejects.toThrow(
+      "second chunk failed",
+    );
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage.mock.calls[0]?.[0]).toBe(staleRoom);
+    expect(sendMessage.mock.calls[1]?.[0]).toBe(staleRoom);
+    expect(matrixLogWarnMock).not.toHaveBeenCalled();
+  });
+
   it("logs and clears cache again when self-heal still fails, then re-resolves on the next invocation", async () => {
     const userId = "@user:example.org";
     const staleRoom = "!stale:example.org";
@@ -408,6 +446,10 @@ describe("sendMessageMatrix media", () => {
 
     expect(recovered.roomId).toBe(recoveredRoom);
     expect(sendMessage.mock.calls[2]?.[0]).toBe(recoveredRoom);
+  });
+
+  afterEach(() => {
+    runtimeStub.channel.text.chunkMarkdownTextWithMode = (text: string) => (text ? [text] : []);
   });
 });
 

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -140,7 +140,9 @@ async function withResolvedRoomRetry<T>(params: {
     } catch (retryErr) {
       const retryAttemptError = asResolvedRoomAttemptError(retryErr);
       const resolvedRetryError = retryAttemptError?.cause ?? retryErr;
-      clearDirectRoomCacheForTarget(client, to);
+      if (retryAttemptError?.sentAnyContent !== true) {
+        clearDirectRoomCacheForTarget(client, to);
+      }
       const LogService = getMatrixLogService();
       LogService.warn(
         "MatrixSend",

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -2,6 +2,7 @@ import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import type { PollInput } from "openclaw/plugin-sdk/matrix";
 import { getMatrixRuntime } from "../runtime.js";
 import { buildPollStartContent, M_POLL_START } from "./poll-types.js";
+import { getMatrixLogService } from "./sdk-runtime.js";
 import { enqueueSend } from "./send-queue.js";
 import { resolveMatrixClient, resolveMediaMaxBytes } from "./send/client.js";
 import {
@@ -17,7 +18,12 @@ import {
   resolveMediaDurationMs,
   uploadMediaMaybeEncrypted,
 } from "./send/media.js";
-import { normalizeThreadId, resolveMatrixRoomId } from "./send/targets.js";
+import {
+  clearDirectRoomCacheForTarget,
+  isMatrixUserTarget,
+  normalizeThreadId,
+  resolveMatrixRoomId,
+} from "./send/targets.js";
 import {
   EventType,
   MsgType,
@@ -30,6 +36,77 @@ import {
 
 const MATRIX_TEXT_LIMIT = 4000;
 const getCore = () => getMatrixRuntime();
+
+function getMatrixErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const candidate = err as {
+    errcode?: unknown;
+    body?: {
+      errcode?: unknown;
+    };
+  };
+  if (typeof candidate.errcode === "string") {
+    return candidate.errcode;
+  }
+  return typeof candidate.body?.errcode === "string" ? candidate.body.errcode : undefined;
+}
+
+function getMatrixStatusCode(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const candidate = err as {
+    statusCode?: unknown;
+  };
+  return typeof candidate.statusCode === "number" ? candidate.statusCode : undefined;
+}
+
+function isRetryableDirectRoomSendError(err: unknown): boolean {
+  const statusCode = getMatrixStatusCode(err);
+  if (statusCode === 403 || statusCode === 404) {
+    return true;
+  }
+  const errcode = getMatrixErrorCode(err);
+  return errcode === "M_FORBIDDEN" || errcode === "M_NOT_FOUND";
+}
+
+async function withResolvedRoomRetry<T>(params: {
+  client: MatrixClient;
+  to: string;
+  action: (roomId: string) => Promise<T>;
+}): Promise<T> {
+  const { client, to, action } = params;
+  const roomId = await resolveMatrixRoomId(client, to);
+  try {
+    return await action(roomId);
+  } catch (err) {
+    if (!isMatrixUserTarget(to) || !isRetryableDirectRoomSendError(err)) {
+      throw err;
+    }
+
+    clearDirectRoomCacheForTarget(client, to);
+
+    try {
+      const refreshedRoomId = await resolveMatrixRoomId(client, to);
+      return await action(refreshedRoomId);
+    } catch (retryErr) {
+      clearDirectRoomCacheForTarget(client, to);
+      const LogService = getMatrixLogService();
+      LogService.warn(
+        "MatrixSend",
+        "Direct-room self-heal failed after send error; waiting for next external invocation",
+        {
+          target: to,
+          firstError: String(err),
+          retryError: String(retryErr),
+        },
+      );
+      throw retryErr;
+    }
+  }
+}
 
 export type { MatrixSendOpts, MatrixSendResult } from "./send/types.js";
 export { resolveMatrixRoomId } from "./send/targets.js";
@@ -51,104 +128,107 @@ export async function sendMessageMatrix(
   });
   const cfg = opts.cfg ?? getCore().config.loadConfig();
   try {
-    const roomId = await resolveMatrixRoomId(client, to);
-    return await enqueueSend(roomId, async () => {
-      const tableMode = getCore().channel.text.resolveMarkdownTableMode({
-        cfg,
-        channel: "matrix",
-        accountId: opts.accountId,
-      });
-      const convertedMessage = getCore().channel.text.convertMarkdownTables(
-        trimmedMessage,
-        tableMode,
-      );
-      const textLimit = getCore().channel.text.resolveTextChunkLimit(cfg, "matrix");
-      const chunkLimit = Math.min(textLimit, MATRIX_TEXT_LIMIT);
-      const chunkMode = getCore().channel.text.resolveChunkMode(cfg, "matrix", opts.accountId);
-      const chunks = getCore().channel.text.chunkMarkdownTextWithMode(
-        convertedMessage,
-        chunkLimit,
-        chunkMode,
-      );
-      const threadId = normalizeThreadId(opts.threadId);
-      const relation = threadId
-        ? buildThreadRelation(threadId, opts.replyToId)
-        : buildReplyRelation(opts.replyToId);
-      const sendContent = async (content: MatrixOutboundContent) => {
-        // @vector-im/matrix-bot-sdk uses sendMessage differently
-        const eventId = await client.sendMessage(roomId, content);
-        return eventId;
-      };
+    return await withResolvedRoomRetry({
+      client,
+      to,
+      action: async (roomId) =>
+        await enqueueSend(roomId, async () => {
+          const tableMode = getCore().channel.text.resolveMarkdownTableMode({
+            cfg,
+            channel: "matrix",
+            accountId: opts.accountId,
+          });
+          const convertedMessage = getCore().channel.text.convertMarkdownTables(
+            trimmedMessage,
+            tableMode,
+          );
+          const textLimit = getCore().channel.text.resolveTextChunkLimit(cfg, "matrix");
+          const chunkLimit = Math.min(textLimit, MATRIX_TEXT_LIMIT);
+          const chunkMode = getCore().channel.text.resolveChunkMode(cfg, "matrix", opts.accountId);
+          const chunks = getCore().channel.text.chunkMarkdownTextWithMode(
+            convertedMessage,
+            chunkLimit,
+            chunkMode,
+          );
+          const threadId = normalizeThreadId(opts.threadId);
+          const relation = threadId
+            ? buildThreadRelation(threadId, opts.replyToId)
+            : buildReplyRelation(opts.replyToId);
+          const sendContent = async (content: MatrixOutboundContent) => {
+            const eventId = await client.sendMessage(roomId, content);
+            return eventId;
+          };
 
-      let lastMessageId = "";
-      if (opts.mediaUrl) {
-        const maxBytes = resolveMediaMaxBytes(opts.accountId, cfg);
-        const media = await getCore().media.loadWebMedia(opts.mediaUrl, maxBytes);
-        const uploaded = await uploadMediaMaybeEncrypted(client, roomId, media.buffer, {
-          contentType: media.contentType,
-          filename: media.fileName,
-        });
-        const durationMs = await resolveMediaDurationMs({
-          buffer: media.buffer,
-          contentType: media.contentType,
-          fileName: media.fileName,
-          kind: media.kind ?? "unknown",
-        });
-        const baseMsgType = resolveMatrixMsgType(media.contentType, media.fileName);
-        const { useVoice } = resolveMatrixVoiceDecision({
-          wantsVoice: opts.audioAsVoice === true,
-          contentType: media.contentType,
-          fileName: media.fileName,
-        });
-        const msgtype = useVoice ? MsgType.Audio : baseMsgType;
-        const isImage = msgtype === MsgType.Image;
-        const imageInfo = isImage
-          ? await prepareImageInfo({ buffer: media.buffer, client })
-          : undefined;
-        const [firstChunk, ...rest] = chunks;
-        const body = useVoice ? "Voice message" : (firstChunk ?? media.fileName ?? "(file)");
-        const content = buildMediaContent({
-          msgtype,
-          body,
-          url: uploaded.url,
-          file: uploaded.file,
-          filename: media.fileName,
-          mimetype: media.contentType,
-          size: media.buffer.byteLength,
-          durationMs,
-          relation,
-          isVoice: useVoice,
-          imageInfo,
-        });
-        const eventId = await sendContent(content);
-        lastMessageId = eventId ?? lastMessageId;
-        const textChunks = useVoice ? chunks : rest;
-        const followupRelation = threadId ? relation : undefined;
-        for (const chunk of textChunks) {
-          const text = chunk.trim();
-          if (!text) {
-            continue;
+          let lastMessageId = "";
+          if (opts.mediaUrl) {
+            const maxBytes = resolveMediaMaxBytes(opts.accountId, cfg);
+            const media = await getCore().media.loadWebMedia(opts.mediaUrl, maxBytes);
+            const uploaded = await uploadMediaMaybeEncrypted(client, roomId, media.buffer, {
+              contentType: media.contentType,
+              filename: media.fileName,
+            });
+            const durationMs = await resolveMediaDurationMs({
+              buffer: media.buffer,
+              contentType: media.contentType,
+              fileName: media.fileName,
+              kind: media.kind ?? "unknown",
+            });
+            const baseMsgType = resolveMatrixMsgType(media.contentType, media.fileName);
+            const { useVoice } = resolveMatrixVoiceDecision({
+              wantsVoice: opts.audioAsVoice === true,
+              contentType: media.contentType,
+              fileName: media.fileName,
+            });
+            const msgtype = useVoice ? MsgType.Audio : baseMsgType;
+            const isImage = msgtype === MsgType.Image;
+            const imageInfo = isImage
+              ? await prepareImageInfo({ buffer: media.buffer, client })
+              : undefined;
+            const [firstChunk, ...rest] = chunks;
+            const body = useVoice ? "Voice message" : (firstChunk ?? media.fileName ?? "(file)");
+            const content = buildMediaContent({
+              msgtype,
+              body,
+              url: uploaded.url,
+              file: uploaded.file,
+              filename: media.fileName,
+              mimetype: media.contentType,
+              size: media.buffer.byteLength,
+              durationMs,
+              relation,
+              isVoice: useVoice,
+              imageInfo,
+            });
+            const eventId = await sendContent(content);
+            lastMessageId = eventId ?? lastMessageId;
+            const textChunks = useVoice ? chunks : rest;
+            const followupRelation = threadId ? relation : undefined;
+            for (const chunk of textChunks) {
+              const text = chunk.trim();
+              if (!text) {
+                continue;
+              }
+              const followup = buildTextContent(text, followupRelation);
+              const followupEventId = await sendContent(followup);
+              lastMessageId = followupEventId ?? lastMessageId;
+            }
+          } else {
+            for (const chunk of chunks.length ? chunks : [""]) {
+              const text = chunk.trim();
+              if (!text) {
+                continue;
+              }
+              const content = buildTextContent(text, relation);
+              const eventId = await sendContent(content);
+              lastMessageId = eventId ?? lastMessageId;
+            }
           }
-          const followup = buildTextContent(text, followupRelation);
-          const followupEventId = await sendContent(followup);
-          lastMessageId = followupEventId ?? lastMessageId;
-        }
-      } else {
-        for (const chunk of chunks.length ? chunks : [""]) {
-          const text = chunk.trim();
-          if (!text) {
-            continue;
-          }
-          const content = buildTextContent(text, relation);
-          const eventId = await sendContent(content);
-          lastMessageId = eventId ?? lastMessageId;
-        }
-      }
 
-      return {
-        messageId: lastMessageId || "unknown",
-        roomId,
-      };
+          return {
+            messageId: lastMessageId || "unknown",
+            roomId,
+          };
+        }),
     });
   } finally {
     if (stopOnDone) {
@@ -176,19 +256,23 @@ export async function sendPollMatrix(
   });
 
   try {
-    const roomId = await resolveMatrixRoomId(client, to);
-    const pollContent = buildPollStartContent(poll);
-    const threadId = normalizeThreadId(opts.threadId);
-    const pollPayload = threadId
-      ? { ...pollContent, "m.relates_to": buildThreadRelation(threadId) }
-      : pollContent;
-    // @vector-im/matrix-bot-sdk sendEvent returns eventId string directly
-    const eventId = await client.sendEvent(roomId, M_POLL_START, pollPayload);
+    return await withResolvedRoomRetry({
+      client,
+      to,
+      action: async (roomId) => {
+        const pollContent = buildPollStartContent(poll);
+        const threadId = normalizeThreadId(opts.threadId);
+        const pollPayload = threadId
+          ? { ...pollContent, "m.relates_to": buildThreadRelation(threadId) }
+          : pollContent;
+        const eventId = await client.sendEvent(roomId, M_POLL_START, pollPayload);
 
-    return {
-      eventId: eventId ?? "unknown",
-      roomId,
-    };
+        return {
+          eventId: eventId ?? "unknown",
+          roomId,
+        };
+      },
+    });
   } finally {
     if (stopOnDone) {
       client.stop();

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -75,6 +75,7 @@ function isRetryableDirectRoomSendError(err: unknown): boolean {
 type ResolvedRoomAttemptError = {
   cause: unknown;
   sentAnyContent: boolean;
+  attemptedSend: boolean;
 };
 
 function asResolvedRoomAttemptError(err: unknown): ResolvedRoomAttemptError | null {
@@ -84,36 +85,53 @@ function asResolvedRoomAttemptError(err: unknown): ResolvedRoomAttemptError | nu
   const candidate = err as {
     cause?: unknown;
     sentAnyContent?: unknown;
+    attemptedSend?: unknown;
   };
-  if (typeof candidate.sentAnyContent !== "boolean") {
+  if (
+    typeof candidate.sentAnyContent !== "boolean" ||
+    typeof candidate.attemptedSend !== "boolean"
+  ) {
     return null;
   }
   return {
     cause: candidate.cause,
     sentAnyContent: candidate.sentAnyContent,
+    attemptedSend: candidate.attemptedSend,
   };
 }
 
 async function withResolvedRoomRetry<T>(params: {
   client: MatrixClient;
   to: string;
-  action: (roomId: string, markContentSent: () => void) => Promise<T>;
+  action: (
+    roomId: string,
+    markContentSent: () => void,
+    markRetryableSendAttempt: () => void,
+  ) => Promise<T>;
 }): Promise<T> {
   const { client, to, action } = params;
   const runAction = async (roomId: string): Promise<T> => {
     let sentAnyContent = false;
+    let attemptedSend = false;
     try {
       return await enqueueSend(
         roomId,
         async () =>
-          await action(roomId, () => {
-            sentAnyContent = true;
-          }),
+          await action(
+            roomId,
+            () => {
+              sentAnyContent = true;
+            },
+            () => {
+              attemptedSend = true;
+            },
+          ),
       );
     } catch (err) {
       throw {
         cause: err,
         sentAnyContent,
+        attemptedSend,
       } satisfies ResolvedRoomAttemptError;
     }
   };
@@ -126,6 +144,7 @@ async function withResolvedRoomRetry<T>(params: {
     const firstError = attemptError?.cause ?? err;
     if (
       !isMatrixUserTarget(to) ||
+      attemptError?.attemptedSend !== true ||
       attemptError?.sentAnyContent === true ||
       !isRetryableDirectRoomSendError(firstError)
     ) {
@@ -181,7 +200,7 @@ export async function sendMessageMatrix(
     return await withResolvedRoomRetry({
       client,
       to,
-      action: async (roomId, markContentSent) => {
+      action: async (roomId, markContentSent, markRetryableSendAttempt) => {
         const tableMode = getCore().channel.text.resolveMarkdownTableMode({
           cfg,
           channel: "matrix",
@@ -204,6 +223,7 @@ export async function sendMessageMatrix(
           ? buildThreadRelation(threadId, opts.replyToId)
           : buildReplyRelation(opts.replyToId);
         const sendContent = async (content: MatrixOutboundContent) => {
+          markRetryableSendAttempt();
           const eventId = await client.sendMessage(roomId, content);
           markContentSent();
           return eventId;
@@ -309,12 +329,13 @@ export async function sendPollMatrix(
     return await withResolvedRoomRetry({
       client,
       to,
-      action: async (roomId, markContentSent) => {
+      action: async (roomId, markContentSent, markRetryableSendAttempt) => {
         const pollContent = buildPollStartContent(poll);
         const threadId = normalizeThreadId(opts.threadId);
         const pollPayload = threadId
           ? { ...pollContent, "m.relates_to": buildThreadRelation(threadId) }
           : pollContent;
+        markRetryableSendAttempt();
         const eventId = await client.sendEvent(roomId, M_POLL_START, pollPayload);
         markContentSent();
 

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -72,26 +72,74 @@ function isRetryableDirectRoomSendError(err: unknown): boolean {
   return errcode === "M_FORBIDDEN" || errcode === "M_NOT_FOUND";
 }
 
+type ResolvedRoomAttemptError = {
+  cause: unknown;
+  sentAnyContent: boolean;
+};
+
+function asResolvedRoomAttemptError(err: unknown): ResolvedRoomAttemptError | null {
+  if (!err || typeof err !== "object") {
+    return null;
+  }
+  const candidate = err as {
+    cause?: unknown;
+    sentAnyContent?: unknown;
+  };
+  if (typeof candidate.sentAnyContent !== "boolean") {
+    return null;
+  }
+  return {
+    cause: candidate.cause,
+    sentAnyContent: candidate.sentAnyContent,
+  };
+}
+
 async function withResolvedRoomRetry<T>(params: {
   client: MatrixClient;
   to: string;
-  action: (roomId: string) => Promise<T>;
+  action: (roomId: string, markContentSent: () => void) => Promise<T>;
 }): Promise<T> {
   const { client, to, action } = params;
+  const runAction = async (roomId: string): Promise<T> => {
+    let sentAnyContent = false;
+    try {
+      return await enqueueSend(
+        roomId,
+        async () =>
+          await action(roomId, () => {
+            sentAnyContent = true;
+          }),
+      );
+    } catch (err) {
+      throw {
+        cause: err,
+        sentAnyContent,
+      } satisfies ResolvedRoomAttemptError;
+    }
+  };
+
   const roomId = await resolveMatrixRoomId(client, to);
   try {
-    return await action(roomId);
+    return await runAction(roomId);
   } catch (err) {
-    if (!isMatrixUserTarget(to) || !isRetryableDirectRoomSendError(err)) {
-      throw err;
+    const attemptError = asResolvedRoomAttemptError(err);
+    const firstError = attemptError?.cause ?? err;
+    if (
+      !isMatrixUserTarget(to) ||
+      attemptError?.sentAnyContent === true ||
+      !isRetryableDirectRoomSendError(firstError)
+    ) {
+      throw firstError;
     }
 
     clearDirectRoomCacheForTarget(client, to);
 
     try {
       const refreshedRoomId = await resolveMatrixRoomId(client, to);
-      return await action(refreshedRoomId);
+      return await runAction(refreshedRoomId);
     } catch (retryErr) {
+      const retryAttemptError = asResolvedRoomAttemptError(retryErr);
+      const resolvedRetryError = retryAttemptError?.cause ?? retryErr;
       clearDirectRoomCacheForTarget(client, to);
       const LogService = getMatrixLogService();
       LogService.warn(
@@ -99,11 +147,11 @@ async function withResolvedRoomRetry<T>(params: {
         "Direct-room self-heal failed after send error; waiting for next external invocation",
         {
           target: to,
-          firstError: String(err),
-          retryError: String(retryErr),
+          firstError: String(firstError),
+          retryError: String(resolvedRetryError),
         },
       );
-      throw retryErr;
+      throw resolvedRetryError;
     }
   }
 }
@@ -131,104 +179,104 @@ export async function sendMessageMatrix(
     return await withResolvedRoomRetry({
       client,
       to,
-      action: async (roomId) =>
-        await enqueueSend(roomId, async () => {
-          const tableMode = getCore().channel.text.resolveMarkdownTableMode({
-            cfg,
-            channel: "matrix",
-            accountId: opts.accountId,
-          });
-          const convertedMessage = getCore().channel.text.convertMarkdownTables(
-            trimmedMessage,
-            tableMode,
-          );
-          const textLimit = getCore().channel.text.resolveTextChunkLimit(cfg, "matrix");
-          const chunkLimit = Math.min(textLimit, MATRIX_TEXT_LIMIT);
-          const chunkMode = getCore().channel.text.resolveChunkMode(cfg, "matrix", opts.accountId);
-          const chunks = getCore().channel.text.chunkMarkdownTextWithMode(
-            convertedMessage,
-            chunkLimit,
-            chunkMode,
-          );
-          const threadId = normalizeThreadId(opts.threadId);
-          const relation = threadId
-            ? buildThreadRelation(threadId, opts.replyToId)
-            : buildReplyRelation(opts.replyToId);
-          const sendContent = async (content: MatrixOutboundContent) => {
-            const eventId = await client.sendMessage(roomId, content);
-            return eventId;
-          };
+      action: async (roomId, markContentSent) => {
+        const tableMode = getCore().channel.text.resolveMarkdownTableMode({
+          cfg,
+          channel: "matrix",
+          accountId: opts.accountId,
+        });
+        const convertedMessage = getCore().channel.text.convertMarkdownTables(
+          trimmedMessage,
+          tableMode,
+        );
+        const textLimit = getCore().channel.text.resolveTextChunkLimit(cfg, "matrix");
+        const chunkLimit = Math.min(textLimit, MATRIX_TEXT_LIMIT);
+        const chunkMode = getCore().channel.text.resolveChunkMode(cfg, "matrix", opts.accountId);
+        const chunks = getCore().channel.text.chunkMarkdownTextWithMode(
+          convertedMessage,
+          chunkLimit,
+          chunkMode,
+        );
+        const threadId = normalizeThreadId(opts.threadId);
+        const relation = threadId
+          ? buildThreadRelation(threadId, opts.replyToId)
+          : buildReplyRelation(opts.replyToId);
+        const sendContent = async (content: MatrixOutboundContent) => {
+          const eventId = await client.sendMessage(roomId, content);
+          markContentSent();
+          return eventId;
+        };
 
-          let lastMessageId = "";
-          if (opts.mediaUrl) {
-            const maxBytes = resolveMediaMaxBytes(opts.accountId, cfg);
-            const media = await getCore().media.loadWebMedia(opts.mediaUrl, maxBytes);
-            const uploaded = await uploadMediaMaybeEncrypted(client, roomId, media.buffer, {
-              contentType: media.contentType,
-              filename: media.fileName,
-            });
-            const durationMs = await resolveMediaDurationMs({
-              buffer: media.buffer,
-              contentType: media.contentType,
-              fileName: media.fileName,
-              kind: media.kind ?? "unknown",
-            });
-            const baseMsgType = resolveMatrixMsgType(media.contentType, media.fileName);
-            const { useVoice } = resolveMatrixVoiceDecision({
-              wantsVoice: opts.audioAsVoice === true,
-              contentType: media.contentType,
-              fileName: media.fileName,
-            });
-            const msgtype = useVoice ? MsgType.Audio : baseMsgType;
-            const isImage = msgtype === MsgType.Image;
-            const imageInfo = isImage
-              ? await prepareImageInfo({ buffer: media.buffer, client })
-              : undefined;
-            const [firstChunk, ...rest] = chunks;
-            const body = useVoice ? "Voice message" : (firstChunk ?? media.fileName ?? "(file)");
-            const content = buildMediaContent({
-              msgtype,
-              body,
-              url: uploaded.url,
-              file: uploaded.file,
-              filename: media.fileName,
-              mimetype: media.contentType,
-              size: media.buffer.byteLength,
-              durationMs,
-              relation,
-              isVoice: useVoice,
-              imageInfo,
-            });
+        let lastMessageId = "";
+        if (opts.mediaUrl) {
+          const maxBytes = resolveMediaMaxBytes(opts.accountId, cfg);
+          const media = await getCore().media.loadWebMedia(opts.mediaUrl, maxBytes);
+          const uploaded = await uploadMediaMaybeEncrypted(client, roomId, media.buffer, {
+            contentType: media.contentType,
+            filename: media.fileName,
+          });
+          const durationMs = await resolveMediaDurationMs({
+            buffer: media.buffer,
+            contentType: media.contentType,
+            fileName: media.fileName,
+            kind: media.kind ?? "unknown",
+          });
+          const baseMsgType = resolveMatrixMsgType(media.contentType, media.fileName);
+          const { useVoice } = resolveMatrixVoiceDecision({
+            wantsVoice: opts.audioAsVoice === true,
+            contentType: media.contentType,
+            fileName: media.fileName,
+          });
+          const msgtype = useVoice ? MsgType.Audio : baseMsgType;
+          const isImage = msgtype === MsgType.Image;
+          const imageInfo = isImage
+            ? await prepareImageInfo({ buffer: media.buffer, client })
+            : undefined;
+          const [firstChunk, ...rest] = chunks;
+          const body = useVoice ? "Voice message" : (firstChunk ?? media.fileName ?? "(file)");
+          const content = buildMediaContent({
+            msgtype,
+            body,
+            url: uploaded.url,
+            file: uploaded.file,
+            filename: media.fileName,
+            mimetype: media.contentType,
+            size: media.buffer.byteLength,
+            durationMs,
+            relation,
+            isVoice: useVoice,
+            imageInfo,
+          });
+          const eventId = await sendContent(content);
+          lastMessageId = eventId ?? lastMessageId;
+          const textChunks = useVoice ? chunks : rest;
+          const followupRelation = threadId ? relation : undefined;
+          for (const chunk of textChunks) {
+            const text = chunk.trim();
+            if (!text) {
+              continue;
+            }
+            const followup = buildTextContent(text, followupRelation);
+            const followupEventId = await sendContent(followup);
+            lastMessageId = followupEventId ?? lastMessageId;
+          }
+        } else {
+          for (const chunk of chunks.length ? chunks : [""]) {
+            const text = chunk.trim();
+            if (!text) {
+              continue;
+            }
+            const content = buildTextContent(text, relation);
             const eventId = await sendContent(content);
             lastMessageId = eventId ?? lastMessageId;
-            const textChunks = useVoice ? chunks : rest;
-            const followupRelation = threadId ? relation : undefined;
-            for (const chunk of textChunks) {
-              const text = chunk.trim();
-              if (!text) {
-                continue;
-              }
-              const followup = buildTextContent(text, followupRelation);
-              const followupEventId = await sendContent(followup);
-              lastMessageId = followupEventId ?? lastMessageId;
-            }
-          } else {
-            for (const chunk of chunks.length ? chunks : [""]) {
-              const text = chunk.trim();
-              if (!text) {
-                continue;
-              }
-              const content = buildTextContent(text, relation);
-              const eventId = await sendContent(content);
-              lastMessageId = eventId ?? lastMessageId;
-            }
           }
+        }
 
-          return {
-            messageId: lastMessageId || "unknown",
-            roomId,
-          };
-        }),
+        return {
+          messageId: lastMessageId || "unknown",
+          roomId,
+        };
+      },
     });
   } finally {
     if (stopOnDone) {
@@ -259,13 +307,14 @@ export async function sendPollMatrix(
     return await withResolvedRoomRetry({
       client,
       to,
-      action: async (roomId) => {
+      action: async (roomId, markContentSent) => {
         const pollContent = buildPollStartContent(poll);
         const threadId = normalizeThreadId(opts.threadId);
         const pollPayload = threadId
           ? { ...pollContent, "m.relates_to": buildThreadRelation(threadId) }
           : pollContent;
         const eventId = await client.sendEvent(roomId, M_POLL_START, pollPayload);
+        markContentSent();
 
         return {
           eventId: eventId ?? "unknown",

--- a/extensions/matrix/src/matrix/send/targets.test.ts
+++ b/extensions/matrix/src/matrix/send/targets.test.ts
@@ -197,6 +197,43 @@ describe("resolveMatrixRoomId", () => {
     expect(first).toBe("!nova:example.org");
     expect(second).toBe("!asst:example.org");
   });
+
+  it("ignores blank and duplicate m.direct room ids", async () => {
+    const userId = "@clean:example.org";
+    const activeRoom = "!active:example.org";
+    const client = createMockClient({
+      directContent: {
+        [userId]: ["   ", activeRoom, activeRoom],
+      },
+      joinedRooms: [activeRoom],
+      membersByRoom: {
+        [activeRoom]: ["@bot:example.org", userId],
+      },
+      roomStateEvents: {
+        [`${activeRoom}|m.room.member|${userId}`]: { is_direct: true },
+        [`${activeRoom}|m.room.member|@bot:example.org`]: {},
+      },
+    });
+
+    const resolved = await resolveMatrixRoomId(client, userId);
+
+    expect(resolved).toBe(activeRoom);
+    expect(client.setAccountData).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the first valid m.direct room when joined room inspection fails", async () => {
+    const userId = "@fallback-valid:example.org";
+    const client = createMockClient({
+      directContent: {
+        [userId]: ["   ", "!valid:example.org", "!other:example.org"],
+      },
+      getJoinedRoomsError: new Error("offline"),
+    });
+
+    const resolved = await resolveMatrixRoomId(client, userId);
+
+    expect(resolved).toBe("!valid:example.org");
+  });
 });
 
 describe("normalizeThreadId", () => {

--- a/extensions/matrix/src/matrix/send/targets.test.ts
+++ b/extensions/matrix/src/matrix/send/targets.test.ts
@@ -4,10 +4,34 @@ import { EventType } from "./types.js";
 
 let resolveMatrixRoomId: typeof import("./targets.js").resolveMatrixRoomId;
 let normalizeThreadId: typeof import("./targets.js").normalizeThreadId;
+let clearDirectRoomCacheForTarget: typeof import("./targets.js").clearDirectRoomCacheForTarget;
+
+type TargetsTestHooks = {
+  getDirectRoomCacheOrderLength(): number;
+  getMaxDirectRoomCacheOrderSize(): number;
+};
+
+function getTargetsTestHooks(): TargetsTestHooks {
+  const hooks = (
+    globalThis as typeof globalThis & {
+      __openclawMatrixTargetsTestHooks__?: TargetsTestHooks;
+    }
+  ).__openclawMatrixTargetsTestHooks__;
+  if (!hooks) {
+    throw new Error("Matrix targets test hooks were not initialized");
+  }
+  return hooks;
+}
 
 beforeEach(async () => {
   vi.resetModules();
-  ({ resolveMatrixRoomId, normalizeThreadId } = await import("./targets.js"));
+  delete (
+    globalThis as typeof globalThis & {
+      __openclawMatrixTargetsTestHooks__?: TargetsTestHooks;
+    }
+  ).__openclawMatrixTargetsTestHooks__;
+  ({ resolveMatrixRoomId, normalizeThreadId, clearDirectRoomCacheForTarget } =
+    await import("./targets.js"));
 });
 
 function createMockClient(opts: {
@@ -233,6 +257,46 @@ describe("resolveMatrixRoomId", () => {
     const resolved = await resolveMatrixRoomId(client, userId);
 
     expect(resolved).toBe("!valid:example.org");
+  });
+
+  it("compacts evicted direct-room cache order entries after repeated invalidations", async () => {
+    const userId = "@churn:example.org";
+    const firstRoom = "!one:example.org";
+    const secondRoom = "!two:example.org";
+    const directContent: Record<string, string[] | undefined> = {
+      [userId]: [firstRoom],
+    };
+    const joinedRooms = [firstRoom];
+    const membersByRoom: Record<string, string[]> = {
+      [firstRoom]: ["@bot:example.org", userId],
+      [secondRoom]: ["@bot:example.org", userId],
+    };
+    const roomStateEvents: Record<string, Record<string, unknown>> = {
+      [`${firstRoom}|m.room.member|${userId}`]: { is_direct: true },
+      [`${firstRoom}|m.room.member|@bot:example.org`]: {},
+      [`${secondRoom}|m.room.member|${userId}`]: { is_direct: true },
+      [`${secondRoom}|m.room.member|@bot:example.org`]: {},
+    };
+    const client = createMockClient({
+      directContent,
+      joinedRooms,
+      membersByRoom,
+      roomStateEvents,
+    });
+
+    const hooks = getTargetsTestHooks();
+    const maxOrderSize = hooks.getMaxDirectRoomCacheOrderSize();
+    await resolveMatrixRoomId(client, userId);
+
+    for (let index = 0; index < maxOrderSize + 50; index += 1) {
+      clearDirectRoomCacheForTarget(client, userId);
+      const nextRoom = index % 2 === 0 ? secondRoom : firstRoom;
+      directContent[userId] = [nextRoom];
+      joinedRooms.splice(0, joinedRooms.length, nextRoom);
+      await resolveMatrixRoomId(client, userId);
+    }
+
+    expect(hooks.getDirectRoomCacheOrderLength()).toBeLessThanOrEqual(maxOrderSize);
   });
 });
 

--- a/extensions/matrix/src/matrix/send/targets.test.ts
+++ b/extensions/matrix/src/matrix/send/targets.test.ts
@@ -10,42 +10,124 @@ beforeEach(async () => {
   ({ resolveMatrixRoomId, normalizeThreadId } = await import("./targets.js"));
 });
 
+function createMockClient(opts: {
+  selfUserId?: string;
+  directContent?: Record<string, string[] | undefined>;
+  joinedRooms?: string[];
+  membersByRoom?: Record<string, string[]>;
+  dmRooms?: Record<string, boolean>;
+  roomStateEvents?: Record<string, Record<string, unknown>>;
+  getAccountDataError?: Error;
+  getJoinedRoomsError?: Error;
+  getJoinedRoomMembers?: ReturnType<typeof vi.fn>;
+}) {
+  const getRoomStateEvent = vi
+    .fn()
+    .mockImplementation(async (roomId: string, eventType: string, stateKey: string) => {
+      const key = `${roomId}|${eventType}|${stateKey}`;
+      const event = opts.roomStateEvents?.[key];
+      if (event === undefined) {
+        const err = new Error(`missing state ${key}`) as Error & {
+          errcode?: string;
+          statusCode?: number;
+        };
+        err.errcode = "M_NOT_FOUND";
+        err.statusCode = 404;
+        throw err;
+      }
+      return event;
+    });
+
+  return {
+    getUserId: vi.fn().mockResolvedValue(opts.selfUserId ?? "@bot:example.org"),
+    getAccountData: opts.getAccountDataError
+      ? vi.fn().mockRejectedValue(opts.getAccountDataError)
+      : vi.fn().mockResolvedValue(opts.directContent ?? {}),
+    getJoinedRooms: opts.getJoinedRoomsError
+      ? vi.fn().mockRejectedValue(opts.getJoinedRoomsError)
+      : vi.fn().mockResolvedValue(opts.joinedRooms ?? []),
+    getJoinedRoomMembers:
+      opts.getJoinedRoomMembers ??
+      vi.fn().mockImplementation(async (roomId: string) => opts.membersByRoom?.[roomId] ?? []),
+    getRoomStateEvent,
+    setAccountData: vi.fn().mockResolvedValue(undefined),
+    dms: {
+      update: vi.fn().mockResolvedValue(undefined),
+      isDm: vi.fn().mockImplementation((roomId: string) => opts.dmRooms?.[roomId] ?? false),
+    },
+  } as unknown as MatrixClient;
+}
+
 describe("resolveMatrixRoomId", () => {
   it("uses m.direct when available", async () => {
     const userId = "@user:example.org";
-    const client = {
-      getAccountData: vi.fn().mockResolvedValue({
+    const client = createMockClient({
+      directContent: {
         [userId]: ["!room:example.org"],
-      }),
-      getJoinedRooms: vi.fn(),
-      getJoinedRoomMembers: vi.fn(),
-      setAccountData: vi.fn(),
-    } as unknown as MatrixClient;
+      },
+      getJoinedRoomsError: new Error("offline"),
+    });
 
     const roomId = await resolveMatrixRoomId(client, userId);
 
     expect(roomId).toBe("!room:example.org");
     // oxlint-disable-next-line typescript/unbound-method
-    expect(client.getJoinedRooms).not.toHaveBeenCalled();
-    // oxlint-disable-next-line typescript/unbound-method
     expect(client.setAccountData).not.toHaveBeenCalled();
+  });
+
+  it("prefers the strongest DM candidate over stale m.direct ordering", async () => {
+    const userId = "@user:example.org";
+    const staleRoom = "!stale:example.org";
+    const activeRoom = "!active:example.org";
+    const client = createMockClient({
+      directContent: {
+        [userId]: [staleRoom, activeRoom],
+      },
+      joinedRooms: [staleRoom, activeRoom],
+      membersByRoom: {
+        [staleRoom]: ["@bot:example.org", userId],
+        [activeRoom]: ["@bot:example.org", userId],
+      },
+      dmRooms: {
+        [activeRoom]: true,
+      },
+      roomStateEvents: {
+        [`${staleRoom}|m.room.member|${userId}`]: {},
+        [`${staleRoom}|m.room.member|@bot:example.org`]: {},
+        [`${staleRoom}|m.room.name|`]: { name: "Old named room" },
+        [`${activeRoom}|m.room.member|${userId}`]: { is_direct: true },
+        [`${activeRoom}|m.room.member|@bot:example.org`]: { is_direct: true },
+      },
+    });
+
+    const resolved = await resolveMatrixRoomId(client, userId);
+
+    expect(resolved).toBe(activeRoom);
+    expect(client.setAccountData).toHaveBeenCalledWith(
+      EventType.Direct,
+      expect.objectContaining({ [userId]: [activeRoom, staleRoom] }),
+    );
   });
 
   it("falls back to joined rooms and persists m.direct", async () => {
     const userId = "@fallback:example.org";
     const roomId = "!room:example.org";
-    const setAccountData = vi.fn().mockResolvedValue(undefined);
-    const client = {
-      getAccountData: vi.fn().mockRejectedValue(new Error("nope")),
-      getJoinedRooms: vi.fn().mockResolvedValue([roomId]),
-      getJoinedRoomMembers: vi.fn().mockResolvedValue(["@bot:example.org", userId]),
-      setAccountData,
-    } as unknown as MatrixClient;
+    const client = createMockClient({
+      getAccountDataError: new Error("nope"),
+      joinedRooms: [roomId],
+      membersByRoom: {
+        [roomId]: ["@bot:example.org", userId],
+      },
+      roomStateEvents: {
+        [`${roomId}|m.room.member|${userId}`]: { is_direct: true },
+        [`${roomId}|m.room.member|@bot:example.org`]: {},
+      },
+    });
 
     const resolved = await resolveMatrixRoomId(client, userId);
 
     expect(resolved).toBe(roomId);
-    expect(setAccountData).toHaveBeenCalledWith(
+    expect(client.setAccountData).toHaveBeenCalledWith(
       EventType.Direct,
       expect.objectContaining({ [userId]: [roomId] }),
     );
@@ -54,39 +136,66 @@ describe("resolveMatrixRoomId", () => {
   it("continues when a room member lookup fails", async () => {
     const userId = "@continue:example.org";
     const roomId = "!good:example.org";
-    const setAccountData = vi.fn().mockResolvedValue(undefined);
     const getJoinedRoomMembers = vi
       .fn()
       .mockRejectedValueOnce(new Error("boom"))
       .mockResolvedValueOnce(["@bot:example.org", userId]);
-    const client = {
-      getAccountData: vi.fn().mockRejectedValue(new Error("nope")),
-      getJoinedRooms: vi.fn().mockResolvedValue(["!bad:example.org", roomId]),
+    const client = createMockClient({
+      getAccountDataError: new Error("nope"),
+      joinedRooms: ["!bad:example.org", roomId],
       getJoinedRoomMembers,
-      setAccountData,
-    } as unknown as MatrixClient;
+      roomStateEvents: {
+        [`${roomId}|m.room.member|${userId}`]: { is_direct: true },
+        [`${roomId}|m.room.member|@bot:example.org`]: {},
+      },
+    });
 
     const resolved = await resolveMatrixRoomId(client, userId);
 
     expect(resolved).toBe(roomId);
-    expect(setAccountData).toHaveBeenCalled();
+    expect(client.setAccountData).toHaveBeenCalled();
   });
 
   it("allows larger rooms when no 1:1 match exists", async () => {
     const userId = "@group:example.org";
     const roomId = "!group:example.org";
-    const client = {
-      getAccountData: vi.fn().mockRejectedValue(new Error("nope")),
-      getJoinedRooms: vi.fn().mockResolvedValue([roomId]),
-      getJoinedRoomMembers: vi
-        .fn()
-        .mockResolvedValue(["@bot:example.org", userId, "@extra:example.org"]),
-      setAccountData: vi.fn().mockResolvedValue(undefined),
-    } as unknown as MatrixClient;
+    const client = createMockClient({
+      getAccountDataError: new Error("nope"),
+      joinedRooms: [roomId],
+      membersByRoom: {
+        [roomId]: ["@bot:example.org", userId, "@extra:example.org"],
+      },
+      roomStateEvents: {
+        [`${roomId}|m.room.member|${userId}`]: {},
+        [`${roomId}|m.room.member|@bot:example.org`]: {},
+      },
+    });
 
     const resolved = await resolveMatrixRoomId(client, userId);
 
     expect(resolved).toBe(roomId);
+  });
+
+  it("scopes cached direct rooms per Matrix client", async () => {
+    const userId = "@cache:example.org";
+    const firstClient = createMockClient({
+      directContent: {
+        [userId]: ["!nova:example.org"],
+      },
+      getJoinedRoomsError: new Error("offline"),
+    });
+    const secondClient = createMockClient({
+      directContent: {
+        [userId]: ["!asst:example.org"],
+      },
+      getJoinedRoomsError: new Error("offline"),
+    });
+
+    const first = await resolveMatrixRoomId(firstClient, userId);
+    const second = await resolveMatrixRoomId(secondClient, userId);
+
+    expect(first).toBe("!nova:example.org");
+    expect(second).toBe("!asst:example.org");
   });
 });
 

--- a/extensions/matrix/src/matrix/send/targets.ts
+++ b/extensions/matrix/src/matrix/send/targets.ts
@@ -19,6 +19,7 @@ export function normalizeThreadId(raw?: string | number | null): string | null {
 
 // Size-capped to prevent unbounded growth (#4948)
 const MAX_DIRECT_ROOM_CACHE_SIZE = 1024;
+const MAX_DIRECT_ROOM_CACHE_ORDER_SIZE = MAX_DIRECT_ROOM_CACHE_SIZE * 2;
 type DirectRoomCacheEntry = {
   roomId: string;
   evicted: boolean;
@@ -31,6 +32,30 @@ const directRoomCacheOrder: Array<{
   entry: DirectRoomCacheEntry;
 }> = [];
 let directRoomCacheSize = 0;
+let directRoomCacheEvictedCount = 0;
+
+function markDirectRoomCacheEntryEvicted(entry: DirectRoomCacheEntry): void {
+  if (entry.evicted) {
+    return;
+  }
+  entry.evicted = true;
+  directRoomCacheEvictedCount += 1;
+}
+
+function maybeCompactDirectRoomCacheOrder(): void {
+  if (directRoomCacheEvictedCount === 0) {
+    return;
+  }
+  if (
+    directRoomCacheOrder.length <= MAX_DIRECT_ROOM_CACHE_ORDER_SIZE &&
+    directRoomCacheEvictedCount <= MAX_DIRECT_ROOM_CACHE_SIZE
+  ) {
+    return;
+  }
+  const compacted = directRoomCacheOrder.filter((slot) => !slot.entry.evicted);
+  directRoomCacheOrder.splice(0, directRoomCacheOrder.length, ...compacted);
+  directRoomCacheEvictedCount = 0;
+}
 
 function getDirectRoomCacheForClient(client: MatrixClient): Map<string, DirectRoomCacheEntry> {
   const existing = directRoomCache.get(client);
@@ -53,16 +78,17 @@ function clearDirectRoomCacheEntry(client: MatrixClient, userId: string): void {
   if (!clientCache || !existing) {
     return;
   }
-  existing.evicted = true;
+  markDirectRoomCacheEntryEvicted(existing);
   clientCache.delete(userId);
   directRoomCacheSize -= 1;
+  maybeCompactDirectRoomCacheOrder();
 }
 
 function setDirectRoomCached(client: MatrixClient, userId: string, roomId: string): void {
   const clientCache = getDirectRoomCacheForClient(client);
   const previous = clientCache.get(userId);
   if (previous) {
-    previous.evicted = true;
+    markDirectRoomCacheEntryEvicted(previous);
     directRoomCacheSize -= 1;
   }
 
@@ -73,13 +99,19 @@ function setDirectRoomCached(client: MatrixClient, userId: string, roomId: strin
 
   while (directRoomCacheSize > MAX_DIRECT_ROOM_CACHE_SIZE) {
     const oldest = directRoomCacheOrder.shift();
-    if (!oldest || oldest.entry.evicted) {
+    if (!oldest) {
+      continue;
+    }
+    if (oldest.entry.evicted) {
+      directRoomCacheEvictedCount -= 1;
       continue;
     }
     oldest.entry.evicted = true;
     oldest.clientCache.delete(oldest.userId);
     directRoomCacheSize -= 1;
   }
+
+  maybeCompactDirectRoomCacheOrder();
 }
 
 function normalizeRoomIdList(input: unknown): string[] {
@@ -387,3 +419,17 @@ export async function resolveMatrixRoomId(client: MatrixClient, raw: string): Pr
   }
   return target;
 }
+
+type TargetsTestHooks = {
+  getDirectRoomCacheOrderLength(): number;
+  getMaxDirectRoomCacheOrderSize(): number;
+};
+
+(
+  globalThis as typeof globalThis & {
+    __openclawMatrixTargetsTestHooks__?: TargetsTestHooks;
+  }
+).__openclawMatrixTargetsTestHooks__ = {
+  getDirectRoomCacheOrderLength: () => directRoomCacheOrder.length,
+  getMaxDirectRoomCacheOrderSize: () => MAX_DIRECT_ROOM_CACHE_ORDER_SIZE,
+};

--- a/extensions/matrix/src/matrix/send/targets.ts
+++ b/extensions/matrix/src/matrix/send/targets.ts
@@ -19,28 +19,87 @@ export function normalizeThreadId(raw?: string | number | null): string | null {
 
 // Size-capped to prevent unbounded growth (#4948)
 const MAX_DIRECT_ROOM_CACHE_SIZE = 1024;
-const directRoomCache = new Map<string, string>();
-const clientIds = new WeakMap<MatrixClient, number>();
-let nextClientId = 1;
+type DirectRoomCacheEntry = {
+  roomId: string;
+  evicted: boolean;
+};
 
-function getDirectRoomCacheKey(client: MatrixClient, userId: string): string {
-  const existing = clientIds.get(client);
+const directRoomCache = new WeakMap<MatrixClient, Map<string, DirectRoomCacheEntry>>();
+const directRoomCacheOrder: Array<{
+  clientCache: Map<string, DirectRoomCacheEntry>;
+  userId: string;
+  entry: DirectRoomCacheEntry;
+}> = [];
+let directRoomCacheSize = 0;
+
+function getDirectRoomCacheForClient(client: MatrixClient): Map<string, DirectRoomCacheEntry> {
+  const existing = directRoomCache.get(client);
   if (existing) {
-    return `${existing}:${userId}`;
+    return existing;
   }
-  const created = nextClientId++;
-  clientIds.set(client, created);
-  return `${created}:${userId}`;
+  const created = new Map<string, DirectRoomCacheEntry>();
+  directRoomCache.set(client, created);
+  return created;
 }
 
-function setDirectRoomCached(key: string, value: string): void {
-  directRoomCache.set(key, value);
-  if (directRoomCache.size > MAX_DIRECT_ROOM_CACHE_SIZE) {
-    const oldest = directRoomCache.keys().next().value;
-    if (oldest !== undefined) {
-      directRoomCache.delete(oldest);
-    }
+function getDirectRoomCached(client: MatrixClient, userId: string): string | null {
+  const clientCache = directRoomCache.get(client);
+  return clientCache?.get(userId)?.roomId ?? null;
+}
+
+function clearDirectRoomCacheEntry(client: MatrixClient, userId: string): void {
+  const clientCache = directRoomCache.get(client);
+  const existing = clientCache?.get(userId);
+  if (!clientCache || !existing) {
+    return;
   }
+  existing.evicted = true;
+  clientCache.delete(userId);
+  directRoomCacheSize -= 1;
+}
+
+function setDirectRoomCached(client: MatrixClient, userId: string, roomId: string): void {
+  const clientCache = getDirectRoomCacheForClient(client);
+  const previous = clientCache.get(userId);
+  if (previous) {
+    previous.evicted = true;
+    directRoomCacheSize -= 1;
+  }
+
+  const entry: DirectRoomCacheEntry = { roomId, evicted: false };
+  clientCache.set(userId, entry);
+  directRoomCacheOrder.push({ clientCache, userId, entry });
+  directRoomCacheSize += 1;
+
+  while (directRoomCacheSize > MAX_DIRECT_ROOM_CACHE_SIZE) {
+    const oldest = directRoomCacheOrder.shift();
+    if (!oldest || oldest.entry.evicted) {
+      continue;
+    }
+    oldest.entry.evicted = true;
+    oldest.clientCache.delete(oldest.userId);
+    directRoomCacheSize -= 1;
+  }
+}
+
+function normalizeRoomIdList(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const entry of input) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
 }
 
 function isMatrixNotFoundError(err: unknown): boolean {
@@ -152,8 +211,7 @@ async function resolveDirectRoomId(client: MatrixClient, userId: string): Promis
     throw new Error(`Matrix user IDs must be fully qualified (got "${trimmed}")`);
   }
 
-  const cacheKey = getDirectRoomCacheKey(client, trimmed);
-  const cached = directRoomCache.get(cacheKey);
+  const cached = getDirectRoomCached(client, trimmed);
   if (cached) {
     return cached;
   }
@@ -165,7 +223,7 @@ async function resolveDirectRoomId(client: MatrixClient, userId: string): Promis
       string,
       string[] | undefined
     >;
-    directList = Array.isArray(directContent?.[trimmed]) ? directContent[trimmed] : [];
+    directList = normalizeRoomIdList(directContent?.[trimmed]);
   } catch {
     // Ignore and fall back.
   }
@@ -180,7 +238,11 @@ async function resolveDirectRoomId(client: MatrixClient, userId: string): Promis
   const joinedRooms = await client.getJoinedRooms().catch(() => []);
   const joinedSet = new Set(joinedRooms);
   const candidateIds = new Set<string>();
-  directList.forEach((roomId) => candidateIds.add(roomId));
+  const directIndexByRoomId = new Map<string, number>();
+  directList.forEach((roomId, index) => {
+    directIndexByRoomId.set(roomId, index);
+    candidateIds.add(roomId);
+  });
   joinedRooms.forEach((roomId) => candidateIds.add(roomId));
 
   const candidates: DirectRoomCandidate[] = [];
@@ -201,7 +263,7 @@ async function resolveDirectRoomId(client: MatrixClient, userId: string): Promis
       }
 
       const dmCached = client.dms?.isDm?.(roomId) === true;
-      const directIndex = directList.indexOf(roomId);
+      const directIndex = directIndexByRoomId.get(roomId);
       const hasDirectUserFlag = await hasDirectFlag(client, roomId, trimmed);
       const hasDirectSelfFlag = await hasDirectFlag(client, roomId, selfUserId);
       const hasExplicitName =
@@ -209,7 +271,7 @@ async function resolveDirectRoomId(client: MatrixClient, userId: string): Promis
 
       candidates.push({
         roomId,
-        directIndex: directIndex >= 0 ? directIndex : null,
+        directIndex: directIndex ?? null,
         dmCached,
         hasDirectFlag: hasDirectUserFlag || hasDirectSelfFlag,
         memberCount: members.length,
@@ -238,7 +300,7 @@ async function resolveDirectRoomId(client: MatrixClient, userId: string): Promis
   })[0];
 
   if (bestCandidate) {
-    setDirectRoomCached(cacheKey, bestCandidate.roomId);
+    setDirectRoomCached(client, trimmed, bestCandidate.roomId);
     if (directList[0] !== bestCandidate.roomId) {
       await persistDirectRoom(client, trimmed, bestCandidate.roomId);
     }
@@ -246,11 +308,56 @@ async function resolveDirectRoomId(client: MatrixClient, userId: string): Promis
   }
 
   if (directList[0]) {
-    setDirectRoomCached(cacheKey, directList[0]);
+    setDirectRoomCached(client, trimmed, directList[0]);
     return directList[0];
   }
 
   throw new Error(`No direct room found for ${trimmed} (m.direct missing)`);
+}
+
+function isPrefixedMatrixTarget(target: string, prefix: string): boolean {
+  return target.toLowerCase().startsWith(prefix);
+}
+
+export function isMatrixUserTarget(raw: string): boolean {
+  const target = normalizeTarget(raw);
+  if (isPrefixedMatrixTarget(target, "matrix:")) {
+    return isMatrixUserTarget(target.slice("matrix:".length));
+  }
+  if (isPrefixedMatrixTarget(target, "room:")) {
+    return isMatrixUserTarget(target.slice("room:".length));
+  }
+  if (isPrefixedMatrixTarget(target, "channel:")) {
+    return isMatrixUserTarget(target.slice("channel:".length));
+  }
+  if (isPrefixedMatrixTarget(target, "user:")) {
+    return target.slice("user:".length).trim().startsWith("@");
+  }
+  return target.startsWith("@");
+}
+
+export function clearDirectRoomCacheForTarget(client: MatrixClient, raw: string): void {
+  if (!isMatrixUserTarget(raw)) {
+    return;
+  }
+  const target = normalizeTarget(raw);
+  if (isPrefixedMatrixTarget(target, "matrix:")) {
+    clearDirectRoomCacheForTarget(client, target.slice("matrix:".length));
+    return;
+  }
+  if (isPrefixedMatrixTarget(target, "room:")) {
+    clearDirectRoomCacheForTarget(client, target.slice("room:".length));
+    return;
+  }
+  if (isPrefixedMatrixTarget(target, "channel:")) {
+    clearDirectRoomCacheForTarget(client, target.slice("channel:".length));
+    return;
+  }
+  if (isPrefixedMatrixTarget(target, "user:")) {
+    clearDirectRoomCacheEntry(client, target.slice("user:".length).trim());
+    return;
+  }
+  clearDirectRoomCacheEntry(client, target);
 }
 
 export async function resolveMatrixRoomId(client: MatrixClient, raw: string): Promise<string> {

--- a/extensions/matrix/src/matrix/send/targets.ts
+++ b/extensions/matrix/src/matrix/send/targets.ts
@@ -20,6 +20,19 @@ export function normalizeThreadId(raw?: string | number | null): string | null {
 // Size-capped to prevent unbounded growth (#4948)
 const MAX_DIRECT_ROOM_CACHE_SIZE = 1024;
 const directRoomCache = new Map<string, string>();
+const clientIds = new WeakMap<MatrixClient, number>();
+let nextClientId = 1;
+
+function getDirectRoomCacheKey(client: MatrixClient, userId: string): string {
+  const existing = clientIds.get(client);
+  if (existing) {
+    return `${existing}:${userId}`;
+  }
+  const created = nextClientId++;
+  clientIds.set(client, created);
+  return `${created}:${userId}`;
+}
+
 function setDirectRoomCached(key: string, value: string): void {
   directRoomCache.set(key, value);
   if (directRoomCache.size > MAX_DIRECT_ROOM_CACHE_SIZE) {
@@ -28,6 +41,82 @@ function setDirectRoomCached(key: string, value: string): void {
       directRoomCache.delete(oldest);
     }
   }
+}
+
+function isMatrixNotFoundError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) {
+    return false;
+  }
+  const candidate = err as { errcode?: string; statusCode?: number };
+  return candidate.errcode === "M_NOT_FOUND" || candidate.statusCode === 404;
+}
+
+async function getSelfUserId(client: MatrixClient): Promise<string | null> {
+  try {
+    return await client.getUserId();
+  } catch {
+    return null;
+  }
+}
+
+async function hasDirectFlag(
+  client: MatrixClient,
+  roomId: string,
+  userId: string | null,
+): Promise<boolean> {
+  if (!userId) {
+    return false;
+  }
+  try {
+    const state = await client.getRoomStateEvent(roomId, "m.room.member", userId);
+    return state?.is_direct === true;
+  } catch {
+    return false;
+  }
+}
+
+async function getRoomHasExplicitName(client: MatrixClient, roomId: string): Promise<boolean> {
+  try {
+    const nameState = await client.getRoomStateEvent(roomId, "m.room.name", "");
+    return Boolean(nameState?.name?.trim());
+  } catch (err) {
+    if (isMatrixNotFoundError(err)) {
+      return false;
+    }
+    return true;
+  }
+}
+
+type DirectRoomCandidate = {
+  roomId: string;
+  directIndex: number | null;
+  dmCached: boolean;
+  hasDirectFlag: boolean;
+  memberCount: number;
+  hasExplicitName: boolean;
+};
+
+function scoreDirectRoomCandidate(candidate: DirectRoomCandidate): number {
+  let score = 0;
+  if (candidate.dmCached) {
+    score += 1000;
+  }
+  if (candidate.hasDirectFlag) {
+    score += 500;
+  }
+  if (candidate.memberCount === 2 && !candidate.hasExplicitName) {
+    score += 250;
+  }
+  if (candidate.directIndex !== null) {
+    score += 100 - Math.min(candidate.directIndex, 100);
+  }
+  if (candidate.memberCount === 2) {
+    score += 25;
+  }
+  if (candidate.hasExplicitName) {
+    score -= 25;
+  }
+  return score;
 }
 
 async function persistDirectRoom(
@@ -63,32 +152,44 @@ async function resolveDirectRoomId(client: MatrixClient, userId: string): Promis
     throw new Error(`Matrix user IDs must be fully qualified (got "${trimmed}")`);
   }
 
-  const cached = directRoomCache.get(trimmed);
+  const cacheKey = getDirectRoomCacheKey(client, trimmed);
+  const cached = directRoomCache.get(cacheKey);
   if (cached) {
     return cached;
   }
 
-  // 1) Fast path: use account data (m.direct) for *this* logged-in user (the bot).
+  // 1) Gather the bot's direct-room hints for this specific Matrix account.
+  let directList: string[] = [];
   try {
     const directContent = (await client.getAccountData(EventType.Direct)) as Record<
       string,
       string[] | undefined
     >;
-    const list = Array.isArray(directContent?.[trimmed]) ? directContent[trimmed] : [];
-    if (list && list.length > 0) {
-      setDirectRoomCached(trimmed, list[0]);
-      return list[0];
-    }
+    directList = Array.isArray(directContent?.[trimmed]) ? directContent[trimmed] : [];
   } catch {
     // Ignore and fall back.
   }
 
-  // 2) Fallback: look for an existing joined room that looks like a 1:1 with the user.
-  // Many clients only maintain m.direct for *their own* account data, so relying on it is brittle.
-  let fallbackRoom: string | null = null;
   try {
-    const rooms = await client.getJoinedRooms();
-    for (const roomId of rooms) {
+    await client.dms?.update?.();
+  } catch {
+    // Ignore DM cache refresh failures and keep going.
+  }
+
+  const selfUserId = await getSelfUserId(client);
+  const joinedRooms = await client.getJoinedRooms().catch(() => []);
+  const joinedSet = new Set(joinedRooms);
+  const candidateIds = new Set<string>();
+  directList.forEach((roomId) => candidateIds.add(roomId));
+  joinedRooms.forEach((roomId) => candidateIds.add(roomId));
+
+  const candidates: DirectRoomCandidate[] = [];
+  try {
+    for (const roomId of candidateIds) {
+      if (!joinedSet.has(roomId)) {
+        continue;
+      }
+
       let members: string[];
       try {
         members = await client.getJoinedRoomMembers(roomId);
@@ -98,24 +199,55 @@ async function resolveDirectRoomId(client: MatrixClient, userId: string): Promis
       if (!members.includes(trimmed)) {
         continue;
       }
-      // Prefer classic 1:1 rooms, but allow larger rooms if requested.
-      if (members.length === 2) {
-        setDirectRoomCached(trimmed, roomId);
-        await persistDirectRoom(client, trimmed, roomId);
-        return roomId;
-      }
-      if (!fallbackRoom) {
-        fallbackRoom = roomId;
-      }
+
+      const dmCached = client.dms?.isDm?.(roomId) === true;
+      const directIndex = directList.indexOf(roomId);
+      const hasDirectUserFlag = await hasDirectFlag(client, roomId, trimmed);
+      const hasDirectSelfFlag = await hasDirectFlag(client, roomId, selfUserId);
+      const hasExplicitName =
+        members.length === 2 ? await getRoomHasExplicitName(client, roomId) : true;
+
+      candidates.push({
+        roomId,
+        directIndex: directIndex >= 0 ? directIndex : null,
+        dmCached,
+        hasDirectFlag: hasDirectUserFlag || hasDirectSelfFlag,
+        memberCount: members.length,
+        hasExplicitName,
+      });
     }
   } catch {
     // Ignore and fall back.
   }
 
-  if (fallbackRoom) {
-    setDirectRoomCached(trimmed, fallbackRoom);
-    await persistDirectRoom(client, trimmed, fallbackRoom);
-    return fallbackRoom;
+  const bestCandidate = [...candidates].sort((left, right) => {
+    const scoreDelta = scoreDirectRoomCandidate(right) - scoreDirectRoomCandidate(left);
+    if (scoreDelta !== 0) {
+      return scoreDelta;
+    }
+    if (left.directIndex !== null && right.directIndex !== null) {
+      return left.directIndex - right.directIndex;
+    }
+    if (left.directIndex !== null) {
+      return -1;
+    }
+    if (right.directIndex !== null) {
+      return 1;
+    }
+    return left.memberCount - right.memberCount;
+  })[0];
+
+  if (bestCandidate) {
+    setDirectRoomCached(cacheKey, bestCandidate.roomId);
+    if (directList[0] !== bestCandidate.roomId) {
+      await persistDirectRoom(client, trimmed, bestCandidate.roomId);
+    }
+    return bestCandidate.roomId;
+  }
+
+  if (directList[0]) {
+    setDirectRoomCached(cacheKey, directList[0]);
+    return directList[0];
   }
 
   throw new Error(`No direct room found for ${trimmed} (m.direct missing)`);


### PR DESCRIPTION
## Summary

- Problem: Matrix heartbeat and other outbound sends that target full Matrix user IDs could drift to the wrong DM room, and stale cached DM room ids could keep failing indefinitely.
- Why it matters: operators had to fall back to raw Matrix room IDs for reliable heartbeat delivery, which is not reasonable in normal Matrix clients and breaks the intended user-id targeting flow.
- What changed: Matrix user-id DM resolution now scopes cache entries per Matrix client, normalizes malformed `m.direct` lists, ranks DM candidates more defensibly, and self-heals stale cached DM room ids after one failed send.
- What did NOT change (scope boundary): this PR does not change Matrix typing behavior, reasoning-stream behavior, or non-Matrix outbound routing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Nova Matrix heartbeat delivery investigation in local branch stack and follow-up fixes

## User-visible / Behavior Changes

Matrix outbound sends can keep targeting full Matrix user IDs for DMs, including heartbeat `to` targets, without requiring operators to discover and pin raw DM room IDs. If a cached DM room id goes stale, the first stale-room send failure clears the cache, re-resolves once, and retries once before deferring to the next external invocation.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout plus user gateway service refresh
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): heartbeat `target: "matrix"`, `accountId: "nova"`, `to: "@kevin:fish.chat"`

### Steps

1. Configure a Matrix outbound target using a full Matrix user ID instead of a raw room ID.
2. Resolve and send through the Matrix outbound path with stale and fresh DM candidates present.
3. Exercise stale cached-room retry behavior and malformed `m.direct` account-data cases.

### Expected

- Matrix user-id targets resolve to the best joined DM room for that Matrix client.
- Stale cached DM room ids self-heal once and do not poison future sends indefinitely.
- Malformed `m.direct` entries do not break DM routing.

### Actual

- Before this change, DM resolution could prefer the wrong room and stale cached room ids could fail repeatedly until process restart or manual intervention.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Ran `pnpm exec vitest run extensions/matrix/src/matrix/send/targets.test.ts extensions/matrix/src/matrix/send.test.ts extensions/matrix/src/matrix/monitor/direct.test.ts`.
  - Ran `pnpm build`.
  - Reproduced and fixed the stale direct-room cache-order growth review issue with a focused churn regression.
- Edge cases checked:
  - Cache is scoped per Matrix client.
  - Blank and duplicate `m.direct` entries are ignored.
  - Generic send failures do not trigger the stale-room retry path.
  - Repeated cache invalidation and re-population does not grow the cache-order queue without bound.
- What you did **not** verify:
  - A fresh full scheduled heartbeat observation on the live system after the final PR follow-up, because the live cadence window is long and there is still no manual `heartbeat now` trigger in this build.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR and fall back to the previous Matrix user-id DM resolver behavior.
- Files/config to restore:
  - `extensions/matrix/src/matrix/send/targets.ts`
  - `extensions/matrix/src/matrix/send.ts`
  - `extensions/matrix/src/matrix/send/targets.test.ts`
  - `extensions/matrix/src/matrix/send.test.ts`
  - `docs/channels/matrix.md`
  - `docs/gateway/heartbeat.md`
  - `docs/gateway/configuration.md`
- Known bad symptoms reviewers should watch for:
  - Heartbeat or other Matrix user-id sends routing to the wrong DM room.
  - Duplicate Matrix message chunks after non-room-related send failures.
  - Long-lived processes accumulating stale direct-room cache-order entries.

## Risks and Mitigations

- Risk:
  - Resolver ranking could still choose the wrong room if homeserver metadata is sparse or inconsistent.
  - Mitigation:
    - The resolver keeps the old first-`m.direct` fallback when joined-room inspection fails and now refreshes `m.direct` ordering when it finds a stronger joined-room candidate.
- Risk:
  - Self-heal retries could duplicate sends after unrelated send failures.
  - Mitigation:
    - Retry is explicitly limited to stale-room style Matrix failures (`403` / `404`, `M_FORBIDDEN` / `M_NOT_FOUND`) and covered by regression tests.
- Risk:
  - Client-scoped cache invalidation churn could grow the auxiliary cache-order queue indefinitely.
  - Mitigation:
    - Evicted slots are compacted once stale entries accumulate past the bounded threshold, with a focused churn regression covering that case.

## AI Assistance Disclosure

- This PR was prepared with AI assistance.
- I reviewed the changed code paths and understand the behavior being changed.
- Testing level: focused regression coverage plus full branch build.
- Verified with:
  - `pnpm exec vitest run extensions/matrix/src/matrix/send/targets.test.ts extensions/matrix/src/matrix/send.test.ts extensions/matrix/src/matrix/monitor/direct.test.ts`
  - `pnpm build`
- Session logs / prompts: available on request from local handoff/session notes.
- AI-assisted: yes, with manual review and targeted verification.
