### PR TITLE
feat(slack): add contextAware option for slash commands

### DIFF
--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -68,6 +68,11 @@ export type SlackSlashCommandConfig = {
   sessionPrefix?: string;
   /** Reply ephemerally (default: true). */
   ephemeral?: boolean;
+  /**
+   * When true, slash command can be invoked without text and will use recent
+   * channel history as context (default: false).
+   */
+  contextAware?: boolean;
 };
 
 export type SlackThreadConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -879,6 +879,7 @@ export const SlackAccountSchema = z
         name: z.string().optional(),
         sessionPrefix: z.string().optional(),
         ephemeral: z.boolean().optional(),
+        contextAware: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/slack/monitor/commands.ts
+++ b/src/slack/monitor/commands.ts
@@ -25,6 +25,7 @@ export function resolveSlackSlashCommandConfig(
     name,
     sessionPrefix: raw?.sessionPrefix?.trim() || "slack:slash",
     ephemeral: raw?.ephemeral !== false,
+    contextAware: raw?.contextAware === true,
   };
 }
 

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -315,7 +315,9 @@ export async function registerSlackMonitorSlashCommands(params: {
         );
         return;
       }
-      if (!prompt.trim()) {
+      // When contextAware is enabled, empty prompts are allowed - we'll fetch channel history
+      const isContextAwareMode = slashCommand.contextAware && !prompt.trim();
+      if (!prompt.trim() && !slashCommand.contextAware) {
         await ack({
           text: "Message required.",
           response_type: "ephemeral",
@@ -555,9 +557,45 @@ export async function registerSlackMonitorSlashCommands(params: {
         targetSessionKey: route.sessionKey,
         lowercaseSessionKey: true,
       });
+
+      // Context-aware mode: fetch recent channel history when no prompt provided
+      let effectivePrompt = prompt;
+      let contextHistory: string | undefined;
+      if (isContextAwareMode && isRoomish) {
+        try {
+          const historyResponse = await ctx.app.client.conversations.history({
+            token: ctx.botToken,
+            channel: command.channel_id,
+            limit: 10,
+          });
+          const messages = historyResponse.messages ?? [];
+          if (messages.length > 0) {
+            // Build context from recent messages (oldest first)
+            const recentContext = messages
+              .reverse()
+              .map((msg) => {
+                const msgUser = msg.user ?? "unknown";
+                const msgText = msg.text ?? "";
+                return `[${msgUser}]: ${msgText}`;
+              })
+              .join("\n");
+            contextHistory = recentContext;
+            effectivePrompt = `[Respond to the recent conversation in this channel]\n\nRecent messages:\n${recentContext}`;
+          } else {
+            effectivePrompt = "[No recent messages to respond to]";
+          }
+        } catch (err) {
+          runtime.error?.(danger(`slack slash: failed to fetch channel history: ${String(err)}`));
+          effectivePrompt = "[Respond to the recent conversation in this channel]";
+        }
+      } else if (isContextAwareMode && !isRoomish) {
+        // Context-aware in DMs - just use a simple prompt
+        effectivePrompt = "[Continue the conversation]";
+      }
+
       const ctxPayload = finalizeInboundContext({
-        Body: prompt,
-        BodyForAgent: prompt,
+        Body: effectivePrompt,
+        BodyForAgent: effectivePrompt,
         RawBody: prompt,
         CommandBody: prompt,
         CommandArgs: commandArgs,


### PR DESCRIPTION
## Summary

When `slashCommand.contextAware` is true, the slash command can be invoked without any text argument. In this mode, it fetches recent channel history (up to 10 messages) and uses that context to respond to the conversation.

## Motivation

This enables a more natural interaction pattern where users can just type `/moss` (or whatever the command is named) and have the agent respond to the recent conversation without needing to explicitly type a question.

Currently, slash commands require a text argument or return "Message required." This makes the interaction feel less conversational.

## Config Example

```json5
{
  channels: {
    slack: {
      slashCommand: {
        enabled: true,
        name: "moss",
        contextAware: true  // NEW
      }
    }
  }
}
```

## Changes

1. Added `contextAware?: boolean` to `SlackSlashCommandConfig` type
2. Updated zod schema to include the new option  
3. Updated `resolveSlackSlashCommandConfig` to handle the new option
4. Modified the slash command handler to:
   - Skip the "Message required" check when `contextAware` is true
   - Fetch recent channel history (10 messages) when invoked without text
   - Build a context-aware prompt with the recent messages

## Testing

Tested manually - when `contextAware: true` and no text is provided, the agent receives recent channel messages as context and responds appropriately.