### PR TITLE
Outbound: normalize attachment file names

### DIFF
--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -55,3 +55,39 @@ describe("message action sandbox media hydration", () => {
     }
   });
 });
+
+describe("message action attachment filename inference", () => {
+  it("strips Windows-style path segments from encoded media URLs", async () => {
+    const args: Record<string, unknown> = {
+      media: "https://example.com/uploads/..%5Csecret.txt?sig=123",
+    };
+
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "slack",
+      args,
+      action: "sendAttachment",
+      dryRun: true,
+      mediaPolicy: { mode: "host" },
+    });
+
+    expect(args.filename).toBe("secret.txt");
+  });
+
+  it("strips Windows-style path segments from raw media hints", async () => {
+    const args: Record<string, unknown> = {
+      media: "..\\private\\voice-note.m4a#fragment",
+    };
+
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "slack",
+      args,
+      action: "sendAttachment",
+      dryRun: true,
+      mediaPolicy: { mode: "host" },
+    });
+
+    expect(args.filename).toBe("voice-note.m4a");
+  });
+});

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -105,23 +105,35 @@ function inferAttachmentFilename(params: {
   mediaHint?: string;
   contentType?: string;
 }): string | undefined {
+  const safeBaseName = (value: string) => path.win32.basename(path.posix.basename(value));
+  const stripQueryAndHash = (value: string) => {
+    const noHash = value.split("#")[0] ?? value;
+    return noHash.split("?")[0] ?? noHash;
+  };
   const mediaHint = params.mediaHint?.trim();
   if (mediaHint) {
     try {
       if (mediaHint.startsWith("file://")) {
         const filePath = fileURLToPath(mediaHint);
-        const base = path.basename(filePath);
+        const base = safeBaseName(filePath);
         if (base) {
           return base;
         }
       } else if (/^https?:\/\//i.test(mediaHint)) {
         const url = new URL(mediaHint);
-        const base = path.basename(url.pathname);
+        const decodedPath = (() => {
+          try {
+            return decodeURIComponent(url.pathname);
+          } catch {
+            return url.pathname;
+          }
+        })();
+        const base = safeBaseName(decodedPath);
         if (base) {
           return base;
         }
       } else {
-        const base = path.basename(mediaHint);
+        const base = safeBaseName(stripQueryAndHash(mediaHint));
         if (base) {
           return base;
         }


### PR DESCRIPTION
## Summary
- normalize outbound attachment file names through separator-agnostic basename handling
- strip encoded and raw Windows-style path segments out of attachment media hints on non-Windows hosts
- add regression coverage through `hydrateAttachmentParamsForAction()` dry-run inference

## Testing
- pnpm test src/infra/outbound/message-action-params.test.ts
- pnpm check
- pnpm build
