### PR TITLE
[AI-assisted] fix(failover): classify codex server_error payloads as retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/insecure auth: preserve explicit shared token and password auth on plain-HTTP Control UI connects so LAN and reverse-proxy sessions no longer drop shared auth before the first WebSocket handshake. (#45088) Thanks @velvet-shark.
 - macOS/onboarding: avoid self-restarting freshly bootstrapped launchd gateways and give new daemon installs longer to become healthy, so `openclaw onboard --install-daemon` no longer false-fails on slower Macs and fresh VM snapshots.
 - Agents/compaction: preserve safeguard compaction summary language continuity via default and configurable custom instructions so persona drift is reduced after auto-compaction. (#10456) Thanks @keepitmello.
+- Agents/failover: classify raw OpenAI Codex `server_error` JSON payloads as retryable timeouts so configured fallback models engage instead of surfacing hard-stop errors.
 
 ## 2026.3.12
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -850,5 +850,10 @@ describe("classifyFailoverReason", () => {
         '{"type":"error","error":{"type":"api_error","message":"Internal server error"}}',
       ),
     ).toBe("timeout");
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID c69ab225-9c66-48c4-87c9-2a46bf07e104 in your message.","param":null},"sequence_number":2}',
+      ),
+    ).toBe("timeout");
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -846,14 +846,23 @@ export function isBillingAssistantError(msg: AssistantMessage | undefined): bool
   return isBillingErrorMessage(msg.errorMessage ?? "");
 }
 
-function isJsonApiInternalServerError(raw: string): boolean {
+function isRetryableJsonApiServerError(raw: string): boolean {
   if (!raw) {
     return false;
   }
-  const value = raw.toLowerCase();
-  // Anthropic often wraps transient 500s in JSON payloads like:
-  // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  const info = parseApiErrorInfo(raw);
+  if (!info) {
+    return false;
+  }
+
+  // OpenAI/Codex can surface transient failures as raw payloads like:
+  // {"type":"error","error":{"type":"server_error","message":"An error occurred while processing your request."}}
+  if (info.type === "server_error") {
+    return true;
+  }
+
+  const message = info.message?.toLowerCase() ?? "";
+  return info.type === "api_error" && message.includes("internal server error");
 }
 
 export function parseImageDimensionError(raw: string): {
@@ -1006,7 +1015,7 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     // Treat remaining transient 5xx provider failures as retryable transport issues.
     return "timeout";
   }
-  if (isJsonApiInternalServerError(raw)) {
+  if (isRetryableJsonApiServerError(raw)) {
     return "timeout";
   }
   if (isCloudCodeAssistFormatError(raw)) {


### PR DESCRIPTION
## Summary

- Problem: raw OpenAI Codex JSON payloads with `error.type = "server_error"` could end agent turns as hard errors instead of entering OpenClaw's fallback lane.
- Why it matters: agents configured with fallback chains like `gpt-5.4 -> gpt-5.3-codex` could stop without ever attempting the next configured model.
- What changed: `classifyFailoverReason` now treats parsed API payloads with `type` or `code` of `server_error` as retryable timeouts, and a regression test covers the exact Codex payload shape.
- What did NOT change (scope boundary): this PR does not alter model ordering, retry counts, or provider auth logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45234
- Related #45234

## User-visible / Behavior Changes

Configured fallback models now engage when OpenAI Codex returns the raw JSON `server_error` payload shape instead of surfacing an immediate hard-stop error.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6
- Runtime/container: Node 25.3.0, pnpm 10.23.0
- Model/provider: OpenAI Codex (`gpt-5.4` primary with `gpt-5.3-codex` fallback in the observed failing deployment)
- Integration/channel (if any): Discord in the observed live failure; fix is channel-agnostic
- Relevant config (redacted): fallback chain configured, raw provider error payload surfaced without HTTP status

### Steps

1. Run an agent with a fallback chain that starts on OpenAI Codex.
2. Surface a raw provider payload like `{"type":"error","error":{"type":"server_error",...}}`.
3. Observe whether the turn enters fallback or stops immediately.

### Expected

- The payload is classified as retryable/transient.
- The run enters the existing timeout/fallback path and attempts the next configured model.

### Actual

- Before this patch, the turn could stop on the raw `server_error` payload without attempting the next fallback model.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm build`, `pnpm check`, `pnpm test`, and `pnpm test src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` all pass locally on this branch.
- Edge cases checked: existing `api_error` + `Internal server error` classification still stays in the timeout lane; the new exact Codex `server_error` payload also classifies as timeout.
- What you did **not** verify: I did not run a live provider-backed end-to-end gateway fallback on this fork.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ae760b36b`.
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`, `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: non-transient provider-side `server_error` payloads would now enter the timeout/fallback lane.

## Risks and Mitigations

- Risk: a provider could use `server_error` for a failure that should not retry.
  - Mitigation: the change is narrow, only for parsed API payloads with explicit `type` or `code` of `server_error`, and it reuses the existing timeout/fallback path rather than inventing a new retry policy.

## AI Assistance

- AI-assisted: Yes
- Degree of testing: Fully tested locally (`pnpm build`, `pnpm check`, `pnpm test`)
- Prompt/session logs: available on request
- I understand what the code does: Yes
- `codex review --base upstream/main`: attempted locally; the review runner began scanning the diff but did not complete cleanly in the local sandbox, and it emitted no findings before interruption.
