### PR TITLE
fix(gateway): read live plugin registry per-request instead of startup snapshot

### DIFF
--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -5,6 +5,7 @@ import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -118,12 +119,16 @@ export async function createGatewayRuntimeState(params: {
     logHooks: params.logHooks,
   });
 
+  // Always read the live active registry so config reloads take effect
+  // without restarting the gateway HTTP handler.
+  const getPluginRegistry = (): PluginRegistry =>
+    getActivePluginRegistry() ?? params.pluginRegistry;
   const handlePluginRequest = createGatewayPluginRequestHandler({
-    registry: params.pluginRegistry,
+    getRegistry: getPluginRegistry,
     log: params.logPlugins,
   });
   const shouldEnforcePluginGatewayAuth = (pathContext: PluginRoutePathContext): boolean => {
-    return shouldEnforceGatewayAuthForPluginPath(params.pluginRegistry, pathContext);
+    return shouldEnforceGatewayAuthForPluginPath(getPluginRegistry(), pathContext);
   };
 
   const bindHosts = await resolveGatewayListenHosts(params.bindHost);

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -4,7 +4,7 @@ import { CANVAS_HOST_PATH } from "../canvas-host/a2ui.js";
 import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/server.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
-import { createEmptyPluginRegistry, type PluginRegistry } from "../plugins/registry.js";
+import type { PluginRegistry } from "../plugins/registry.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
@@ -122,9 +122,10 @@ export async function createGatewayRuntimeState(params: {
   // Always read the live active registry so config reloads take effect
   // without restarting the gateway HTTP handler.
   // getActivePluginRegistry() is always non-null (initialised with an empty
-  // registry on module load), so every request sees the latest registry.
+  // registry on module load), so the fallback to params.pluginRegistry is
+  // only reached if that invariant is ever broken.
   const getPluginRegistry = (): PluginRegistry =>
-    getActivePluginRegistry() ?? createEmptyPluginRegistry();
+    getActivePluginRegistry() ?? params.pluginRegistry;
   const handlePluginRequest = createGatewayPluginRequestHandler({
     getRegistry: getPluginRegistry,
     log: params.logPlugins,

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -4,7 +4,7 @@ import { CANVAS_HOST_PATH } from "../canvas-host/a2ui.js";
 import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/server.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
-import type { PluginRegistry } from "../plugins/registry.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "../plugins/registry.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
@@ -121,8 +121,10 @@ export async function createGatewayRuntimeState(params: {
 
   // Always read the live active registry so config reloads take effect
   // without restarting the gateway HTTP handler.
+  // getActivePluginRegistry() is always non-null (initialised with an empty
+  // registry on module load), so every request sees the latest registry.
   const getPluginRegistry = (): PluginRegistry =>
-    getActivePluginRegistry() ?? params.pluginRegistry;
+    getActivePluginRegistry() ?? createEmptyPluginRegistry();
   const handlePluginRequest = createGatewayPluginRequestHandler({
     getRegistry: getPluginRegistry,
     log: params.logPlugins,

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -137,6 +137,32 @@ describe("createGatewayPluginRequestHandler", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("missing scope: operator.admin"));
   });
 
+  it("uses the registry returned at request time, not at construction time", async () => {
+    const log = createPluginLog();
+    let currentRegistry = createTestRegistry(); // initially empty — no routes
+    const handler = createGatewayPluginRequestHandler({
+      getRegistry: () => currentRegistry,
+      log,
+    });
+
+    // First request: no routes registered → should not handle
+    const { res: res1 } = makeMockHttpResponse();
+    const handled1 = await handler({ url: "/hook" } as IncomingMessage, res1);
+    expect(handled1).toBe(false);
+
+    // Simulate a config reload that adds a route
+    const routeHandler = vi.fn(async () => true);
+    currentRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/hook", handler: routeHandler })],
+    });
+
+    // Second request: route now exists → should handle
+    const { res: res2 } = makeMockHttpResponse();
+    const handled2 = await handler({ url: "/hook" } as IncomingMessage, res2);
+    expect(handled2).toBe(true);
+    expect(routeHandler).toHaveBeenCalledOnce();
+  });
+
   it("returns false when no routes are registered", async () => {
     const log = createPluginLog();
     const handler = createGatewayPluginRequestHandler({

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -105,18 +105,19 @@ describe("createGatewayPluginRequestHandler", () => {
     const subagent = await createSubagentRuntime();
     const log = createPluginLog();
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [
-          createRoute({
-            path: "/hook",
-            auth: "plugin",
-            handler: async (_req, _res) => {
-              await subagent.deleteSession({ sessionKey: "agent:main:subagent:child" });
-              return true;
-            },
-          }),
-        ],
-      }),
+      getRegistry: () =>
+        createTestRegistry({
+          httpRoutes: [
+            createRoute({
+              path: "/hook",
+              auth: "plugin",
+              handler: async (_req, _res) => {
+                await subagent.deleteSession({ sessionKey: "agent:main:subagent:child" });
+                return true;
+              },
+            }),
+          ],
+        }),
       log,
     });
 
@@ -139,7 +140,7 @@ describe("createGatewayPluginRequestHandler", () => {
   it("returns false when no routes are registered", async () => {
     const log = createPluginLog();
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry(),
+      getRegistry: () => createTestRegistry(),
       log,
     });
     const { res } = makeMockHttpResponse();
@@ -152,9 +153,10 @@ describe("createGatewayPluginRequestHandler", () => {
       res.statusCode = 200;
     });
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [createRoute({ path: "/demo", handler: routeHandler })],
-      }),
+      getRegistry: () =>
+        createTestRegistry({
+          httpRoutes: [createRoute({ path: "/demo", handler: routeHandler })],
+        }),
       log: createPluginLog(),
     });
 
@@ -170,12 +172,13 @@ describe("createGatewayPluginRequestHandler", () => {
     });
     const prefixHandler = vi.fn(async () => true);
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [
-          createRoute({ path: "/api", match: "prefix", handler: prefixHandler }),
-          createRoute({ path: "/api/demo", match: "exact", handler: exactHandler }),
-        ],
-      }),
+      getRegistry: () =>
+        createTestRegistry({
+          httpRoutes: [
+            createRoute({ path: "/api", match: "prefix", handler: prefixHandler }),
+            createRoute({ path: "/api/demo", match: "exact", handler: exactHandler }),
+          ],
+        }),
       log: createPluginLog(),
     });
 
@@ -190,12 +193,13 @@ describe("createGatewayPluginRequestHandler", () => {
     const first = vi.fn(async () => false);
     const second = vi.fn(async () => true);
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [
-          createRoute({ path: "/hook", match: "exact", handler: first }),
-          createRoute({ path: "/hook", match: "prefix", handler: second }),
-        ],
-      }),
+      getRegistry: () =>
+        createTestRegistry({
+          httpRoutes: [
+            createRoute({ path: "/hook", match: "exact", handler: first }),
+            createRoute({ path: "/hook", match: "prefix", handler: second }),
+          ],
+        }),
       log: createPluginLog(),
     });
 
@@ -210,22 +214,23 @@ describe("createGatewayPluginRequestHandler", () => {
     const exactPluginHandler = vi.fn(async () => false);
     const prefixGatewayHandler = vi.fn(async () => true);
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [
-          createRoute({
-            path: "/plugin/secure/report",
-            match: "exact",
-            auth: "plugin",
-            handler: exactPluginHandler,
-          }),
-          createRoute({
-            path: "/plugin/secure",
-            match: "prefix",
-            auth: "gateway",
-            handler: prefixGatewayHandler,
-          }),
-        ],
-      }),
+      getRegistry: () =>
+        createTestRegistry({
+          httpRoutes: [
+            createRoute({
+              path: "/plugin/secure/report",
+              match: "exact",
+              auth: "plugin",
+              handler: exactPluginHandler,
+            }),
+            createRoute({
+              path: "/plugin/secure",
+              match: "prefix",
+              auth: "gateway",
+              handler: prefixGatewayHandler,
+            }),
+          ],
+        }),
       log: createPluginLog(),
     });
 
@@ -247,22 +252,23 @@ describe("createGatewayPluginRequestHandler", () => {
     const exactPluginHandler = vi.fn(async () => false);
     const prefixGatewayHandler = vi.fn(async () => true);
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [
-          createRoute({
-            path: "/plugin/secure/report",
-            match: "exact",
-            auth: "plugin",
-            handler: exactPluginHandler,
-          }),
-          createRoute({
-            path: "/plugin/secure",
-            match: "prefix",
-            auth: "gateway",
-            handler: prefixGatewayHandler,
-          }),
-        ],
-      }),
+      getRegistry: () =>
+        createTestRegistry({
+          httpRoutes: [
+            createRoute({
+              path: "/plugin/secure/report",
+              match: "exact",
+              auth: "plugin",
+              handler: exactPluginHandler,
+            }),
+            createRoute({
+              path: "/plugin/secure",
+              match: "prefix",
+              auth: "gateway",
+              handler: prefixGatewayHandler,
+            }),
+          ],
+        }),
       log: createPluginLog(),
     });
 
@@ -285,9 +291,10 @@ describe("createGatewayPluginRequestHandler", () => {
       res.statusCode = 200;
     });
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [createRoute({ path: "/api/demo", handler: routeHandler })],
-      }),
+      getRegistry: () =>
+        createTestRegistry({
+          httpRoutes: [createRoute({ path: "/api/demo", handler: routeHandler })],
+        }),
       log: createPluginLog(),
     });
 
@@ -300,16 +307,17 @@ describe("createGatewayPluginRequestHandler", () => {
   it("logs and responds with 500 when a route throws", async () => {
     const log = createPluginLog();
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [
-          createRoute({
-            path: "/boom",
-            handler: async () => {
-              throw new Error("boom");
-            },
-          }),
-        ],
-      }),
+      getRegistry: () =>
+        createTestRegistry({
+          httpRoutes: [
+            createRoute({
+              path: "/boom",
+              handler: async () => {
+                throw new Error("boom");
+              },
+            }),
+          ],
+        }),
       log,
     });
 

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -60,11 +60,12 @@ export type PluginHttpRequestHandler = (
 ) => Promise<boolean>;
 
 export function createGatewayPluginRequestHandler(params: {
-  registry: PluginRegistry;
+  getRegistry: () => PluginRegistry;
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
-  const { registry, log } = params;
+  const { getRegistry, log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
+    const registry = getRegistry();
     const routes = registry.httpRoutes ?? [];
     if (routes.length === 0) {
       return false;


### PR DESCRIPTION
## Summary
- Plugin webhook routes returned 404 after config reloads because the HTTP handler captured a static registry reference at construction time
- Route handler and auth checker now call `getActivePluginRegistry()` at request time via a shared getter
- Keeps route dispatch and auth enforcement consistent on a single registry

Supersedes #45186 (cleaned up to gateway-only changes).

## Test plan
- [x] All 13 existing `plugins-http.test.ts` tests pass
- [x] TypeScript type-check clean
- [ ] Manual: verify webhook routes survive a config reload without gateway restart
