### PR TITLE
fix(commands): support always/inbound/tagged for /tts command

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -232,8 +232,11 @@ function buildChatCommands(): ChatCommandDefinition[] {
           description: "TTS action",
           type: "string",
           choices: [
-            { value: "on", label: "On" },
             { value: "off", label: "Off" },
+            { value: "on", label: "On" },
+            { value: "inbound", label: "Inbound" },
+            { value: "tagged", label: "Tagged" },
+            { value: "always", label: "Always" },
             { value: "status", label: "Status" },
             { value: "provider", label: "Provider" },
             { value: "limit", label: "Limit" },
@@ -253,8 +256,11 @@ function buildChatCommands(): ChatCommandDefinition[] {
         arg: "action",
         title:
           "TTS Actions:\n" +
-          "• On – Enable TTS for responses\n" +
           "• Off – Disable TTS\n" +
+          "• On – Enable TTS for responses (equals always)\n" +
+          "• Inbound – TTS for inbound messages only\n" +
+          "• Tagged – TTS for tagged messages only\n" +
+          "• Always – Always enable TTS\n" +
           "• Status – Show current settings\n" +
           "• Provider – Set voice provider (edge, elevenlabs, openai)\n" +
           "• Limit – Set max characters for TTS\n" +

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -4,13 +4,14 @@ import {
   getTtsMaxLength,
   getTtsProvider,
   isSummarizationEnabled,
-  isTtsEnabled,
   isTtsProviderConfigured,
   resolveTtsApiKey,
   resolveTtsConfig,
+  resolveTtsAutoMode,
   resolveTtsPrefsPath,
   setLastTtsAttempt,
   setSummarizationEnabled,
+  setTtsAutoMode,
   setTtsEnabled,
   setTtsMaxLength,
   setTtsProvider,
@@ -46,8 +47,11 @@ function ttsUsage(): ReplyPayload {
     text:
       `🔊 **TTS (Text-to-Speech) Help**\n\n` +
       `**Commands:**\n` +
-      `• /tts on — Enable automatic TTS for replies\n` +
       `• /tts off — Disable TTS\n` +
+      `• /tts on — Enable automatic TTS for replies (equals always)\n` +
+      `• /tts inbound — TTS for inbound messages only\n` +
+      `• /tts tagged — TTS for tagged messages only\n` +
+      `• /tts always — Always enable TTS\n` +
       `• /tts status — Show current settings\n` +
       `• /tts provider [name] — View/change provider\n` +
       `• /tts limit [number] — View/change text limit\n` +
@@ -62,6 +66,10 @@ function ttsUsage(): ReplyPayload {
       `• Summary ON: AI summarizes, then generates audio\n` +
       `• Summary OFF: Truncates text, then generates audio\n\n` +
       `**Examples:**\n` +
+      `/tts on\n` +
+      `/tts inbound\n` +
+      `/tts tagged\n` +
+      `/tts always\n` +
       `/tts provider edge\n` +
       `/tts limit 2000\n` +
       `/tts audio Hello, this is a test!`,
@@ -101,6 +109,30 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
   if (action === "off") {
     setTtsEnabled(prefsPath, false);
     return { shouldContinue: false, reply: { text: "🔇 TTS disabled." } };
+  }
+
+  if (action === "always") {
+    setTtsAutoMode(prefsPath, "always");
+    return {
+      shouldContinue: false,
+      reply: { text: "🔊 TTS auto mode set to: always (play for all messages)." },
+    };
+  }
+
+  if (action === "inbound") {
+    setTtsAutoMode(prefsPath, "inbound");
+    return {
+      shouldContinue: false,
+      reply: { text: "🔊 TTS auto mode set to: inbound (play only for inbound messages)." },
+    };
+  }
+
+  if (action === "tagged") {
+    setTtsAutoMode(prefsPath, "tagged");
+    return {
+      shouldContinue: false,
+      reply: { text: "🔊 TTS auto mode set to: tagged (play only when explicitly tagged)." },
+    };
   }
 
   if (action === "audio") {
@@ -247,15 +279,16 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
   }
 
   if (action === "status") {
-    const enabled = isTtsEnabled(config, prefsPath);
+    const autoMode = resolveTtsAutoMode({ config, prefsPath });
     const provider = getTtsProvider(config, prefsPath);
     const hasKey = isTtsProviderConfigured(config, provider);
     const maxLength = getTtsMaxLength(prefsPath);
     const summarize = isSummarizationEnabled(prefsPath);
     const last = getLastTtsAttempt();
+    const stateText = autoMode === "off" ? "❌ disabled" : `✅ enabled (${autoMode})`;
     const lines = [
       "📊 TTS status",
-      `State: ${enabled ? "✅ enabled" : "❌ disabled"}`,
+      `State: ${stateText}`,
       `Provider: ${provider} (${hasKey ? "✅ configured" : "❌ not configured"})`,
       `Text limit: ${maxLength} chars`,
       `Auto-summary: ${summarize ? "on" : "off"}`,

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -2075,4 +2075,56 @@ describe("handleCommands /tts", () => {
     expect(result.shouldContinue).toBe(false);
     expect(result.reply?.text).toContain("TTS status");
   });
+
+  it("supports /tts always to set auto mode to always", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      messages: { tts: { prefsPath: path.join(testWorkspaceDir, "tts-always.json") } },
+    } as OpenClawConfig;
+    const params = buildParams("/tts always", cfg);
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("always");
+  });
+
+  it("supports /tts inbound to set auto mode to inbound", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      messages: { tts: { prefsPath: path.join(testWorkspaceDir, "tts-inbound.json") } },
+    } as OpenClawConfig;
+    const params = buildParams("/tts inbound", cfg);
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("inbound");
+  });
+
+  it("supports /tts tagged to set auto mode to tagged", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      messages: { tts: { prefsPath: path.join(testWorkspaceDir, "tts-tagged.json") } },
+    } as OpenClawConfig;
+    const params = buildParams("/tts tagged", cfg);
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("tagged");
+  });
+
+  it("shows specific auto mode in status after setting /tts inbound", async () => {
+    const prefsPath = path.join(testWorkspaceDir, "tts-status-mode.json");
+    // Set auto mode to inbound via prefs
+    const fs = await import("node:fs");
+    fs.writeFileSync(prefsPath, JSON.stringify({ tts: { auto: "inbound" } }, null, 2));
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      messages: { tts: { prefsPath } },
+    } as OpenClawConfig;
+    const params = buildParams("/tts status", cfg);
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("enabled (inbound)");
+  });
 });


### PR DESCRIPTION
## Summary

Add support for action parameter values (always, inbound, tagged) to the /tts command. These map to the existing TtsAutoMode system via setTtsAutoMode().

- Import setTtsAutoMode from tts.ts
- Add handlers for /tts always, /tts inbound, /tts tagged
- Update help text to document new options
- Add test cases for all three new commands

Fixes #45244

## Changes

- src/auto-reply/reply/commands-tts.ts - add action handlers + update help
- src/auto-reply/reply/commands.test.ts - add 3 test cases

## Test plan

- [x] Run unit tests (4 new tests pass)
- [x] Verify help text shows new commands