### PR TITLE
fix(auth): preserve per-model cooldown windows

### DIFF
--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -114,6 +114,21 @@ describe("markAuthProfileFailure", () => {
       expect(reloaded.usageStats?.["anthropic:default"]?.cooldownUntil).toBe(firstCooldownUntil);
     });
   });
+  it("records the model that triggered a rate-limit cooldown", async () => {
+    await withAuthProfileStore(async ({ agentDir, store }) => {
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+        modelId: "claude-opus-4-6",
+        agentDir,
+      });
+
+      const stats = store.usageStats?.["anthropic:default"];
+      expect(stats?.cooldownReason).toBe("rate_limit");
+      expect(stats?.cooldownModel).toBe("claude-opus-4-6");
+    });
+  });
   it("records overloaded failures in the cooldown bucket", async () => {
     await withAuthProfileStore(async ({ agentDir, store }) => {
       await markAuthProfileFailure({

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -51,6 +51,8 @@ export type AuthProfileFailureReason =
 export type ProfileUsageStats = {
   lastUsed?: number;
   cooldownUntil?: number;
+  cooldownReason?: AuthProfileFailureReason;
+  cooldownModel?: string;
   disabledUntil?: number;
   disabledReason?: AuthProfileFailureReason;
   errorCount?: number;

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -94,6 +94,35 @@ describe("isProfileInCooldown", () => {
     expect(isProfileInCooldown(store, "anthropic:default")).toBe(true);
   });
 
+  it("does not block a different model when the cooldown came from a rate limit on another model", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "rate_limit",
+        cooldownModel: "claude-opus-4-6",
+      },
+    });
+    expect(isProfileInCooldown(store, "anthropic:default", undefined, "claude-sonnet-4-6")).toBe(
+      false,
+    );
+    expect(isProfileInCooldown(store, "anthropic:default", undefined, "claude-opus-4-6")).toBe(
+      true,
+    );
+  });
+
+  it("still blocks a different model for non-rate-limit cooldowns", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "overloaded",
+        cooldownModel: "claude-opus-4-6",
+      },
+    });
+    expect(isProfileInCooldown(store, "anthropic:default", undefined, "claude-sonnet-4-6")).toBe(
+      true,
+    );
+  });
+
   it("returns false when cooldownUntil has passed", () => {
     const store = makeStore({
       "anthropic:default": { cooldownUntil: Date.now() - 1_000 },
@@ -538,7 +567,8 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
   async function markFailureAt(params: {
     store: ReturnType<typeof makeStore>;
     now: number;
-    reason: "rate_limit" | "billing" | "auth_permanent";
+    reason: "rate_limit" | "billing" | "auth_permanent" | "overloaded";
+    modelId?: string;
   }): Promise<void> {
     vi.useFakeTimers();
     vi.setSystemTime(params.now);
@@ -547,6 +577,7 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
         store: params.store,
         profileId: "anthropic:default",
         reason: params.reason,
+        modelId: params.modelId,
       });
     } finally {
       vi.useRealTimers();
@@ -607,6 +638,31 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
       expect(testCase.readUntil(stats)).toBe(existingUntil);
     });
   }
+
+  it("keeps rate-limit cooldown metadata unchanged while the active window is still in effect", async () => {
+    const now = 1_000_000;
+    const existingStats: WindowStats = {
+      cooldownUntil: now + 50 * 60 * 1000,
+      cooldownReason: "rate_limit",
+      cooldownModel: "claude-opus-4-6",
+      errorCount: 3,
+      failureCounts: { rate_limit: 3 },
+      lastFailureAt: now - 10 * 60 * 1000,
+    };
+    const store = makeStore({ "anthropic:default": existingStats });
+
+    await markFailureAt({
+      store,
+      now,
+      reason: "overloaded",
+      modelId: "claude-sonnet-4-6",
+    });
+
+    const stats = store.usageStats?.["anthropic:default"];
+    expect(stats?.cooldownUntil).toBe(existingStats.cooldownUntil);
+    expect(stats?.cooldownReason).toBe("rate_limit");
+    expect(stats?.cooldownModel).toBe("claude-opus-4-6");
+  });
 
   // When a cooldown/disabled window expires, the error count resets to prevent
   // stale counters from escalating the next cooldown (the root cause of

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -123,6 +123,22 @@ describe("isProfileInCooldown", () => {
     );
   });
 
+  it("still blocks when a disabled window is active even if the stored rate-limit cooldown is for another model", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "rate_limit",
+        cooldownModel: "claude-opus-4-6",
+        disabledUntil: Date.now() + 5 * 60_000,
+        disabledReason: "billing",
+      },
+    });
+
+    expect(isProfileInCooldown(store, "anthropic:default", undefined, "claude-sonnet-4-6")).toBe(
+      true,
+    );
+  });
+
   it("returns false when cooldownUntil has passed", () => {
     const store = makeStore({
       "anthropic:default": { cooldownUntil: Date.now() - 1_000 },
@@ -368,6 +384,8 @@ describe("clearExpiredCooldowns", () => {
         cooldownUntil: Date.now() - 1_000,
         disabledUntil: future,
         disabledReason: "billing",
+        cooldownReason: "rate_limit",
+        cooldownModel: "claude-opus-4-6",
         errorCount: 5,
         failureCounts: { rate_limit: 3, billing: 2 },
       },
@@ -378,6 +396,8 @@ describe("clearExpiredCooldowns", () => {
     const stats = store.usageStats?.["anthropic:default"];
     // cooldownUntil cleared
     expect(stats?.cooldownUntil).toBeUndefined();
+    expect(stats?.cooldownReason).toBeUndefined();
+    expect(stats?.cooldownModel).toBeUndefined();
     // disabledUntil still active — not touched
     expect(stats?.disabledUntil).toBe(future);
     expect(stats?.disabledReason).toBe("billing");

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -44,6 +44,7 @@ export function isProfileInCooldown(
   store: AuthProfileStore,
   profileId: string,
   now?: number,
+  forModel?: string,
 ): boolean {
   if (isAuthCooldownBypassedForProvider(store.profiles[profileId]?.provider)) {
     return false;
@@ -54,6 +55,16 @@ export function isProfileInCooldown(
   }
   const unusableUntil = resolveProfileUnusableUntil(stats);
   const ts = now ?? Date.now();
+  if (
+    stats.cooldownReason === "rate_limit" &&
+    typeof forModel === "string" &&
+    forModel.trim().length > 0 &&
+    typeof stats.cooldownModel === "string" &&
+    stats.cooldownModel.trim().length > 0 &&
+    stats.cooldownModel.trim() !== forModel.trim()
+  ) {
+    return false;
+  }
   return unusableUntil ? ts < unusableUntil : false;
 }
 
@@ -397,6 +408,7 @@ function computeNextProfileUsageStats(params: {
   existing: ProfileUsageStats;
   now: number;
   reason: AuthProfileFailureReason;
+  modelId?: string;
   cfgResolved: ResolvedAuthCooldownConfig;
 }): ProfileUsageStats {
   const windowMs = params.cfgResolved.failureWindowMs;
@@ -442,15 +454,36 @@ function computeNextProfileUsageStats(params: {
       recomputedUntil: params.now + backoffMs,
     });
     updatedStats.disabledReason = params.reason;
+    updatedStats.cooldownReason = undefined;
+    updatedStats.cooldownModel = undefined;
   } else {
     const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    const existingCooldownUntil = params.existing.cooldownUntil;
+    const keepsExistingCooldownWindow =
+      typeof existingCooldownUntil === "number" &&
+      Number.isFinite(existingCooldownUntil) &&
+      existingCooldownUntil > params.now;
     // Keep active cooldown windows immutable so retries within the window
     // cannot push recovery further out.
     updatedStats.cooldownUntil = keepActiveWindowOrRecompute({
-      existingUntil: params.existing.cooldownUntil,
+      existingUntil: existingCooldownUntil,
       now: params.now,
       recomputedUntil: params.now + backoffMs,
     });
+    if (keepsExistingCooldownWindow) {
+      // Keep metadata aligned with the preserved active window so a later
+      // transient failure cannot widen a model-scoped cooldown back to profile-wide.
+      updatedStats.cooldownReason = params.existing.cooldownReason;
+      updatedStats.cooldownModel = params.existing.cooldownModel;
+    } else {
+      updatedStats.cooldownReason = params.reason;
+      updatedStats.cooldownModel =
+        params.reason === "rate_limit" &&
+        typeof params.modelId === "string" &&
+        params.modelId.trim().length > 0
+          ? params.modelId.trim()
+          : undefined;
+    }
   }
 
   return updatedStats;
@@ -465,11 +498,12 @@ export async function markAuthProfileFailure(params: {
   store: AuthProfileStore;
   profileId: string;
   reason: AuthProfileFailureReason;
+  modelId?: string;
   cfg?: OpenClawConfig;
   agentDir?: string;
   runId?: string;
 }): Promise<void> {
-  const { store, profileId, reason, agentDir, cfg, runId } = params;
+  const { store, profileId, reason, modelId, agentDir, cfg, runId } = params;
   const profile = store.profiles[profileId];
   if (!profile || isAuthCooldownBypassedForProvider(profile.provider)) {
     return;
@@ -497,6 +531,7 @@ export async function markAuthProfileFailure(params: {
         existing: previousStats ?? {},
         now,
         reason,
+        modelId,
         cfgResolved,
       });
       nextStats = computed;
@@ -535,6 +570,7 @@ export async function markAuthProfileFailure(params: {
     existing: previousStats ?? {},
     now,
     reason,
+    modelId,
     cfgResolved,
   });
   nextStats = computed;

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -56,6 +56,7 @@ export function isProfileInCooldown(
   const unusableUntil = resolveProfileUnusableUntil(stats);
   const ts = now ?? Date.now();
   if (
+    !isActiveUnusableWindow(stats.disabledUntil, ts) &&
     stats.cooldownReason === "rate_limit" &&
     typeof forModel === "string" &&
     forModel.trim().length > 0 &&
@@ -223,6 +224,8 @@ export function clearExpiredCooldowns(store: AuthProfileStore, now?: number): bo
 
     if (cooldownExpired) {
       stats.cooldownUntil = undefined;
+      stats.cooldownReason = undefined;
+      stats.cooldownModel = undefined;
       profileMutated = true;
     }
     if (disabledExpired) {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1211,6 +1211,50 @@ describe("runWithModelFallback", () => {
       });
     });
 
+    it("does not skip a provider when the stored rate-limit cooldown is for a different model", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+      const store: AuthProfileStore = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "test-key" },
+          "groq:default": { type: "api_key", provider: "groq", key: "test-key" },
+        },
+        usageStats: {
+          "anthropic:default": {
+            cooldownUntil: Date.now() + 300000,
+            cooldownReason: "rate_limit",
+            cooldownModel: "claude-opus-4-6",
+          },
+        },
+      };
+      saveAuthProfileStore(store, tmpDir);
+
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-sonnet-4-5",
+              fallbacks: ["groq/llama-3.3-70b-versatile"],
+            },
+          },
+        },
+      });
+
+      const run = vi.fn().mockResolvedValueOnce("sonnet success");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        run,
+        agentDir: tmpDir,
+      });
+
+      expect(result.result).toBe("sonnet success");
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5");
+    });
+
     it("skips same-provider models on auth cooldown but still tries no-profile fallback providers", async () => {
       const { dir } = await makeAuthStoreWithCooldown("anthropic", "auth");
       const cfg = makeCfg({

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -542,7 +542,9 @@ export async function runWithModelFallback<T>(params: {
         store: authStore,
         provider: candidate.provider,
       });
-      const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
+      const isAnyProfileAvailable = profileIds.some(
+        (id) => !isProfileInCooldown(authStore, id, undefined, candidate.model),
+      );
 
       if (profileIds.length > 0 && !isAnyProfileAvailable) {
         // All profiles for this provider are in cooldown.

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -218,6 +218,8 @@ const writeAuthStore = async (
       {
         lastUsed?: number;
         cooldownUntil?: number;
+        cooldownReason?: AuthProfileFailureReason;
+        cooldownModel?: string;
         disabledUntil?: number;
         disabledReason?: AuthProfileFailureReason;
         failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
@@ -332,6 +334,8 @@ async function readUsageStats(agentDir: string) {
       {
         lastUsed?: number;
         cooldownUntil?: number;
+        cooldownReason?: AuthProfileFailureReason;
+        cooldownModel?: string;
         disabledUntil?: number;
         disabledReason?: AuthProfileFailureReason;
       }
@@ -1119,6 +1123,43 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
         allowTransientCooldownProbe: true,
         timeoutMs: 5_000,
         runId: "run:billing-cooldown-probe-no-fallbacks",
+      });
+
+      expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);
+      expect(result.payloads?.[0]?.text ?? "").toContain("ok");
+    });
+  });
+
+  it("does not block a locked profile when its rate-limit cooldown came from a different model", async () => {
+    await withTimedAgentWorkspace(async ({ agentDir, workspaceDir, now }) => {
+      await writeAuthStore(agentDir, {
+        usageStats: {
+          "openai:p1": {
+            lastUsed: 1,
+            cooldownUntil: now + 60 * 60 * 1000,
+            cooldownReason: "rate_limit",
+            cooldownModel: "mock-2",
+          },
+          "openai:p2": { lastUsed: 2 },
+        },
+      });
+
+      mockSingleSuccessfulAttempt();
+
+      const result = await runEmbeddedPiAgent({
+        sessionId: "session:test",
+        sessionKey: "agent:test:model-specific-cooldown-lock",
+        sessionFile: path.join(workspaceDir, "session.jsonl"),
+        workspaceDir,
+        agentDir,
+        config: makeConfig(),
+        prompt: "hello",
+        provider: "openai",
+        model: "mock-1",
+        authProfileId: "openai:p1",
+        authProfileIdSource: "user",
+        timeoutMs: 5_000,
+        runId: "run:model-specific-cooldown-lock",
       });
 
       expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -638,7 +638,7 @@ export async function runEmbeddedPiAgent(
         let nextIndex = profileIndex + 1;
         while (nextIndex < profileCandidates.length) {
           const candidate = profileCandidates[nextIndex];
-          if (candidate && isProfileInCooldown(authStore, candidate)) {
+          if (candidate && isProfileInCooldown(authStore, candidate, undefined, modelId)) {
             nextIndex += 1;
             continue;
           }
@@ -665,7 +665,9 @@ export async function runEmbeddedPiAgent(
         );
         const allAutoProfilesInCooldown =
           autoProfileCandidates.length > 0 &&
-          autoProfileCandidates.every((candidate) => isProfileInCooldown(authStore, candidate));
+          autoProfileCandidates.every((candidate) =>
+            isProfileInCooldown(authStore, candidate, undefined, modelId),
+          );
         const unavailableReason = allAutoProfilesInCooldown
           ? (resolveProfilesUnavailableReason({
               store: authStore,
@@ -684,7 +686,9 @@ export async function runEmbeddedPiAgent(
         while (profileIndex < profileCandidates.length) {
           const candidate = profileCandidates[profileIndex];
           const inCooldown =
-            candidate && candidate !== lockedProfileId && isProfileInCooldown(authStore, candidate);
+            candidate &&
+            candidate !== lockedProfileId &&
+            isProfileInCooldown(authStore, candidate, undefined, modelId);
           if (inCooldown) {
             if (allowTransientCooldownProbe && !didTransientCooldownProbe) {
               didTransientCooldownProbe = true;
@@ -763,6 +767,7 @@ export async function runEmbeddedPiAgent(
           store: authStore,
           profileId,
           reason,
+          modelId,
           cfg: params.config,
           agentDir,
           runId: params.runId,


### PR DESCRIPTION
## Summary

- Problem: auth-profile cooldowns were being made model-aware for rate limits, but an active model-scoped cooldown could still be rewritten by a later transient failure during the same window.
- Why it matters: that rewrite widened the cooldown back to profile-wide behavior and could block same-provider fallback models again.
- What changed: store the triggering model on rate-limit cooldowns, use model-aware cooldown checks in fallback and embedded-runner paths, and preserve cooldown metadata when an active cooldown window is intentionally kept immutable.
- What did NOT change (scope boundary): auth/billing-style profile-wide failures still remain profile-wide, and this PR does not change model-id normalization behavior beyond the existing string comparison.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens
- [ ] Skills / tool execution
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44332
- Related #43879

## User-visible / Behavior Changes

Rate-limit cooldowns on one model no longer block fallback to a different model on the same auth profile, and later transient failures during that active cooldown window no longer collapse the cooldown back to profile-wide behavior.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local workspace
- Model/provider: auth-profile cooldown + fallback paths
- Integration/channel (if any): N/A
- Relevant config (redacted): auth profiles with same-provider multi-model fallback

### Steps

1. Put an auth profile into a rate-limit cooldown for model A.
2. Run fallback/model-selection for model B on the same provider/profile.
3. Trigger a later transient cooldown-class failure during the active window.

### Expected

- Model B is not blocked just because model A was rate-limited.
- The active cooldown keeps its original model-scoped metadata until expiry.

### Actual

- Verified by regression tests after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: model-aware cooldown check, preserved active cooldown metadata, same-provider fallback remains available when the stored cooldown is for a different model.
- Edge cases checked: non-rate-limit cooldowns still block other models; active cooldown windows still do not extend on retry.
- What you did **not** verify: the `*.e2e.test.ts` file via the default `pnpm test` entrypoint, because this repo excludes E2E tests from that filter.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or switch back to provider-wide cooldown behavior by removing the model-aware cooldown checks.
- Files/config to restore: `src/agents/auth-profiles/usage.ts`, `src/agents/model-fallback.ts`, `src/agents/pi-embedded-runner/run.ts`
- Known bad symptoms reviewers should watch for: same-provider fallback models being skipped after a rate limit on a different model, or cooldown metadata changing mid-window.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: model IDs are compared as strings, so alias/canonical mismatches would not count as the same model.
- Mitigation: current callers already pass normalized model IDs; this PR keeps that assumption explicit and covered by focused tests.
