### PR TITLE
fix(cli): add windowsHide to restart script spawn on Windows

### DIFF
--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -169,6 +169,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    windowsHide: true,
   });
   child.unref();
 }


### PR DESCRIPTION
The restart helper uses `spawn('cmd.exe', ...)` to run the gateway restart batch script, but doesn't pass `windowsHide: true` in the options. This makes the cmd window flash on screen every time the gateway restarts.

Every other spawn call in the codebase that targets Windows already sets `windowsHide: true` (machine-name, qmd-manager, invoke, secrets, docker, windows-spawn) — this one was just missed.

Fixes #44693