### PR TITLE
test: annotate CI fixture cases

### DIFF
--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -251,7 +251,7 @@ describe("resolveGatewayRuntimeConfig", () => {
   });
 
   describe("HTTP security headers", () => {
-    it.each([
+    const securityHeaderCases = [
       {
         name: "resolves strict transport security headers from config",
         strictTransportSecurity: "  max-age=31536000; includeSubDomains  ",
@@ -267,7 +267,13 @@ describe("resolveGatewayRuntimeConfig", () => {
         strictTransportSecurity: "   ",
         expected: undefined,
       },
-    ])("$name", async ({ strictTransportSecurity, expected }) => {
+    ] satisfies Array<{
+      name: string;
+      strictTransportSecurity: string | false;
+      expected: string | undefined;
+    }>;
+
+    it.each(securityHeaderCases)("$name", async ({ strictTransportSecurity, expected }) => {
       const result = await resolveGatewayRuntimeConfig({
         cfg: {
           gateway: {

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -355,7 +355,7 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.threadId, params.name).toBe(params.expectedThreadId);
   };
 
-  it.each([
+  const heartbeatTargetCases = [
     {
       name: "allows heartbeat delivery to Slack DMs by default and drops inherited thread ids",
       entry: {
@@ -462,16 +462,28 @@ describe("resolveSessionDeliveryTarget", () => {
       expectedChannel: "none",
       expectedReason: "dm-blocked",
     },
-  ])("$name", ({ name, entry, directPolicy, expectedChannel, expectedTo, expectedReason }) => {
-    expectHeartbeatTarget({
-      name,
-      entry,
-      directPolicy,
-      expectedChannel,
-      expectedTo,
-      expectedReason,
-    });
-  });
+  ] satisfies Array<{
+    name: string;
+    entry: Parameters<typeof resolveHeartbeatDeliveryTarget>[0]["entry"];
+    directPolicy?: "allow" | "block";
+    expectedChannel: string;
+    expectedTo?: string;
+    expectedReason?: string;
+  }>;
+
+  it.each(heartbeatTargetCases)(
+    "$name",
+    ({ name, entry, directPolicy, expectedChannel, expectedTo, expectedReason }) => {
+      expectHeartbeatTarget({
+        name,
+        entry,
+        directPolicy,
+        expectedChannel,
+        expectedTo,
+        expectedReason,
+      });
+    },
+  );
 
   it("allows heartbeat delivery to Discord DMs by default", () => {
     const cfg: OpenClawConfig = {};


### PR DESCRIPTION
## Summary
- add explicit typed fixture arrays in `server-runtime-config.test.ts`
- add explicit typed fixture arrays in `targets.test.ts`
- unblock `pnpm tsgo` / CI `check` after the latest `main` type inference drift

## Verification
- `pnpm tsgo`
- `pnpm exec vitest run src/gateway/server-runtime-config.test.ts src/infra/outbound/targets.test.ts`
- `pnpm check`
