### PR TITLE
fix(infra): cache provider usage summary to prevent 429s

### DIFF
--- a/src/infra/provider-usage.load.test.ts
+++ b/src/infra/provider-usage.load.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock all provider fetch functions so loadProviderUsageSummary never hits the network.
+vi.mock("./provider-usage.fetch.js", () => ({
+  fetchClaudeUsage: vi.fn(),
+  fetchCodexUsage: vi.fn(),
+  fetchCopilotUsage: vi.fn(),
+  fetchGeminiUsage: vi.fn(),
+  fetchMinimaxUsage: vi.fn(),
+  fetchZaiUsage: vi.fn(),
+}));
+
+vi.mock("./provider-usage.auth.js", () => ({
+  resolveProviderAuths: vi.fn().mockResolvedValue([{ provider: "anthropic", token: "tok" }]),
+}));
+
+vi.mock("./fetch.js", () => ({
+  resolveFetch: () => globalThis.fetch,
+}));
+
+import { fetchClaudeUsage } from "./provider-usage.fetch.js";
+import { loadProviderUsageSummary, __test } from "./provider-usage.load.js";
+
+const { usageCache, USAGE_CACHE_TTL_MS } = __test;
+
+function resetCache() {
+  usageCache.summary = undefined;
+  usageCache.updatedAt = undefined;
+  usageCache.inFlight = undefined;
+}
+
+describe("loadProviderUsageSummary caching", () => {
+  beforeEach(() => {
+    resetCache();
+    vi.mocked(fetchClaudeUsage).mockReset();
+  });
+
+  it("caches results and does not re-fetch within TTL", async () => {
+    vi.mocked(fetchClaudeUsage).mockResolvedValue({
+      provider: "anthropic",
+      displayName: "Anthropic",
+      windows: [{ label: "daily", usedPercent: 42 }],
+    });
+
+    const first = await loadProviderUsageSummary();
+    const second = await loadProviderUsageSummary();
+
+    expect(first.providers).toHaveLength(1);
+    expect(second).toBe(first);
+    expect(fetchClaudeUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after TTL expires", async () => {
+    vi.mocked(fetchClaudeUsage).mockResolvedValue({
+      provider: "anthropic",
+      displayName: "Anthropic",
+      windows: [{ label: "daily", usedPercent: 10 }],
+    });
+
+    await loadProviderUsageSummary();
+    expect(fetchClaudeUsage).toHaveBeenCalledTimes(1);
+
+    // Expire the cache
+    usageCache.updatedAt = Date.now() - USAGE_CACHE_TTL_MS - 1;
+
+    vi.mocked(fetchClaudeUsage).mockResolvedValue({
+      provider: "anthropic",
+      displayName: "Anthropic",
+      windows: [{ label: "daily", usedPercent: 80 }],
+    });
+
+    // First call after expiry returns stale data while triggering background refresh
+    const stale = await loadProviderUsageSummary();
+    expect(stale.providers[0].windows[0].usedPercent).toBe(10);
+    expect(fetchClaudeUsage).toHaveBeenCalledTimes(2);
+
+    // Wait a tick for the background refresh to land
+    await vi.waitFor(() => {
+      expect(usageCache.summary!.providers[0].windows[0].usedPercent).toBe(80);
+    });
+
+    // Next call within TTL returns the refreshed data
+    const fresh = await loadProviderUsageSummary();
+    expect(fresh.providers[0].windows[0].usedPercent).toBe(80);
+    expect(fetchClaudeUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent requests", async () => {
+    let resolveOnce: (v: unknown) => void;
+    const slow = new Promise((r) => {
+      resolveOnce = r;
+    });
+
+    vi.mocked(fetchClaudeUsage).mockImplementation(() =>
+      slow.then(() => ({
+        provider: "anthropic" as const,
+        displayName: "Anthropic",
+        windows: [{ label: "daily", usedPercent: 55 }],
+      })),
+    );
+
+    const p1 = loadProviderUsageSummary();
+    const p2 = loadProviderUsageSummary();
+
+    resolveOnce!(undefined);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe(r2);
+    expect(fetchClaudeUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns stale data on fetch error when cache exists", async () => {
+    vi.mocked(fetchClaudeUsage).mockResolvedValue({
+      provider: "anthropic",
+      displayName: "Anthropic",
+      windows: [{ label: "daily", usedPercent: 25 }],
+    });
+
+    await loadProviderUsageSummary();
+
+    // Expire cache, then fail
+    usageCache.updatedAt = Date.now() - USAGE_CACHE_TTL_MS - 1;
+    vi.mocked(fetchClaudeUsage).mockRejectedValue(new Error("429"));
+
+    const fallback = await loadProviderUsageSummary();
+    expect(fallback.providers[0].windows[0].usedPercent).toBe(25);
+  });
+
+  it("propagates error when no cached data exists", async () => {
+    vi.mocked(fetchClaudeUsage).mockRejectedValue(new Error("429"));
+
+    await expect(loadProviderUsageSummary()).rejects.toThrow("429");
+  });
+});

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -115,41 +115,50 @@ async function fetchProviderUsageSummary(opts: UsageSummaryOptions = {}): Promis
 export async function loadProviderUsageSummary(
   opts: UsageSummaryOptions = {},
 ): Promise<UsageSummary> {
-  const now = Date.now();
-  if (
-    usageCache.summary &&
-    usageCache.updatedAt &&
-    now - usageCache.updatedAt < USAGE_CACHE_TTL_MS
-  ) {
-    return usageCache.summary;
-  }
+  // Skip cache when caller overrides auth or fetch (tests, one-off calls).
+  const useCache = !opts.auth && !opts.fetch;
 
-  if (usageCache.inFlight) {
-    if (usageCache.summary) {
+  if (useCache) {
+    const now = Date.now();
+    if (
+      usageCache.summary &&
+      usageCache.updatedAt &&
+      now - usageCache.updatedAt < USAGE_CACHE_TTL_MS
+    ) {
       return usageCache.summary;
     }
-    return await usageCache.inFlight;
+
+    if (usageCache.inFlight) {
+      if (usageCache.summary) {
+        return usageCache.summary;
+      }
+      return await usageCache.inFlight;
+    }
   }
 
   const inFlight = fetchProviderUsageSummary(opts)
     .then((summary) => {
-      usageCache.summary = summary;
-      usageCache.updatedAt = Date.now();
+      if (useCache) {
+        usageCache.summary = summary;
+        usageCache.updatedAt = Date.now();
+      }
       usageCache.inFlight = undefined;
       return summary;
     })
     .catch((err) => {
       usageCache.inFlight = undefined;
-      if (usageCache.summary) {
+      if (useCache && usageCache.summary) {
         return usageCache.summary;
       }
       throw err;
     });
 
-  usageCache.inFlight = inFlight;
+  if (useCache) {
+    usageCache.inFlight = inFlight;
 
-  if (usageCache.summary) {
-    return usageCache.summary;
+    if (usageCache.summary) {
+      return usageCache.summary;
+    }
   }
   return await inFlight;
 }

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -30,9 +30,17 @@ type UsageSummaryOptions = {
   fetch?: typeof fetch;
 };
 
-export async function loadProviderUsageSummary(
-  opts: UsageSummaryOptions = {},
-): Promise<UsageSummary> {
+const USAGE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+type UsageCacheEntry = {
+  summary?: UsageSummary;
+  updatedAt?: number;
+  inFlight?: Promise<UsageSummary>;
+};
+
+const usageCache: UsageCacheEntry = {};
+
+async function fetchProviderUsageSummary(opts: UsageSummaryOptions = {}): Promise<UsageSummary> {
   const now = opts.now ?? Date.now();
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const fetchFn = resolveFetch(opts.fetch);
@@ -103,3 +111,48 @@ export async function loadProviderUsageSummary(
 
   return { updatedAt: now, providers };
 }
+
+export async function loadProviderUsageSummary(
+  opts: UsageSummaryOptions = {},
+): Promise<UsageSummary> {
+  const now = Date.now();
+  if (
+    usageCache.summary &&
+    usageCache.updatedAt &&
+    now - usageCache.updatedAt < USAGE_CACHE_TTL_MS
+  ) {
+    return usageCache.summary;
+  }
+
+  if (usageCache.inFlight) {
+    if (usageCache.summary) {
+      return usageCache.summary;
+    }
+    return await usageCache.inFlight;
+  }
+
+  const inFlight = fetchProviderUsageSummary(opts)
+    .then((summary) => {
+      usageCache.summary = summary;
+      usageCache.updatedAt = Date.now();
+      usageCache.inFlight = undefined;
+      return summary;
+    })
+    .catch((err) => {
+      usageCache.inFlight = undefined;
+      if (usageCache.summary) {
+        return usageCache.summary;
+      }
+      throw err;
+    });
+
+  usageCache.inFlight = inFlight;
+
+  if (usageCache.summary) {
+    return usageCache.summary;
+  }
+  return await inFlight;
+}
+
+// Exposed for unit tests.
+export const __test = { usageCache, USAGE_CACHE_TTL_MS };


### PR DESCRIPTION
Ran into this while debugging why the usage panel never loads for Anthropic — turns out `loadProviderUsageSummary` hits the API on every single call with zero caching. With a few agents + heartbeats that's enough to trigger 429s consistently.

Added an in-memory cache with a 5-min TTL to `loadProviderUsageSummary`, same pattern as the existing `loadCostUsageSummaryCached` in the gateway. Also deduplicates in-flight requests so concurrent callers share a single fetch, and falls back to stale data if a refresh fails.

Didn't need to touch any call sites since the cache sits inside the function itself — all 6 callers (session-status tool, /status command, gateway usage.status, models list, channels list, auto-reply status) benefit automatically.

Fixes #45332