### PR TITLE
Plugins: normalize scan warning paths

### DIFF
--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -565,6 +565,42 @@ describe("installPluginFromArchive", () => {
     expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
   });
 
+  it("normalizes critical finding paths outside the plugin directory", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+    const scanSpy = vi.spyOn(skillScanner, "scanDirectoryWithSummary").mockResolvedValueOnce({
+      critical: 1,
+      warn: 0,
+      findings: [
+        {
+          ruleId: "no-eval",
+          severity: "critical",
+          message: "dynamic eval",
+          file: path.join(path.parse(pluginDir).root, "tmp", "outside", "evil.js"),
+          line: 7,
+        },
+      ],
+    });
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "path-warning-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(true);
+    expect(
+      warnings.some((w) => w.includes("dangerous code patterns: dynamic eval (evil.js:7)")),
+    ).toBe(true);
+    expect(warnings.some((w) => w.includes("/tmp/outside/evil.js"))).toBe(false);
+    scanSpy.mockRestore();
+  });
+
   it("scans extension entry files in hidden directories", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
     fs.mkdirSync(path.join(pluginDir, ".hidden"), { recursive: true });

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -45,6 +45,19 @@ type PackageManifest = PluginPackageManifest & {
   dependencies?: Record<string, string>;
 };
 
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
+function formatPluginScanFindingPath(filePath: string, packageDir: string): string {
+  const relPath = path.relative(packageDir, filePath);
+  const displayPath =
+    relPath && relPath !== "." && !relPath.startsWith("..")
+      ? relPath
+      : basenameAcrossSeparators(filePath);
+  return displayPath.replaceAll("\\", "/");
+}
+
 const MISSING_EXTENSIONS_ERROR =
   'package.json missing openclaw.extensions; update the plugin package to include openclaw.extensions (for example ["./dist/index.js"]). See https://docs.openclaw.ai/help/troubleshooting#plugin-install-fails-with-missing-openclaw-extensions';
 
@@ -289,7 +302,10 @@ async function installPluginFromPackageDir(
     if (scanSummary.critical > 0) {
       const criticalDetails = scanSummary.findings
         .filter((f) => f.severity === "critical")
-        .map((f) => `${f.message} (${f.file}:${f.line})`)
+        .map(
+          (f) =>
+            `${f.message} (${formatPluginScanFindingPath(f.file, params.packageDir)}:${f.line})`,
+        )
         .join("; ");
       logger.warn?.(
         `WARNING: Plugin "${pluginId}" contains dangerous code patterns: ${criticalDetails}`,


### PR DESCRIPTION
## Summary
- normalize plugin code-safety warning paths before showing them to users
- keep plugin-relative paths when findings are inside the package, but collapse outside paths to a basename only
- add a regression test for critical findings reported from outside the plugin directory

## Testing
- pnpm exec vitest run src/plugins/install.test.ts -t "normalizes critical finding paths outside the plugin directory"
- pnpm exec oxfmt --check src/plugins/install.ts src/plugins/install.test.ts
- pnpm build

## Notes
- `pnpm check` currently fails on `origin/main` due to unrelated baseline TypeScript/test typing errors outside this change.
