### PR TITLE
fix(subagents): notify user on announce give-up instead of silently dropping result

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1023,6 +1023,10 @@ async function finalizeSubagentCleanup(
     const completionReason = resolveCleanupCompletionReason(entry);
     await emitCompletionEndedHookIfNeeded(entry, completionReason);
     logAnnounceGiveUp(entry, deferredDecision.reason);
+    // Best-effort last-resort notification — same as the restart path in
+    // resumeSubagentRun, but called here for the common case where retries are
+    // exhausted during the same process lifetime without a restart.
+    void notifyAnnounceGiveUp(entry);
     completeCleanupBookkeeping({
       runId,
       entry,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -16,6 +16,7 @@ import { onAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { defaultRuntime } from "../runtime.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
+import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import { ensureRuntimePluginsLoaded } from "./runtime-plugins.js";
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import {
@@ -130,6 +131,76 @@ function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit" | "ex
   defaultRuntime.log(
     `[warn] Subagent announce give up (${reason}) run=${entry.runId} child=${entry.childSessionKey} requester=${entry.requesterSessionKey} retries=${retryCount} endedAgo=${endedAgoLabel}`,
   );
+}
+
+/**
+ * Last-resort notification when the announce retry budget is exhausted.
+ *
+ * The normal announce pipeline injects a message into the requester's *model
+ * session* so the agent can summarise and forward the result.  When that path
+ * fails repeatedly, the result is silently dropped — the user never finds out.
+ *
+ * This function attempts one final best-effort delivery directly to the user's
+ * channel (channel + accountId + to stored in `entry.requesterOrigin`) by
+ * calling the gateway `agent` method with `deliver: true` so the gateway
+ * bypasses the session queue and sends the raw text to the user's inbox.
+ *
+ * Failure is intentionally swallowed — if this also fails the outcome is
+ * identical to the previous behaviour (silent drop), but a log entry is added
+ * so operators can correlate lost results via the audit log.
+ */
+async function notifyAnnounceGiveUp(entry: SubagentRunRecord): Promise<void> {
+  try {
+    const origin = normalizeDeliveryContext(entry.requesterOrigin);
+    const channel = typeof origin?.channel === "string" ? origin.channel.trim().toLowerCase() : "";
+    const to = typeof origin?.to === "string" ? origin.to.trim() : "";
+    const hasDeliverableTarget =
+      Boolean(channel) && Boolean(to) && isDeliverableMessageChannel(channel);
+    if (!hasDeliverableTarget) {
+      // No usable delivery target — nothing to do beyond the warning already logged.
+      return;
+    }
+
+    const taskLabel = entry.label?.trim() || entry.task?.trim() || "task";
+    const retryCount = entry.announceRetryCount ?? 0;
+    const resultText = (entry.frozenResultText ?? "").trim();
+
+    const notifyText = [
+      `⚠️ Subagent result delivery failed after ${retryCount} attempts.`,
+      `Task: ${taskLabel}`,
+      resultText ? `\nResult (recovered):\n${resultText}` : "\n(No result text was captured.)",
+    ].join("\n");
+
+    const threadId =
+      origin?.threadId != null && origin.threadId !== "" ? String(origin.threadId) : undefined;
+
+    await callGateway({
+      method: "agent",
+      params: {
+        sessionKey: entry.requesterSessionKey,
+        message: notifyText,
+        deliver: true,
+        channel,
+        accountId: origin?.accountId,
+        to,
+        threadId,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: entry.childSessionKey,
+          sourceTool: "subagent_announce_giveup_notify",
+        },
+      },
+      timeoutMs: 30_000,
+    });
+
+    defaultRuntime.log(
+      `[info] Subagent announce give-up notify delivered run=${entry.runId} channel=${channel}`,
+    );
+  } catch (err) {
+    defaultRuntime.log(
+      `[warn] Subagent announce give-up notify failed run=${entry.runId}: ${String(err)}`,
+    );
+  }
 }
 
 function persistSubagentRuns() {
@@ -608,6 +679,10 @@ function resumeSubagentRun(runId: string) {
     logAnnounceGiveUp(entry, "retry-limit");
     entry.cleanupCompletedAt = Date.now();
     persistSubagentRuns();
+    // Best-effort: attempt one last direct channel delivery so the user is
+    // not left waiting indefinitely.  Fire-and-forget — failure is logged
+    // inside notifyAnnounceGiveUp and must not propagate to the caller.
+    void notifyAnnounceGiveUp(entry);
     return;
   }
   if (

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -17,6 +17,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { defaultRuntime } from "../runtime.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
+import { buildAnnounceIdempotencyKey } from "./announce-idempotency.js";
 import { ensureRuntimePluginsLoaded } from "./runtime-plugins.js";
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import {
@@ -169,14 +170,25 @@ async function notifyAnnounceGiveUp(entry: SubagentRunRecord): Promise<void> {
     const retryCount = entry.announceRetryCount ?? 0;
     const resultText = (entry.frozenResultText ?? "").trim();
 
+    // Format as an announce-style message so the requester agent can synthesise
+    // a proper user notification.  Runs reaching retry-limit have an existing
+    // session (missing-session-entry runs are pruned by the orphan path before
+    // reaching this code), so the LLM round-trip is safe and consistent with the
+    // normal announce mechanism.
     const notifyText = [
-      `⚠️ Subagent result delivery failed after ${retryCount} attempts.`,
-      `Task: ${taskLabel}`,
-      resultText ? `\nResult (recovered):\n${resultText}` : "\n(No result text was captured.)",
-    ].join("\n");
+      `[Subagent delivery failed] Task: ${taskLabel}`,
+      `Announce attempts exhausted after ${retryCount} retries.`,
+      resultText ? `Recovered result:\n${resultText}` : "(No result text was captured.)",
+      "Inform the user that the background task completed but its result could not be delivered automatically. Include the recovered result if present. Keep it concise.",
+    ].join("\n\n");
 
     const threadId =
       origin?.threadId != null && origin.threadId !== "" ? String(origin.threadId) : undefined;
+
+    // Deterministic key derived from the run ID so concurrent give-up calls for
+    // the same run deduplicate correctly (avoids the "agent:undefined" collision
+    // that an absent key would produce in the gateway dedup layer).
+    const idempotencyKey = buildAnnounceIdempotencyKey(`${entry.runId}:giveup-notify`);
 
     await callGateway({
       method: "agent",
@@ -193,6 +205,7 @@ async function notifyAnnounceGiveUp(entry: SubagentRunRecord): Promise<void> {
           sourceSessionKey: entry.childSessionKey,
           sourceTool: "subagent_announce_giveup_notify",
         },
+        idempotencyKey,
       },
       timeoutMs: 30_000,
     });

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -150,6 +150,10 @@ function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit" | "ex
  * so operators can correlate lost results via the audit log.
  */
 async function notifyAnnounceGiveUp(entry: SubagentRunRecord): Promise<void> {
+  // Do not notify for intentionally killed runs — the user already knows.
+  if (entry.suppressAnnounceReason === "killed") {
+    return;
+  }
   try {
     const origin = normalizeDeliveryContext(entry.requesterOrigin);
     const channel = typeof origin?.channel === "string" ? origin.channel.trim().toLowerCase() : "";


### PR DESCRIPTION
## Problem

When the subagent announce retry budget (`MAX_ANNOUNCE_RETRY_COUNT = 3`) is exhausted, `logAnnounceGiveUp` logs a warning, marks the run done, and the completed result is **permanently discarded with no indication to the user**.

This is Pattern 1 from #44925 — documented across 9+ production incidents (E31, E42, E45, E79, E42 × n...):

```
Subagent completion direct announce failed
Subagent announce give up (retry-limit)
Subagent orphan run pruned ... reason=missing-session-entry
```

The user has no idea the task completed. They wait indefinitely or manually ask "what happened?".

## Fix

Add `notifyAnnounceGiveUp(entry)`, called fire-and-forget from the `retry-limit` branch in `resumeSubagentRun()`.

When `entry.requesterOrigin` carries a deliverable `channel` + `to` address (captured at spawn time, already stored in `SubagentRunRecord`), it calls the gateway `agent` method with `deliver: true` to push the result **directly to the user's channel**, bypassing the session-based announce pipeline that just failed.

The notification surfaces:
- a clear warning that delivery retried and failed
- the task label
- the recovered result text from `entry.frozenResultText` (when available)

## Behaviour

| Scenario | Before | After |
|---|---|---|
| announce retry-limit hit, origin has channel+to | silent drop | best-effort last notify to user |
| announce retry-limit hit, no usable origin | silent drop | silent drop (unchanged) |
| last-resort notify also fails | silent drop | silent drop + audit log entry |

Failure is intentionally swallowed — if the last-resort delivery also fails, the outcome is identical to the previous behaviour but the attempt is auditable.

## Scope

This targets Pattern 1 (silent drop after retry-limit). Pattern 2 (timeout with no auto-restart) and Pattern 3 (file creation claims unverified) are separate issues.

Related: #44925, #44919, #43367