### PR TITLE
fix(routing): normalize Signal peer bindings for route matching

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -219,6 +219,9 @@ describe("resolveAgentRoute", () => {
     });
     expect(route.agentId).toBe("signal-group");
     expect(route.matchedBy).toBe("binding.peer");
+    expect(route.sessionKey).toBe(
+      "agent:signal-group:signal:group:npy/ppdwlkd996qtl3+0d2jdqgzpy3ysf9nty4p7bae=",
+    );
   });
 
   test("keeps peer binding matching case-sensitive for non-signal channels", () => {

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -193,6 +193,34 @@ describe("resolveAgentRoute", () => {
     expect(route.sessionKey).toBe("agent:main:discord:channel:1468834856187203680");
   });
 
+  test("matches peer bindings case-insensitively for normalized session ids", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "signal-group",
+          match: {
+            channel: "signal",
+            peer: {
+              kind: "group",
+              id: "NPy/PPdwLKD996QtL3+0d2JdQgzPY3Ysf9NTY4P7BaE=",
+            },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "signal",
+      accountId: "default",
+      peer: {
+        kind: "group",
+        id: "npy/ppdwlkd996qtl3+0d2jdqgzpy3ysf9nty4p7bae=",
+      },
+    });
+    expect(route.agentId).toBe("signal-group");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
   test("guild binding wins over account binding when peer not bound", () => {
     const cfg: OpenClawConfig = {
       bindings: [

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -221,6 +221,34 @@ describe("resolveAgentRoute", () => {
     expect(route.matchedBy).toBe("binding.peer");
   });
 
+  test("keeps peer binding matching case-sensitive for non-signal channels", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "line-group",
+          match: {
+            channel: "line",
+            peer: {
+              kind: "group",
+              id: "AbCd123",
+            },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "line",
+      accountId: "default",
+      peer: {
+        kind: "group",
+        id: "abcd123",
+      },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.matchedBy).toBe("default");
+  });
+
   test("guild binding wins over account binding when peer not bound", () => {
     const cfg: OpenClawConfig = {
       bindings: [

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -90,6 +90,10 @@ function normalizeId(value: unknown): string {
 
 function normalizePeerIdForChannel(channel: string, value: unknown): string {
   const normalized = normalizeId(value);
+  // Signal route/session matching already uses lowercase peer ids internally.
+  // Keep this canonicalization scoped to routing only: outbound Signal targets
+  // still preserve group-id casing because signal-cli treats group ids as
+  // base64-like, case-sensitive values.
   return channel === "signal" ? normalized.toLowerCase() : normalized;
 }
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -88,8 +88,9 @@ function normalizeId(value: unknown): string {
   return "";
 }
 
-function normalizePeerId(value: unknown): string {
-  return normalizeId(value).toLowerCase();
+function normalizePeerIdForChannel(channel: string, value: unknown): string {
+  const normalized = normalizeId(value);
+  return channel === "signal" ? normalized.toLowerCase() : normalized;
 }
 
 export function buildAgentSessionKey(params: {
@@ -109,7 +110,7 @@ export function buildAgentSessionKey(params: {
     channel,
     accountId: params.accountId,
     peerKind: peer?.kind ?? "direct",
-    peerId: peer ? normalizePeerId(peer.id) || "unknown" : null,
+    peerId: peer ? normalizeId(peer.id) || "unknown" : null,
     dmScope: params.dmScope,
     identityLinks: params.identityLinks,
   });
@@ -249,7 +250,7 @@ function buildEvaluatedBindingsByChannel(
     if (!channel) {
       continue;
     }
-    const match = normalizeBindingMatch(binding.match);
+    const match = normalizeBindingMatch(channel, binding.match);
     const evaluated: EvaluatedBinding = {
       binding,
       match,
@@ -475,13 +476,14 @@ function getEvaluatedBindingIndexForChannelAccount(
 }
 
 function normalizePeerConstraint(
+  channel: string,
   peer: { kind?: string; id?: string } | undefined,
 ): NormalizedPeerConstraint {
   if (!peer) {
     return { state: "none" };
   }
   const kind = normalizeChatType(peer.kind);
-  const id = normalizePeerId(peer.id);
+  const id = normalizePeerIdForChannel(channel, peer.id);
   if (!kind || !id) {
     return { state: "invalid" };
   }
@@ -489,6 +491,7 @@ function normalizePeerConstraint(
 }
 
 function normalizeBindingMatch(
+  channel: string,
   match:
     | {
         accountId?: string | undefined;
@@ -502,7 +505,7 @@ function normalizeBindingMatch(
   const rawRoles = match?.roles;
   return {
     accountPattern: (match?.accountId ?? "").trim(),
-    peer: normalizePeerConstraint(match?.peer),
+    peer: normalizePeerConstraint(channel, match?.peer),
     guildId: normalizeId(match?.guildId) || null,
     teamId: normalizeId(match?.teamId) || null,
     roles: Array.isArray(rawRoles) && rawRoles.length > 0 ? rawRoles : null,
@@ -621,7 +624,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const peer = input.peer
     ? {
         kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
-        id: normalizePeerId(input.peer.id),
+        id: normalizePeerIdForChannel(channel, input.peer.id),
       }
     : null;
   const guildId = normalizeId(input.guildId);
@@ -634,7 +637,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const parentPeer = input.parentPeer
     ? {
         kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
-        id: normalizePeerId(input.parentPeer.id),
+        id: normalizePeerIdForChannel(channel, input.parentPeer.id),
       }
     : null;
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -88,6 +88,10 @@ function normalizeId(value: unknown): string {
   return "";
 }
 
+function normalizePeerId(value: unknown): string {
+  return normalizeId(value).toLowerCase();
+}
+
 export function buildAgentSessionKey(params: {
   agentId: string;
   channel: string;
@@ -105,7 +109,7 @@ export function buildAgentSessionKey(params: {
     channel,
     accountId: params.accountId,
     peerKind: peer?.kind ?? "direct",
-    peerId: peer ? normalizeId(peer.id) || "unknown" : null,
+    peerId: peer ? normalizePeerId(peer.id) || "unknown" : null,
     dmScope: params.dmScope,
     identityLinks: params.identityLinks,
   });
@@ -477,7 +481,7 @@ function normalizePeerConstraint(
     return { state: "none" };
   }
   const kind = normalizeChatType(peer.kind);
-  const id = normalizeId(peer.id);
+  const id = normalizePeerId(peer.id);
   if (!kind || !id) {
     return { state: "invalid" };
   }
@@ -617,7 +621,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const peer = input.peer
     ? {
         kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
-        id: normalizeId(input.peer.id),
+        id: normalizePeerId(input.peer.id),
       }
     : null;
   const guildId = normalizeId(input.guildId);
@@ -630,7 +634,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const parentPeer = input.parentPeer
     ? {
         kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
-        id: normalizeId(input.parentPeer.id),
+        id: normalizePeerId(input.parentPeer.id),
       }
     : null;
 


### PR DESCRIPTION
## Summary

- Problem: Signal `bindings[].match.peer.id` could fail to match inbound group routes when config used the original mixed-case group id but OpenClaw canonicalized the routing/session path differently.
- Why it matters: messages silently route to the default agent instead of the bound agent, which is exactly the failure reported in #45296.
- What changed: route binding peer-id normalization is now canonicalized only for `channel: "signal"`, and regression tests cover both the Signal mixed-case case and a non-Signal case-sensitive guardrail.
- What did NOT change (scope boundary): this does not change Signal outbound target formatting or generic peer-id matching for other channels.
- AI-assisted: yes (Codex). I also ran local `codex review --base origin/main` and narrowed the initial change after it surfaced the over-broad non-Signal risk.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45296
- Related #45296

## User-visible / Behavior Changes

Signal peer bindings now match inbound routing even when the binding uses the original mixed-case group id and the runtime routing path is canonicalized.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Signal routing bindings
- Relevant config (redacted): top-level `bindings[]` with `match.channel: "signal"` and `match.peer.kind: "group"`

### Steps

1. Configure a Signal binding with a mixed-case `match.peer.id` group id.
2. Resolve an inbound Signal group route using the lowercased canonical form that OpenClaw uses in session/routing paths.
3. Observe agent selection.

### Expected

- The binding should still match and route to the configured agent.

### Actual

- Before this fix, the route could fall through to the default agent.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/routing/session-key.test.ts src/routing/resolve-route.test.ts`; `pnpm exec oxlint src/routing/resolve-route.ts src/routing/resolve-route.test.ts`
- Edge cases checked: Signal mixed-case binding matches; non-Signal case-sensitive channel binding remains case-sensitive.
- What you did **not** verify: full `pnpm build && pnpm check && pnpm test` suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/branch commit pair.
- Files/config to restore: `src/routing/resolve-route.ts`, `src/routing/resolve-route.test.ts`
- Known bad symptoms reviewers should watch for: unexpected peer binding matches outside Signal would indicate the channel scoping regressed.

## Risks and Mitigations

- Risk: accidentally broadening peer-id normalization beyond Signal could make case-sensitive channel bindings match too loosely.
  - Mitigation: normalization is now explicitly gated to `channel === "signal"`, and the test suite includes a non-Signal case-sensitive guardrail.
