### PR TITLE
Plugin SDK: normalize temp download filenames

### DIFF
--- a/src/plugin-sdk/temp-path.test.ts
+++ b/src/plugin-sdk/temp-path.test.ts
@@ -68,4 +68,24 @@ describe("withTempDownloadPath", () => {
     expect(path.basename(capturedPath)).toBe("evil.bin");
     expect(capturedPath).not.toContain("..");
   });
+
+  it("strips Windows path segments from fileName on non-Windows hosts", async () => {
+    const tmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
+    let capturedPath = "";
+    await withTempDownloadPath(
+      {
+        prefix: "line-media",
+        fileName: "..\\private\\voice-note.m4a",
+      },
+      async (tmpPath) => {
+        capturedPath = tmpPath;
+      },
+    );
+
+    const resolved = path.resolve(capturedPath);
+    const rel = path.relative(tmpRoot, resolved);
+    expect(rel === ".." || rel.startsWith(`..${path.sep}`)).toBe(false);
+    expect(path.basename(capturedPath)).toBe("voice-note.m4a");
+    expect(capturedPath).not.toContain("private");
+  });
 });

--- a/src/plugin-sdk/temp-path.ts
+++ b/src/plugin-sdk/temp-path.ts
@@ -21,8 +21,12 @@ function sanitizeExtension(extension?: string): string {
   return `.${token}`;
 }
 
+function basenameAcrossSeparators(fileName: string): string {
+  return path.win32.basename(path.posix.basename(fileName));
+}
+
 function sanitizeFileName(fileName: string): string {
-  const base = path.basename(fileName).replace(/[^a-zA-Z0-9._-]+/g, "-");
+  const base = basenameAcrossSeparators(fileName).replace(/[^a-zA-Z0-9._-]+/g, "-");
   const normalized = base.replace(/^-+|-+$/g, "");
   return normalized || "download.bin";
 }


### PR DESCRIPTION
## Summary
- normalize temp download file names across path separators
- avoid leaking Windows-style path fragments into temp download paths on macOS/Linux
- add regression coverage for Windows-style file names

## Testing
- pnpm test src/plugin-sdk/temp-path.test.ts
- pnpm exec oxfmt --check src/plugin-sdk/temp-path.ts src/plugin-sdk/temp-path.test.ts
- pnpm build
- pnpm check *(currently blocked on unrelated upstream CHANGELOG.md formatting drift on main)*
