### PR TITLE
fix(agents): handle FastAPI `detail` error payloads to prevent raw JSON leaking to chat

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -204,6 +204,15 @@ describe("formatAssistantErrorText", () => {
       "LLM request failed: network connection was interrupted.",
     );
   });
+  it("formats FastAPI-style detail error payloads", () => {
+    const msg = makeAssistantError(
+      '{"detail":"The \'gpt-5.3-codex\' model is not supported when using Codex with a ChatGPT account."}',
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe(
+      "LLM error: The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+    );
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {
@@ -225,6 +234,15 @@ describe("formatRawAssistantErrorForUi", () => {
   it("formats plain HTTP status lines", () => {
     expect(formatRawAssistantErrorForUi("500 Internal Server Error")).toBe(
       "HTTP 500: Internal Server Error",
+    );
+  });
+
+  it("formats FastAPI-style detail payloads", () => {
+    const text = formatRawAssistantErrorForUi(
+      '{"detail":"The \'gpt-5.3-codex\' model is not supported when using Codex with a ChatGPT account."}',
+    );
+    expect(text).toBe(
+      "LLM error: The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
     );
   });
 

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -38,6 +38,10 @@ function isErrorPayloadObject(payload: unknown): payload is ErrorPayload {
       }
     }
   }
+  // FastAPI/Starlette/Codex API error shape: {"detail": "..."}
+  if (typeof record.detail === "string") {
+    return true;
+  }
   return false;
 }
 
@@ -132,7 +136,12 @@ export function parseApiErrorInfo(raw?: string): ApiErrorInfo | null {
         : undefined;
 
   const topType = typeof payload.type === "string" ? payload.type : undefined;
-  const topMessage = typeof payload.message === "string" ? payload.message : undefined;
+  const topMessage =
+    typeof payload.message === "string"
+      ? payload.message
+      : typeof payload.detail === "string"
+        ? payload.detail
+        : undefined;
 
   let errType: string | undefined;
   let errMessage: string | undefined;


### PR DESCRIPTION
## Summary

Fixes #44910. When OpenClaw spawns subagents, error payloads using the FastAPI/Starlette/Codex API `detail` field convention (e.g. `{"detail":"The 'gpt-5.3-codex' model is not supported..."}`) were reaching the user's chat verbatim as raw JSON.

**Root cause:** `isErrorPayloadObject` in `src/agents/pi-embedded-helpers/errors.ts` did not recognize the `{"detail":"..."}` shape, so `parseApiErrorPayload` returned `null`, bypassing all error formatting and suppression logic.

**Changes:**
- `isErrorPayloadObject`: add check for `typeof record.detail === "string"` so FastAPI-style payloads are recognized as error objects
- `parseApiErrorInfo`: fall back to `payload.detail` when `payload.message` is absent, so the message is extracted cleanly
- New unit tests covering both `formatRawAssistantErrorForUi` and `formatAssistantErrorText` for `{"detail":"..."}` payloads

**Before:** `{"detail":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}` forwarded verbatim to Telegram chat.

**After:** `LLM error: The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.`

## Test plan

- [x] New unit tests added and passing (`pnpm test src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts` — 23 tests pass)
- [x] `pnpm build` clean (no errors, no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings)
- [x] `pnpm check` clean

> [!NOTE]
> This PR is AI-assisted. The fix is understood and fully covered by new unit tests.

Out of scope (separate PRs per contributor @dsantoreis's comment on #44910):
- Gating provider model probes behind credential-existence checks
- Silently suppressing errors from unconfigured providers at the routing layer