### PR TITLE
feat: add self-escalation tool for lightweight model hand-off

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -28,6 +28,25 @@ Related:
 - `agents.defaults.imageModel` is used **only when** the primary model can’t accept images.
 - Per-agent defaults can override `agents.defaults.model` via `agents.list[].model` plus bindings (see [/concepts/multi-agent](/concepts/multi-agent)).
 
+## Self-escalation
+
+When running a lightweight primary model (e.g. Haiku or Sonnet), you can configure a more capable escalation model. The lighter model receives an `escalate` tool and can hand off complex tasks mid-turn:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "bedrock/claude-haiku-4-5",
+        "escalation": "bedrock/claude-opus-4-6"
+      }
+    }
+  }
+}
+```
+
+When the model calls `escalate`, the current turn completes and is automatically re-run on the escalation model. The escalation model does not receive the `escalate` tool (preventing loops). Per-agent escalation overrides are supported via `agents.list[].model.escalation`.
+
 ## Quick model policy
 
 - Set your primary to the strongest latest-generation model available to you.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1588,6 +1588,7 @@ export async function runEmbeddedPiAgent(
                     },
                   ]
                 : undefined,
+              escalationRequested: attempt.escalationRequested,
             },
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -92,6 +92,7 @@ import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { normalizeToolName } from "../../tool-policy.js";
+import { createEscalateTool, resolveEscalationModel } from "../../tools/escalate-tool.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
@@ -1529,6 +1530,25 @@ export async function runEmbeddedAttempt(
             abortSessionForYield?.();
           },
         });
+
+    // Self-escalation: register the escalate tool when an escalation model is configured
+    // and the current model is NOT the escalation target.
+    let escalationRequested: { reason: string } | undefined;
+    const escalationModel = resolveEscalationModel(params.config, sessionAgentId);
+    const escalationEnabled =
+      !!escalationModel &&
+      !params.disableTools &&
+      `${normalizeProviderId(params.provider)}/${params.modelId}` !== escalationModel.ref;
+    if (escalationEnabled) {
+      toolsRaw.push(
+        createEscalateTool({
+          onEscalate: (reason) => {
+            escalationRequested = { reason };
+          },
+        }),
+      );
+    }
+
     const toolsEnabled = supportsModelTools(params.model);
     const tools = sanitizeToolsForGoogle({
       tools: toolsEnabled ? toolsRaw : [],
@@ -1639,11 +1659,21 @@ export async function runEmbeddedAttempt(
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
 
+    // Augment extra system prompt with escalation guidance when the tool is available.
+    let effectiveExtraSystemPrompt = params.extraSystemPrompt;
+    if (escalationEnabled && toolsEnabled) {
+      const hint =
+        "If a task requires deep reasoning, complex analysis, multi-step debugging, creative writing, or you are uncertain about factual accuracy, use the escalate tool IMMEDIATELY as your first action — do not generate any text first.";
+      effectiveExtraSystemPrompt = effectiveExtraSystemPrompt
+        ? `${effectiveExtraSystemPrompt}\n\n${hint}`
+        : hint;
+    }
+
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,
       defaultThinkLevel: params.thinkLevel,
       reasoningLevel: params.reasoningLevel ?? "off",
-      extraSystemPrompt: params.extraSystemPrompt,
+      extraSystemPrompt: effectiveExtraSystemPrompt,
       ownerNumbers: params.ownerNumbers,
       ownerDisplay: ownerDisplay.ownerDisplay,
       ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
@@ -2786,6 +2816,7 @@ export async function runEmbeddedAttempt(
         // Client tool call detected (OpenResponses hosted tools)
         clientToolCall: clientToolCallDetected ?? undefined,
         yieldDetected: yieldDetected || undefined,
+        escalationRequested,
       };
     } finally {
       // Always tear down the session (and release the lock) before we leave this attempt.

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -66,4 +66,6 @@ export type EmbeddedRunAttemptResult = {
   clientToolCall?: { name: string; params: Record<string, unknown> };
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
+  /** Set when the escalate tool was invoked during this attempt. */
+  escalationRequested?: { reason: string };
 };

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -44,6 +44,8 @@ export type EmbeddedPiRunMeta = {
       | "retry_limit";
     message: string;
   };
+  /** Set when the escalate tool was invoked during this run. */
+  escalationRequested?: { reason: string };
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */
   stopReason?: string;
   /** Pending tool calls when stopReason is "tool_calls". */

--- a/src/agents/tools/escalate-tool.test.ts
+++ b/src/agents/tools/escalate-tool.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { normalizeProviderId } from "../model-selection.js";
+import { createEscalateTool, resolveEscalationModel } from "./escalate-tool.js";
+
+describe("createEscalateTool", () => {
+  it("invokes onEscalate callback with reason", async () => {
+    let captured: string | undefined;
+    const tool = createEscalateTool({
+      onEscalate: (reason) => {
+        captured = reason;
+      },
+    });
+
+    expect(tool.name).toBe("escalate");
+    await tool.execute("call-1", { reason: "complex reasoning needed" });
+    expect(captured).toBe("complex reasoning needed");
+  });
+
+  it("returns a JSON result indicating escalation", async () => {
+    const tool = createEscalateTool({ onEscalate: () => {} });
+    const result = await tool.execute("call-2", { reason: "needs deeper analysis" });
+    expect(result).toBeDefined();
+  });
+
+  it("last call wins when called multiple times", async () => {
+    let captured: string | undefined;
+    const tool = createEscalateTool({
+      onEscalate: (reason) => {
+        captured = reason;
+      },
+    });
+
+    await tool.execute("call-1", { reason: "first" });
+    await tool.execute("call-2", { reason: "second" });
+    expect(captured).toBe("second");
+  });
+});
+
+describe("resolveEscalationModel", () => {
+  it("parses a valid provider/model ref", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "bedrock/claude-opus-4-6" } } },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg)).toEqual({
+      provider: "amazon-bedrock",
+      model: "claude-opus-4-6",
+      ref: "amazon-bedrock/claude-opus-4-6",
+    });
+  });
+
+  it("returns undefined when config is undefined", () => {
+    expect(resolveEscalationModel(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when model config is a string", () => {
+    const cfg = {
+      agents: { defaults: { model: "bedrock/claude-haiku" } },
+    } as OpenClawConfig;
+    expect(resolveEscalationModel(cfg)).toBeUndefined();
+  });
+
+  it("returns undefined when escalation field is missing", () => {
+    const cfg = {
+      agents: { defaults: { model: { primary: "bedrock/claude-haiku" } } },
+    } as OpenClawConfig;
+    expect(resolveEscalationModel(cfg)).toBeUndefined();
+  });
+
+  it("returns undefined for invalid refs", () => {
+    const cases = ["no-slash-model", "/model-only", "", "   ", "bedrock/"];
+    for (const ref of cases) {
+      const cfg = {
+        agents: { defaults: { model: { escalation: ref } } },
+      } as OpenClawConfig;
+      expect(resolveEscalationModel(cfg)).toBeUndefined();
+    }
+  });
+
+  it("trims whitespace and normalizes provider", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "  bedrock/claude-opus-4-6  " } } },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg)).toEqual({
+      provider: "amazon-bedrock",
+      model: "claude-opus-4-6",
+      ref: "amazon-bedrock/claude-opus-4-6",
+    });
+  });
+
+  it("handles refs with multiple slashes", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { escalation: "bedrock/eu.anthropic.claude-opus-4-6" } },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg)).toEqual({
+      provider: "amazon-bedrock",
+      model: "eu.anthropic.claude-opus-4-6",
+      ref: "amazon-bedrock/eu.anthropic.claude-opus-4-6",
+    });
+  });
+
+  it("prefers per-agent escalation over global default", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { escalation: "bedrock/claude-opus-4-6" } },
+        list: [{ id: "my-agent", model: { escalation: "openai/gpt-4o" } }],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg, "my-agent")).toEqual({
+      provider: "openai",
+      model: "gpt-4o",
+      ref: "openai/gpt-4o",
+    });
+  });
+
+  it("falls back to global default when agent has no escalation", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { escalation: "bedrock/claude-opus-4-6" } },
+        list: [{ id: "my-agent", model: { primary: "openai/gpt-4o-mini" } }],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg, "my-agent")).toEqual({
+      provider: "amazon-bedrock",
+      model: "claude-opus-4-6",
+      ref: "amazon-bedrock/claude-opus-4-6",
+    });
+  });
+});
+
+describe("escalation identity check", () => {
+  const isEscalationTarget = (provider: string, modelId: string, escalationRef: string) =>
+    `${normalizeProviderId(provider)}/${modelId}` === escalationRef;
+
+  it("matches when current model is the escalation target", () => {
+    const ref = resolveEscalationModel({
+      agents: { defaults: { model: { escalation: "bedrock/claude-opus-4-6" } } },
+    } as OpenClawConfig)!;
+    expect(isEscalationTarget("amazon-bedrock", "claude-opus-4-6", ref.ref)).toBe(true);
+  });
+
+  it("matches when provider alias normalizes", () => {
+    const ref = resolveEscalationModel({
+      agents: { defaults: { model: { escalation: "bedrock/claude-opus-4-6" } } },
+    } as OpenClawConfig)!;
+    expect(isEscalationTarget("bedrock", "claude-opus-4-6", ref.ref)).toBe(true);
+  });
+
+  it("does not match when model differs", () => {
+    const ref = resolveEscalationModel({
+      agents: { defaults: { model: { escalation: "bedrock/claude-opus-4-6" } } },
+    } as OpenClawConfig)!;
+    expect(isEscalationTarget("amazon-bedrock", "claude-haiku-4-5", ref.ref)).toBe(false);
+  });
+});

--- a/src/agents/tools/escalate-tool.ts
+++ b/src/agents/tools/escalate-tool.ts
@@ -1,0 +1,89 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveAgentConfig } from "../agent-scope.js";
+import { normalizeProviderId } from "../model-selection.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+
+const EscalateSchema = Type.Object({
+  reason: Type.String(),
+});
+
+/**
+ * Create the `escalate` tool that lets a lighter model hand off to
+ * a more capable one mid-turn.
+ *
+ * When called, the tool invokes the `onEscalate` callback. The caller
+ * (attempt.ts) captures the reason in a local variable and returns it
+ * in the attempt result — no global state needed.
+ */
+export function createEscalateTool(params: { onEscalate: (reason: string) => void }): AnyAgentTool {
+  return {
+    label: "Escalate",
+    name: "escalate",
+    description:
+      "Escalate this conversation turn to a more capable model. Use this IMMEDIATELY as your first action — before generating any text — when the task requires deep reasoning, complex multi-step analysis, nuanced judgement, creative writing, debugging intricate issues, or when you are uncertain about factual accuracy. Do NOT use this for simple greetings, short answers, or straightforward tasks you can handle confidently.",
+    parameters: EscalateSchema,
+    execute: async (_toolCallId, rawParams) => {
+      const reason = readStringParam(rawParams as Record<string, unknown>, "reason", {
+        required: true,
+      });
+      params.onEscalate(reason);
+      return jsonResult({ escalated: true, reason });
+    },
+  };
+}
+
+/**
+ * Parse the escalation model reference from config into provider + model + ref.
+ * Checks per-agent config first, then falls back to global defaults.
+ * Returns undefined if no escalation model is configured or the ref is invalid.
+ */
+export function resolveEscalationModel(
+  config?: OpenClawConfig,
+  agentId?: string,
+): { provider: string; model: string; ref: string } | undefined {
+  const raw =
+    (agentId ? resolveAgentEscalation(config, agentId) : undefined) ??
+    resolveDefaultEscalation(config);
+  return parseEscalationRef(raw);
+}
+
+function resolveDefaultEscalation(config?: OpenClawConfig): string | undefined {
+  const modelCfg = config?.agents?.defaults?.model;
+  if (!modelCfg || typeof modelCfg === "string") {
+    return undefined;
+  }
+  return modelCfg.escalation;
+}
+
+function resolveAgentEscalation(config?: OpenClawConfig, agentId?: string): string | undefined {
+  if (!config || !agentId) {
+    return undefined;
+  }
+  const agentCfg = resolveAgentConfig(config, agentId);
+  const modelCfg = agentCfg?.model;
+  if (!modelCfg || typeof modelCfg === "string") {
+    return undefined;
+  }
+  return modelCfg.escalation;
+}
+
+function parseEscalationRef(
+  raw?: string,
+): { provider: string; model: string; ref: string } | undefined {
+  const ref = raw?.trim();
+  if (!ref) {
+    return undefined;
+  }
+  const slash = ref.indexOf("/");
+  if (slash <= 0) {
+    return undefined;
+  }
+  const model = ref.slice(slash + 1);
+  if (!model) {
+    return undefined;
+  }
+  const provider = normalizeProviderId(ref.slice(0, slash));
+  return { provider, model, ref: `${provider}/${model}` };
+}

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -15,6 +15,7 @@ import {
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import { resolveEscalationModel } from "../../agents/tools/escalate-tool.js";
 import {
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
@@ -23,6 +24,7 @@ import {
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
   isMarkdownCapableMessageChannel,
@@ -49,6 +51,8 @@ import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 import type { TypingSignaler } from "./typing-mode.js";
+
+const log = createSubsystemLogger("agent-runner");
 
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -141,6 +145,9 @@ export async function runAgentTurnWithFallback(params: {
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
   let didResetAfterCompactionFailure = false;
   let didRetryTransientHttpError = false;
+  let didEscalate = false;
+  let escalationProviderOverride: string | undefined;
+  let escalationModelOverride: string | undefined;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
@@ -202,6 +209,9 @@ export async function runAgentTurnWithFallback(params: {
       const fallbackResult = await runWithModelFallback({
         ...resolveModelFallbackOptions(params.followupRun.run),
         runId,
+        ...(escalationProviderOverride && escalationModelOverride
+          ? { provider: escalationProviderOverride, model: escalationModelOverride }
+          : {}),
         run: (provider, model, runOptions) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.
@@ -514,6 +524,25 @@ export async function runAgentTurnWithFallback(params: {
               text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
             },
           };
+        }
+      }
+
+      // Self-escalation: if the model called the escalate tool, re-run on the escalation model.
+      if (!didEscalate && runResult?.meta?.escalationRequested) {
+        const escalation = runResult.meta.escalationRequested;
+        const resolved = resolveEscalationModel(
+          params.followupRun.run.config,
+          params.followupRun.run.agentId,
+        );
+        if (resolved) {
+          didEscalate = true;
+          escalationProviderOverride = resolved.provider;
+          escalationModelOverride = resolved.model;
+          log.info(
+            `Self-escalation triggered: reason="${escalation.reason}" → ${resolved.provider}/${resolved.model}`,
+          );
+          didNotifyAgentRunStart = false;
+          continue;
         }
       }
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -16,10 +16,7 @@ export type AgentModelEntryConfig = {
   streaming?: boolean;
 };
 
-export type AgentModelListConfig = {
-  primary?: string;
-  fallbacks?: string[];
-};
+export type AgentModelListConfig = Exclude<AgentModelConfig, string>;
 
 export type AgentContextPruningConfig = {
   mode?: "off" | "cache-ttl";

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -11,6 +11,8 @@ export type AgentModelConfig =
       primary?: string;
       /** Per-agent model fallbacks (provider/model). */
       fallbacks?: string[];
+      /** Escalation model (provider/model) for self-escalation. */
+      escalation?: string;
     };
 
 export type AgentSandboxConfig = {

--- a/src/config/zod-schema.agent-model.ts
+++ b/src/config/zod-schema.agent-model.ts
@@ -6,6 +6,7 @@ export const AgentModelSchema = z.union([
     .object({
       primary: z.string().optional(),
       fallbacks: z.array(z.string()).optional(),
+      escalation: z.string().optional(),
     })
     .strict(),
 ]);


### PR DESCRIPTION
## Summary

- Adds an `escalate` tool that lightweight models (Haiku, Sonnet) can invoke mid-turn to hand off complex tasks to a more capable model (e.g. Opus)
- Configured via `agents.defaults.model.escalation` (per-agent override supported via `agents.list[].model.escalation`)
- The escalation model does **not** receive the `escalate` tool, preventing loops
- Uses a callback/return-value pattern (no global state) — the escalation request flows through the existing run result chain, identical to the `clientToolCall` pattern

## Design

The implementation touches 3 layers:

1. **Tool** (`src/agents/tools/escalate-tool.ts`): `createEscalateTool()` takes an `onEscalate` callback; `resolveEscalationModel()` parses config with provider normalization
2. **Runner** (`attempt.ts` → `run.ts`): local `escalationRequested` variable set via closure, returned through the result chain on the success path only
3. **Consumer** (`agent-runner-execution.ts`): checks `meta.escalationRequested`, sets provider/model overrides, continues the loop. `didEscalate` flag prevents re-escalation

No changes needed to params, followup-runner, memory runner, CLI agent, cron runner, or slug generator — the tool is simply not injected when the current model already matches the escalation target.

## Config example

```json
{
  "agents": {
    "defaults": {
      "model": {
        "primary": "bedrock/claude-haiku-4-5",
        "escalation": "bedrock/claude-opus-4-6"
      }
    }
  }
}
```

## Test plan

- [x] `pnpm build` — type-checks clean
- [x] 15 unit tests in `escalate-tool.test.ts`: tool callback, resolver parsing (valid/invalid refs, per-agent override, global fallback, whitespace, multi-slash), identity check with provider normalization
- [x] No regressions in `src/auto-reply/` test suite (pre-existing directive failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)