### PR TITLE
Doctor: prune stale plugins and flag runtime drift

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -326,4 +326,28 @@ describe("gatherDaemonStatus", () => {
     expect(callGatewayStatusProbe).not.toHaveBeenCalled();
     expect(status.rpc).toBeUndefined();
   });
+
+  it("reports service state-dir and version drift", async () => {
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+      environment: {
+        HOME: "/Users/tester",
+        OPENCLAW_STATE_DIR: "/Users/tester/.openclaw-tests/2026.3.2-state",
+        OPENCLAW_CONFIG_PATH: "/Users/tester/.openclaw-tests/2026.3.2-state/openclaw.json",
+        OPENCLAW_SERVICE_VERSION: "2026.3.8",
+      },
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: false,
+      deep: false,
+    });
+
+    expect(status.config?.stateDirMismatch).toBe(true);
+    expect(status.config?.serviceUsesTestStateDir).toBe(true);
+    expect(status.config?.daemon?.stateDir).toBe("/Users/tester/.openclaw-tests/2026.3.2-state");
+    expect(status.version?.service).toBe("2026.3.8");
+    expect(status.version?.mismatch).toBe(true);
+  });
 });

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -1,6 +1,8 @@
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../../test-utils/env.js";
 
+const fsRealpath = vi.fn(async (value: string) => value);
 const callGatewayStatusProbe = vi.fn(async (_opts?: unknown) => ({ ok: true as const }));
 const loadGatewayTlsRuntime = vi.fn(async (_cfg?: unknown) => ({
   enabled: true,
@@ -48,6 +50,18 @@ let cliLoadedConfig: Record<string, unknown> = {
     bind: "loopback",
   },
 };
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      realpath: fsRealpath,
+    },
+    realpath: fsRealpath,
+  };
+});
 
 vi.mock("../../config/config.js", () => ({
   createConfigIO: ({ configPath }: { configPath: string }) => {
@@ -132,6 +146,8 @@ describe("gatherDaemonStatus", () => {
     delete process.env.OPENCLAW_GATEWAY_PASSWORD;
     delete process.env.DAEMON_GATEWAY_TOKEN;
     delete process.env.DAEMON_GATEWAY_PASSWORD;
+    fsRealpath.mockClear();
+    fsRealpath.mockImplementation(async (value: string) => value);
     callGatewayStatusProbe.mockClear();
     loadGatewayTlsRuntime.mockClear();
     daemonLoadedConfig = {
@@ -349,5 +365,33 @@ describe("gatherDaemonStatus", () => {
     expect(status.config?.daemon?.stateDir).toBe("/Users/tester/.openclaw-tests/2026.3.2-state");
     expect(status.version?.service).toBe("2026.3.8");
     expect(status.version?.mismatch).toBe(true);
+  });
+
+  it("does not report config or state-dir drift when paths resolve to the same realpath", async () => {
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+      environment: {
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon/link",
+        OPENCLAW_CONFIG_PATH: "/tmp/openclaw-daemon/link/openclaw.json",
+      },
+    });
+    fsRealpath.mockImplementation(async (value: string) => {
+      if (value === path.resolve("/tmp/openclaw-daemon/link")) {
+        return path.resolve("/tmp/openclaw-cli");
+      }
+      if (value === path.resolve("/tmp/openclaw-daemon/link/openclaw.json")) {
+        return path.resolve("/tmp/openclaw-cli/openclaw.json");
+      }
+      return value;
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: false,
+      deep: false,
+    });
+
+    expect(status.config?.mismatch).toBeUndefined();
+    expect(status.config?.stateDirMismatch).toBeUndefined();
   });
 });

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -1,9 +1,11 @@
+import path from "node:path";
 import {
   createConfigIO,
   resolveConfigPath,
   resolveGatewayPort,
   resolveStateDir,
 } from "../../config/config.js";
+import { detectOpenClawTestStateDir } from "../../config/state-dir-classify.js";
 import type {
   OpenClawConfig,
   GatewayBindMode,
@@ -28,12 +30,14 @@ import {
 } from "../../infra/ports.js";
 import { pickPrimaryTailnetIPv4 } from "../../infra/tailnet.js";
 import { loadGatewayTlsRuntime } from "../../infra/tls/gateway.js";
+import { resolveRuntimeServiceVersion } from "../../version.js";
 import { probeGatewayStatus } from "./probe.js";
 import { normalizeListenerAddress, parsePortFromArgs, pickProbeHostForBind } from "./shared.js";
 import type { GatewayRpcOpts } from "./types.js";
 
 type ConfigSummary = {
   path: string;
+  stateDir: string;
   exists: boolean;
   valid: boolean;
   issues?: Array<{ path: string; message: string }>;
@@ -64,6 +68,8 @@ type DaemonConfigContext = {
   cliConfigSummary: ConfigSummary;
   daemonConfigSummary: ConfigSummary;
   configMismatch: boolean;
+  stateDirMismatch: boolean;
+  daemonUsesTestStateDir: boolean;
 };
 
 type ResolvedGatewayStatus = {
@@ -91,6 +97,13 @@ export type DaemonStatus = {
   config?: {
     cli: ConfigSummary;
     daemon?: ConfigSummary;
+    mismatch?: boolean;
+    stateDirMismatch?: boolean;
+    serviceUsesTestStateDir?: boolean;
+  };
+  version?: {
+    cli: string;
+    service?: string;
     mismatch?: boolean;
   };
   gateway?: GatewayStatusSummary;
@@ -134,10 +147,12 @@ async function loadDaemonConfigContext(
   } satisfies Record<string, string | undefined>;
 
   const cliConfigPath = resolveConfigPath(process.env, resolveStateDir(process.env));
+  const cliStateDir = resolveStateDir(process.env);
   const daemonConfigPath = resolveConfigPath(
     mergedDaemonEnv as NodeJS.ProcessEnv,
     resolveStateDir(mergedDaemonEnv as NodeJS.ProcessEnv),
   );
+  const daemonStateDir = resolveStateDir(mergedDaemonEnv as NodeJS.ProcessEnv);
 
   const cliIO = createConfigIO({ env: process.env, configPath: cliConfigPath });
   const daemonIO = createConfigIO({
@@ -154,6 +169,7 @@ async function loadDaemonConfigContext(
 
   const cliConfigSummary: ConfigSummary = {
     path: cliSnapshot?.path ?? cliConfigPath,
+    stateDir: cliStateDir,
     exists: cliSnapshot?.exists ?? false,
     valid: cliSnapshot?.valid ?? true,
     ...(cliSnapshot?.issues?.length ? { issues: cliSnapshot.issues } : {}),
@@ -161,6 +177,7 @@ async function loadDaemonConfigContext(
   };
   const daemonConfigSummary: ConfigSummary = {
     path: daemonSnapshot?.path ?? daemonConfigPath,
+    stateDir: daemonStateDir,
     exists: daemonSnapshot?.exists ?? false,
     valid: daemonSnapshot?.valid ?? true,
     ...(daemonSnapshot?.issues?.length ? { issues: daemonSnapshot.issues } : {}),
@@ -174,6 +191,12 @@ async function loadDaemonConfigContext(
     cliConfigSummary,
     daemonConfigSummary,
     configMismatch: cliConfigSummary.path !== daemonConfigSummary.path,
+    stateDirMismatch:
+      path.resolve(cliConfigSummary.stateDir) !== path.resolve(daemonConfigSummary.stateDir),
+    daemonUsesTestStateDir:
+      detectOpenClawTestStateDir(daemonConfigSummary.stateDir, {
+        homedir: mergedDaemonEnv.HOME?.trim() || process.env.HOME,
+      }) !== null,
   };
 }
 
@@ -276,6 +299,8 @@ export async function gatherDaemonStatus(
     cliConfigSummary,
     daemonConfigSummary,
     configMismatch,
+    stateDirMismatch,
+    daemonUsesTestStateDir,
   } = await loadDaemonConfigContext(serviceEnv);
   const { gateway, daemonPort, cliPort, probeUrlOverride } = await resolveGatewayStatusSummary({
     cliCfg,
@@ -333,6 +358,10 @@ export async function gatherDaemonStatus(
     lastError = (await readLastGatewayErrorLine(mergedDaemonEnv as NodeJS.ProcessEnv)) ?? undefined;
   }
 
+  const cliVersion = resolveRuntimeServiceVersion(process.env);
+  const serviceVersion = trimToUndefined(serviceEnv?.OPENCLAW_SERVICE_VERSION) ?? undefined;
+  const versionMismatch = Boolean(serviceVersion && serviceVersion !== cliVersion);
+
   return {
     service: {
       label: service.label,
@@ -347,6 +376,13 @@ export async function gatherDaemonStatus(
       cli: cliConfigSummary,
       daemon: daemonConfigSummary,
       ...(configMismatch ? { mismatch: true } : {}),
+      ...(stateDirMismatch ? { stateDirMismatch: true } : {}),
+      ...(daemonUsesTestStateDir ? { serviceUsesTestStateDir: true } : {}),
+    },
+    version: {
+      cli: cliVersion,
+      ...(serviceVersion ? { service: serviceVersion } : {}),
+      ...(versionMismatch ? { mismatch: true } : {}),
     },
     gateway,
     port: portStatus,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import {
   createConfigIO,
@@ -138,6 +139,15 @@ function shouldReportPortUsage(status: PortUsageStatus | undefined, rpcOk?: bool
   return true;
 }
 
+async function normalizePathForComparison(value: string): Promise<string> {
+  const resolvedPath = path.resolve(value);
+  try {
+    return await fs.realpath(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
+}
+
 async function loadDaemonConfigContext(
   serviceEnv?: Record<string, string>,
 ): Promise<DaemonConfigContext> {
@@ -183,6 +193,17 @@ async function loadDaemonConfigContext(
     ...(daemonSnapshot?.issues?.length ? { issues: daemonSnapshot.issues } : {}),
     controlUi: daemonCfg.gateway?.controlUi,
   };
+  const [
+    normalizedCliConfigPath,
+    normalizedDaemonConfigPath,
+    normalizedCliStateDir,
+    normalizedDaemonStateDir,
+  ] = await Promise.all([
+    normalizePathForComparison(cliConfigSummary.path),
+    normalizePathForComparison(daemonConfigSummary.path),
+    normalizePathForComparison(cliConfigSummary.stateDir),
+    normalizePathForComparison(daemonConfigSummary.stateDir),
+  ]);
 
   return {
     mergedDaemonEnv,
@@ -190,9 +211,8 @@ async function loadDaemonConfigContext(
     daemonCfg,
     cliConfigSummary,
     daemonConfigSummary,
-    configMismatch: cliConfigSummary.path !== daemonConfigSummary.path,
-    stateDirMismatch:
-      path.resolve(cliConfigSummary.stateDir) !== path.resolve(daemonConfigSummary.stateDir),
+    configMismatch: normalizedCliConfigPath !== normalizedDaemonConfigPath,
+    stateDirMismatch: normalizedCliStateDir !== normalizedDaemonStateDir,
     daemonUsesTestStateDir:
       detectOpenClawTestStateDir(daemonConfigSummary.stateDir, {
         homedir: mergedDaemonEnv.HOME?.trim() || process.env.HOME,

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -108,6 +108,9 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
   if (status.config) {
     const cliCfg = `${shortenHomePath(status.config.cli.path)}${status.config.cli.exists ? "" : " (missing)"}${status.config.cli.valid ? "" : " (invalid)"}`;
     defaultRuntime.log(`${label("Config (cli):")} ${infoText(cliCfg)}`);
+    defaultRuntime.log(
+      `${label("State dir (cli):")} ${infoText(shortenHomePath(status.config.cli.stateDir))}`,
+    );
     if (!status.config.cli.valid && status.config.cli.issues?.length) {
       for (const issue of status.config.cli.issues.slice(0, 5)) {
         defaultRuntime.error(
@@ -118,6 +121,9 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
     if (status.config.daemon) {
       const daemonCfg = `${shortenHomePath(status.config.daemon.path)}${status.config.daemon.exists ? "" : " (missing)"}${status.config.daemon.valid ? "" : " (invalid)"}`;
       defaultRuntime.log(`${label("Config (service):")} ${infoText(daemonCfg)}`);
+      defaultRuntime.log(
+        `${label("State dir (service):")} ${infoText(shortenHomePath(status.config.daemon.stateDir))}`,
+      );
       if (!status.config.daemon.valid && status.config.daemon.issues?.length) {
         for (const issue of status.config.daemon.issues.slice(0, 5)) {
           defaultRuntime.error(
@@ -135,6 +141,35 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
       defaultRuntime.error(
         errorText(
           `Fix: rerun \`${formatCliCommand("openclaw gateway install --force")}\` from the same --profile / OPENCLAW_STATE_DIR you expect.`,
+        ),
+      );
+    }
+    if (status.config.stateDirMismatch) {
+      defaultRuntime.error(
+        errorText(
+          "Root cause: CLI and service are using different state directories (likely wrapper/service drift).",
+        ),
+      );
+    }
+    if (status.config.serviceUsesTestStateDir) {
+      defaultRuntime.error(
+        errorText(
+          "Gateway service is using a ~/.openclaw-tests/* state dir instead of the primary runtime state.",
+        ),
+      );
+    }
+    spacer();
+  }
+
+  if (status.version) {
+    defaultRuntime.log(`${label("Version (cli):")} ${infoText(status.version.cli)}`);
+    if (status.version.service) {
+      defaultRuntime.log(`${label("Version (service):")} ${infoText(status.version.service)}`);
+    }
+    if (status.version.mismatch) {
+      defaultRuntime.error(
+        errorText(
+          "Root cause: service version does not match the current CLI/runtime. Reinstall the gateway service to realign it.",
         ),
       );
     }

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -179,6 +179,90 @@ describe("doctor config flow", () => {
     });
   });
 
+  it("removes removed plugin refs on repair", async () => {
+    await withTempHome(async (home) => {
+      const removedPluginDir = path.join(home, "google-antigravity-auth");
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(removedPluginDir, { recursive: true });
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(removedPluginDir, "index.js"),
+        'export default { id: "google-antigravity-auth", register() {} };\n',
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(removedPluginDir, "openclaw.plugin.json"),
+        JSON.stringify(
+          {
+            id: "google-antigravity-auth",
+            configSchema: { type: "object" },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            plugins: {
+              allow: ["google-antigravity-auth"],
+              entries: {
+                "google-antigravity-auth": { enabled: true },
+              },
+              load: {
+                paths: [removedPluginDir],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const result = await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+
+      expect(result.cfg.plugins).toBeUndefined();
+    });
+  });
+
+  it("removes redundant bundled discord overrides on repair", async () => {
+    const bundledDiscordPath = path.join(process.cwd(), "extensions", "discord");
+    const result = await runDoctorConfigWithInput({
+      repair: true,
+      config: {
+        channels: {
+          discord: {
+            enabled: true,
+          },
+        },
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+          installs: {
+            discord: {
+              source: "path",
+              sourcePath: bundledDiscordPath,
+              installPath: bundledDiscordPath,
+            },
+          },
+          load: {
+            paths: [bundledDiscordPath],
+          },
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(result.cfg.plugins).toBeUndefined();
+  });
+
   it("preserves discord streaming intent while stripping unsupported keys on repair", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -15,6 +15,7 @@ import { CONFIG_PATH, migrateLegacyConfig, readConfigFileSnapshot } from "../con
 import { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import { repairPluginConfigNoise } from "../config/plugin-repair.js";
 import { parseToolsBySenderTypedKey } from "../config/types.tools.js";
 import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
 import {
@@ -1752,6 +1753,27 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       cfg = autoEnable.config;
     } else {
       fixHints.push(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply these changes.`);
+    }
+  }
+
+  const pluginRepair = repairPluginConfigNoise(candidate);
+  if (pluginRepair.changes.length > 0) {
+    candidate = pluginRepair.config;
+    pendingChanges = true;
+    if (shouldRepair) {
+      cfg = pluginRepair.config;
+      note(pluginRepair.changes.join("\n"), "Doctor changes");
+    } else {
+      note(
+        [
+          ...pluginRepair.changes,
+          `- Run "${formatCliCommand("openclaw doctor --fix")}" to remove stale plugin config.`,
+        ].join("\n"),
+        "Doctor warnings",
+      );
+      fixHints.push(
+        `Run "${formatCliCommand("openclaw doctor --fix")}" to remove stale plugin config.`,
+      );
     }
   }
 

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   resolveGatewayAuthTokenForService: vi.fn(),
   resolveGatewayPort: vi.fn(() => 18789),
   resolveIsNixMode: vi.fn(() => false),
+  resolveStateDir: vi.fn((env: NodeJS.ProcessEnv) => env.OPENCLAW_STATE_DIR ?? "/tmp/openclaw"),
   findExtraGatewayServices: vi.fn().mockResolvedValue([]),
   renderGatewayServiceCleanupHints: vi.fn().mockReturnValue([]),
   uninstallLegacySystemdUnits: vi.fn().mockResolvedValue([]),
@@ -36,6 +37,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../config/paths.js", () => ({
   resolveGatewayPort: mocks.resolveGatewayPort,
   resolveIsNixMode: mocks.resolveIsNixMode,
+  resolveStateDir: mocks.resolveStateDir,
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -480,6 +482,47 @@ describe("maybeRepairGatewayServiceConfig", () => {
             config: cfg,
           }),
         );
+      },
+    );
+  });
+
+  it("treats test-state and version drift as repair-worthy service config", async () => {
+    await withEnvAsync(
+      {
+        HOME: "/Users/tester",
+        OPENCLAW_STATE_DIR: "/Users/tester/.openclaw",
+        OPENCLAW_CONFIG_PATH: "/Users/tester/.openclaw/openclaw.json",
+      },
+      async () => {
+        mocks.readCommand.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          environment: {
+            HOME: "/Users/tester",
+            OPENCLAW_STATE_DIR: "/Users/tester/.openclaw-tests/2026.3.2-state",
+            OPENCLAW_CONFIG_PATH: "/Users/tester/.openclaw-tests/2026.3.2-state/openclaw.json",
+            OPENCLAW_SERVICE_VERSION: "2026.3.8",
+          },
+        });
+        mocks.auditGatewayServiceConfig.mockResolvedValue({
+          ok: true,
+          issues: [],
+        });
+        mocks.buildGatewayInstallPlan.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          workingDirectory: "/tmp",
+          environment: {},
+        });
+        mocks.install.mockResolvedValue(undefined);
+
+        await runRepair({ gateway: {} });
+
+        expect(mocks.install).toHaveBeenCalledTimes(1);
+        const configNotes = mocks.note.mock.calls
+          .filter((call) => call[1] === "Gateway service config")
+          .map((call) => String(call[0]))
+          .join("\n");
+        expect(configNotes).toContain("test-state directory");
+        expect(configNotes).toContain("2026.3.8");
       },
     );
   });

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -526,6 +526,51 @@ describe("maybeRepairGatewayServiceConfig", () => {
       },
     );
   });
+
+  it("does not flag state-dir mismatch when service and CLI paths share a realpath", async () => {
+    await withEnvAsync(
+      {
+        HOME: "/Users/tester",
+        OPENCLAW_STATE_DIR: "/Users/tester/.openclaw",
+        OPENCLAW_CONFIG_PATH: "/Users/tester/.openclaw/openclaw.json",
+      },
+      async () => {
+        mocks.readCommand.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          environment: {
+            HOME: "/Users/tester",
+            OPENCLAW_STATE_DIR: "/Users/tester/.openclaw-symlink",
+            OPENCLAW_CONFIG_PATH: "/Users/tester/.openclaw-symlink/openclaw.json",
+          },
+        });
+        mocks.auditGatewayServiceConfig.mockResolvedValue({
+          ok: true,
+          issues: [],
+        });
+        mocks.buildGatewayInstallPlan.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          workingDirectory: "/tmp",
+          environment: {},
+        });
+        mocks.install.mockResolvedValue(undefined);
+        fsMocks.realpath.mockImplementation(async (value: string) => {
+          if (value === "/Users/tester/.openclaw-symlink") {
+            return "/Users/tester/.openclaw";
+          }
+          return value;
+        });
+
+        await runRepair({ gateway: {} });
+
+        const configNotes = mocks.note.mock.calls
+          .filter((call) => call[1] === "Gateway service config")
+          .map((call) => String(call[0]))
+          .join("\n");
+        expect(configNotes).not.toContain("state dir does not match");
+        expect(mocks.install).not.toHaveBeenCalled();
+      },
+    );
+  });
 });
 
 describe("maybeScanExtraGatewayServices", () => {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -4,7 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { writeConfigFile, type OpenClawConfig } from "../config/config.js";
-import { resolveGatewayPort, resolveIsNixMode } from "../config/paths.js";
+import { resolveGatewayPort, resolveIsNixMode, resolveStateDir } from "../config/paths.js";
+import { detectOpenClawTestStateDir } from "../config/state-dir-classify.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import {
   findExtraGatewayServices,
@@ -22,6 +23,7 @@ import { resolveGatewayService } from "../daemon/service.js";
 import { uninstallLegacySystemdUnits } from "../daemon/systemd.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
+import { resolveRuntimeServiceVersion } from "../version.js";
 import { buildGatewayInstallPlan } from "./daemon-install-helpers.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME, type GatewayDaemonRuntime } from "./daemon-runtime.js";
 import { resolveGatewayAuthTokenForService } from "./doctor-gateway-auth-token.js";
@@ -289,6 +291,44 @@ export async function maybeRepairGatewayServiceConfig(
       code: SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
       message: "Gateway service entrypoint does not match the current install.",
       detail: `${currentEntrypoint} -> ${expectedEntrypoint}`,
+      level: "recommended",
+    });
+  }
+
+  const serviceEnv = command.environment ?? {};
+  const serviceStateDir = resolveStateDir(serviceEnv as NodeJS.ProcessEnv, () => {
+    const home = serviceEnv.HOME?.trim();
+    return home || os.homedir();
+  });
+  const cliStateDir = resolveStateDir(process.env, os.homedir);
+  if (path.resolve(serviceStateDir) !== path.resolve(cliStateDir)) {
+    audit.issues.push({
+      code: "gateway-state-dir-mismatch",
+      message: "Gateway service state dir does not match the current CLI environment.",
+      detail: `${serviceStateDir} -> ${cliStateDir}`,
+      level: "recommended",
+    });
+  }
+
+  const testStateDir = detectOpenClawTestStateDir(serviceStateDir, {
+    homedir: serviceEnv.HOME?.trim() || os.homedir(),
+  });
+  if (testStateDir) {
+    audit.issues.push({
+      code: "gateway-state-dir-test-profile",
+      message: "Gateway service is running from a test-state directory.",
+      detail: testStateDir.path,
+      level: "recommended",
+    });
+  }
+
+  const cliVersion = resolveRuntimeServiceVersion(process.env);
+  const serviceVersion = serviceEnv.OPENCLAW_SERVICE_VERSION?.trim();
+  if (serviceVersion && serviceVersion !== cliVersion) {
+    audit.issues.push({
+      code: "gateway-version-mismatch",
+      message: "Gateway service version does not match the current CLI/runtime.",
+      detail: `${serviceVersion} -> ${cliVersion}`,
       level: "recommended",
     });
   }

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -56,7 +56,7 @@ function findGatewayEntrypoint(programArguments?: string[]): string | null {
   return programArguments[gatewayIndex - 1] ?? null;
 }
 
-async function normalizeExecutablePath(value: string): Promise<string> {
+async function normalizePathForComparison(value: string): Promise<string> {
   const resolvedPath = path.resolve(value);
   try {
     return await fs.realpath(resolvedPath);
@@ -277,10 +277,10 @@ export async function maybeRepairGatewayServiceConfig(
   const expectedEntrypoint = findGatewayEntrypoint(programArguments);
   const currentEntrypoint = findGatewayEntrypoint(command.programArguments);
   const normalizedExpectedEntrypoint = expectedEntrypoint
-    ? await normalizeExecutablePath(expectedEntrypoint)
+    ? await normalizePathForComparison(expectedEntrypoint)
     : null;
   const normalizedCurrentEntrypoint = currentEntrypoint
-    ? await normalizeExecutablePath(currentEntrypoint)
+    ? await normalizePathForComparison(currentEntrypoint)
     : null;
   if (
     normalizedExpectedEntrypoint &&
@@ -301,7 +301,11 @@ export async function maybeRepairGatewayServiceConfig(
     return home || os.homedir();
   });
   const cliStateDir = resolveStateDir(process.env, os.homedir);
-  if (path.resolve(serviceStateDir) !== path.resolve(cliStateDir)) {
+  const [normalizedServiceStateDir, normalizedCliStateDir] = await Promise.all([
+    normalizePathForComparison(serviceStateDir),
+    normalizePathForComparison(cliStateDir),
+  ]);
+  if (normalizedServiceStateDir !== normalizedCliStateDir) {
     audit.issues.push({
       code: "gateway-state-dir-mismatch",
       message: "Gateway service state dir does not match the current CLI environment.",

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -139,6 +139,16 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(stateIntegrityText()).toContain("CRITICAL: OAuth dir missing");
   });
 
+  it("warns when state dir points at a test-state root", async () => {
+    process.env.OPENCLAW_STATE_DIR = path.join(tempHome, ".openclaw-tests", "2026.3.2-state");
+    fs.mkdirSync(process.env.OPENCLAW_STATE_DIR, { recursive: true, mode: 0o700 });
+
+    const text = await runStateIntegrityText({});
+
+    expect(text).toContain("State directory is under a test-state root");
+    expect(text).toContain(".openclaw");
+  });
+
   it("detects orphan transcripts and offers archival remediation", async () => {
     const cfg: OpenClawConfig = {};
     setupSessionState(cfg, process.env, process.env.HOME ?? "");

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -15,6 +15,7 @@ import {
   resolveSessionTranscriptsDirForAgent,
   resolveStorePath,
 } from "../config/sessions.js";
+import { detectOpenClawTestStateDir } from "../config/state-dir-classify.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { note } from "../terminal/note.js";
@@ -490,8 +491,23 @@ export async function noteStateIntegrity(
   const displayStoreDir = shortenHomePath(storeDir);
   const displayConfigPath = configPath ? shortenHomePath(configPath) : undefined;
   const requireOAuthDir = shouldRequireOAuthDir(cfg, env);
+  const testStateDir = detectOpenClawTestStateDir(stateDir, {
+    homedir: homedir(),
+    resolveRealPath: tryResolveRealPath,
+  });
   const cloudSyncedStateDir = detectMacCloudSyncedStateDir(stateDir);
   const linuxSdBackedStateDir = detectLinuxSdBackedStateDir(stateDir);
+
+  if (testStateDir) {
+    warnings.push(
+      [
+        `- State directory is under a test-state root (${displayStateDir}).`,
+        `- Test state dirs are useful for experiments, but they frequently drift from the primary runtime at ${shortenHomePath(defaultStateDir)}.`,
+        "- For the live gateway, prefer the primary state dir unless you intentionally want an isolated sandbox.",
+        `  Fix: unset OPENCLAW_STATE_DIR / OPENCLAW_CONFIG_PATH or reinstall the service against ${shortenHomePath(defaultStateDir)}.`,
+      ].join("\n"),
+    );
+  }
 
   if (cloudSyncedStateDir) {
     warnings.push(

--- a/src/config/plugin-repair.test.ts
+++ b/src/config/plugin-repair.test.ts
@@ -54,4 +54,50 @@ describe("repairPluginConfigNoise", () => {
       priority: "after-bundled",
     });
   });
+
+  it("preserves unknown plugins.load fields when stale load paths are fully pruned", async () => {
+    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-repair-"));
+    try {
+      const removedDir = path.join(fixtureRoot, "removed-plugin");
+      await fs.mkdir(removedDir, { recursive: true });
+      await fs.writeFile(
+        path.join(removedDir, "openclaw.plugin.json"),
+        JSON.stringify(
+          {
+            id: "google-antigravity-auth",
+            configSchema: { type: "object" },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const cfg = {
+        plugins: {
+          load: {
+            paths: [removedDir],
+            priority: "after-bundled",
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const repaired = repairPluginConfigNoise(cfg);
+      const repairedLoad = repaired.config.plugins?.load as
+        | {
+            paths?: string[];
+            priority?: string;
+          }
+        | undefined;
+
+      expect(repaired.changes).toContain(
+        '- Removed plugins.load.paths entry for removed plugin "google-antigravity-auth"',
+      );
+      expect(repairedLoad).toEqual({
+        priority: "after-bundled",
+      });
+    } finally {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/config/plugin-repair.test.ts
+++ b/src/config/plugin-repair.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { repairPluginConfigNoise } from "./plugin-repair.js";
+import type { OpenClawConfig } from "./types.js";
+
+describe("repairPluginConfigNoise", () => {
+  it("does not prune load paths based on directory basename alone", async () => {
+    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-repair-"));
+    try {
+      const archivedDir = path.join(fixtureRoot, "google-antigravity-auth");
+      await fs.mkdir(archivedDir, { recursive: true });
+
+      const cfg: OpenClawConfig = {
+        plugins: {
+          load: { paths: [archivedDir] },
+        },
+      };
+
+      const repaired = repairPluginConfigNoise(cfg);
+
+      expect(repaired.changes).toEqual([]);
+      expect(repaired.config.plugins?.load?.paths).toEqual([archivedDir]);
+    } finally {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves unknown plugins.load fields when rebuilding repaired config", () => {
+    const customPath = "/tmp/custom-plugin";
+    const cfg = {
+      plugins: {
+        allow: ["google-antigravity-auth", "discord"],
+        load: {
+          paths: [customPath],
+          priority: "after-bundled",
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const repaired = repairPluginConfigNoise(cfg);
+    const repairedLoad = repaired.config.plugins?.load as
+      | {
+          paths?: string[];
+          priority?: string;
+        }
+      | undefined;
+
+    expect(repaired.changes).toContain('- Removed plugins.allow entry "google-antigravity-auth"');
+    expect(repaired.config.plugins?.allow).toEqual(["discord"]);
+    expect(repairedLoad).toEqual({
+      paths: [customPath],
+      priority: "after-bundled",
+    });
+  });
+});

--- a/src/config/plugin-repair.ts
+++ b/src/config/plugin-repair.ts
@@ -1,0 +1,197 @@
+import path from "node:path";
+import { normalizeChatChannelId } from "../channels/registry.js";
+import { resolveBundledPluginSources } from "../plugins/bundled-sources.js";
+import { loadPluginManifest } from "../plugins/manifest.js";
+import { defaultSlotIdForKey } from "../plugins/slots.js";
+import type { OpenClawConfig } from "./types.js";
+
+export const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth"]);
+
+type PluginRepairResult = {
+  config: OpenClawConfig;
+  changes: string[];
+};
+
+function pathsEqual(left?: string, right?: string): boolean {
+  if (!left || !right) {
+    return false;
+  }
+  return path.resolve(left) === path.resolve(right);
+}
+
+function cleanupPluginsShape(config: OpenClawConfig): OpenClawConfig {
+  const plugins = config.plugins;
+  if (!plugins) {
+    return config;
+  }
+
+  const nextPlugins = { ...plugins };
+
+  if (!nextPlugins.allow || nextPlugins.allow.length === 0) {
+    delete nextPlugins.allow;
+  }
+  if (!nextPlugins.deny || nextPlugins.deny.length === 0) {
+    delete nextPlugins.deny;
+  }
+  if (!nextPlugins.entries || Object.keys(nextPlugins.entries).length === 0) {
+    delete nextPlugins.entries;
+  }
+  if (!nextPlugins.installs || Object.keys(nextPlugins.installs).length === 0) {
+    delete nextPlugins.installs;
+  }
+  if (!nextPlugins.load || !nextPlugins.load.paths || nextPlugins.load.paths.length === 0) {
+    delete nextPlugins.load;
+  }
+  if (!nextPlugins.slots || Object.keys(nextPlugins.slots).length === 0) {
+    delete nextPlugins.slots;
+  }
+
+  if (Object.keys(nextPlugins).length === 0) {
+    return { ...config, plugins: undefined };
+  }
+  return { ...config, plugins: nextPlugins };
+}
+
+function resolveLoadPathPluginId(loadPath: string): string | null {
+  const manifest = loadPluginManifest(loadPath, false);
+  if (manifest.ok) {
+    return manifest.manifest.id;
+  }
+  const base = path.basename(loadPath).trim();
+  return base || null;
+}
+
+function isRedundantBundledChannelEnable(cfg: OpenClawConfig, pluginId: string): boolean {
+  const channelId = normalizeChatChannelId(pluginId);
+  if (!channelId) {
+    return false;
+  }
+  const channel = cfg.channels?.[channelId];
+  if (!channel || typeof channel !== "object" || Array.isArray(channel)) {
+    return false;
+  }
+  return (channel as Record<string, unknown>).enabled === true;
+}
+
+export function repairPluginConfigNoise(cfg: OpenClawConfig): PluginRepairResult {
+  if (!cfg.plugins) {
+    return { config: cfg, changes: [] };
+  }
+
+  const next = structuredClone(cfg);
+  const plugins = next.plugins;
+  if (!plugins) {
+    return { config: cfg, changes: [] };
+  }
+
+  const changes: string[] = [];
+  const bundled = resolveBundledPluginSources({});
+  const entries = { ...plugins.entries };
+  const installs = { ...plugins.installs };
+  const allow = [...(plugins.allow ?? [])];
+  const deny = [...(plugins.deny ?? [])];
+  const loadPaths = [...(plugins.load?.paths ?? [])];
+  const slots = plugins.slots ? { ...plugins.slots } : undefined;
+
+  for (const removedId of LEGACY_REMOVED_PLUGIN_IDS) {
+    if (removedId in entries) {
+      delete entries[removedId];
+      changes.push(`- Removed plugins.entries.${removedId}`);
+    }
+    if (removedId in installs) {
+      delete installs[removedId];
+      changes.push(`- Removed plugins.installs.${removedId}`);
+    }
+  }
+
+  const filteredAllow = allow.filter((pluginId) => {
+    const keep = !LEGACY_REMOVED_PLUGIN_IDS.has(pluginId);
+    if (!keep) {
+      changes.push(`- Removed plugins.allow entry "${pluginId}"`);
+    }
+    return keep;
+  });
+
+  const filteredDeny = deny.filter((pluginId) => {
+    const keep = !LEGACY_REMOVED_PLUGIN_IDS.has(pluginId);
+    if (!keep) {
+      changes.push(`- Removed plugins.deny entry "${pluginId}"`);
+    }
+    return keep;
+  });
+
+  const filteredLoadPaths = loadPaths.filter((loadPath) => {
+    const pluginId = resolveLoadPathPluginId(loadPath);
+    if (pluginId && LEGACY_REMOVED_PLUGIN_IDS.has(pluginId)) {
+      changes.push(`- Removed plugins.load.paths entry for removed plugin "${pluginId}"`);
+      return false;
+    }
+    if (!pluginId) {
+      return true;
+    }
+    const bundledInfo = bundled.get(pluginId);
+    if (bundledInfo && pathsEqual(loadPath, bundledInfo.localPath)) {
+      changes.push(`- Removed plugins.load.paths override for bundled plugin "${pluginId}"`);
+      return false;
+    }
+    return true;
+  });
+
+  for (const [pluginId, installRecord] of Object.entries(installs)) {
+    const bundledInfo = bundled.get(pluginId);
+    if (
+      installRecord?.source === "path" &&
+      bundledInfo &&
+      pathsEqual(installRecord.sourcePath, bundledInfo.localPath)
+    ) {
+      delete installs[pluginId];
+      changes.push(`- Removed plugins.installs.${pluginId} bundled path override`);
+    }
+  }
+
+  for (const [pluginId, entry] of Object.entries(entries)) {
+    if (
+      bundled.has(pluginId) &&
+      entry?.enabled === true &&
+      Object.keys(entry).length === 1 &&
+      isRedundantBundledChannelEnable(next, pluginId)
+    ) {
+      delete entries[pluginId];
+      changes.push(`- Removed redundant plugins.entries.${pluginId}.enabled=true override`);
+    }
+  }
+
+  if (slots?.memory && LEGACY_REMOVED_PLUGIN_IDS.has(slots.memory)) {
+    const removedSlotId = slots.memory;
+    slots.memory = defaultSlotIdForKey("memory");
+    changes.push(
+      `- Reset plugins.slots.memory from removed plugin "${removedSlotId}" to "${slots.memory}"`,
+    );
+  }
+  if (slots?.contextEngine && LEGACY_REMOVED_PLUGIN_IDS.has(slots.contextEngine)) {
+    const removedSlotId = slots.contextEngine;
+    slots.contextEngine = defaultSlotIdForKey("contextEngine");
+    changes.push(
+      `- Reset plugins.slots.contextEngine from removed plugin "${removedSlotId}" to "${slots.contextEngine}"`,
+    );
+  }
+
+  if (changes.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  next.plugins = {
+    ...(typeof plugins.enabled === "boolean" ? { enabled: plugins.enabled } : {}),
+    ...(filteredAllow.length > 0 ? { allow: filteredAllow } : {}),
+    ...(filteredDeny.length > 0 ? { deny: filteredDeny } : {}),
+    ...(filteredLoadPaths.length > 0 ? { load: { paths: filteredLoadPaths } } : {}),
+    ...(slots ? { slots } : {}),
+    ...(Object.keys(entries).length > 0 ? { entries } : {}),
+    ...(Object.keys(installs).length > 0 ? { installs } : {}),
+  };
+
+  return {
+    config: cleanupPluginsShape(next),
+    changes,
+  };
+}

--- a/src/config/plugin-repair.ts
+++ b/src/config/plugin-repair.ts
@@ -12,11 +12,25 @@ type PluginRepairResult = {
   changes: string[];
 };
 
+type PluginLoadLike = Record<string, unknown> | undefined;
+
 function pathsEqual(left?: string, right?: string): boolean {
   if (!left || !right) {
     return false;
   }
   return path.resolve(left) === path.resolve(right);
+}
+
+function cleanupPluginLoadShape(load: PluginLoadLike) {
+  if (!load || typeof load !== "object" || Array.isArray(load)) {
+    return undefined;
+  }
+  const nextLoad = { ...load };
+  const paths = Array.isArray(nextLoad.paths) ? nextLoad.paths : undefined;
+  if (!paths || paths.length === 0) {
+    delete nextLoad.paths;
+  }
+  return Object.keys(nextLoad).length > 0 ? nextLoad : undefined;
 }
 
 function cleanupPluginsShape(config: OpenClawConfig): OpenClawConfig {
@@ -39,8 +53,11 @@ function cleanupPluginsShape(config: OpenClawConfig): OpenClawConfig {
   if (!nextPlugins.installs || Object.keys(nextPlugins.installs).length === 0) {
     delete nextPlugins.installs;
   }
-  if (!nextPlugins.load || !nextPlugins.load.paths || nextPlugins.load.paths.length === 0) {
+  const cleanedLoad = cleanupPluginLoadShape(nextPlugins.load);
+  if (!cleanedLoad) {
     delete nextPlugins.load;
+  } else {
+    nextPlugins.load = cleanedLoad as typeof nextPlugins.load;
   }
   if (!nextPlugins.slots || Object.keys(nextPlugins.slots).length === 0) {
     delete nextPlugins.slots;
@@ -189,13 +206,21 @@ export function repairPluginConfigNoise(cfg: OpenClawConfig): PluginRepairResult
     return { config: cfg, changes: [] };
   }
 
+  const repairedLoadInput = {
+    ...(plugins.load ? (plugins.load as Record<string, unknown>) : {}),
+  };
+  if (filteredLoadPaths.length > 0) {
+    repairedLoadInput.paths = filteredLoadPaths;
+  } else {
+    delete repairedLoadInput.paths;
+  }
+  const repairedLoad = cleanupPluginLoadShape(repairedLoadInput);
+
   next.plugins = {
     ...(typeof plugins.enabled === "boolean" ? { enabled: plugins.enabled } : {}),
     ...(filteredAllow.length > 0 ? { allow: filteredAllow } : {}),
     ...(filteredDeny.length > 0 ? { deny: filteredDeny } : {}),
-    ...(filteredLoadPaths.length > 0
-      ? { load: { ...plugins.load, paths: filteredLoadPaths } }
-      : {}),
+    ...(repairedLoad ? { load: repairedLoad as typeof plugins.load } : {}),
     ...(slots ? { slots } : {}),
     ...(Object.keys(entries).length > 0 ? { entries } : {}),
     ...(Object.keys(installs).length > 0 ? { installs } : {}),

--- a/src/config/plugin-repair.ts
+++ b/src/config/plugin-repair.ts
@@ -57,8 +57,19 @@ function resolveLoadPathPluginId(loadPath: string): string | null {
   if (manifest.ok) {
     return manifest.manifest.id;
   }
-  const base = path.basename(loadPath).trim();
-  return base || null;
+  return null;
+}
+
+function findBundledLoadPathPluginId(
+  loadPath: string,
+  bundled: ReadonlyMap<string, { localPath: string }>,
+): string | null {
+  for (const [pluginId, bundledInfo] of bundled.entries()) {
+    if (pathsEqual(loadPath, bundledInfo.localPath)) {
+      return pluginId;
+    }
+  }
+  return null;
 }
 
 function isRedundantBundledChannelEnable(cfg: OpenClawConfig, pluginId: string): boolean {
@@ -121,17 +132,15 @@ export function repairPluginConfigNoise(cfg: OpenClawConfig): PluginRepairResult
   });
 
   const filteredLoadPaths = loadPaths.filter((loadPath) => {
+    const bundledPluginId = findBundledLoadPathPluginId(loadPath, bundled);
+    if (bundledPluginId) {
+      changes.push(`- Removed plugins.load.paths override for bundled plugin "${bundledPluginId}"`);
+      return false;
+    }
+
     const pluginId = resolveLoadPathPluginId(loadPath);
     if (pluginId && LEGACY_REMOVED_PLUGIN_IDS.has(pluginId)) {
       changes.push(`- Removed plugins.load.paths entry for removed plugin "${pluginId}"`);
-      return false;
-    }
-    if (!pluginId) {
-      return true;
-    }
-    const bundledInfo = bundled.get(pluginId);
-    if (bundledInfo && pathsEqual(loadPath, bundledInfo.localPath)) {
-      changes.push(`- Removed plugins.load.paths override for bundled plugin "${pluginId}"`);
       return false;
     }
     return true;
@@ -184,7 +193,9 @@ export function repairPluginConfigNoise(cfg: OpenClawConfig): PluginRepairResult
     ...(typeof plugins.enabled === "boolean" ? { enabled: plugins.enabled } : {}),
     ...(filteredAllow.length > 0 ? { allow: filteredAllow } : {}),
     ...(filteredDeny.length > 0 ? { deny: filteredDeny } : {}),
-    ...(filteredLoadPaths.length > 0 ? { load: { paths: filteredLoadPaths } } : {}),
+    ...(filteredLoadPaths.length > 0
+      ? { load: { ...plugins.load, paths: filteredLoadPaths } }
+      : {}),
     ...(slots ? { slots } : {}),
     ...(Object.keys(entries).length > 0 ? { entries } : {}),
     ...(Object.keys(installs).length > 0 ? { installs } : {}),

--- a/src/config/state-dir-classify.ts
+++ b/src/config/state-dir-classify.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+
+function isPathUnderRoot(targetPath: string, rootPath: string): boolean {
+  const normalizedTarget = path.resolve(targetPath);
+  const normalizedRoot = path.resolve(rootPath);
+  const rootToken = path.parse(normalizedRoot).root;
+  if (normalizedRoot === rootToken) {
+    return normalizedTarget.startsWith(rootToken);
+  }
+  return (
+    normalizedTarget === normalizedRoot ||
+    normalizedTarget.startsWith(`${normalizedRoot}${path.sep}`)
+  );
+}
+
+export function detectOpenClawTestStateDir(
+  stateDir: string,
+  deps?: {
+    homedir?: string;
+    resolveRealPath?: (targetPath: string) => string | null;
+  },
+): { path: string; root: string } | null {
+  const resolvedPath = (deps?.resolveRealPath?.(stateDir) ?? stateDir).trim();
+  if (!resolvedPath) {
+    return null;
+  }
+
+  const candidate = path.resolve(resolvedPath);
+  const explicitRoot = deps?.homedir ? path.join(deps.homedir, ".openclaw-tests") : null;
+  if (explicitRoot && isPathUnderRoot(candidate, explicitRoot)) {
+    return { path: candidate, root: path.resolve(explicitRoot) };
+  }
+
+  const testStateToken = `${path.sep}.openclaw-tests${path.sep}`;
+  if (candidate.includes(testStateToken) || candidate.endsWith(`${path.sep}.openclaw-tests`)) {
+    const prefix = candidate.split(`${path.sep}.openclaw-tests`)[0] || path.parse(candidate).root;
+    return {
+      path: candidate,
+      root: path.resolve(prefix, ".openclaw-tests"),
+    };
+  }
+
+  return null;
+}

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -21,10 +21,9 @@ import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-di
 import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
 import { applyAgentDefaults, applyModelDefaults, applySessionDefaults } from "./defaults.js";
 import { findLegacyConfigIssues } from "./legacy.js";
+import { LEGACY_REMOVED_PLUGIN_IDS } from "./plugin-repair.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { OpenClawSchema } from "./zod-schema.js";
-
-const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth"]);
 
 type UnknownIssueRecord = Record<string, unknown>;
 type AllowedValuesCollection = {


### PR DESCRIPTION
## Summary

Fixes two operator-facing cleanup problems in gateway diagnostics and config repair:

1. `doctor` now auto-prunes removed plugin ids and redundant bundled-plugin overrides instead of only warning.
2. `gateway status` / doctor now surface runtime drift when the live service is running from a different version or state classification than the current CLI/runtime.

## Problem

In a real gateway cleanup, we ran into two recurring sources of operator confusion:

- stale removed plugin entries like `google-antigravity-auth` stayed in config and kept producing repair noise
- bundled `discord` path overrides could linger even though the bundled plugin should win
- the background service could be healthy but still be running with a stale `OPENCLAW_SERVICE_VERSION` or a test-state dir, which made the runtime/config surface look aligned when it was not

That combination makes environment cleanup noisy and slows down debugging of the real delivery/runtime issues.

## Root cause

- config validation identified removed plugins but did not aggressively prune all stale references
- bundled plugin overrides were still allowed to survive in places where they add no value and increase ambiguity
- status/doctor gathered service metadata, but did not classify test-state usage or report service/runtime drift clearly enough for operators

## Fix

- add shared plugin repair helpers that remove stale plugin ids from `plugins.allow`, `plugins.entries`, `plugins.installs`, and `plugins.load.paths`
- strip redundant bundled-plugin path overrides for `discord`
- classify state dirs so doctor/status can flag live services running from `~/.openclaw-tests/*`
- report service/runtime version mismatch and suspicious test-state usage more explicitly in status/doctor output
- add regression coverage for all of the above paths

## Testing

- `pnpm build`
- `pnpm exec vitest run src/commands/doctor-config-flow.test.ts src/commands/doctor-state-integrity.test.ts src/commands/doctor-gateway-services.test.ts src/cli/daemon-cli/status.gather.test.ts src/config/config.plugin-validation.test.ts`

## Notes

This is intentionally scoped to operator-facing repair/status behavior. It does not change token schemas, channel routing shapes, or plugin loading policy beyond cleaning obviously stale/redundant config.
