### PR TITLE
fix(gateway-status): validate WebSocket URL hostnames against SSRF (CWE-918)

### DIFF
--- a/src/commands/gateway-status/helpers.security.test.ts
+++ b/src/commands/gateway-status/helpers.security.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { resolveTargets } from "./helpers.js";
+
+function minimalCfg() {
+  return {} as Parameters<typeof resolveTargets>[0];
+}
+
+describe("CWE-918: gateway-status URL SSRF validation", () => {
+  describe("blocked URLs (should be rejected by normalizeWsUrl)", () => {
+    it("should reject cloud metadata IP (169.254.169.254)", () => {
+      const targets = resolveTargets(minimalCfg(), "ws://169.254.169.254:80");
+      expect(targets.find((t) => t.kind === "explicit")).toBeUndefined();
+    });
+
+    it("should reject link-local range (169.254.x.x)", () => {
+      const targets = resolveTargets(minimalCfg(), "ws://169.254.1.1:18789");
+      expect(targets.find((t) => t.kind === "explicit")).toBeUndefined();
+    });
+
+    it("should reject metadata.google.internal", () => {
+      const targets = resolveTargets(minimalCfg(), "ws://metadata.google.internal:80");
+      expect(targets.find((t) => t.kind === "explicit")).toBeUndefined();
+    });
+
+    it("should reject *.internal and *.local hostnames", () => {
+      const targets1 = resolveTargets(minimalCfg(), "ws://service.internal:18789");
+      expect(targets1.find((t) => t.kind === "explicit")).toBeUndefined();
+
+      const targets2 = resolveTargets(minimalCfg(), "ws://gateway.local:18789");
+      expect(targets2.find((t) => t.kind === "explicit")).toBeUndefined();
+    });
+
+    it("should reject 0.0.0.0", () => {
+      const targets = resolveTargets(minimalCfg(), "ws://0.0.0.0:18789");
+      expect(targets.find((t) => t.kind === "explicit")).toBeUndefined();
+    });
+  });
+
+  describe("allowed URLs (legitimate gateway probe targets)", () => {
+    it("should allow localhost", () => {
+      const targets = resolveTargets(minimalCfg(), "ws://localhost:18789");
+      expect(targets.find((t) => t.kind === "explicit")?.url).toBe("ws://localhost:18789");
+    });
+
+    it("should allow 127.0.0.1", () => {
+      const targets = resolveTargets(minimalCfg(), "ws://127.0.0.1:18789");
+      expect(targets.find((t) => t.kind === "explicit")?.url).toBe("ws://127.0.0.1:18789");
+    });
+
+    it("should allow private network IPs (LAN gateways)", () => {
+      const targets = resolveTargets(minimalCfg(), "ws://192.168.1.100:18789");
+      expect(targets.find((t) => t.kind === "explicit")?.url).toBe("ws://192.168.1.100:18789");
+    });
+
+    it("should allow public hostnames", () => {
+      const targets = resolveTargets(minimalCfg(), "wss://gateway.example.com:18789");
+      expect(targets.find((t) => t.kind === "explicit")?.url).toBe(
+        "wss://gateway.example.com:18789",
+      );
+    });
+
+    it("should still reject non-ws protocols", () => {
+      const targets = resolveTargets(minimalCfg(), "http://example.com:18789");
+      expect(targets.find((t) => t.kind === "explicit")).toBeUndefined();
+    });
+  });
+});

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -4,6 +4,7 @@ import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import { readGatewayPasswordEnv, readGatewayTokenEnv } from "../../gateway/credentials.js";
 import type { GatewayProbeResult } from "../../gateway/probe.js";
 import { resolveConfiguredSecretInputString } from "../../gateway/resolve-configured-secret-input-string.js";
+import { isBlockedHostname } from "../../infra/net/ssrf.js";
 import { pickPrimaryTailnetIPv4 } from "../../infra/tailnet.js";
 import { colorize, theme } from "../../terminal/theme.js";
 import { pickGatewaySelfPresence } from "../gateway-presence.js";
@@ -80,12 +81,34 @@ export function parseTimeoutMs(raw: unknown, fallbackMs: number): number {
   return parsed;
 }
 
+// Cloud metadata / link-local IPs that are never legitimate gateway probe targets.
+const BLOCKED_GATEWAY_URL_PREFIXES = ["169.254."];
+const BLOCKED_GATEWAY_URL_IPS = new Set(["0.0.0.0"]);
+
 function normalizeWsUrl(value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed) {
     return null;
   }
   if (!trimmed.startsWith("ws://") && !trimmed.startsWith("wss://")) {
+    return null;
+  }
+  // CWE-918: Validate hostname to block cloud metadata and dangerous endpoints.
+  try {
+    const parsed = new URL(trimmed);
+    const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    if (BLOCKED_GATEWAY_URL_IPS.has(hostname)) {
+      return null;
+    }
+    for (const prefix of BLOCKED_GATEWAY_URL_PREFIXES) {
+      if (hostname.startsWith(prefix)) {
+        return null;
+      }
+    }
+    if (hostname !== "localhost" && isBlockedHostname(hostname)) {
+      return null;
+    }
+  } catch {
     return null;
   }
   return trimmed;


### PR DESCRIPTION
## Summary
- Add hostname validation to `normalizeWsUrl()` in gateway-status helpers to block SSRF via cloud metadata endpoints, dangerous hostnames, and wildcard addresses
- Preserve access to localhost and private LAN IPs for legitimate gateway probe targets

## Vulnerability
- **CWE**: CWE-918
- **File**: `src/commands/gateway-status/helpers.ts:88-115`
- **Severity**: High
- **Impact**: An attacker-controlled WebSocket URL passed to `gateway-status` could target cloud metadata endpoints (169.254.169.254) or internal services (*.internal, *.local) for SSRF

## Reproduction
```typescript
// Before fix: these URLs would be accepted as valid gateway probe targets
resolveTargets(cfg, "ws://169.254.169.254:80");      // cloud metadata
resolveTargets(cfg, "ws://metadata.google.internal:80"); // GCP metadata
resolveTargets(cfg, "ws://service.internal:18789");   // internal service
resolveTargets(cfg, "ws://0.0.0.0:18789");            // wildcard bind
```

## Fix
Added hostname validation to `normalizeWsUrl()` that:
1. Blocks cloud metadata IPs (169.254.x.x prefix)
2. Blocks wildcard address (0.0.0.0)
3. Blocks dangerous hostnames (*.internal, *.local, metadata.google.internal) via `isBlockedHostname()`
4. Explicitly allows `localhost` since it's a legitimate gateway probe target

## Test Results (Red → Green)

### Before fix: POC tests trigger vulnerability (FAIL)
```
$ pnpm test src/commands/gateway-status/helpers.security.test.ts

 FAIL  src/commands/gateway-status/helpers.security.test.ts
  ✗ should reject cloud metadata IP (169.254.169.254)
  ✗ should reject link-local range (169.254.x.x)
  ✗ should reject metadata.google.internal
  ✗ should reject *.internal and *.local hostnames
  ✗ should reject 0.0.0.0
```

### After fix: vulnerability patched (PASS)
```
$ pnpm test src/commands/gateway-status/helpers.security.test.ts

 PASS  src/commands/gateway-status/helpers.security.test.ts
  ✓ should reject cloud metadata IP (169.254.169.254)
  ✓ should reject link-local range (169.254.x.x)
  ✓ should reject metadata.google.internal
  ✓ should reject *.internal and *.local hostnames
  ✓ should reject 0.0.0.0
  ✓ should allow localhost
  ✓ should allow 127.0.0.1
  ✓ should allow private network IPs (LAN gateways)
  ✓ should allow public hostnames
  ✓ should still reject non-ws protocols

Tests: 10 passed, 10 total
```

### Full regression: no regressions
```
$ pnpm build && pnpm check && pnpm test
... all passed (pre-existing Windows symlink EPERM failures only)
```

## Checklist
- [x] POC test cases: FAIL before fix, PASS after fix
- [x] Normal input regression tests PASS
- [x] `pnpm build && pnpm check && pnpm test` all passed
- [x] No new security issues introduced

## AI Disclosure
- [x] AI-assisted (Claude)
- [x] Test coverage: POC verification + full regression pass