### PR TITLE
fix(tts): validate baseUrl against cloud metadata and dangerous hostnames (CWE-918)

### DIFF
--- a/src/tts/tts-core.security.test.ts
+++ b/src/tts/tts-core.security.test.ts
@@ -1,53 +1,65 @@
 import { describe, expect, it } from "vitest";
-import { isBlockedHostname } from "../infra/net/ssrf.js";
+import { assertTtsBaseUrlAllowed } from "./tts-core.js";
 
 describe("CWE-918: TTS base URL SSRF validation", () => {
   describe("blocked addresses (cloud metadata and dangerous hostnames)", () => {
     it("should block cloud metadata IP (169.254.169.254)", () => {
-      // Verified via assertTtsBaseUrlAllowed prefix check on 169.254.
-      expect("169.254.169.254".startsWith("169.254.")).toBe(true);
+      expect(() => assertTtsBaseUrlAllowed("http://169.254.169.254/")).toThrow(
+        /link-local\/metadata/,
+      );
+      expect(() => assertTtsBaseUrlAllowed("http://169.254.169.254:80/")).toThrow(
+        /link-local\/metadata/,
+      );
     });
 
     it("should block link-local range (169.254.x.x)", () => {
-      expect("169.254.1.1".startsWith("169.254.")).toBe(true);
-      expect("169.254.0.1".startsWith("169.254.")).toBe(true);
+      expect(() => assertTtsBaseUrlAllowed("http://169.254.1.1:8080/")).toThrow(
+        /link-local\/metadata/,
+      );
+      expect(() => assertTtsBaseUrlAllowed("http://169.254.0.1/")).toThrow(/link-local\/metadata/);
+    });
+
+    it("should block 0.0.0.0", () => {
+      expect(() => assertTtsBaseUrlAllowed("http://0.0.0.0:8880/v1")).toThrow(/blocked address/);
     });
 
     it("should block metadata.google.internal", () => {
-      expect(isBlockedHostname("metadata.google.internal")).toBe(true);
+      expect(() =>
+        assertTtsBaseUrlAllowed("http://metadata.google.internal/computeMetadata/v1/"),
+      ).toThrow(/blocked hostname/);
     });
 
     it("should block *.internal and *.local hostnames", () => {
-      expect(isBlockedHostname("service.internal")).toBe(true);
-      expect(isBlockedHostname("tts.local")).toBe(true);
+      expect(() => assertTtsBaseUrlAllowed("http://service.internal:8080/")).toThrow(
+        /blocked hostname/,
+      );
+      expect(() => assertTtsBaseUrlAllowed("http://tts.local:8080/")).toThrow(/blocked hostname/);
     });
 
     it("should block localhost.localdomain", () => {
-      expect(isBlockedHostname("localhost.localdomain")).toBe(true);
+      expect(() => assertTtsBaseUrlAllowed("http://localhost.localdomain:8080/")).toThrow(
+        /blocked hostname/,
+      );
     });
   });
 
   describe("allowed addresses (legitimate TTS endpoints)", () => {
-    it("should allow api.elevenlabs.io", () => {
-      expect(isBlockedHostname("api.elevenlabs.io")).toBe(false);
-    });
-
-    it("should allow api.openai.com", () => {
-      expect(isBlockedHostname("api.openai.com")).toBe(false);
-    });
-
     it("should allow localhost (self-hosted TTS like Kokoro)", () => {
-      // localhost is explicitly allowlisted in assertTtsBaseUrlAllowed
-      expect(isBlockedHostname("localhost")).toBe(true); // blocked by general policy
-      // but assertTtsBaseUrlAllowed has an explicit exception for "localhost"
+      expect(() => assertTtsBaseUrlAllowed("http://localhost:8880/v1")).not.toThrow();
+    });
+
+    it("should allow public hostnames", () => {
+      expect(() => assertTtsBaseUrlAllowed("https://api.elevenlabs.io/v1")).not.toThrow();
+      expect(() => assertTtsBaseUrlAllowed("https://api.openai.com/v1")).not.toThrow();
+      expect(() => assertTtsBaseUrlAllowed("https://tts.example.com/v1")).not.toThrow();
     });
 
     it("should allow public IPs", () => {
-      expect(isBlockedHostname("93.184.216.34")).toBe(false);
+      expect(() => assertTtsBaseUrlAllowed("http://93.184.216.34:8880/v1")).not.toThrow();
     });
 
-    it("should allow custom public TTS endpoints", () => {
-      expect(isBlockedHostname("tts.example.com")).toBe(false);
+    it("should reject invalid URLs", () => {
+      expect(() => assertTtsBaseUrlAllowed("not-a-url")).toThrow(/Invalid TTS base URL/);
     });
   });
 });

--- a/src/tts/tts-core.security.test.ts
+++ b/src/tts/tts-core.security.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { isBlockedHostname } from "../infra/net/ssrf.js";
+
+describe("CWE-918: TTS base URL SSRF validation", () => {
+  describe("blocked addresses (cloud metadata and dangerous hostnames)", () => {
+    it("should block cloud metadata IP (169.254.169.254)", () => {
+      // Verified via assertTtsBaseUrlAllowed prefix check on 169.254.
+      expect("169.254.169.254".startsWith("169.254.")).toBe(true);
+    });
+
+    it("should block link-local range (169.254.x.x)", () => {
+      expect("169.254.1.1".startsWith("169.254.")).toBe(true);
+      expect("169.254.0.1".startsWith("169.254.")).toBe(true);
+    });
+
+    it("should block metadata.google.internal", () => {
+      expect(isBlockedHostname("metadata.google.internal")).toBe(true);
+    });
+
+    it("should block *.internal and *.local hostnames", () => {
+      expect(isBlockedHostname("service.internal")).toBe(true);
+      expect(isBlockedHostname("tts.local")).toBe(true);
+    });
+
+    it("should block localhost.localdomain", () => {
+      expect(isBlockedHostname("localhost.localdomain")).toBe(true);
+    });
+  });
+
+  describe("allowed addresses (legitimate TTS endpoints)", () => {
+    it("should allow api.elevenlabs.io", () => {
+      expect(isBlockedHostname("api.elevenlabs.io")).toBe(false);
+    });
+
+    it("should allow api.openai.com", () => {
+      expect(isBlockedHostname("api.openai.com")).toBe(false);
+    });
+
+    it("should allow localhost (self-hosted TTS like Kokoro)", () => {
+      // localhost is explicitly allowlisted in assertTtsBaseUrlAllowed
+      expect(isBlockedHostname("localhost")).toBe(true); // blocked by general policy
+      // but assertTtsBaseUrlAllowed has an explicit exception for "localhost"
+    });
+
+    it("should allow public IPs", () => {
+      expect(isBlockedHostname("93.184.216.34")).toBe(false);
+    });
+
+    it("should allow custom public TTS endpoints", () => {
+      expect(isBlockedHostname("tts.example.com")).toBe(false);
+    });
+  });
+});

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -36,7 +36,7 @@ export function isValidVoiceId(voiceId: string): boolean {
  * private networks, so loopback and private IPs are allowed. Only cloud
  * metadata / link-local IPs and dangerous hostnames are blocked.
  */
-function assertTtsBaseUrlAllowed(url: string): void {
+export function assertTtsBaseUrlAllowed(url: string): void {
   let parsed: URL;
   try {
     parsed = new URL(url);

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -12,6 +12,7 @@ import {
 import { createConfiguredOllamaStreamFn } from "../agents/ollama-stream.js";
 import { resolveModel } from "../agents/pi-embedded-runner/model.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { isBlockedHostname } from "../infra/net/ssrf.js";
 import type {
   ResolvedTtsConfig,
   ResolvedTtsModelOverrides,
@@ -27,12 +28,45 @@ export function isValidVoiceId(voiceId: string): boolean {
   return /^[a-zA-Z0-9]{10,40}$/.test(voiceId);
 }
 
+/**
+ * Validate that a TTS base URL does not target cloud metadata endpoints
+ * or other known-dangerous destinations (CWE-918).
+ *
+ * Users may run self-hosted TTS servers (e.g., Kokoro) on localhost or
+ * private networks, so loopback and private IPs are allowed. Only cloud
+ * metadata / link-local IPs and dangerous hostnames are blocked.
+ */
+function assertTtsBaseUrlAllowed(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid TTS base URL: ${url}`);
+  }
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+
+  // Block link-local / cloud metadata IPs (169.254.x.x)
+  if (hostname.startsWith("169.254.")) {
+    throw new Error(`TTS base URL targets a link-local/metadata address: ${hostname}`);
+  }
+  if (hostname === "0.0.0.0") {
+    throw new Error(`TTS base URL targets a blocked address: ${hostname}`);
+  }
+
+  // Block dangerous hostnames, but allow localhost for self-hosted TTS
+  if (hostname !== "localhost" && isBlockedHostname(hostname)) {
+    throw new Error(`TTS base URL targets a blocked hostname: ${hostname}`);
+  }
+}
+
 function normalizeElevenLabsBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.trim();
   if (!trimmed) {
     return DEFAULT_ELEVENLABS_BASE_URL;
   }
-  return trimmed.replace(/\/+$/, "");
+  const normalized = trimmed.replace(/\/+$/, "");
+  assertTtsBaseUrlAllowed(normalized);
+  return normalized;
 }
 
 function normalizeOpenAITtsBaseUrl(baseUrl?: string): string {
@@ -40,7 +74,9 @@ function normalizeOpenAITtsBaseUrl(baseUrl?: string): string {
   if (!trimmed) {
     return DEFAULT_OPENAI_BASE_URL;
   }
-  return trimmed.replace(/\/+$/, "");
+  const normalized = trimmed.replace(/\/+$/, "");
+  assertTtsBaseUrlAllowed(normalized);
+  return normalized;
 }
 
 function trimToUndefined(value?: string): string | undefined {


### PR DESCRIPTION
## Summary
Fix SSRF vulnerability in TTS module where provider baseUrl (configurable via OPENAI_TTS_BASE_URL env var or YAML config) has no hostname/IP validation (CWE-918).

## Vulnerability
- **CWE**: CWE-918 (Server-Side Request Forgery)
- **File**: src/tts/tts-core.ts:30-44 (normalizeElevenLabsBaseUrl, normalizeOpenAITtsBaseUrl)
- **Severity**: High
- **Impact**: An attacker who controls the TTS configuration or OPENAI_TTS_BASE_URL environment variable can redirect HTTP requests to cloud metadata endpoints (169.254.169.254), link-local addresses, or dangerous internal hostnames.

## Reproduction
1. Set environment variable: OPENAI_TTS_BASE_URL=http://169.254.169.254/latest/meta-data/
2. TTS module makes HTTP requests to the metadata endpoint via openaiTTS() or elevenLabsTTS()
3. Cloud instance credentials / metadata are accessible

## Fix
Added assertTtsBaseUrlAllowed() validation inside both normalizeElevenLabsBaseUrl() and normalizeOpenAITtsBaseUrl() that blocks cloud metadata / link-local IPs (169.254.x.x), dangerous hostnames (metadata.google.internal, *.internal, *.local), and 0.0.0.0. Localhost and private networks are allowed since users may run self-hosted TTS servers (e.g., Kokoro).

## Test Results
- 10/10 security tests pass
- 47/47 full TTS module regression tests pass

## Checklist
- [x] POC test cases: metadata/link-local/dangerous hostnames blocked
- [x] Normal input regression tests PASS
- [x] Module-level regression tests pass (47/47)
- [x] No new security issues introduced

## AI Disclosure
- [x] AI-assisted (Claude)
- [x] Test coverage: POC verification + full module regression tests pass