### PR TITLE
fix(agents): avoid TDZ crash on ANTHROPIC_MODEL_ALIASES during config load

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -31,13 +31,6 @@ export type ModelAliasIndex = {
   byKey: Map<string, string[]>;
 };
 
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
-};
-
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
 }
@@ -150,8 +143,16 @@ function normalizeAnthropicModelId(model: string): string {
   if (!trimmed) {
     return trimmed;
   }
+  // Inline alias map to avoid TDZ when this module is accessed via circular
+  // imports before module-level const initialisation completes (#45157).
+  const aliases: Record<string, string> = {
+    "opus-4.6": "claude-opus-4-6",
+    "opus-4.5": "claude-opus-4-5",
+    "sonnet-4.6": "claude-sonnet-4-6",
+    "sonnet-4.5": "claude-sonnet-4-5",
+  };
   const lower = trimmed.toLowerCase();
-  return ANTHROPIC_MODEL_ALIASES[lower] ?? trimmed;
+  return aliases[lower] ?? trimmed;
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {


### PR DESCRIPTION
## Summary

v2026.3.12 regression: `ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization` when loading config.

**Root cause**: `model-selection.ts` has circular import chains (e.g. `model-selection` -> `models-config.providers` -> `provider-discovery` -> `model-selection`). When Node resolves the cycle, the module body is partially evaluated and `ANTHROPIC_MODEL_ALIASES` (a `const` at module level) hasn't been initialised when `normalizeAnthropicModelId()` is called via the re-entrant import.

**Fix**: Move the alias map from a module-level `const` into the body of `normalizeAnthropicModelId()`, so it is created at call-time (after all modules finish loading) rather than at module-evaluation time.

The map is 4 entries and the function is called infrequently (config load + model resolution), so per-call allocation is negligible.

Closes #45157
Closes #45138

lobster-biscuit
