### PR TITLE
Fix Codex CLI auth profile sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/websocket pairing bypass for disabled auth: skip device-pairing enforcement when `gateway.auth.mode=none` so Control UI connections behind reverse proxies no longer get stuck on `pairing required` (code 1008) despite auth being explicitly disabled. (#42931)
 - Auth/login lockout recovery: clear stale `auth_permanent` and `billing` disabled state for all profiles matching the target provider when `openclaw models auth login` is invoked, so users locked out by expired or revoked OAuth tokens can recover by re-authenticating instead of waiting for the cooldown timer to expire. (#43057)
 - Auto-reply/context-engine compaction: persist the exact embedded-run metadata compaction count for main and followup runner session accounting, so metadata-only auto-compactions no longer undercount multi-compaction runs. (#42629) thanks @uf-hy.
+- Auth/Codex CLI reuse: sync reused Codex CLI credentials into the supported `openai-codex:default` OAuth profile instead of reviving the deprecated `openai-codex:codex-cli` slot, so doctor cleanup no longer loops. (#45353) thanks @Gugu-sugar.
 
 ## 2026.3.12
 

--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -16,8 +16,10 @@ vi.mock("./cli-credentials.js", () => ({
 const { syncExternalCliCredentials } = await import("./auth-profiles/external-cli-sync.js");
 const { CODEX_CLI_PROFILE_ID } = await import("./auth-profiles/constants.js");
 
+const OPENAI_CODEX_DEFAULT_PROFILE_ID = "openai-codex:default";
+
 describe("syncExternalCliCredentials", () => {
-  it("syncs Codex CLI credentials into the compatibility auth profile", () => {
+  it("syncs Codex CLI credentials into the supported default auth profile", () => {
     const expires = Date.now() + 60_000;
     mocks.readCodexCliCredentialsCached.mockReturnValue({
       type: "oauth",
@@ -39,7 +41,7 @@ describe("syncExternalCliCredentials", () => {
     expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalledWith(
       expect.objectContaining({ ttlMs: expect.any(Number) }),
     );
-    expect(store.profiles[CODEX_CLI_PROFILE_ID]).toMatchObject({
+    expect(store.profiles[OPENAI_CODEX_DEFAULT_PROFILE_ID]).toMatchObject({
       type: "oauth",
       provider: "openai-codex",
       access: "access-token",
@@ -47,5 +49,6 @@ describe("syncExternalCliCredentials", () => {
       expires,
       accountId: "acct_123",
     });
+    expect(store.profiles[CODEX_CLI_PROFILE_ID]).toBeUndefined();
   });
 });

--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
+
+const mocks = vi.hoisted(() => ({
+  readCodexCliCredentialsCached: vi.fn(),
+  readQwenCliCredentialsCached: vi.fn(() => null),
+  readMiniMaxCliCredentialsCached: vi.fn(() => null),
+}));
+
+vi.mock("./cli-credentials.js", () => ({
+  readCodexCliCredentialsCached: mocks.readCodexCliCredentialsCached,
+  readQwenCliCredentialsCached: mocks.readQwenCliCredentialsCached,
+  readMiniMaxCliCredentialsCached: mocks.readMiniMaxCliCredentialsCached,
+}));
+
+const { syncExternalCliCredentials } = await import("./auth-profiles/external-cli-sync.js");
+const { CODEX_CLI_PROFILE_ID } = await import("./auth-profiles/constants.js");
+
+describe("syncExternalCliCredentials", () => {
+  it("syncs Codex CLI credentials into the compatibility auth profile", () => {
+    const expires = Date.now() + 60_000;
+    mocks.readCodexCliCredentialsCached.mockReturnValue({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "access-token",
+      refresh: "refresh-token",
+      expires,
+      accountId: "acct_123",
+    });
+
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {},
+    };
+
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mutated).toBe(true);
+    expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
+    expect(store.profiles[CODEX_CLI_PROFILE_ID]).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "access-token",
+      refresh: "refresh-token",
+      expires,
+      accountId: "acct_123",
+    });
+  });
+});

--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -36,7 +36,9 @@ describe("syncExternalCliCredentials", () => {
     const mutated = syncExternalCliCredentials(store);
 
     expect(mutated).toBe(true);
-    expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
+    expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalledWith(
+      expect.objectContaining({ ttlMs: expect.any(Number) }),
+    );
     expect(store.profiles[CODEX_CLI_PROFILE_ID]).toMatchObject({
       type: "oauth",
       provider: "openai-codex",

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -4,7 +4,6 @@ import {
   readMiniMaxCliCredentialsCached,
 } from "../cli-credentials.js";
 import {
-  CODEX_CLI_PROFILE_ID,
   EXTERNAL_CLI_NEAR_EXPIRY_MS,
   EXTERNAL_CLI_SYNC_TTL_MS,
   QWEN_CLI_PROFILE_ID,
@@ -12,6 +11,8 @@ import {
   log,
 } from "./constants.js";
 import type { AuthProfileCredential, AuthProfileStore, OAuthCredential } from "./types.js";
+
+const OPENAI_CODEX_DEFAULT_PROFILE_ID = "openai-codex:default";
 
 function shallowEqualOAuthCredentials(a: OAuthCredential | undefined, b: OAuthCredential): boolean {
   if (!a) {
@@ -140,7 +141,7 @@ export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
   if (
     syncExternalCliCredentialsForProvider(
       store,
-      CODEX_CLI_PROFILE_ID,
+      OPENAI_CODEX_DEFAULT_PROFILE_ID,
       "openai-codex",
       () => readCodexCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS }),
       now,

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -1,8 +1,10 @@
 import {
+  readCodexCliCredentialsCached,
   readQwenCliCredentialsCached,
   readMiniMaxCliCredentialsCached,
 } from "../cli-credentials.js";
 import {
+  CODEX_CLI_PROFILE_ID,
   EXTERNAL_CLI_NEAR_EXPIRY_MS,
   EXTERNAL_CLI_SYNC_TTL_MS,
   QWEN_CLI_PROFILE_ID,
@@ -37,7 +39,11 @@ function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: nu
   if (cred.type !== "oauth" && cred.type !== "token") {
     return false;
   }
-  if (cred.provider !== "qwen-portal" && cred.provider !== "minimax-portal") {
+  if (
+    cred.provider !== "qwen-portal" &&
+    cred.provider !== "minimax-portal" &&
+    cred.provider !== "openai-codex"
+  ) {
     return false;
   }
   if (typeof cred.expires !== "number") {
@@ -82,7 +88,8 @@ function syncExternalCliCredentialsForProvider(
 }
 
 /**
- * Sync OAuth credentials from external CLI tools (Qwen Code CLI, MiniMax CLI) into the store.
+ * Sync OAuth credentials from external CLI tools (Qwen Code CLI, MiniMax CLI, Codex CLI)
+ * into the store.
  *
  * Returns true if any credentials were updated.
  */
@@ -125,6 +132,17 @@ export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
       MINIMAX_CLI_PROFILE_ID,
       "minimax-portal",
       () => readMiniMaxCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS }),
+      now,
+    )
+  ) {
+    mutated = true;
+  }
+  if (
+    syncExternalCliCredentialsForProvider(
+      store,
+      CODEX_CLI_PROFILE_ID,
+      "openai-codex",
+      () => readCodexCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS }),
       now,
     )
   ) {

--- a/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
+++ b/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
@@ -63,6 +63,13 @@ describe("maybeRemoveDeprecatedCliAuthProfiles", () => {
               refresh: "token-r2",
               expires: Date.now() + 60_000,
             },
+            "openai-codex:default": {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "token-c",
+              refresh: "token-r3",
+              expires: Date.now() + 60_000,
+            },
           },
         },
         null,
@@ -76,10 +83,11 @@ describe("maybeRemoveDeprecatedCliAuthProfiles", () => {
         profiles: {
           "anthropic:claude-cli": { provider: "anthropic", mode: "oauth" },
           "openai-codex:codex-cli": { provider: "openai-codex", mode: "oauth" },
+          "openai-codex:default": { provider: "openai-codex", mode: "oauth" },
         },
         order: {
           anthropic: ["anthropic:claude-cli"],
-          "openai-codex": ["openai-codex:codex-cli"],
+          "openai-codex": ["openai-codex:codex-cli", "openai-codex:default"],
         },
       },
     } as const;
@@ -94,10 +102,12 @@ describe("maybeRemoveDeprecatedCliAuthProfiles", () => {
     };
     expect(raw.profiles?.["anthropic:claude-cli"]).toBeUndefined();
     expect(raw.profiles?.["openai-codex:codex-cli"]).toBeUndefined();
+    expect(raw.profiles?.["openai-codex:default"]).toBeDefined();
 
     expect(next.auth?.profiles?.["anthropic:claude-cli"]).toBeUndefined();
     expect(next.auth?.profiles?.["openai-codex:codex-cli"]).toBeUndefined();
+    expect(next.auth?.profiles?.["openai-codex:default"]).toBeDefined();
     expect(next.auth?.order?.anthropic).toBeUndefined();
-    expect(next.auth?.order?.["openai-codex"]).toBeUndefined();
+    expect(next.auth?.order?.["openai-codex"]).toEqual(["openai-codex:default"]);
   });
 });


### PR DESCRIPTION
Title: Codex CLI credentials are no longer synced into the default auth profile store

Summary

There appears to be a regression in Codex CLI credential reuse.

The codebase still has:

- `readCodexCliCredentials()` for `~/.codex/auth.json`
- the compatibility profile ID `openai-codex:codex-cli`
- docs that say the wizard can reuse `~/.codex/auth.json`

But the default external CLI sync path only syncs Qwen and MiniMax, not Codex.

Impact

Even when `~/.codex/auth.json` exists and is readable, the default auth store loading
path does not populate `openai-codex:codex-cli`, so Codex CLI credentials are not
reused unless some other path writes them explicitly.

Relevant locations

- `src/agents/cli-credentials.ts`
- `src/agents/auth-profiles/constants.ts`
- `src/agents/auth-profiles/external-cli-sync.ts`
- `src/agents/auth-profiles/store.ts`
- `docs/start/wizard-cli-reference.md`

Proposed fix

Add Codex back to `syncExternalCliCredentials()` and add a regression test so the
default auth store path keeps reusing `~/.codex/auth.json`.
