### PR TITLE
Web: normalize sandbox media file names

### DIFF
--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -154,6 +154,16 @@ describe("web media loading", () => {
     }
   });
 
+  it("normalizes Windows path separators for sandbox-validated local paths", async () => {
+    const result = await loadWebMediaRaw("C:\\private\\voice-note.m4a", {
+      maxBytes: 1024 * 1024,
+      sandboxValidated: true,
+      readFile: async () => Buffer.from("ok"),
+    });
+
+    expect(result.fileName).toBe("voice-note.m4a");
+  });
+
   it("compresses large local images under the provided cap", async () => {
     const { buffer, file } = await createLargeTestJpeg();
 

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -34,6 +34,10 @@ type WebMediaOptions = {
   readFile?: (filePath: string) => Promise<Buffer>;
 };
 
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
 function resolveWebMediaOptions(params: {
   maxBytesOrOptions?: number | WebMediaOptions;
   options?: { ssrfPolicy?: SsrFPolicy; localRoots?: readonly string[] | "any" };
@@ -386,7 +390,7 @@ async function loadWebMediaInternal(
   }
   const mime = await detectMime({ buffer: data, filePath: mediaUrl });
   const kind = kindFromMime(mime);
-  let fileName = path.basename(mediaUrl) || undefined;
+  let fileName = basenameAcrossSeparators(mediaUrl) || undefined;
   if (fileName && !path.extname(fileName) && mime) {
     const ext = extensionForMime(mime);
     if (ext) {


### PR DESCRIPTION
## Summary
- normalize sandbox-validated local media file names across path separators
- avoid leaking Windows-style path segments into returned fileName metadata
- add regression coverage for sandbox-validated local media loads

## Testing
- pnpm exec vitest run src/web/media.test.ts -t "normalizes Windows path separators for sandbox-validated local paths"
- pnpm exec oxfmt --check src/web/media.ts src/web/media.test.ts
- pnpm check
- pnpm build

## Notes
- src/web/media.test.ts currently has unrelated remote fetch assertions that are flaky against the stricter SSRF preconnect behavior on main, so the validation here uses the focused regression case added in this PR.
