### PR TITLE
fix(core): harden delivery fallback and outbound recovery

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -311,6 +311,14 @@ describe("isContextOverflowError", () => {
     }
   });
 
+  it("matches input_length stop reason surfaced by OpenAI-compatible providers", () => {
+    const samples = ["Unhandled stop reason: input_length", "unhandled stop reason: input_length"];
+    for (const sample of samples) {
+      expect(isContextOverflowError(sample)).toBe(true);
+      expect(isLikelyContextOverflowError(sample)).toBe(true);
+    }
+  });
+
   it("matches Chinese context overflow error messages from proxy providers", () => {
     const samples = [
       "上下文过长",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -109,6 +109,7 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     // Anthropic API and OpenAI-compatible providers (e.g. ZhipuAI/GLM) return this stop reason
     // when the context window is exceeded. pi-ai surfaces it as "Unhandled stop reason: model_context_window_exceeded".
     lower.includes("context_window_exceeded") ||
+    lower.includes("unhandled stop reason: input_length") ||
     // Chinese proxy error messages for context overflow
     errorMessage.includes("上下文过长") ||
     errorMessage.includes("上下文超出") ||

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -71,6 +71,29 @@ async function writeCurrentProcessLock(lockPath: string, extra?: Record<string, 
   );
 }
 
+async function writeArgusSessionStore(params: {
+  sessionFile: string;
+  argus: NonNullable<import("../config/sessions/types.js").SessionEntry["argus"]>;
+}) {
+  const storePath = path.join(path.dirname(params.sessionFile), "sessions.json");
+  await fs.writeFile(
+    storePath,
+    JSON.stringify(
+      {
+        "agent:main:main": {
+          sessionId: "sess-1",
+          updatedAt: Date.now(),
+          sessionFile: params.sessionFile,
+          argus: params.argus,
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
 async function expectActiveInProcessLockIsNotReclaimed(params?: {
   legacyStarttime?: unknown;
 }): Promise<void> {
@@ -210,6 +233,46 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
+  it("watchdog preserves argus-protected in-process locks", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const sessionFile = path.join(root, "session.jsonl");
+      const lockPath = `${sessionFile}.lock`;
+      await writeArgusSessionStore({
+        sessionFile,
+        argus: {
+          mainlineState: "protected",
+          protectUntil: Date.now() + 10 * 60_000,
+        },
+      });
+      await expect(
+        __testing.readArgusSessionContext({ sessionFile, nowMs: Date.now() }),
+      ).resolves.toMatchObject({ argusProtected: true, argusRecoveryActive: false });
+      const lock = await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 500,
+        maxHoldMs: 1,
+      });
+
+      await __testing.runLockWatchdogCheck(Date.now() + 1000);
+      await expect(fs.access(lockPath)).resolves.toBeUndefined();
+      await expect(
+        acquireSessionWriteLock({
+          sessionFile,
+          timeoutMs: 50,
+          allowReentrant: false,
+        }),
+      ).rejects.toThrow(/session file locked/);
+
+      await lock.release();
+      await expect(fs.access(lockPath)).rejects.toThrow();
+    } finally {
+      warnSpy.mockRestore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("derives max hold from timeout plus grace", () => {
     expect(resolveSessionLockMaxHoldFromTimeout({ timeoutMs: 600_000 })).toBe(720_000);
     expect(resolveSessionLockMaxHoldFromTimeout({ timeoutMs: 1_000, minMs: 5_000 })).toBe(121_000);
@@ -276,6 +339,51 @@ describe("acquireSessionWriteLock", () => {
       await expect(fs.access(staleDeadLock)).rejects.toThrow();
       await expect(fs.access(staleAliveLock)).rejects.toThrow();
       await expect(fs.access(freshAliveLock)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps argus-protected stale lock files during cleanup", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const nowMs = Date.now();
+    const protectedLock = path.join(sessionsDir, "protected.jsonl.lock");
+    const protectedSessionFile = path.join(sessionsDir, "protected.jsonl");
+
+    try {
+      await writeArgusSessionStore({
+        sessionFile: protectedSessionFile,
+        argus: {
+          mainlineState: "protected",
+          protectUntil: nowMs + 10 * 60_000,
+          recoveryState: "active",
+          recoveryUpdatedAt: nowMs,
+          recoveryReason: "resume mainline",
+        },
+      });
+      await fs.writeFile(
+        protectedLock,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date(nowMs - 120_000).toISOString(),
+        }),
+        "utf8",
+      );
+
+      const result = await cleanStaleLockFiles({
+        sessionsDir,
+        staleMs: 30_000,
+        nowMs,
+        removeStale: true,
+      });
+
+      expect(result.cleaned).toHaveLength(0);
+      expect(result.locks[0]?.argusProtected).toBe(true);
+      expect(result.locks[0]?.argusRecoveryActive).toBe(true);
+      await expect(fs.access(protectedLock)).resolves.toBeUndefined();
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -1,6 +1,11 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  isArgusProtectedSession,
+  isArgusRecoverySession,
+  type SessionEntry,
+} from "../config/sessions/types.js";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
 
@@ -21,6 +26,8 @@ type HeldLock = {
   lockPath: string;
   acquiredAt: number;
   maxHoldMs: number;
+  argusProtectUntil?: number;
+  argusRecoveryActive?: boolean;
   releasePromise?: Promise<void>;
 };
 
@@ -32,6 +39,8 @@ export type SessionLockInspection = {
   ageMs: number | null;
   stale: boolean;
   staleReasons: string[];
+  argusProtected: boolean;
+  argusRecoveryActive: boolean;
   removed: boolean;
 };
 
@@ -60,7 +69,14 @@ type WatchdogState = {
 
 type LockInspectionDetails = Pick<
   SessionLockInspection,
-  "pid" | "pidAlive" | "createdAt" | "ageMs" | "stale" | "staleReasons"
+  | "pid"
+  | "pidAlive"
+  | "createdAt"
+  | "ageMs"
+  | "stale"
+  | "staleReasons"
+  | "argusProtected"
+  | "argusRecoveryActive"
 >;
 
 const HELD_LOCKS = resolveProcessScopedMap<HeldLock>(HELD_LOCKS_KEY);
@@ -197,6 +213,12 @@ async function runLockWatchdogCheck(nowMs = Date.now()): Promise<number> {
     if (heldForMs <= held.maxHoldMs) {
       continue;
     }
+    if (
+      (typeof held.argusProtectUntil === "number" && held.argusProtectUntil > nowMs) ||
+      held.argusRecoveryActive
+    ) {
+      continue;
+    }
 
     // eslint-disable-next-line no-console
     console.warn(
@@ -291,11 +313,69 @@ async function readLockPayload(lockPath: string): Promise<LockFilePayload | null
   }
 }
 
-function inspectLockPayload(
+function resolveSessionStorePathForLock(sessionFile: string): string {
+  return path.join(path.dirname(sessionFile), "sessions.json");
+}
+
+function resolveStoredSessionFilePath(params: {
+  sessionDir: string;
+  sessionFile: string;
+  entry: SessionEntry;
+}): string | null {
+  const stored = params.entry.sessionFile?.trim();
+  if (!stored) {
+    return null;
+  }
+  const candidate = path.isAbsolute(stored)
+    ? path.resolve(stored)
+    : path.resolve(params.sessionDir, stored);
+  return path.normalize(candidate);
+}
+
+async function readArgusSessionContext(params: { sessionFile: string; nowMs: number }): Promise<{
+  argusProtected: boolean;
+  argusProtectUntil?: number;
+  argusRecoveryActive: boolean;
+}> {
+  const storePath = resolveSessionStorePathForLock(params.sessionFile);
+  try {
+    const raw = await fs.readFile(storePath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, SessionEntry>;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { argusProtected: false, argusRecoveryActive: false };
+    }
+    const sessionDir = path.dirname(storePath);
+    const targetFile = path.normalize(path.resolve(params.sessionFile));
+    for (const entry of Object.values(parsed)) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+      const resolved = resolveStoredSessionFilePath({
+        sessionDir,
+        sessionFile: targetFile,
+        entry,
+      });
+      if (!resolved || resolved !== targetFile) {
+        continue;
+      }
+      return {
+        argusProtected: isArgusProtectedSession(entry, params.nowMs),
+        argusProtectUntil: entry.argus?.protectUntil,
+        argusRecoveryActive: isArgusRecoverySession(entry),
+      };
+    }
+  } catch {
+    return { argusProtected: false, argusRecoveryActive: false };
+  }
+  return { argusProtected: false, argusRecoveryActive: false };
+}
+
+async function inspectLockPayload(
   payload: LockFilePayload | null,
   staleMs: number,
   nowMs: number,
-): LockInspectionDetails {
+  sessionFile?: string,
+): Promise<LockInspectionDetails> {
   const pid = isValidLockNumber(payload?.pid) && payload.pid > 0 ? payload.pid : null;
   const pidAlive = pid !== null ? isPidAlive(pid) : false;
   const createdAt = typeof payload?.createdAt === "string" ? payload.createdAt : null;
@@ -328,6 +408,31 @@ function inspectLockPayload(
     staleReasons.push("too-old");
   }
 
+  const argusContext = sessionFile
+    ? await readArgusSessionContext({ sessionFile, nowMs })
+    : { argusProtected: false, argusRecoveryActive: false };
+  if (argusContext.argusProtected || argusContext.argusRecoveryActive) {
+    const filteredReasons = staleReasons.filter((reason) => reason !== "too-old");
+    if (argusContext.argusProtected) {
+      filteredReasons.push("argus-protected");
+    }
+    if (argusContext.argusRecoveryActive) {
+      filteredReasons.push("argus-recovery-active");
+    }
+    return {
+      pid,
+      pidAlive,
+      createdAt,
+      ageMs,
+      stale: filteredReasons.some(
+        (reason) => reason !== "argus-protected" && reason !== "argus-recovery-active",
+      ),
+      staleReasons: filteredReasons,
+      argusProtected: argusContext.argusProtected,
+      argusRecoveryActive: argusContext.argusRecoveryActive,
+    };
+  }
+
   return {
     pid,
     pidAlive,
@@ -335,6 +440,8 @@ function inspectLockPayload(
     ageMs,
     stale: staleReasons.length > 0,
     staleReasons,
+    argusProtected: false,
+    argusRecoveryActive: false,
   };
 }
 
@@ -419,7 +526,12 @@ export async function cleanStaleLockFiles(params: {
   for (const entry of lockEntries) {
     const lockPath = path.join(sessionsDir, entry.name);
     const payload = await readLockPayload(lockPath);
-    const inspected = inspectLockPayload(payload, staleMs, nowMs);
+    const inspected = await inspectLockPayload(
+      payload,
+      staleMs,
+      nowMs,
+      lockPath.slice(0, -".lock".length),
+    );
     const lockInfo: SessionLockInspection = {
       lockPath,
       ...inspected,
@@ -491,12 +603,18 @@ export async function acquireSessionWriteLock(params: {
         lockPayload.starttime = starttime;
       }
       await handle.writeFile(JSON.stringify(lockPayload, null, 2), "utf8");
+      const argusContext = await readArgusSessionContext({
+        sessionFile,
+        nowMs: Date.now(),
+      });
       const createdHeld: HeldLock = {
         count: 1,
         handle,
         lockPath,
         acquiredAt: Date.now(),
         maxHoldMs,
+        argusProtectUntil: argusContext.argusProtectUntil,
+        argusRecoveryActive: argusContext.argusRecoveryActive,
       };
       HELD_LOCKS.set(normalizedSessionFile, createdHeld);
       return {
@@ -523,7 +641,7 @@ export async function acquireSessionWriteLock(params: {
       }
       const payload = await readLockPayload(lockPath);
       const nowMs = Date.now();
-      const inspected = inspectLockPayload(payload, staleMs, nowMs);
+      const inspected = await inspectLockPayload(payload, staleMs, nowMs, normalizedSessionFile);
       const orphanSelfLock = shouldTreatAsOrphanSelfLock({
         payload,
         normalizedSessionFile,
@@ -556,5 +674,6 @@ export const __testing = {
   cleanupSignals: [...CLEANUP_SIGNALS],
   handleTerminationSignal,
   releaseAllLocksSync,
+  readArgusSessionContext,
   runLockWatchdogCheck,
 };

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -319,7 +319,6 @@ function resolveSessionStorePathForLock(sessionFile: string): string {
 
 function resolveStoredSessionFilePath(params: {
   sessionDir: string;
-  sessionFile: string;
   entry: SessionEntry;
 }): string | null {
   const stored = params.entry.sessionFile?.trim();
@@ -352,7 +351,6 @@ async function readArgusSessionContext(params: { sessionFile: string; nowMs: num
       }
       const resolved = resolveStoredSessionFilePath({
         sessionDir,
-        sessionFile: targetFile,
         entry,
       });
       if (!resolved || resolved !== targetFile) {

--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -8,6 +8,13 @@ const mocks = vi.hoisted(() => ({
   deliverOutboundPayloads: vi.fn(async () => []),
   getChannelPlugin: vi.fn(() => ({})),
   resolveOutboundTarget: vi.fn(() => ({ ok: true as const, to: "+15551234567" })),
+  resolveMessageChannelSelection: vi.fn(
+    async ({ fallbackChannel }: { fallbackChannel?: string }) => ({
+      channel: fallbackChannel ?? "telegram",
+      configured: fallbackChannel ? [fallbackChannel] : ["telegram"],
+      source: fallbackChannel ? "tool-context-fallback" : "single-configured",
+    }),
+  ),
 }));
 
 vi.mock("../channels/plugins/index.js", () => ({
@@ -17,6 +24,10 @@ vi.mock("../channels/plugins/index.js", () => ({
 
 vi.mock("../infra/outbound/deliver.js", () => ({
   deliverOutboundPayloads: mocks.deliverOutboundPayloads,
+}));
+
+vi.mock("../infra/outbound/channel-selection.js", () => ({
+  resolveMessageChannelSelection: mocks.resolveMessageChannelSelection,
 }));
 
 vi.mock("../infra/outbound/targets.js", async () => {
@@ -75,6 +86,7 @@ describe("deliverAgentCommandResult", () => {
   beforeEach(() => {
     mocks.deliverOutboundPayloads.mockClear();
     mocks.resolveOutboundTarget.mockClear();
+    mocks.resolveMessageChannelSelection.mockClear();
   });
 
   it("prefers explicit accountId for outbound delivery", async () => {
@@ -233,6 +245,25 @@ describe("deliverAgentCommandResult", () => {
 
     expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith(
       expect.objectContaining({ channel: "whatsapp", to: undefined }),
+    );
+  });
+
+  it("still routes via session lastChannel without requiring extra channel selection", async () => {
+    await runDelivery({
+      opts: {
+        message: "hello",
+        deliver: true,
+        messageChannel: "webchat",
+      },
+      sessionEntry: {
+        lastChannel: "telegram",
+        lastTo: "123",
+      } as SessionEntry,
+    });
+
+    expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
+    expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "telegram", to: "123" }),
     );
   });
 

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -18,7 +18,10 @@ import {
 } from "../../infra/outbound/payloads.js";
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import {
+  isDeliverableMessageChannel,
+  isInternalMessageChannel,
+} from "../../utils/message-channel.js";
 import type { AgentCommandOpts } from "./types.js";
 
 type RunResult = Awaited<
@@ -97,8 +100,15 @@ export async function deliverAgentCommandResult(params: {
   let deliveryChannel = deliveryPlan.resolvedChannel;
   const explicitChannelHint = (opts.replyChannel ?? opts.channel)?.trim();
   if (deliver && isInternalMessageChannel(deliveryChannel) && !explicitChannelHint) {
+    const selectionFallbackChannel =
+      turnSourceChannel && isDeliverableMessageChannel(turnSourceChannel)
+        ? turnSourceChannel
+        : deliveryPlan.baseDelivery.lastChannel;
     try {
-      const selection = await resolveMessageChannelSelection({ cfg });
+      const selection = await resolveMessageChannelSelection({
+        cfg,
+        fallbackChannel: selectionFallbackChannel,
+      });
       deliveryChannel = selection.channel;
     } catch {
       // Keep the internal channel marker; error handling below reports the failure.

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -48,6 +48,28 @@ export type SessionAcpMeta = {
   lastError?: string;
 };
 
+export type SessionArgusMainlineState = "active" | "protected";
+
+export type SessionArgusRecoveryState = "pending" | "active" | "verified";
+
+export type SessionArgusMeta = {
+  /**
+   * Tracks whether the session currently owns the primary user-visible task line.
+   */
+  mainlineState: SessionArgusMainlineState;
+  /**
+   * Protection window end (epoch ms). During this window, stale follow-ups and
+   * recovery work should not preempt the active mainline.
+   */
+  protectUntil: number;
+  /**
+   * Optional recovery state for unfinished task-line repair.
+   */
+  recoveryState?: SessionArgusRecoveryState;
+  recoveryUpdatedAt?: number;
+  recoveryReason?: string;
+};
+
 export type AcpSessionRuntimeOptions = {
   /**
    * ACP runtime mode set via session/set_mode (for example: "plan", "normal", "auto").
@@ -164,6 +186,7 @@ export type SessionEntry = {
   skillsSnapshot?: SessionSkillSnapshot;
   systemPromptReport?: SessionSystemPromptReport;
   acp?: SessionAcpMeta;
+  argus?: SessionArgusMeta;
 };
 
 function normalizeRuntimeField(value: string | undefined): string | undefined {
@@ -223,6 +246,23 @@ export function setSessionRuntimeModel(
   entry.modelProvider = provider;
   entry.model = model;
   return true;
+}
+
+export function isArgusProtectedSession(
+  entry: Pick<SessionEntry, "argus"> | undefined,
+  now = Date.now(),
+): boolean {
+  return Boolean(
+    entry?.argus &&
+    entry.argus.mainlineState &&
+    Number.isFinite(entry.argus.protectUntil) &&
+    entry.argus.protectUntil > now,
+  );
+}
+
+export function isArgusRecoverySession(entry: Pick<SessionEntry, "argus"> | undefined): boolean {
+  const state = entry?.argus?.recoveryState;
+  return state === "pending" || state === "active";
 }
 
 export type SessionEntryMergePolicy = "touch-activity" | "preserve-activity";

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -24,9 +24,23 @@ vi.mock("../../gateway/call.js", () => ({
   callGateway: vi.fn().mockResolvedValue({ status: "ok" }),
 }));
 
+vi.mock("../../config/config.js", () => ({
+  loadConfig: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...original,
+    loadSessionStore: vi.fn().mockReturnValue({}),
+    resolveStorePath: vi.fn().mockReturnValue("/tmp/sessions.json"),
+  };
+});
+
 const { listDescendantRunsForRequester } = await import("../../agents/subagent-registry.js");
 const { readLatestAssistantReply } = await import("../../agents/tools/agent-step.js");
 const { callGateway } = await import("../../gateway/call.js");
+const { loadSessionStore } = await import("../../config/sessions.js");
 
 async function resolveAfterAdvancingTimers<T>(promise: Promise<T>, advanceMs = 100): Promise<T> {
   await vi.advanceTimersByTimeAsync(advanceMs);
@@ -283,6 +297,30 @@ describe("waitForDescendantSubagentSummary", () => {
     });
     expect(result).toBe("on it");
     expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("suppresses descendant synthesis when requester session is argus-protected", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main:cron-session": {
+        sessionId: "sess-1",
+        updatedAt: Date.now(),
+        argus: {
+          mainlineState: "protected",
+          protectUntil: Date.now() + 10 * 60_000,
+        },
+      },
+    });
+
+    const result = await waitForDescendantSubagentSummary({
+      sessionKey: "agent:main:cron-session",
+      initialReply: "on it",
+      timeoutMs: 100,
+      observedActiveDescendants: true,
+    });
+
+    expect(result).toBeUndefined();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(readLatestAssistantReply).not.toHaveBeenCalled();
   });
 
   it("awaits active descendants via agent.wait and returns synthesis after grace period", async () => {

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -1,7 +1,15 @@
 import { listDescendantRunsForRequester } from "../../agents/subagent-registry.js";
 import { readLatestAssistantReply } from "../../agents/tools/agent-step.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { loadConfig } from "../../config/config.js";
+import {
+  isArgusProtectedSession,
+  isArgusRecoverySession,
+  loadSessionStore,
+  resolveStorePath,
+} from "../../config/sessions.js";
 import { callGateway } from "../../gateway/call.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 
 const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
 
@@ -37,6 +45,19 @@ const INTERIM_CRON_HINTS = [
 
 function normalizeHintText(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function shouldDeferArgusProtectedFollowup(sessionKey: string): boolean {
+  try {
+    const cfg = loadConfig();
+    const agentId = resolveAgentIdFromSessionKey(sessionKey);
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    const store = loadSessionStore(storePath);
+    const entry = store[sessionKey];
+    return isArgusProtectedSession(entry) || isArgusRecoverySession(entry);
+  } catch {
+    return false;
+  }
 }
 
 export function isLikelyInterimCronMessage(value: string): boolean {
@@ -118,6 +139,9 @@ export async function waitForDescendantSubagentSummary(params: {
   timeoutMs: number;
   observedActiveDescendants?: boolean;
 }): Promise<string | undefined> {
+  if (shouldDeferArgusProtectedFollowup(params.sessionKey)) {
+    return undefined;
+  }
   const initialReply = params.initialReply?.trim();
   const deadline = Date.now() + Math.max(CRON_SUBAGENT_WAIT_MIN_MS, Math.floor(params.timeoutMs));
 

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -72,6 +72,19 @@ export const SessionsPatchParamsSchema = Type.Object(
     model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     spawnedBy: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     spawnDepth: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+    argusMainlineState: Type.Optional(
+      Type.Union([Type.Literal("active"), Type.Literal("protected"), Type.Null()]),
+    ),
+    argusProtectMinutes: Type.Optional(Type.Union([Type.Integer({ minimum: 1 }), Type.Null()])),
+    argusRecoveryState: Type.Optional(
+      Type.Union([
+        Type.Literal("pending"),
+        Type.Literal("active"),
+        Type.Literal("verified"),
+        Type.Null(),
+      ]),
+    ),
+    argusRecoveryReason: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     sendPolicy: Type.Optional(
       Type.Union([Type.Literal("allow"), Type.Literal("deny"), Type.Null()]),
     ),

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -10,6 +10,13 @@ const mocks = vi.hoisted(() => ({
   registerAgentRunContext: vi.fn(),
   sessionsResetHandler: vi.fn(),
   loadConfigReturn: {} as Record<string, unknown>,
+  resolveMessageChannelSelection: vi.fn(
+    async ({ fallbackChannel }: { fallbackChannel?: string }) => ({
+      channel: fallbackChannel ?? "telegram",
+      configured: fallbackChannel ? [fallbackChannel] : ["telegram"],
+      source: fallbackChannel ? "tool-context-fallback" : "single-configured",
+    }),
+  ),
 }));
 
 vi.mock("../session-utils.js", async () => {
@@ -61,6 +68,16 @@ vi.mock("../../infra/agent-events.js", () => ({
   registerAgentRunContext: mocks.registerAgentRunContext,
   onAgentEvent: vi.fn(),
 }));
+
+vi.mock("../../infra/outbound/channel-selection.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/outbound/channel-selection.js")>(
+    "../../infra/outbound/channel-selection.js",
+  );
+  return {
+    ...actual,
+    resolveMessageChannelSelection: mocks.resolveMessageChannelSelection,
+  };
+});
 
 vi.mock("./sessions.js", () => ({
   sessionsHandlers: {
@@ -488,6 +505,47 @@ describe("gateway agent handler", () => {
     expect(callArgs.channel).toBe("telegram");
     expect(callArgs.messageChannel).toBe("webchat");
     expect(callArgs.runContext?.messageChannel).toBe("webchat");
+  });
+
+  it("uses session lastChannel as fallback when delivery starts from an internal origin", async () => {
+    mocks.resolveMessageChannelSelection.mockClear();
+    mockMainSessionEntry({
+      sessionId: "existing-session-id",
+      lastChannel: "telegram",
+      lastTo: "12345",
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "fallback delivery",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        replyChannel: "webchat",
+        idempotencyKey: "test-fallback-delivery-channel",
+      },
+      {
+        reqId: "fallback-delivery-1",
+        client: {
+          connect: {
+            client: { id: "webchat-ui", mode: "webchat" },
+          },
+        } as AgentHandlerArgs["client"],
+        isWebchatConnect: () => true,
+      },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    expect(mocks.resolveMessageChannelSelection).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackChannel: "telegram" }),
+    );
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+    };
+    expect(callArgs.channel).toBe("telegram");
   });
 
   it("handles missing cliSessionIds gracefully", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -598,8 +598,14 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
       const cfgResolved = cfgForAgent ?? cfg;
+      const selectionFallbackChannel = isDeliverableMessageChannel(turnSourceChannel)
+        ? turnSourceChannel
+        : deliveryPlan.baseDelivery.lastChannel;
       try {
-        const selection = await resolveMessageChannelSelection({ cfg: cfgResolved });
+        const selection = await resolveMessageChannelSelection({
+          cfg: cfgResolved,
+          fallbackChannel: selectionFallbackChannel,
+        });
         resolvedChannel = selection.channel;
         deliveryTargetMode = deliveryTargetMode ?? "implicit";
         effectivePlan = {

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -252,6 +252,73 @@ describe("gateway sessions patch", () => {
     expect(entry.spawnDepth).toBe(2);
   });
 
+  test("persists argus mainline protection metadata", async () => {
+    const before = Date.now();
+    const entry = expectPatchOk(
+      await runPatch({
+        patch: {
+          key: MAIN_SESSION_KEY,
+          argusMainlineState: "protected",
+          argusProtectMinutes: 15,
+        },
+      }),
+    );
+    expect(entry.argus?.mainlineState).toBe("protected");
+    expect(entry.argus?.protectUntil).toBeGreaterThanOrEqual(before + 14 * 60_000);
+  });
+
+  test("persists argus recovery state and reason", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        patch: {
+          key: MAIN_SESSION_KEY,
+          argusRecoveryState: "active",
+          argusRecoveryReason: "resume unfinished mainline",
+        },
+      }),
+    );
+    expect(entry.argus?.mainlineState).toBe("protected");
+    expect(entry.argus?.recoveryState).toBe("active");
+    expect(entry.argus?.recoveryReason).toBe("resume unfinished mainline");
+    expect(typeof entry.argus?.recoveryUpdatedAt).toBe("number");
+  });
+
+  test("clears argus metadata when patch sets null", async () => {
+    const store: Record<string, SessionEntry> = {
+      [MAIN_SESSION_KEY]: {
+        sessionId: "sess",
+        updatedAt: 1,
+        argus: {
+          mainlineState: "protected",
+          protectUntil: Date.now() + 60_000,
+          recoveryState: "pending",
+          recoveryUpdatedAt: Date.now(),
+          recoveryReason: "waiting",
+        },
+      } as SessionEntry,
+    };
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: {
+          key: MAIN_SESSION_KEY,
+          argusMainlineState: null,
+          argusProtectMinutes: null,
+          argusRecoveryState: null,
+          argusRecoveryReason: null,
+        },
+      }),
+    );
+    expect(entry.argus).toBeUndefined();
+  });
+
+  test("rejects invalid argusProtectMinutes values", async () => {
+    const result = await runPatch({
+      patch: { key: MAIN_SESSION_KEY, argusProtectMinutes: 0 },
+    });
+    expectPatchError(result, "invalid argusProtectMinutes");
+  });
+
   test("rejects spawnDepth on non-subagent sessions", async () => {
     const result = await runPatch({
       patch: { key: MAIN_SESSION_KEY, spawnDepth: 1 },

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -62,6 +62,22 @@ function normalizeExecAsk(raw: string): "off" | "on-miss" | "always" | undefined
   return undefined;
 }
 
+function normalizeArgusMainlineState(raw: string): "active" | "protected" | undefined {
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "active" || normalized === "protected") {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeArgusRecoveryState(raw: string): "pending" | "active" | "verified" | undefined {
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "pending" || normalized === "active" || normalized === "verified") {
+    return normalized;
+  }
+  return undefined;
+}
+
 export async function applySessionsPatchToStore(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
@@ -126,6 +142,122 @@ export async function applySessionsPatchToStore(params: {
         return invalid("spawnDepth cannot be changed once set");
       }
       next.spawnDepth = normalized;
+    }
+  }
+
+  const currentArgus = existing?.argus;
+  let nextArgus: Partial<NonNullable<SessionEntry["argus"]>> | undefined = currentArgus
+    ? { ...currentArgus }
+    : undefined;
+  let didTouchArgus = false;
+
+  if ("argusMainlineState" in patch) {
+    const raw = patch.argusMainlineState;
+    didTouchArgus = true;
+    if (raw === null) {
+      if (nextArgus) {
+        delete nextArgus.mainlineState;
+        delete nextArgus.protectUntil;
+      }
+    } else if (raw !== undefined) {
+      const normalized = normalizeArgusMainlineState(String(raw));
+      if (!normalized) {
+        return invalid('invalid argusMainlineState (use "active"|"protected")');
+      }
+      nextArgus = nextArgus ?? {
+        mainlineState: normalized,
+        protectUntil: now,
+      };
+      nextArgus.mainlineState = normalized;
+    }
+  }
+
+  if ("argusProtectMinutes" in patch) {
+    const raw = patch.argusProtectMinutes;
+    didTouchArgus = true;
+    if (raw === null) {
+      if (nextArgus) {
+        delete nextArgus.protectUntil;
+      }
+    } else if (raw !== undefined) {
+      const numeric = Number(raw);
+      if (!Number.isInteger(numeric) || numeric < 1) {
+        return invalid("invalid argusProtectMinutes (use an integer >= 1)");
+      }
+      nextArgus = nextArgus ?? {
+        mainlineState: "protected",
+        protectUntil: now,
+      };
+      nextArgus.protectUntil = now + numeric * 60_000;
+      if (!nextArgus.mainlineState) {
+        nextArgus.mainlineState = "protected";
+      }
+    }
+  }
+
+  if ("argusRecoveryState" in patch) {
+    const raw = patch.argusRecoveryState;
+    didTouchArgus = true;
+    if (raw === null) {
+      if (nextArgus) {
+        delete nextArgus.recoveryState;
+        delete nextArgus.recoveryUpdatedAt;
+        delete nextArgus.recoveryReason;
+      }
+    } else if (raw !== undefined) {
+      const normalized = normalizeArgusRecoveryState(String(raw));
+      if (!normalized) {
+        return invalid('invalid argusRecoveryState (use "pending"|"active"|"verified")');
+      }
+      nextArgus = nextArgus ?? {
+        mainlineState: "protected",
+        protectUntil: now,
+      };
+      nextArgus.recoveryState = normalized;
+      nextArgus.recoveryUpdatedAt = now;
+    }
+  }
+
+  if ("argusRecoveryReason" in patch) {
+    const raw = patch.argusRecoveryReason;
+    didTouchArgus = true;
+    if (raw === null) {
+      if (nextArgus) {
+        delete nextArgus.recoveryReason;
+      }
+    } else if (raw !== undefined) {
+      const trimmed = String(raw).trim();
+      if (!trimmed) {
+        return invalid("invalid argusRecoveryReason: empty");
+      }
+      nextArgus = nextArgus ?? {
+        mainlineState: "protected",
+        protectUntil: now,
+      };
+      nextArgus.recoveryReason = trimmed;
+      nextArgus.recoveryUpdatedAt = now;
+    }
+  }
+
+  if (didTouchArgus) {
+    const hasMainline = Boolean(
+      nextArgus?.mainlineState &&
+      typeof nextArgus.protectUntil === "number" &&
+      Number.isFinite(nextArgus.protectUntil),
+    );
+    const hasRecovery = Boolean(nextArgus?.recoveryState);
+    if (hasRecovery && !hasMainline) {
+      nextArgus = nextArgus ?? {
+        mainlineState: "protected",
+        protectUntil: now,
+      };
+      nextArgus.mainlineState = nextArgus.mainlineState ?? "protected";
+      nextArgus.protectUntil = nextArgus.protectUntil ?? now;
+    }
+    if (!hasMainline && !hasRecovery) {
+      delete next.argus;
+    } else if (nextArgus) {
+      next.argus = nextArgus as NonNullable<SessionEntry["argus"]>;
     }
   }
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -30,6 +30,8 @@ const queueMocks = vi.hoisted(() => ({
   enqueueDelivery: vi.fn(async () => "mock-queue-id"),
   ackDelivery: vi.fn(async () => {}),
   failDelivery: vi.fn(async () => {}),
+  hasPendingUserVisibleDeliveries: vi.fn(async () => false),
+  updateDeliveryPayloads: vi.fn(async () => {}),
 }));
 const logMocks = vi.hoisted(() => ({
   warn: vi.fn(),
@@ -55,6 +57,8 @@ vi.mock("./delivery-queue.js", () => ({
   enqueueDelivery: queueMocks.enqueueDelivery,
   ackDelivery: queueMocks.ackDelivery,
   failDelivery: queueMocks.failDelivery,
+  hasPendingUserVisibleDeliveries: queueMocks.hasPendingUserVisibleDeliveries,
+  updateDeliveryPayloads: queueMocks.updateDeliveryPayloads,
 }));
 vi.mock("../../logging/subsystem.js", () => ({
   createSubsystemLogger: () => {
@@ -202,6 +206,10 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.ackDelivery.mockResolvedValue(undefined);
     queueMocks.failDelivery.mockClear();
     queueMocks.failDelivery.mockResolvedValue(undefined);
+    queueMocks.hasPendingUserVisibleDeliveries.mockClear();
+    queueMocks.hasPendingUserVisibleDeliveries.mockResolvedValue(false);
+    queueMocks.updateDeliveryPayloads.mockClear();
+    queueMocks.updateDeliveryPayloads.mockResolvedValue(undefined);
     logMocks.warn.mockClear();
   });
 
@@ -728,7 +736,7 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
-  it("calls failDelivery instead of ackDelivery on bestEffort partial failure", async () => {
+  it("shrinks queued payloads before failDelivery on bestEffort partial failure", async () => {
     const { onError } = await runBestEffortPartialFailureDelivery();
 
     // onError was called for the first payload's failure.
@@ -736,6 +744,10 @@ describe("deliverOutboundPayloads", () => {
 
     // Queue entry should NOT be acked — failDelivery should be called instead.
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.updateDeliveryPayloads).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.arrayContaining([expect.objectContaining({ text: "a" })]),
+    );
     expect(queueMocks.failDelivery).toHaveBeenCalledWith(
       "mock-queue-id",
       "partial delivery failure (bestEffort)",
@@ -762,6 +774,29 @@ describe("deliverOutboundPayloads", () => {
     expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
     expect(sendWhatsApp).not.toHaveBeenCalled();
+  });
+
+  it("defers silent internal followups when user-visible queue entries are pending", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    queueMocks.hasPendingUserVisibleDeliveries.mockResolvedValue(true);
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "internal followup" }],
+      deps: { sendWhatsApp },
+      silent: true,
+    });
+
+    expect(results).toEqual([]);
+    expect(queueMocks.enqueueDelivery).toHaveBeenCalledTimes(1);
+    expect(queueMocks.hasPendingUserVisibleDeliveries).toHaveBeenCalledWith({
+      excludeId: "mock-queue-id",
+    });
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
   it("passes normalized payload to onError", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -36,7 +36,13 @@ import type { sendMessageSlack } from "../../slack/send.js";
 import type { sendMessageTelegram } from "../../telegram/send.js";
 import type { sendMessageWhatsApp } from "../../web/outbound.js";
 import { throwIfAborted } from "./abort.js";
-import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
+import {
+  ackDelivery,
+  enqueueDelivery,
+  failDelivery,
+  hasPendingUserVisibleDeliveries,
+  updateDeliveryPayloads,
+} from "./delivery-queue.js";
 import type { OutboundIdentity } from "./identity.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
@@ -233,7 +239,11 @@ type DeliverOutboundPayloadsCoreParams = {
   gifPlayback?: boolean;
   abortSignal?: AbortSignal;
   bestEffort?: boolean;
-  onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
+  onError?: (
+    err: unknown,
+    payload: NormalizedOutboundPayload,
+    meta?: { remainingPayloads: ReplyPayload[] },
+  ) => void;
   onPayload?: (payload: NormalizedOutboundPayload) => void;
   /** Session/agent context used for hooks and media local-root scoping. */
   session?: OutboundSessionContext;
@@ -248,6 +258,7 @@ type DeliverOutboundPayloadsCoreParams = {
     groupId?: string;
   };
   silent?: boolean;
+  captureRetryPayloads?: (payloads: ReplyPayload[]) => void;
 };
 
 type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & {
@@ -482,11 +493,21 @@ export async function deliverOutboundPayloads(
         mirror: params.mirror,
       }).catch(() => null); // Best-effort — don't block delivery if queue write fails.
 
+  if (!params.skipQueue && queueId && params.silent) {
+    const shouldDeferForLaneWatch = await hasPendingUserVisibleDeliveries({
+      excludeId: queueId,
+    }).catch(() => false);
+    if (shouldDeferForLaneWatch) {
+      return [];
+    }
+  }
+
   // Wrap onError to detect partial failures under bestEffort mode.
   // When bestEffort is true, per-payload errors are caught and passed to onError
   // without throwing — so the outer try/catch never fires. We track whether any
   // payload failed so we can call failDelivery instead of ackDelivery.
   let hadPartialFailure = false;
+  let remainingPayloadsForRetry: ReplyPayload[] | null = null;
   const wrappedParams = params.onError
     ? {
         ...params,
@@ -494,13 +515,28 @@ export async function deliverOutboundPayloads(
           hadPartialFailure = true;
           params.onError!(err, payload);
         },
+        captureRetryPayloads: (payloadsForRetry: ReplyPayload[]) => {
+          remainingPayloadsForRetry = payloadsForRetry;
+        },
       }
-    : params;
+    : {
+        ...params,
+        onError: (_err: unknown, _payload: NormalizedOutboundPayload) => {
+          hadPartialFailure = true;
+        },
+        captureRetryPayloads: (payloadsForRetry: ReplyPayload[]) => {
+          remainingPayloadsForRetry = payloadsForRetry;
+        },
+      };
 
   try {
     const results = await deliverOutboundPayloadsCore(wrappedParams);
     if (queueId) {
       if (hadPartialFailure) {
+        const retryPayloads = remainingPayloadsForRetry as ReplyPayload[] | null;
+        if (retryPayloads && retryPayloads.length > 0) {
+          await updateDeliveryPayloads(queueId, retryPayloads).catch(() => {});
+        }
         await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(() => {});
       } else {
         await ackDelivery(queueId).catch(() => {}); // Best-effort cleanup.
@@ -663,6 +699,8 @@ async function deliverOutboundPayloadsCore(
     };
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel);
+  const failedPayloadIndexes = new Set<number>();
+  const deliveredPayloadIndexes = new Set<number>();
   const hookRunner = getGlobalHookRunner();
   const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
   const mirrorIsGroup = params.mirror?.isGroup;
@@ -687,7 +725,7 @@ async function deliverOutboundPayloadsCore(
       },
     );
   }
-  for (const payload of normalizedPayloads) {
+  for (const [payloadIndex, payload] of normalizedPayloads.entries()) {
     let payloadSummary = buildPayloadSummary(payload);
     try {
       throwIfAborted(abortSignal);
@@ -716,6 +754,7 @@ async function deliverOutboundPayloadsCore(
       if (handler.sendPayload && effectivePayload.channelData) {
         const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
         results.push(delivery);
+        deliveredPayloadIndexes.add(payloadIndex);
         emitMessageSent({
           success: true,
           content: payloadSummary.text,
@@ -731,6 +770,9 @@ async function deliverOutboundPayloadsCore(
           await sendTextChunks(payloadSummary.text, sendOverrides);
         }
         const messageId = results.at(-1)?.messageId;
+        if (results.length > beforeCount) {
+          deliveredPayloadIndexes.add(payloadIndex);
+        }
         emitMessageSent({
           success: results.length > beforeCount,
           content: payloadSummary.text,
@@ -757,6 +799,9 @@ async function deliverOutboundPayloadsCore(
         const beforeCount = results.length;
         await sendTextChunks(fallbackText, sendOverrides);
         const messageId = results.at(-1)?.messageId;
+        if (results.length > beforeCount) {
+          deliveredPayloadIndexes.add(payloadIndex);
+        }
         emitMessageSent({
           success: results.length > beforeCount,
           content: payloadSummary.text,
@@ -786,7 +831,9 @@ async function deliverOutboundPayloadsCore(
         content: payloadSummary.text,
         messageId: lastMessageId,
       });
+      deliveredPayloadIndexes.add(payloadIndex);
     } catch (err) {
+      failedPayloadIndexes.add(payloadIndex);
       emitMessageSent({
         success: false,
         content: payloadSummary.text,
@@ -797,6 +844,14 @@ async function deliverOutboundPayloadsCore(
       }
       params.onError?.(err, payloadSummary);
     }
+  }
+  if (failedPayloadIndexes.size > 0) {
+    params.captureRetryPayloads?.(
+      normalizedPayloads.filter(
+        (_candidate, index) =>
+          failedPayloadIndexes.has(index) || !deliveredPayloadIndexes.has(index),
+      ),
+    );
   }
   if (params.mirror && results.length > 0) {
     const mirrorText = resolveMirroredTranscriptText({

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -25,6 +25,8 @@ type DeliveryMirrorPayload = {
   mediaUrls?: string[];
 };
 
+export type DeliveryLanePriority = "user-visible" | "internal-followup";
+
 type QueuedDeliveryPayload = {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
@@ -40,6 +42,7 @@ type QueuedDeliveryPayload = {
   bestEffort?: boolean;
   gifPlayback?: boolean;
   silent?: boolean;
+  lanePriority?: DeliveryLanePriority;
   mirror?: DeliveryMirrorPayload;
 };
 
@@ -57,6 +60,19 @@ export type RecoverySummary = {
   skippedMaxRetries: number;
   deferredBackoff: number;
 };
+
+function resolveLanePriority(params: QueuedDeliveryPayload): DeliveryLanePriority {
+  if (params.lanePriority) {
+    return params.lanePriority;
+  }
+  if (params.silent) {
+    return "internal-followup";
+  }
+  if (params.mirror?.sessionKey?.trim()) {
+    return "user-visible";
+  }
+  return "user-visible";
+}
 
 function resolveQueueDir(stateDir?: string): string {
   const base = stateDir ?? resolveStateDir();
@@ -124,6 +140,7 @@ export async function enqueueDelivery(
     bestEffort: params.bestEffort,
     gifPlayback: params.gifPlayback,
     silent: params.silent,
+    lanePriority: resolveLanePriority(params),
     mirror: params.mirror,
     retryCount: 0,
   };
@@ -171,6 +188,23 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
   entry.retryCount += 1;
   entry.lastAttemptAt = Date.now();
   entry.lastError = error;
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  await fs.promises.writeFile(tmp, JSON.stringify(entry, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  await fs.promises.rename(tmp, filePath);
+}
+
+export async function updateDeliveryPayloads(
+  id: string,
+  payloads: ReplyPayload[],
+  stateDir?: string,
+): Promise<void> {
+  const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
+  const raw = await fs.promises.readFile(filePath, "utf-8");
+  const entry: QueuedDelivery = JSON.parse(raw);
+  entry.payloads = payloads;
   const tmp = `${filePath}.${process.pid}.tmp`;
   await fs.promises.writeFile(tmp, JSON.stringify(entry, null, 2), {
     encoding: "utf-8",
@@ -231,6 +265,21 @@ export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDe
   return entries;
 }
 
+export async function hasPendingUserVisibleDeliveries(params?: {
+  stateDir?: string;
+  excludeId?: string | null;
+}): Promise<boolean> {
+  const pending = await loadPendingDeliveries(params?.stateDir);
+  return pending.some(
+    (entry) =>
+      entry.id !== params?.excludeId && (entry.lanePriority ?? "user-visible") === "user-visible",
+  );
+}
+
+function lanePriorityWeight(priority: DeliveryLanePriority | undefined): number {
+  return priority === "internal-followup" ? 1 : 0;
+}
+
 /** Move a queue entry to the failed/ subdirectory. */
 export async function moveToFailed(id: string, stateDir?: string): Promise<void> {
   const queueDir = resolveQueueDir(stateDir);
@@ -279,24 +328,31 @@ function normalizeLegacyQueuedDeliveryEntry(entry: QueuedDelivery): {
   entry: QueuedDelivery;
   migrated: boolean;
 } {
+  let migrated = false;
+  let next = entry;
+  if (!entry.lanePriority) {
+    next = {
+      ...next,
+      lanePriority: resolveLanePriority(entry),
+    };
+    migrated = true;
+  }
   const hasAttemptTimestamp =
-    typeof entry.lastAttemptAt === "number" &&
-    Number.isFinite(entry.lastAttemptAt) &&
-    entry.lastAttemptAt > 0;
-  if (hasAttemptTimestamp || entry.retryCount <= 0) {
-    return { entry, migrated: false };
+    typeof next.lastAttemptAt === "number" &&
+    Number.isFinite(next.lastAttemptAt) &&
+    next.lastAttemptAt > 0;
+  if (hasAttemptTimestamp || next.retryCount <= 0) {
+    return { entry: next, migrated };
   }
   const hasEnqueuedTimestamp =
-    typeof entry.enqueuedAt === "number" &&
-    Number.isFinite(entry.enqueuedAt) &&
-    entry.enqueuedAt > 0;
+    typeof next.enqueuedAt === "number" && Number.isFinite(next.enqueuedAt) && next.enqueuedAt > 0;
   if (!hasEnqueuedTimestamp) {
-    return { entry, migrated: false };
+    return { entry: next, migrated };
   }
   return {
     entry: {
-      ...entry,
-      lastAttemptAt: entry.enqueuedAt,
+      ...next,
+      lastAttemptAt: next.enqueuedAt,
     },
     migrated: true,
   };
@@ -334,7 +390,13 @@ export async function recoverPendingDeliveries(opts: {
   }
 
   // Process oldest first.
-  pending.sort((a, b) => a.enqueuedAt - b.enqueuedAt);
+  pending.sort((a, b) => {
+    const laneDelta = lanePriorityWeight(a.lanePriority) - lanePriorityWeight(b.lanePriority);
+    if (laneDelta !== 0) {
+      return laneDelta;
+    }
+    return a.enqueuedAt - b.enqueuedAt;
+  });
 
   opts.log.info(`Found ${pending.length} pending delivery entries — starting recovery`);
 

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   resolveOutboundTarget: vi.fn(),
   deliverOutboundPayloads: vi.fn(),
   loadOpenClawPlugins: vi.fn(),
+  extractDeliveryInfo: vi.fn(() => ({ deliveryContext: undefined, threadId: undefined })),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
@@ -15,12 +16,24 @@ vi.mock("../../channels/plugins/index.js", () => ({
 
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveDefaultAgentId: () => "main",
+  resolveSessionAgentId: () => "main",
   resolveAgentWorkspaceDir: () => "/tmp/openclaw-test-workspace",
 }));
 
 vi.mock("../../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: ({ config }: { config: unknown }) => ({ config, changes: [] }),
 }));
+
+vi.mock("../../config/sessions.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config/sessions.js")>(
+    "../../config/sessions.js",
+  );
+  return {
+    ...actual,
+    extractDeliveryInfo: (...args: unknown[]) =>
+      (mocks.extractDeliveryInfo as (...args: unknown[]) => unknown)(...args),
+  };
+});
 
 vi.mock("../../plugins/loader.js", () => ({
   loadOpenClawPlugins: mocks.loadOpenClawPlugins,
@@ -45,6 +58,8 @@ describe("sendMessage", () => {
     mocks.resolveOutboundTarget.mockClear();
     mocks.deliverOutboundPayloads.mockClear();
     mocks.loadOpenClawPlugins.mockClear();
+    mocks.extractDeliveryInfo.mockClear();
+    mocks.extractDeliveryInfo.mockReturnValue({ deliveryContext: undefined, threadId: undefined });
 
     mocks.getChannelPlugin.mockReturnValue({
       outbound: { deliveryMode: "direct" },
@@ -94,5 +109,70 @@ describe("sendMessage", () => {
     });
 
     expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses mirror session deliveryContext channel as fallback in multi-channel mode", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: {
+            id: "telegram",
+            meta: {
+              id: "telegram",
+              label: "Telegram",
+              selectionLabel: "Telegram",
+              docsPath: "/channels/telegram",
+              blurb: "Telegram test stub.",
+            },
+            capabilities: { chatTypes: ["direct"] },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({}),
+              isConfigured: async () => true,
+            },
+            outbound: { deliveryMode: "direct" },
+          },
+        },
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: {
+            id: "discord",
+            meta: {
+              id: "discord",
+              label: "Discord",
+              selectionLabel: "Discord",
+              docsPath: "/channels/discord",
+              blurb: "Discord test stub.",
+            },
+            capabilities: { chatTypes: ["direct"] },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({}),
+              isConfigured: async () => true,
+            },
+            outbound: { deliveryMode: "direct" },
+          },
+        },
+      ]),
+    );
+    mocks.extractDeliveryInfo.mockReturnValue({
+      deliveryContext: { channel: "telegram", to: "123456" },
+      threadId: undefined,
+    });
+
+    await sendMessage({
+      cfg: {},
+      to: "123456",
+      content: "hi",
+      mirror: { sessionKey: "agent:main:main" },
+    });
+
+    expect(mocks.extractDeliveryInfo).toHaveBeenCalledWith("agent:main:main");
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "telegram", to: "123456" }),
+    );
   });
 });

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
+import { extractDeliveryInfo } from "../../config/sessions.js";
 import { callGatewayLeastPrivilege, randomIdempotencyKey } from "../../gateway/call.js";
 import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
@@ -107,11 +108,16 @@ export type MessagePollResult = {
 async function resolveRequiredChannel(params: {
   cfg: OpenClawConfig;
   channel?: string;
+  sessionKey?: string;
 }): Promise<string> {
+  const fallbackChannel = params.sessionKey
+    ? extractDeliveryInfo(params.sessionKey).deliveryContext?.channel
+    : undefined;
   return (
     await resolveMessageChannelSelection({
       cfg: params.cfg,
       channel: params.channel,
+      fallbackChannel,
     })
   ).channel;
 }
@@ -165,7 +171,11 @@ async function callMessageGateway<T>(params: {
 
 export async function sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
   const cfg = params.cfg ?? loadConfig();
-  const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
+  const channel = await resolveRequiredChannel({
+    cfg,
+    channel: params.channel,
+    sessionKey: params.mirror?.sessionKey,
+  });
   const plugin = resolveRequiredPlugin(channel, cfg);
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
   const normalizedPayloads = normalizeReplyPayloadsForDelivery([

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -17,6 +17,7 @@ import {
   MAX_RETRIES,
   moveToFailed,
   recoverPendingDeliveries,
+  updateDeliveryPayloads,
 } from "./delivery-queue.js";
 import { DirectoryCache } from "./directory-cache.js";
 import { buildOutboundResultEnvelope } from "./envelope.js";
@@ -95,6 +96,7 @@ describe("delivery-queue", () => {
         bestEffort: true,
         gifPlayback: true,
         silent: true,
+        lanePriority: "internal-followup",
         mirror: {
           sessionKey: "agent:main:main",
           text: "hello",
@@ -180,6 +182,29 @@ describe("delivery-queue", () => {
       expect(typeof entry.lastAttemptAt).toBe("number");
       expect(entry.lastAttemptAt).toBeGreaterThan(0);
       expect(entry.lastError).toBe("connection refused");
+    });
+  });
+
+  describe("updateDeliveryPayloads", () => {
+    it("replaces payloads without resetting retry metadata", async () => {
+      const id = await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "123",
+          payloads: [{ text: "first" }, { text: "second" }],
+        },
+        tmpDir,
+      );
+
+      await failDelivery(id, "temporary failure", tmpDir);
+      await updateDeliveryPayloads(id, [{ text: "second" }], tmpDir);
+
+      const queueDir = path.join(tmpDir, "delivery-queue");
+      const entry = JSON.parse(fs.readFileSync(path.join(queueDir, `${id}.json`), "utf-8"));
+      expect(entry.payloads).toEqual([{ text: "second" }]);
+      expect(entry.retryCount).toBe(1);
+      expect(entry.lastError).toBe("temporary failure");
+      expect(typeof entry.lastAttemptAt).toBe("number");
     });
   });
 
@@ -344,6 +369,7 @@ describe("delivery-queue", () => {
         entry.enqueuedAt = state.enqueuedAt;
       }
       fs.writeFileSync(filePath, JSON.stringify(entry), "utf-8");
+      return entry;
     };
     const runRecovery = async ({
       deliver,
@@ -563,6 +589,56 @@ describe("delivery-queue", () => {
       const remaining = await loadPendingDeliveries(tmpDir);
       expect(remaining).toHaveLength(1);
       expect(remaining[0]?.id).toBe(blockedId);
+    });
+
+    it("recovers user-visible entries ahead of older internal followup entries", async () => {
+      const internalId = await enqueueDelivery(
+        {
+          channel: "whatsapp",
+          to: "+1",
+          payloads: [{ text: "internal" }],
+          silent: true,
+        },
+        tmpDir,
+      );
+      const userVisibleId = await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "2",
+          payloads: [{ text: "visible" }],
+          mirror: { sessionKey: "agent:main:main" },
+        },
+        tmpDir,
+      );
+
+      const internalEntry = setEntryState(internalId, {
+        retryCount: 0,
+        enqueuedAt: Date.now() - 20_000,
+      });
+      const userEntry = setEntryState(userVisibleId, {
+        retryCount: 0,
+        enqueuedAt: Date.now() - 10_000,
+      });
+      expect(internalEntry.lanePriority).toBe("internal-followup");
+      expect(userEntry.lanePriority).toBe("user-visible");
+
+      const deliver = vi.fn().mockResolvedValue([]);
+      const { result } = await runRecovery({ deliver, maxRecoveryMs: 60_000 });
+
+      expect(result).toEqual({
+        recovered: 2,
+        failed: 0,
+        skippedMaxRetries: 0,
+        deferredBackoff: 0,
+      });
+      expect(deliver).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ channel: "telegram", to: "2", skipQueue: true }),
+      );
+      expect(deliver).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ channel: "whatsapp", to: "+1", skipQueue: true }),
+      );
     });
 
     it("recovers deferred entries on a later restart once backoff elapsed", async () => {

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -97,6 +97,25 @@ describe("sanitizeForPlainText", () => {
     expect(sanitizeForPlainText("hello world")).toBe("hello world");
   });
 
+  it("strips leaked LongCat wrapper tags and stop markers", () => {
+    expect(sanitizeForPlainText("hello</x>\n</longcat_think>\n<|eot_id|>\nworld")).toBe(
+      "hello\nworld",
+    );
+  });
+
+  it("strips malformed leaked reply tags", () => {
+    expect(sanitizeForPlainText(":[[reply_to_current]hello")).toBe("hello");
+  });
+
+  it("strips leaked raw tool-call lines", () => {
+    const input = [
+      '{"name": "exec", "arguments": {"command":"pwd"}}',
+      "</longcat_tool_call>",
+      "actual answer",
+    ].join("\n");
+    expect(sanitizeForPlainText(input)).toBe("actual answer");
+  });
+
   it("does not corrupt angle brackets in prose", () => {
     // `a < b` does not match `<tag>` pattern because there is no closing `>`
     // immediately after a tag-like sequence.

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -107,6 +107,10 @@ describe("sanitizeForPlainText", () => {
     expect(sanitizeForPlainText(":[[reply_to_current]hello")).toBe("hello");
   });
 
+  it("strips malformed leaked reply tags on later lines too", () => {
+    expect(sanitizeForPlainText("preamble\n:[[reply_to_current]hello")).toBe("preamble\nhello");
+  });
+
   it("strips leaked raw tool-call lines", () => {
     const input = [
       '{"name": "exec", "arguments": {"command":"pwd"}}',

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -36,29 +36,45 @@ export function isPlainTextSurface(channelId: string): boolean {
  * prose (e.g. `a < b`).
  */
 export function sanitizeForPlainText(text: string): string {
-  return (
-    text
-      // Preserve angle-bracket autolinks as plain URLs before tag stripping.
-      .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
-      // Line breaks
-      .replace(/<br\s*\/?>/gi, "\n")
-      // Block elements → newlines
-      .replace(/<\/?(p|div)>/gi, "\n")
-      // Bold → WhatsApp/Signal bold
-      .replace(/<(b|strong)>(.*?)<\/\1>/gi, "*$2*")
-      // Italic → WhatsApp/Signal italic
-      .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
-      // Strikethrough → WhatsApp/Signal strikethrough
-      .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, "~$2~")
-      // Inline code
-      .replace(/<code>(.*?)<\/code>/gi, "`$1`")
-      // Headings → bold text with newline
-      .replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gi, "\n*$1*\n")
-      // List items → bullet points
-      .replace(/<li[^>]*>(.*?)<\/li>/gi, "• $1\n")
-      // Strip remaining HTML tags (require tag-like structure: <word...>)
-      .replace(/<\/?[a-z][a-z0-9]*\b[^>]*>/gi, "")
-      // Collapse 3+ consecutive newlines into 2
-      .replace(/\n{3,}/g, "\n\n")
-  );
+  const hadLeakage =
+    /<\/?(?:longcat_think|longcat_tool_call|x)>/i.test(text) ||
+    /<\|eot_id\|>/i.test(text) ||
+    /^\s*:?\[\[\s*reply_to_current\s*\]/im.test(text) ||
+    /^\s*\{"name"\s*:\s*"[^"]+"\s*,\s*"arguments"\s*:\s*\{/im.test(text);
+
+  const sanitized = text
+    // Strip leaked LongCat/internal wrapper tags and stop markers.
+    .replace(/<\/?(?:longcat_think|longcat_tool_call|x)>/gi, "")
+    .replace(/<\|eot_id\|>/gi, "")
+    // Drop malformed leaked reply tags before the normal directive parser can see them.
+    .replace(/^\s*:?\[\[\s*reply_to_current\s*\](?:\s*)/i, "")
+    // Drop raw tool-call JSON lines that leaked into plain text.
+    .replace(/^\s*\{"name"\s*:\s*"[^"]+"\s*,\s*"arguments"\s*:\s*\{.*$/gim, "")
+    .replace(/^\s*<\/(?:longcat_tool_call|function)>\s*$/gim, "")
+    // Preserve angle-bracket autolinks as plain URLs before tag stripping.
+    .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
+    // Line breaks
+    .replace(/<br\s*\/?>/gi, "\n")
+    // Block elements → newlines
+    .replace(/<\/?(p|div)>/gi, "\n")
+    // Bold → WhatsApp/Signal bold
+    .replace(/<(b|strong)>(.*?)<\/\1>/gi, "*$2*")
+    // Italic → WhatsApp/Signal italic
+    .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
+    // Strikethrough → WhatsApp/Signal strikethrough
+    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, "~$2~")
+    // Inline code
+    .replace(/<code>(.*?)<\/code>/gi, "`$1`")
+    // Headings → bold text with newline
+    .replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gi, "\n*$1*\n")
+    // List items → bullet points
+    .replace(/<li[^>]*>(.*?)<\/li>/gi, "• $1\n")
+    // Strip remaining HTML tags (require tag-like structure: <word...>)
+    .replace(/<\/?[a-z][a-z0-9]*\b[^>]*>/gi, "")
+    // Collapse blank lines created by stripped leaked wrappers/tool-call blocks.
+    .replace(/\n[ \t]*\n[ \t]*\n+/g, "\n\n")
+    // Collapse 3+ consecutive newlines into 2
+    .replace(/\n{3,}/g, "\n\n");
+
+  return hadLeakage ? sanitized.replace(/\n{2,}/g, "\n").replace(/^\n+|\n+$/g, "") : sanitized;
 }

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -47,7 +47,7 @@ export function sanitizeForPlainText(text: string): string {
     .replace(/<\/?(?:longcat_think|longcat_tool_call|x)>/gi, "")
     .replace(/<\|eot_id\|>/gi, "")
     // Drop malformed leaked reply tags before the normal directive parser can see them.
-    .replace(/^\s*:?\[\[\s*reply_to_current\s*\](?:\s*)/i, "")
+    .replace(/^\s*:?\[\[\s*reply_to_current\s*\](?:\s*)/im, "")
     // Drop raw tool-call JSON lines that leaked into plain text.
     .replace(/^\s*\{"name"\s*:\s*"[^"]+"\s*,\s*"arguments"\s*:\s*\{.*$/gim, "")
     .replace(/^\s*<\/(?:longcat_tool_call|function)>\s*$/gim, "")

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -33,6 +33,7 @@ type TelegramPollingSessionOpts = {
 
 export class TelegramPollingSession {
   #restartAttempts = 0;
+  #conflictAttempts = 0;
   #webhookCleared = false;
   #forceRestarted = false;
   #activeRunner: ReturnType<typeof run> | undefined;
@@ -206,7 +207,7 @@ export class TelegramPollingSession {
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
         stalledRestart = true;
         this.opts.log(
-          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
+          `[telegram:${this.opts.accountId}] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
         );
         void stopRunner();
       }
@@ -224,8 +225,10 @@ export class TelegramPollingSession {
           ? "unhandled network error"
           : "runner stopped (maxRetryTime exceeded or graceful stop)";
       this.#forceRestarted = false;
+      this.#conflictAttempts = 0;
       const shouldRestart = await this.#waitBeforeRestart(
-        (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
+        (delay) =>
+          `[telegram:${this.opts.accountId}] polling runner stopped (${reason}); restarting in ${delay}.`,
       );
       return shouldRestart ? "continue" : "exit";
     } catch (err) {
@@ -236,6 +239,9 @@ export class TelegramPollingSession {
       const isConflict = isGetUpdatesConflict(err);
       if (isConflict) {
         this.#webhookCleared = false;
+        this.#conflictAttempts += 1;
+      } else {
+        this.#conflictAttempts = 0;
       }
       const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
       if (!isConflict && !isRecoverable) {
@@ -243,9 +249,13 @@ export class TelegramPollingSession {
       }
       const reason = isConflict ? "getUpdates conflict" : "network error";
       const errMsg = formatErrorMessage(err);
-      const shouldRestart = await this.#waitBeforeRestart(
-        (delay) => `Telegram ${reason}: ${errMsg}; retrying in ${delay}.`,
-      );
+      const shouldRestart = await this.#waitBeforeRestart((delay) => {
+        const hint =
+          isConflict && this.#conflictAttempts >= 3
+            ? " likely another bot process or host is polling the same token."
+            : "";
+        return `[telegram:${this.opts.accountId}] ${reason}: ${errMsg}; retrying in ${delay}.${hint}`;
+      });
       return shouldRestart ? "continue" : "exit";
     } finally {
       clearInterval(watchdog);


### PR DESCRIPTION
## Summary
- preserve the last deliverable channel when agent delivery starts from an internal route
- use mirrored session delivery context as a fallback when resolving outbound channels
- treat `Unhandled stop reason: input_length` as a context overflow signal
- strip leaked wrapper/tool-call artifacts from plain-text outbound replies
- improve Telegram polling restart logs when repeated getUpdates conflicts happen

## Testing
- repo lint/checks run automatically in commit hook
- added/update unit tests for delivery fallback, outbound message fallback, sanitize-text, overflow detection, and gateway routing