### PR TITLE
[codex] fix: harden cron provider routing and plugin startup

### DIFF
--- a/src/agents/pi-embedded-runner/lanes.test.ts
+++ b/src/agents/pi-embedded-runner/lanes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { CommandLane } from "../../process/lanes.js";
+import { resolveEmbeddedSessionLane, resolveGlobalLane, resolveSessionLane } from "./lanes.js";
+
+describe("pi embedded runner lane resolution", () => {
+  it("prefixes session lanes", () => {
+    expect(resolveSessionLane("abc")).toBe("session:abc");
+    expect(resolveEmbeddedSessionLane("session:abc")).toBe("session:abc");
+  });
+
+  it("maps cron global lane to nested to avoid self-deadlock", () => {
+    expect(resolveGlobalLane(CommandLane.Cron)).toBe(CommandLane.Nested);
+    expect(resolveGlobalLane("cron")).toBe(CommandLane.Nested);
+  });
+
+  it("preserves other global lanes", () => {
+    expect(resolveGlobalLane()).toBe(CommandLane.Main);
+    expect(resolveGlobalLane(CommandLane.Subagent)).toBe(CommandLane.Subagent);
+    expect(resolveGlobalLane(CommandLane.Nested)).toBe(CommandLane.Nested);
+  });
+});

--- a/src/agents/pi-embedded-runner/lanes.ts
+++ b/src/agents/pi-embedded-runner/lanes.ts
@@ -7,7 +7,18 @@ export function resolveSessionLane(key: string) {
 
 export function resolveGlobalLane(lane?: string) {
   const cleaned = lane?.trim();
-  return cleaned ? cleaned : CommandLane.Main;
+  if (!cleaned) {
+    return CommandLane.Main;
+  }
+  // Isolated cron runs already execute inside the outer cron service lane.
+  // Re-enqueuing embedded work onto the same global "cron" lane causes a
+  // self-deadlock: the outer cron task awaits an inner task that cannot start
+  // until the outer task releases the lane. Use the existing nested lane for
+  // the embedded portion instead.
+  if (cleaned === "cron") {
+    return CommandLane.Nested;
+  }
+  return cleaned;
 }
 
 export function resolveEmbeddedSessionLane(key: string) {

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -11,6 +11,7 @@ import {
   resolveCronSessionMock,
   resetRunCronIsolatedAgentTurnHarness,
   restoreFastTestEnv,
+  runEmbeddedPiAgentMock,
   runWithModelFallbackMock,
   updateSessionStoreMock,
 } from "./run.test-harness.js";
@@ -249,5 +250,109 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     // on the session entry rather than left undefined.
     expect(cronSession.sessionEntry.model).toBe("claude-opus-4-6");
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+  });
+
+  it("returns error when explicit pacing provider target cannot resolve", async () => {
+    const jobWithoutModel = makeJob({
+      pacing: { providerTarget: "gemini", role: "maintenance" },
+      payload: { kind: "agentTurn", message: "run deep research digest" },
+    });
+
+    resolveAllowedModelRefMock.mockReturnValueOnce({
+      error: "model not allowed: google/gemini-3.1-pro-preview",
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("explicit pacing.providerTarget 'gemini'");
+    expect(result.error).toContain("google/gemini-3.1-pro-preview");
+    expect(runWithModelFallbackMock).not.toHaveBeenCalled();
+  });
+
+  it("continues with defaults when inferred provider target cannot resolve", async () => {
+    const jobWithoutModel = makeJob({
+      name: "Deep Research Digest",
+      payload: { kind: "agentTurn", message: "perform deep research and market comparison" },
+    });
+
+    resolveAllowedModelRefMock.mockReturnValueOnce({
+      error: "model not allowed: google/gemini-3.1-pro-preview",
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+    expect(cronSession.sessionEntry.model).toBe("claude-opus-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+  });
+
+  it("disables model fallback when pacing provider target is explicit", async () => {
+    const jobWithoutModel = makeJob({
+      pacing: { providerTarget: "gemini", role: "maintenance" },
+      payload: { kind: "agentTurn", message: "run deep research digest" },
+    });
+
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "blockrun", model: "google/gemini-3.1-pro" },
+    });
+
+    runWithModelFallbackMock.mockResolvedValueOnce(
+      makeSuccessfulRunResult({
+        provider: "blockrun",
+        model: "google/gemini-3.1-pro",
+        result: {
+          payloads: [{ text: "digest complete" }],
+          meta: {
+            agentMeta: {
+              model: "google/gemini-3.1-pro",
+              provider: "blockrun",
+              usage: { input: 100, output: 50 },
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+    expect(runWithModelFallbackMock.mock.calls[0][0].fallbacksOverride).toEqual([]);
+  });
+
+  it("runs embedded cron exec with ask=off to avoid approval-pending prompts", async () => {
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "inspect workspace and summarize" },
+    });
+
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "anthropic", model: "claude-sonnet-4-6" },
+    });
+
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "done" }],
+      meta: {
+        agentMeta: {
+          model: "claude-sonnet-4-6",
+          provider: "anthropic",
+          usage: { input: 10, output: 5 },
+        },
+      },
+    });
+
+    runWithModelFallbackMock.mockImplementationOnce(async ({ provider, model, run }) => ({
+      provider,
+      model,
+      attempts: [],
+      result: await run(provider, model, {}),
+    }));
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
+
+    expect(result.status).toBe("ok");
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
+    expect(runEmbeddedPiAgentMock.mock.calls[0][0].execOverrides).toEqual({ ask: "off" });
   });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -56,6 +56,7 @@ import {
   isExternalHookSession,
 } from "../../security/external-content.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
+import { resolveCronProviderRouting } from "../provider-routing.js";
 import type { CronJob, CronRunOutcome, CronRunTelemetry } from "../types.js";
 import {
   dispatchCronDelivery,
@@ -94,6 +95,10 @@ export type RunCronAgentTurnResult = {
   deliveryAttempted?: boolean;
 } & CronRunOutcome &
   CronRunTelemetry;
+
+type RunCronAgentTurnResultBase = Omit<RunCronAgentTurnResult, "sessionId" | "sessionKey"> & {
+  deliveryError?: string;
+};
 
 type ResolvedAgentConfig = NonNullable<ReturnType<typeof resolveAgentConfig>>;
 
@@ -146,6 +151,16 @@ function buildCronAgentDefaultsConfig(params: {
 type ResolvedCronDeliveryTarget = Awaited<ReturnType<typeof resolveDeliveryTarget>>;
 
 type IsolatedDeliveryContract = "cron-owned" | "shared";
+function resolveCronFallbacksOverride(params: {
+  payloadFallbacks?: string[];
+  agentFallbacks?: string[];
+  providerRouting: ReturnType<typeof resolveCronProviderRouting>;
+}): string[] | undefined {
+  if (params.providerRouting?.source === "explicit") {
+    return [];
+  }
+  return params.payloadFallbacks ?? params.agentFallbacks;
+}
 
 function resolveCronToolPolicy(params: {
   deliveryRequested: boolean;
@@ -364,9 +379,7 @@ export async function runCronIsolatedAgentTurn(params: {
       }
     });
   };
-  const withRunSession = (
-    result: Omit<RunCronAgentTurnResult, "sessionId" | "sessionKey">,
-  ): RunCronAgentTurnResult => ({
+  const withRunSession = (result: RunCronAgentTurnResultBase): RunCronAgentTurnResult => ({
     ...result,
     sessionId: runSessionId,
     sessionKey: runSessionKey,
@@ -382,6 +395,7 @@ export async function runCronIsolatedAgentTurn(params: {
   // Respect session model override — check session.modelOverride before falling
   // back to the default config model. This ensures /model changes are honoured
   // by cron and isolated agent runs.
+  let sessionModelOverrideApplied = false;
   if (!modelOverride && !hooksGmailModelApplied) {
     const sessionModelOverride = cronSession.sessionEntry.modelOverride?.trim();
     if (sessionModelOverride) {
@@ -397,6 +411,37 @@ export async function runCronIsolatedAgentTurn(params: {
       if (!("error" in resolvedSessionOverride)) {
         provider = resolvedSessionOverride.ref.provider;
         model = resolvedSessionOverride.ref.model;
+        sessionModelOverrideApplied = true;
+      }
+    }
+  }
+
+  let providerRouting: ReturnType<typeof resolveCronProviderRouting> = null;
+  if (!modelOverride && !hooksGmailModelApplied && !sessionModelOverrideApplied) {
+    providerRouting = resolveCronProviderRouting({
+      job: params.job,
+      provider,
+      model,
+      configuredModelRefs: Object.keys(cfgWithAgentDefaults.agents?.defaults?.models ?? {}),
+    });
+    if (providerRouting) {
+      const resolvedRoutingModel = resolveAllowedModelRef({
+        cfg: cfgWithAgentDefaults,
+        catalog: await loadCatalog(),
+        raw: providerRouting.modelRef,
+        defaultProvider: resolvedDefault.provider,
+        defaultModel: resolvedDefault.model,
+      });
+      if (!("error" in resolvedRoutingModel)) {
+        provider = resolvedRoutingModel.ref.provider;
+        model = resolvedRoutingModel.ref.model;
+      } else if (providerRouting.source === "explicit") {
+        return withRunSession({
+          status: "error",
+          error: `[cron:${params.job.id}] explicit pacing.providerTarget '${providerRouting.providerTarget}' could not resolve '${providerRouting.modelRef}' (${resolvedRoutingModel.error})`,
+        });
+      } else {
+        providerRouting = null;
       }
     }
   }
@@ -557,8 +602,11 @@ export async function runCronIsolatedAgentTurn(params: {
         model,
         runId: cronSession.sessionEntry.sessionId,
         agentDir,
-        fallbacksOverride:
-          payloadFallbacks ?? resolveAgentModelFallbacksOverride(params.cfg, agentId),
+        fallbacksOverride: resolveCronFallbacksOverride({
+          payloadFallbacks,
+          agentFallbacks: resolveAgentModelFallbacksOverride(params.cfg, agentId),
+          providerRouting,
+        }),
         run: async (providerOverride, modelOverride, runOptions) => {
           if (abortSignal?.aborted) {
             throw new Error(abortReason());
@@ -631,6 +679,7 @@ export async function runCronIsolatedAgentTurn(params: {
             runId: cronSession.sessionEntry.sessionId,
             requireExplicitMessageTarget: toolPolicy.requireExplicitMessageTarget,
             disableMessageTool: toolPolicy.disableMessageTool,
+            execOverrides: { ask: "off" },
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
             abortSignal,
             bootstrapPromptWarningSignaturesSeen,
@@ -809,7 +858,11 @@ export async function runCronIsolatedAgentTurn(params: {
   const embeddedRunError = hasFatalErrorPayload
     ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
     : undefined;
-  const resolveRunOutcome = (params?: { delivered?: boolean; deliveryAttempted?: boolean }) =>
+  const resolveRunOutcome = (params?: {
+    delivered?: boolean;
+    deliveryAttempted?: boolean;
+    deliveryError?: string;
+  }) =>
     withRunSession({
       status: hasFatalErrorPayload ? "error" : "ok",
       ...(hasFatalErrorPayload
@@ -819,6 +872,7 @@ export async function runCronIsolatedAgentTurn(params: {
       outputText,
       delivered: params?.delivered,
       deliveryAttempted: params?.deliveryAttempted,
+      deliveryError: params?.deliveryError,
       ...telemetry,
     });
 
@@ -879,8 +933,12 @@ export async function runCronIsolatedAgentTurn(params: {
   }
   const delivered = deliveryResult.delivered;
   const deliveryAttempted = deliveryResult.deliveryAttempted;
+  const deliveryError =
+    "deliveryError" in deliveryResult && typeof deliveryResult.deliveryError === "string"
+      ? deliveryResult.deliveryError
+      : undefined;
   summary = deliveryResult.summary;
   outputText = deliveryResult.outputText;
 
-  return resolveRunOutcome({ delivered, deliveryAttempted });
+  return resolveRunOutcome({ delivered, deliveryAttempted, deliveryError });
 }

--- a/src/cron/provider-routing.test.ts
+++ b/src/cron/provider-routing.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  inferCronProviderTarget,
+  resolveCronProviderRouting,
+  resolveCronProviderTargetModelRef,
+} from "./provider-routing.js";
+
+describe("cron provider routing", () => {
+  it("infers gemini for research-heavy cron jobs", () => {
+    const inferred = inferCronProviderTarget({
+      agentId: "leo",
+      name: "leo-nightly-research",
+      description: "Produce one strategy research artifact",
+      payload: {
+        kind: "agentTurn",
+        message: "Do deep research with web_search and summarize market signals.",
+      },
+    });
+
+    expect(inferred).toMatchObject({
+      providerTarget: "gemini",
+    });
+  });
+
+  it("infers claude for refactor/lint review work", () => {
+    const inferred = inferCronProviderTarget({
+      agentId: "storie",
+      name: "docs-and-canon-review",
+      description: "Review canon drift and clean up docs",
+      payload: {
+        kind: "agentTurn",
+        message:
+          "Refactor the note structure, fix lint-like docs drift, and review contradictions.",
+      },
+    });
+
+    expect(inferred).toMatchObject({
+      providerTarget: "claude",
+    });
+  });
+
+  it("infers codex for implementation-heavy maintenance work", () => {
+    const inferred = inferCronProviderTarget({
+      agentId: "cody",
+      name: "feature-backlog-dispatch",
+      description: "Dispatch implementation backlog",
+      payload: {
+        kind: "agentTurn",
+        message: "Implement one feature, fix test coverage gaps, and scan the repo backlog.",
+      },
+    });
+
+    expect(inferred).toMatchObject({
+      providerTarget: "codex",
+    });
+  });
+
+  it("prefers explicit pacing metadata over inference", () => {
+    const routing = resolveCronProviderRouting({
+      job: {
+        agentId: "leo",
+        name: "leo-nightly-research",
+        description: "Produce one strategy research artifact",
+        pacing: { providerTarget: "claude", role: "maintenance" },
+        payload: {
+          kind: "agentTurn",
+          message: "Do deep research with web_search and summarize market signals.",
+        },
+      },
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(routing).toMatchObject({
+      providerTarget: "claude",
+      source: "explicit",
+      modelRef: "anthropic/claude-opus-4-6",
+    });
+  });
+
+  it("prefers a configured gemini-family allowlist model when current model is not gemini", () => {
+    expect(
+      resolveCronProviderTargetModelRef({
+        providerTarget: "gemini",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        configuredModelRefs: [
+          "anthropic/claude-opus-4-6",
+          "blockrun/google/gemini-3.1-pro",
+          "blockrun/google/gemini-3-flash-preview",
+        ],
+      }),
+    ).toBe("blockrun/google/gemini-3.1-pro");
+  });
+
+  it("falls back to the gemini default model when no configured gemini-family model exists", () => {
+    expect(
+      resolveCronProviderTargetModelRef({
+        providerTarget: "gemini",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      }),
+    ).toBe("google/gemini-3.1-pro-preview");
+  });
+});

--- a/src/cron/provider-routing.ts
+++ b/src/cron/provider-routing.ts
@@ -1,0 +1,335 @@
+import { GOOGLE_GEMINI_DEFAULT_MODEL } from "../commands/google-gemini-model-default.js";
+import { OPENAI_CODEX_DEFAULT_MODEL } from "../commands/openai-codex-model-default.js";
+import type { CronJob } from "./types.js";
+
+type CronProviderTarget = "claude" | "codex" | "gemini";
+
+type CronProviderRoutingJob = Pick<CronJob, "agentId" | "name" | "description" | "payload"> & {
+  pacing?: {
+    providerTarget?: CronProviderTarget;
+    role?: string;
+  };
+};
+
+export type CronProviderInferenceConfidence = "medium" | "high";
+export type CronProviderRoutingSource = "explicit" | "inferred";
+
+export type CronProviderInference = {
+  providerTarget: CronProviderTarget;
+  confidence: CronProviderInferenceConfidence;
+  reason: string;
+};
+
+export type ResolvedCronProviderRouting = CronProviderInference & {
+  source: CronProviderRoutingSource;
+  modelRef: string;
+};
+
+type ScoreCard = Record<CronProviderTarget, number>;
+
+const CLAUDE_PROVIDER_MODEL = "anthropic/claude-sonnet-4-6";
+
+const CODEX_TERMS: Array<[string, number]> = [
+  ["implement", 3],
+  ["implementation", 3],
+  ["feature", 3],
+  ["bugfix", 3],
+  ["bug fix", 3],
+  ["repo", 2],
+  ["code", 2],
+  ["programming", 2],
+  ["test", 2],
+  ["coverage", 2],
+  ["dependency", 2],
+  ["audit", 2],
+  ["dead code", 3],
+  ["dispatch", 2],
+  ["backlog", 2],
+  ["sweep", 2],
+  ["scan", 2],
+];
+
+const CLAUDE_TERMS: Array<[string, number]> = [
+  ["refactor", 4],
+  ["lint", 4],
+  ["cleanup", 3],
+  ["clean up", 3],
+  ["docs drift", 4],
+  ["docs", 2],
+  ["review", 2],
+  ["canon", 3],
+  ["narrative", 2],
+  ["creative", 2],
+  ["visual", 2],
+  ["coaching", 2],
+  ["family", 2],
+  ["brief", 1],
+  ["artifact", 1],
+];
+
+const GEMINI_TERMS: Array<[string, number]> = [
+  ["deep research", 5],
+  ["research brief", 5],
+  ["narrative research", 5],
+  ["market research", 5],
+  ["research", 4],
+  ["web_search", 3],
+  ["web search", 3],
+  ["signal scan", 3],
+  ["signals", 2],
+  ["market", 2],
+  ["competitor", 3],
+  ["compare", 2],
+  ["comparison", 2],
+  ["benchmark", 2],
+  ["survey", 2],
+  ["investigate", 2],
+  ["synthesis", 2],
+  ["synthesize", 2],
+  ["trend", 2],
+  ["monetization", 2],
+];
+
+function buildHaystack(job: Pick<CronJob, "agentId" | "name" | "description" | "payload">): string {
+  const taskText = job.payload.kind === "agentTurn" ? job.payload.message : job.payload.text;
+  return [job.agentId, job.name, job.description, taskText].filter(Boolean).join(" ").toLowerCase();
+}
+
+function applyTermScores(haystack: string, terms: Array<[string, number]>): number {
+  let score = 0;
+  for (const [term, weight] of terms) {
+    if (haystack.includes(term)) {
+      score += weight;
+    }
+  }
+  return score;
+}
+
+function withAgentBias(job: Pick<CronJob, "agentId">, scores: ScoreCard): ScoreCard {
+  const agentId = (job.agentId || "").trim().toLowerCase();
+  if (agentId === "cody" || agentId === "archie") {
+    scores.codex += 1;
+  }
+  if (
+    ["leo", "storie", "artie", "exdi", "grove", "liev", "nesta", "mako", "clawdy"].includes(agentId)
+  ) {
+    scores.claude += 1;
+  }
+  return scores;
+}
+
+export function inferCronProviderTarget(
+  job: Pick<CronJob, "agentId" | "name" | "description" | "payload">,
+): CronProviderInference | null {
+  const haystack = buildHaystack(job);
+  if (!haystack.trim()) {
+    return null;
+  }
+
+  const scores = withAgentBias(job, {
+    codex: applyTermScores(haystack, CODEX_TERMS),
+    claude: applyTermScores(haystack, CLAUDE_TERMS),
+    gemini: applyTermScores(haystack, GEMINI_TERMS),
+  });
+
+  const ranked = (Object.entries(scores) as Array<[CronProviderTarget, number]>).toSorted(
+    (a, b) => b[1] - a[1],
+  );
+  const [winner, winnerScore] = ranked[0] ?? [];
+  const runnerUpScore = ranked[1]?.[1] ?? 0;
+  if (!winner || winnerScore < 3) {
+    return null;
+  }
+  if (winnerScore - runnerUpScore < 2) {
+    return null;
+  }
+
+  const confidence: CronProviderInferenceConfidence = winnerScore >= 6 ? "high" : "medium";
+  if (winner === "gemini") {
+    return { providerTarget: winner, confidence, reason: "research-heavy cron content" };
+  }
+  if (winner === "codex") {
+    return { providerTarget: winner, confidence, reason: "implementation-heavy cron content" };
+  }
+  return { providerTarget: winner, confidence, reason: "review/refactor-heavy cron content" };
+}
+
+function matchesProviderFamily(params: {
+  providerTarget: CronProviderTarget;
+  provider: string;
+  model: string;
+}): boolean {
+  const provider = params.provider.trim().toLowerCase();
+  const model = params.model.trim().toLowerCase();
+  if (params.providerTarget === "claude") {
+    return (
+      provider === "anthropic" ||
+      provider === "claude" ||
+      provider === "claude-cli" ||
+      model.includes("claude")
+    );
+  }
+  if (params.providerTarget === "codex") {
+    return provider === "openai-codex" || provider === "codex-cli" || model.includes("codex");
+  }
+  return (
+    provider === "google" ||
+    provider === "google-gemini-cli" ||
+    provider === "gemini" ||
+    model.includes("gemini")
+  );
+}
+
+function matchesProviderTargetRef(providerTarget: CronProviderTarget, rawRef: string): boolean {
+  const normalized = rawRef.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (providerTarget === "claude") {
+    return normalized.includes("claude");
+  }
+  if (providerTarget === "codex") {
+    return (
+      normalized.startsWith("codex/") ||
+      normalized.startsWith("codex-cli/") ||
+      normalized.includes("codex")
+    );
+  }
+  return normalized.includes("gemini");
+}
+
+function rankConfiguredProviderTargetModelRef(
+  providerTarget: CronProviderTarget,
+  rawRef: string,
+): number {
+  const normalized = rawRef.trim().toLowerCase();
+  if (providerTarget === "claude") {
+    if (normalized.startsWith("anthropic/")) {
+      return 0;
+    }
+    if (normalized.startsWith("claude-cli/")) {
+      return 1;
+    }
+    if (normalized.includes("claude")) {
+      return 2;
+    }
+    return 99;
+  }
+  if (providerTarget === "codex") {
+    if (normalized.startsWith("codex/")) {
+      return 0;
+    }
+    if (normalized.startsWith("codex-cli/")) {
+      return 1;
+    }
+    if (normalized.includes("codex")) {
+      return 2;
+    }
+    return 99;
+  }
+  if (normalized.startsWith("google/")) {
+    if (normalized.includes("pro")) {
+      return 0;
+    }
+    if (normalized.includes("flash")) {
+      return 1;
+    }
+    return 2;
+  }
+  if (normalized.startsWith("blockrun/google/")) {
+    if (normalized.includes("pro")) {
+      return 3;
+    }
+    if (normalized.includes("flash")) {
+      return 4;
+    }
+    return 5;
+  }
+  if (normalized.includes("gemini")) {
+    return 6;
+  }
+  return 99;
+}
+
+function findConfiguredProviderTargetModelRef(params: {
+  providerTarget: CronProviderTarget;
+  configuredModelRefs?: string[];
+}): string | null {
+  const matches = (params.configuredModelRefs ?? []).filter((rawRef) =>
+    matchesProviderTargetRef(params.providerTarget, rawRef),
+  );
+  if (matches.length === 0) {
+    return null;
+  }
+  return (
+    matches.toSorted((a, b) => {
+      const rankDiff =
+        rankConfiguredProviderTargetModelRef(params.providerTarget, a) -
+        rankConfiguredProviderTargetModelRef(params.providerTarget, b);
+      return rankDiff !== 0 ? rankDiff : a.localeCompare(b);
+    })[0] ?? null
+  );
+}
+
+export function resolveCronProviderTargetModelRef(params: {
+  providerTarget: CronProviderTarget;
+  provider: string;
+  model: string;
+  configuredModelRefs?: string[];
+}): string {
+  if (matchesProviderFamily(params)) {
+    return `${params.provider}/${params.model}`;
+  }
+  const configuredMatch = findConfiguredProviderTargetModelRef({
+    providerTarget: params.providerTarget,
+    configuredModelRefs: params.configuredModelRefs,
+  });
+  if (configuredMatch) {
+    return configuredMatch;
+  }
+  if (params.providerTarget === "codex") {
+    return OPENAI_CODEX_DEFAULT_MODEL;
+  }
+  if (params.providerTarget === "gemini") {
+    return GOOGLE_GEMINI_DEFAULT_MODEL;
+  }
+  return CLAUDE_PROVIDER_MODEL;
+}
+
+export function resolveCronProviderRouting(params: {
+  job: CronProviderRoutingJob;
+  provider: string;
+  model: string;
+  configuredModelRefs?: string[];
+}): ResolvedCronProviderRouting | null {
+  const explicit = params.job.pacing?.providerTarget;
+  if (explicit === "claude" || explicit === "codex" || explicit === "gemini") {
+    return {
+      providerTarget: explicit,
+      source: "explicit",
+      confidence: "high",
+      reason: "explicit provider ownership tag",
+      modelRef: resolveCronProviderTargetModelRef({
+        providerTarget: explicit,
+        provider: params.provider,
+        model: params.model,
+        configuredModelRefs: params.configuredModelRefs,
+      }),
+    };
+  }
+
+  const inferred = inferCronProviderTarget(params.job);
+  if (!inferred) {
+    return null;
+  }
+  return {
+    ...inferred,
+    source: "inferred",
+    modelRef: resolveCronProviderTargetModelRef({
+      providerTarget: inferred.providerTarget,
+      provider: params.provider,
+      model: params.model,
+      configuredModelRefs: params.configuredModelRefs,
+    }),
+  };
+}

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1409,6 +1409,60 @@ describe("loadOpenClawPlugins", () => {
     expect(overridden?.origin).toBe("bundled");
   });
 
+  it("prefers the active bundled plugin over a config load path into another OpenClaw checkout's bundled extension", () => {
+    const bundledDir = makeTempDir();
+    writePlugin({
+      id: "shadow",
+      body: `module.exports = { id: "shadow", register() {} };`,
+      dir: bundledDir,
+      filename: "shadow.cjs",
+    });
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+    const externalRoot = makeTempDir();
+    fs.writeFileSync(
+      path.join(externalRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "0.0.0-test" }, null, 2),
+      "utf-8",
+    );
+    const externalPluginDir = path.join(externalRoot, "extensions", "shadow");
+    fs.mkdirSync(externalPluginDir, { recursive: true });
+    writePlugin({
+      id: "shadow",
+      body: `module.exports = { id: "shadow", register() {} };`,
+      dir: externalPluginDir,
+      filename: "index.cjs",
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          allow: ["shadow"],
+          load: { paths: [externalPluginDir] },
+          entries: {
+            shadow: { enabled: true },
+          },
+        },
+      },
+    });
+
+    const entries = registry.plugins.filter((entry) => entry.id === "shadow");
+    const loaded = entries.find((entry) => entry.status === "loaded");
+    const overridden = entries.find((entry) => entry.status === "disabled");
+    expect(loaded?.origin).toBe("bundled");
+    expect(overridden?.origin).toBe("config");
+    expect(overridden?.error).toContain("overridden by bundled plugin");
+    expect(
+      registry.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.pluginId === "shadow" &&
+          diagnostic.level === "warn" &&
+          diagnostic.message?.includes("another OpenClaw checkout's bundled plugin"),
+      ),
+    ).toBe(true);
+  });
+
   it("prefers bundled plugin over auto-discovered global duplicate ids", () => {
     const bundledDir = makeTempDir();
     writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -9,6 +9,7 @@ import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
+import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { clearPluginCommands } from "./commands.js";
 import {
   applyTestPluginDefaults,
@@ -17,9 +18,9 @@ import {
   resolveMemorySlotDecision,
   type NormalizedPluginsConfig,
 } from "./config-state.js";
-import { discoverOpenClawPlugins } from "./discovery.js";
+import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
 import { initializeGlobalHookRunner } from "./hook-runner-global.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
 import { isPathInside, safeStatSync } from "./path-safety.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
 import { resolvePluginCacheInputs } from "./roots.js";
@@ -364,6 +365,16 @@ type PluginProvenanceIndex = {
   installRules: Map<string, InstallTrackingRule>;
 };
 
+type ResolvedDiscoveredPlugin = {
+  candidate: PluginCandidate;
+  manifestRecord: PluginManifestRecord;
+};
+
+type PreferredPluginSelection = {
+  preferredRootById: Map<string, string>;
+  shadowedConfigSourcesById: Map<string, string[]>;
+};
+
 function createPathMatcher(): PathMatcher {
   return { exact: new Set<string>(), dirs: [] };
 }
@@ -509,6 +520,112 @@ function warnAboutUntrackedLoadedPlugins(params: {
   }
 }
 
+function isConfigShadowingBundledPlugin(params: {
+  candidate: PluginCandidate;
+  activeBundledDir?: string | null;
+}): boolean {
+  if (params.candidate.origin !== "config") {
+    return false;
+  }
+  const candidateRoot = resolveUserPath(params.candidate.rootDir);
+  const activeBundledDir = params.activeBundledDir
+    ? resolveUserPath(params.activeBundledDir)
+    : null;
+  if (
+    activeBundledDir &&
+    (candidateRoot === activeBundledDir || isPathInside(activeBundledDir, candidateRoot))
+  ) {
+    return false;
+  }
+  const candidatePackageRoot = resolveOpenClawPackageRootSync({ cwd: candidateRoot });
+  if (!candidatePackageRoot) {
+    return false;
+  }
+  const candidateBundledDir = path.join(candidatePackageRoot, "extensions");
+  return candidateRoot === candidateBundledDir || isPathInside(candidateBundledDir, candidateRoot);
+}
+
+function choosePreferredDiscoveredPlugin(params: {
+  current: ResolvedDiscoveredPlugin;
+  next: ResolvedDiscoveredPlugin;
+  activeBundledDir?: string | null;
+}): ResolvedDiscoveredPlugin {
+  const currentIsBundled = params.current.candidate.origin === "bundled";
+  const nextIsBundled = params.next.candidate.origin === "bundled";
+  if (currentIsBundled === nextIsBundled) {
+    return params.current;
+  }
+  if (
+    currentIsBundled &&
+    isConfigShadowingBundledPlugin({
+      candidate: params.next.candidate,
+      activeBundledDir: params.activeBundledDir,
+    })
+  ) {
+    return params.current;
+  }
+  if (
+    nextIsBundled &&
+    isConfigShadowingBundledPlugin({
+      candidate: params.current.candidate,
+      activeBundledDir: params.activeBundledDir,
+    })
+  ) {
+    return params.next;
+  }
+  return params.current;
+}
+
+function buildPreferredPluginSelection(
+  discoveredPlugins: ResolvedDiscoveredPlugin[],
+): PreferredPluginSelection {
+  const groupedById = new Map<string, ResolvedDiscoveredPlugin[]>();
+  for (const entry of discoveredPlugins) {
+    const existing = groupedById.get(entry.manifestRecord.id);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      groupedById.set(entry.manifestRecord.id, [entry]);
+    }
+  }
+
+  const activeBundledDir = resolveBundledPluginsDir();
+  const preferredRootById = new Map<string, string>();
+  const shadowedConfigSourcesById = new Map<string, string[]>();
+  for (const [pluginId, entries] of groupedById.entries()) {
+    let preferred = entries[0];
+    for (const entry of entries.slice(1)) {
+      preferred = choosePreferredDiscoveredPlugin({
+        current: preferred,
+        next: entry,
+        activeBundledDir,
+      });
+    }
+    preferredRootById.set(pluginId, preferred.candidate.rootDir);
+
+    if (preferred.candidate.origin !== "bundled") {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.candidate.rootDir === preferred.candidate.rootDir) {
+        continue;
+      }
+      if (
+        isConfigShadowingBundledPlugin({
+          candidate: entry.candidate,
+          activeBundledDir,
+        })
+      ) {
+        const existing = shadowedConfigSourcesById.get(pluginId) ?? [];
+        existing.push(entry.candidate.source);
+        shadowedConfigSourcesById.set(pluginId, existing);
+      }
+    }
+  }
+
+  return { preferredRootById, shadowedConfigSourcesById };
+}
+
 function activatePluginRegistry(registry: PluginRegistry, cacheKey: string): void {
   setActivePluginRegistry(registry, cacheKey);
   initializeGlobalHookRunner(registry);
@@ -636,18 +753,52 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const manifestByRoot = new Map(
     manifestRegistry.plugins.map((record) => [record.rootDir, record]),
   );
+  const discoveredPlugins: ResolvedDiscoveredPlugin[] = [];
+  for (const candidate of discovery.candidates) {
+    const manifestRecord = manifestByRoot.get(candidate.rootDir);
+    if (!manifestRecord) {
+      continue;
+    }
+    discoveredPlugins.push({ candidate, manifestRecord });
+  }
+  const preferredSelection = buildPreferredPluginSelection(discoveredPlugins);
+  for (const [pluginId, sources] of preferredSelection.shadowedConfigSourcesById.entries()) {
+    for (const source of sources) {
+      registry.diagnostics.push({
+        level: "warn",
+        pluginId,
+        source,
+        message:
+          "config load path points at another OpenClaw checkout's bundled plugin; using the active bundled plugin instead",
+      });
+    }
+  }
 
   const seenIds = new Map<string, PluginRecord["origin"]>();
   const memorySlot = normalized.slots.memory;
   let selectedMemoryPluginId: string | null = null;
   let memorySlotMatched = false;
 
-  for (const candidate of discovery.candidates) {
-    const manifestRecord = manifestByRoot.get(candidate.rootDir);
-    if (!manifestRecord) {
+  for (const { candidate, manifestRecord } of discoveredPlugins) {
+    const pluginId = manifestRecord.id;
+    const preferredRoot = preferredSelection.preferredRootById.get(pluginId);
+    if (preferredRoot && preferredRoot !== candidate.rootDir) {
+      const record = createPluginRecord({
+        id: pluginId,
+        name: manifestRecord.name ?? pluginId,
+        description: manifestRecord.description,
+        version: manifestRecord.version,
+        source: candidate.source,
+        origin: candidate.origin,
+        workspaceDir: candidate.workspaceDir,
+        enabled: false,
+        configSchema: Boolean(manifestRecord.configSchema),
+      });
+      record.status = "disabled";
+      record.error = "overridden by bundled plugin";
+      registry.plugins.push(record);
       continue;
     }
-    const pluginId = manifestRecord.id;
     const existingOrigin = seenIds.get(pluginId);
     if (existingOrigin) {
       const record = createPluginRecord({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -545,6 +545,9 @@ function isConfigShadowingBundledPlugin(params: {
   return candidateRoot === candidateBundledDir || isPathInside(candidateBundledDir, candidateRoot);
 }
 
+// Explicitly configured/workspace plugins may override bundled plugins. The only
+// exception here is a config load path that points into another OpenClaw checkout
+//'s bundled extensions, which should defer to the active checkout's bundled copy.
 function choosePreferredDiscoveredPlugin(params: {
   current: ResolvedDiscoveredPlugin;
   next: ResolvedDiscoveredPlugin;


### PR DESCRIPTION
## Summary

This PR is a clean upstream-based version of the earlier closed PRs. It is one commit on top of `openclaw/openclaw:main` and narrows the scope to three runtime fixes:

1. **Prevent cron lane self-deadlock**
   - Map inner embedded `cron` runs onto the nested lane instead of re-enqueueing onto the already-occupied global cron lane.

2. **Harden cron provider routing**
   - Add provider-target resolution for cron jobs.
   - If a cron job has an explicit provider target and that target cannot be resolved, fail instead of silently falling back to another provider.
   - For isolated embedded cron runs, force `execOverrides.ask = "off"` so unattended jobs do not block on approval-pending exec.

3. **Prefer the active checkout's bundled plugin over stale config-shadowed bundled paths**
   - If config load paths point into another OpenClaw checkout's bundled `extensions/`, prefer the active checkout's bundled plugin and emit a warning diagnostic.

## Why this PR exists

The earlier PRs were auto-closed because the branches were not based on upstream `main`, so GitHub saw a large unrelated diff. This branch is rebased cleanly onto `upstream/main` and contains only the intended changes.

## Validation

### Clean branch shape
- `git rev-list --left-right --count upstream/main...HEAD` → `0 1`
- `git diff --stat upstream/main...HEAD` → 8 files

### Focused tests
- `src/agents/pi-embedded-runner/lanes.test.ts`
- `src/cron/provider-routing.test.ts`
- `src/cron/isolated-agent/run.cron-model-override.test.ts`
- `src/plugins/loader.test.ts`

### Prior runtime verification for this patch set
Performed on the original task worktree before recreating this clean upstream branch:
- explicit Gemini cron targeting no longer silently falls back to Codex
- isolated unattended cron runs pass `execOverrides.ask = "off"`
- gateway plugin load with real config: ~1.3s
- gateway bind with real config: ~4s

## Notes

- This clean upstream branch intentionally excludes the earlier Zulip-specific lazy-import change because `upstream/main` no longer contains that extension path.
