### PR TITLE
fix: Fixed renderContextNotice blocking the chat when context limit i…

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -934,9 +934,10 @@
   position: absolute;
   inset: 0;
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
   align-items: flex-start;
   pointer-events: none;
+  z-index: 5;
 }
 
 .context-notice {
@@ -944,6 +945,7 @@
   align-items: center;
   gap: 0.75rem;
   width: min(90%, 320px);
+  margin: 10px;
   padding: 0.75rem 1rem;
   border-radius: 0.5rem;
   background-color: var(--ctx-bg);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -929,3 +929,35 @@
   background: var(--panel-strong);
   border-color: var(--accent);
 }
+
+.context-notice-wrapper {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  pointer-events: none;
+}
+
+.context-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: min(90%, 320px);
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background-color: var(--ctx-bg);
+  border: 1px solid var(--ctx-color);
+  color: var(--ctx-color);
+}
+
+.context-notice__icon {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.context-notice__detail {
+  font-size: 0.875rem;
+  opacity: 0.8;
+}

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -264,14 +264,14 @@ function renderContextNotice(
     return nothing;
   }
   const pct = Math.min(Math.round(ratio * 100), 100);
-  // Lerp from amber (#d97706) at 85% to red (#dc2626) at 95%+
+  // Lerp from amber (#d97706) at 85% to red (#ff0000) at 95%+
   const t = Math.min(Math.max((ratio - 0.85) / 0.1, 0), 1);
-  // RGB: amber(217,119,6) → red(220,38,38)
-  const r = Math.round(217 + (220 - 217) * t);
-  const g = Math.round(119 + (38 - 119) * t);
-  const b = Math.round(6 + (38 - 6) * t);
+  // RGB: amber(217,119,6) → red(255,0,0)
+  const r = Math.round(217 + (255 - 217) * t);
+  const g = Math.round(119 + (0 - 119) * t);
+  const b = Math.round(6 + (0 - 6) * t);
   const color = `rgb(${r}, ${g}, ${b})`;
-  const bgOpacity = 0.08 + 0.08 * t;
+  const bgOpacity = 0.25 + 0.25 * t;
   const bg = `rgba(${r}, ${g}, ${b}, ${bgOpacity})`;
   return html`
     <div class="context-notice-wrapper">

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -274,10 +274,12 @@ function renderContextNotice(
   const bgOpacity = 0.08 + 0.08 * t;
   const bg = `rgba(${r}, ${g}, ${b}, ${bgOpacity})`;
   return html`
-    <div class="context-notice" role="status" style="--ctx-color:${color};--ctx-bg:${bg}">
-      <svg class="context-notice__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-      <span>${pct}% context used</span>
-      <span class="context-notice__detail">${formatTokensCompact(used)} / ${formatTokensCompact(limit)}</span>
+    <div class="context-notice-wrapper">
+      <div class="context-notice" role="status" style="--ctx-color:${color};--ctx-bg:${bg}">
+        <svg class="context-notice__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <span>${pct}% context used</span>
+        <span class="context-notice__detail">${formatTokensCompact(used)} / ${formatTokensCompact(limit)}</span>
+      </div>
     </div>
   `;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Context limit warning is blocking the chat box in Web UI/Control UI
- Why it matters: Literally prevents you from using the chat box when context limit is reached
- What changed: I added a bunch of css in `ui/src/styles/chat/layout.css` and added a div wrapper around the existing div that encapsulates around the context icon/warning text to position/center it in `ui/src/ui/views/chat.ts`
- What did NOT change (scope boundary): Nothing much is changed,just mainly two files,everything else is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # https://github.com/openclaw/openclaw/issues/45089
- Related # https://github.com/openclaw/openclaw/issues/45141

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) : No
- Secrets/tokens handling changed? (`Yes/No`) : No
- New/changed network calls? (`Yes/No`) : No
- Command/tool execution surface changed? (`Yes/No`) : No
- Data access scope changed? (`Yes/No`) : No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24 (linux 6.19.6-1-liquorix-amd64)
- Runtime/container: N/A
- Model/provider:`ollama/qwen3.5:397b-cloud`
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Hit a context limit
2. The context limit warning will overlap the entire chat box,preventing the user from seeing the chat history or interact with the session/agent at all.

### Expected

- I should be able to chat with the agent,with the context warning being displayed,but not totally obstructing and preventing full interaction with my agent.

### Actual

- The context limit warning just obstructs,or takes up space,preventing from the chat history,or input box on the bottom from being displayed.

## Evidence

Attach at least one: 
<img width="1914" height="959" alt="Screenshot from 2026-03-13 22-53-30" src="https://github.com/user-attachments/assets/a9e6fcde-c1c5-4b98-a740-be620aac3aca" />


- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I have verified that my changes should not obstruct the chat box now and that the user can now interact with their agent.
- Edge cases checked: None
- What you did **not** verify: I haven't tried with any other themes or any other screen size.I only tested it on my specific machine,with my browser,on a desktop sized screen configuration.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) : Yes
- Config/env changes? (`Yes/No`) : No
- Migration needed? (`Yes/No`) : No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Just remove the div wrapper (.context-notice-wrapper) so that the nested div is now the most root/top level at `ui/src/ui/views/chat.ts` and css styles I added at `ui/src/styles/chat/layout.css`
- Files/config to restore:  `ui/src/styles/chat/layout.css` and `ui/src/ui/views/chat.ts`
- Known bad symptoms reviewers should watch for: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: None
