### PR TITLE
fix: defer eager context window warmup to avoid TDZ error (AI-assisted)

### DIFF
--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -66,6 +66,9 @@ describe("lookupContextTokens", () => {
     process.argv = ["node", "openclaw", "--profile", "--", "config", "validate"];
     try {
       await import("./context.js");
+      // The eager warmup is deferred via queueMicrotask to avoid TDZ errors
+      // (see #45085), so flush the microtask queue before asserting.
+      await Promise.resolve();
       expect(loadConfigMock).toHaveBeenCalledTimes(1);
     } finally {
       process.argv = argvSnapshot;

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -194,9 +194,13 @@ export function lookupContextTokens(modelId?: string): number | undefined {
 }
 
 if (!shouldSkipEagerContextWindowWarmup()) {
-  // Keep prior behavior where model limits begin loading during startup.
-  // This avoids a cold-start miss on the first context token lookup.
-  void ensureContextWindowCacheLoaded();
+  // Defer the warmup to avoid a Temporal Dead Zone (TDZ) error when
+  // module-level constants (e.g. ANTHROPIC_MODEL_ALIASES in
+  // model-selection.ts) are referenced before they are initialized.
+  // `queueMicrotask` runs after all top-level module code has executed,
+  // preserving the eager semantics while avoiding the TDZ.
+  // See: https://github.com/openclaw/openclaw/issues/45085
+  queueMicrotask(() => void ensureContextWindowCacheLoaded());
 }
 
 function resolveConfiguredModelParams(


### PR DESCRIPTION
## Summary

Fixes #45085 — `ReferenceError: Cannot access ANTHROPIC_MODEL_ALIASES before initialization` on every `openclaw status` (and any CLI command that loads the main bundle) in v2026.3.12.

## Root Cause

The top-level eager warmup in `src/agents/context.ts` calls `ensureContextWindowCacheLoaded()` synchronously during module evaluation. This reaches `normalizeAnthropicModelId()` → `ANTHROPIC_MODEL_ALIASES`, but that `const` is declared later in the bundle and has not been initialized yet (Temporal Dead Zone).

## Fix

Replace the synchronous top-level call with a deferred microtask:

```ts
// Before
if (!shouldSkipEagerContextWindowWarmup()) {
  void ensureContextWindowCacheLoaded();
}

// After
if (!shouldSkipEagerContextWindowWarmup()) {
  queueMicrotask(() => void ensureContextWindowCacheLoaded());
}
```

`queueMicrotask` defers execution until after all module-level `const` declarations have been evaluated, while still firing before any user-level `await` — preserving the eager warmup semantics.

## Tests

- Updated `context.lookup.test.ts` to flush the microtask queue (`await Promise.resolve()`) before asserting on deferred warmup calls.
- Full test suite: **7631 passed**, 3 skipped, 1 pre-existing failure (unrelated `media/store.redirect.test.ts` file permission check).
- `pnpm build` passes cleanly.
- `pnpm check` has no new type errors (pre-existing errors in unrelated test files only).

## Impact

- **CLI**: `openclaw status` and other commands no longer print the spurious "Failed to read config" error.
- **Gateway**: No behavioral change (already worked via try/catch).
- **Context window cache**: Now correctly pre-warmed at startup (previously the TDZ error caused the warmup to silently fail).

## AI Disclosure

This PR was authored by an AI assistant (Claude/OpenClaw) with human oversight. The contributor understands the change: replacing a synchronous module-level call with `queueMicrotask()` to defer execution past the TDZ boundary while preserving eager warmup semantics. Fully tested locally with `pnpm build && pnpm check && pnpm test`.