### PR TITLE
feat(bedrock): add AWS_BEARER_TOKEN_BEDROCK bearer token authentication

### DIFF
--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -8,15 +8,38 @@ title: "Amazon Bedrock"
 
 # Amazon Bedrock
 
-OpenClaw can use **Amazon Bedrock** models via pi‑ai’s **Bedrock Converse**
-streaming provider. Bedrock auth uses the **AWS SDK default credential chain**,
-not an API key.
+OpenClaw can use **Amazon Bedrock** models via pi‑ai's **Bedrock Converse**
+streaming provider.
+
+## Authentication
+
+Bedrock supports two authentication methods. When both are available, bearer
+token auth takes precedence.
+
+**Auth precedence (highest → lowest):**
+
+1. **Bearer token** — `AWS_BEARER_TOKEN_BEDROCK` env var. Sends `Authorization: Bearer <token>` directly; no AWS SDK signing required.
+2. **AWS SDK credential chain** — `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, instance roles, etc.
+
+### Bearer token (API key) authentication
+
+Generate a Bedrock API key from the [Amazon Bedrock console](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html),
+then export it:
+
+```bash
+export AWS_BEARER_TOKEN_BEDROCK="your-bedrock-api-key"
+export AWS_REGION="us-east-1"
+openclaw gateway
+```
+
+When this env var is set, OpenClaw bypasses AWS SDK signing and sends the token
+as an `Authorization: Bearer` header on every Bedrock request.
 
 ## What pi-ai supports
 
 - Provider: `amazon-bedrock`
 - API: `bedrock-converse-stream`
-- Auth: AWS credentials (env vars, shared config, or instance role)
+- Auth: Bearer token (`AWS_BEARER_TOKEN_BEDROCK`) or AWS credentials (env vars, shared config, or instance role)
 - Region: `AWS_REGION` or `AWS_DEFAULT_REGION` (default: `us-east-1`)
 
 ## Automatic model discovery
@@ -167,9 +190,9 @@ openclaw models list
 - Bedrock requires **model access** enabled in your AWS account/region.
 - Automatic discovery needs the `bedrock:ListFoundationModels` permission.
 - If you use profiles, set `AWS_PROFILE` on the gateway host.
-- OpenClaw surfaces the credential source in this order: `AWS_BEARER_TOKEN_BEDROCK`,
+- Auth precedence: `AWS_BEARER_TOKEN_BEDROCK` (bearer token, highest priority),
   then `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, then `AWS_PROFILE`, then the
-  default AWS SDK chain.
+  default AWS SDK chain. When bearer token is set, AWS SDK signing is bypassed.
 - Reasoning support depends on the model; check the Bedrock model card for
   current capabilities.
 - If you prefer a managed key flow, you can also place an OpenAI‑compatible

--- a/src/agents/bedrock-bearer.live.test.ts
+++ b/src/agents/bedrock-bearer.live.test.ts
@@ -1,0 +1,64 @@
+import type { Model } from "@mariozechner/pi-ai";
+import { streamSimple } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { isTruthyEnvValue } from "../infra/env.js";
+import {
+  createSingleUserPromptMessage,
+  extractNonEmptyAssistantText,
+} from "./live-test-helpers.js";
+import { resolveBedrockBearerToken } from "./model-auth.js";
+import { createBedrockBearerTokenWrapper } from "./pi-embedded-runner/anthropic-stream-wrappers.js";
+
+const BEARER_TOKEN = resolveBedrockBearerToken() ?? "";
+const LIVE = isTruthyEnvValue(process.env.BEDROCK_LIVE_TEST) || isTruthyEnvValue(process.env.LIVE);
+const REGION = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? "us-east-1";
+const MODEL_ID =
+  process.env.BEDROCK_LIVE_MODEL?.trim() || "us.anthropic.claude-3-5-haiku-20241022-v1:0";
+
+const describeLive = LIVE && BEARER_TOKEN ? describe : describe.skip;
+
+describeLive("bedrock bearer token auth (live)", () => {
+  it("sends a request using Authorization: Bearer and receives a response", async () => {
+    const model: Model<"bedrock-converse-stream"> = {
+      id: MODEL_ID,
+      name: `Bedrock ${MODEL_ID}`,
+      api: "bedrock-converse-stream",
+      provider: "amazon-bedrock",
+      baseUrl: `https://bedrock-runtime.${REGION}.amazonaws.com`,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 4096,
+    };
+
+    // Apply the bearer token wrapper — this is the code path under test.
+    const wrappedStreamFn = createBedrockBearerTokenWrapper(streamSimple, BEARER_TOKEN);
+
+    // StreamFn may return a Promise; await to handle both sync and async.
+    const stream = await wrappedStreamFn(
+      model,
+      { messages: createSingleUserPromptMessage() },
+      { maxTokens: 64 },
+    );
+
+    let sawDone = false;
+    let assistantText = "";
+    for await (const event of stream) {
+      if (event.type === "text_delta") {
+        assistantText += event.delta;
+      }
+      if (event.type === "done") {
+        sawDone = true;
+        // Also extract from the final message in case deltas were empty.
+        const doneText = extractNonEmptyAssistantText(event.message.content);
+        if (doneText && !assistantText.trim()) {
+          assistantText = doneText;
+        }
+      }
+    }
+
+    expect(sawDone).toBe(true);
+    expect(assistantText.trim().length).toBeGreaterThan(0);
+  }, 30_000);
+});

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -45,11 +45,17 @@ async function resolveBedrockProvider() {
 async function expectBedrockAuthSource(params: {
   env: Record<string, string | undefined>;
   expectedSource: string;
+  expectedMode?: "aws-sdk" | "api-key";
+  expectedApiKey?: string;
 }) {
   await withEnvAsync(params.env, async () => {
     const resolved = await resolveBedrockProvider();
-    expect(resolved.mode).toBe("aws-sdk");
-    expect(resolved.apiKey).toBeUndefined();
+    expect(resolved.mode).toBe(params.expectedMode ?? "aws-sdk");
+    if (params.expectedApiKey !== undefined) {
+      expect(resolved.apiKey).toBe(params.expectedApiKey);
+    } else {
+      expect(resolved.apiKey).toBeUndefined();
+    }
     expect(resolved.source).toContain(params.expectedSource);
   });
 }
@@ -362,6 +368,8 @@ describe("getApiKeyForModel", () => {
         AWS_PROFILE: "profile",
       },
       expectedSource: "AWS_BEARER_TOKEN_BEDROCK",
+      expectedMode: "api-key",
+      expectedApiKey: "bedrock-token",
     });
   });
 

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -562,6 +562,35 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
     ).rejects.toThrow('No API key found for provider "custom"');
   });
 
+  it("does not leak bearer token to non-bedrock provider with aws-sdk auth", async () => {
+    await withEnvAsync(
+      {
+        AWS_BEARER_TOKEN_BEDROCK: "bedrock-only-token", // pragma: allowlist secret
+        AWS_ACCESS_KEY_ID: "access",
+        AWS_SECRET_ACCESS_KEY: "secret", // pragma: allowlist secret
+      },
+      async () => {
+        const auth = await resolveApiKeyForProvider({
+          provider: "google-vertex",
+          cfg: {
+            models: {
+              providers: {
+                "google-vertex": {
+                  auth: "aws-sdk",
+                  models: [],
+                },
+              },
+            },
+          },
+        });
+
+        // Non-Bedrock provider should get aws-sdk mode, not the bearer token.
+        expect(auth.mode).toBe("aws-sdk");
+        expect(auth.apiKey).toBeUndefined();
+      },
+    );
+  });
+
   it("keeps built-in aws-sdk fallback for local baseUrl overrides", async () => {
     await withEnvAsync({ AWS_BEARER_TOKEN_BEDROCK: undefined }, async () => {
       const auth = await resolveApiKeyForProvider({

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -75,24 +75,26 @@ describe("resolveModelAuthMode", () => {
     expect(resolveModelAuthMode("openai", undefined, store)).toBe("mixed");
   });
 
-  it("returns aws-sdk when provider auth is overridden", () => {
-    expect(
-      resolveModelAuthMode(
-        "amazon-bedrock",
-        {
-          models: {
-            providers: {
-              "amazon-bedrock": {
-                baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-                models: [],
-                auth: "aws-sdk",
+  it("returns aws-sdk when provider auth is overridden", async () => {
+    await withEnvAsync({ AWS_BEARER_TOKEN_BEDROCK: undefined }, async () => {
+      expect(
+        resolveModelAuthMode(
+          "amazon-bedrock",
+          {
+            models: {
+              providers: {
+                "amazon-bedrock": {
+                  baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+                  models: [],
+                  auth: "aws-sdk",
+                },
               },
             },
           },
-        },
-        { version: 1, profiles: {} },
-      ),
-    ).toBe("aws-sdk");
+          { version: 1, profiles: {} },
+        ),
+      ).toBe("aws-sdk");
+    });
   });
 
   it("returns aws-sdk for bedrock alias without explicit auth override", async () => {
@@ -109,6 +111,36 @@ describe("resolveModelAuthMode", () => {
         "aws-sdk",
       );
     });
+  });
+
+  it("returns api-key for bedrock even with explicit aws-sdk override when bearer token is set", async () => {
+    await withEnvAsync(
+      {
+        AWS_BEARER_TOKEN_BEDROCK: "bedrock-bearer-override", // pragma: allowlist secret
+        AWS_ACCESS_KEY_ID: undefined,
+        AWS_SECRET_ACCESS_KEY: undefined,
+        AWS_PROFILE: undefined,
+      },
+      async () => {
+        expect(
+          resolveModelAuthMode(
+            "amazon-bedrock",
+            {
+              models: {
+                providers: {
+                  "amazon-bedrock": {
+                    baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+                    models: [],
+                    auth: "aws-sdk",
+                  },
+                },
+              },
+            },
+            { version: 1, profiles: {} },
+          ),
+        ).toBe("api-key");
+      },
+    );
   });
 
   it("returns api-key for bedrock when bearer token is set", async () => {
@@ -531,22 +563,24 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
   });
 
   it("keeps built-in aws-sdk fallback for local baseUrl overrides", async () => {
-    const auth = await resolveApiKeyForProvider({
-      provider: "amazon-bedrock",
-      cfg: {
-        models: {
-          providers: {
-            "amazon-bedrock": {
-              baseUrl: "http://127.0.0.1:8080/v1",
-              models: [],
+    await withEnvAsync({ AWS_BEARER_TOKEN_BEDROCK: undefined }, async () => {
+      const auth = await resolveApiKeyForProvider({
+        provider: "amazon-bedrock",
+        cfg: {
+          models: {
+            providers: {
+              "amazon-bedrock": {
+                baseUrl: "http://*********:8080/v1",
+                models: [],
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    expect(auth.mode).toBe("aws-sdk");
-    expect(auth.apiKey).toBeUndefined();
+      expect(auth.mode).toBe("aws-sdk");
+      expect(auth.apiKey).toBeUndefined();
+    });
   });
 });
 

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1,5 +1,6 @@
 import { streamSimpleOpenAICompletions, type Model } from "@mariozechner/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import {
@@ -13,6 +14,7 @@ import {
   requireApiKey,
   resolveApiKeyForProvider,
   resolveAwsSdkEnvVarName,
+  resolveBedrockBearerToken,
   resolveModelAuthMode,
   resolveUsableCustomProviderApiKey,
 } from "./model-auth.js";
@@ -93,16 +95,53 @@ describe("resolveModelAuthMode", () => {
     ).toBe("aws-sdk");
   });
 
-  it("returns aws-sdk for bedrock alias without explicit auth override", () => {
-    expect(resolveModelAuthMode("bedrock", undefined, { version: 1, profiles: {} })).toBe(
-      "aws-sdk",
-    );
+  it("returns aws-sdk for bedrock alias without explicit auth override", async () => {
+    await withEnvAsync({ AWS_BEARER_TOKEN_BEDROCK: undefined }, async () => {
+      expect(resolveModelAuthMode("bedrock", undefined, { version: 1, profiles: {} })).toBe(
+        "aws-sdk",
+      );
+    });
   });
 
-  it("returns aws-sdk for aws-bedrock alias without explicit auth override", () => {
-    expect(resolveModelAuthMode("aws-bedrock", undefined, { version: 1, profiles: {} })).toBe(
-      "aws-sdk",
+  it("returns aws-sdk for aws-bedrock alias without explicit auth override", async () => {
+    await withEnvAsync({ AWS_BEARER_TOKEN_BEDROCK: undefined }, async () => {
+      expect(resolveModelAuthMode("aws-bedrock", undefined, { version: 1, profiles: {} })).toBe(
+        "aws-sdk",
+      );
+    });
+  });
+
+  it("returns api-key for bedrock when bearer token is set", async () => {
+    await withEnvAsync(
+      {
+        AWS_BEARER_TOKEN_BEDROCK: "bedrock-bearer-test", // pragma: allowlist secret
+        AWS_ACCESS_KEY_ID: undefined,
+        AWS_SECRET_ACCESS_KEY: undefined,
+        AWS_PROFILE: undefined,
+      },
+      async () => {
+        expect(
+          resolveModelAuthMode("amazon-bedrock", undefined, { version: 1, profiles: {} }),
+        ).toBe("api-key");
+      },
     );
+  });
+});
+
+describe("resolveBedrockBearerToken", () => {
+  it("returns the trimmed token value when set", () => {
+    const env = { AWS_BEARER_TOKEN_BEDROCK: "  my-token  " } as NodeJS.ProcessEnv;
+    expect(resolveBedrockBearerToken(env)).toBe("my-token");
+  });
+
+  it("returns undefined when env var is missing", () => {
+    expect(resolveBedrockBearerToken({} as NodeJS.ProcessEnv)).toBeUndefined();
+  });
+
+  it("returns undefined when env var is empty/whitespace", () => {
+    expect(
+      resolveBedrockBearerToken({ AWS_BEARER_TOKEN_BEDROCK: "  " } as NodeJS.ProcessEnv),
+    ).toBeUndefined();
   });
 });
 

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -143,6 +143,32 @@ describe("resolveModelAuthMode", () => {
     );
   });
 
+  it("returns aws-sdk for non-bedrock provider with aws-sdk override even when bearer token is set", async () => {
+    await withEnvAsync(
+      {
+        AWS_BEARER_TOKEN_BEDROCK: "bedrock-only-token", // pragma: allowlist secret
+      },
+      async () => {
+        expect(
+          resolveModelAuthMode(
+            "google-vertex",
+            {
+              models: {
+                providers: {
+                  "google-vertex": {
+                    auth: "aws-sdk",
+                    models: [],
+                  },
+                },
+              },
+            },
+            { version: 1, profiles: {} },
+          ),
+        ).toBe("aws-sdk");
+      },
+    );
+  });
+
   it("returns api-key for bedrock when bearer token is set", async () => {
     await withEnvAsync(
       {

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -156,6 +156,7 @@ describe("resolveModelAuthMode", () => {
               models: {
                 providers: {
                   "google-vertex": {
+                    baseUrl: "https://vertex.example.com",
                     auth: "aws-sdk",
                     models: [],
                   },
@@ -602,6 +603,7 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
             models: {
               providers: {
                 "google-vertex": {
+                  baseUrl: "https://vertex.example.com",
                   auth: "aws-sdk",
                   models: [],
                 },

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -239,11 +239,15 @@ export function resolveBedrockBearerToken(
  * Only true when:
  * 1. Provider normalizes to amazon-bedrock
  * 2. AWS_BEARER_TOKEN_BEDROCK env var is set
- * 3. Auth override is either undefined (implicit) or "aws-sdk" — if the user
- *    explicitly configured api-key/oauth/token, that credential path takes
- *    precedence and the bearer wrapper must not overwrite it.
+ * 3. Auth override is either undefined (implicit) or "aws-sdk"
+ * 4. No auth profiles exist for this provider (profiles take precedence
+ *    over the bearer env fallback in resolveApiKeyForProvider)
  */
-export function shouldInjectBedrockBearerWrapper(provider: string, cfg?: OpenClawConfig): boolean {
+export function shouldInjectBedrockBearerWrapper(
+  provider: string,
+  cfg?: OpenClawConfig,
+  store?: AuthProfileStore,
+): boolean {
   if (normalizeProviderId(provider) !== "amazon-bedrock") {
     return false;
   }
@@ -251,7 +255,16 @@ export function shouldInjectBedrockBearerWrapper(provider: string, cfg?: OpenCla
     return false;
   }
   const authOverride = resolveProviderAuthOverride(cfg, provider);
-  return authOverride === undefined || authOverride === "aws-sdk";
+  if (authOverride !== undefined && authOverride !== "aws-sdk") {
+    return false;
+  }
+  // If profiles exist for this provider, resolveApiKeyForProvider uses them
+  // before the bearer env fallback — don't overwrite with the bearer wrapper.
+  const authStore = store ?? ensureAuthProfileStore();
+  if (listProfilesForProvider(authStore, provider).length > 0) {
+    return false;
+  }
+  return true;
 }
 
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -236,17 +236,20 @@ export function resolveBedrockBearerToken(
 
 /**
  * Returns true when the Bedrock bearer token wrapper should be injected.
- * Only true when:
- * 1. Provider normalizes to amazon-bedrock
- * 2. AWS_BEARER_TOKEN_BEDROCK env var is set
- * 3. Auth override is either undefined (implicit) or "aws-sdk"
- * 4. No auth profiles exist for this provider (profiles take precedence
- *    over the bearer env fallback in resolveApiKeyForProvider)
+ *
+ * When `resolvedAuthSource` is provided (from `resolveApiKeyForProvider`),
+ * the decision is based on whether auth actually resolved to the bearer env
+ * var — this is the most accurate path and avoids false positives/negatives
+ * from profile-existence heuristics.
+ *
+ * When `resolvedAuthSource` is not available (e.g. in `applyExtraParamsToAgent`
+ * which doesn't receive resolved auth), falls back to a static check:
+ * provider is Bedrock + bearer env is set + auth override is compatible.
  */
 export function shouldInjectBedrockBearerWrapper(
   provider: string,
   cfg?: OpenClawConfig,
-  store?: AuthProfileStore,
+  resolvedAuthSource?: string,
 ): boolean {
   if (normalizeProviderId(provider) !== "amazon-bedrock") {
     return false;
@@ -254,21 +257,14 @@ export function shouldInjectBedrockBearerWrapper(
   if (!resolveBedrockBearerToken()) {
     return false;
   }
+  // When the caller provides the resolved auth source, use it directly:
+  // only inject when auth actually resolved to the bearer env var.
+  if (resolvedAuthSource !== undefined) {
+    return resolvedAuthSource.includes(AWS_BEARER_ENV);
+  }
+  // Fallback heuristic when resolved auth is not available.
   const authOverride = resolveProviderAuthOverride(cfg, provider);
-  if (authOverride !== undefined && authOverride !== "aws-sdk") {
-    return false;
-  }
-  // When auth: "aws-sdk" is set, resolveApiKeyForProvider skips profiles and
-  // goes directly to resolveAwsSdkAuthInfo (which returns the bearer token).
-  // Only check profiles when there is no explicit override — in that path,
-  // profiles are resolved before the bearer env fallback.
-  if (authOverride === undefined) {
-    const authStore = store ?? ensureAuthProfileStore();
-    if (listProfilesForProvider(authStore, provider).length > 0) {
-      return false;
-    }
-  }
-  return true;
+  return authOverride === undefined || authOverride === "aws-sdk";
 }
 
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -224,6 +224,17 @@ function resolveEnvSourceLabel(params: {
   return `${prefix}${params.label}`;
 }
 
+/**
+ * Returns the trimmed bearer token value from AWS_BEARER_TOKEN_BEDROCK, or undefined.
+ * Exported for use by the stream-wrapper layer that injects the Authorization header.
+ */
+export function resolveBedrockBearerToken(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const value = env[AWS_BEARER_ENV]?.trim();
+  return value || undefined;
+}
+
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {
   if (env[AWS_BEARER_ENV]?.trim()) {
     return AWS_BEARER_ENV;
@@ -237,11 +248,20 @@ export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): s
   return undefined;
 }
 
-function resolveAwsSdkAuthInfo(): { mode: "aws-sdk"; source: string } {
+function resolveAwsSdkAuthInfo(env: NodeJS.ProcessEnv = process.env): {
+  mode: "aws-sdk" | "api-key";
+  source: string;
+  apiKey?: string;
+} {
   const applied = new Set(getShellEnvAppliedKeys());
-  if (process.env[AWS_BEARER_ENV]?.trim()) {
+  const bearerToken = resolveBedrockBearerToken(env);
+  if (bearerToken) {
+    // Bearer token auth: return the actual token so the downstream pipeline
+    // stores it as a runtime API key and the stream wrapper injects it as
+    // an Authorization: Bearer header (bypassing AWS SDK signing).
     return {
-      mode: "aws-sdk",
+      mode: "api-key",
+      apiKey: bearerToken,
       source: resolveEnvSourceLabel({
         applied,
         envVars: [AWS_BEARER_ENV],
@@ -249,7 +269,7 @@ function resolveAwsSdkAuthInfo(): { mode: "aws-sdk"; source: string } {
       }),
     };
   }
-  if (process.env[AWS_ACCESS_KEY_ENV]?.trim() && process.env[AWS_SECRET_KEY_ENV]?.trim()) {
+  if (env[AWS_ACCESS_KEY_ENV]?.trim() && env[AWS_SECRET_KEY_ENV]?.trim()) {
     return {
       mode: "aws-sdk",
       source: resolveEnvSourceLabel({
@@ -259,7 +279,7 @@ function resolveAwsSdkAuthInfo(): { mode: "aws-sdk"; source: string } {
       }),
     };
   }
-  if (process.env[AWS_PROFILE_ENV]?.trim()) {
+  if (env[AWS_PROFILE_ENV]?.trim()) {
     return {
       mode: "aws-sdk",
       source: resolveEnvSourceLabel({
@@ -363,7 +383,12 @@ export async function resolveApiKeyForProvider(params: {
 
   const normalized = normalizeProviderId(provider);
   if (authOverride === undefined && normalized === "amazon-bedrock") {
-    return resolveAwsSdkAuthInfo();
+    const awsAuth = resolveAwsSdkAuthInfo();
+    return {
+      apiKey: awsAuth.apiKey,
+      source: awsAuth.source,
+      mode: awsAuth.mode,
+    };
   }
 
   const { buildProviderMissingAuthMessageWithPlugin } = await loadProviderRuntime();
@@ -439,7 +464,8 @@ export function resolveModelAuthMode(
   }
 
   if (authOverride === undefined && normalizeProviderId(resolved) === "amazon-bedrock") {
-    return "aws-sdk";
+    // Bearer token takes precedence: report as api-key so UI/status shows the right mode.
+    return resolveBedrockBearerToken() ? "api-key" : "aws-sdk";
   }
 
   const envKey = resolveEnvApiKey(resolved);

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -234,6 +234,26 @@ export function resolveBedrockBearerToken(
   return normalizeOptionalSecretInput(env[AWS_BEARER_ENV]);
 }
 
+/**
+ * Returns true when the Bedrock bearer token wrapper should be injected.
+ * Only true when:
+ * 1. Provider normalizes to amazon-bedrock
+ * 2. AWS_BEARER_TOKEN_BEDROCK env var is set
+ * 3. Auth override is either undefined (implicit) or "aws-sdk" — if the user
+ *    explicitly configured api-key/oauth/token, that credential path takes
+ *    precedence and the bearer wrapper must not overwrite it.
+ */
+export function shouldInjectBedrockBearerWrapper(provider: string, cfg?: OpenClawConfig): boolean {
+  if (normalizeProviderId(provider) !== "amazon-bedrock") {
+    return false;
+  }
+  if (!resolveBedrockBearerToken()) {
+    return false;
+  }
+  const authOverride = resolveProviderAuthOverride(cfg, provider);
+  return authOverride === undefined || authOverride === "aws-sdk";
+}
+
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {
   if (env[AWS_BEARER_ENV]?.trim()) {
     return AWS_BEARER_ENV;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -435,7 +435,9 @@ export function resolveModelAuthMode(
 
   const authOverride = resolveProviderAuthOverride(cfg, resolved);
   if (authOverride === "aws-sdk") {
-    return "aws-sdk";
+    // Bearer token takes precedence over the aws-sdk override so the
+    // reported mode matches what resolveApiKeyForProvider actually returns.
+    return resolveBedrockBearerToken() ? "api-key" : "aws-sdk";
   }
 
   const authStore = store ?? ensureAuthProfileStore();

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -438,9 +438,12 @@ export function resolveModelAuthMode(
 
   const authOverride = resolveProviderAuthOverride(cfg, resolved);
   if (authOverride === "aws-sdk") {
-    // Bearer token takes precedence over the aws-sdk override so the
+    // Bearer token takes precedence only for Bedrock providers so the
     // reported mode matches what resolveApiKeyForProvider actually returns.
-    return resolveBedrockBearerToken() ? "api-key" : "aws-sdk";
+    if (normalizeProviderId(resolved) === "amazon-bedrock" && resolveBedrockBearerToken()) {
+      return "api-key";
+    }
+    return "aws-sdk";
   }
 
   const authStore = store ?? ensureAuthProfileStore();

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -258,11 +258,15 @@ export function shouldInjectBedrockBearerWrapper(
   if (authOverride !== undefined && authOverride !== "aws-sdk") {
     return false;
   }
-  // If profiles exist for this provider, resolveApiKeyForProvider uses them
-  // before the bearer env fallback — don't overwrite with the bearer wrapper.
-  const authStore = store ?? ensureAuthProfileStore();
-  if (listProfilesForProvider(authStore, provider).length > 0) {
-    return false;
+  // When auth: "aws-sdk" is set, resolveApiKeyForProvider skips profiles and
+  // goes directly to resolveAwsSdkAuthInfo (which returns the bearer token).
+  // Only check profiles when there is no explicit override — in that path,
+  // profiles are resolved before the bearer env fallback.
+  if (authOverride === undefined) {
+    const authStore = store ?? ensureAuthProfileStore();
+    if (listProfilesForProvider(authStore, provider).length > 0) {
+      return false;
+    }
   }
   return true;
 }

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -231,8 +231,7 @@ function resolveEnvSourceLabel(params: {
 export function resolveBedrockBearerToken(
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
-  const value = env[AWS_BEARER_ENV]?.trim();
-  return value || undefined;
+  return normalizeOptionalSecretInput(env[AWS_BEARER_ENV]);
 }
 
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -247,26 +247,30 @@ export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): s
   return undefined;
 }
 
-function resolveAwsSdkAuthInfo(env: NodeJS.ProcessEnv = process.env): {
+function resolveAwsSdkAuthInfo(
+  provider: string,
+  env: NodeJS.ProcessEnv = process.env,
+): {
   mode: "aws-sdk" | "api-key";
   source: string;
   apiKey?: string;
 } {
   const applied = new Set(getShellEnvAppliedKeys());
-  const bearerToken = resolveBedrockBearerToken(env);
-  if (bearerToken) {
-    // Bearer token auth: return the actual token so the downstream pipeline
-    // stores it as a runtime API key and the stream wrapper injects it as
-    // an Authorization: Bearer header (bypassing AWS SDK signing).
-    return {
-      mode: "api-key",
-      apiKey: bearerToken,
-      source: resolveEnvSourceLabel({
-        applied,
-        envVars: [AWS_BEARER_ENV],
-        label: AWS_BEARER_ENV,
-      }),
-    };
+  // Only check bearer token for Bedrock providers to avoid leaking Bedrock
+  // credentials to unrelated providers that also use aws-sdk auth.
+  if (normalizeProviderId(provider) === "amazon-bedrock") {
+    const bearerToken = resolveBedrockBearerToken(env);
+    if (bearerToken) {
+      return {
+        mode: "api-key",
+        apiKey: bearerToken,
+        source: resolveEnvSourceLabel({
+          applied,
+          envVars: [AWS_BEARER_ENV],
+          label: AWS_BEARER_ENV,
+        }),
+      };
+    }
   }
   if (env[AWS_ACCESS_KEY_ENV]?.trim() && env[AWS_SECRET_KEY_ENV]?.trim()) {
     return {
@@ -330,7 +334,7 @@ export async function resolveApiKeyForProvider(params: {
 
   const authOverride = resolveProviderAuthOverride(cfg, provider);
   if (authOverride === "aws-sdk") {
-    return resolveAwsSdkAuthInfo();
+    return resolveAwsSdkAuthInfo(provider);
   }
 
   const order = resolveAuthProfileOrder({
@@ -382,7 +386,7 @@ export async function resolveApiKeyForProvider(params: {
 
   const normalized = normalizeProviderId(provider);
   if (authOverride === undefined && normalized === "amazon-bedrock") {
-    const awsAuth = resolveAwsSdkAuthInfo();
+    const awsAuth = resolveAwsSdkAuthInfo(provider);
     return {
       apiKey: awsAuth.apiKey,
       source: awsAuth.source,

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2508,6 +2508,42 @@ describe("applyExtraParamsToAgent", () => {
     }
   });
 
+  it("replaces pre-existing lowercase authorization header with Bearer token", () => {
+    const prev = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    process.env.AWS_BEARER_TOKEN_BEDROCK = "bedrock-test-token"; // pragma: allowlist secret
+    try {
+      const { calls, agent } = createOptionsCaptureAgent();
+
+      applyExtraParamsToAgent(agent, undefined, "amazon-bedrock", "us.anthropic.claude-sonnet-4-5");
+
+      const model = {
+        api: "bedrock-converse-stream",
+        provider: "amazon-bedrock",
+        id: "us.anthropic.claude-sonnet-4-5",
+      } as Model<"bedrock-converse-stream">;
+      const context: Context = { messages: [] };
+
+      void agent.streamFn?.(model, context, {
+        headers: { authorization: "Basic old-creds", "X-Custom": "1" },
+      });
+
+      expect(calls).toHaveLength(1);
+      const headers = calls[0]?.headers ?? {};
+      // Should have replaced lowercase authorization, not both.
+      expect(headers).toMatchObject({
+        "X-Custom": "1",
+        Authorization: "Bearer bedrock-test-token",
+      });
+      expect(headers).not.toHaveProperty("authorization");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      } else {
+        process.env.AWS_BEARER_TOKEN_BEDROCK = prev;
+      }
+    }
+  });
+
   it("does not inject Bearer header when AWS_BEARER_TOKEN_BEDROCK is not set", () => {
     const prev = process.env.AWS_BEARER_TOKEN_BEDROCK;
     delete process.env.AWS_BEARER_TOKEN_BEDROCK;

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2397,6 +2397,7 @@ describe("applyExtraParamsToAgent", () => {
     },
   );
 
+<<<<<<< HEAD
   it("strips prompt cache fields for non-OpenAI openai-responses endpoints", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "custom-proxy",
@@ -2474,5 +2475,65 @@ describe("applyExtraParamsToAgent", () => {
     });
     expect(payload.prompt_cache_key).toBe("session-default");
     expect(payload.prompt_cache_retention).toBe("24h");
+  });
+
+  it("injects Authorization Bearer header when AWS_BEARER_TOKEN_BEDROCK is set", () => {
+    const prev = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    process.env.AWS_BEARER_TOKEN_BEDROCK = "bedrock-test-token"; // pragma: allowlist secret
+    try {
+      const { calls, agent } = createOptionsCaptureAgent();
+
+      applyExtraParamsToAgent(agent, undefined, "amazon-bedrock", "us.anthropic.claude-sonnet-4-5");
+
+      const model = {
+        api: "bedrock-converse-stream",
+        provider: "amazon-bedrock",
+        id: "us.anthropic.claude-sonnet-4-5",
+      } as Model<"bedrock-converse-stream">;
+      const context: Context = { messages: [] };
+
+      void agent.streamFn?.(model, context, { headers: { "X-Custom": "1" } });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.headers).toMatchObject({
+        "X-Custom": "1",
+        Authorization: "Bearer bedrock-test-token",
+      });
+    } finally {
+      if (prev === undefined) {
+        delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      } else {
+        process.env.AWS_BEARER_TOKEN_BEDROCK = prev;
+      }
+    }
+  });
+
+  it("does not inject Bearer header when AWS_BEARER_TOKEN_BEDROCK is not set", () => {
+    const prev = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    try {
+      const { calls, agent } = createOptionsCaptureAgent();
+
+      applyExtraParamsToAgent(agent, undefined, "amazon-bedrock", "us.anthropic.claude-sonnet-4-5");
+
+      const model = {
+        api: "bedrock-converse-stream",
+        provider: "amazon-bedrock",
+        id: "us.anthropic.claude-sonnet-4-5",
+      } as Model<"bedrock-converse-stream">;
+      const context: Context = { messages: [] };
+
+      void agent.streamFn?.(model, context, {});
+
+      expect(calls).toHaveLength(1);
+      const headers = calls[0]?.headers ?? {};
+      expect(headers).not.toHaveProperty("Authorization");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      } else {
+        process.env.AWS_BEARER_TOKEN_BEDROCK = prev;
+      }
+    }
   });
 });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2397,7 +2397,6 @@ describe("applyExtraParamsToAgent", () => {
     },
   );
 
-<<<<<<< HEAD
   it("strips prompt cache fields for non-OpenAI openai-responses endpoints", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "custom-proxy",

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -400,7 +400,16 @@ export function createBedrockBearerTokenWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    const merged: Record<string, string> = { ...options?.headers };
+    const merged: Record<string, string> = {};
+    // Copy existing headers, stripping any case-insensitive Authorization
+    // variant to avoid duplicate/comma-joined values in the request.
+    if (options?.headers) {
+      for (const [key, value] of Object.entries(options.headers)) {
+        if (key.toLowerCase() !== "authorization") {
+          merged[key] = value;
+        }
+      }
+    }
     merged.Authorization = `Bearer ${bearerToken}`;
     return underlying(model, context, {
       ...options,

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -390,6 +390,25 @@ export function createBedrockNoCacheWrapper(baseStreamFn: StreamFn | undefined):
     });
 }
 
+/**
+ * Injects `Authorization: Bearer <token>` for Bedrock requests that use
+ * bearer-token auth instead of AWS SDK signing.
+ */
+export function createBedrockBearerTokenWrapper(
+  baseStreamFn: StreamFn | undefined,
+  bearerToken: string,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const merged: Record<string, string> = { ...options?.headers };
+    merged.Authorization = `Bearer ${bearerToken}`;
+    return underlying(model, context, {
+      ...options,
+      headers: merged,
+    });
+  };
+}
+
 export function isAnthropicBedrockModel(modelId: string): boolean {
   const normalized = modelId.toLowerCase();
   return normalized.includes("anthropic.claude") || normalized.includes("anthropic/claude");

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -53,8 +53,8 @@ import {
   getApiKeyForModel,
   resolveBedrockBearerToken,
   resolveModelAuthMode,
+  shouldInjectBedrockBearerWrapper,
 } from "../model-auth.js";
-import { normalizeProviderId } from "../model-selection.js";
 import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { createConfiguredOllamaStreamFn } from "../ollama-stream.js";
@@ -844,17 +844,15 @@ export async function compactEmbeddedPiSessionDirect(
       // The main run flow applies this via applyExtraParamsToAgent, but
       // compaction creates its session directly — without the wrapper,
       // compaction calls would fail when only bearer token auth is set.
-      if (normalizeProviderId(provider) === "amazon-bedrock") {
+      if (shouldInjectBedrockBearerWrapper(provider, params.config)) {
         const bearerToken = resolveBedrockBearerToken();
-        if (bearerToken) {
-          log.debug(
-            `applying Bedrock bearer token auth header for compaction (${provider}/${modelId})`,
-          );
-          session.agent.streamFn = createBedrockBearerTokenWrapper(
-            session.agent.streamFn,
-            bearerToken,
-          );
-        }
+        log.debug(
+          `applying Bedrock bearer token auth header for compaction (${provider}/${modelId})`,
+        );
+        session.agent.streamFn = createBedrockBearerTokenWrapper(
+          session.agent.streamFn,
+          bearerToken!,
+        );
       }
 
       applySystemPromptOverrideToSession(session, systemPromptOverride());

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -844,7 +844,7 @@ export async function compactEmbeddedPiSessionDirect(
       // The main run flow applies this via applyExtraParamsToAgent, but
       // compaction creates its session directly — without the wrapper,
       // compaction calls would fail when only bearer token auth is set.
-      if (shouldInjectBedrockBearerWrapper(provider, params.config)) {
+      if (shouldInjectBedrockBearerWrapper(provider, params.config, apiKeyInfo?.source)) {
         const bearerToken = resolveBedrockBearerToken();
         log.debug(
           `applying Bedrock bearer token auth header for compaction (${provider}/${modelId})`,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -51,6 +51,7 @@ import { resolveMemorySearchConfig } from "../memory-search.js";
 import {
   applyLocalNoAuthHeaderOverride,
   getApiKeyForModel,
+  resolveBedrockBearerToken,
   resolveModelAuthMode,
 } from "../model-auth.js";
 import { supportsModelTools } from "../model-tool-support.js";
@@ -83,6 +84,7 @@ import {
   type SkillSnapshot,
 } from "../skills.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
+import { createBedrockBearerTokenWrapper } from "./anthropic-stream-wrappers.js";
 import {
   compactWithSafetyTimeout,
   resolveCompactionTimeoutMs,
@@ -837,6 +839,23 @@ export async function compactEmbeddedPiSessionDirect(
         settingsManager,
         resourceLoader,
       });
+      // Inject Bedrock bearer token header for compaction requests.
+      // The main run flow applies this via applyExtraParamsToAgent, but
+      // compaction creates its session directly — without the wrapper,
+      // compaction calls would fail when only bearer token auth is set.
+      if (provider === "amazon-bedrock") {
+        const bearerToken = resolveBedrockBearerToken();
+        if (bearerToken) {
+          log.debug(
+            `applying Bedrock bearer token auth header for compaction (${provider}/${modelId})`,
+          );
+          session.agent.streamFn = createBedrockBearerTokenWrapper(
+            session.agent.streamFn,
+            bearerToken,
+          );
+        }
+      }
+
       applySystemPromptOverrideToSession(session, systemPromptOverride());
       if (model.api === "ollama") {
         const providerBaseUrl =

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -54,6 +54,7 @@ import {
   resolveBedrockBearerToken,
   resolveModelAuthMode,
 } from "../model-auth.js";
+import { normalizeProviderId } from "../model-selection.js";
 import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { createConfiguredOllamaStreamFn } from "../ollama-stream.js";
@@ -843,7 +844,7 @@ export async function compactEmbeddedPiSessionDirect(
       // The main run flow applies this via applyExtraParamsToAgent, but
       // compaction creates its session directly — without the wrapper,
       // compaction calls would fail when only bearer token auth is set.
-      if (provider === "amazon-bedrock") {
+      if (normalizeProviderId(provider) === "amazon-bedrock") {
         const bearerToken = resolveBedrockBearerToken();
         if (bearerToken) {
           log.debug(

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1,7 +1,10 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
-import { resolveBedrockBearerToken } from "../../agents/model-auth.js";
+import {
+  resolveBedrockBearerToken,
+  shouldInjectBedrockBearerWrapper,
+} from "../../agents/model-auth.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -292,12 +295,10 @@ export function applyExtraParamsToAgent(
     agent.streamFn = createBedrockNoCacheWrapper(agent.streamFn);
   }
 
-  if (normalizeProviderId(provider) === "amazon-bedrock") {
+  if (shouldInjectBedrockBearerWrapper(provider, cfg)) {
     const bearerToken = resolveBedrockBearerToken();
-    if (bearerToken) {
-      log.debug(`applying Bedrock bearer token auth header for ${provider}/${modelId}`);
-      agent.streamFn = createBedrockBearerTokenWrapper(agent.streamFn, bearerToken);
-    }
+    log.debug(`applying Bedrock bearer token auth header for ${provider}/${modelId}`);
+    agent.streamFn = createBedrockBearerTokenWrapper(agent.streamFn, bearerToken!);
   }
 
   // Guard Google payloads against invalid negative thinking budgets emitted by

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1,6 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
+import { resolveBedrockBearerToken } from "../../agents/model-auth.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
@@ -12,6 +13,7 @@ import {
   createBedrockNoCacheWrapper,
   createAnthropicFastModeWrapper,
   createAnthropicToolPayloadCompatibilityWrapper,
+  createBedrockBearerTokenWrapper,
   isAnthropicBedrockModel,
   resolveAnthropicFastMode,
   resolveAnthropicBetas,
@@ -289,10 +291,17 @@ export function applyExtraParamsToAgent(
     agent.streamFn = createBedrockNoCacheWrapper(agent.streamFn);
   }
 
+  if (provider === "amazon-bedrock") {
+    const bearerToken = resolveBedrockBearerToken();
+    if (bearerToken) {
+      log.debug(`applying Bedrock bearer token auth header for ${provider}/${modelId}`);
+      agent.streamFn = createBedrockBearerTokenWrapper(agent.streamFn, bearerToken);
+    }
+  }
+
   // Guard Google payloads against invalid negative thinking budgets emitted by
   // upstream model-ID heuristics for Gemini 3.1 variants.
   agent.streamFn = createGoogleThinkingPayloadWrapper(agent.streamFn, thinkingLevel);
-
   const anthropicFastMode = resolveAnthropicFastMode(effectiveExtraParams);
   if (anthropicFastMode !== undefined) {
     log.debug(`applying Anthropic fast mode=${anthropicFastMode} for ${provider}/${modelId}`);

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -2,6 +2,7 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { resolveBedrockBearerToken } from "../../agents/model-auth.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
@@ -286,12 +287,12 @@ export function applyExtraParamsToAgent(
     agent.streamFn = createMoonshotThinkingWrapper(agent.streamFn, thinkingType);
   }
 
-  if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {
+  if (normalizeProviderId(provider) === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {
     log.debug(`disabling prompt caching for non-Anthropic Bedrock model ${provider}/${modelId}`);
     agent.streamFn = createBedrockNoCacheWrapper(agent.streamFn);
   }
 
-  if (provider === "amazon-bedrock") {
+  if (normalizeProviderId(provider) === "amazon-bedrock") {
     const bearerToken = resolveBedrockBearerToken();
     if (bearerToken) {
       log.debug(`applying Bedrock bearer token auth header for ${provider}/${modelId}`);


### PR DESCRIPTION
## Summary

- Problem: Amazon Bedrock API Key (Bearer Token) authentication was partially scaffolded (env var detection) but the token was never injected as an `Authorization: Bearer` header in API requests.
- Why it matters: Users with Bedrock API Keys (e.g. from AWS API Gateway or third-party Bedrock proxies) cannot authenticate without full AWS SDK credentials, which are not always available or desired.
- What changed: When `AWS_BEARER_TOKEN_BEDROCK` is set, it is now used as a `Bearer` token in the `Authorization` header, bypassing AWS SDK signing entirely. Auth mode resolves as `api-key`, and the token takes precedence over SDK credential chains.
- What did NOT change: When `AWS_BEARER_TOKEN_BEDROCK` is absent, behavior is identical to before — falls back to the existing AWS SDK credential chain (access keys, profile, SSO, etc.).

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30215

## User-visible / Behavior Changes

- New env var `AWS_BEARER_TOKEN_BEDROCK`: when set, Bedrock requests use `Authorization: Bearer <token>` instead of AWS SigV4 signing.
- Auth precedence for Bedrock: bearer token > access keys > profile > SSO/instance.
- `openclaw status` / auth mode display now shows `api-key` when bearer token is active.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes` — new env var is read and injected as a Bearer header.
- New/changed network calls? `Yes` — the Authorization header is added to Bedrock HTTP requests when bearer token is set.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: The bearer token is read from env only, never logged or persisted. It replaces the SDK auth chain so the request surface is the same (HTTPS to Bedrock endpoint). The token is trimmed and validated (empty/whitespace is rejected).

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: Amazon Bedrock (us.anthropic.claude-3-5-haiku-20241022-v1:0)
- Integration/channel: N/A
- Relevant config: `AWS_BEARER_TOKEN_BEDROCK` env var set

### Steps

1. Set `AWS_BEARER_TOKEN_BEDROCK` to a valid Bedrock API Key.
2. Run `BEDROCK_LIVE_TEST=1 pnpm exec vitest run src/agents/bedrock-bearer.live.test.ts --config vitest.live.config.ts`
3. Observe the test sends a request with `Authorization: Bearer` and receives a streamed response.

### Expected

- Live test passes, receiving assistant text from Bedrock via bearer token auth.

### Actual

- Live test passes (verified with real credentials).

## Evidence

- [x] Failing test/log before + passing after
  - 119 unit tests pass (`model-auth.test.ts`, `model-auth.profiles.test.ts`, `pi-embedded-runner-extraparams.test.ts`)
  - Live smoke test (`bedrock-bearer.live.test.ts`) passes with real `AWS_BEARER_TOKEN_BEDROCK` credentials — stream completes with assistant text.
- [x] Trace/log snippets: Live test output confirms `sawDone=true` and non-empty assistant text.

## Human Verification (required)

- Verified scenarios: Bearer token auth with real Bedrock API Key via live test; fallback to aws-sdk mode when token is absent (unit tests with env isolation).
- Edge cases checked: Empty/whitespace token rejected; env var isolation in unit tests (withEnvAsync); auth precedence (bearer > access keys > profile).
- What I did **not** verify: Production gateway integration (only verified via stream wrapper + live test).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — no behavior change when `AWS_BEARER_TOKEN_BEDROCK` is unset.
- Config/env changes? `Yes` — new optional env var `AWS_BEARER_TOKEN_BEDROCK`.
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Unset `AWS_BEARER_TOKEN_BEDROCK` env var — falls back to existing AWS SDK chain.
- Files/config to restore: N/A (env-var gated).
- Known bad symptoms: If a stale/invalid bearer token is set, Bedrock requests will fail with 401/403; fix by unsetting the env var or updating the token.

## Risks and Mitigations

- Risk: Bearer token is sent as plain HTTP header to Bedrock endpoint.
  - Mitigation: Bedrock endpoints are HTTPS-only; token is read from env only, never logged.
