### PR TITLE
fix: allow localhost control UI over SSH tunnels

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -31,9 +31,21 @@ describe("checkBrowserOrigin", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("rejects loopback origin mismatches when request is not local", () => {
+  it("accepts exact loopback origins for localhost hosts even when the socket is not detected as local", () => {
     const result = checkBrowserOrigin({
       requestHost: "127.0.0.1:18789",
+      origin: "http://127.0.0.1:18789",
+      isLocalClient: false,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.matchedBy).toBe("local-loopback");
+    }
+  });
+
+  it("rejects non-matching loopback dev origins when request is not local", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
       origin: "http://localhost:5173",
       isLocalClient: false,
     });

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -1,4 +1,4 @@
-import { isLoopbackHost, normalizeHostHeader } from "./net.js";
+import { isLoopbackHost, normalizeHostHeader, resolveHostName } from "./net.js";
 
 type OriginCheckResult =
   | {
@@ -31,6 +31,7 @@ export function checkBrowserOrigin(params: {
   origin?: string;
   allowedOrigins?: string[];
   allowHostHeaderOriginFallback?: boolean;
+  allowLoopbackHostOriginFallback?: boolean;
   isLocalClient?: boolean;
 }): OriginCheckResult {
   const parsedOrigin = parseOrigin(params.origin);
@@ -52,6 +53,20 @@ export function checkBrowserOrigin(params: {
     parsedOrigin.host === requestHost
   ) {
     return { ok: true, matchedBy: "host-header-fallback" };
+  }
+
+  const requestHostname = resolveHostName(params.requestHost);
+
+  // Accept true loopback browser origins for localhost-hosted Control UI, even when
+  // the TCP peer itself is not detected as loopback (for example SSH local port
+  // forwarding, where the browser origin is still 127.0.0.1 but the remote socket
+  // may not appear as a direct loopback client to the gateway).
+  if (
+    params.allowLoopbackHostOriginFallback !== false &&
+    isLoopbackHost(parsedOrigin.hostname) &&
+    isLoopbackHost(requestHostname)
+  ) {
+    return { ok: true, matchedBy: "local-loopback" };
   }
 
   // Dev fallback only for genuinely local socket clients, not Host-header claims.

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -411,6 +411,7 @@ export function attachGatewayWsMessageHandler(params: {
             origin: requestOrigin,
             allowedOrigins: configSnapshot.gateway?.controlUi?.allowedOrigins,
             allowHostHeaderOriginFallback: hostHeaderOriginFallbackEnabled,
+            allowLoopbackHostOriginFallback: !hasProxyHeaders,
             isLocalClient,
           });
           if (!originCheck.ok) {


### PR DESCRIPTION
## Summary\n- accept exact loopback Control UI origins when the request host is also loopback\n- keep the stricter proxy-header path so forged forwarded requests do not get the localhost fallback\n- add a regression test for SSH-tunneled localhost Control UI access\n\n## Testing\n- pnpm exec vitest run src/gateway/origin-check.test.ts src/gateway/server.auth.browser-hardening.test.ts -t "loopback|forged|browser-origin behavior unchanged"\n