### PR TITLE
Agents: normalize sandbox media fallback paths

### DIFF
--- a/src/agents/sandbox-media-paths.test.ts
+++ b/src/agents/sandbox-media-paths.test.ts
@@ -1,5 +1,9 @@
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { createSandboxBridgeReadFile } from "./sandbox-media-paths.js";
+import {
+  createSandboxBridgeReadFile,
+  resolveSandboxedBridgeMediaPath,
+} from "./sandbox-media-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 describe("createSandboxBridgeReadFile", () => {
@@ -17,6 +21,43 @@ describe("createSandboxBridgeReadFile", () => {
     expect(readFile).toHaveBeenCalledWith({
       filePath: "media/inbound/example.png",
       cwd: "/tmp/sandbox-root",
+    });
+  });
+});
+
+describe("resolveSandboxedBridgeMediaPath", () => {
+  it("normalizes Windows path separators for inbound fallback lookups", async () => {
+    const fallbackDir = "/sandbox/inbound";
+    const fallbackPath = path.join(fallbackDir, "voice-note.m4a");
+    const resolvePath = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("missing");
+      })
+      .mockReturnValueOnce({ hostPath: "/host/inbound/voice-note.m4a" });
+    const stat = vi.fn(async ({ filePath }: { filePath: string }) =>
+      filePath === fallbackPath ? { isFile: true } : null,
+    );
+
+    const result = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/sandbox",
+        bridge: {
+          resolvePath,
+          stat,
+        } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "..\\private\\voice-note.m4a",
+      inboundFallbackDir: fallbackDir,
+    });
+
+    expect(stat).toHaveBeenCalledWith({
+      filePath: fallbackPath,
+      cwd: "/sandbox",
+    });
+    expect(result).toEqual({
+      resolved: "/host/inbound/voice-note.m4a",
+      rewrittenFrom: "..\\private\\voice-note.m4a",
     });
   });
 });

--- a/src/agents/sandbox-media-paths.ts
+++ b/src/agents/sandbox-media-paths.ts
@@ -8,6 +8,10 @@ export type SandboxedBridgeMediaPathConfig = {
   workspaceOnly?: boolean;
 };
 
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
 export function createSandboxBridgeReadFile(params: {
   sandbox: Pick<SandboxedBridgeMediaPathConfig, "root" | "bridge">;
 }): (filePath: string) => Promise<Buffer> {
@@ -51,7 +55,7 @@ export async function resolveSandboxedBridgeMediaPath(params: {
     if (!fallbackDir) {
       throw err;
     }
-    const fallbackPath = path.join(fallbackDir, path.basename(filePath));
+    const fallbackPath = path.join(fallbackDir, basenameAcrossSeparators(filePath));
     try {
       const stat = await params.sandbox.bridge.stat({
         filePath: fallbackPath,


### PR DESCRIPTION
## Summary
- normalize sandbox media fallback names across path separators
- keep inbound fallback lookups working when upstream media paths use Windows separators
- add regression coverage for sandbox fallback rewrites

## Testing
- pnpm test src/agents/sandbox-media-paths.test.ts
- pnpm exec oxfmt --check src/agents/sandbox-media-paths.ts src/agents/sandbox-media-paths.test.ts
- pnpm build
- pnpm check *(currently blocked on unrelated upstream CHANGELOG.md formatting drift on main)*
