### PR TITLE
fix(telegram): suppress media-fetch error reply in requireMention groups

### DIFF
--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -60,6 +60,7 @@ import {
   getTelegramTextParts,
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
+  hasBotMention,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
@@ -888,6 +889,7 @@ export const registerTelegramHandlers = ({
     storeAllowFrom: string[];
     sendOversizeWarning: boolean;
     oversizeLogMessage: string;
+    groupConfig?: TelegramGroupConfig;
   }) => {
     const {
       ctx,
@@ -898,6 +900,7 @@ export const registerTelegramHandlers = ({
       storeAllowFrom,
       sendOversizeWarning,
       oversizeLogMessage,
+      groupConfig,
     } = params;
 
     // Text fragment handling - Telegram splits long pastes into multiple inbound messages (~4096 chars).
@@ -1018,14 +1021,24 @@ export const registerTelegramHandlers = ({
         return;
       }
       logger.warn({ chatId, error: String(mediaErr) }, "media fetch failed");
-      await withTelegramApiErrorLogging({
-        operation: "sendMessage",
-        runtime,
-        fn: () =>
-          bot.api.sendMessage(chatId, "⚠️ Failed to download media. Please try again.", {
-            reply_to_message_id: msg.message_id,
-          }),
-      }).catch(() => {});
+      // Don't send the error reply for group messages where requireMention is set
+      // and the bot was not mentioned — the bot would have silently skipped this
+      // message anyway, so responding with an error is unexpected and noisy.
+      const botUsername = ctx.me?.username;
+      const wouldSkipMention =
+        groupConfig?.requireMention === true &&
+        botUsername != null &&
+        !hasBotMention(msg, botUsername);
+      if (!wouldSkipMention) {
+        await withTelegramApiErrorLogging({
+          operation: "sendMessage",
+          runtime,
+          fn: () =>
+            bot.api.sendMessage(chatId, "⚠️ Failed to download media. Please try again.", {
+              reply_to_message_id: msg.message_id,
+            }),
+        }).catch(() => {});
+      }
       return;
     }
 
@@ -1684,6 +1697,7 @@ export const registerTelegramHandlers = ({
         storeAllowFrom,
         sendOversizeWarning: event.sendOversizeWarning,
         oversizeLogMessage: event.oversizeLogMessage,
+        groupConfig,
       });
     } catch (err) {
       runtime.error?.(danger(`${event.errorMessage}: ${String(err)}`));

--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -1024,11 +1024,17 @@ export const registerTelegramHandlers = ({
       // Don't send the error reply for group messages where requireMention is set
       // and the bot was not mentioned — the bot would have silently skipped this
       // message anyway, so responding with an error is unexpected and noisy.
+      // Check both explicit @bot mentions AND implicit mentions (replies to bot
+      // messages) to mirror the actual mention gate in bot-message-context.body.ts.
       const botUsername = ctx.me?.username;
+      const botId = ctx.me?.id;
+      const replyToBotMessage =
+        botId != null && msg.reply_to_message?.from?.id === botId;
       const wouldSkipMention =
         groupConfig?.requireMention === true &&
         botUsername != null &&
-        !hasBotMention(msg, botUsername);
+        !hasBotMention(msg, botUsername) &&
+        !replyToBotMessage;
       if (!wouldSkipMention) {
         await withTelegramApiErrorLogging({
           operation: "sendMessage",

--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -1028,8 +1028,7 @@ export const registerTelegramHandlers = ({
       // messages) to mirror the actual mention gate in bot-message-context.body.ts.
       const botUsername = ctx.me?.username;
       const botId = ctx.me?.id;
-      const replyToBotMessage =
-        botId != null && msg.reply_to_message?.from?.id === botId;
+      const replyToBotMessage = botId != null && msg.reply_to_message?.from?.id === botId;
       const wouldSkipMention =
         groupConfig?.requireMention === true &&
         botUsername != null &&

--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -10,6 +10,10 @@ import {
   buildModelsProviderData,
   formatModelsAvailableHeader,
 } from "../../../src/auto-reply/reply/commands-models.js";
+import {
+  buildMentionRegexes,
+  matchesMentionPatterns,
+} from "../../../src/auto-reply/reply/mentions.js";
 import { resolveStoredModelOverride } from "../../../src/auto-reply/reply/model-selection.js";
 import { listSkillCommandsForAgents } from "../../../src/auto-reply/skill-commands.js";
 import { buildCommandsMessagePaginated } from "../../../src/auto-reply/status.js";
@@ -1024,16 +1028,28 @@ export const registerTelegramHandlers = ({
       // Don't send the error reply for group messages where requireMention is set
       // and the bot was not mentioned — the bot would have silently skipped this
       // message anyway, so responding with an error is unexpected and noisy.
-      // Check both explicit @bot mentions AND implicit mentions (replies to bot
-      // messages) to mirror the actual mention gate in bot-message-context.body.ts.
+      // Mirrors the actual mention gate in bot-message-context.body.ts: explicit
+      // @bot, regex patterns (agent name/emoji), implicit reply-to-bot, and
+      // authorized control-command bypass.
       const botUsername = ctx.me?.username;
       const botId = ctx.me?.id;
       const replyToBotMessage = botId != null && msg.reply_to_message?.from?.id === botId;
+      const messageTextParts = getTelegramTextParts(msg);
+      const mentionRegexes = buildMentionRegexes(loadConfig());
+      const regexMentioned = matchesMentionPatterns(messageTextParts.text, mentionRegexes);
+      const textContent = messageTextParts.text.trim();
+      const senderId = msg.from?.id ? String(msg.from.id) : "";
+      const commandBypass =
+        textContent.startsWith("/") &&
+        (storeAllowFrom.length === 0 || storeAllowFrom.includes(senderId));
+      const canDetectMention = Boolean(botUsername) || mentionRegexes.length > 0;
       const wouldSkipMention =
         groupConfig?.requireMention === true &&
-        botUsername != null &&
-        !hasBotMention(msg, botUsername) &&
-        !replyToBotMessage;
+        canDetectMention &&
+        !(botUsername ? hasBotMention(msg, botUsername) : false) &&
+        !replyToBotMessage &&
+        !regexMentioned &&
+        !commandBypass;
       if (!wouldSkipMention) {
         await withTelegramApiErrorLogging({
           operation: "sendMessage",


### PR DESCRIPTION
## Summary

- When `requireMention` is enabled for a Telegram group, the bot should silently ignore messages that don't mention it. However, if a media download fails on such a message, the bot still sends a `"⚠️ Failed to download media"` error reply — which is unexpected and noisy since the user never addressed the bot.
- This fix checks whether the bot would have skipped the message due to `requireMention` before sending the error reply. If the bot wasn't mentioned, the error is silently suppressed.

## Test plan

- [ ] In a Telegram group with `requireMention: true`, send an image/video **without** mentioning the bot → bot should stay silent even if media fetch fails
- [ ] In the same group, send an image/video **with** @bot mention and simulate a media fetch failure → bot should still show the error reply
- [ ] In a group **without** `requireMention`, media fetch errors should still produce the warning as before (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)