### PR TITLE
usage: add cache TTL for loadProviderUsageSummary (fix #45332)

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -860,6 +860,8 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.cache.enabled":
     "Caches computed chunk embeddings in SQLite so reindexing and incremental updates run faster (default: true). Keep this enabled unless investigating cache correctness or minimizing disk usage.",
   memory: "Memory backend configuration (global).",
+  "usage.cacheTtlMs":
+    "Cache TTL in ms for provider usage summaries (e.g. Anthropic OAuth usage). Reduces API calls when status/heartbeats run frequently. Default: 300000 (5 min). Set to 0 to disable caching.",
   "memory.backend":
     'Selects the global memory engine: "builtin" uses OpenClaw memory internals, while "qmd" uses the QMD sidecar pipeline. Keep "builtin" unless you intentionally operate QMD.',
   "memory.citations":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -370,6 +370,8 @@ export const FIELD_LABELS: Record<string, string> = {
     "Memory Search Temporal Decay Half-life (Days)",
   "agents.defaults.memorySearch.cache.enabled": "Memory Search Embedding Cache",
   "agents.defaults.memorySearch.cache.maxEntries": "Memory Search Embedding Cache Max Entries",
+  usage: "Usage",
+  "usage.cacheTtlMs": "Provider Usage Cache TTL (ms)",
   memory: "Memory",
   "memory.backend": "Memory Backend",
   "memory.citations": "Memory Citations Mode",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -120,6 +120,11 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  /** Provider usage panel cache (e.g. Anthropic OAuth usage). */
+  usage?: {
+    /** Cache TTL in ms for loadProviderUsageSummary results. Default: 300000 (5 min). */
+    cacheTtlMs?: number;
+  };
 };
 
 export type ConfigValidationIssue = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -826,6 +826,12 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    usage: z
+      .object({
+        cacheTtlMs: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
     memory: MemorySchema,
     skills: z
       .object({

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -150,7 +150,10 @@ export async function loadProviderUsageSummary(
   });
 
   const result = { updatedAt: now, providers };
-  if (key !== null) {
+  // Only cache when all included providers returned clean results (no transient errors
+  // like 429 or Timeout), so a failed poll cannot poison the cache for the full TTL.
+  const hasTransientError = providers.some((p) => p.error);
+  if (key !== null && !hasTransientError) {
     setCached(key, result, now, ttlMs);
   }
   return result;

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -28,7 +28,9 @@ type CacheEntry = { value: UsageSummary; expiresAt: number };
 const usageCache = new Map<string, CacheEntry>();
 
 function cacheKey(opts: UsageSummaryOptions): string {
-  return opts.agentDir ?? "";
+  // Include sorted providers list to prevent cross-caller key collisions.
+  const providers = (opts.providers ?? usageProviders).slice().toSorted().join(",");
+  return `${opts.agentDir ?? ""}|${providers}`;
 }
 
 function getCached(key: string, now: number, ttlMs: number): UsageSummary | undefined {
@@ -42,11 +44,12 @@ function getCached(key: string, now: number, ttlMs: number): UsageSummary | unde
   return entry.value;
 }
 
-function setCached(key: string, value: UsageSummary, ttlMs: number): void {
+function setCached(key: string, value: UsageSummary, now: number, ttlMs: number): void {
   if (ttlMs <= 0) {
     return;
   }
-  usageCache.set(key, { value, expiresAt: Date.now() + ttlMs });
+  // Use the same `now` as getCached to keep clocks consistent.
+  usageCache.set(key, { value, expiresAt: now + ttlMs });
 }
 
 type UsageSummaryOptions = {
@@ -148,7 +151,7 @@ export async function loadProviderUsageSummary(
 
   const result = { updatedAt: now, providers };
   if (key !== null) {
-    setCached(key, result, ttlMs);
+    setCached(key, result, now, ttlMs);
   }
   return result;
 }

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -1,3 +1,4 @@
+import { loadConfig } from "../config/config.js";
 import { resolveFetch } from "./fetch.js";
 import { type ProviderAuth, resolveProviderAuths } from "./provider-usage.auth.js";
 import {
@@ -21,6 +22,33 @@ import type {
   UsageSummary,
 } from "./provider-usage.types.js";
 
+const DEFAULT_CACHE_TTL_MS = 300_000; // 5 min
+
+type CacheEntry = { value: UsageSummary; expiresAt: number };
+const usageCache = new Map<string, CacheEntry>();
+
+function cacheKey(opts: UsageSummaryOptions): string {
+  return opts.agentDir ?? "";
+}
+
+function getCached(key: string, now: number, ttlMs: number): UsageSummary | undefined {
+  if (ttlMs <= 0) {
+    return undefined;
+  }
+  const entry = usageCache.get(key);
+  if (!entry || now >= entry.expiresAt) {
+    return undefined;
+  }
+  return entry.value;
+}
+
+function setCached(key: string, value: UsageSummary, ttlMs: number): void {
+  if (ttlMs <= 0) {
+    return;
+  }
+  usageCache.set(key, { value, expiresAt: Date.now() + ttlMs });
+}
+
 type UsageSummaryOptions = {
   now?: number;
   timeoutMs?: number;
@@ -28,6 +56,8 @@ type UsageSummaryOptions = {
   auth?: ProviderAuth[];
   agentDir?: string;
   fetch?: typeof fetch;
+  /** Override config cache TTL (0 = disable). When undefined, uses usage.cacheTtlMs from config. */
+  cacheTtlMs?: number;
 };
 
 export async function loadProviderUsageSummary(
@@ -38,6 +68,21 @@ export async function loadProviderUsageSummary(
   const fetchFn = resolveFetch(opts.fetch);
   if (!fetchFn) {
     throw new Error("fetch is not available");
+  }
+
+  const cfg = loadConfig();
+  const ttlMs =
+    opts.cacheTtlMs !== undefined
+      ? opts.cacheTtlMs
+      : (cfg.usage?.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS);
+
+  // Skip cache when explicit auth is passed (tests/mock scenarios).
+  const key = opts.auth ? null : cacheKey(opts);
+  if (key !== null) {
+    const cached = getCached(key, now, ttlMs);
+    if (cached !== undefined) {
+      return cached;
+    }
   }
 
   const auths = await resolveProviderAuths({
@@ -101,5 +146,9 @@ export async function loadProviderUsageSummary(
     return !ignoredErrors.has(entry.error);
   });
 
-  return { updatedAt: now, providers };
+  const result = { updatedAt: now, providers };
+  if (key !== null) {
+    setCached(key, result, ttlMs);
+  }
+  return result;
 }

--- a/src/infra/provider-usage.test.ts
+++ b/src/infra/provider-usage.test.ts
@@ -291,7 +291,17 @@ describe("provider usage loading", () => {
 
         const claude = expectSingleAnthropicProvider(summary);
         expect(claude?.windows[0]?.label).toBe("5h");
-        expect(mockFetch).toHaveBeenCalled();
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        // Second call with same opts hits cache; no additional fetch
+        const summary2 = await loadProviderUsageSummary({
+          now: usageNow,
+          providers: ["anthropic"],
+          agentDir,
+          fetch: mockFetch as unknown as typeof fetch,
+        });
+        expect(summary2).toEqual(summary);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
       },
       {
         env: {
@@ -433,6 +443,26 @@ describe("provider usage loading", () => {
     } finally {
       ignoredErrors.delete("HTTP 500");
     }
+  });
+
+  it("bypasses cache when auth is passed, so each call fetches", async () => {
+    const mockFetch = createProviderUsageFetch(async (url) => {
+      if (url.includes("api.anthropic.com/api/oauth/usage")) {
+        return makeResponse(200, {
+          five_hour: { utilization: 15, resets_at: "2026-01-07T01:00:00Z" },
+        });
+      }
+      return makeResponse(404, "not found");
+    });
+    const opts = {
+      now: usageNow,
+      auth: [{ provider: "anthropic", token: "token-a" }] as ProviderAuth[],
+      fetch: mockFetch as unknown as typeof fetch,
+    };
+    const a = await loadProviderUsageSummary(opts);
+    const b = await loadProviderUsageSummary(opts);
+    expect(a).toEqual(b);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("throws when fetch is unavailable", async () => {


### PR DESCRIPTION
## Summary

- **Problem:** Every `session_status` call, heartbeat, and `/status` hits `api.anthropic.com/api/oauth/usage` with no caching, causing frequent 429s and broken usage panels for multi-agent setups.
- **Why it matters:** Users with Anthropic OAuth + heartbeat cannot use the usage panel.
- **What changed:** Added in-memory caching for `loadProviderUsageSummary` with a 5-minute default TTL, configurable via `usage.cacheTtlMs`. Cache key is based on `agentDir`.
- **What did NOT change:** Other provider usage logic, API contracts, and auth behavior are unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts (new `usage.cacheTtlMs` config)
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45332
- Related #

## User-visible / Behavior Changes

- New config `usage.cacheTtlMs` (default 300000 ms / 5 min)
- Repeated usage queries for the same agent within TTL return cached data, reducing Anthropic API calls
- Set `usage.cacheTtlMs: 0` to disable caching

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (fewer requests due to caching)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 15 (arm64)
- Runtime/container: Node 22+
- Model/provider: anthropic (OAuth)
- Integration/channel: N/A
- Relevant config: `usage: { cacheTtlMs: 300000 }` (optional)

### Steps

1. Configure Anthropic OAuth and enable heartbeat
2. Call `session_status` or `/status` repeatedly
3. Confirm the usage panel shows data and no longer hits 429

### Expected

- Within TTL, repeated calls return cached results without new API requests
- Usage panel shows data correctly

### Actual

- Before: Every call hit the Anthropic API, often causing 429
- After: Same agent reuses cache for 5 minutes

## Evidence

- [x] New tests in `provider-usage.test.ts`: cache hit and bypass when explicit `auth` is passed
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- **Verified scenarios:** Ran related tests locally; confirmed explicit `auth` bypasses cache
- **Edge cases:** `cacheTtlMs: 0` disables cache; multi-agent uses separate caches per `agentDir`
- **Not verified:** End-to-end validation in a real OAuth environment

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR
- [ ] I left unresolved only those that still need reviewer/maintainer input

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **Yes** (optional `usage.cacheTtlMs`)
- Migration needed? **No**
- Upgrade steps: None; default behavior applies

## Failure Recovery

- How to disable/revert: Set `usage.cacheTtlMs: 0` to disable caching
- Files/config to restore: Revert commit
- Symptoms to watch: Usage data may be stale; 429s may return if cache is disabled or misconfigured

## Risks and Mitigations

- Risk: Cached usage data can be up to 5 minutes stale  
  Mitigation: Default TTL is 5 min; users can lower it or set `0` for real-time data.