### PR TITLE
fix: skip state migration preflight for logs

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -383,6 +383,7 @@ describe("argv helpers", () => {
     const nonMutatingArgv = [
       ["node", "openclaw", "status"],
       ["node", "openclaw", "health"],
+      ["node", "openclaw", "logs", "--follow"],
       ["node", "openclaw", "sessions"],
       ["node", "openclaw", "config", "get", "update"],
       ["node", "openclaw", "config", "unset", "update"],
@@ -405,6 +406,7 @@ describe("argv helpers", () => {
   });
 
   it.each([
+    { path: ["logs"], expected: false },
     { path: ["status"], expected: false },
     { path: ["config", "get"], expected: false },
     { path: ["models", "status"], expected: false },

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -305,7 +305,7 @@ export function shouldMigrateStateFromPath(path: string[]): boolean {
     return true;
   }
   const [primary, secondary] = path;
-  if (primary === "health" || primary === "status" || primary === "sessions") {
+  if (primary === "health" || primary === "logs" || primary === "status" || primary === "sessions") {
     return false;
   }
   if (primary === "config" && (secondary === "get" || secondary === "unset")) {


### PR DESCRIPTION
## Summary
Skip doctor state migration preflight for the `logs` command by treating it as a read-only command in `shouldMigrateStateFromPath()`.

## Problem
`openclaw logs --follow` can fail in interactive TTY text mode when doctor preflight emits notes or warnings before the log tail connects. In practice, `--json`, piped output, and `OPENCLAW_SUPPRESS_NOTES=1` continue to work, which points to the CLI preflight/output path rather than `logs.tail` itself.

## Why this change
`logs` is a read-only RPC tail command and should not trigger doctor state migration preflight or interactive notes before connecting to the gateway.

## Validation
- Added argv coverage for `logs --follow` in the non-mutating command set
- Added command-path coverage for `logs` in `shouldMigrateStateFromPath()`
- Ran: `pnpm exec vitest run src/cli/argv.test.ts --config vitest.unit.config.ts`
- Result: 52 passed
