### PR TITLE
test: fix stale message-channel mock in compact.hooks.test

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -91,8 +91,10 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
   getOAuthProviders: vi.fn(() => []),
 }));
 
-vi.mock("@mariozechner/pi-coding-agent", () => {
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-coding-agent")>();
   return {
+    ...actual,
     createAgentSession: vi.fn(async () => {
       const session = {
         sessionId: "session-1",
@@ -277,9 +279,13 @@ vi.mock("../../config/channel-capabilities.js", () => ({
   resolveChannelCapabilities: vi.fn(() => undefined),
 }));
 
-vi.mock("../../utils/message-channel.js", () => ({
-  normalizeMessageChannel: vi.fn(() => undefined),
-}));
+vi.mock("../../utils/message-channel.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils/message-channel.js")>();
+  return {
+    ...actual,
+    normalizeMessageChannel: vi.fn(() => undefined),
+  };
+});
 
 vi.mock("../pi-embedded-helpers.js", () => ({
   ensureSessionHeader: vi.fn(async () => {}),

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -64,7 +64,7 @@ describe("formatBackupCreateSummary", () => {
             displayPath: "~/.openclaw/config.json",
           },
           {
-            kind: "oauth",
+            kind: "credentials",
             sourcePath: "/oauth",
             archivePath: "archive/oauth",
             displayPath: "~/.openclaw/oauth",

--- a/src/infra/pairing-pending.test.ts
+++ b/src/infra/pairing-pending.test.ts
@@ -33,7 +33,7 @@ describe("rejectPendingPairingRequest", () => {
         idKey: "accountId",
         loadState: async () => state,
         persistState,
-        getId: (pending) => pending.accountId,
+        getId: (pending: { accountId: string }) => pending.accountId,
       }),
     ).resolves.toEqual({
       requestId: "reject",


### PR DESCRIPTION
The vi.mock for message-channel.js was missing the INTERNAL_MESSAGE_CHANNEL export added in a recent commit. Updated the mock to spread importOriginal so future exports are automatically included.

Also fixed the @mariozechner/pi-coding-agent mock which had the same stale-mock pattern.