### PR TITLE
fix(telegram): fallback to text when sendVoice upload fails

### DIFF
--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -36,6 +36,7 @@ import {
 import { resolveTelegramReplyId, type TelegramThreadSpec } from "./helpers.js";
 
 const VOICE_FORBIDDEN_RE = /VOICE_MESSAGES_FORBIDDEN/;
+const VOICE_NETWORK_RE = /Network request for ['"]?sendVoice['"]? failed/i;
 const CAPTION_TOO_LONG_RE = /caption is too long/i;
 
 type DeliveryProgress = {
@@ -192,6 +193,10 @@ function isVoiceMessagesForbidden(err: unknown): boolean {
     return VOICE_FORBIDDEN_RE.test(err.description);
   }
   return VOICE_FORBIDDEN_RE.test(formatErrorMessage(err));
+}
+
+function isSendVoiceNetworkError(err: unknown): boolean {
+  return VOICE_NETWORK_RE.test(formatErrorMessage(err));
 }
 
 function isCaptionTooLong(err: unknown): boolean {
@@ -361,14 +366,18 @@ async function deliverMediaReply(params: {
           }
           markDelivered(params.progress);
         } catch (voiceErr) {
-          if (isVoiceMessagesForbidden(voiceErr)) {
+          if (isVoiceMessagesForbidden(voiceErr) || isSendVoiceNetworkError(voiceErr)) {
             const fallbackText = params.reply.text;
             if (!fallbackText || !fallbackText.trim()) {
               throw voiceErr;
             }
-            logVerbose(
-              "telegram sendVoice forbidden (recipient has voice messages blocked in privacy settings); falling back to text",
-            );
+            if (isVoiceMessagesForbidden(voiceErr)) {
+              logVerbose(
+                "telegram sendVoice forbidden (recipient has voice messages blocked in privacy settings); falling back to text",
+              );
+            } else {
+              logVerbose("telegram sendVoice network failure; falling back to text");
+            }
             const voiceFallbackReplyTo = resolveReplyToForSend({
               replyToId: params.replyToId,
               replyToMode: params.replyToMode,

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -694,9 +694,37 @@ describe("deliverReplies", () => {
     expect(sendMessage.mock.calls[1][2]).not.toHaveProperty("reply_markup");
   });
 
-  it("rethrows non-VOICE_MESSAGES_FORBIDDEN errors from sendVoice", async () => {
+  it("falls back to text when sendVoice fails with a network upload error", async () => {
     const runtime = createRuntime();
-    const sendVoice = vi.fn().mockRejectedValue(new Error("Network error"));
+    const sendVoice = vi
+      .fn()
+      .mockRejectedValue(new Error("Network request for 'sendVoice' failed!"));
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 7,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendVoice, sendMessage });
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await deliverWith({
+      replies: [{ mediaUrl: "https://example.com/note.ogg", text: "Hello", audioAsVoice: true }],
+      runtime,
+      bot,
+    });
+
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.stringContaining("Hello"),
+      expect.any(Object),
+    );
+  });
+
+  it("rethrows non-network/non-forbidden errors from sendVoice", async () => {
+    const runtime = createRuntime();
+    const sendVoice = vi.fn().mockRejectedValue(new Error("socket hang up"));
     const sendMessage = vi.fn();
     const bot = createBot({ sendVoice, sendMessage });
 
@@ -708,10 +736,9 @@ describe("deliverReplies", () => {
         runtime,
         bot,
       }),
-    ).rejects.toThrow("Network error");
+    ).rejects.toThrow("socket hang up");
 
     expect(sendVoice).toHaveBeenCalledTimes(1);
-    // Text fallback should NOT be attempted for other errors
     expect(sendMessage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- add a sendVoice network-error detector for Telegram delivery
- reuse the existing text fallback path when voice upload fails due to network transport issues
- keep existing behavior for non-network/non-forbidden errors (still rethrow)

## Why
Issue #45329 reports that failed sendVoice uploads currently terminate delivery instead of gracefully falling back to text, even though the text payload exists.

## Tests
- updated delivery.test.ts to verify fallback occurs for Network request for 'sendVoice' failed!
- added a guard test to ensure unrelated errors still rethrow

Closes #45329