### PR TITLE
fix(telegram): fallback to text on sendVoice transport failures

### DIFF
--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -26,6 +26,7 @@ import {
   renderTelegramHtmlText,
   wrapFileReferencesInHtml,
 } from "../format.js";
+import { isSafeToRetrySendError } from "../network-errors.js";
 import { buildInlineKeyboard } from "../send.js";
 import { resolveTelegramVoiceSend } from "../voice.js";
 import {
@@ -201,6 +202,10 @@ function isCaptionTooLong(err: unknown): boolean {
   return CAPTION_TOO_LONG_RE.test(formatErrorMessage(err));
 }
 
+function isVoiceNetworkTransportError(err: unknown): boolean {
+  return isSafeToRetrySendError(err);
+}
+
 async function sendTelegramVoiceFallbackText(opts: {
   bot: Bot;
   chatId: string;
@@ -215,26 +220,24 @@ async function sendTelegramVoiceFallbackText(opts: {
 }): Promise<number | undefined> {
   let firstDeliveredMessageId: number | undefined;
   const chunks = opts.chunkText(opts.text);
-  let appliedReplyTo = false;
+  let isFirstChunk = true;
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
     // Only apply reply reference, quote text, and buttons to the first chunk.
-    const replyToForChunk = !appliedReplyTo ? opts.replyToId : undefined;
+    const replyToForChunk = isFirstChunk ? opts.replyToId : undefined;
     const messageId = await sendTelegramText(opts.bot, opts.chatId, chunk.html, opts.runtime, {
       replyToMessageId: replyToForChunk,
-      replyQuoteText: !appliedReplyTo ? opts.replyQuoteText : undefined,
+      replyQuoteText: isFirstChunk ? opts.replyQuoteText : undefined,
       thread: opts.thread,
       textMode: "html",
       plainText: chunk.text,
       linkPreview: opts.linkPreview,
-      replyMarkup: !appliedReplyTo ? opts.replyMarkup : undefined,
+      replyMarkup: isFirstChunk ? opts.replyMarkup : undefined,
     });
     if (firstDeliveredMessageId == null) {
       firstDeliveredMessageId = messageId;
     }
-    if (replyToForChunk) {
-      appliedReplyTo = true;
-    }
+    isFirstChunk = false;
   }
   return firstDeliveredMessageId;
 }
@@ -352,7 +355,8 @@ async function deliverMediaReply(params: {
             runtime: params.runtime,
             thread: params.thread,
             requestParams: mediaParams,
-            shouldLog: (err) => !isVoiceMessagesForbidden(err),
+            shouldLog: (err) =>
+              !isVoiceMessagesForbidden(err) && !isVoiceNetworkTransportError(err),
             send: (effectiveParams) =>
               params.bot.api.sendVoice(params.chatId, file, { ...effectiveParams }),
           });
@@ -369,6 +373,39 @@ async function deliverMediaReply(params: {
             logVerbose(
               "telegram sendVoice forbidden (recipient has voice messages blocked in privacy settings); falling back to text",
             );
+            const voiceFallbackReplyTo = resolveReplyToForSend({
+              replyToId: params.replyToId,
+              replyToMode: params.replyToMode,
+              progress: params.progress,
+            });
+            const fallbackMessageId = await sendTelegramVoiceFallbackText({
+              bot: params.bot,
+              chatId: params.chatId,
+              runtime: params.runtime,
+              text: fallbackText,
+              chunkText: params.chunkText,
+              replyToId: voiceFallbackReplyTo,
+              thread: params.thread,
+              linkPreview: params.linkPreview,
+              replyMarkup: params.replyMarkup,
+              replyQuoteText: params.replyQuoteText,
+            });
+            if (firstDeliveredMessageId == null) {
+              firstDeliveredMessageId = fallbackMessageId;
+            }
+            markReplyApplied(params.progress, voiceFallbackReplyTo);
+            markDelivered(params.progress);
+            continue;
+          }
+          if (isVoiceNetworkTransportError(voiceErr)) {
+            if (!isFirstMedia) {
+              throw voiceErr;
+            }
+            const fallbackText = params.reply.text;
+            if (!fallbackText || !fallbackText.trim()) {
+              throw voiceErr;
+            }
+            logVerbose("telegram sendVoice network/transport failure; falling back to text");
             const voiceFallbackReplyTo = resolveReplyToForSend({
               replyToId: params.replyToId,
               replyToMode: params.replyToMode,

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -97,6 +97,18 @@ function createVoiceMessagesForbiddenError() {
   );
 }
 
+function createVoicePreConnectNetworkError() {
+  const err = new Error("connect ECONNREFUSED 149.154.167.220:443");
+  (err as NodeJS.ErrnoException).code = "ECONNREFUSED";
+  return err;
+}
+
+function createVoicePostSendTransportError() {
+  const err = new Error("read ECONNRESET");
+  (err as NodeJS.ErrnoException).code = "ECONNRESET";
+  return err;
+}
+
 function createThreadNotFoundError(operation = "sendMessage") {
   return new Error(
     `GrammyError: Call to '${operation}' failed! (400: Bad Request: message thread not found)`,
@@ -643,6 +655,7 @@ describe("deliverReplies", () => {
       expect.stringContaining("Hello there"),
       expect.any(Object),
     );
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it("voice fallback applies reply-to only on first chunk when replyToMode is first", async () => {
@@ -694,9 +707,126 @@ describe("deliverReplies", () => {
     expect(sendMessage.mock.calls[1][2]).not.toHaveProperty("reply_markup");
   });
 
-  it("rethrows non-VOICE_MESSAGES_FORBIDDEN errors from sendVoice", async () => {
+  it("voice fallback attaches inline keyboard only to first chunk when replyToMode is off", async () => {
+    const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
+      voiceError: createVoiceMessagesForbiddenError(),
+      sendMessageResult: {
+        message_id: 16,
+        chat: { id: "123" },
+      },
+    });
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await deliverWith({
+      replies: [
+        {
+          mediaUrl: "https://example.com/note.ogg",
+          text: "chunk-one\n\nchunk-two",
+          audioAsVoice: true,
+          channelData: {
+            telegram: {
+              buttons: [[{ text: "Ack", callback_data: "ack" }]],
+            },
+          },
+        },
+      ],
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 12,
+    });
+
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(sendMessage.mock.calls[0][2]).toEqual(
+      expect.objectContaining({
+        reply_markup: {
+          inline_keyboard: [[{ text: "Ack", callback_data: "ack" }]],
+        },
+      }),
+    );
+    expect(sendMessage.mock.calls[1][2]).not.toHaveProperty("reply_markup");
+  });
+
+  it("falls back to text when sendVoice fails with pre-connect network errors", async () => {
+    const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
+      voiceError: createVoicePreConnectNetworkError(),
+      sendMessageResult: {
+        message_id: 7,
+        chat: { id: "123" },
+      },
+    });
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await deliverWith({
+      replies: [{ mediaUrl: "https://example.com/note.ogg", text: "Hello", audioAsVoice: true }],
+      runtime,
+      bot,
+    });
+
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.stringContaining("Hello"),
+      expect.any(Object),
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("rethrows post-send transport errors from sendVoice without text fallback", async () => {
+    const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
+      voiceError: createVoicePostSendTransportError(),
+    });
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await expect(
+      deliverWith({
+        replies: [{ mediaUrl: "https://example.com/note.ogg", text: "Hello", audioAsVoice: true }],
+        runtime,
+        bot,
+      }),
+    ).rejects.toThrow("ECONNRESET");
+
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not fallback to text when non-first media voice send fails with pre-connect errors", async () => {
     const runtime = createRuntime();
-    const sendVoice = vi.fn().mockRejectedValue(new Error("Network error"));
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 30, chat: { id: "123" } });
+    const sendVoice = vi.fn().mockRejectedValue(createVoicePreConnectNetworkError());
+    const sendMessage = vi.fn();
+    const bot = createBot({ sendPhoto, sendVoice, sendMessage });
+
+    mockMediaLoad("a.jpg", "image/jpeg", "img1");
+    mockMediaLoad("b.ogg", "audio/ogg", "voice2");
+
+    await expect(
+      deliverWith({
+        replies: [
+          {
+            mediaUrls: ["https://example.com/a.jpg", "https://example.com/b.ogg"],
+            text: "first-caption-only",
+            audioAsVoice: true,
+          },
+        ],
+        runtime,
+        bot,
+      }),
+    ).rejects.toThrow("ECONNREFUSED");
+
+    expect(sendPhoto).toHaveBeenCalledTimes(1);
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-network errors from sendVoice", async () => {
+    const runtime = createRuntime();
+    const sendVoice = vi.fn().mockRejectedValue(new Error("400: Bad Request: invalid voice"));
     const sendMessage = vi.fn();
     const bot = createBot({ sendVoice, sendMessage });
 
@@ -708,10 +838,10 @@ describe("deliverReplies", () => {
         runtime,
         bot,
       }),
-    ).rejects.toThrow("Network error");
+    ).rejects.toThrow("invalid voice");
 
     expect(sendVoice).toHaveBeenCalledTimes(1);
-    // Text fallback should NOT be attempted for other errors
+    // Text fallback should NOT be attempted for non-network errors.
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
@@ -854,5 +984,26 @@ describe("deliverReplies", () => {
 
     expect(sendVoice).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("rethrows network/transport sendVoice errors when no text fallback is available", async () => {
+    const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
+      voiceError: createVoicePreConnectNetworkError(),
+    });
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await expect(
+      deliverWith({
+        replies: [{ mediaUrl: "https://example.com/note.ogg", audioAsVoice: true }],
+        runtime,
+        bot,
+      }),
+    ).rejects.toThrow("ECONNREFUSED");
+
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a Telegram voice-send fallback path for network/transport failures during `sendVoice`
- preserve existing successful voice delivery behavior and existing special cases (`VOICE_MESSAGES_FORBIDDEN`, caption-too-long)
- add test coverage for network-failure fallback and keep non-network sendVoice errors as hard failures

## Testing
- `corepack pnpm exec vitest run --config vitest.channels.config.ts src/telegram/bot/delivery.test.ts`
- `corepack pnpm exec oxlint --type-aware src/telegram/bot/delivery.replies.ts src/telegram/bot/delivery.test.ts`

Closes #45329