### PR TITLE
Agents: normalize exec preflight script names

### DIFF
--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -35,6 +35,36 @@ describeNonWin("exec script preflight", () => {
     });
   });
 
+  it("normalizes Windows-style script paths in preflight errors", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      const pyPath = path.join(tmp, "C:\\temp\\bad.py");
+
+      await fs.writeFile(
+        pyPath,
+        [
+          "import json",
+          "# model accidentally wrote shell syntax:",
+          "payload = $DM_JSON",
+          "print(payload)",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+
+      const error = await tool
+        .execute("call-windows-path", {
+          command: "python C:\\temp\\bad.py",
+          workdir: tmp,
+        })
+        .catch((err) => err);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toMatch(/bad\.py:3\./);
+      expect((error as Error).message).not.toMatch(/C:\\temp\\/);
+    });
+  });
+
   it("blocks obvious shell-as-js output before node execution", async () => {
     await withTempDir("openclaw-exec-preflight-", async (tmp) => {
       const jsPath = path.join(tmp, "bad.js");

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -77,6 +77,10 @@ function extractScriptTargetFromCommand(
   return null;
 }
 
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
 async function validateScriptFileForShellBleed(params: {
   command: string;
   workdir: string;
@@ -123,7 +127,7 @@ async function validateScriptFileForShellBleed(params: {
     throw new Error(
       [
         `exec preflight: detected likely shell variable injection (${token}) in ${target.kind} script: ${path.basename(
-          absPath,
+          basenameAcrossSeparators(absPath),
         )}:${line}.`,
         target.kind === "python"
           ? `In Python, use os.environ.get(${JSON.stringify(token.slice(1))}) instead of raw ${token}.`


### PR DESCRIPTION
## Summary
- normalize exec preflight script names across path separators
- avoid leaking full Windows-style script paths in preflight error messages on macOS/Linux
- add regression coverage for Windows-style script path handling

## Testing
- pnpm test src/agents/bash-tools.exec.script-preflight.test.ts
- pnpm exec oxfmt --check src/agents/bash-tools.exec.ts src/agents/bash-tools.exec.script-preflight.test.ts
- pnpm check
- pnpm build
