### PR TITLE
fix: reuse chat-new-messages style for scroll-pill button

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1169,7 +1169,7 @@ export function renderChat(props: ChatProps) {
         props.showNewMessages
           ? html`
             <button
-              class="agent-chat__scroll-pill"
+              class="agent-chat__scroll-pill chat-new-messages"
               type="button"
               @click=${props.onScrollToBottom}
             >


### PR DESCRIPTION
## Summary

- Problem: The `.agent-chat__scroll-pill` button (the "New messages" floating pill in Dashboard agent chat) has no CSS styles. The `icons.arrowDown` SVG inside it has no size constraints, causing the icon to render at full viewport width and the button to appear as unstyled raw text.
- Why it matters: The pill is unusable — the oversized SVG blocks the UI and the button has no visual affordance (no background, border, or hover state).
- What changed: Added the existing `chat-new-messages` class to the button element in `chat.ts`, reusing the already-defined pill styles (flex layout, border-radius, hover effect, SVG sizing) instead of duplicating CSS.
- What did NOT change (scope boundary): No new CSS added. No changes to the existing `.chat-new-messages` styles. The `agent-chat__scroll-pill` class is preserved for semantic/JS targeting purposes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #44813

## User-visible / Behavior Changes

- The "New messages" scroll-to-bottom pill in Dashboard agent chat now renders as a styled floating pill button (rounded, bordered, with hover effect) instead of unstyled raw text with an oversized SVG icon.
- The arrow-down SVG icon is constrained to 16×16px.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Dashboard (web UI)
- Model/provider: Any
- Integration/channel (if any): Dashboard agent chat view
- Relevant config (redacted): N/A

### Steps

1. Open the Dashboard agent chat view.
2. Send multiple messages to create enough content for scrolling.
3. Scroll up so that new incoming messages are below the viewport.
4. Observe the "New messages" pill that appears.

### Expected

- A styled floating pill button with a 16×16px arrow-down icon, rounded borders, and hover effect — matching the `.chat-new-messages` style used elsewhere.

### Actual

- An unstyled button with raw "New messages" text and an oversized SVG icon that fills the viewport width.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

before:
<img width="1511" height="817" alt="企业微信20260314-022258@2x" src="https://github.com/user-attachments/assets/0e22b4f1-88f9-4f72-bc9a-28cf5c08a59e" />

after:
<img width="1194" height="162" alt="企业微信20260314-022859@2x" src="https://github.com/user-attachments/assets/67ce26b1-68b1-4ac1-a34f-31c7d4614fdd" />


## Human Verification (required)

- Verified scenarios: Opened Dashboard agent chat, triggered the "New messages" pill by scrolling up, confirmed it renders with proper pill styling and the SVG is 16×16px.
- Edge cases checked: Dark mode and light mode rendering; clicking the pill still scrolls to bottom correctly.
- What you did **not** verify: Other browsers beyond Chrome/Safari.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit touching `ui/src/ui/views/chat.ts`.
- Files/config to restore: `ui/src/ui/views/chat.ts`
- Known bad symptoms reviewers should watch for: Pill button not appearing; scroll-to-bottom click handler broken (unlikely — only class attribute changed).

## Risks and Mitigations

None. The change is a single class addition to an HTML element, reusing existing well-tested CSS. No new styles introduced.
