### PR TITLE
Agents: normalize skill download filenames

### DIFF
--- a/src/agents/skills-install-download.ts
+++ b/src/agents/skills-install-download.ts
@@ -59,6 +59,27 @@ function resolveArchiveType(spec: SkillInstallSpec, filename: string): string | 
   return undefined;
 }
 
+function basenameAcrossSeparators(value: string): string {
+  const withoutQuery = value.split(/[?#]/, 1)[0] ?? value;
+  return path.win32.basename(path.posix.basename(withoutQuery));
+}
+
+function resolveDownloadFilename(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const decodedPath = (() => {
+      try {
+        return decodeURIComponent(parsed.pathname);
+      } catch {
+        return parsed.pathname;
+      }
+    })();
+    return basenameAcrossSeparators(decodedPath);
+  } catch {
+    return basenameAcrossSeparators(url);
+  }
+}
+
 async function downloadFile(params: {
   url: string;
   rootDir: string;
@@ -119,13 +140,7 @@ export async function installDownloadSpec(params: {
     };
   }
 
-  let filename = "";
-  try {
-    const parsed = new URL(url);
-    filename = path.basename(parsed.pathname);
-  } catch {
-    filename = path.basename(url);
-  }
+  let filename = resolveDownloadFilename(url);
   if (!filename) {
     filename = "download";
   }

--- a/src/agents/skills-install.download.test.ts
+++ b/src/agents/skills-install.download.test.ts
@@ -167,6 +167,52 @@ beforeEach(() => {
 });
 
 describe("installDownloadSpec extraction safety", () => {
+  it("normalizes encoded Windows path segments in download URLs", async () => {
+    const entry = buildEntry("encoded-windows-path");
+    const targetDir = path.join(resolveSkillToolsRootDir(entry), "target");
+
+    mockArchiveResponse(new Uint8Array([1, 2, 3]));
+
+    const result = await installDownloadSpec({
+      entry,
+      spec: {
+        kind: "download",
+        id: "dl",
+        url: "https://example.invalid/%2E%2E%5Csecret.zip",
+        extract: false,
+        targetDir,
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain(path.join(targetDir, "secret.zip"));
+    expect(result.message).not.toContain("..\\");
+  });
+
+  it("normalizes fallback download names across path separators", async () => {
+    const entry = buildEntry("raw-windows-path");
+    const targetDir = path.join(resolveSkillToolsRootDir(entry), "target");
+
+    mockArchiveResponse(new Uint8Array([1, 2, 3]));
+
+    const result = await installDownloadSpec({
+      entry,
+      spec: {
+        kind: "download",
+        id: "dl",
+        url: "..\\private\\archive.zip",
+        extract: false,
+        targetDir,
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain(path.join(targetDir, "archive.zip"));
+    expect(result.message).not.toContain("..\\");
+  });
+
   it("rejects archive traversal writes outside targetDir", async () => {
     for (const testCase of [
       {


### PR DESCRIPTION
## Summary
- normalize skill download archive names across path separators
- decode URL pathnames before deriving the downloaded archive filename
- add regression coverage for encoded and raw Windows-style path segments

## Testing
- pnpm test src/agents/skills-install.download.test.ts
- pnpm check
- pnpm build
