### PR TITLE
fix(gateway): reject unknown agent IDs on OpenAI + OpenResponses HTTP paths

### DIFF
--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from "node:http";
 import { describe, expect, it } from "vitest";
-import { resolveGatewayRequestContext } from "./http-utils.js";
+import { InvalidGatewayAgentIdError, resolveGatewayRequestContext } from "./http-utils.js";
 
 function createReq(headers: Record<string, string> = {}): IncomingMessage {
   return { headers } as IncomingMessage;
@@ -41,5 +41,73 @@ describe("resolveGatewayRequestContext", () => {
     });
 
     expect(result.sessionKey).toContain("openresponses-user:alice");
+  });
+
+  it("defaults to main when no explicit agent is selected", () => {
+    const result = resolveGatewayRequestContext({
+      req: createReq(),
+      model: "openclaw",
+      sessionPrefix: "openai",
+      defaultMessageChannel: "webchat",
+      knownAgentIds: ["alpha", "beta"],
+    });
+
+    expect(result.agentId).toBe("main");
+    expect(result.sessionKey).toMatch(/^agent:main:/);
+  });
+
+  it("uses a known header-selected agent id", () => {
+    const result = resolveGatewayRequestContext({
+      req: createReq({ "x-openclaw-agent": " Beta " }),
+      model: "openclaw",
+      sessionPrefix: "openai",
+      defaultMessageChannel: "webchat",
+      knownAgentIds: ["alpha", "beta"],
+    });
+
+    expect(result.agentId).toBe("beta");
+    expect(result.sessionKey).toMatch(/^agent:beta:/);
+  });
+
+  it("rejects unknown header-selected agent ids", () => {
+    expect(() =>
+      resolveGatewayRequestContext({
+        req: createReq({ "x-openclaw-agent-id": "ghost" }),
+        model: "openclaw",
+        sessionPrefix: "openai",
+        defaultMessageChannel: "webchat",
+        knownAgentIds: ["alpha", "beta"],
+      }),
+    ).toThrowError(InvalidGatewayAgentIdError);
+    expect(() =>
+      resolveGatewayRequestContext({
+        req: createReq({ "x-openclaw-agent-id": "ghost" }),
+        model: "openclaw",
+        sessionPrefix: "openai",
+        defaultMessageChannel: "webchat",
+        knownAgentIds: ["alpha", "beta"],
+      }),
+    ).toThrow(/Unknown agent id "ghost"/);
+  });
+
+  it("rejects unknown model-selected agent ids", () => {
+    expect(() =>
+      resolveGatewayRequestContext({
+        req: createReq(),
+        model: "agent:ghost",
+        sessionPrefix: "openresponses",
+        defaultMessageChannel: "webchat",
+        knownAgentIds: ["alpha", "beta"],
+      }),
+    ).toThrowError(InvalidGatewayAgentIdError);
+    expect(() =>
+      resolveGatewayRequestContext({
+        req: createReq(),
+        model: "agent:ghost",
+        sessionPrefix: "openresponses",
+        defaultMessageChannel: "webchat",
+        knownAgentIds: ["alpha", "beta"],
+      }),
+    ).toThrow(/Unknown agent id "ghost"/);
   });
 });

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -1,7 +1,22 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage } from "node:http";
+import { formatCliCommand } from "../cli/command-format.js";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
+
+type ExplicitAgentSelection = {
+  rawAgentId: string;
+  agentId: string;
+};
+
+export class InvalidGatewayAgentIdError extends Error {
+  constructor(rawAgentId: string) {
+    super(
+      `Unknown agent id "${rawAgentId}". Use "${formatCliCommand("openclaw agents list")}" to see configured agents.`,
+    );
+    this.name = "InvalidGatewayAgentIdError";
+  }
+}
 
 export function getHeader(req: IncomingMessage, name: string): string | undefined {
   const raw = req.headers[name.toLowerCase()];
@@ -23,7 +38,9 @@ export function getBearerToken(req: IncomingMessage): string | undefined {
   return token || undefined;
 }
 
-export function resolveAgentIdFromHeader(req: IncomingMessage): string | undefined {
+function resolveExplicitAgentIdFromHeader(
+  req: IncomingMessage,
+): ExplicitAgentSelection | undefined {
   const raw =
     getHeader(req, "x-openclaw-agent-id")?.trim() ||
     getHeader(req, "x-openclaw-agent")?.trim() ||
@@ -31,10 +48,16 @@ export function resolveAgentIdFromHeader(req: IncomingMessage): string | undefin
   if (!raw) {
     return undefined;
   }
-  return normalizeAgentId(raw);
+  return { rawAgentId: raw, agentId: normalizeAgentId(raw) };
 }
 
-export function resolveAgentIdFromModel(model: string | undefined): string | undefined {
+export function resolveAgentIdFromHeader(req: IncomingMessage): string | undefined {
+  return resolveExplicitAgentIdFromHeader(req)?.agentId;
+}
+
+function resolveExplicitAgentIdFromModel(
+  model: string | undefined,
+): ExplicitAgentSelection | undefined {
   const raw = model?.trim();
   if (!raw) {
     return undefined;
@@ -47,20 +70,39 @@ export function resolveAgentIdFromModel(model: string | undefined): string | und
   if (!agentId) {
     return undefined;
   }
-  return normalizeAgentId(agentId);
+  return { rawAgentId: agentId, agentId: normalizeAgentId(agentId) };
+}
+
+export function resolveAgentIdFromModel(model: string | undefined): string | undefined {
+  return resolveExplicitAgentIdFromModel(model)?.agentId;
+}
+
+function assertKnownExplicitAgentSelection(
+  selection: ExplicitAgentSelection,
+  knownAgentIds: readonly string[] | undefined,
+): string {
+  if (!knownAgentIds?.includes(selection.agentId)) {
+    throw new InvalidGatewayAgentIdError(selection.rawAgentId);
+  }
+  return selection.agentId;
 }
 
 export function resolveAgentIdForRequest(params: {
   req: IncomingMessage;
   model: string | undefined;
+  knownAgentIds?: readonly string[];
 }): string {
-  const fromHeader = resolveAgentIdFromHeader(params.req);
+  const fromHeader = resolveExplicitAgentIdFromHeader(params.req);
   if (fromHeader) {
-    return fromHeader;
+    return assertKnownExplicitAgentSelection(fromHeader, params.knownAgentIds);
   }
 
-  const fromModel = resolveAgentIdFromModel(params.model);
-  return fromModel ?? "main";
+  const fromModel = resolveExplicitAgentIdFromModel(params.model);
+  if (fromModel) {
+    return assertKnownExplicitAgentSelection(fromModel, params.knownAgentIds);
+  }
+
+  return "main";
 }
 
 export function resolveSessionKey(params: {
@@ -86,8 +128,13 @@ export function resolveGatewayRequestContext(params: {
   sessionPrefix: string;
   defaultMessageChannel: string;
   useMessageChannelHeader?: boolean;
+  knownAgentIds?: readonly string[];
 }): { agentId: string; sessionKey: string; messageChannel: string } {
-  const agentId = resolveAgentIdForRequest({ req: params.req, model: params.model });
+  const agentId = resolveAgentIdForRequest({
+    req: params.req,
+    model: params.model,
+    knownAgentIds: params.knownAgentIds,
+  });
   const sessionKey = resolveSessionKey({
     req: params.req,
     agentId,

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -21,6 +21,12 @@ beforeAll(async () => {
   ({ startGatewayServer } = await import("./server.js"));
   enabledPort = await getFreePort();
   enabledServer = await startServer(enabledPort);
+});
+
+beforeEach(() => {
+  testState.agentsConfig = {
+    list: [{ id: "alpha" }, { id: "beta" }],
+  };
 });
 
 afterAll(async () => {
@@ -183,6 +189,13 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       {
         await expectAgentSessionKeyMatch({
           body: { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+          matcher: /^agent:main:/,
+        });
+      }
+
+      {
+        await expectAgentSessionKeyMatch({
+          body: { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
           headers: { "x-openclaw-agent-id": "beta" },
           matcher: /^agent:beta:/,
         });
@@ -207,6 +220,33 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           headers: { "x-openclaw-agent-id": "alpha" },
           matcher: /^agent:alpha:/,
         });
+      }
+
+      {
+        agentCommand.mockClear();
+        const res = await postChatCompletions(
+          port,
+          { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+          { "x-openclaw-agent-id": "ghost" },
+        );
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("invalid_request_error");
+        expect(json.error?.message ?? "").toContain('Unknown agent id "ghost"');
+        expect(agentCommand).toHaveBeenCalledTimes(0);
+      }
+
+      {
+        agentCommand.mockClear();
+        const res = await postChatCompletions(port, {
+          model: "openclaw:ghost",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("invalid_request_error");
+        expect(json.error?.message ?? "").toContain('Unknown agent id "ghost"');
+        expect(agentCommand).toHaveBeenCalledTimes(0);
       }
 
       {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { listAgentIds } from "../agents/agent-scope.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import type { ImageContent } from "../commands/agent/types.js";
+import { loadConfig } from "../config/config.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
@@ -25,9 +27,9 @@ import {
 } from "./agent-prompt.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
+import { sendInvalidRequest, sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
-import { resolveGatewayRequestContext } from "./http-utils.js";
+import { InvalidGatewayAgentIdError, resolveGatewayRequestContext } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 
 type OpenAiHttpOptions = {
@@ -431,14 +433,25 @@ export async function handleOpenAiHttpRequest(
   const model = typeof payload.model === "string" ? payload.model : "openclaw";
   const user = typeof payload.user === "string" ? payload.user : undefined;
 
-  const { sessionKey, messageChannel } = resolveGatewayRequestContext({
-    req,
-    model,
-    user,
-    sessionPrefix: "openai",
-    defaultMessageChannel: "webchat",
-    useMessageChannelHeader: true,
-  });
+  let sessionKey: string;
+  let messageChannel: string;
+  try {
+    ({ sessionKey, messageChannel } = resolveGatewayRequestContext({
+      req,
+      model,
+      user,
+      sessionPrefix: "openai",
+      defaultMessageChannel: "webchat",
+      useMessageChannelHeader: true,
+      knownAgentIds: listAgentIds(loadConfig()),
+    }));
+  } catch (err) {
+    if (err instanceof InvalidGatewayAgentIdError) {
+      sendInvalidRequest(res, err.message);
+      return true;
+    }
+    throw err;
+  }
   const activeTurnContext = resolveActiveTurnContext(payload.messages);
   const prompt = buildAgentPrompt(payload.messages, activeTurnContext.activeUserMessageIndex);
   let images: ImageContent[] = [];

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
-import { agentCommand, getFreePort, installGatewayTestHooks } from "./test-helpers.js";
+import { agentCommand, getFreePort, installGatewayTestHooks, testState } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -15,6 +15,12 @@ let enabledPort: number;
 beforeAll(async () => {
   enabledPort = await getFreePort();
   enabledServer = await startServer(enabledPort, { openResponsesEnabled: true });
+});
+
+beforeEach(() => {
+  testState.agentsConfig = {
+    list: [{ id: "alpha" }, { id: "beta" }],
+  };
 });
 
 afterAll(async () => {
@@ -214,6 +220,15 @@ describe("OpenResponses HTTP API (e2e)", () => {
       await ensureResponseConsumed(resMissingModel);
 
       mockAgentOnce([{ text: "hello" }]);
+      const resDefault = await postResponses(port, { model: "openclaw", input: "hi" });
+      expect(resDefault.status).toBe(200);
+      const optsDefault = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0];
+      expect((optsDefault as { sessionKey?: string } | undefined)?.sessionKey ?? "").toMatch(
+        /^agent:main:/,
+      );
+      await ensureResponseConsumed(resDefault);
+
+      mockAgentOnce([{ text: "hello" }]);
       const resHeader = await postResponses(
         port,
         { model: "openclaw", input: "hi" },
@@ -237,6 +252,28 @@ describe("OpenResponses HTTP API (e2e)", () => {
         /^agent:beta:/,
       );
       await ensureResponseConsumed(resModel);
+
+      agentCommand.mockClear();
+      const resUnknownHeader = await postResponses(
+        port,
+        { model: "openclaw", input: "hi" },
+        { "x-openclaw-agent-id": "ghost" },
+      );
+      const unknownHeaderError = await expectInvalidRequest(
+        resUnknownHeader,
+        /Unknown agent id "ghost"/,
+      );
+      expect(unknownHeaderError?.type).toBe("invalid_request_error");
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+
+      agentCommand.mockClear();
+      const resUnknownModel = await postResponses(port, { model: "agent:ghost", input: "hi" });
+      const unknownModelError = await expectInvalidRequest(
+        resUnknownModel,
+        /Unknown agent id "ghost"/,
+      );
+      expect(unknownModelError?.type).toBe("invalid_request_error");
+      expect(agentCommand).toHaveBeenCalledTimes(0);
 
       mockAgentOnce([{ text: "hello" }]);
       const resChannelHeader = await postResponses(

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -8,10 +8,12 @@
 
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { listAgentIds } from "../agents/agent-scope.js";
 import type { ClientToolDefinition } from "../agents/pi-embedded-runner/run/params.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import type { ImageContent } from "../commands/agent/types.js";
+import { loadConfig } from "../config/config.js";
 import type { GatewayHttpResponsesConfig } from "../config/types.gateway.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
@@ -32,9 +34,9 @@ import { defaultRuntime } from "../runtime.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
+import { sendInvalidRequest, sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
-import { resolveGatewayRequestContext } from "./http-utils.js";
+import { InvalidGatewayAgentIdError, resolveGatewayRequestContext } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 import {
   CreateResponseBodySchema,
@@ -426,14 +428,25 @@ export async function handleOpenResponsesHttpRequest(
     });
     return true;
   }
-  const { sessionKey, messageChannel } = resolveGatewayRequestContext({
-    req,
-    model,
-    user,
-    sessionPrefix: "openresponses",
-    defaultMessageChannel: "webchat",
-    useMessageChannelHeader: false,
-  });
+  let sessionKey: string;
+  let messageChannel: string;
+  try {
+    ({ sessionKey, messageChannel } = resolveGatewayRequestContext({
+      req,
+      model,
+      user,
+      sessionPrefix: "openresponses",
+      defaultMessageChannel: "webchat",
+      useMessageChannelHeader: false,
+      knownAgentIds: listAgentIds(loadConfig()),
+    }));
+  } catch (err) {
+    if (err instanceof InvalidGatewayAgentIdError) {
+      sendInvalidRequest(res, err.message);
+      return true;
+    }
+    throw err;
+  }
 
   // Build prompt from input
   const prompt = buildAgentPrompt(payload.input);


### PR DESCRIPTION
## Problem

Unknown agent IDs passed via `x-openclaw-agent-id`, `x-openclaw-agent`, or model selectors like `openclaw:ghost` / `agent:ghost` were silently accepted and routed to `main` instead of being rejected.

Repro on the installed gateway:
```
x-openclaw-agent-id: definitely-not-a-real-agent → 200 PONG   (wrong)
x-openclaw-agent-id: <unconfigured> → 200 PONG                (wrong)
```

## Fix

- **`src/gateway/http-utils.ts`** — adds `InvalidGatewayAgentIdError` and wires it into `resolveAgentIdForRequest` / `resolveGatewayRequestContext` when a `knownAgentIds` list is supplied. Implicit fallback to `main` (no header, no model selector) is unchanged.
- **`src/gateway/openai-http.ts`** — passes `listAgentIds(loadConfig())` as `knownAgentIds` and maps `InvalidGatewayAgentIdError` → `sendInvalidRequest(400)`.
- **`src/gateway/openresponses-http.ts`** — same change for `/v1/responses`.

## Tests

All 16 tests pass locally (`vitest.gateway.config.ts`):

| File | Tests |
|---|---|
| `http-utils.request-context.test.ts` | 7 (4 new: defaults-to-main, known header, unknown header rejected, unknown model rejected) |
| `openai-http.test.ts` | 4 (2 new: ghost via header + ghost via model → 400) |
| `openresponses-http.test.ts` | 5 (3 new: default-routes-main, ghost via header → 400, ghost via model → 400) |

## Error shape (consistent with existing gateway errors)

```json
{
  "error": {
    "type": "invalid_request_error",
    "message": "Unknown agent id \"ghost\". Use \"openclaw agents list\" to see configured agents."
  }
}
```