### PR TITLE
fix: retry Telegram inbound media downloads over IPv4 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Config/web fetch: restore runtime validation for documented `tools.web.fetch.readability` and `tools.web.fetch.firecrawl` settings so valid web fetch configs no longer fail with unrecognized-key errors. (#42583) Thanks @stim64045-spec.
 - Signal/config validation: add `channels.signal.groups` schema support so per-group `requireMention`, `tools`, and `toolsBySender` overrides no longer get rejected during config validation. (#27199) Thanks @unisone.
 - Config/discovery: accept `discovery.wideArea.domain` in strict config validation so unicast DNS-SD gateway configs no longer fail with an unrecognized-key error. (#35615) Thanks @ingyukoh.
+- Telegram/inbound media IPv4 fallback: retry SSRF-guarded Telegram file downloads once with the same IPv4 fallback policy as Bot API calls so fresh installs on IPv6-broken hosts no longer fail to download inbound images.
 - Security/exec approvals: unwrap more `pnpm` runtime forms during approval binding, including `pnpm --reporter ... exec` and direct `pnpm node` file runs, with matching regression coverage and docs updates.
 - Security/exec approvals: fail closed for Perl `-M` and `-I` approval flows so preload and load-path module resolution stays outside approval-backed runtime execution unless the operator uses a broader explicit trust path.
 - Control UI/insecure auth: preserve explicit shared token and password auth on plain-HTTP Control UI connects so LAN and reverse-proxy sessions no longer drop shared auth before the first WebSocket handshake. (#45088) Thanks @velvet-shark.

--- a/src/media/fetch.telegram-network.test.ts
+++ b/src/media/fetch.telegram-network.test.ts
@@ -216,4 +216,45 @@ describe("fetchRemoteMedia telegram network policy", () => {
       }),
     );
   });
+
+  it("preserves both primary and fallback errors when Telegram media retry fails twice", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "149.154.167.220", family: 4 },
+      { address: "2001:67c:4e8:f004::9", family: 6 },
+    ]) as unknown as LookupFn;
+    const primaryError = createTelegramFetchFailedError("EHOSTUNREACH");
+    const fallbackError = createTelegramFetchFailedError("ETIMEDOUT");
+    undiciFetch.mockRejectedValueOnce(primaryError).mockRejectedValueOnce(fallbackError);
+
+    const telegramTransport = resolveTelegramTransport(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await expect(
+      fetchRemoteMedia({
+        url: "https://api.telegram.org/file/bottok/photos/3.jpg",
+        fetchImpl: telegramTransport.sourceFetch,
+        dispatcherPolicy: telegramTransport.pinnedDispatcherPolicy,
+        fallbackDispatcherPolicy: telegramTransport.fallbackPinnedDispatcherPolicy,
+        shouldRetryFetchError: shouldRetryTelegramIpv4Fallback,
+        lookupFn,
+        maxBytes: 1024,
+        ssrfPolicy: {
+          allowedHostnames: ["api.telegram.org"],
+          allowRfc2544BenchmarkRange: true,
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "MediaFetchError",
+      code: "fetch_failed",
+      cause: expect.objectContaining({
+        name: "Error",
+        cause: fallbackError,
+        primaryError,
+      }),
+    });
+  });
 });

--- a/src/media/fetch.telegram-network.test.ts
+++ b/src/media/fetch.telegram-network.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveTelegramTransport } from "../telegram/fetch.js";
+import { resolveTelegramTransport, shouldRetryTelegramIpv4Fallback } from "../telegram/fetch.js";
 import { fetchRemoteMedia } from "./fetch.js";
 
 const undiciFetch = vi.hoisted(() => vi.fn());
@@ -37,6 +37,12 @@ vi.mock("undici", () => ({
 
 describe("fetchRemoteMedia telegram network policy", () => {
   type LookupFn = NonNullable<Parameters<typeof fetchRemoteMedia>[0]["lookupFn"]>;
+
+  function createTelegramFetchFailedError(code: string): Error {
+    return Object.assign(new TypeError("fetch failed"), {
+      cause: { code },
+    });
+  }
 
   afterEach(() => {
     undiciFetch.mockReset();
@@ -138,5 +144,76 @@ describe("fetchRemoteMedia telegram network policy", () => {
 
     expect(init?.dispatcher?.options?.uri).toBe("http://127.0.0.1:7890");
     expect(ProxyAgentCtor).toHaveBeenCalled();
+  });
+
+  it("retries Telegram file downloads with IPv4 fallback when the first fetch fails", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "149.154.167.220", family: 4 },
+      { address: "2001:67c:4e8:f004::9", family: 6 },
+    ]) as unknown as LookupFn;
+    undiciFetch
+      .mockRejectedValueOnce(createTelegramFetchFailedError("EHOSTUNREACH"))
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([0xff, 0xd8, 0xff, 0x00]), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      );
+
+    const telegramTransport = resolveTelegramTransport(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await fetchRemoteMedia({
+      url: "https://api.telegram.org/file/bottok/photos/2.jpg",
+      fetchImpl: telegramTransport.sourceFetch,
+      dispatcherPolicy: telegramTransport.pinnedDispatcherPolicy,
+      fallbackDispatcherPolicy: telegramTransport.fallbackPinnedDispatcherPolicy,
+      shouldRetryFetchError: shouldRetryTelegramIpv4Fallback,
+      lookupFn,
+      maxBytes: 1024,
+      ssrfPolicy: {
+        allowedHostnames: ["api.telegram.org"],
+        allowRfc2544BenchmarkRange: true,
+      },
+    });
+
+    const firstInit = undiciFetch.mock.calls[0]?.[1] as
+      | (RequestInit & {
+          dispatcher?: {
+            options?: {
+              connect?: Record<string, unknown>;
+            };
+          };
+        })
+      | undefined;
+    const secondInit = undiciFetch.mock.calls[1]?.[1] as
+      | (RequestInit & {
+          dispatcher?: {
+            options?: {
+              connect?: Record<string, unknown>;
+            };
+          };
+        })
+      | undefined;
+
+    expect(undiciFetch).toHaveBeenCalledTimes(2);
+    expect(firstInit?.dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+        lookup: expect.any(Function),
+      }),
+    );
+    expect(secondInit?.dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+        lookup: expect.any(Function),
+      }),
+    );
   });
 });

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -25,13 +25,21 @@ function makeStallingFetch(firstChunk: Uint8Array) {
   });
 }
 
+function makeLookupFn() {
+  return vi.fn(async () => [{ address: "149.154.167.220", family: 4 }]) as unknown as NonNullable<
+    Parameters<typeof fetchRemoteMedia>[0]["lookupFn"]
+  >;
+}
+
 describe("fetchRemoteMedia", () => {
-  type LookupFn = NonNullable<Parameters<typeof fetchRemoteMedia>[0]["lookupFn"]>;
+  const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcd";
+  const redactedTelegramToken = `${telegramToken.slice(0, 6)}…${telegramToken.slice(-4)}`;
+  const telegramFileUrl = `https://api.telegram.org/file/bot${telegramToken}/photos/1.jpg`;
 
   it("rejects when content-length exceeds maxBytes", async () => {
     const lookupFn = vi.fn(async () => [
       { address: "93.184.216.34", family: 4 },
-    ]) as unknown as LookupFn;
+    ]) as unknown as NonNullable<Parameters<typeof fetchRemoteMedia>[0]["lookupFn"]>;
     const fetchImpl = async () =>
       new Response(makeStream([new Uint8Array([1, 2, 3, 4, 5])]), {
         status: 200,
@@ -51,7 +59,7 @@ describe("fetchRemoteMedia", () => {
   it("rejects when streamed payload exceeds maxBytes", async () => {
     const lookupFn = vi.fn(async () => [
       { address: "93.184.216.34", family: 4 },
-    ]) as unknown as LookupFn;
+    ]) as unknown as NonNullable<Parameters<typeof fetchRemoteMedia>[0]["lookupFn"]>;
     const fetchImpl = async () =>
       new Response(makeStream([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])]), {
         status: 200,
@@ -70,7 +78,7 @@ describe("fetchRemoteMedia", () => {
   it("aborts stalled body reads when idle timeout expires", async () => {
     const lookupFn = vi.fn(async () => [
       { address: "93.184.216.34", family: 4 },
-    ]) as unknown as LookupFn;
+    ]) as unknown as NonNullable<Parameters<typeof fetchRemoteMedia>[0]["lookupFn"]>;
     const fetchImpl = makeStallingFetch(new Uint8Array([1, 2]));
 
     await expect(
@@ -86,6 +94,48 @@ describe("fetchRemoteMedia", () => {
       name: "MediaFetchError",
     });
   }, 5_000);
+
+  it("redacts Telegram bot tokens from fetch failure messages", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error(`dial failed for ${telegramFileUrl}`);
+    });
+
+    const error = await fetchRemoteMedia({
+      url: telegramFileUrl,
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 1024,
+      ssrfPolicy: {
+        allowedHostnames: ["api.telegram.org"],
+        allowRfc2544BenchmarkRange: true,
+      },
+    }).catch((err: unknown) => err as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    const errorText = error instanceof Error ? String(error) : "";
+    expect(errorText).not.toContain(telegramToken);
+    expect(errorText).toContain(`bot${redactedTelegramToken}`);
+  });
+
+  it("redacts Telegram bot tokens from HTTP error messages", async () => {
+    const fetchImpl = vi.fn(async () => new Response("unauthorized", { status: 401 }));
+
+    const error = await fetchRemoteMedia({
+      url: telegramFileUrl,
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 1024,
+      ssrfPolicy: {
+        allowedHostnames: ["api.telegram.org"],
+        allowRfc2544BenchmarkRange: true,
+      },
+    }).catch((err: unknown) => err as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    const errorText = error instanceof Error ? String(error) : "";
+    expect(errorText).not.toContain(telegramToken);
+    expect(errorText).toContain(`bot${redactedTelegramToken}`);
+  });
 
   it("blocks private IP literals before fetching", async () => {
     const fetchImpl = vi.fn();

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -125,7 +125,16 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
         typeof shouldRetryFetchError === "function" &&
         shouldRetryFetchError(err)
       ) {
-        result = await runGuardedFetch(fallbackDispatcherPolicy);
+        try {
+          result = await runGuardedFetch(fallbackDispatcherPolicy);
+        } catch (fallbackErr) {
+          const combined = new Error(
+            `Primary fetch failed and fallback fetch also failed for ${url}`,
+            { cause: fallbackErr },
+          );
+          (combined as Error & { primaryError?: unknown }).primaryError = err;
+          throw combined;
+        }
       } else {
         throw err;
       }

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
+import { formatErrorMessage } from "../infra/errors.js";
 import { fetchWithSsrFGuard, withStrictGuardedFetchMode } from "../infra/net/fetch-guard.js";
 import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import { redactSensitiveText } from "../logging/redact.js";
 import { detectMime, extensionForMime } from "./mime.js";
 import { readResponseWithLimit } from "./read-response-with-limit.js";
 
@@ -84,6 +86,10 @@ async function readErrorBodySnippet(res: Response, maxChars = 200): Promise<stri
   }
 }
 
+function redactMediaUrl(url: string): string {
+  return redactSensitiveText(url);
+}
+
 export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<FetchMediaResult> {
   const {
     url,
@@ -99,6 +105,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     fallbackDispatcherPolicy,
     shouldRetryFetchError,
   } = options;
+  const sourceUrl = redactMediaUrl(url);
 
   let res: Response;
   let finalUrl = url;
@@ -129,7 +136,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
           result = await runGuardedFetch(fallbackDispatcherPolicy);
         } catch (fallbackErr) {
           const combined = new Error(
-            `Primary fetch failed and fallback fetch also failed for ${url}`,
+            `Primary fetch failed and fallback fetch also failed for ${sourceUrl}`,
             { cause: fallbackErr },
           );
           (combined as Error & { primaryError?: unknown }).primaryError = err;
@@ -143,15 +150,19 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     finalUrl = result.finalUrl;
     release = result.release;
   } catch (err) {
-    throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${url}: ${String(err)}`, {
-      cause: err,
-    });
+    throw new MediaFetchError(
+      "fetch_failed",
+      `Failed to fetch media from ${sourceUrl}: ${formatErrorMessage(err)}`,
+      {
+        cause: err,
+      },
+    );
   }
 
   try {
     if (!res.ok) {
       const statusText = res.statusText ? ` ${res.statusText}` : "";
-      const redirected = finalUrl !== url ? ` (redirected to ${finalUrl})` : "";
+      const redirected = finalUrl !== url ? ` (redirected to ${redactMediaUrl(finalUrl)})` : "";
       let detail = `HTTP ${res.status}${statusText}`;
       if (!res.body) {
         detail = `HTTP ${res.status}${statusText}; empty response body`;
@@ -163,7 +174,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       }
       throw new MediaFetchError(
         "http_error",
-        `Failed to fetch media from ${url}${redirected}: ${detail}`,
+        `Failed to fetch media from ${sourceUrl}${redirected}: ${redactSensitiveText(detail)}`,
       );
     }
 
@@ -173,7 +184,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       if (Number.isFinite(length) && length > maxBytes) {
         throw new MediaFetchError(
           "max_bytes",
-          `Failed to fetch media from ${url}: content length ${length} exceeds maxBytes ${maxBytes}`,
+          `Failed to fetch media from ${sourceUrl}: content length ${length} exceeds maxBytes ${maxBytes}`,
         );
       }
     }
@@ -185,7 +196,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
             onOverflow: ({ maxBytes, res }) =>
               new MediaFetchError(
                 "max_bytes",
-                `Failed to fetch media from ${res.url || url}: payload exceeds maxBytes ${maxBytes}`,
+                `Failed to fetch media from ${redactMediaUrl(res.url || url)}: payload exceeds maxBytes ${maxBytes}`,
               ),
             chunkTimeoutMs: readIdleTimeoutMs,
           })
@@ -196,7 +207,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       }
       throw new MediaFetchError(
         "fetch_failed",
-        `Failed to fetch media from ${res.url || url}: ${String(err)}`,
+        `Failed to fetch media from ${redactMediaUrl(res.url || url)}: ${formatErrorMessage(err)}`,
         { cause: err },
       );
     }

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -15,8 +15,8 @@ export type MediaFetchErrorCode = "max_bytes" | "http_error" | "fetch_failed";
 export class MediaFetchError extends Error {
   readonly code: MediaFetchErrorCode;
 
-  constructor(code: MediaFetchErrorCode, message: string) {
-    super(message);
+  constructor(code: MediaFetchErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message, options);
     this.code = code;
     this.name = "MediaFetchError";
   }
@@ -36,6 +36,8 @@ type FetchMediaOptions = {
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
   dispatcherPolicy?: PinnedDispatcherPolicy;
+  fallbackDispatcherPolicy?: PinnedDispatcherPolicy;
+  shouldRetryFetchError?: (error: unknown) => boolean;
 };
 
 function stripQuotes(value: string): string {
@@ -94,13 +96,15 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     ssrfPolicy,
     lookupFn,
     dispatcherPolicy,
+    fallbackDispatcherPolicy,
+    shouldRetryFetchError,
   } = options;
 
   let res: Response;
   let finalUrl = url;
   let release: (() => Promise<void>) | null = null;
-  try {
-    const result = await fetchWithSsrFGuard(
+  const runGuardedFetch = async (policy?: PinnedDispatcherPolicy) =>
+    await fetchWithSsrFGuard(
       withStrictGuardedFetchMode({
         url,
         fetchImpl,
@@ -108,14 +112,31 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
         maxRedirects,
         policy: ssrfPolicy,
         lookupFn,
-        dispatcherPolicy,
+        dispatcherPolicy: policy,
       }),
     );
+  try {
+    let result;
+    try {
+      result = await runGuardedFetch(dispatcherPolicy);
+    } catch (err) {
+      if (
+        fallbackDispatcherPolicy &&
+        typeof shouldRetryFetchError === "function" &&
+        shouldRetryFetchError(err)
+      ) {
+        result = await runGuardedFetch(fallbackDispatcherPolicy);
+      } else {
+        throw err;
+      }
+    }
     res = result.response;
     finalUrl = result.finalUrl;
     release = result.release;
   } catch (err) {
-    throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${url}: ${String(err)}`);
+    throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${url}: ${String(err)}`, {
+      cause: err,
+    });
   }
 
   try {
@@ -167,6 +188,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       throw new MediaFetchError(
         "fetch_failed",
         `Failed to fetch media from ${res.url || url}: ${String(err)}`,
+        { cause: err },
       );
     }
     let fileNameFromUrl: string | undefined;

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -4,7 +4,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { retryAsync } from "../../infra/retry.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
-import type { TelegramTransport } from "../fetch.js";
+import { shouldRetryTelegramIpv4Fallback, type TelegramTransport } from "../fetch.js";
 import { cacheSticker, getCachedSticker } from "../sticker-cache.js";
 import { resolveTelegramMediaPlaceholder } from "./helpers.js";
 import type { StickerMetadata, TelegramContext } from "./types.js";
@@ -130,6 +130,8 @@ async function downloadAndSaveTelegramFile(params: {
     url,
     fetchImpl: params.transport.sourceFetch,
     dispatcherPolicy: params.transport.pinnedDispatcherPolicy,
+    fallbackDispatcherPolicy: params.transport.fallbackPinnedDispatcherPolicy,
+    shouldRetryFetchError: shouldRetryTelegramIpv4Fallback,
     filePathHint: params.filePath,
     maxBytes: params.maxBytes,
     readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -389,11 +389,16 @@ function shouldRetryWithIpv4Fallback(err: unknown): boolean {
   return true;
 }
 
+export function shouldRetryTelegramIpv4Fallback(err: unknown): boolean {
+  return shouldRetryWithIpv4Fallback(err);
+}
+
 // Prefer wrapped fetch when available to normalize AbortSignal across runtimes.
 export type TelegramTransport = {
   fetch: typeof fetch;
   sourceFetch: typeof fetch;
   pinnedDispatcherPolicy?: PinnedDispatcherPolicy;
+  fallbackPinnedDispatcherPolicy?: PinnedDispatcherPolicy;
 };
 
 export function resolveTelegramTransport(
@@ -438,20 +443,24 @@ export function resolveTelegramTransport(
     defaultDispatcher.mode === "direct" ||
     (defaultDispatcher.mode === "env-proxy" && shouldBypassEnvProxy);
   const stickyShouldUseEnvProxy = defaultDispatcher.mode === "env-proxy";
+  const fallbackPinnedDispatcherPolicy = allowStickyIpv4Fallback
+    ? resolveTelegramDispatcherPolicy({
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+        useEnvProxy: stickyShouldUseEnvProxy,
+        forceIpv4: true,
+        proxyUrl: explicitProxyUrl,
+      }).policy
+    : undefined;
 
   let stickyIpv4FallbackEnabled = false;
   let stickyIpv4Dispatcher: TelegramDispatcher | null = null;
   const resolveStickyIpv4Dispatcher = () => {
     if (!stickyIpv4Dispatcher) {
-      stickyIpv4Dispatcher = createTelegramDispatcher(
-        resolveTelegramDispatcherPolicy({
-          autoSelectFamily: false,
-          dnsResultOrder: "ipv4first",
-          useEnvProxy: stickyShouldUseEnvProxy,
-          forceIpv4: true,
-          proxyUrl: explicitProxyUrl,
-        }).policy,
-      ).dispatcher;
+      if (!fallbackPinnedDispatcherPolicy) {
+        return defaultDispatcher.dispatcher;
+      }
+      stickyIpv4Dispatcher = createTelegramDispatcher(fallbackPinnedDispatcherPolicy).dispatcher;
     }
     return stickyIpv4Dispatcher;
   };
@@ -493,6 +502,7 @@ export function resolveTelegramTransport(
     fetch: resolvedFetch,
     sourceFetch,
     pinnedDispatcherPolicy: defaultDispatcher.effectivePolicy,
+    fallbackPinnedDispatcherPolicy,
   };
 }
 


### PR DESCRIPTION
## Summary

- Problem: fresh installs on IPv6-broken hosts can reach Telegram generally but still fail when downloading inbound media from `api.telegram.org/file/...`.
- Why it matters: the first user-visible symptom is "can't send images to the bot", which looks like Telegram media is broken right after setup.
- What changed: reuse Telegram's existing IPv4 fallback classification for SSRF-guarded inbound file downloads, and retry those downloads once with an IPv4-only dispatcher policy.
- What did NOT change (scope boundary): this PR does not change the separate media-group partial-failure behavior that already has its own red baseline test.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

- Telegram inbound media downloads now retry once with IPv4-only transport when the initial guarded file fetch fails with the same dual-stack/network errors already handled by the main Telegram transport path.
- No config changes are required; existing `channels.telegram.network.*` settings continue to apply.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local git worktree on `origin/main` snapshot `6a812b621`, Node `v25.8.1`, pnpm `10.23.0`
- Model/provider: N/A
- Integration/channel (if any): Telegram inbound media download path
- Relevant config (redacted): default Telegram transport plus `channels.telegram.network.*` fallback behavior

### Steps

1. Create a Telegram transport with Node 22+ style fallback settings.
2. Attempt an inbound media download through the SSRF-guarded file fetch path.
3. Make the first fetch fail with a dual-stack network error like `EHOSTUNREACH`.

### Expected

- The guarded file download retries once with IPv4-only transport and succeeds.

### Actual

- Before this change, only Bot API calls had sticky IPv4 fallback; inbound file downloads reused the base dispatcher policy and failed fast.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added and ran a targeted regression test proving SSRF-guarded Telegram file downloads retry with `family: 4` after an initial `fetch failed`/`EHOSTUNREACH` path.
  - Re-ran existing Telegram transport and media retry suites.
  - Ran repo `pnpm check` and `pnpm build` in a clean detached worktree branch.
- Edge cases checked:
  - Existing explicit-proxy/direct transport policy preservation tests still pass.
  - Existing direct-message fallback warning test still passes.
- What you did **not** verify:
  - Live Telegram manual repro against a real bot/account in this worktree.
  - The separate media-group partial-failure regression; it remains red before and after this change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `cd441b72a73f3d551190327e02c4055e353f8c95`
- Files/config to restore: `src/media/fetch.ts`, `src/telegram/fetch.ts`, `src/telegram/bot/delivery.resolve-media.ts`, `src/media/fetch.telegram-network.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: unexpected retries on non-Telegram guarded fetches, or Telegram inbound media still failing without the retry test proving `family: 4` dispatch

## Risks and Mitigations

- Risk: retry classification could become broader than intended if reused outside Telegram media.
  - Mitigation: the retry hook is only wired from Telegram media download call sites and reuses the existing Telegram-specific fallback classifier.
