### PR TITLE
i18n: replace hardcoded strings in overview with t() keys across all locales

### DIFF
--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -80,7 +80,9 @@ export const de: TranslationMap = {
       sessions: "Sitzungen",
       sessionsHint: "Letzte vom Gateway verfolgte Sitzungsschlüssel.",
       cron: "Cron",
+      cronCount: "{count} gesamt",
       cronNext: "Nächste Ausführung {time}",
+      cronFailed: "Fehler: {count}",
     },
     notes: {
       title: "Notizen",
@@ -98,6 +100,8 @@ export const de: TranslationMap = {
         "Dieses Gateway erfordert Authentifizierung. Fügen Sie ein Token oder Passwort hinzu und klicken Sie auf Verbinden.",
       failed:
         "Authentifizierung fehlgeschlagen. Kopieren Sie erneut eine URL mit Token über {command}, oder aktualisieren Sie das Token und klicken Sie auf Verbinden.",
+      tokenizedUrl: "URL mit Token",
+      setToken: "Token setzen",
     },
     pairing: {
       hint: "Dieses Gerät benötigt eine Pairing-Freigabe vom Gateway-Host.",
@@ -126,6 +130,43 @@ export const de: TranslationMap = {
       hidePassword: "Passwort ausblenden",
       showPassword: "Passwort anzeigen",
       togglePassword: "Passwortsichtbarkeit umschalten",
+    },
+    connection: {
+      title: "So verbinden Sie sich",
+      step1: "Starten Sie das Gateway auf Ihrem Host-Rechner:",
+      step2: "Rufen Sie eine Dashboard-URL mit Token ab:",
+      step3:
+        "Fügen Sie oben die WebSocket-URL und das Token ein oder öffnen Sie die URL mit Token direkt.",
+      step4: "Oder erzeugen Sie ein wiederverwendbares Token:",
+      docsHint: "Für den Fernzugriff wird Tailscale Serve empfohlen. ",
+      docsLink: "Dokumentation lesen →",
+    },
+    cards: {
+      cost: "Kosten",
+      costHint: "Tokens: {tokens} · Nachrichten: {messages}",
+      skills: "Fähigkeiten",
+      skillsBlocked: "Blockiert: {count}",
+      skillsActive: "Aktiv: {count}",
+      recentSessions: "Letzte Sitzungen",
+    },
+    attention: {
+      title: "Achtung",
+    },
+    eventLog: {
+      title: "Ereignisprotokoll",
+    },
+    logTail: {
+      title: "Gateway-Protokolle",
+    },
+    quickActions: {
+      newSession: "Neue Sitzung",
+      automation: "Automatisierung",
+      refreshAll: "Alles aktualisieren",
+      terminal: "Terminal",
+    },
+    palette: {
+      placeholder: "Befehl eingeben…",
+      noResults: "Keine Ergebnisse",
     },
   },
   chat: {

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -108,6 +108,25 @@ export const de: TranslationMap = {
       hint: "Diese Seite ist HTTP, daher blockiert der Browser die Geräteidentifikation. Verwenden Sie HTTPS (Tailscale Serve) oder öffnen Sie {url} auf dem Gateway-Host.",
       stayHttp: "Wenn Sie bei HTTP bleiben müssen, setzen Sie {config} (nur Token).",
     },
+    docs: {
+      devicePairing: "Docs: Gerätekopplung",
+      controlUiAuth: "Docs: Control-UI-Authentifizierung",
+      tailscaleServe: "Docs: Tailscale Serve",
+      insecureHttp: "Docs: Unsicheres HTTP",
+    },
+    placeholders: {
+      password: "System- oder gemeinsames Passwort",
+      wsUrl: "ws://100.x.y.z:18789",
+      token: "OPENCLAW_GATEWAY_TOKEN",
+    },
+    accessibility: {
+      hideToken: "Token ausblenden",
+      showToken: "Token anzeigen",
+      toggleToken: "Token-Sichtbarkeit umschalten",
+      hidePassword: "Passwort ausblenden",
+      showPassword: "Passwort anzeigen",
+      togglePassword: "Passwortsichtbarkeit umschalten",
+    },
   },
   chat: {
     disconnected: "Verbindung zum Gateway getrennt.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -92,7 +92,9 @@ export const en: TranslationMap = {
       sessions: "Sessions",
       sessionsHint: "Recent session keys tracked by the gateway.",
       cron: "Cron",
+      cronCount: "{count} total",
       cronNext: "Next wake {time}",
+      cronFailed: "Errors: {count}",
     },
     notes: {
       title: "Notes",
@@ -108,6 +110,8 @@ export const en: TranslationMap = {
       required: "This gateway requires auth. Add a token or password, then click Connect.",
       failed:
         "Auth failed. Re-copy a tokenized URL with {command}, or update the token, then click Connect.",
+      tokenizedUrl: "tokenized URL",
+      setToken: "set token",
     },
     pairing: {
       hint: "This device needs pairing approval from the gateway host.",
@@ -148,7 +152,10 @@ export const en: TranslationMap = {
     },
     cards: {
       cost: "Cost",
+      costHint: "Tokens: {tokens} · Messages: {messages}",
       skills: "Skills",
+      skillsBlocked: "Blocked: {count}",
+      skillsActive: "Active: {count}",
       recentSessions: "Recent Sessions",
     },
     attention: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -118,6 +118,25 @@ export const en: TranslationMap = {
       hint: "This page is HTTP, so the browser blocks device identity. Use HTTPS (Tailscale Serve) or open {url} on the gateway host.",
       stayHttp: "If you must stay on HTTP, set {config} (token-only).",
     },
+    docs: {
+      devicePairing: "Docs: Device pairing",
+      controlUiAuth: "Docs: Control UI auth",
+      tailscaleServe: "Docs: Tailscale Serve",
+      insecureHttp: "Docs: Insecure HTTP",
+    },
+    placeholders: {
+      password: "system or shared password",
+      wsUrl: "ws://100.x.y.z:18789",
+      token: "OPENCLAW_GATEWAY_TOKEN",
+    },
+    accessibility: {
+      hideToken: "Hide token",
+      showToken: "Show token",
+      toggleToken: "Toggle token visibility",
+      hidePassword: "Hide password",
+      showPassword: "Show password",
+      togglePassword: "Toggle password visibility",
+    },
     connection: {
       title: "How to connect",
       step1: "Start the gateway on your host machine:",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -79,7 +79,9 @@ export const es: TranslationMap = {
       sessions: "Sesiones",
       sessionsHint: "Claves de sesión recientes rastreadas por la puerta de enlace.",
       cron: "Cron",
+      cronCount: "{count} en total",
       cronNext: "Próximo despertar {time}",
+      cronFailed: "Errores: {count}",
     },
     notes: {
       title: "Notas",
@@ -97,6 +99,8 @@ export const es: TranslationMap = {
         "Esta puerta de enlace requiere autenticación. Añade un token o contraseña y haz clic en Conectar.",
       failed:
         "Autenticación fallida. Vuelve a copiar una URL con token mediante {command}, o actualiza el token y haz clic en Conectar.",
+      tokenizedUrl: "URL con token",
+      setToken: "configurar token",
     },
     pairing: {
       hint: "Este dispositivo necesita aprobación de emparejamiento del host de la puerta de enlace.",
@@ -125,6 +129,42 @@ export const es: TranslationMap = {
       hidePassword: "Ocultar contraseña",
       showPassword: "Mostrar contraseña",
       togglePassword: "Alternar visibilidad de la contraseña",
+    },
+    connection: {
+      title: "Cómo conectarse",
+      step1: "Inicia la puerta de enlace en tu equipo host:",
+      step2: "Obtén una URL del panel con token:",
+      step3: "Pega arriba la URL de WebSocket y el token, o abre directamente la URL con token.",
+      step4: "O genera un token reutilizable:",
+      docsHint: "Para acceso remoto, se recomienda Tailscale Serve. ",
+      docsLink: "Leer la documentación →",
+    },
+    cards: {
+      cost: "Costo",
+      costHint: "Tokens: {tokens} · Mensajes: {messages}",
+      skills: "Habilidades",
+      skillsBlocked: "Bloqueadas: {count}",
+      skillsActive: "Activas: {count}",
+      recentSessions: "Sesiones recientes",
+    },
+    attention: {
+      title: "Atención",
+    },
+    eventLog: {
+      title: "Registro de eventos",
+    },
+    logTail: {
+      title: "Logs del gateway",
+    },
+    quickActions: {
+      newSession: "Nueva sesión",
+      automation: "Automatización",
+      refreshAll: "Actualizar todo",
+      terminal: "Terminal",
+    },
+    palette: {
+      placeholder: "Escribe un comando…",
+      noResults: "Sin resultados",
     },
   },
   chat: {

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -107,6 +107,25 @@ export const es: TranslationMap = {
       hint: "Esta página es HTTP, por lo que el navegador bloquea el acceso a la identidad del dispositivo. Usa HTTPS (Tailscale Serve) o abre {url} en el equipo host.",
       stayHttp: "Si debes permanecer en HTTP, utiliza {config} (solo token).",
     },
+    docs: {
+      devicePairing: "Docs: Emparejamiento de dispositivos",
+      controlUiAuth: "Docs: Autenticación de Control UI",
+      tailscaleServe: "Docs: Tailscale Serve",
+      insecureHttp: "Docs: HTTP inseguro",
+    },
+    placeholders: {
+      password: "contraseña del sistema o compartida",
+      wsUrl: "ws://100.x.y.z:18789",
+      token: "OPENCLAW_GATEWAY_TOKEN",
+    },
+    accessibility: {
+      hideToken: "Ocultar token",
+      showToken: "Mostrar token",
+      toggleToken: "Alternar visibilidad del token",
+      hidePassword: "Ocultar contraseña",
+      showPassword: "Mostrar contraseña",
+      togglePassword: "Alternar visibilidad de la contraseña",
+    },
   },
   chat: {
     disconnected: "Desconectado de la puerta de enlace.",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -91,7 +91,9 @@ export const pt_BR: TranslationMap = {
       sessions: "Sessões",
       sessionsHint: "Chaves de sessão recentes rastreadas pelo gateway.",
       cron: "Cron",
+      cronCount: "{count} no total",
       cronNext: "Próximo despertar {time}",
+      cronFailed: "Erros: {count}",
     },
     notes: {
       title: "Notas",
@@ -109,6 +111,8 @@ export const pt_BR: TranslationMap = {
         "Este gateway requer autenticação. Adicione um token ou senha e clique em Conectar.",
       failed:
         "Falha na autenticação. Recopie uma URL com token usando {command}, ou atualize o token e clique em Conectar.",
+      tokenizedUrl: "URL com token",
+      setToken: "definir token",
     },
     pairing: {
       hint: "Este dispositivo precisa de aprovação de pareamento do host do gateway.",
@@ -149,7 +153,10 @@ export const pt_BR: TranslationMap = {
     },
     cards: {
       cost: "Custo",
+      costHint: "Tokens: {tokens} · Mensagens: {messages}",
       skills: "Habilidades",
+      skillsBlocked: "Bloqueadas: {count}",
+      skillsActive: "Ativas: {count}",
       recentSessions: "Sessões Recentes",
     },
     attention: {

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -119,6 +119,25 @@ export const pt_BR: TranslationMap = {
       hint: "Esta página é HTTP, então o navegador bloqueia a identidade do dispositivo. Use HTTPS (Tailscale Serve) ou abra {url} no host do gateway.",
       stayHttp: "Se você precisar permanecer em HTTP, defina {config} (apenas token).",
     },
+    docs: {
+      devicePairing: "Docs: Pareamento de dispositivos",
+      controlUiAuth: "Docs: Autenticação da Control UI",
+      tailscaleServe: "Docs: Tailscale Serve",
+      insecureHttp: "Docs: HTTP inseguro",
+    },
+    placeholders: {
+      password: "senha do sistema ou compartilhada",
+      wsUrl: "ws://100.x.y.z:18789",
+      token: "OPENCLAW_GATEWAY_TOKEN",
+    },
+    accessibility: {
+      hideToken: "Ocultar token",
+      showToken: "Mostrar token",
+      toggleToken: "Alternar visibilidade do token",
+      hidePassword: "Ocultar senha",
+      showPassword: "Mostrar senha",
+      togglePassword: "Alternar visibilidade da senha",
+    },
     connection: {
       title: "Como conectar",
       step1: "Inicie o gateway na sua máquina host:",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -91,7 +91,9 @@ export const zh_CN: TranslationMap = {
       sessions: "会话",
       sessionsHint: "网关跟踪的最近会话密钥。",
       cron: "定时任务",
+      cronCount: "共 {count} 个",
       cronNext: "下次唤醒 {time}",
+      cronFailed: "错误：{count}",
     },
     notes: {
       title: "备注",
@@ -106,6 +108,8 @@ export const zh_CN: TranslationMap = {
     auth: {
       required: "此网关需要身份验证。添加令牌或密码，然后点击连接。",
       failed: "身份验证失败。请使用 {command} 重新复制令牌化 URL，或更新令牌，然后点击连接。",
+      tokenizedUrl: "带令牌的 URL",
+      setToken: "设置令牌",
     },
     pairing: {
       hint: "此设备需要网关主机的配对批准。",
@@ -146,7 +150,10 @@ export const zh_CN: TranslationMap = {
     },
     cards: {
       cost: "费用",
+      costHint: "令牌：{tokens} · 消息：{messages}",
       skills: "技能",
+      skillsBlocked: "被阻止：{count}",
+      skillsActive: "可用：{count}",
       recentSessions: "最近会话",
     },
     attention: {

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -116,6 +116,25 @@ export const zh_CN: TranslationMap = {
       hint: "此页面为 HTTP，因此浏览器阻止设备标识。请使用 HTTPS (Tailscale Serve) 或在网关主机上打开 {url}。",
       stayHttp: "如果您必须保持 HTTP，请设置 {config} (仅限令牌)。",
     },
+    docs: {
+      devicePairing: "文档：设备配对",
+      controlUiAuth: "文档：Control UI 身份验证",
+      tailscaleServe: "文档：Tailscale Serve",
+      insecureHttp: "文档：不安全 HTTP",
+    },
+    placeholders: {
+      password: "系统或共享密码",
+      wsUrl: "ws://100.x.y.z:18789",
+      token: "OPENCLAW_GATEWAY_TOKEN",
+    },
+    accessibility: {
+      hideToken: "隐藏令牌",
+      showToken: "显示令牌",
+      toggleToken: "切换令牌可见性",
+      hidePassword: "隐藏密码",
+      showPassword: "显示密码",
+      togglePassword: "切换密码可见性",
+    },
     connection: {
       title: "如何连接",
       step1: "在主机上启动网关：",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -91,7 +91,9 @@ export const zh_TW: TranslationMap = {
       sessions: "會話",
       sessionsHint: "網關跟蹤的最近會話密鑰。",
       cron: "定時任務",
+      cronCount: "共 {count} 個",
       cronNext: "下次喚醒 {time}",
+      cronFailed: "錯誤：{count}",
     },
     notes: {
       title: "備註",
@@ -106,6 +108,8 @@ export const zh_TW: TranslationMap = {
     auth: {
       required: "此網關需要身份驗證。添加令牌或密碼，然後點擊連接。",
       failed: "身份驗證失敗。請使用 {command} 重新複製令牌化 URL，或更新令牌，然後點擊連接。",
+      tokenizedUrl: "帶令牌的 URL",
+      setToken: "設定令牌",
     },
     pairing: {
       hint: "此裝置需要閘道主機的配對批准。",
@@ -146,7 +150,10 @@ export const zh_TW: TranslationMap = {
     },
     cards: {
       cost: "費用",
+      costHint: "令牌：{tokens} · 訊息：{messages}",
       skills: "技能",
+      skillsBlocked: "已封鎖：{count}",
+      skillsActive: "可用：{count}",
       recentSessions: "最近會話",
     },
     attention: {

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -116,6 +116,25 @@ export const zh_TW: TranslationMap = {
       hint: "此頁面為 HTTP，因此瀏覽器阻止設備標識。請使用 HTTPS (Tailscale Serve) 或在網關主機上打開 {url}。",
       stayHttp: "如果您必須保持 HTTP，請設置 {config} (僅限令牌)。",
     },
+    docs: {
+      devicePairing: "文件：裝置配對",
+      controlUiAuth: "文件：Control UI 身份驗證",
+      tailscaleServe: "文件：Tailscale Serve",
+      insecureHttp: "文件：不安全 HTTP",
+    },
+    placeholders: {
+      password: "系統或共享密碼",
+      wsUrl: "ws://100.x.y.z:18789",
+      token: "OPENCLAW_GATEWAY_TOKEN",
+    },
+    accessibility: {
+      hideToken: "隱藏令牌",
+      showToken: "顯示令牌",
+      toggleToken: "切換令牌可見性",
+      hidePassword: "隱藏密碼",
+      showPassword: "顯示密碼",
+      togglePassword: "切換密碼可見性",
+    },
     connection: {
       title: "如何連接",
       step1: "在主機上啟動閘道：",

--- a/ui/src/ui/views/overview-cards.ts
+++ b/ui/src/ui/views/overview-cards.ts
@@ -90,12 +90,12 @@ export function renderOverviewCards(props: OverviewCardsProps) {
     cronEnabled == null
       ? t("common.na")
       : cronEnabled
-        ? `${cronJobCount} jobs`
+        ? t("overview.stats.cronCount", { count: String(cronJobCount) })
         : t("common.disabled");
 
   const cronHint =
     failedCronCount > 0
-      ? html`<span class="danger">${failedCronCount} failed</span>`
+      ? html`<span class="danger">${t("overview.stats.cronFailed", { count: String(failedCronCount) })}</span>`
       : cronNext
         ? t("overview.stats.cronNext", { time: formatNextRun(cronNext) })
         : "";
@@ -106,7 +106,10 @@ export function renderOverviewCards(props: OverviewCardsProps) {
       tab: "usage",
       label: t("overview.cards.cost"),
       value: totalCost,
-      hint: `${totalTokens} tokens · ${totalMessages} msgs`,
+      hint: t("overview.cards.costHint", {
+        tokens: totalTokens,
+        messages: totalMessages,
+      }),
     },
     {
       kind: "sessions",
@@ -120,7 +123,10 @@ export function renderOverviewCards(props: OverviewCardsProps) {
       tab: "skills",
       label: t("overview.cards.skills"),
       value: `${enabledSkills}/${totalSkills}`,
-      hint: blockedSkills > 0 ? `${blockedSkills} blocked` : `${enabledSkills} active`,
+      hint:
+        blockedSkills > 0
+          ? t("overview.cards.skillsBlocked", { count: String(blockedSkills) })
+          : t("overview.cards.skillsActive", { count: String(enabledSkills) }),
     },
     {
       kind: "cron",

--- a/ui/src/ui/views/overview.test.ts
+++ b/ui/src/ui/views/overview.test.ts
@@ -1,0 +1,157 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../../src/gateway/protocol/connect-error-details.js";
+import { i18n } from "../../i18n/index.ts";
+import type {
+  CronJob,
+  CronStatus,
+  SessionsListResult,
+  SessionsUsageResult,
+  SkillStatusReport,
+} from "../types.ts";
+import { renderOverview, type OverviewProps } from "./overview.ts";
+
+function createProps(overrides: Partial<OverviewProps> = {}): OverviewProps {
+  return {
+    connected: false,
+    hello: null,
+    settings: {
+      gatewayUrl: "ws://127.0.0.1:18789",
+      token: "",
+      sessionKey: "main",
+      locale: "en",
+    },
+    password: "",
+    lastError: "disconnected (4008): connect failed",
+    lastErrorCode: ConnectErrorDetailCodes.AUTH_REQUIRED,
+    presenceCount: 0,
+    sessionsCount: null,
+    cronEnabled: null,
+    cronNext: null,
+    lastChannelsRefresh: null,
+    usageResult: null,
+    sessionsResult: null,
+    skillsReport: null,
+    cronJobs: [],
+    cronStatus: null,
+    attentionItems: [],
+    eventLog: [],
+    overviewLogLines: [],
+    showGatewayToken: false,
+    showGatewayPassword: false,
+    onSettingsChange: () => undefined,
+    onPasswordChange: () => undefined,
+    onSessionKeyChange: () => undefined,
+    onToggleGatewayTokenVisibility: () => undefined,
+    onToggleGatewayPasswordVisibility: () => undefined,
+    onConnect: () => undefined,
+    onRefresh: () => undefined,
+    onNavigate: () => undefined,
+    onRefreshLogs: () => undefined,
+    ...overrides,
+  };
+}
+
+describe("overview view", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+  });
+
+  it("localizes auth-required helper labels in Spanish", async () => {
+    await i18n.setLocale("es");
+
+    const container = document.createElement("div");
+    render(
+      renderOverview(
+        createProps({
+          settings: {
+            gatewayUrl: "ws://127.0.0.1:18789",
+            token: "",
+            sessionKey: "main",
+            locale: "es",
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("URL con token");
+    expect(container.textContent).toContain("configurar token");
+    expect(container.textContent).toContain("Cómo conectarse");
+    expect(container.textContent).not.toContain("How to connect");
+  });
+
+  it("localizes overview cards in Spanish", async () => {
+    await i18n.setLocale("es");
+
+    const container = document.createElement("div");
+    render(
+      renderOverview(
+        createProps({
+          settings: {
+            gatewayUrl: "ws://127.0.0.1:18789",
+            token: "",
+            sessionKey: "main",
+            locale: "es",
+          },
+          usageResult: {
+            updatedAt: 0,
+            startDate: "2026-03-01",
+            endDate: "2026-03-13",
+            sessions: [],
+            totals: {
+              totalCost: 12.34,
+              totalTokens: 345,
+            },
+            aggregates: {
+              messages: { total: 7 },
+            },
+          } as SessionsUsageResult,
+          sessionsResult: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: { model: null, contextTokens: null },
+            sessions: [
+              {
+                key: "main",
+                displayName: "Principal",
+                model: "gpt-5",
+                updatedAt: 1,
+              },
+            ],
+          } as SessionsListResult,
+          skillsReport: {
+            workspaceDir: "",
+            managedSkillsDir: "",
+            skills: [
+              { disabled: false, blockedByAllowlist: true },
+              { disabled: false, blockedByAllowlist: true },
+              { disabled: false, blockedByAllowlist: false },
+            ],
+          } as SkillStatusReport,
+          cronJobs: [
+            { state: { lastStatus: "error" } },
+            { state: { lastStatus: "error" } },
+          ] as CronJob[],
+          cronStatus: {
+            enabled: true,
+            jobs: 2,
+            nextWakeAtMs: null,
+          } as CronStatus,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Costo");
+    expect(container.textContent).toContain("Tokens: 345");
+    expect(container.textContent).toContain("Mensajes: 7");
+    expect(container.textContent).toContain("Bloqueadas: 2");
+    expect(container.textContent).toContain("2 en total");
+    expect(container.textContent).toContain("Errores: 2");
+    expect(container.textContent).not.toContain("Blocked: 2");
+  });
+});

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -116,8 +116,10 @@ export function renderOverview(props: OverviewProps) {
         <div class="muted" style="margin-top: 8px">
           ${t("overview.auth.required")}
           <div style="margin-top: 6px">
-            <span class="mono">openclaw dashboard --no-open</span> → tokenized URL<br />
-            <span class="mono">openclaw doctor --generate-gateway-token</span> → set token
+            <span class="mono">openclaw dashboard --no-open</span> →
+            ${t("overview.auth.tokenizedUrl")}<br />
+            <span class="mono">openclaw doctor --generate-gateway-token</span> →
+            ${t("overview.auth.setToken")}
           </div>
           <div style="margin-top: 6px">
             <a

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -94,8 +94,8 @@ export function renderOverview(props: OverviewProps) {
             href="https://docs.openclaw.ai/web/control-ui#device-pairing-first-connection"
             target=${EXTERNAL_LINK_TARGET}
             rel=${buildExternalLinkRel()}
-            title="Device pairing docs (opens in new tab)"
-            >Docs: Device pairing</a
+            title=${t("overview.docs.devicePairing")}
+            >${t("overview.docs.devicePairing")}</a
           >
         </div>
       </div>
@@ -125,8 +125,8 @@ export function renderOverview(props: OverviewProps) {
               href="https://docs.openclaw.ai/web/dashboard"
               target=${EXTERNAL_LINK_TARGET}
               rel=${buildExternalLinkRel()}
-              title="Control UI auth docs (opens in new tab)"
-              >Docs: Control UI auth</a
+              title=${t("overview.docs.controlUiAuth")}
+              >${t("overview.docs.controlUiAuth")}</a
             >
           </div>
         </div>
@@ -141,8 +141,8 @@ export function renderOverview(props: OverviewProps) {
             href="https://docs.openclaw.ai/web/dashboard"
             target=${EXTERNAL_LINK_TARGET}
             rel=${buildExternalLinkRel()}
-            title="Control UI auth docs (opens in new tab)"
-            >Docs: Control UI auth</a
+            title=${t("overview.docs.controlUiAuth")}
+            >${t("overview.docs.controlUiAuth")}</a
           >
         </div>
       </div>
@@ -172,8 +172,8 @@ export function renderOverview(props: OverviewProps) {
             href="https://docs.openclaw.ai/gateway/tailscale"
             target=${EXTERNAL_LINK_TARGET}
             rel=${buildExternalLinkRel()}
-            title="Tailscale Serve docs (opens in new tab)"
-            >Docs: Tailscale Serve</a
+            title=${t("overview.docs.tailscaleServe")}
+            >${t("overview.docs.tailscaleServe")}</a
           >
           <span class="muted"> · </span>
           <a
@@ -181,8 +181,8 @@ export function renderOverview(props: OverviewProps) {
             href="https://docs.openclaw.ai/web/control-ui#insecure-http"
             target=${EXTERNAL_LINK_TARGET}
             rel=${buildExternalLinkRel()}
-            title="Insecure HTTP docs (opens in new tab)"
-            >Docs: Insecure HTTP</a
+            title=${t("overview.docs.insecureHttp")}
+            >${t("overview.docs.insecureHttp")}</a
           >
         </div>
       </div>
@@ -209,7 +209,7 @@ export function renderOverview(props: OverviewProps) {
                   token: v.trim() === props.settings.gatewayUrl.trim() ? props.settings.token : "",
                 });
               }}
-              placeholder="ws://100.x.y.z:18789"
+              placeholder=${t("overview.placeholders.wsUrl")}
             />
           </label>
           ${
@@ -228,14 +228,14 @@ export function renderOverview(props: OverviewProps) {
                         const v = (e.target as HTMLInputElement).value;
                         props.onSettingsChange({ ...props.settings, token: v });
                       }}
-                      placeholder="OPENCLAW_GATEWAY_TOKEN"
+                      placeholder=${t("overview.placeholders.token")}
                     />
                     <button
                       type="button"
                       class="btn btn--icon ${props.showGatewayToken ? "active" : ""}"
                       style="width: 36px; height: 36px;"
-                      title=${props.showGatewayToken ? "Hide token" : "Show token"}
-                      aria-label="Toggle token visibility"
+                      title=${props.showGatewayToken ? t("overview.accessibility.hideToken") : t("overview.accessibility.showToken")}
+                      aria-label=${t("overview.accessibility.toggleToken")}
                       aria-pressed=${props.showGatewayToken}
                       @click=${props.onToggleGatewayTokenVisibility}
                     >
@@ -255,14 +255,14 @@ export function renderOverview(props: OverviewProps) {
                         const v = (e.target as HTMLInputElement).value;
                         props.onPasswordChange(v);
                       }}
-                      placeholder="system or shared password"
+                      placeholder=${t("overview.placeholders.password")}
                     />
                     <button
                       type="button"
                       class="btn btn--icon ${props.showGatewayPassword ? "active" : ""}"
                       style="width: 36px; height: 36px;"
-                      title=${props.showGatewayPassword ? "Hide password" : "Show password"}
-                      aria-label="Toggle password visibility"
+                      title=${props.showGatewayPassword ? t("overview.accessibility.hidePassword") : t("overview.accessibility.showPassword")}
+                      aria-label=${t("overview.accessibility.togglePassword")}
                       aria-pressed=${props.showGatewayPassword}
                       @click=${props.onToggleGatewayPasswordVisibility}
                     >


### PR DESCRIPTION
## Summary

Replaces all hardcoded English strings in `ui/src/ui/views/overview.ts` with proper `t()` i18n calls, and propagates the new translation keys to all 5 supported locales.

## Problem

Despite the dashboard having a full i18n system with 6 supported languages, the Gateway Access section of the Overview tab contained several hardcoded English strings that bypassed the `t()` function entirely. Users selecting Spanish, German, Chinese, etc. would still see English in:

- Doc link text and title attributes (Docs: Device pairing, Docs: Control UI auth, Docs: Tailscale Serve, Docs: Insecure HTTP)
- Input placeholders (system or shared password, ws://100.x.y.z:18789, OPENCLAW_GATEWAY_TOKEN)
- Accessibility attributes — button title and aria-label for the show/hide token and password toggles

## Changes

**`ui/src/ui/views/overview.ts`**
- All 4 doc link texts/titles now use `t("overview.docs.*")`
- All 3 input placeholders now use `t("overview.placeholders.*")`
- Show/hide token and password button title + aria-label now use `t("overview.accessibility.*")`

**`ui/src/i18n/locales/en.ts`** — Added three new key groups under `overview`: `docs`, `placeholders`, `accessibility`

**All other locales (es, de, pt-BR, zh-CN, zh-TW)** — Same three key groups added with native-language translations.

## Testing

- `pnpm tsgo` passes with no errors
- No runtime logic was changed; only string references replaced with `t()` calls