### PR TITLE
CLI: normalize secrets audit paths

### DIFF
--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "./test-runtime-capture.js";
@@ -99,6 +100,42 @@ describe("secrets CLI", () => {
     ).rejects.toBeTruthy();
     expect(runSecretsAudit).toHaveBeenCalled();
     expect(resolveSecretsAuditExitCode).toHaveBeenCalledWith(expect.anything(), true);
+  });
+
+  it("normalizes audit finding file paths in human output", async () => {
+    const absoluteConfigPath = path.join(
+      path.parse(process.cwd()).root,
+      "tmp",
+      "outside",
+      "secret-config.json",
+    );
+    runSecretsAudit.mockResolvedValue({
+      version: 1,
+      status: "findings",
+      filesScanned: [],
+      summary: {
+        plaintextCount: 1,
+        unresolvedRefCount: 0,
+        shadowedRefCount: 0,
+        legacyResidueCount: 0,
+      },
+      findings: [
+        {
+          code: "plaintext-secret",
+          file: absoluteConfigPath,
+          jsonPath: "providers.openai.apiKey",
+          message: "Plaintext secret found",
+        },
+      ],
+    });
+    resolveSecretsAuditExitCode.mockReturnValue(0);
+
+    await createProgram().parseAsync(["secrets", "audit"], { from: "user" });
+
+    expect(
+      runtimeLogs.some((line) => line.includes("secret-config.json:providers.openai.apiKey")),
+    ).toBe(true);
+    expect(runtimeLogs.some((line) => line.includes(absoluteConfigPath))).toBe(false);
   });
 
   it("runs secrets configure then apply when confirmed", async () => {

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { confirm } from "@clack/prompts";
 import type { Command } from "commander";
 import { danger } from "../globals.js";
@@ -30,6 +31,15 @@ type SecretsApplyOptions = {
   dryRun?: boolean;
   json?: boolean;
 };
+
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
+function formatSecretsAuditFindingLocation(filePath: string, jsonPath?: string): string {
+  const normalizedFile = basenameAcrossSeparators(filePath);
+  return jsonPath ? `${normalizedFile}:${jsonPath}` : normalizedFile;
+}
 
 function readPlanFile(pathname: string): SecretsApplyPlan {
   const raw = fs.readFileSync(pathname, "utf8");
@@ -95,7 +105,7 @@ export function registerSecretsCli(program: Command) {
           if (report.findings.length > 0) {
             for (const finding of report.findings.slice(0, 20)) {
               defaultRuntime.log(
-                `- [${finding.code}] ${finding.file}:${finding.jsonPath} ${finding.message}`,
+                `- [${finding.code}] ${formatSecretsAuditFindingLocation(finding.file, finding.jsonPath)} ${finding.message}`,
               );
             }
             if (report.findings.length > 20) {


### PR DESCRIPTION
## Summary
- normalize `secrets audit` finding locations before printing them in human-readable CLI output
- preserve the JSON path while collapsing raw scanner file paths down to a safe display name
- add a CLI regression test to ensure absolute paths are not echoed back to the terminal

## Testing
- pnpm test src/cli/secrets-cli.test.ts
- pnpm exec oxfmt --check src/cli/secrets-cli.ts src/cli/secrets-cli.test.ts
- pnpm build

## Notes
- `pnpm check` is currently failing on `origin/main` with unrelated baseline TypeScript/test typing errors outside this change.
