### PR TITLE
Media: normalize stored original filenames

### DIFF
--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -383,6 +383,14 @@ describe("media store", () => {
         expect(result).toBe("报告_2024.pdf");
       });
     });
+
+    it("normalizes Windows path separators when extracting original names", async () => {
+      await withTempStore(async (store) => {
+        const filename = "voice-note---a1b2c3d4-e5f6-7890-abcd-ef1234567890.m4a";
+        const result = store.extractOriginalFilename(`..\\private\\${filename}`);
+        expect(result).toBe("voice-note.m4a");
+      });
+    });
   });
 
   describe("saveMediaBuffer with originalFilename", () => {
@@ -421,6 +429,22 @@ describe("media store", () => {
 
         // Unsafe chars should be replaced with underscores
         expect(saved.id).toMatch(/^my_file_test---[a-f0-9-]{36}\.txt$/);
+      });
+    });
+
+    it("strips Windows path segments from original filenames", async () => {
+      await withTempStore(async (store) => {
+        const buf = Buffer.from("test");
+        const saved = await store.saveMediaBuffer(
+          buf,
+          "audio/mp4",
+          "inbound",
+          5 * 1024 * 1024,
+          "..\\private\\voice-note.m4a",
+        );
+
+        expect(saved.id).toMatch(/^voice-note---[a-f0-9-]{36}\.m4a$/);
+        expect(saved.id).not.toContain("private");
       });
     });
 

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -57,13 +57,17 @@ function sanitizeFilename(name: string): string {
   return sanitized.replace(/_+/g, "_").replace(/^_|_$/g, "").slice(0, 60);
 }
 
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
 /**
  * Extract original filename from path if it matches the embedded format.
  * Pattern: {original}---{uuid}.{ext} → returns "{original}.{ext}"
  * Falls back to basename if no pattern match, or "file.bin" if empty.
  */
 export function extractOriginalFilename(filePath: string): string {
-  const basename = path.basename(filePath);
+  const basename = basenameAcrossSeparators(filePath);
   if (!basename) {
     return "file.bin";
   } // Fallback for empty input
@@ -363,7 +367,7 @@ export async function saveMediaBuffer(
   let id: string;
   if (originalFilename) {
     // Embed original name: {sanitized}---{uuid}.ext
-    const base = path.parse(originalFilename).name;
+    const base = path.parse(basenameAcrossSeparators(originalFilename)).name;
     const sanitized = sanitizeFilename(base);
     id = sanitized ? `${sanitized}---${uuid}${ext}` : `${uuid}${ext}`;
   } else {


### PR DESCRIPTION
## Summary
- normalize stored original file names across path separators
- avoid leaking Windows-style path fragments into embedded media file names on macOS/Linux
- add regression coverage for storing and extracting original file names

## Testing
- pnpm test src/media/store.test.ts
- pnpm exec oxfmt --check src/media/store.ts src/media/store.test.ts
- pnpm build
- pnpm check *(currently blocked on unrelated upstream CHANGELOG.md formatting drift on main)*
