### PR TITLE
[AI-assisted] fix(agents): honor group:memory tool allowlists

### DIFF
--- a/src/agents/pi-tools.memory-group-plugin.test.ts
+++ b/src/agents/pi-tools.memory-group-plugin.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { createOpenClawCodingTools } from "./pi-tools.js";
+
+describe("createOpenClawCodingTools memory plugin allowlist", () => {
+  it("includes memory-core tools when agent allowlist uses group:memory", () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        enabled: true,
+        allow: ["memory-core"],
+        slots: {
+          memory: "memory-core",
+        },
+        entries: {
+          "memory-core": {
+            enabled: true,
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "openai",
+            model: "text-embedding-3-small",
+            fallback: "none",
+            sources: ["memory"],
+          },
+        },
+        list: [
+          {
+            id: "nova",
+            workspace: "~/workspace-nova",
+            tools: {
+              allow: ["group:fs", "group:runtime", "group:memory"],
+            },
+          },
+        ],
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      agentId: "nova",
+      sessionKey: "agent:nova:main",
+      workspaceDir: "/tmp/test-nova",
+      agentDir: "/tmp/agent-nova",
+      senderIsOwner: true,
+    });
+
+    const toolNames = tools.map((tool) => tool.name);
+    expect(toolNames).toContain("memory_search");
+    expect(toolNames).toContain("memory_get");
+  });
+});

--- a/src/agents/tool-policy.plugin-only-allowlist.test.ts
+++ b/src/agents/tool-policy.plugin-only-allowlist.test.ts
@@ -36,6 +36,22 @@ describe("stripPluginOnlyAllowlist", () => {
     expect(policy.unknownAllowlist).toEqual([]);
   });
 
+  it("keeps core-group shorthands that expand to plugin-backed tools without warning", () => {
+    const memoryPluginGroups: PluginToolGroups = {
+      all: ["memory_search", "memory_get"],
+      byPlugin: new Map([["memory-core", ["memory_search", "memory_get"]]]),
+    };
+
+    const policy = stripPluginOnlyAllowlist(
+      { allow: ["read", "group:memory"] },
+      memoryPluginGroups,
+      coreTools,
+    );
+
+    expect(policy.policy?.allow).toEqual(["read", "group:memory"]);
+    expect(policy.unknownAllowlist).toEqual([]);
+  });
+
   it("strips allowlist with unknown entries when no core tools match", () => {
     const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
     const policy = stripPluginOnlyAllowlist({ allow: ["lobster"] }, emptyPlugins, coreTools);

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -174,9 +174,13 @@ export function stripPluginOnlyAllowlist(
       hasCoreEntry = true;
       continue;
     }
-    const isPluginEntry =
-      entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry);
     const expanded = expandToolGroups([entry]);
+    const matchesPluginEntry = expanded.some((tool) => pluginTools.has(tool));
+    const isPluginEntry =
+      entry === "group:plugins" ||
+      pluginIds.has(entry) ||
+      pluginTools.has(entry) ||
+      matchesPluginEntry;
     const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
     if (isCoreEntry) {
       hasCoreEntry = true;

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -82,6 +82,17 @@ function setOptionalDemoRegistry() {
   ]);
 }
 
+function setOptionalMemoryRegistry() {
+  setRegistry([
+    {
+      pluginId: "memory-core",
+      optional: true,
+      source: "/tmp/memory-core.js",
+      factory: () => [makeTool("memory_search"), makeTool("memory_get")],
+    },
+  ]);
+}
+
 function resolveOptionalDemoTools(toolAllowlist?: string[]) {
   return resolvePluginTools({
     context: createContext() as never,
@@ -115,6 +126,17 @@ describe("resolvePluginTools optional tools", () => {
 
     expect(toolsByPlugin.map((tool) => tool.name)).toEqual(["optional_tool"]);
     expect(toolsByGroup.map((tool) => tool.name)).toEqual(["optional_tool"]);
+  });
+
+  it("allows optional tools via expanded core group shorthands", () => {
+    setOptionalMemoryRegistry();
+
+    const tools = resolvePluginTools({
+      context: createContext() as never,
+      toolAllowlist: ["group:memory"],
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["memory_search", "memory_get"]);
   });
 
   it("rejects plugin id collisions with core tool names", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1,4 +1,4 @@
-import { normalizeToolName } from "../agents/tool-policy.js";
+import { expandToolGroups, normalizeToolList, normalizeToolName } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.js";
@@ -20,7 +20,11 @@ export function getPluginToolMeta(tool: AnyAgentTool): PluginToolMeta | undefine
 }
 
 function normalizeAllowlist(list?: string[]) {
-  return new Set((list ?? []).map(normalizeToolName).filter(Boolean));
+  const normalized = new Set(normalizeToolList(list));
+  for (const entry of expandToolGroups(list)) {
+    normalized.add(entry);
+  }
+  return normalized;
 }
 
 function isOptionalToolAllowed(params: {


### PR DESCRIPTION
## Summary

- Problem: `group:memory` was documented as a normal tool-policy shorthand, but `memory_search` and `memory_get` are exposed by the `memory-core` plugin, so optional plugin gating and warning classification could still treat that shorthand as unknown.
- Why it matters: agents like Nova could lose memory tools or emit misleading `allowlist contains unknown entries (group:memory)` warnings even when the active memory slot was `memory-core`.
- What changed: optional plugin tool allowlists now expand core group shorthands before matching, and the plugin-only allowlist warning path now treats core group shorthands that resolve to plugin-backed tools as known entries.
- What did NOT change (scope boundary): this PR does not change memory search behavior, embeddings, storage backends, or gateway heartbeat logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #45109

## User-visible / Behavior Changes

Agents that allow `group:memory` can now actually receive `memory_search` and `memory_get` from the active `memory-core` plugin, and the runtime no longer warns that `group:memory` is an unknown allowlist entry in that configuration.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): agent allowlist includes `group:memory`; active plugin slot `plugins.slots.memory = "memory-core"`

### Steps

1. Configure an agent tool allowlist using `group:memory` with the bundled `memory-core` plugin active.
2. Build the agent tool set and resolve optional plugin tools.
3. Verify both warning classification and final tool availability.

### Expected

- `group:memory` is treated as a valid allowlist shorthand.
- `memory_search` and `memory_get` are available when `memory-core` is active.
- No misleading unknown-entry warning is emitted for `group:memory`.

### Actual

- Before this change, `group:memory` could be treated as unknown for optional plugin gating and warning classification, which could hide the memory tools behind the allowlist path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Ran `pnpm exec vitest run src/plugins/tools.optional.test.ts src/agents/tool-policy.plugin-only-allowlist.test.ts src/agents/pi-tools-agent-config.test.ts src/agents/pi-tools.memory-group-plugin.test.ts`.
  - Ran `pnpm build`.
  - Confirmed the live gateway stopped logging the Nova `group:memory` unknown-entry warning after rebuild + restart.
- Edge cases checked:
  - Core group shorthands that expand to plugin-backed tool names are no longer treated as unknown.
  - Optional plugin gating accepts `group:memory` without requiring direct tool-name entries.
  - Higher-level agent tool assembly includes `memory_search` / `memory_get` when the active slot is `memory-core`.
- What you did **not** verify:
  - I did not fully resolve the separate local loopback `openclaw agent` fallback issue on this host; that transport problem is orthogonal to this allowlist fix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR.
- Files/config to restore:
  - `src/plugins/tools.ts`
  - `src/agents/tool-policy.ts`
  - `src/plugins/tools.optional.test.ts`
  - `src/agents/tool-policy.plugin-only-allowlist.test.ts`
  - `src/agents/pi-tools.memory-group-plugin.test.ts`
- Known bad symptoms reviewers should watch for:
  - Agents with `group:memory` still missing `memory_search` / `memory_get`.
  - Runtime warnings still reporting `group:memory` as an unknown allowlist entry.

## Risks and Mitigations

- Risk:
  - Expanding core group shorthands inside optional plugin gating could accidentally admit unrelated plugin tools if a core group is ever broadened without corresponding tests.
  - Mitigation:
    - The change is covered at three levels: warning classification, optional plugin gating, and actual agent tool assembly with a real `memory-core` configuration.

## AI Assistance Disclosure

- This PR was prepared with AI assistance.
- I reviewed the changed code paths and understand the behavior being changed.
- Testing level: focused regression coverage plus full branch build.
- Verified with:
  - `pnpm exec vitest run src/plugins/tools.optional.test.ts src/agents/tool-policy.plugin-only-allowlist.test.ts src/agents/pi-tools-agent-config.test.ts src/agents/pi-tools.memory-group-plugin.test.ts`
  - `pnpm build`
- Session logs / prompts: available on request from local handoff/session notes.
- AI-assisted: yes, with manual review and targeted verification.
