### PR TITLE
fix(test): disable color output in loader tests for cross-platform consistency

### DIFF
--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -32,8 +32,11 @@ describe("loader", () => {
     await fs.mkdir(tmpDir, { recursive: true });
 
     // Disable bundled hooks during tests by setting env var to non-existent directory
-    envSnapshot = captureEnv(["OPENCLAW_BUNDLED_HOOKS_DIR"]);
+    // Disable color output to ensure consistent log format across platforms
+    envSnapshot = captureEnv(["OPENCLAW_BUNDLED_HOOKS_DIR", "NO_COLOR", "FORCE_COLOR"]);
     process.env.OPENCLAW_BUNDLED_HOOKS_DIR = "/nonexistent/bundled/hooks";
+    process.env.NO_COLOR = "1";
+    delete process.env.FORCE_COLOR;
     setLoggerOverride({ level: "silent", consoleLevel: "error" });
     loggingState.rawConsole = {
       log: vi.fn(),


### PR DESCRIPTION
## Problem

The 'sanitizes control characters in loader error logs' test was failing on Windows CI because chalk was generating ANSI color codes. While `stripAnsi` should remove these codes, there were inconsistencies across platforms.

## Solution

Set `NO_COLOR=1` and clear `FORCE_COLOR` in the test's `beforeEach` to ensure consistent log output format across all platforms (Linux, macOS, Windows).

## Testing

- This fix ensures the test passes on Windows CI where it was previously failing
- No functional changes to the actual code, only test setup

Fixes flaky test in #43525