### PR TITLE
feat(slack): add mux receiver for multi-gateway deployments

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -60,6 +60,9 @@ function getTokenForOperation(
 
 function isSlackAccountConfigured(account: ResolvedSlackAccount): boolean {
   const mode = account.config.mode ?? "socket";
+  if (mode === "mux") {
+    return Boolean(account.config.mux?.url);
+  }
   const hasBotToken = Boolean(account.botToken?.trim());
   if (!hasBotToken) {
     return false;

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -79,11 +79,22 @@ export type SlackThreadConfig = {
   initialHistoryLimit?: number;
 };
 
+export type SlackMuxConfig = {
+  /** WebSocket URL of the mux service. */
+  url?: string;
+  /** MCP server URL for OAuth token cache lookup. */
+  mcpServerUrl?: string;
+  /** Explicit auth token for the mux connection. */
+  token?: string;
+};
+
 export type SlackAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
-  /** Slack connection mode (socket|http). Default: socket. */
-  mode?: "socket" | "http";
+  /** Slack connection mode (socket|http|mux). Default: socket. */
+  mode?: "socket" | "http" | "mux";
+  /** Mux receiver configuration (required when mode is "mux"). */
+  mux?: SlackMuxConfig;
   /** Slack signing secret (required for HTTP mode). */
   signingSecret?: string;
   /** Slack Events API webhook path (default: /slack/events). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -784,6 +784,14 @@ export const GoogleChatConfigSchema = GoogleChatAccountSchema.extend({
   defaultAccount: z.string().optional(),
 });
 
+export const SlackMuxSchema = z
+  .object({
+    url: z.string().min(1).optional(),
+    mcpServerUrl: z.string().optional(),
+    token: z.string().optional().register(sensitive),
+  })
+  .strict();
+
 export const SlackDmSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -828,9 +836,10 @@ const SlackReplyToModeByChatTypeSchema = z
 export const SlackAccountSchema = z
   .object({
     name: z.string().optional(),
-    mode: z.enum(["socket", "http"]).optional(),
+    mode: z.enum(["socket", "http", "mux"]).optional(),
     signingSecret: SecretInputSchema.optional().register(sensitive),
     webhookPath: z.string().optional(),
+    mux: SlackMuxSchema.optional(),
     capabilities: z.array(z.string()).optional(),
     markdown: MarkdownConfigSchema,
     enabled: z.boolean().optional(),
@@ -903,7 +912,7 @@ export const SlackAccountSchema = z
   });
 
 export const SlackConfigSchema = SlackAccountSchema.safeExtend({
-  mode: z.enum(["socket", "http"]).optional().default("socket"),
+  mode: z.enum(["socket", "http", "mux"]).optional().default("socket"),
   signingSecret: SecretInputSchema.optional().register(sensitive),
   webhookPath: z.string().optional().default("/slack/events"),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),
@@ -932,6 +941,13 @@ export const SlackConfigSchema = SlackAccountSchema.safeExtend({
   });
 
   const baseMode = value.mode ?? "socket";
+  if (baseMode === "mux" && !value.mux?.url) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["mux", "url"],
+      message: 'channels.slack.mode="mux" requires channels.slack.mux.url',
+    });
+  }
   if (!value.accounts) {
     validateSlackSigningSecretRequirements(value, ctx);
     return;
@@ -944,6 +960,13 @@ export const SlackConfigSchema = SlackAccountSchema.safeExtend({
       continue;
     }
     const accountMode = account.mode ?? baseMode;
+    if (accountMode === "mux" && !account.mux?.url && !value.mux?.url) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["accounts", accountId, "mux", "url"],
+        message: 'channels.slack.accounts.*.mode="mux" requires mux.url at account or base level',
+      });
+    }
     const effectivePolicy =
       account.dmPolicy ?? account.dm?.policy ?? value.dmPolicy ?? value.dm?.policy ?? "pairing";
     const effectiveAllowFrom =

--- a/src/slack/account-inspect.ts
+++ b/src/slack/account-inspect.ts
@@ -162,11 +162,14 @@ export function inspectSlackAccount(params: {
         : envUser
           ? "available"
           : "missing",
-    configured: isHttpMode
-      ? (configBot.status !== "missing" || Boolean(envBot)) &&
-        configSigningSecret.status !== "missing"
-      : (configBot.status !== "missing" || Boolean(envBot)) &&
-        (configApp.status !== "missing" || Boolean(envApp)),
+    configured:
+      mode === "mux"
+        ? Boolean(merged.mux?.url)
+        : isHttpMode
+          ? (configBot.status !== "missing" || Boolean(envBot)) &&
+            configSigningSecret.status !== "missing"
+          : (configBot.status !== "missing" || Boolean(envBot)) &&
+            (configApp.status !== "missing" || Boolean(envApp)),
     config: merged,
     groupPolicy: merged.groupPolicy,
     textChunkLimit: merged.textChunkLimit,

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -124,6 +124,12 @@ export function createSlackMonitorContext(params: {
   const channelHistories = new Map<string, HistoryEntry[]>();
   const logger = getChildLogger({ module: "slack-auto-reply" });
 
+  // Mutable live bindings: in mux mode auth.test runs after context creation,
+  // so these values are patched post-construction.  Closures that reference them
+  // (shouldDropMismatchedSlackEvent, sessionKeyFn) read the live variables.
+  let liveTeamId = params.teamId;
+  let liveApiAppId = params.apiAppId;
+
   const channelCache = new Map<
     string,
     {
@@ -180,7 +186,7 @@ export function createSlackMonitorContext(params: {
           cfg: params.cfg,
           channel: "slack",
           accountId: params.accountId,
-          teamId: params.teamId,
+          teamId: liveTeamId,
           peer: { kind: peerKind, id: peerId },
         });
         return route.sessionKey;
@@ -372,28 +378,28 @@ export function createSlackMonitorContext(params: {
           ? raw.team.id
           : "";
 
-    if (params.apiAppId && incomingApiAppId && incomingApiAppId !== params.apiAppId) {
+    if (liveApiAppId && incomingApiAppId && incomingApiAppId !== liveApiAppId) {
       logVerbose(
-        `slack: drop event with api_app_id=${incomingApiAppId} (expected ${params.apiAppId})`,
+        `slack: drop event with api_app_id=${incomingApiAppId} (expected ${liveApiAppId})`,
       );
       return true;
     }
-    if (params.teamId && incomingTeamId && incomingTeamId !== params.teamId) {
-      logVerbose(`slack: drop event with team_id=${incomingTeamId} (expected ${params.teamId})`);
+    if (liveTeamId && incomingTeamId && incomingTeamId !== liveTeamId) {
+      logVerbose(`slack: drop event with team_id=${incomingTeamId} (expected ${liveTeamId})`);
       return true;
     }
     return false;
   };
 
-  return {
+  const ctx: SlackMonitorContext = {
     cfg: params.cfg,
     accountId: params.accountId,
     botToken: params.botToken,
     app: params.app,
     runtime: params.runtime,
     botUserId: params.botUserId,
-    teamId: params.teamId,
-    apiAppId: params.apiAppId,
+    teamId: liveTeamId,
+    apiAppId: liveApiAppId,
     historyLimit: params.historyLimit,
     channelHistories,
     sessionScope: params.sessionScope,
@@ -429,4 +435,26 @@ export function createSlackMonitorContext(params: {
     resolveUserName,
     setSlackThreadStatus,
   };
+
+  // Make teamId and apiAppId settable so that provider.ts can patch them
+  // after deferred auth.test in mux mode.  The live bindings ensure closures
+  // (shouldDropMismatchedSlackEvent, sessionKeyFn) see the updated values.
+  Object.defineProperty(ctx, "teamId", {
+    get: () => liveTeamId,
+    set: (v: string) => {
+      liveTeamId = v;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(ctx, "apiAppId", {
+    get: () => liveApiAppId,
+    set: (v: string) => {
+      liveApiAppId = v;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
+  return ctx;
 }

--- a/src/slack/monitor/message-handler/prepare-content.ts
+++ b/src/slack/monitor/message-handler/prepare-content.ts
@@ -49,17 +49,23 @@ export async function resolveSlackMessageContent(params: {
     threadStarter: params.threadStarter,
   });
 
-  const media = await resolveSlackMedia({
-    files: ownFiles,
-    token: params.botToken,
-    maxBytes: params.mediaMaxBytes,
-  });
+  // In mux mode botToken is empty — skip media downloads that require a real
+  // Slack token for Bearer auth (file URLs are not proxied through the mux).
+  const media = params.botToken
+    ? await resolveSlackMedia({
+        files: ownFiles,
+        token: params.botToken,
+        maxBytes: params.mediaMaxBytes,
+      })
+    : null;
 
-  const attachmentContent = await resolveSlackAttachmentContent({
-    attachments: params.message.attachments,
-    token: params.botToken,
-    maxBytes: params.mediaMaxBytes,
-  });
+  const attachmentContent = params.botToken
+    ? await resolveSlackAttachmentContent({
+        attachments: params.message.attachments,
+        token: params.botToken,
+        maxBytes: params.mediaMaxBytes,
+      })
+    : null;
 
   const mergedMedia = [...(media ?? []), ...(attachmentContent?.media ?? [])];
   const effectiveDirectMedia = mergedMedia.length > 0 ? mergedMedia : null;

--- a/src/slack/monitor/message-handler/prepare-thread-context.ts
+++ b/src/slack/monitor/message-handler/prepare-thread-context.ts
@@ -55,7 +55,12 @@ export async function resolveSlackThreadContextData(params: {
     threadStarterBody = starter.text;
     const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
     threadLabel = `Slack thread ${params.roomLabel}${snippet ? `: ${snippet}` : ""}`;
-    if (!params.effectiveDirectMedia && starter.files && starter.files.length > 0) {
+    if (
+      !params.effectiveDirectMedia &&
+      starter.files &&
+      starter.files.length > 0 &&
+      params.ctx.botToken
+    ) {
       threadStarterMedia = await resolveSlackMedia({
         files: starter.files,
         token: params.ctx.botToken,

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -28,8 +28,10 @@ import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveSlackAccount } from "../accounts.js";
 import { resolveSlackWebClientOptions } from "../client.js";
 import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/index.js";
+import { MuxReceiver, installMuxApiProxy } from "../mux-receiver.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
 import { resolveSlackUserAllowlist } from "../resolve-users.js";
+import { setMuxProxyClient } from "../send.js";
 import { resolveSlackAppToken, resolveSlackBotToken } from "../token.js";
 import { normalizeAllowList } from "./allow-list.js";
 import { resolveSlackSlashCommandConfig } from "./commands.js";
@@ -135,7 +137,15 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   });
   const botToken = resolveSlackBotToken(opts.botToken ?? account.botToken);
   const appToken = resolveSlackAppToken(opts.appToken ?? account.appToken);
-  if (!botToken || (slackMode !== "http" && !appToken)) {
+
+  if (slackMode === "mux") {
+    const muxUrl = account.config.mux?.url ?? cfg.channels?.slack?.mux?.url;
+    if (!muxUrl) {
+      throw new Error(
+        `Slack mux URL missing for account "${account.accountId}" (set channels.slack.mux.url or channels.slack.accounts.${account.accountId}.mux.url).`,
+      );
+    }
+  } else if (!botToken || (slackMode !== "http" && !appToken)) {
     const missing =
       slackMode === "http"
         ? `Slack bot token missing for account "${account.accountId}" (set channels.slack.accounts.${account.accountId}.botToken or SLACK_BOT_TOKEN for default).`
@@ -185,7 +195,17 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const mediaMaxBytes = (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
 
-  const receiver =
+  const muxReceiver =
+    slackMode === "mux"
+      ? new MuxReceiver({
+          mux: {
+            ...cfg.channels?.slack?.mux,
+            ...account.config.mux,
+          },
+          runtime,
+        })
+      : null;
+  const httpReceiver =
     slackMode === "http"
       ? new HTTPReceiver({
           signingSecret: signingSecret ?? "",
@@ -194,21 +214,31 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       : null;
   const clientOptions = resolveSlackWebClientOptions();
   const app = new App(
-    slackMode === "socket"
+    slackMode === "mux"
       ? {
-          token: botToken,
-          appToken,
-          socketMode: true,
+          authorize: async () => ({ botToken: "", botId: "", botUserId: "" }),
+          receiver: muxReceiver ?? undefined,
           clientOptions,
         }
-      : {
-          token: botToken,
-          receiver: receiver ?? undefined,
-          clientOptions,
-        },
+      : slackMode === "socket"
+        ? {
+            token: botToken,
+            appToken,
+            socketMode: true,
+            clientOptions,
+          }
+        : {
+            token: botToken,
+            receiver: httpReceiver ?? undefined,
+            clientOptions,
+          },
   );
+  if (muxReceiver) {
+    installMuxApiProxy(app as unknown as Parameters<typeof installMuxApiProxy>[0], muxReceiver);
+    setMuxProxyClient(app.client);
+  }
   const slackHttpHandler =
-    slackMode === "http" && receiver
+    slackMode === "http" && httpReceiver
       ? async (req: IncomingMessage, res: ServerResponse) => {
           const guard = installRequestBodyLimitGuard(req, res, {
             maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
@@ -219,7 +249,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             return;
           }
           try {
-            await Promise.resolve(receiver.requestListener(req, res));
+            await Promise.resolve(httpReceiver.requestListener(req, res));
           } catch (err) {
             if (!guard.isTripped()) {
               throw err;
@@ -235,25 +265,34 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let teamId = "";
   let apiAppId = "";
   const expectedApiAppIdFromAppToken = parseApiAppIdFromAppToken(appToken);
-  try {
-    const auth = await app.client.auth.test({ token: botToken });
-    botUserId = auth.user_id ?? "";
-    teamId = auth.team_id ?? "";
-    apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
-  } catch {
-    // auth test failing is non-fatal; message handler falls back to regex mentions.
-  }
 
-  if (apiAppId && expectedApiAppIdFromAppToken && apiAppId !== expectedApiAppIdFromAppToken) {
-    runtime.error?.(
-      `slack token mismatch: bot token api_app_id=${apiAppId} but app token looks like api_app_id=${expectedApiAppIdFromAppToken}`,
-    );
+  const runAuthTest = async () => {
+    try {
+      const auth = await app.client.auth.test(botToken ? { token: botToken } : {});
+      botUserId = auth.user_id ?? "";
+      teamId = auth.team_id ?? "";
+      apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
+    } catch {
+      // auth test failing is non-fatal; message handler falls back to regex mentions.
+    }
+
+    if (apiAppId && expectedApiAppIdFromAppToken && apiAppId !== expectedApiAppIdFromAppToken) {
+      runtime.error?.(
+        `slack token mismatch: bot token api_app_id=${apiAppId} but app token looks like api_app_id=${expectedApiAppIdFromAppToken}`,
+      );
+    }
+  };
+
+  // In mux mode, auth.test is deferred until after app.start() because the
+  // WebSocket must be connected before proxied API calls can be made.
+  if (slackMode !== "mux") {
+    await runAuthTest();
   }
 
   const ctx = createSlackMonitorContext({
     cfg,
     accountId: account.accountId,
-    botToken,
+    botToken: botToken ?? "",
     app,
     runtime,
     botUserId,
@@ -405,7 +444,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   }
 
   const stopOnAbort = () => {
-    if (opts.abortSignal?.aborted && slackMode === "socket") {
+    if (opts.abortSignal?.aborted && (slackMode === "socket" || slackMode === "mux")) {
       void app.stop();
     }
   };
@@ -490,6 +529,26 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         } catch {
           break;
         }
+      }
+    } else if (slackMode === "mux") {
+      await app.start();
+      publishSlackConnectedStatus(opts.setStatus);
+      runtime.log?.("slack mux mode connected");
+
+      // Run deferred auth.test now that the WebSocket is connected
+      await runAuthTest();
+      ctx.botUserId = botUserId;
+      ctx.teamId = teamId;
+      ctx.apiAppId = apiAppId;
+      muxReceiver!.setAuthReady();
+
+      // Keep alive until abort
+      if (!opts.abortSignal?.aborted) {
+        await new Promise<void>((resolve) => {
+          opts.abortSignal?.addEventListener("abort", () => resolve(), {
+            once: true,
+          });
+        });
       }
     } else {
       runtime.log?.(`slack http mode listening at ${slackWebhookPath}`);

--- a/src/slack/monitor/types.ts
+++ b/src/slack/monitor/types.ts
@@ -6,7 +6,7 @@ export type MonitorSlackOpts = {
   botToken?: string;
   appToken?: string;
   accountId?: string;
-  mode?: "socket" | "http";
+  mode?: "socket" | "http" | "mux";
   config?: OpenClawConfig;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;

--- a/src/slack/mux-receiver.test.ts
+++ b/src/slack/mux-receiver.test.ts
@@ -1,0 +1,700 @@
+import { createServer } from "node:net";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import type { RuntimeEnv } from "../runtime.js";
+import { MuxReceiver, installMuxApiProxy } from "./mux-receiver.js";
+
+function getAvailablePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.listen(0, () => {
+      const port = (srv.address() as { port: number }).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function parseWsMessage(data: unknown): Record<string, unknown> {
+  const text =
+    typeof data === "string" ? data : Buffer.isBuffer(data) ? data.toString("utf-8") : String(data);
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+function createTestRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+describe("MuxReceiver", () => {
+  let wss: WebSocketServer;
+  let port: number;
+  let runtime: RuntimeEnv;
+  let receiver: MuxReceiver;
+
+  beforeEach(async () => {
+    port = await getAvailablePort();
+    wss = new WebSocketServer({ port });
+    runtime = createTestRuntime();
+  });
+
+  afterEach(async () => {
+    await receiver?.stop();
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  });
+
+  test("start connects to mux and stop disconnects", async () => {
+    const connected = new Promise<void>((resolve) => {
+      wss.on("connection", () => resolve());
+    });
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({
+      processEvent: vi.fn(),
+      client: { apiCall: vi.fn() },
+    });
+
+    await receiver.start();
+    await connected;
+
+    expect(runtime.log).toHaveBeenCalledWith("slack mux connected");
+    expect(wss.clients.size).toBe(1);
+
+    await receiver.stop();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(wss.clients.size).toBe(0);
+  });
+
+  test("forwards slack_event to app.processEvent", async () => {
+    const processEvent = vi.fn().mockResolvedValue(undefined);
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent, client: { apiCall: vi.fn() } });
+
+    wss.on("connection", (ws) => {
+      ws.send(
+        JSON.stringify({
+          type: "slack_event",
+          payload: {
+            type: "event_callback",
+            event: { type: "message", text: "hello", channel: "C123" },
+          },
+          headers: { "x-slack-signature": "v0=abc", "x-slack-request-timestamp": "123" },
+        }),
+      );
+    });
+
+    await receiver.start();
+    // Mark auth as ready so buffered events are flushed and processed.
+    receiver.setAuthReady();
+    await vi.waitFor(() => expect(processEvent).toHaveBeenCalledTimes(1));
+
+    const event = processEvent.mock.calls[0][0];
+    expect(event.body.type).toBe("event_callback");
+    expect(event.body.event).toEqual({
+      type: "message",
+      text: "hello",
+      channel: "C123",
+    });
+  });
+
+  test("apiCall proxies through mux and returns response", async () => {
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    wss.on("connection", (ws) => {
+      ws.on("message", (data) => {
+        const msg = parseWsMessage(data);
+        if (msg.type === "slack_api") {
+          ws.send(
+            JSON.stringify({
+              type: "slack_api_response",
+              id: msg.id,
+              ok: true,
+              response: { user_id: "U123", team_id: "T456" },
+            }),
+          );
+        }
+      });
+    });
+
+    await receiver.start();
+    const result = await receiver.apiCall("auth.test", {});
+    expect(result).toEqual({ user_id: "U123", team_id: "T456" });
+  });
+
+  test("apiCall rejects on mux error response", async () => {
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    wss.on("connection", (ws) => {
+      ws.on("message", (data) => {
+        const msg = parseWsMessage(data);
+        if (msg.type === "slack_api") {
+          ws.send(
+            JSON.stringify({
+              type: "slack_api_response",
+              id: msg.id,
+              ok: false,
+              response: {},
+              error: "channel_not_found",
+            }),
+          );
+        }
+      });
+    });
+
+    await receiver.start();
+    await expect(receiver.apiCall("conversations.info", { channel: "C000" })).rejects.toThrow(
+      "channel_not_found",
+    );
+  });
+
+  test("apiCall throws when WebSocket is not connected", async () => {
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    await expect(receiver.apiCall("chat.postMessage", {})).rejects.toThrow(
+      "WebSocket not connected",
+    );
+  });
+
+  test("propagates ack payload back through mux when event has id", async () => {
+    const ackReceived = new Promise<Record<string, unknown>>((resolve) => {
+      wss.on("connection", (ws) => {
+        ws.send(
+          JSON.stringify({
+            type: "slack_event",
+            id: "evt-001",
+            payload: { type: "block_actions", actions: [] },
+            headers: {},
+          }),
+        );
+        ws.on("message", (data) => {
+          const msg = parseWsMessage(data);
+          if (msg.type === "slack_ack") {
+            resolve(msg);
+          }
+        });
+      });
+    });
+
+    const processEvent = vi
+      .fn()
+      .mockImplementation(async (event: { ack: (...args: unknown[]) => Promise<void> }) => {
+        await event.ack({ text: "got it" });
+      });
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent, client: { apiCall: vi.fn() } });
+
+    await receiver.start();
+    receiver.setAuthReady();
+    const ack = await ackReceived;
+    expect(ack).toMatchObject({ type: "slack_ack", id: "evt-001", payload: { text: "got it" } });
+  });
+
+  test("ack is no-op when event has no id", async () => {
+    const processEvent = vi
+      .fn()
+      .mockImplementation(async (event: { ack: (...args: unknown[]) => Promise<void> }) => {
+        // Should not throw even though there's no event id
+        await event.ack({ text: "irrelevant" });
+      });
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent, client: { apiCall: vi.fn() } });
+
+    wss.on("connection", (ws) => {
+      ws.send(
+        JSON.stringify({
+          type: "slack_event",
+          // No id field — backward-compat no-op path
+          payload: { type: "event_callback", event: { type: "message" } },
+          headers: {},
+        }),
+      );
+    });
+
+    await receiver.start();
+    receiver.setAuthReady();
+    await vi.waitFor(() => expect(processEvent).toHaveBeenCalledTimes(1));
+    // If we reach here without throwing, the no-op ack worked correctly.
+  });
+
+  test("responds to application-level ping with pong", async () => {
+    const pongReceived = new Promise<Record<string, unknown>>((resolve) => {
+      wss.on("connection", (ws) => {
+        ws.send(JSON.stringify({ type: "ping", ts: 12345 }));
+        ws.on("message", (data) => {
+          const msg = parseWsMessage(data);
+          if (msg.type === "pong") {
+            resolve(msg);
+          }
+        });
+      });
+    });
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    await receiver.start();
+    const pong = await pongReceived;
+    expect(pong).toEqual({ type: "pong", ts: 12345 });
+  });
+
+  test("reconnects with exponential backoff after disconnect", async () => {
+    let connectionCount = 0;
+    wss.on("connection", (ws) => {
+      connectionCount++;
+      if (connectionCount === 1) {
+        ws.close(1001, "going away");
+      }
+    });
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    await receiver.start();
+    await vi.waitFor(() => expect(connectionCount).toBeGreaterThanOrEqual(2), { timeout: 5000 });
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("reconnecting in"));
+  });
+
+  test("rejects in-flight API calls on disconnect", async () => {
+    let serverWs: WebSocket | undefined;
+    wss.on("connection", (ws) => {
+      serverWs = ws;
+    });
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    await receiver.start();
+
+    // Start an API call but don't respond from server
+    const apiPromise = receiver.apiCall("chat.postMessage", { channel: "C123", text: "hi" });
+    // Server closes the connection
+    serverWs!.close(1001, "going away");
+
+    await expect(apiPromise).rejects.toThrow("MuxReceiver: WebSocket disconnected");
+  });
+
+  test("does not reconnect on initial connection failure", async () => {
+    // Close the server so the initial connection fails
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    await expect(receiver.start()).rejects.toThrow();
+    // Give time for any reconnect attempt to fire
+    await new Promise((r) => setTimeout(r, 200));
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("reconnecting in"));
+  });
+
+  test("stop cancels pending apiCall promises", async () => {
+    wss.on("connection", () => {
+      // Server intentionally never responds to API calls.
+    });
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    await receiver.start();
+
+    const apiPromise = receiver.apiCall("chat.postMessage", { channel: "C123", text: "hi" });
+    await receiver.stop();
+
+    await expect(apiPromise).rejects.toThrow("MuxReceiver stopped");
+  });
+
+  test("sends auth header when token is configured", async () => {
+    const authHeader = new Promise<string | undefined>((resolve) => {
+      wss.on("connection", (_ws, req) => {
+        resolve(req.headers.authorization);
+      });
+    });
+
+    receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}`, token: "test-token-123" },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    await receiver.start();
+    expect(await authHeader).toBe("Bearer test-token-123");
+  });
+
+  test("resolves GCP metadata token when no config or env token", async () => {
+    const authHeader = new Promise<string | undefined>((resolve) => {
+      wss.on("connection", (_ws, req) => {
+        resolve(req.headers.authorization);
+      });
+    });
+
+    // Mock fetch to simulate GCP metadata server
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockImplementation((url: string, opts: RequestInit) => {
+      if (
+        url.startsWith("http://metadata.google.internal/") &&
+        (opts.headers as Record<string, string>)?.["Metadata-Flavor"] === "Google"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve("gcp-oidc-token-789"),
+        });
+      }
+      return originalFetch(url, opts);
+    }) as typeof fetch;
+
+    try {
+      receiver = new MuxReceiver({
+        mux: { url: `ws://127.0.0.1:${port}` },
+        runtime,
+      });
+      receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+      await receiver.start();
+      expect(await authHeader).toBe("Bearer gcp-oidc-token-789");
+
+      // Verify audience was derived from mux URL
+      const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain(`audience=${encodeURIComponent(`http://127.0.0.1:${port}`)}`);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("falls through GCP metadata when server is unavailable", async () => {
+    const authHeader = new Promise<string | undefined>((resolve) => {
+      wss.on("connection", (_ws, req) => {
+        resolve(req.headers.authorization);
+      });
+    });
+
+    // Mock fetch to simulate metadata server timeout/failure
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.startsWith("http://metadata.google.internal/")) {
+        return Promise.reject(new Error("ECONNREFUSED"));
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    try {
+      receiver = new MuxReceiver({
+        mux: { url: `ws://127.0.0.1:${port}` },
+        runtime,
+      });
+      receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+      await receiver.start();
+      // Should connect without auth (no token resolved)
+      expect(await authHeader).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("derives correct HTTPS audience from WSS mux URL", async () => {
+    const authHeader = new Promise<string | undefined>((resolve) => {
+      wss.on("connection", (_ws, req) => {
+        resolve(req.headers.authorization);
+      });
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockImplementation((url: string, opts: RequestInit) => {
+      if (
+        url.startsWith("http://metadata.google.internal/") &&
+        (opts.headers as Record<string, string>)?.["Metadata-Flavor"] === "Google"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve("gcp-wss-token"),
+        });
+      }
+      return originalFetch(url, opts);
+    }) as typeof fetch;
+
+    try {
+      // Use wss:// URL but connect to local ws:// for the test
+      receiver = new MuxReceiver({
+        mux: { url: `ws://127.0.0.1:${port}/ws` },
+        runtime,
+      });
+      receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+      await receiver.start();
+      expect(await authHeader).toBe("Bearer gcp-wss-token");
+
+      // Verify /ws path was stripped from audience
+      const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain(`audience=${encodeURIComponent(`http://127.0.0.1:${port}`)}`);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("uses MUX_TOKEN env var when no config token", async () => {
+    const authHeader = new Promise<string | undefined>((resolve) => {
+      wss.on("connection", (_ws, req) => {
+        resolve(req.headers.authorization);
+      });
+    });
+
+    const originalEnv = process.env.MUX_TOKEN;
+    process.env.MUX_TOKEN = "env-token-456";
+    try {
+      receiver = new MuxReceiver({
+        mux: { url: `ws://127.0.0.1:${port}` },
+        runtime,
+      });
+      receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+      await receiver.start();
+      expect(await authHeader).toBe("Bearer env-token-456");
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.MUX_TOKEN;
+      } else {
+        process.env.MUX_TOKEN = originalEnv;
+      }
+    }
+  });
+});
+
+describe("installMuxApiProxy", () => {
+  test("patches app.client.apiCall to route through MuxReceiver", async () => {
+    const port = await getAvailablePort();
+    const wss = new WebSocketServer({ port });
+    const runtime = createTestRuntime();
+
+    wss.on("connection", (ws) => {
+      ws.on("message", (data) => {
+        const msg = parseWsMessage(data);
+        if (msg.type === "slack_api") {
+          ws.send(
+            JSON.stringify({
+              type: "slack_api_response",
+              id: msg.id,
+              ok: true,
+              response: { ok: true, channel: "C123" },
+            }),
+          );
+        }
+      });
+    });
+
+    const receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    const _originalApiCall = vi.fn();
+    const fakeApp = {
+      client: { apiCall: _originalApiCall } as Record<string, unknown> & {
+        apiCall: (...args: unknown[]) => Promise<unknown>;
+      },
+    };
+
+    installMuxApiProxy(fakeApp, receiver);
+    await receiver.start();
+
+    const result = await fakeApp.client.apiCall("chat.postMessage", {
+      channel: "C123",
+      text: "hi",
+    });
+    expect(result).toEqual({ ok: true, channel: "C123" });
+    expect(_originalApiCall).not.toHaveBeenCalled();
+
+    await receiver.stop();
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  });
+});
+
+describe("installMuxApiProxy – convenience method rebinding", () => {
+  test("rebinds nested convenience methods to route through mux proxy", async () => {
+    const port = await getAvailablePort();
+    const wss = new WebSocketServer({ port });
+    const runtime = createTestRuntime();
+
+    const receivedMethods: string[] = [];
+    wss.on("connection", (ws) => {
+      ws.on("message", (data) => {
+        const msg = parseWsMessage(data);
+        if (msg.type === "slack_api") {
+          receivedMethods.push(msg.method as string);
+          ws.send(
+            JSON.stringify({
+              type: "slack_api_response",
+              id: msg.id,
+              ok: true,
+              response: { ok: true },
+            }),
+          );
+        }
+      });
+    });
+
+    const receiver = new MuxReceiver({
+      mux: { url: `ws://127.0.0.1:${port}` },
+      runtime,
+    });
+    receiver.init({ processEvent: vi.fn(), client: { apiCall: vi.fn() } });
+
+    // Simulate the structure that Bolt's WebClient creates via bindApiCall:
+    // convenience methods are pre-bound to the original apiCall.
+    const originalApiCall = vi.fn();
+    const fakeApp = {
+      client: {
+        apiCall: originalApiCall,
+        chat: {
+          postMessage: originalApiCall.bind(null, "chat.postMessage"),
+          update: originalApiCall.bind(null, "chat.update"),
+        },
+        conversations: {
+          info: originalApiCall.bind(null, "conversations.info"),
+          history: originalApiCall.bind(null, "conversations.history"),
+        },
+        // Nested group (like admin.apps.config.set)
+        admin: {
+          apps: {
+            config: {
+              set: originalApiCall.bind(null, "admin.apps.config.set"),
+            },
+          },
+        },
+      } as Record<string, unknown> & {
+        apiCall: (...args: unknown[]) => Promise<unknown>;
+      },
+    };
+
+    installMuxApiProxy(fakeApp, receiver);
+    await receiver.start();
+
+    // Call convenience methods — they should route through the mux, NOT the original
+    const client = fakeApp.client as Record<
+      string,
+      Record<string, (...args: unknown[]) => Promise<unknown>>
+    >;
+    await client.chat.postMessage({ channel: "C123", text: "hello" });
+    await client.conversations.info({ channel: "C123" });
+
+    // Nested method
+    const admin = fakeApp.client.admin as Record<
+      string,
+      Record<string, Record<string, (...args: unknown[]) => Promise<unknown>>>
+    >;
+    await admin.apps.config.set({ app_id: "A123" });
+
+    expect(originalApiCall).not.toHaveBeenCalled();
+    expect(receivedMethods).toEqual([
+      "chat.postMessage",
+      "conversations.info",
+      "admin.apps.config.set",
+    ]);
+
+    await receiver.stop();
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  });
+});
+
+describe("config validation", () => {
+  test("SlackConfigSchema rejects account mux mode without mux.url", async () => {
+    const { SlackConfigSchema } = await import("../config/zod-schema.providers-core.js");
+    const result = SlackConfigSchema.safeParse({
+      accounts: { test: { mode: "mux" } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const muxUrlIssue = result.error.issues.find((i) => i.path.join(".").includes("mux"));
+      expect(muxUrlIssue).toBeDefined();
+    }
+  });
+
+  test("SlackAccountSchema accepts mux mode with mux.url", async () => {
+    const { SlackAccountSchema } = await import("../config/zod-schema.providers-core.js");
+    const result = SlackAccountSchema.safeParse({
+      mode: "mux",
+      mux: { url: "wss://mux.example.com/ws" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("SlackConfigSchema rejects base mux mode without mux.url", async () => {
+    const { SlackConfigSchema } = await import("../config/zod-schema.providers-core.js");
+    const result = SlackConfigSchema.safeParse({ mode: "mux" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const muxUrlIssue = result.error.issues.find((i) => i.path.join(".") === "mux.url");
+      expect(muxUrlIssue).toBeDefined();
+    }
+  });
+
+  test("SlackConfigSchema rejects account mux mode without mux.url", async () => {
+    const { SlackConfigSchema } = await import("../config/zod-schema.providers-core.js");
+    const result = SlackConfigSchema.safeParse({
+      accounts: {
+        work: { mode: "mux" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const muxUrlIssue = result.error.issues.find(
+        (i) => i.path.includes("mux") && i.path.includes("url"),
+      );
+      expect(muxUrlIssue).toBeDefined();
+    }
+  });
+
+  test("SlackConfigSchema accepts account mux with inherited base url", async () => {
+    const { SlackConfigSchema } = await import("../config/zod-schema.providers-core.js");
+    const result = SlackConfigSchema.safeParse({
+      mux: { url: "wss://mux.example.com/ws" },
+      accounts: {
+        work: { mode: "mux", mux: { token: "work-token" } },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/slack/mux-receiver.ts
+++ b/src/slack/mux-receiver.ts
@@ -1,0 +1,557 @@
+import { createHash, randomUUID } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { WebSocket } from "ws";
+import type { SlackMuxConfig } from "../config/types.slack.ts";
+import type { RuntimeEnv } from "../runtime.ts";
+import { audienceFromWsUrl, resolveGcpIdentityToken } from "../utils/gcp-metadata-token.ts";
+
+type BoltApp = {
+  processEvent(event: ReceiverEvent): Promise<void>;
+  client: {
+    apiCall(method: string, options?: Record<string, unknown>): Promise<unknown>;
+  };
+};
+
+export type ReceiverEvent = {
+  body: Record<string, unknown>;
+  retryNum?: number;
+  retryReason?: string;
+  customProperties?: Record<string, unknown>;
+  ack: (...args: unknown[]) => Promise<void>;
+};
+
+/** Inbound message from the mux: a forwarded Slack Events API envelope. */
+type MuxSlackEvent = {
+  type: "slack_event";
+  /** Optional per-event ID used to route ack payloads back to the mux. */
+  id?: string;
+  payload: Record<string, unknown>;
+  headers: Record<string, string>;
+};
+
+type MuxApiResponse = {
+  type: "slack_api_response";
+  id: string;
+  ok: boolean;
+  response: Record<string, unknown>;
+  error?: string;
+};
+
+type MuxPing = {
+  type: "ping";
+  ts?: number;
+};
+
+type MuxInbound = MuxSlackEvent | MuxApiResponse | MuxPing;
+
+type PendingApiCall = {
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export type MuxReceiverOptions = {
+  mux: SlackMuxConfig;
+  runtime?: RuntimeEnv;
+};
+
+const API_CALL_TIMEOUT_MS = 30_000;
+const MAX_BACKOFF_MS = 30_000;
+const INITIAL_BACKOFF_MS = 1_000;
+/** Client-side WebSocket ping interval to keep the connection alive through
+ *  load balancers / proxies that drop idle connections (e.g. GKE Gateway
+ *  default 30 s idle timeout). Must be well under the LB timeout. */
+const CLIENT_PING_INTERVAL_MS = 15_000;
+
+export class MuxReceiver {
+  private app: BoltApp | null = null;
+  private ws: WebSocket | null = null;
+  private stopped = false;
+  private backoffMs = INITIAL_BACKOFF_MS;
+  private pending = new Map<string, PendingApiCall>();
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private resolvedToken: string | null = null;
+  /** Buffer events received before auth identity is initialized so that
+   *  self-message and workspace/app mismatch guards are never bypassed. */
+  private authReady = false;
+  private pendingEvents: MuxSlackEvent[] = [];
+
+  private readonly mux: SlackMuxConfig;
+  private readonly runtime: RuntimeEnv | undefined;
+
+  constructor(opts: MuxReceiverOptions) {
+    this.mux = opts.mux;
+    this.runtime = opts.runtime;
+  }
+
+  /** Called by Bolt's App constructor. */
+  init(app: BoltApp): void {
+    this.app = app;
+  }
+
+  /** Signal that auth identity is initialized. Flushes any buffered events
+   *  that arrived during the startup window between WebSocket open and the
+   *  completion of auth.test. */
+  setAuthReady(): void {
+    if (this.authReady) {
+      return;
+    }
+    this.authReady = true;
+    const buffered = this.pendingEvents.splice(0);
+    for (const event of buffered) {
+      this.handleSlackEvent(event);
+    }
+  }
+
+  async start(): Promise<void> {
+    this.stopped = false;
+    await this.refreshToken();
+    await this.connect();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.stopClientPing();
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("MuxReceiver stopped"));
+      this.pending.delete(id);
+    }
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
+        this.ws.close(1000, "shutdown");
+      }
+      this.ws = null;
+    }
+  }
+
+  /**
+   * Proxy a Slack Web API call through the mux WSS connection.
+   * Returns the API response (or throws on timeout/error).
+   */
+  async apiCall(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error("MuxReceiver: WebSocket not connected");
+    }
+
+    const id = randomUUID();
+    const msg = JSON.stringify({ type: "slack_api", id, method, params });
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(`MuxReceiver: API call ${method} timed out after ${API_CALL_TIMEOUT_MS}ms`),
+        );
+      }, API_CALL_TIMEOUT_MS);
+
+      this.pending.set(id, { resolve, reject, timer });
+      ws.send(msg);
+    });
+  }
+
+  // ── private ────────────────────────────────────────────────────────
+
+  private async connect(): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+
+    const url = this.mux.url;
+    if (!url) {
+      throw new Error("MuxReceiver: mux.url is required");
+    }
+    const headers: Record<string, string> = {};
+    if (this.resolvedToken) {
+      headers.authorization = `Bearer ${this.resolvedToken}`;
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      // Close any existing WebSocket before opening a new one to prevent
+      // the mux from seeing two connections from the same entity (which
+      // triggers a supersede → close → reconnect → supersede loop).
+      if (this.ws) {
+        const old = this.ws;
+        this.ws = null;
+        old.removeAllListeners();
+        try {
+          old.close(1000, "reconnecting");
+        } catch {}
+      }
+
+      const ws = new WebSocket(url, { headers });
+      this.ws = ws;
+      let everOpened = false;
+
+      ws.on("open", () => {
+        everOpened = true;
+        this.backoffMs = INITIAL_BACKOFF_MS;
+        this.startClientPing(ws);
+        this.runtime?.log?.("slack mux connected");
+        resolve();
+      });
+
+      ws.on("message", (data) => {
+        this.handleMessage(data);
+      });
+
+      ws.on("close", (code, reason) => {
+        const reasonStr = typeof reason === "string" ? reason : String(reason ?? "");
+        this.runtime?.log?.(`slack mux disconnected: code=${code} reason=${reasonStr}`);
+        this.stopClientPing();
+        this.ws = null;
+        // Fail any in-flight API calls immediately rather than letting them
+        // hang for up to API_CALL_TIMEOUT_MS during a disconnect.
+        for (const [id, pending] of this.pending) {
+          clearTimeout(pending.timer);
+          pending.reject(new Error("MuxReceiver: WebSocket disconnected"));
+          this.pending.delete(id);
+        }
+        // Only reconnect after a successful open.  On the very first connection
+        // attempt, error→close fires in sequence — the error handler already
+        // rejected the connect() promise, so starting a background reconnect
+        // loop would leave the receiver in an inconsistent state.
+        if (everOpened) {
+          this.scheduleReconnect();
+        }
+      });
+
+      ws.on("error", (err) => {
+        this.runtime?.error?.(`slack mux error: ${err.message}`);
+        reject(err);
+      });
+
+      ws.on("ping", () => {
+        ws.pong();
+      });
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped) {
+      return;
+    }
+
+    const delay = this.backoffMs;
+    this.backoffMs = Math.min(this.backoffMs * 2, MAX_BACKOFF_MS);
+    this.runtime?.log?.(`slack mux reconnecting in ${delay}ms`);
+
+    setTimeout(() => {
+      if (this.stopped) {
+        return;
+      }
+      this.refreshToken()
+        .then(() => this.connect())
+        .catch((err) => {
+          this.runtime?.error?.(`slack mux reconnect failed: ${(err as Error).message}`);
+          // The failed connect() won't schedule another reconnect because
+          // everOpened is false for that attempt.  Keep retrying.
+          this.scheduleReconnect();
+        });
+    }, delay);
+  }
+
+  /** Send periodic WebSocket pings to keep the connection alive through
+   *  load balancers that drop idle connections. */
+  private startClientPing(ws: WebSocket): void {
+    this.stopClientPing();
+    this.pingTimer = setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        // Send both protocol-level ping AND application-level ping.
+        // GKE Cloud LB may not count WebSocket control frames (ping/pong)
+        // as traffic for idle timeout — data frames are needed.
+        ws.ping();
+        ws.send(JSON.stringify({ type: "ping", ts: Date.now() }));
+      }
+    }, CLIENT_PING_INTERVAL_MS);
+    if (this.pingTimer.unref) {
+      this.pingTimer.unref();
+    }
+  }
+
+  private stopClientPing(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+  }
+
+  private handleMessage(raw: unknown): void {
+    let msg: MuxInbound;
+    try {
+      const text =
+        typeof raw === "string" ? raw : Buffer.isBuffer(raw) ? raw.toString("utf-8") : String(raw);
+      msg = JSON.parse(text) as MuxInbound;
+    } catch {
+      this.runtime?.error?.("slack mux: failed to parse inbound message");
+      return;
+    }
+
+    switch (msg.type) {
+      case "slack_event":
+        if (!this.authReady) {
+          // Buffer events until auth identity is initialized to ensure
+          // self-message and workspace/app filtering guards are populated.
+          this.pendingEvents.push(msg);
+        } else {
+          this.handleSlackEvent(msg);
+        }
+        break;
+      case "slack_api_response":
+        this.handleApiResponse(msg);
+        break;
+      case "ping":
+        this.ws?.send(JSON.stringify({ type: "pong", ts: msg.ts }));
+        break;
+      default:
+        break;
+    }
+  }
+
+  private handleSlackEvent(msg: MuxSlackEvent): void {
+    if (!this.app) {
+      return;
+    }
+
+    // Forward Slack retry metadata so Bolt handlers can detect and deduplicate
+    // retried event deliveries (x-slack-retry-num / x-slack-retry-reason).
+    const retryNumRaw = msg.headers["x-slack-retry-num"];
+    const retryReason = msg.headers["x-slack-retry-reason"];
+    const eventId = msg.id;
+    const event: ReceiverEvent = {
+      body: msg.payload,
+      // Propagate ack payload back through the mux so slash-command /
+      // interactive-component handlers that call ack({ options: [...] }) or
+      // ack(responsePayload) can return data to Slack via the mux server.
+      // If no event id was provided (older mux versions), fall back to no-op.
+      ack: async (...args: unknown[]) => {
+        if (!eventId || !this.ws || this.ws.readyState !== WebSocket.OPEN) {
+          return;
+        }
+        const payload = args.length > 0 ? args[0] : undefined;
+        this.ws.send(
+          JSON.stringify({
+            type: "slack_ack",
+            id: eventId,
+            ...(payload !== undefined ? { payload } : {}),
+          }),
+        );
+      },
+      ...(retryNumRaw !== undefined ? { retryNum: parseInt(retryNumRaw, 10) } : {}),
+      ...(retryReason !== undefined ? { retryReason } : {}),
+    };
+    this.app.processEvent(event).catch((err) => {
+      this.runtime?.error?.(`slack mux: processEvent error: ${err}`);
+    });
+  }
+
+  private handleApiResponse(msg: MuxApiResponse): void {
+    const pending = this.pending.get(msg.id);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timer);
+    this.pending.delete(msg.id);
+
+    if (msg.ok) {
+      pending.resolve(msg.response);
+    } else {
+      pending.reject(new Error(msg.error ?? "Slack API error via mux"));
+    }
+  }
+
+  // ── token resolution ───────────────────────────────────────────────
+
+  /** Re-resolve the auth token.  Called on initial start and before each
+   *  reconnect so that expired cached tokens are replaced. */
+  private async refreshToken(): Promise<void> {
+    this.resolvedToken = await this.resolveToken();
+  }
+
+  private async resolveToken(): Promise<string | null> {
+    const configToken = this.mux.token?.trim();
+    if (configToken) {
+      return configToken;
+    }
+
+    const envToken = process.env.MUX_TOKEN?.trim();
+    if (envToken) {
+      return envToken;
+    }
+
+    // Try GCP identity token (ADC → metadata server fallback)
+    const muxUrl = this.mux.url;
+    if (muxUrl) {
+      const gcpResult = await resolveGcpIdentityToken(audienceFromWsUrl(muxUrl));
+      if (gcpResult) {
+        this.runtime?.log?.(`slack mux: resolved GCP identity token from ${gcpResult.source}`);
+        return gcpResult.token;
+      }
+    }
+
+    try {
+      return await this.resolveFromMcpRemoteCache();
+    } catch {
+      this.runtime?.log?.("slack mux: no cached mcp-remote token found");
+      return null;
+    }
+  }
+
+  private async resolveFromMcpRemoteCache(): Promise<string | null> {
+    const mcpServerUrl = this.resolveMcpServerUrl();
+    if (!mcpServerUrl) {
+      return null;
+    }
+
+    const hash = createHash("md5").update(mcpServerUrl).digest("hex");
+    const cacheBase = join(homedir(), ".mcp-auth");
+
+    let dirs: string[];
+    try {
+      dirs = await readdir(cacheBase);
+    } catch {
+      return null;
+    }
+
+    const mcpRemoteDirs = dirs
+      .filter((d) => d.startsWith("mcp-remote-"))
+      .toSorted()
+      .toReversed();
+
+    for (const dir of mcpRemoteDirs) {
+      const tokensPath = join(cacheBase, dir, `${hash}_tokens.json`);
+      try {
+        const raw = await readFile(tokensPath, "utf-8");
+        const tokens = JSON.parse(raw) as {
+          access_token?: string;
+          refresh_token?: string;
+          expires_in?: number;
+        };
+
+        if (tokens.access_token && !this.isJwtExpired(tokens.access_token)) {
+          return tokens.access_token;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return null;
+  }
+
+  private resolveMcpServerUrl(): string | null {
+    if (this.mux.mcpServerUrl) {
+      return this.mux.mcpServerUrl;
+    }
+    return process.env.MUX_MCP_SERVER_URL?.trim() || null;
+  }
+
+  private isJwtExpired(token: string): boolean {
+    try {
+      const parts = token.split(".");
+      if (parts.length !== 3) {
+        return false;
+      }
+      const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf-8")) as {
+        exp?: number;
+      };
+      if (!payload.exp) {
+        return false;
+      }
+      // Treat tokens as expired 60s *before* actual expiry to avoid using
+      // nearly-expired tokens that may fail mid-request.
+      return payload.exp < Date.now() / 1000 + 60;
+    } catch {
+      return false;
+    }
+  }
+
+  // Token refresh (via OAuth refresh_token flow) is intentionally omitted to avoid raw
+  // fetch() in channel runtime code. If the cached token is expired, the user should
+  // re-authenticate via mcp-remote or set an explicit mux.token / MUX_TOKEN.
+}
+
+/**
+ * Monkey-patch Bolt's `app.client` to route all Slack Web API calls through the mux.
+ * Must be called after the Bolt App is created with a MuxReceiver.
+ *
+ * Bolt's `@slack/web-api` binds convenience methods (e.g. `chat.postMessage`) at
+ * construction time via `self.apiCall.bind(self, method)`.  This captures the
+ * *original* `apiCall` function reference — so simply replacing `app.client.apiCall`
+ * after construction has no effect on convenience methods.
+ *
+ * To work around this, we:
+ *  1. Replace the top-level `apiCall` (catches any direct callers).
+ *  2. Recursively walk every method-group object on the client and replace each
+ *     bound function with a new one that delegates to the proxy.
+ */
+export function installMuxApiProxy(
+  app: {
+    client: Record<string, unknown> & {
+      apiCall: (method: string, options?: Record<string, unknown>) => Promise<unknown>;
+    };
+  },
+  receiver: MuxReceiver,
+): void {
+  const proxyApiCall = async (
+    method: string,
+    options?: Record<string, unknown>,
+  ): Promise<unknown> => {
+    return receiver.apiCall(method, options ?? {});
+  };
+
+  // 1. Patch the top-level apiCall
+  app.client.apiCall = proxyApiCall;
+
+  // 2. Rebind all convenience methods that were captured via .bind() at construction.
+  //    Method groups are plain objects hanging off app.client (e.g. client.chat,
+  //    client.conversations, client.admin, ...).  Some are nested up to 4 levels
+  //    deep (e.g. admin.apps.config.set).
+  const skipKeys = new Set([
+    // Internal / non-API properties that should not be walked
+    "apiCall",
+    "token",
+    "slackApiUrl",
+    "retryConfig",
+    "requestQueue",
+    "tlsConfig",
+    "rejectRateLimitedCalls",
+    "teamId",
+    "logger",
+    "axios",
+    "middleware",
+  ]);
+
+  function rebindGroup(obj: Record<string, unknown>, prefix: string): void {
+    for (const key of Object.keys(obj)) {
+      const value = obj[key];
+      if (typeof value === "function") {
+        const methodName = `${prefix}.${key}`;
+        // Replace bound apiCall with proxy-routed version.
+        // The original bound function had signature: (options?) => apiCall(method, options)
+        // We replicate that, routing through the mux proxy instead.
+        obj[key] = (options?: Record<string, unknown>): Promise<unknown> => {
+          return proxyApiCall(methodName, options);
+        };
+      } else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        // Recurse into nested groups (e.g. admin.apps.activities)
+        rebindGroup(value as Record<string, unknown>, `${prefix}.${key}`);
+      }
+    }
+  }
+
+  for (const key of Object.keys(app.client)) {
+    if (skipKeys.has(key)) {
+      continue;
+    }
+    const value = app.client[key];
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      rebindGroup(value as Record<string, unknown>, key);
+    }
+  }
+}

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -22,6 +22,15 @@ import { markdownToSlackMrkdwnChunks } from "./format.js";
 import { parseSlackTarget } from "./targets.js";
 import { resolveSlackBotToken } from "./token.js";
 
+/** Mux-proxied WebClient registered at startup for outbound sends when no
+ *  explicit token is available (mux mode). */
+let _muxClient: WebClient | null = null;
+
+/** Register the mux-proxied app.client so sendMessageSlack can fall back to it. */
+export function setMuxProxyClient(client: WebClient): void {
+  _muxClient = client;
+}
+
 const SLACK_TEXT_LIMIT = 4000;
 const SLACK_UPLOAD_SSRF_POLICY = {
   allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
@@ -140,23 +149,12 @@ function resolveToken(params: {
   accountId: string;
   fallbackToken?: string;
   fallbackSource?: SlackTokenSource;
-}) {
+}): string | undefined {
   const explicit = resolveSlackBotToken(params.explicit);
   if (explicit) {
     return explicit;
   }
-  const fallback = resolveSlackBotToken(params.fallbackToken);
-  if (!fallback) {
-    logVerbose(
-      `slack send: missing bot token for account=${params.accountId} explicit=${Boolean(
-        params.explicit,
-      )} source=${params.fallbackSource ?? "unknown"}`,
-    );
-    throw new Error(
-      `Slack bot token missing for account "${params.accountId}" (set channels.slack.accounts.${params.accountId}.botToken or SLACK_BOT_TOKEN for default).`,
-    );
-  }
-  return fallback;
+  return resolveSlackBotToken(params.fallbackToken);
 }
 
 function parseRecipient(raw: string): SlackRecipient {
@@ -274,7 +272,12 @@ export async function sendMessageSlack(
     fallbackToken: account.botToken,
     fallbackSource: account.botTokenSource,
   });
-  const client = opts.client ?? createSlackWebClient(token);
+  const client = opts.client ?? (token ? createSlackWebClient(token) : _muxClient);
+  if (!client) {
+    throw new Error(
+      `Slack bot token missing for account "${account.accountId}" (set channels.slack.accounts.${account.accountId}.botToken or SLACK_BOT_TOKEN for default).`,
+    );
+  }
   const recipient = parseRecipient(to);
   const { channelId } = await resolveChannelId(client, recipient);
   if (blocks) {

--- a/src/utils/gcp-metadata-token.test.ts
+++ b/src/utils/gcp-metadata-token.test.ts
@@ -1,0 +1,174 @@
+import { readFile } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { audienceFromWsUrl, resolveGcpIdentityToken } from "./gcp-metadata-token.js";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+const mockReadFile = vi.mocked(readFile);
+
+describe("resolveGcpIdentityToken", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalEnv = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv === undefined) {
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    } else {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = originalEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe("ADC path", () => {
+    test("resolves identity token from service account key file", async () => {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = "/gcp/adc.json";
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          type: "service_account",
+          client_email: "test@project.iam.gserviceaccount.com",
+          private_key: (await import("node:crypto")).generateKeyPairSync("rsa", {
+            modulusLength: 2048,
+            publicKeyEncoding: { type: "spki", format: "pem" },
+            privateKeyEncoding: { type: "pkcs8", format: "pem" },
+          }).privateKey,
+        }),
+      );
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id_token: "adc-identity-token-123" }),
+      }) as typeof fetch;
+
+      const result = await resolveGcpIdentityToken("https://mux.example.com");
+      expect(result).toEqual({ token: "adc-identity-token-123", source: "adc" });
+
+      // Verify it hit the OAuth2 endpoint, not metadata
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe("https://oauth2.googleapis.com/token");
+    });
+
+    test("skips ADC when GOOGLE_APPLICATION_CREDENTIALS not set", async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) as typeof fetch;
+
+      const token = await resolveGcpIdentityToken("https://mux.example.com");
+      expect(token).toBeNull();
+
+      // Should have tried metadata, not OAuth2
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain("metadata.google.internal");
+    });
+
+    test("skips ADC for non-service_account type and falls to metadata", async () => {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = "/gcp/adc.json";
+      mockReadFile.mockResolvedValue(JSON.stringify({ type: "authorized_user", client_id: "xxx" }));
+
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) as typeof fetch;
+
+      const token = await resolveGcpIdentityToken("https://mux.example.com");
+      expect(token).toBeNull();
+    });
+
+    test("falls through to metadata when ADC file is unreadable", async () => {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = "/nonexistent/adc.json";
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("metadata-token"),
+      }) as typeof fetch;
+
+      const result = await resolveGcpIdentityToken("https://mux.example.com");
+      expect(result).toEqual({ token: "metadata-token", source: "metadata" });
+    });
+  });
+
+  describe("metadata path", () => {
+    test("returns token from metadata server", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("gcp-oidc-token-123"),
+      }) as typeof fetch;
+
+      const result = await resolveGcpIdentityToken("https://mux.example.com");
+      expect(result).toEqual({ token: "gcp-oidc-token-123", source: "metadata" });
+
+      const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain("audience=https%3A%2F%2Fmux.example.com");
+      expect((opts as RequestInit).headers).toEqual({ "Metadata-Flavor": "Google" });
+    });
+
+    test("returns null when metadata server is unavailable", async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) as typeof fetch;
+
+      const token = await resolveGcpIdentityToken("https://mux.example.com");
+      expect(token).toBeNull();
+    });
+
+    test("returns null on non-200 response", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      }) as typeof fetch;
+
+      const token = await resolveGcpIdentityToken("https://mux.example.com");
+      expect(token).toBeNull();
+    });
+
+    test("returns null on empty response body", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("  "),
+      }) as typeof fetch;
+
+      const token = await resolveGcpIdentityToken("https://mux.example.com");
+      expect(token).toBeNull();
+    });
+
+    test("respects custom timeout", async () => {
+      globalThis.fetch = vi.fn().mockImplementation(
+        (_url: string, opts: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            opts.signal?.addEventListener("abort", () =>
+              reject(new DOMException("aborted", "AbortError")),
+            );
+          }),
+      ) as typeof fetch;
+
+      const result = await resolveGcpIdentityToken("https://mux.example.com", { timeoutMs: 50 });
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe("audienceFromWsUrl", () => {
+  test("converts wss to https and strips /ws path", () => {
+    expect(audienceFromWsUrl("wss://mux.example.com/ws")).toBe("https://mux.example.com");
+  });
+
+  test("converts ws to http and strips /ws path", () => {
+    expect(audienceFromWsUrl("ws://localhost:8081/ws")).toBe("http://localhost:8081");
+  });
+
+  test("strips trailing slash on /ws/", () => {
+    expect(audienceFromWsUrl("wss://mux.example.com/ws/")).toBe("https://mux.example.com");
+  });
+
+  test("preserves URL without /ws path", () => {
+    expect(audienceFromWsUrl("wss://mux.example.com")).toBe("https://mux.example.com");
+  });
+
+  test("preserves non-ws paths", () => {
+    expect(audienceFromWsUrl("wss://mux.example.com/connect")).toBe(
+      "https://mux.example.com/connect",
+    );
+  });
+});

--- a/src/utils/gcp-metadata-token.ts
+++ b/src/utils/gcp-metadata-token.ts
@@ -1,0 +1,143 @@
+import { sign } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+/**
+ * Resolve a GCP identity token. Tries (in order):
+ *
+ * 1. **ADC** (Application Default Credentials) — works locally when
+ *    `GOOGLE_APPLICATION_CREDENTIALS` points to a service account key file.
+ *    Signs a JWT and exchanges it for an identity token via Google's OAuth2 endpoint.
+ *
+ * 2. **Metadata server** — works on GKE with Workload Identity Federation.
+ *    The pod's KSA is projected as a GCP service account and the metadata
+ *    server issues OIDC identity tokens scoped to the given audience.
+ *
+ * Returns null when neither path is available.
+ */
+export async function resolveGcpIdentityToken(
+  audience: string,
+  options?: { timeoutMs?: number },
+): Promise<{ token: string; source: "adc" | "metadata" } | null> {
+  const timeoutMs = options?.timeoutMs ?? 3_000;
+
+  // Try ADC first (local dev with mounted service account key)
+  const adcToken = await resolveFromAdc(audience, timeoutMs);
+  if (adcToken) {
+    return { token: adcToken, source: "adc" };
+  }
+
+  // Fall back to metadata server (GKE)
+  const metadataToken = await resolveFromMetadata(audience, timeoutMs);
+  if (metadataToken) {
+    return { token: metadataToken, source: "metadata" };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve an identity token from a service account key file (ADC).
+ *
+ * Reads the key from GOOGLE_APPLICATION_CREDENTIALS, creates a self-signed
+ * JWT with target_audience claim, and exchanges it at Google's OAuth2 endpoint
+ * for an identity token.
+ */
+async function resolveFromAdc(audience: string, timeoutMs: number): Promise<string | null> {
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!credPath) {
+    return null;
+  }
+
+  try {
+    const raw = await readFile(credPath, "utf-8");
+    const creds = JSON.parse(raw);
+
+    // Only service_account type supports identity token exchange
+    if (creds.type !== "service_account" || !creds.private_key || !creds.client_email) {
+      return null;
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const payload = {
+      iss: creds.client_email,
+      sub: creds.client_email,
+      aud: "https://oauth2.googleapis.com/token",
+      iat: now,
+      exp: now + 300,
+      target_audience: audience,
+    };
+
+    // Create self-signed JWT
+    const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+    const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const unsigned = `${header}.${body}`;
+    const signature = sign("sha256", Buffer.from(unsigned), creds.private_key);
+    const jwt = `${unsigned}.${signature.toString("base64url")}`;
+
+    // Exchange for identity token
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch("https://oauth2.googleapis.com/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=${jwt}`,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const data = (await response.json()) as { id_token?: string };
+      return data.id_token?.trim() || null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve an identity token from the GCP metadata server.
+ */
+async function resolveFromMetadata(audience: string, timeoutMs: number): Promise<string | null> {
+  const metadataUrl = `http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${encodeURIComponent(audience)}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(metadataUrl, {
+      headers: { "Metadata-Flavor": "Google" },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const token = (await response.text()).trim();
+    return token || null;
+  } catch {
+    // Not running on GCP or metadata server not available
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Derive an HTTPS audience URL from a WebSocket URL.
+ *
+ * wss://host/ws → https://host
+ * ws://host/ws  → http://host
+ */
+export function audienceFromWsUrl(wsUrl: string): string {
+  return wsUrl
+    .replace(/^wss:/, "https:")
+    .replace(/^ws:/, "http:")
+    .replace(/\/ws\/?$/, "");
+}


### PR DESCRIPTION
## Summary

Adds a new Slack connection mode `mux` that connects to an external [openclaw-mux](https://github.com/openclaw/openclaw-mux) service via WebSocket. This enables **multi-gateway deployments** where a central mux service receives Slack Events API webhooks and routes them to the correct OpenClaw gateway instance.

### Why?

Slack's Events API delivers each event to a **single HTTP endpoint**. If you run multiple OpenClaw gateways (e.g., one per team member sharing a Slack workspace), only one gateway receives each event. The mux solves this by:

1. Receiving all Slack events at a single endpoint
2. Routing each event to the correct gateway via WebSocket based on the target Slack user
3. Proxying Slack API calls back through the WebSocket (so gateways don't need direct bot tokens)

### What changes?

**New files:**
- `src/slack/mux-receiver.ts` — WebSocket client that connects to the mux, receives forwarded Slack events, and proxies API calls
- `src/slack/mux-receiver.test.ts` — 24 tests
- `src/utils/gcp-metadata-token.ts` — GCP OIDC identity token resolver for workload identity auth
- `src/utils/gcp-metadata-token.test.ts` — 14 tests

**Modified files (minimal, backwards-compatible):**
- `src/config/types.slack.ts` — adds `SlackMuxConfig` type, `"mux"` to mode enum
- `src/config/zod-schema.providers-core.ts` — adds `SlackMuxSchema`, validation
- `src/slack/monitor/provider.ts` — creates `MuxReceiver` alongside existing socket/http paths
- `src/slack/send.ts` — supports API call proxying through mux WebSocket
- Small adaptations in `account-inspect.ts`, `context.ts`, `prepare-content.ts`, `prepare-thread-context.ts`, `types.ts`
- `extensions/slack/src/channel.ts` — 3 lines

### Configuration

```json
{
  "channels": {
    "slack": {
      "mode": "mux",
      "mux": {
        "url": "wss://your-mux-service.example.com/ws",
        "token": "optional-static-auth-token"
      }
    }
  }
}
```

**Defaults unchanged** — `mode` defaults to `"socket"`. Mux is purely opt-in. Existing installations are unaffected.

### Auth modes

The mux receiver supports:
- **Static token** — `mux.token` in config
- **GCP workload identity** — automatic OIDC token from GKE metadata server (for cloud deployments)
- **Agent directory** — reads agent auth profiles for token resolution

### Tests

- 38 new tests (24 mux-receiver + 14 gcp-metadata-token)
- All 416 existing Slack tests pass unchanged

### Companion repo

The mux server itself lives at [openclaw-mux](https://github.com/openclaw/openclaw-mux) — a NestJS service that handles Slack signature verification, event routing, OAuth install flow, and WebSocket connection management.

†