### PR TITLE
fix(gateway): keep BB webhook routes alive across reloads and restarts

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -248,6 +248,7 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
   const pluginRegistry = loadOpenClawPlugins({
     config: cfg,
     cache: true,
+    activate: false,
     workspaceDir,
     logger: {
       info: () => {},

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -5,6 +5,7 @@ import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -129,6 +130,10 @@ export async function createGatewayRuntimeState(params: {
     log: params.logPlugins,
   });
   const shouldEnforcePluginGatewayAuth = (pathContext: PluginRoutePathContext): boolean => {
+    const activeRegistry = getActivePluginRegistry();
+    if (activeRegistry && shouldEnforceGatewayAuthForPluginPath(activeRegistry, pathContext)) {
+      return true;
+    }
     return shouldEnforceGatewayAuthForPluginPath(params.pluginRegistry, pathContext);
   };
 

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "../server-methods/types.js";
 import { makeMockHttpResponse } from "../test-http-response.js";
@@ -31,6 +32,29 @@ type PluginHandlerLog = Parameters<typeof createGatewayPluginRequestHandler>[0][
 function createPluginLog(): PluginHandlerLog {
   return { warn: vi.fn() } as unknown as PluginHandlerLog;
 }
+
+function createHandlerWithRegistry(params: {
+  registry: Parameters<typeof createGatewayPluginRequestHandler>[0]["registry"];
+  log?: PluginHandlerLog;
+}) {
+  setActivePluginRegistry(params.registry);
+  return createGatewayPluginRequestHandler({
+    registry: params.registry,
+    log: params.log ?? createPluginLog(),
+  });
+}
+
+let previousRegistry = getActivePluginRegistry();
+
+beforeEach(() => {
+  previousRegistry = getActivePluginRegistry();
+});
+
+afterEach(() => {
+  if (previousRegistry) {
+    setActivePluginRegistry(previousRegistry);
+  }
+});
 
 function createRoute(params: {
   path: string;
@@ -104,7 +128,7 @@ describe("createGatewayPluginRequestHandler", () => {
 
     const subagent = await createSubagentRuntime();
     const log = createPluginLog();
-    const handler = createGatewayPluginRequestHandler({
+    const handler = createHandlerWithRegistry({
       registry: createTestRegistry({
         httpRoutes: [
           createRoute({
@@ -138,10 +162,7 @@ describe("createGatewayPluginRequestHandler", () => {
 
   it("returns false when no routes are registered", async () => {
     const log = createPluginLog();
-    const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry(),
-      log,
-    });
+    const handler = createHandlerWithRegistry({ registry: createTestRegistry(), log });
     const { res } = makeMockHttpResponse();
     const handled = await handler({} as IncomingMessage, res);
     expect(handled).toBe(false);
@@ -151,11 +172,10 @@ describe("createGatewayPluginRequestHandler", () => {
     const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
       res.statusCode = 200;
     });
-    const handler = createGatewayPluginRequestHandler({
+    const handler = createHandlerWithRegistry({
       registry: createTestRegistry({
         httpRoutes: [createRoute({ path: "/demo", handler: routeHandler })],
       }),
-      log: createPluginLog(),
     });
 
     const { res } = makeMockHttpResponse();
@@ -169,14 +189,13 @@ describe("createGatewayPluginRequestHandler", () => {
       res.statusCode = 200;
     });
     const prefixHandler = vi.fn(async () => true);
-    const handler = createGatewayPluginRequestHandler({
+    const handler = createHandlerWithRegistry({
       registry: createTestRegistry({
         httpRoutes: [
           createRoute({ path: "/api", match: "prefix", handler: prefixHandler }),
           createRoute({ path: "/api/demo", match: "exact", handler: exactHandler }),
         ],
       }),
-      log: createPluginLog(),
     });
 
     const { res } = makeMockHttpResponse();
@@ -189,14 +208,13 @@ describe("createGatewayPluginRequestHandler", () => {
   it("supports route fallthrough when handler returns false", async () => {
     const first = vi.fn(async () => false);
     const second = vi.fn(async () => true);
-    const handler = createGatewayPluginRequestHandler({
+    const handler = createHandlerWithRegistry({
       registry: createTestRegistry({
         httpRoutes: [
           createRoute({ path: "/hook", match: "exact", handler: first }),
           createRoute({ path: "/hook", match: "prefix", handler: second }),
         ],
       }),
-      log: createPluginLog(),
     });
 
     const { res } = makeMockHttpResponse();
@@ -209,7 +227,7 @@ describe("createGatewayPluginRequestHandler", () => {
   it("fails closed when a matched gateway route reaches dispatch without auth", async () => {
     const exactPluginHandler = vi.fn(async () => false);
     const prefixGatewayHandler = vi.fn(async () => true);
-    const handler = createGatewayPluginRequestHandler({
+    const handler = createHandlerWithRegistry({
       registry: createTestRegistry({
         httpRoutes: [
           createRoute({
@@ -226,7 +244,6 @@ describe("createGatewayPluginRequestHandler", () => {
           }),
         ],
       }),
-      log: createPluginLog(),
     });
 
     const { res } = makeMockHttpResponse();
@@ -246,7 +263,7 @@ describe("createGatewayPluginRequestHandler", () => {
   it("allows gateway route fallthrough only after gateway auth succeeds", async () => {
     const exactPluginHandler = vi.fn(async () => false);
     const prefixGatewayHandler = vi.fn(async () => true);
-    const handler = createGatewayPluginRequestHandler({
+    const handler = createHandlerWithRegistry({
       registry: createTestRegistry({
         httpRoutes: [
           createRoute({
@@ -263,7 +280,6 @@ describe("createGatewayPluginRequestHandler", () => {
           }),
         ],
       }),
-      log: createPluginLog(),
     });
 
     const { res } = makeMockHttpResponse();
@@ -284,11 +300,10 @@ describe("createGatewayPluginRequestHandler", () => {
     const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
       res.statusCode = 200;
     });
-    const handler = createGatewayPluginRequestHandler({
+    const handler = createHandlerWithRegistry({
       registry: createTestRegistry({
         httpRoutes: [createRoute({ path: "/api/demo", handler: routeHandler })],
       }),
-      log: createPluginLog(),
     });
 
     const { res } = makeMockHttpResponse();
@@ -297,9 +312,53 @@ describe("createGatewayPluginRequestHandler", () => {
     expect(routeHandler).toHaveBeenCalledTimes(1);
   });
 
+  it("uses the current active plugin registry after registry swaps", async () => {
+    const staleHandler = vi.fn(async () => true);
+    const liveHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 204;
+      return true;
+    });
+    const staleRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/stale", handler: staleHandler })],
+    });
+    setActivePluginRegistry(staleRegistry);
+    const handler = createHandlerWithRegistry({ registry: staleRegistry });
+
+    const liveRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/live", handler: liveHandler })],
+    });
+    setActivePluginRegistry(liveRegistry);
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/live" } as IncomingMessage, res);
+
+    expect(handled).toBe(true);
+    expect(liveHandler).toHaveBeenCalledTimes(1);
+    expect(staleHandler).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the startup registry when the active registry loses the route", async () => {
+    const startupHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 202;
+      return true;
+    });
+    const startupRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/hook", handler: startupHandler })],
+    });
+    const handler = createHandlerWithRegistry({ registry: startupRegistry });
+
+    setActivePluginRegistry(createTestRegistry());
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/hook" } as IncomingMessage, res);
+
+    expect(handled).toBe(true);
+    expect(startupHandler).toHaveBeenCalledTimes(1);
+  });
+
   it("logs and responds with 500 when a route throws", async () => {
     const log = createPluginLog();
-    const handler = createGatewayPluginRequestHandler({
+    const handler = createHandlerWithRegistry({
       registry: createTestRegistry({
         httpRoutes: [
           createRoute({

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -48,9 +48,13 @@ let previousRegistry = getActivePluginRegistry();
 
 beforeEach(() => {
   previousRegistry = getActivePluginRegistry();
+  (process as typeof process & { __openclawPluginRegistry?: unknown }).__openclawPluginRegistry =
+    undefined;
 });
 
 afterEach(() => {
+  (process as typeof process & { __openclawPluginRegistry?: unknown }).__openclawPluginRegistry =
+    undefined;
   if (previousRegistry) {
     setActivePluginRegistry(previousRegistry);
   }
@@ -354,6 +358,25 @@ describe("createGatewayPluginRequestHandler", () => {
 
     expect(handled).toBe(true);
     expect(startupHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches routes from the process-backed registry when the local realm is empty", async () => {
+    const liveHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 204;
+      return true;
+    });
+    const handler = createHandlerWithRegistry({ registry: createTestRegistry() });
+    const liveRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/cross-realm", handler: liveHandler })],
+    });
+    (process as typeof process & { __openclawPluginRegistry?: unknown }).__openclawPluginRegistry =
+      liveRegistry;
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/cross-realm" } as IncomingMessage, res);
+
+    expect(handled).toBe(true);
+    expect(liveHandler).toHaveBeenCalledTimes(1);
   });
 
   it("logs and responds with 500 when a route throws", async () => {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, PAIRING_SCOPE, WRITE_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
@@ -25,6 +26,14 @@ export {
 export { shouldEnforceGatewayAuthForPluginPath } from "./plugins-http/route-auth.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+
+function resolveCandidateRegistries(initialRegistry: PluginRegistry): PluginRegistry[] {
+  const activeRegistry = getActivePluginRegistry();
+  if (!activeRegistry || activeRegistry === initialRegistry) {
+    return [initialRegistry];
+  }
+  return [activeRegistry, initialRegistry];
+}
 
 function createPluginRouteRuntimeClient(params: {
   requiresGatewayAuth: boolean;
@@ -63,21 +72,34 @@ export function createGatewayPluginRequestHandler(params: {
   registry: PluginRegistry;
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
-  const { registry, log } = params;
+  const { registry: initialRegistry, log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
-    const routes = registry.httpRoutes ?? [];
-    if (routes.length === 0) {
-      return false;
-    }
-
     const pathContext =
       providedPathContext ??
       (() => {
         const url = new URL(req.url ?? "/", "http://localhost");
         return resolvePluginRoutePathContext(url.pathname);
       })();
-    const matchedRoutes = findMatchingPluginHttpRoutes(registry, pathContext);
-    if (matchedRoutes.length === 0) {
+
+    // Route registrations can temporarily live on either the current active
+    // registry or the startup snapshot during config/plugin churn. Check both
+    // so webhooks keep resolving across registry swaps in either direction.
+    let registry: PluginRegistry | null = null;
+    let matchedRoutes: ReturnType<typeof findMatchingPluginHttpRoutes> | null = null;
+    for (const candidate of resolveCandidateRegistries(initialRegistry)) {
+      const routes = candidate.httpRoutes ?? [];
+      if (routes.length === 0) {
+        continue;
+      }
+      const candidateMatches = findMatchingPluginHttpRoutes(candidate, pathContext);
+      if (candidateMatches.length === 0) {
+        continue;
+      }
+      registry = candidate;
+      matchedRoutes = candidateMatches;
+      break;
+    }
+    if (!registry || !matchedRoutes) {
       return false;
     }
     const requiresGatewayAuth = matchedPluginRoutesRequireGatewayAuth(matchedRoutes);

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -26,6 +26,9 @@ export {
 export { shouldEnforceGatewayAuthForPluginPath } from "./plugins-http/route-auth.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+type ProcessWithPluginRegistry = typeof process & {
+  __openclawPluginRegistry?: PluginRegistry;
+};
 
 function resolveCandidateRegistries(initialRegistry: PluginRegistry): PluginRegistry[] {
   const activeRegistry = getActivePluginRegistry();
@@ -73,6 +76,10 @@ export function createGatewayPluginRequestHandler(params: {
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
   const { registry: initialRegistry, log } = params;
+  // jiti plugin loading can create a separate VM realm from the gateway HTTP
+  // server. Persist the live registry on process so route matching can still
+  // see plugin-owned webhooks from either side.
+  (process as ProcessWithPluginRegistry).__openclawPluginRegistry = initialRegistry;
   return async (req, res, providedPathContext, dispatchContext) => {
     const pathContext =
       providedPathContext ??
@@ -87,10 +94,6 @@ export function createGatewayPluginRequestHandler(params: {
     let registry: PluginRegistry | null = null;
     let matchedRoutes: ReturnType<typeof findMatchingPluginHttpRoutes> | null = null;
     for (const candidate of resolveCandidateRegistries(initialRegistry)) {
-      const routes = candidate.httpRoutes ?? [];
-      if (routes.length === 0) {
-        continue;
-      }
       const candidateMatches = findMatchingPluginHttpRoutes(candidate, pathContext);
       if (candidateMatches.length === 0) {
         continue;

--- a/src/gateway/server/plugins-http/route-match.ts
+++ b/src/gateway/server/plugins-http/route-match.ts
@@ -7,6 +7,17 @@ import {
 } from "./path-context.js";
 
 type PluginHttpRouteEntry = NonNullable<PluginRegistry["httpRoutes"]>[number];
+type ProcessWithPluginRegistry = typeof process & {
+  __openclawPluginRegistry?: PluginRegistry;
+};
+
+function resolveCandidateRoutes(registry: PluginRegistry): PluginHttpRouteEntry[] {
+  const ownRoutes = registry.httpRoutes ?? [];
+  const liveRegistry = (process as ProcessWithPluginRegistry).__openclawPluginRegistry;
+  const liveRoutes =
+    liveRegistry && liveRegistry !== registry ? (liveRegistry.httpRoutes ?? []) : [];
+  return liveRoutes.length > 0 ? [...ownRoutes, ...liveRoutes] : ownRoutes;
+}
 
 export function doesPluginRouteMatchPath(
   route: PluginHttpRouteEntry,
@@ -23,7 +34,7 @@ export function findMatchingPluginHttpRoutes(
   registry: PluginRegistry,
   context: PluginRoutePathContext,
 ): PluginHttpRouteEntry[] {
-  const routes = registry.httpRoutes ?? [];
+  const routes = resolveCandidateRoutes(registry);
   if (routes.length === 0) {
     return [];
   }

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -14,15 +14,17 @@ async function importFreshPluginTestModules() {
   vi.unmock("./hooks.js");
   vi.unmock("./loader.js");
   vi.unmock("jiti");
-  const [loader, hookRunnerGlobal, hooks] = await Promise.all([
+  const [loader, hookRunnerGlobal, hooks, runtime] = await Promise.all([
     import("./loader.js"),
     import("./hook-runner-global.js"),
     import("./hooks.js"),
+    import("./runtime.js"),
   ]);
   return {
     ...loader,
     ...hookRunnerGlobal,
     ...hooks,
+    ...runtime,
   };
 }
 
@@ -30,9 +32,11 @@ const {
   __testing,
   clearPluginLoaderCache,
   createHookRunner,
+  getActivePluginRegistry,
   getGlobalHookRunner,
   loadOpenClawPlugins,
   resetGlobalHookRunner,
+  setActivePluginRegistry,
 } = await importFreshPluginTestModules();
 const previousUmask = process.umask(0o022);
 
@@ -470,6 +474,51 @@ describe("loadOpenClawPlugins", () => {
     expect(getGlobalHookRunner()).not.toBeNull();
 
     resetGlobalHookRunner();
+  });
+
+  it("keeps the live registry unchanged when loading read-only registries", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const activePlugin = writePlugin({
+      id: "active-registry",
+      filename: "active-registry.cjs",
+      body: `module.exports = { id: "active-registry", register() {} };`,
+    });
+    const readOnlyPlugin = writePlugin({
+      id: "read-only-registry",
+      filename: "read-only-registry.cjs",
+      body: `module.exports = { id: "read-only-registry", register() {} };`,
+    });
+
+    const activeRegistry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: activePlugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [activePlugin.file] },
+          allow: ["active-registry"],
+        },
+      },
+    });
+    setActivePluginRegistry(activeRegistry, "live-registry");
+
+    const readOnlyOptions = {
+      activate: false,
+      cache: true,
+      workspaceDir: readOnlyPlugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [readOnlyPlugin.file] },
+          allow: ["read-only-registry"],
+        },
+      },
+    } satisfies Parameters<typeof loadOpenClawPlugins>[0];
+
+    const first = loadOpenClawPlugins(readOnlyOptions);
+    const second = loadOpenClawPlugins(readOnlyOptions);
+
+    expect(first.plugins.some((entry) => entry.id === "read-only-registry")).toBe(true);
+    expect(second).toBe(first);
+    expect(getActivePluginRegistry()).toBe(activeRegistry);
   });
 
   it("does not reuse cached bundled plugin registries across env changes", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -46,6 +46,7 @@ export type PluginLoadOptions = {
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   runtimeOptions?: CreatePluginRuntimeOptions;
   cache?: boolean;
+  activate?: boolean;
   mode?: "full" | "validate";
 };
 
@@ -529,10 +530,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     env,
   });
   const cacheEnabled = options.cache !== false;
+  const shouldActivate = options.activate !== false;
   if (cacheEnabled) {
     const cached = getCachedPluginRegistry(cacheKey);
     if (cached) {
-      activatePluginRegistry(cached, cacheKey);
+      if (shouldActivate) {
+        activatePluginRegistry(cached, cacheKey);
+      }
       return cached;
     }
   }
@@ -892,7 +896,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   if (cacheEnabled) {
     setCachedPluginRegistry(cacheKey, registry);
   }
-  activatePluginRegistry(registry, cacheKey);
+  if (shouldActivate) {
+    activatePluginRegistry(registry, cacheKey);
+  }
   return registry;
 }
 


### PR DESCRIPTION
## Summary

- Fix BlueBubbles webhook routes going missing after config/plugin registry churn.
- Fix BlueBubbles webhook routes going missing again after a gateway restart when jiti plugin loading crosses VM realms.
- Keep scope tight to gateway plugin-route lookup and matching; no payload parsing or outbound BB behavior changes.

## Problem

There were two distinct gateway-side failure modes that both surfaced as BlueBubbles inbound webhooks returning `404 Not Found` even though logs still reported `BlueBubbles webhook listening`:

1. After config reloads or read-only plugin loads, the live plugin registry could move while the HTTP handler still consulted the startup snapshot.
2. After restart, jiti plugin loading could register plugin routes in a different VM realm, leaving the HTTP handler with a registry object whose local `httpRoutes` array appeared empty.

In both cases, BlueBubbles looked connected, but inbound messages stopped reaching the agent because the live gateway route lookup no longer saw the webhook.

## What changed

- Plugin HTTP request handling now prefers the current active registry but falls back to the startup registry when needed.
- Read-only plugin loads no longer replace the live registry.
- Plugin route matching now also consults the authoritative process-backed registry when a jiti realm exposes an empty local route table.
- The request handler no longer short-circuits just because the current candidate registry reports an empty `httpRoutes` array.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #45015
- Supersedes closed #45186

## User-visible / Behavior Changes

- BlueBubbles inbound webhooks remain reachable after config reloads and after gateway restarts instead of intermittently falling back to `404 Not Found`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, local gateway from source
- Model/provider: n/a
- Integration/channel (if any): BlueBubbles
- Relevant config (redacted): gateway with both Telegram and BlueBubbles enabled; BlueBubbles webhook configured on `/bluebubbles-webhook`

### Steps

1. Start the gateway with BlueBubbles enabled.
2. Trigger either a config/plugin registry churn path or a full gateway restart.
3. POST to the configured BlueBubbles webhook URL or send a BlueBubbles message.

### Expected

- The BlueBubbles webhook route remains mounted on the live gateway and inbound messages continue routing normally.

### Actual

- The provider logs still said `BlueBubbles webhook listening`, but the live gateway returned `404 Not Found` because route lookup no longer saw the webhook on the effective registry path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Before the restart/jiti-realm fix, manual POST to the configured BlueBubbles webhook URL returned `404 Not Found` after restart.
- After the fix, the same URL returned `400 invalid payload`, confirming the route was mounted again and only the intentionally malformed test payload was rejected.
- `node dist/index.js channels status --probe` reported BlueBubbles `running`, `connected`, `works` after rebuild/restart.
- Verified targeted regression tests for both registry-churn and webhook-route matching paths.
- Did not run the full cross-platform CI matrix locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `438fd245b` and `0217e3440`
- Files/config to restore: `src/gateway/server/plugins-http.ts`, `src/gateway/server/plugins-http/route-match.ts`, `src/gateway/server/plugins-http.test.ts`, `src/gateway/server-runtime-state.ts`, `src/gateway/server-methods/config.ts`, `src/plugins/loader.ts`, `src/plugins/loader.test.ts`
- Known bad symptoms reviewers should watch for: plugin webhook routes unexpectedly shadowing or disappearing after config churn or restart

## Risks and Mitigations

- Risk: request-time registry selection could choose the wrong route source when multiple registries disagree.
  - Mitigation: targeted regression coverage now covers active-registry preference, startup-registry fallback, and process-backed cross-realm route matching.
