### PR TITLE
fix(infra/net): pass pinned DNS lookup to ProxyAgent in explicit-proxy mode (CWE-918)

### DIFF
--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -102,7 +102,7 @@ describe("createPinnedDispatcher", () => {
     });
   });
 
-  it("keeps explicit proxy routing intact", () => {
+  it("passes pinned lookup to explicit proxy via requestTls", () => {
     const lookup = vi.fn() as unknown as PinnedHostname["lookup"];
     const pinned: PinnedHostname = {
       hostname: "api.telegram.org",
@@ -122,6 +122,9 @@ describe("createPinnedDispatcher", () => {
       uri: "http://127.0.0.1:7890",
       proxyTls: {
         autoSelectFamily: false,
+      },
+      requestTls: {
+        lookup,
       },
     });
   });

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -268,6 +268,7 @@ export type PinnedDispatcherPolicy =
   | {
       mode: "explicit-proxy";
       proxyUrl: string;
+      connect?: Record<string, unknown>;
       proxyTls?: Record<string, unknown>;
     };
 
@@ -370,13 +371,14 @@ export function createPinnedDispatcher(
   }
 
   const proxyUrl = policy.proxyUrl.trim();
-  if (!policy.proxyTls) {
-    return new ProxyAgent(proxyUrl);
-  }
-  return new ProxyAgent({
+  // CWE-918: Pass pinned lookup to ProxyAgent so the target hostname resolves
+  // to the pre-validated IP addresses, preventing DNS rebinding attacks.
+  const proxyOpts: Record<string, unknown> = {
     uri: proxyUrl,
-    proxyTls: { ...policy.proxyTls },
-  });
+    ...(policy.proxyTls ? { proxyTls: { ...policy.proxyTls } } : {}),
+    requestTls: withPinnedLookup(pinned.lookup, policy.connect),
+  };
+  return new ProxyAgent(proxyOpts as ConstructorParameters<typeof ProxyAgent>[0]);
 }
 
 export async function closeDispatcher(dispatcher?: Dispatcher | null): Promise<void> {

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -373,12 +373,12 @@ export function createPinnedDispatcher(
   const proxyUrl = policy.proxyUrl.trim();
   // CWE-918: Pass pinned lookup to ProxyAgent so the target hostname resolves
   // to the pre-validated IP addresses, preventing DNS rebinding attacks.
-  const proxyOpts: Record<string, unknown> = {
+  const proxyOpts = {
     uri: proxyUrl,
     ...(policy.proxyTls ? { proxyTls: { ...policy.proxyTls } } : {}),
     requestTls: withPinnedLookup(pinned.lookup, policy.connect),
-  };
-  return new ProxyAgent(proxyOpts as ConstructorParameters<typeof ProxyAgent>[0]);
+  } as unknown as ConstructorParameters<typeof ProxyAgent>[0];
+  return new ProxyAgent(proxyOpts);
 }
 
 export async function closeDispatcher(dispatcher?: Dispatcher | null): Promise<void> {


### PR DESCRIPTION
## Summary
Fix DNS pinning bypass in explicit-proxy mode where ProxyAgent was created without the pinned lookup, allowing DNS rebinding attacks (CWE-918).

## Vulnerability
- **CWE**: CWE-918 (Server-Side Request Forgery)
- **File**: src/infra/net/ssrf.ts:372-379 (createPinnedDispatcher)
- **Severity**: High
- **Impact**: In explicit-proxy mode, createPinnedDispatcher created a ProxyAgent without passing the pinned DNS lookup. The pre-validated IP addresses from resolvePinnedHostnameWithPolicy() were discarded, allowing DNS rebinding attacks where the proxy resolves a different IP than what was validated.

## Reproduction
1. Configure an explicit proxy via dispatcherPolicy
2. Call fetchWithSsrFGuard with a DNS rebinding domain
3. Validation passes (public IP at check time)
4. ProxyAgent resolves DNS independently, gets private IP
5. SSRF to internal services succeeds

## Fix
- Pass pinned.lookup to ProxyAgent via requestTls connect options
- Add connect field to the explicit-proxy PinnedDispatcherPolicy type for caller-provided transport hints
- Update existing test to verify pinned lookup is passed

## Test Results

### After fix (PASS)
```
$ pnpm vitest run src/infra/net/

 ✓ 7 test files, 59 tests passed
```

The existing dispatcher test now verifies that pinned lookup is passed to ProxyAgent in explicit-proxy mode.

## Checklist
- [x] Existing test updated to verify pinned lookup is passed
- [x] Module-level regression tests pass (59/59)
- [x] No new security issues introduced

## AI Disclosure
- [x] AI-assisted (Claude)
- [x] Test coverage: updated existing test + full module regression tests pass