### PR TITLE
CI: enable CodeQL analysis on pull requests and pushes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,9 @@
 name: CodeQL
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -16,8 +19,84 @@ permissions:
   security-events: write
 
 jobs:
+  # Detect docs-only changes to skip all analysis (same pattern as CI).
+  docs-scope:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    outputs:
+      docs_only: ${{ steps.check.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
+
+      - name: Ensure docs-scope base commit
+        if: github.event_name != 'workflow_dispatch'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
+      - name: Detect docs-only changes
+        if: github.event_name != 'workflow_dispatch'
+        id: check
+        uses: ./.github/actions/detect-docs-changes
+
+  # Detect which areas changed so each language only runs on relevant PRs.
+  # Push to main and workflow_dispatch keep broad coverage.
+  changed-scope:
+    needs: [docs-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    outputs:
+      run_node: ${{ steps.scope.outputs.run_node }}
+      run_macos: ${{ steps.scope.outputs.run_macos }}
+      run_android: ${{ steps.scope.outputs.run_android }}
+      run_skills_python: ${{ steps.scope.outputs.run_skills_python }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
+
+      - name: Ensure changed-scope base commit
+        if: github.event_name != 'workflow_dispatch'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
+      - name: Detect changed scopes
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual runs analyze everything.
+            echo "run_node=true" >> "$GITHUB_OUTPUT"
+            echo "run_macos=true" >> "$GITHUB_OUTPUT"
+            echo "run_android=true" >> "$GITHUB_OUTPUT"
+            echo "run_skills_python=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BASE="${{ github.event.before }}"
+          else
+            BASE="${{ github.event.pull_request.base.sha }}"
+          fi
+
+          node scripts/ci-changed-scope.mjs --base "$BASE" --head HEAD
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: [docs-scope, changed-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true'
     runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
@@ -25,6 +104,7 @@ jobs:
         include:
           - language: javascript-typescript
             runs_on: blacksmith-16vcpu-ubuntu-2404
+            scope: run_node
             needs_node: true
             needs_python: false
             needs_java: false
@@ -34,6 +114,7 @@ jobs:
             config_file: ./.github/codeql/codeql-javascript-typescript.yml
           - language: actions
             runs_on: blacksmith-16vcpu-ubuntu-2404
+            scope: run_node
             needs_node: false
             needs_python: false
             needs_java: false
@@ -43,6 +124,7 @@ jobs:
             config_file: ""
           - language: python
             runs_on: blacksmith-16vcpu-ubuntu-2404
+            scope: run_skills_python
             needs_node: false
             needs_python: true
             needs_java: false
@@ -52,6 +134,7 @@ jobs:
             config_file: ""
           - language: java-kotlin
             runs_on: blacksmith-16vcpu-ubuntu-2404
+            scope: run_android
             needs_node: false
             needs_python: false
             needs_java: true
@@ -61,6 +144,7 @@ jobs:
             config_file: ""
           - language: swift
             runs_on: macos-latest
+            scope: run_macos
             needs_node: false
             needs_python: false
             needs_java: false
@@ -69,33 +153,62 @@ jobs:
             needs_autobuild: false
             config_file: ""
     steps:
+      # Skip this matrix entry when the relevant scope was not touched.
+      # Push to main and workflow_dispatch set all scopes to true (run everything).
+      - name: Check scope
+        id: scope-check
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_NODE: ${{ needs.changed-scope.outputs.run_node }}
+          RUN_MACOS: ${{ needs.changed-scope.outputs.run_macos }}
+          RUN_ANDROID: ${{ needs.changed-scope.outputs.run_android }}
+          RUN_SKILLS_PYTHON: ${{ needs.changed-scope.outputs.run_skills_python }}
+          SCOPE_KEY: ${{ matrix.scope }}
+        run: |
+          # Map the matrix scope key to the corresponding output value.
+          case "$SCOPE_KEY" in
+            run_node)           SHOULD_RUN="$RUN_NODE" ;;
+            run_macos)          SHOULD_RUN="$RUN_MACOS" ;;
+            run_android)        SHOULD_RUN="$RUN_ANDROID" ;;
+            run_skills_python)  SHOULD_RUN="$RUN_SKILLS_PYTHON" ;;
+            *)                  SHOULD_RUN="true" ;;
+          esac
+
+          if [ "$SHOULD_RUN" = "true" ] || [ "$EVENT_NAME" = "push" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
+        if: steps.scope-check.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           submodules: false
 
       - name: Setup Node environment
-        if: matrix.needs_node
+        if: steps.scope-check.outputs.skip != 'true' && matrix.needs_node
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
           use-sticky-disk: "false"
 
       - name: Setup Python
-        if: matrix.needs_python
+        if: steps.scope-check.outputs.skip != 'true' && matrix.needs_python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Setup Java
-        if: matrix.needs_java
+        if: steps.scope-check.outputs.skip != 'true' && matrix.needs_java
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Setup Swift build tools
-        if: matrix.needs_swift_tools
+        if: steps.scope-check.outputs.skip != 'true' && matrix.needs_swift_tools
         run: |
           sudo xcode-select -s /Applications/Xcode_26.1.app
           xcodebuild -version
@@ -103,6 +216,7 @@ jobs:
           swift --version
 
       - name: Initialize CodeQL
+        if: steps.scope-check.outputs.skip != 'true'
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
@@ -110,16 +224,16 @@ jobs:
           config-file: ${{ matrix.config_file || '' }}
 
       - name: Autobuild
-        if: matrix.needs_autobuild
+        if: steps.scope-check.outputs.skip != 'true' && matrix.needs_autobuild
         uses: github/codeql-action/autobuild@v4
 
       - name: Build Android for CodeQL
-        if: matrix.language == 'java-kotlin'
+        if: steps.scope-check.outputs.skip != 'true' && matrix.language == 'java-kotlin'
         working-directory: apps/android
         run: ./gradlew --no-daemon :app:assembleDebug
 
       - name: Build Swift for CodeQL
-        if: matrix.language == 'swift'
+        if: steps.scope-check.outputs.skip != 'true' && matrix.language == 'swift'
         run: |
           set -euo pipefail
           swift build --package-path apps/macos --configuration release
@@ -132,6 +246,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Analyze
+        if: steps.scope-check.outputs.skip != 'true'
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,7 +96,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     needs: [docs-scope, changed-scope]
-    if: needs.docs-scope.outputs.docs_only != 'true'
+    if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.result != 'failure'
     runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Problem: CodeQL security analysis only runs on manual dispatch, missing automated coverage on PRs and merges
- Why it matters: security vulnerabilities in PRs are not caught until someone manually triggers a scan
- What changed: added `push` and `pull_request` triggers with per-language path filtering using existing `docs-scope` and `changed-scope` infrastructure
- What did NOT change (scope boundary): no changes to CodeQL queries, language matrix, or analysis configuration

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related: CodeQL gap identified during triage automation audit

## User-visible / Behavior Changes

None — this only affects CI pipeline behavior.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- CI: GitHub Actions

### Steps

1. Open a PR touching TypeScript files
2. Observe CodeQL JS/TS analysis runs automatically
3. Open a PR touching only docs
4. Observe CodeQL is skipped entirely

### Expected

- CodeQL runs per-language based on changed files
- Docs-only PRs skip all analysis
- JS-only PRs skip Swift/Android/Python analysis

### Actual

- Currently CodeQL only runs on manual dispatch

## Evidence

- [x] Verified workflow YAML syntax is valid
- [x] Path filtering reuses existing `docs-scope` and `changed-scope` from ci.yml

## Human Verification (required)

- Verified scenarios: YAML structure matches existing ci.yml patterns, scope gating logic tested mentally against JS-only, docs-only, Swift-only, and full-repo change scenarios
- Edge cases checked: workflow_dispatch always runs all languages, push to main always runs all languages
- What I did **not** verify: actual GitHub Actions execution (requires PR to be opened)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert to `workflow_dispatch` only trigger
- Files/config to restore: `.github/workflows/codeql.yml`
- Known bad symptoms reviewers should watch for: excessive CI cost from Swift/macOS runs on unrelated PRs

## Risks and Mitigations

- Risk: increased CI cost from CodeQL runs on every PR
  - Mitigation: per-language path filtering skips irrelevant analyses; docs-only changes skip entirely