### PR TITLE
feat(discord): add preview boundary rotation option for partial streaming

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -578,6 +578,7 @@ Default slash command settings:
     - `progress` is accepted for cross-channel consistency and maps to `partial` on Discord.
     - `channels.discord.streamMode` is a legacy alias and is auto-migrated.
     - `partial` edits a single preview message as tokens arrive.
+    - `channels.discord.previewSplitOnAssistantBoundary` rotates preview streaming to a new preview message when a new assistant message starts or a reasoning block ends. It defaults to `true` for `streaming: "block"` and `false` otherwise.
     - `block` emits draft-sized chunks (use `draftChunk` to tune size and breakpoints).
 
     Example:
@@ -587,6 +588,19 @@ Default slash command settings:
   channels: {
     discord: {
       streaming: "partial",
+    },
+  },
+}
+```
+
+    To keep `partial` preview edits but start a new preview message at assistant boundaries:
+
+```json5
+{
+  channels: {
+    discord: {
+      streaming: "partial",
+      previewSplitOnAssistantBoundary: true,
     },
   },
 }
@@ -1199,7 +1213,7 @@ High-signal Discord fields:
 - inbound worker: `inboundWorker.runTimeoutMs`
 - reply/history: `replyToMode`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
 - delivery: `textChunkLimit`, `chunkMode`, `maxLinesPerMessage`
-- streaming: `streaming` (legacy alias: `streamMode`), `draftChunk`, `blockStreaming`, `blockStreamingCoalesce`
+- streaming: `streaming` (legacy alias: `streamMode`), `previewSplitOnAssistantBoundary`, `draftChunk`, `blockStreaming`, `blockStreamingCoalesce`
 - media/retry: `mediaMaxMb`, `retry`
   - `mediaMaxMb` caps outbound Discord uploads (default: `8MB`)
 - actions: `actions.*`

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -145,7 +145,8 @@ Telegram:
 Discord:
 
 - Uses send + edit preview messages.
-- `block` mode uses draft chunking (`draftChunk`).
+- `partial` reuses a single preview message by default, but `channels.discord.previewSplitOnAssistantBoundary: true` rotates to a new preview message when a new assistant message starts or a reasoning block ends.
+- `block` mode uses draft chunking (`draftChunk`) and enables assistant-boundary preview rotation by default.
 - Preview streaming is skipped when Discord block streaming is explicitly enabled.
 
 Slack:

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -265,6 +265,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       textChunkLimit: 2000,
       chunkMode: "length", // length | newline
       streaming: "off", // off | partial | block | progress (progress maps to partial on Discord)
+      previewSplitOnAssistantBoundary: false, // default: true when streaming=block, else false
       maxLinesPerMessage: 17,
       ui: {
         components: {
@@ -321,6 +322,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - `channels.discord.voice.daveEncryption` and `channels.discord.voice.decryptionFailureTolerance` pass through to `@discordjs/voice` DAVE options (`true` and `24` by default).
 - OpenClaw additionally attempts voice receive recovery by leaving/rejoining a voice session after repeated decrypt failures.
 - `channels.discord.streaming` is the canonical stream mode key. Legacy `streamMode` and boolean `streaming` values are auto-migrated.
+- `channels.discord.previewSplitOnAssistantBoundary` rotates preview streaming to a new preview message when a new assistant message starts or a reasoning block ends. Defaults to `true` for `streaming: "block"` and `false` otherwise.
 - `channels.discord.autoPresence` maps runtime availability to bot presence (healthy => online, degraded => idle, exhausted => dnd) and allows optional status text overrides.
 - `channels.discord.dangerouslyAllowNameMatching` re-enables mutable name/tag matching (break-glass compatibility mode).
 

--- a/src/config/discord-preview-streaming.test.ts
+++ b/src/config/discord-preview-streaming.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDiscordPreviewSplitOnAssistantBoundary,
+  resolveDiscordPreviewStreamMode,
+} from "./discord-preview-streaming.js";
+
+describe("resolveDiscordPreviewStreamMode", () => {
+  it("maps progress to partial", () => {
+    expect(resolveDiscordPreviewStreamMode({ streaming: "progress" })).toBe("partial");
+  });
+});
+
+describe("resolveDiscordPreviewSplitOnAssistantBoundary", () => {
+  it("defaults to false for partial preview mode", () => {
+    expect(resolveDiscordPreviewSplitOnAssistantBoundary({ streaming: "partial" })).toBe(false);
+  });
+
+  it("defaults to true for block preview mode", () => {
+    expect(resolveDiscordPreviewSplitOnAssistantBoundary({ streaming: "block" })).toBe(true);
+  });
+
+  it("accepts an explicit override in partial mode", () => {
+    expect(
+      resolveDiscordPreviewSplitOnAssistantBoundary({
+        streaming: "partial",
+        previewSplitOnAssistantBoundary: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts an explicit override in block mode", () => {
+    expect(
+      resolveDiscordPreviewSplitOnAssistantBoundary({
+        streaming: "block",
+        previewSplitOnAssistantBoundary: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/config/discord-preview-streaming.ts
+++ b/src/config/discord-preview-streaming.ts
@@ -107,6 +107,19 @@ export function resolveDiscordPreviewStreamMode(
   return "off";
 }
 
+export function resolveDiscordPreviewSplitOnAssistantBoundary(
+  params: {
+    previewSplitOnAssistantBoundary?: unknown;
+    streamMode?: unknown;
+    streaming?: unknown;
+  } = {},
+): boolean {
+  if (typeof params.previewSplitOnAssistantBoundary === "boolean") {
+    return params.previewSplitOnAssistantBoundary;
+  }
+  return resolveDiscordPreviewStreamMode(params) === "block";
+}
+
 export function resolveSlackStreamingMode(
   params: {
     streamMode?: unknown;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1456,6 +1456,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Unified Telegram stream preview mode: "off" | "partial" | "block" | "progress" (default: "partial"). "progress" maps to "partial" on Telegram. Legacy boolean/streamMode keys are auto-mapped.',
   "channels.discord.streaming":
     'Unified Discord stream preview mode: "off" | "partial" | "block" | "progress". "progress" maps to "partial" on Discord. Legacy boolean/streamMode keys are auto-mapped.',
+  "channels.discord.previewSplitOnAssistantBoundary":
+    'Rotate Discord preview streaming to a new preview message when a new assistant message starts or a reasoning block ends. Default: true when channels.discord.streaming="block", otherwise false.',
   "channels.discord.streamMode":
     "Legacy Discord preview mode alias (off | partial | block); auto-migrated to channels.discord.streaming.",
   "channels.discord.draftChunk.minChars":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -742,6 +742,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.discord.commands.native": "Discord Native Commands",
   "channels.discord.commands.nativeSkills": "Discord Native Skill Commands",
   "channels.discord.streaming": "Discord Streaming Mode",
+  "channels.discord.previewSplitOnAssistantBoundary": "Discord Preview Split On Assistant Boundary",
   "channels.discord.streamMode": "Discord Stream Mode (Legacy)",
   "channels.discord.draftChunk.minChars": "Discord Draft Chunk Min Chars",
   "channels.discord.draftChunk.maxChars": "Discord Draft Chunk Max Chars",

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -253,6 +253,13 @@ export type DiscordAccountConfig = {
    */
   streaming?: DiscordStreamMode | boolean;
   /**
+   * Rotate Discord preview streaming to a new preview message when a new
+   * assistant message starts (for example after a tool call or reasoning block).
+   *
+   * Defaults to `true` for `streaming: "block"` and `false` otherwise.
+   */
+  previewSplitOnAssistantBoundary?: boolean;
+  /**
    * @deprecated Legacy key; migrated automatically to `streaming`.
    */
   streamMode?: "partial" | "block" | "off";

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -442,6 +442,7 @@ export const DiscordAccountSchema = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     // Canonical streaming mode. Legacy aliases (`streamMode`, boolean `streaming`) are auto-mapped.
     streaming: z.union([z.boolean(), z.enum(["off", "partial", "block", "progress"])]).optional(),
+    previewSplitOnAssistantBoundary: z.boolean().optional(),
     streamMode: z.enum(["partial", "block", "off"]).optional(),
     draftChunk: BlockStreamingChunkSchema.optional(),
     maxLinesPerMessage: z.number().int().positive().optional(),

--- a/src/discord/draft-stream.test.ts
+++ b/src/discord/draft-stream.test.ts
@@ -1,0 +1,102 @@
+import { Routes } from "discord-api-types/v10";
+import { describe, expect, it, vi } from "vitest";
+import { createDiscordDraftStream } from "./draft-stream.js";
+
+function createHarness(params?: {
+  throttleMs?: number;
+  minInitialChars?: number;
+  post?: (typeof vi)["fn"];
+  patch?: (typeof vi)["fn"];
+  del?: (typeof vi)["fn"];
+}) {
+  const rest = {
+    post: params?.post ?? vi.fn().mockResolvedValue({ id: "17" }),
+    patch: params?.patch ?? vi.fn().mockResolvedValue({}),
+    delete: params?.del ?? vi.fn().mockResolvedValue({}),
+  };
+  const stream = createDiscordDraftStream({
+    rest: rest as never,
+    channelId: "123",
+    throttleMs: params?.throttleMs,
+    minInitialChars: params?.minInitialChars,
+  });
+  return { rest, stream };
+}
+
+describe("createDiscordDraftStream", () => {
+  it("creates a new message after forceNewMessage is called", async () => {
+    const { rest, stream } = createHarness({
+      post: vi.fn().mockResolvedValueOnce({ id: "17" }).mockResolvedValueOnce({ id: "42" }),
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    expect(rest.post).toHaveBeenCalledTimes(1);
+
+    stream.update("Hello edited");
+    await stream.flush();
+    expect(rest.patch).toHaveBeenCalledWith(Routes.channelMessage("123", "17"), {
+      body: { content: "Hello edited" },
+    });
+
+    stream.forceNewMessage();
+    stream.update("After thinking");
+    await stream.flush();
+
+    expect(rest.post).toHaveBeenCalledTimes(2);
+    expect(rest.post).toHaveBeenLastCalledWith(Routes.channelMessages("123"), {
+      body: { content: "After thinking" },
+    });
+    expect(stream.messageId()).toBe("42");
+  });
+
+  it("sends first update immediately after forceNewMessage within throttle window", async () => {
+    vi.useFakeTimers();
+    try {
+      const { rest, stream } = createHarness({
+        throttleMs: 1000,
+        post: vi.fn().mockResolvedValueOnce({ id: "17" }).mockResolvedValueOnce({ id: "42" }),
+      });
+
+      stream.update("Hello");
+      await vi.waitFor(() => expect(rest.post).toHaveBeenCalledTimes(1));
+
+      stream.update("Hello edited");
+      expect(rest.patch).not.toHaveBeenCalled();
+
+      stream.forceNewMessage();
+      stream.update("Second message");
+      await vi.waitFor(() => expect(rest.post).toHaveBeenCalledTimes(2));
+      expect(rest.post).toHaveBeenLastCalledWith(Routes.channelMessages("123"), {
+        body: { content: "Second message" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not rebind to an old message when forceNewMessage races an in-flight send", async () => {
+    let resolveFirstSend: ((value: { id: string }) => void) | undefined;
+    const firstSend = new Promise<{ id: string }>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+    const post = vi.fn().mockReturnValueOnce(firstSend).mockResolvedValueOnce({ id: "42" });
+    const { rest, stream } = createHarness({ post });
+
+    stream.update("Message A partial");
+    await vi.waitFor(() => expect(rest.post).toHaveBeenCalledTimes(1));
+
+    stream.forceNewMessage();
+    stream.update("Message B partial");
+
+    resolveFirstSend?.({ id: "17" });
+    await stream.flush();
+
+    expect(rest.post).toHaveBeenCalledTimes(2);
+    expect(rest.post).toHaveBeenNthCalledWith(2, Routes.channelMessages("123"), {
+      body: { content: "Message B partial" },
+    });
+    expect(rest.patch).not.toHaveBeenCalled();
+    expect(stream.messageId()).toBe("42");
+  });
+});

--- a/src/discord/draft-stream.ts
+++ b/src/discord/draft-stream.ts
@@ -40,8 +40,10 @@ export function createDiscordDraftStream(params: {
   const streamState = { stopped: false, final: false };
   let streamMessageId: string | undefined;
   let lastSentText = "";
+  let generation = 0;
 
   const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
+    const sendGeneration = generation;
     // Allow final flush even if stopped (e.g., after clear()).
     if (streamState.stopped && !streamState.final) {
       return false;
@@ -94,6 +96,12 @@ export function createDiscordDraftStream(params: {
         params.warn?.("discord stream preview stopped (missing message id from send)");
         return false;
       }
+      if (sendGeneration !== generation) {
+        params.log?.(
+          `discord stream preview send superseded before id bind (generation ${sendGeneration} -> ${generation})`,
+        );
+        return true;
+      }
       streamMessageId = sentMessageId;
       return true;
     } catch (err) {
@@ -127,9 +135,11 @@ export function createDiscordDraftStream(params: {
   });
 
   const forceNewMessage = () => {
+    generation += 1;
     streamMessageId = undefined;
     lastSentText = "";
     loop.resetPending();
+    loop.resetThrottleWindow();
   };
 
   params.log?.(`discord stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -568,6 +568,27 @@ describe("processDiscordMessage draft streaming", () => {
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("can force new preview messages on assistant boundaries in partial mode", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({ text: "Hello" });
+      await params?.replyOptions?.onAssistantMessageStart?.();
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createBaseContext({
+      discordConfig: {
+        streamMode: "partial",
+        previewSplitOnAssistantBoundary: true,
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("strips reasoning tags from partial stream updates", async () => {
     const draftStream = createMockDraftStreamForTest();
 

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -22,7 +22,10 @@ import {
 } from "../../channels/status-reactions.js";
 import { createTypingCallbacks } from "../../channels/typing.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
-import { resolveDiscordPreviewStreamMode } from "../../config/discord-preview-streaming.js";
+import {
+  resolveDiscordPreviewSplitOnAssistantBoundary,
+  resolveDiscordPreviewStreamMode,
+} from "../../config/discord-preview-streaming.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
@@ -470,7 +473,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     draftStream && discordStreamMode === "block"
       ? resolveDiscordDraftStreamingChunking(cfg, accountId)
       : undefined;
-  const shouldSplitPreviewMessages = discordStreamMode === "block";
+  const shouldSplitPreviewMessages = resolveDiscordPreviewSplitOnAssistantBoundary(discordConfig);
   const draftChunker = draftChunking ? new EmbeddedBlockChunker(draftChunking) : undefined;
   let lastPartialText = "";
   let draftText = "";


### PR DESCRIPTION
## Summary

Discord preview streaming currently behaves differently by mode:

- `streaming: "partial"` keeps editing a single preview message.
- `streaming: "block"` rotates to a new preview message at assistant boundaries.

This PR adds a Discord config option to expose that boundary-rotation behavior independently of draft chunking mode:

- `channels.discord.previewSplitOnAssistantBoundary?: boolean`

When enabled, Discord preview streaming rotates to a new preview message when a new assistant message starts (or reasoning block ends), even in `streaming: "partial"`.

## Why

In long tool-heavy runs, users may want `partial`’s smoother preview updates but still preserve prior assistant preview blocks across boundaries instead of overwriting the same preview message.

## Config behavior

New field:

- `channels.discord.previewSplitOnAssistantBoundary`

Default behavior preserves existing semantics:

- defaults to `true` when `channels.discord.streaming = "block"`
- defaults to `false` otherwise

So this is backward compatible unless explicitly enabled.

## Implementation notes

- Added resolver: `resolveDiscordPreviewSplitOnAssistantBoundary(...)`
- Wired Discord message handler boundary logic to use the new resolver instead of hardcoding `streaming === "block"`.
- Added/updated docs and schema metadata (types, zod, schema help/labels, channel docs, configuration reference, streaming concept docs).

### Safety hardening in Discord draft stream

While exposing boundary rotation as a first-class option, this PR also hardens Discord `forceNewMessage()` behavior:

- generation guard avoids rebinding to an old in-flight send after rotation
- `forceNewMessage()` now resets throttle window so first update after rotation can send immediately

This aligns behavior with existing expectations from other channel draft-stream implementations.

## Tests

Added:

- `src/config/discord-preview-streaming.test.ts`
- `src/discord/draft-stream.test.ts`

Updated:

- `src/discord/monitor/message-handler.process.test.ts`
  - added partial-mode boundary-rotation test with `previewSplitOnAssistantBoundary: true`

Targeted test runs:

- `pnpm vitest run src/config/discord-preview-streaming.test.ts src/discord/draft-stream.test.ts src/discord/monitor/message-handler.process.test.ts`
- `pnpm vitest run src/config/schema.help.quality.test.ts src/config/config.discord.test.ts`

## Maintainer sanity check

I may have missed an existing config combination that already achieves this behavior in Discord `partial` mode. If so, please let me know and I can adjust or close this PR.
