### PR TITLE
fix(ui): session dropdown shows label instead of key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Z.AI/onboarding: detect a working default model even for explicit `zai-coding-*` endpoint choices, so Coding Plan setup can keep the selected endpoint while defaulting to `glm-5` when available or `glm-4.7` as fallback. (#45969)
+- Control UI/chat sessions: show human-readable labels in the grouped session dropdown again, keep unique scoped fallbacks when metadata is missing, and disambiguate duplicate labels only when needed. (#45130) thanks @luzhidong.
 
 ## 2026.3.13
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -691,12 +691,8 @@ function resolveSessionScopedOptionLabel(
   }
 
   const label = row.label?.trim() || "";
-  if (label && label !== key) {
-    return resolveSessionDisplayName(key, row);
-  }
-
   const displayName = row.displayName?.trim() || "";
-  if (displayName && displayName !== key) {
+  if ((label && label !== key) || (displayName && displayName !== key)) {
     return resolveSessionDisplayName(key, row);
   }
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -672,12 +672,7 @@ function resolveSessionScopedOptionLabel(
   if (!row) {
     return rest?.trim() || key;
   }
-  // Priority: label > displayName > key
-  const label =
-    typeof row.label === "string" && row.label.trim().length > 0 ? row.label.trim() : null;
-  if (label) {
-    return label;
-  }
+  // Priority: displayName > label > rest > key
   const displayName =
     typeof row.displayName === "string" && row.displayName.trim().length > 0
       ? row.displayName.trim()
@@ -685,7 +680,12 @@ function resolveSessionScopedOptionLabel(
   if (displayName && displayName !== key) {
     return displayName;
   }
-  return key;
+  const label =
+    typeof row.label === "string" && row.label.trim().length > 0 ? row.label.trim() : null;
+  if (label) {
+    return label;
+  }
+  return rest?.trim() || key;
 }
 
 type ThemeOption = { id: ThemeName; label: string; icon: string };

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -673,9 +673,8 @@ function resolveSessionScopedOptionLabel(
     return rest?.trim() || key;
   }
   // Priority: label > displayName > key
-  const label = typeof row.label === "string" && row.label.trim().length > 0
-    ? row.label.trim()
-    : null;
+  const label =
+    typeof row.label === "string" && row.label.trim().length > 0 ? row.label.trim() : null;
   if (label) {
     return label;
   }

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -669,23 +669,22 @@ function resolveSessionScopedOptionLabel(
   row?: SessionsListResult["sessions"][number],
   rest?: string,
 ) {
+  const base = rest?.trim() || key;
   if (!row) {
-    return rest?.trim() || key;
+    return base;
   }
-  // Priority: displayName > label > rest > key
-  const displayName =
-    typeof row.displayName === "string" && row.displayName.trim().length > 0
-      ? row.displayName.trim()
-      : null;
+
+  const label = row.label?.trim() || "";
+  if (label && label !== key) {
+    return resolveSessionDisplayName(key, row);
+  }
+
+  const displayName = row.displayName?.trim() || "";
   if (displayName && displayName !== key) {
-    return displayName;
+    return resolveSessionDisplayName(key, row);
   }
-  const label =
-    typeof row.label === "string" && row.label.trim().length > 0 ? row.label.trim() : null;
-  if (label) {
-    return label;
-  }
-  return rest?.trim() || key;
+
+  return base;
 }
 
 type ThemeOption = { id: ThemeName; label: string; icon: string };

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -575,6 +575,7 @@ export function isCronSessionKey(key: string): boolean {
 type SessionOptionEntry = {
   key: string;
   label: string;
+  scopeLabel: string;
   title: string;
 };
 
@@ -625,10 +626,12 @@ export function resolveSessionOptionGroups(
           resolveAgentGroupLabel(state, parsed.agentId),
         )
       : ensureGroup("other", "Other Sessions");
+    const scopeLabel = parsed?.rest?.trim() || key;
     const label = resolveSessionScopedOptionLabel(key, row, parsed?.rest);
     group.options.push({
       key,
       label,
+      scopeLabel,
       title: key,
     });
   };
@@ -643,6 +646,19 @@ export function resolveSessionOptionGroups(
     addOption(row.key);
   }
   addOption(sessionKey);
+
+  for (const group of groups.values()) {
+    const counts = new Map<string, number>();
+    for (const option of group.options) {
+      counts.set(option.label, (counts.get(option.label) ?? 0) + 1);
+    }
+    for (const option of group.options) {
+      if ((counts.get(option.label) ?? 0) > 1 && option.scopeLabel !== option.label) {
+        option.label = `${option.label} · ${option.scopeLabel}`;
+      }
+    }
+  }
+
   return Array.from(groups.values());
 }
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -669,22 +669,24 @@ function resolveSessionScopedOptionLabel(
   row?: SessionsListResult["sessions"][number],
   rest?: string,
 ) {
-  const base = rest?.trim() || key;
   if (!row) {
-    return base;
+    return rest?.trim() || key;
+  }
+  // Priority: label > displayName > key
+  const label = typeof row.label === "string" && row.label.trim().length > 0
+    ? row.label.trim()
+    : null;
+  if (label) {
+    return label;
   }
   const displayName =
     typeof row.displayName === "string" && row.displayName.trim().length > 0
       ? row.displayName.trim()
       : null;
-  const label = typeof row.label === "string" ? row.label.trim() : "";
-  const showDisplayName = Boolean(
-    displayName && displayName !== key && displayName !== label && displayName !== base,
-  );
-  if (!showDisplayName) {
-    return base;
+  if (displayName && displayName !== key) {
+    return displayName;
   }
-  return `${base} · ${displayName}`;
+  return key;
 }
 
 type ThemeOption = { id: ThemeName; label: string; icon: string };

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -726,4 +726,45 @@ describe("chat view", () => {
     expect(labels).toContain("subagent:4f2146de-887b-4176-9abe-91140082959b");
     expect(labels).not.toContain("Subagent:");
   });
+
+  it("disambiguates duplicate grouped labels with the scoped key suffix", () => {
+    const { state } = createChatHeaderState({ omitSessionFromList: true });
+    state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
+    state.settings.sessionKey = state.sessionKey;
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 2,
+      defaults: { model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b",
+          kind: "direct",
+          updatedAt: null,
+          label: "cron-config-check",
+        },
+        {
+          key: "agent:main:subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
+          kind: "direct",
+          updatedAt: null,
+          label: "cron-config-check",
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
+    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
+      option.textContent?.trim(),
+    );
+
+    expect(labels).toContain(
+      "Subagent: cron-config-check · subagent:4f2146de-887b-4176-9abe-91140082959b",
+    );
+    expect(labels).toContain(
+      "Subagent: cron-config-check · subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
+    );
+    expect(labels).not.toContain("Subagent: cron-config-check");
+  });
 });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -647,4 +647,83 @@ describe("chat view", () => {
     expect(rerendered?.value).toBe("gpt-5-mini");
     vi.unstubAllGlobals();
   });
+
+  it("prefers the session label over displayName in the grouped chat session selector", () => {
+    const { state } = createChatHeaderState({ omitSessionFromList: true });
+    state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
+    state.settings.sessionKey = state.sessionKey;
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: state.sessionKey,
+          kind: "direct",
+          updatedAt: null,
+          label: "cron-config-check",
+          displayName: "webchat:g-agent-main-subagent-4f2146de-887b-4176-9abe-91140082959b",
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
+    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
+      option.textContent?.trim(),
+    );
+
+    expect(labels).toContain("Subagent: cron-config-check");
+    expect(labels).not.toContain(state.sessionKey);
+    expect(labels).not.toContain(
+      "subagent:4f2146de-887b-4176-9abe-91140082959b · webchat:g-agent-main-subagent-4f2146de-887b-4176-9abe-91140082959b",
+    );
+  });
+
+  it("keeps a unique scoped fallback when the current grouped session is missing from sessions.list", () => {
+    const { state } = createChatHeaderState({ omitSessionFromList: true });
+    state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
+    state.settings.sessionKey = state.sessionKey;
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
+    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
+      option.textContent?.trim(),
+    );
+
+    expect(labels).toContain("subagent:4f2146de-887b-4176-9abe-91140082959b");
+    expect(labels).not.toContain("Subagent:");
+  });
+
+  it("keeps a unique scoped fallback when a grouped session row has no label or displayName", () => {
+    const { state } = createChatHeaderState({ omitSessionFromList: true });
+    state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
+    state.settings.sessionKey = state.sessionKey;
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: state.sessionKey,
+          kind: "direct",
+          updatedAt: null,
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
+    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
+      option.textContent?.trim(),
+    );
+
+    expect(labels).toContain("subagent:4f2146de-887b-4176-9abe-91140082959b");
+    expect(labels).not.toContain("Subagent:");
+  });
 });


### PR DESCRIPTION
Fixes #45120

## Problem
In OpenClaw 2026.3.12, the session dropdown in the Control UI chat tab shows session keys (e.g., `agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b`) instead of human-readable labels (e.g., `cron-config-check`).

## Root Cause
The `resolveSessionScopedOptionLabel` function in `ui/src/ui/app-render.helpers.ts` does not properly use the `row.label` field. It prioritizes `displayName` over `label`.

## Fix
Changed the priority to: **label > displayName > key**

- If session has a `label`, use it
- Otherwise, if it has a `displayName`, use that
- Fall back to the raw key

## Testing
Tested locally with OpenClaw 2026.3.12 - session dropdown now correctly shows labels.

## Screenshot
Before: Shows `agent:main:subagent:4f2146de...`
After: Shows `cron-config-check`