### PR TITLE
Agents: normalize session repair warning paths

### DIFF
--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -87,6 +87,27 @@ describe("repairSessionFileIfNeeded", () => {
     expect(warn.mock.calls[0]?.[0]).toContain("invalid session header");
   });
 
+  it("normalizes Windows-style session file names in warnings", async () => {
+    const { dir } = await createTempSessionPath();
+    const file = path.join(dir, "C:\\temp\\session.jsonl");
+    const badHeader = {
+      type: "message",
+      id: "msg-1",
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "hello" },
+    };
+    const content = `${JSON.stringify(badHeader)}\n{"type":"message"`;
+    await fs.writeFile(file, content, "utf-8");
+
+    const warn = vi.fn();
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, warn });
+
+    expect(result.repaired).toBe(false);
+    expect(result.reason).toBe("invalid session header");
+    expect(warn.mock.calls[0]?.[0]).toContain("session.jsonl");
+    expect(warn.mock.calls[0]?.[0]).not.toContain("C:\\temp\\");
+  });
+
   it("returns a detailed reason when read errors are not ENOENT", async () => {
     const { dir } = await createTempSessionPath();
     const warn = vi.fn();

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -8,6 +8,10 @@ type RepairReport = {
   reason?: string;
 };
 
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
 function isSessionHeader(entry: unknown): entry is { type: string; id: string } {
   if (!entry || typeof entry !== "object") {
     return false;
@@ -34,7 +38,9 @@ export async function repairSessionFileIfNeeded(params: {
       return { repaired: false, droppedLines: 0, reason: "missing session file" };
     }
     const reason = `failed to read session file: ${err instanceof Error ? err.message : "unknown error"}`;
-    params.warn?.(`session file repair skipped: ${reason} (${path.basename(sessionFile)})`);
+    params.warn?.(
+      `session file repair skipped: ${reason} (${basenameAcrossSeparators(sessionFile)})`,
+    );
     return { repaired: false, droppedLines: 0, reason };
   }
 
@@ -60,7 +66,7 @@ export async function repairSessionFileIfNeeded(params: {
 
   if (!isSessionHeader(entries[0])) {
     params.warn?.(
-      `session file repair skipped: invalid session header (${path.basename(sessionFile)})`,
+      `session file repair skipped: invalid session header (${basenameAcrossSeparators(sessionFile)})`,
     );
     return { repaired: false, droppedLines, reason: "invalid session header" };
   }
@@ -88,7 +94,7 @@ export async function repairSessionFileIfNeeded(params: {
       await fs.unlink(tmpPath);
     } catch (cleanupErr) {
       params.warn?.(
-        `session file repair cleanup failed: ${cleanupErr instanceof Error ? cleanupErr.message : "unknown error"} (${path.basename(
+        `session file repair cleanup failed: ${cleanupErr instanceof Error ? cleanupErr.message : "unknown error"} (${basenameAcrossSeparators(
           tmpPath,
         )})`,
       );
@@ -101,7 +107,7 @@ export async function repairSessionFileIfNeeded(params: {
   }
 
   params.warn?.(
-    `session file repaired: dropped ${droppedLines} malformed line(s) (${path.basename(
+    `session file repaired: dropped ${droppedLines} malformed line(s) (${basenameAcrossSeparators(
       sessionFile,
     )})`,
   );


### PR DESCRIPTION
## Summary
- normalize session repair warning file names across path separators
- avoid leaking full Windows-style session paths in repair warnings on macOS/Linux
- add regression coverage for Windows-style session file names

## Testing
- pnpm test src/agents/session-file-repair.test.ts
- pnpm exec oxfmt --check src/agents/session-file-repair.ts src/agents/session-file-repair.test.ts
- pnpm check
- pnpm build
