### PR TITLE
fix: recover subagents after restart, preserve gateway webhook routes, and skip subagent memory flush

### DIFF
--- a/src/agents/subagent-registry.restart-recovery.test.ts
+++ b/src/agents/subagent-registry.restart-recovery.test.ts
@@ -1,0 +1,291 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { callGatewaySpy, announceSpy } = vi.hoisted(() => ({
+  callGatewaySpy: vi.fn(),
+  announceSpy: vi.fn(async () => true),
+}));
+
+const noop = () => {};
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: callGatewaySpy,
+  randomIdempotencyKey: () => "test-idem-key",
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn(() => noop),
+}));
+
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: announceSpy,
+  captureSubagentCompletionReply: vi.fn(async () => undefined),
+}));
+
+import { captureEnv } from "../test-utils/env.js";
+import {
+  initSubagentRegistry,
+  listSubagentRunsForRequester,
+  resetSubagentRegistryForTests,
+} from "./subagent-registry.js";
+import { loadSubagentRegistryFromDisk } from "./subagent-registry.store.js";
+
+describe("subagent restart recovery", () => {
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+  let tempStateDir: string | null = null;
+
+  const resolveAgentIdFromSessionKey = (sessionKey: string) => {
+    const match = sessionKey.match(/^agent:([^:]+):/i);
+    return (match?.[1] ?? "main").trim().toLowerCase() || "main";
+  };
+
+  const resolveSessionStorePath = (stateDir: string, agentId: string) =>
+    path.join(stateDir, "agents", agentId, "sessions", "sessions.json");
+
+  const readSessionStore = async (storePath: string) => {
+    try {
+      const raw = await fs.readFile(storePath, "utf8");
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, Record<string, unknown>>;
+      }
+    } catch {
+      // ignore
+    }
+    return {} as Record<string, Record<string, unknown>>;
+  };
+
+  const writeChildSessionEntry = async (params: {
+    sessionKey: string;
+    sessionId?: string;
+    updatedAt?: number;
+  }) => {
+    if (!tempStateDir) {
+      throw new Error("tempStateDir not initialized");
+    }
+    const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+    const storePath = resolveSessionStorePath(tempStateDir, agentId);
+    const store = await readSessionStore(storePath);
+    store[params.sessionKey] = {
+      ...store[params.sessionKey],
+      sessionId: params.sessionId ?? `sess-${agentId}-${Date.now()}`,
+      updatedAt: params.updatedAt ?? Date.now(),
+    };
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, `${JSON.stringify(store)}\n`, "utf8");
+    return storePath;
+  };
+
+  const writePersistedRegistry = async (persisted: Record<string, unknown>) => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-restart-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+    const registryPath = path.join(tempStateDir, "subagents", "runs.json");
+    await fs.mkdir(path.dirname(registryPath), { recursive: true });
+    await fs.writeFile(registryPath, `${JSON.stringify(persisted)}\n`, "utf8");
+    // Seed child session entries
+    const runs = (persisted.runs ?? {}) as Record<
+      string,
+      { runId?: string; childSessionKey?: string }
+    >;
+    for (const [runId, run] of Object.entries(runs)) {
+      const childSessionKey = run?.childSessionKey?.trim();
+      if (!childSessionKey) {
+        continue;
+      }
+      await writeChildSessionEntry({
+        sessionKey: childSessionKey,
+        sessionId: `sess-${run.runId ?? runId}`,
+      });
+    }
+    return registryPath;
+  };
+
+  const flushQueuedRegistryWork = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  afterEach(async () => {
+    callGatewaySpy.mockReset();
+    announceSpy.mockClear();
+    resetSubagentRegistryForTests({ persist: false });
+    if (tempStateDir) {
+      await fs.rm(tempStateDir, { recursive: true, force: true });
+      tempStateDir = null;
+    }
+    envSnapshot.restore();
+  });
+
+  it("retriggers subagent with continuation message after restart for incomplete run", async () => {
+    const now = Date.now();
+    const persisted = {
+      version: 2,
+      runs: {
+        "run-active": {
+          runId: "run-active",
+          childSessionKey: "agent:main:subagent:active-child",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          requesterOrigin: { channel: "bluebubbles", accountId: "acct-1" },
+          task: "do something complex",
+          cleanup: "keep",
+          label: "complex-task",
+          createdAt: now - 5000,
+          startedAt: now - 4000,
+          // No endedAt — the run was in progress when gateway restarted
+        },
+      },
+    };
+
+    // Mock callGateway: "agent" returns new runId, "agent.wait" returns ok
+    callGatewaySpy.mockImplementation(async (opts: { method: string }) => {
+      if (opts.method === "agent") {
+        return { runId: "run-active-v2" };
+      }
+      if (opts.method === "agent.wait") {
+        return { status: "ok", startedAt: now, endedAt: now + 1000 };
+      }
+      return {};
+    });
+
+    await writePersistedRegistry(persisted);
+    resetSubagentRegistryForTests({ persist: false });
+    initSubagentRegistry();
+    await flushQueuedRegistryWork();
+
+    // Verify callGateway was called with method "agent" for re-triggering
+    const agentCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method: string }).method === "agent",
+    );
+    expect(agentCalls.length).toBeGreaterThanOrEqual(1);
+
+    const agentCallParams = (agentCalls[0][0] as { params: Record<string, unknown> }).params;
+    expect(agentCallParams.sessionKey).toBe("agent:main:subagent:active-child");
+    // Verify continuation message is sent
+    expect(agentCallParams.message).toContain("gateway process restarted");
+    expect(agentCallParams.deliver).toBe(false);
+    expect(agentCallParams.lane).toBeDefined();
+    expect(agentCallParams.label).toBe("complex-task");
+  });
+
+  it("marks run as errored when retrigger agent call fails", async () => {
+    const now = Date.now();
+    const persisted = {
+      version: 2,
+      runs: {
+        "run-fail": {
+          runId: "run-fail",
+          childSessionKey: "agent:main:subagent:fail-child",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "doomed task",
+          cleanup: "keep",
+          createdAt: now - 5000,
+          startedAt: now - 4000,
+          // No endedAt
+        },
+      },
+    };
+
+    callGatewaySpy.mockImplementation(async (opts: { method: string }) => {
+      if (opts.method === "agent") {
+        throw new Error("gateway unreachable");
+      }
+      return {};
+    });
+
+    const registryPath = await writePersistedRegistry(persisted);
+    resetSubagentRegistryForTests({ persist: false });
+    initSubagentRegistry();
+    await flushQueuedRegistryWork();
+
+    // The run should be marked as ended with an error
+    const persistedAfter = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
+      runs?: Record<string, { endedAt?: number; outcome?: { status: string; error?: string } }>;
+    };
+
+    const run = persistedAfter.runs?.["run-fail"];
+    expect(run?.endedAt).toBeDefined();
+    expect(run?.outcome?.status).toBe("error");
+    expect(run?.outcome?.error).toContain("restart recovery failed");
+  });
+
+  it("falls back to wait when retrigger returns no runId", async () => {
+    const now = Date.now();
+    const persisted = {
+      version: 2,
+      runs: {
+        "run-no-id": {
+          runId: "run-no-id",
+          childSessionKey: "agent:main:subagent:no-id-child",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "task with no runId",
+          cleanup: "keep",
+          createdAt: now - 5000,
+          startedAt: now - 4000,
+          // No endedAt
+        },
+      },
+    };
+
+    callGatewaySpy.mockImplementation(async (opts: { method: string }) => {
+      if (opts.method === "agent") {
+        return {}; // No runId returned
+      }
+      if (opts.method === "agent.wait") {
+        return { status: "ok", startedAt: now, endedAt: now + 1000 };
+      }
+      return {};
+    });
+
+    await writePersistedRegistry(persisted);
+    resetSubagentRegistryForTests({ persist: false });
+    initSubagentRegistry();
+    await flushQueuedRegistryWork();
+
+    // Should have called agent.wait as fallback
+    const waitCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method: string }).method === "agent.wait",
+    );
+    expect(waitCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not retrigger runs that already have endedAt set", async () => {
+    const now = Date.now();
+    const persisted = {
+      version: 2,
+      runs: {
+        "run-ended": {
+          runId: "run-ended",
+          childSessionKey: "agent:main:subagent:ended-child",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "already done",
+          cleanup: "keep",
+          createdAt: now - 5000,
+          startedAt: now - 4000,
+          endedAt: now - 1000, // Already ended
+        },
+      },
+    };
+
+    callGatewaySpy.mockImplementation(async () => ({}));
+    announceSpy.mockResolvedValue(true);
+
+    await writePersistedRegistry(persisted);
+    resetSubagentRegistryForTests({ persist: false });
+    initSubagentRegistry();
+    await flushQueuedRegistryWork();
+
+    // No "agent" method calls for re-triggering (only cleanup/announce flows)
+    const agentCalls = callGatewaySpy.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method: string }).method === "agent",
+    );
+    expect(agentCalls).toHaveLength(0);
+  });
+});

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -11,8 +11,9 @@ import {
 import { ensureContextEnginesInitialized } from "../context-engine/init.js";
 import { resolveContextEngine } from "../context-engine/registry.js";
 import type { SubagentEndReason } from "../context-engine/types.js";
-import { callGateway } from "../gateway/call.js";
+import { callGateway, randomIdempotencyKey } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
+import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { defaultRuntime } from "../runtime.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
@@ -578,6 +579,88 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
   return true;
 }
 
+/**
+ * Re-trigger a subagent whose agent turn was killed during gateway restart.
+ * Sends a continuation message to the subagent's existing session so it gets
+ * a fresh agent turn to finish its work.  The new runId replaces the old one
+ * in the registry so completion tracking continues seamlessly.
+ */
+async function retriggerSubagentAfterRestart(
+  runId: string,
+  entry: SubagentRunRecord,
+): Promise<void> {
+  const childSessionKey = entry.childSessionKey;
+  const requesterOrigin = normalizeDeliveryContext(entry.requesterOrigin);
+
+  try {
+    const cfg = loadConfig();
+    const runTimeoutSeconds = entry.runTimeoutSeconds ?? 0;
+
+    const continuationMessage = [
+      "[System] The gateway process restarted while you were working.",
+      "Any exec processes you had running were terminated.",
+      "Your conversation history is intact. Continue your task from where you left off.",
+      "If you were waiting on a process, check if it needs to be re-run.",
+    ].join("\n");
+
+    const response = await callGateway<{ runId?: string }>({
+      method: "agent",
+      params: {
+        message: continuationMessage,
+        sessionKey: childSessionKey,
+        channel: requesterOrigin?.channel,
+        to: requesterOrigin?.to ?? undefined,
+        accountId: requesterOrigin?.accountId ?? undefined,
+        threadId:
+          requesterOrigin?.threadId != null ? String(requesterOrigin.threadId) : undefined,
+        idempotencyKey: randomIdempotencyKey(),
+        deliver: false,
+        lane: AGENT_LANE_SUBAGENT,
+        timeout: runTimeoutSeconds,
+        label: entry.label || undefined,
+      },
+      timeoutMs: 10_000,
+    });
+
+    const newRunId = response?.runId;
+    if (typeof newRunId !== "string" || !newRunId.trim()) {
+      // Agent call didn't return a runId, fall back to waiting on old run.
+      defaultRuntime.log(
+        `[warn] Subagent restart recovery: agent call returned no runId for ${childSessionKey}, falling back to wait`,
+      );
+      const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
+      void waitForSubagentCompletion(runId, waitTimeoutMs);
+      return;
+    }
+
+    // Replace the old run entry with the new runId.
+    replaceSubagentRunAfterSteer({
+      previousRunId: runId,
+      nextRunId: newRunId,
+      fallback: entry,
+      runTimeoutSeconds,
+    });
+
+    defaultRuntime.log(
+      `[info] Subagent restart recovery: retriggered ${childSessionKey} old=${runId} new=${newRunId}`,
+    );
+  } catch (err) {
+    defaultRuntime.log(
+      `[warn] Subagent restart recovery failed for ${childSessionKey}: ${String(err)}`,
+    );
+    // Mark the run as failed so it doesn't hang forever.
+    void completeSubagentRun({
+      runId,
+      endedAt: Date.now(),
+      outcome: { status: "error", error: `restart recovery failed: ${String(err)}` },
+      reason: SUBAGENT_ENDED_REASON_ERROR,
+      sendFarewell: true,
+      accountId: requesterOrigin?.accountId,
+      triggerCleanup: true,
+    });
+  }
+}
+
 function resumeSubagentRun(runId: string) {
   if (!runId || resumedRuns.has(runId)) {
     return;
@@ -650,11 +733,10 @@ function resumeSubagentRun(runId: string) {
     return;
   }
 
-  // Wait for completion again after restart.
-  const cfg = loadConfig();
-  const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, entry.runTimeoutSeconds);
-  void waitForSubagentCompletion(runId, waitTimeoutMs);
+  // After gateway restart, the agent turn that was mid-execution was killed.
+  // Re-trigger the subagent with a continuation message so it can resume work.
   resumedRuns.add(runId);
+  void retriggerSubagentAfterRestart(runId, entry);
 }
 
 function restoreSubagentRunsOnce() {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { shouldAttemptMemoryFlushRun } from "./agent-runner-memory.js";
+
+describe("shouldAttemptMemoryFlushRun", () => {
+  it("skips subagent sessions", () => {
+    expect(
+      shouldAttemptMemoryFlushRun({
+        memoryFlushWritable: true,
+        isHeartbeat: false,
+        isCli: false,
+        sessionKey: "agent:main:subagent:worker",
+      }),
+    ).toBe(false);
+  });
+
+  it("skips heartbeat and cli runs", () => {
+    expect(
+      shouldAttemptMemoryFlushRun({
+        memoryFlushWritable: true,
+        isHeartbeat: true,
+        isCli: false,
+        sessionKey: "main",
+      }),
+    ).toBe(false);
+    expect(
+      shouldAttemptMemoryFlushRun({
+        memoryFlushWritable: true,
+        isHeartbeat: false,
+        isCli: true,
+        sessionKey: "main",
+      }),
+    ).toBe(false);
+  });
+
+  it("allows regular writable sessions", () => {
+    expect(
+      shouldAttemptMemoryFlushRun({
+        memoryFlushWritable: true,
+        isHeartbeat: false,
+        isCli: false,
+        sessionKey: "main",
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -23,6 +23,7 @@ import {
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions } from "../types.js";
@@ -66,6 +67,20 @@ export function resolveEffectivePromptTokens(
   // Flush gating projects the next input context by adding the previous
   // completion and the current user prompt estimate.
   return base + output + estimate;
+}
+
+export function shouldAttemptMemoryFlushRun(params: {
+  memoryFlushWritable: boolean;
+  isHeartbeat: boolean;
+  isCli: boolean;
+  sessionKey?: string;
+}): boolean {
+  return (
+    params.memoryFlushWritable &&
+    !params.isHeartbeat &&
+    !params.isCli &&
+    !isSubagentSessionKey(params.sessionKey)
+  );
 }
 
 export type SessionTranscriptUsageSnapshot = {
@@ -267,14 +282,15 @@ export async function runMemoryFlushIfNeeded(params: {
   if (!memoryFlushSettings) {
     return params.sessionEntry;
   }
+  const effectiveSessionKey = params.sessionKey ?? params.followupRun.run.sessionKey;
 
   const memoryFlushWritable = (() => {
-    if (!params.sessionKey) {
+    if (!effectiveSessionKey) {
       return true;
     }
     const runtime = resolveSandboxRuntimeStatus({
       cfg: params.cfg,
-      sessionKey: params.sessionKey,
+      sessionKey: effectiveSessionKey,
     });
     if (!runtime.sandboxed) {
       return true;
@@ -284,10 +300,16 @@ export async function runMemoryFlushIfNeeded(params: {
   })();
 
   const isCli = isCliProvider(params.followupRun.run.provider, params.cfg);
-  const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
+  const canAttemptFlush = shouldAttemptMemoryFlushRun({
+    memoryFlushWritable,
+    isHeartbeat: params.isHeartbeat,
+    isCli,
+    sessionKey: effectiveSessionKey,
+  });
+  const isSubagentSession = isSubagentSessionKey(effectiveSessionKey);
   let entry =
     params.sessionEntry ??
-    (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
+    (effectiveSessionKey ? params.sessionStore?.[effectiveSessionKey] : undefined);
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
@@ -342,7 +364,7 @@ export async function runMemoryFlushIfNeeded(params: {
     ? await readSessionLogSnapshot({
         sessionId: params.followupRun.run.sessionId,
         sessionEntry: entry,
-        sessionKey: params.sessionKey ?? params.followupRun.run.sessionKey,
+        sessionKey: effectiveSessionKey,
         opts: { storePath: params.storePath },
         includeByteSize: shouldCheckTranscriptSizeForForcedFlush,
         includeUsage: shouldReadTranscript,
@@ -371,20 +393,20 @@ export async function runMemoryFlushIfNeeded(params: {
       totalTokensFresh: true,
     };
     entry = nextEntry;
-    if (params.sessionKey && params.sessionStore) {
-      params.sessionStore[params.sessionKey] = nextEntry;
+    if (effectiveSessionKey && params.sessionStore) {
+      params.sessionStore[effectiveSessionKey] = nextEntry;
     }
-    if (params.storePath && params.sessionKey) {
+    if (params.storePath && effectiveSessionKey) {
       try {
         const updatedEntry = await updateSessionStoreEntry({
           storePath: params.storePath,
-          sessionKey: params.sessionKey,
+          sessionKey: effectiveSessionKey,
           update: async () => ({ totalTokens: transcriptPromptTokens, totalTokensFresh: true }),
         });
         if (updatedEntry) {
           entry = updatedEntry;
           if (params.sessionStore) {
-            params.sessionStore[params.sessionKey] = updatedEntry;
+            params.sessionStore[effectiveSessionKey] = updatedEntry;
           }
         }
       } catch (err) {
@@ -421,6 +443,7 @@ export async function runMemoryFlushIfNeeded(params: {
       `tokenCount=${tokenCountForFlush ?? "undefined"} ` +
       `contextWindow=${contextWindowTokens} threshold=${flushThreshold} ` +
       `isHeartbeat=${params.isHeartbeat} isCli=${isCli} memoryFlushWritable=${memoryFlushWritable} ` +
+      `isSubagentSession=${isSubagentSession} ` +
       `compactionCount=${entry?.compactionCount ?? 0} memoryFlushCompactionCount=${entry?.memoryFlushCompactionCount ?? "undefined"} ` +
       `persistedPromptTokens=${persistedPromptTokens ?? "undefined"} persistedFresh=${entry?.totalTokensFresh === true} ` +
       `promptTokensEst=${promptTokenEstimate ?? "undefined"} transcriptPromptTokens=${transcriptPromptTokens ?? "undefined"} transcriptOutputTokens=${transcriptOutputTokens ?? "undefined"} ` +
@@ -456,12 +479,14 @@ export async function runMemoryFlushIfNeeded(params: {
   const activeSessionStore = params.sessionStore;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     activeSessionEntry?.systemPromptReport ??
-      (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.systemPromptReport : undefined),
+      (effectiveSessionKey
+        ? activeSessionStore?.[effectiveSessionKey]?.systemPromptReport
+        : undefined),
   );
   const flushRunId = crypto.randomUUID();
-  if (params.sessionKey) {
+  if (effectiveSessionKey) {
     registerAgentRunContext(flushRunId, {
-      sessionKey: params.sessionKey,
+      sessionKey: effectiveSessionKey,
       verboseLevel: params.resolvedVerboseLevel,
     });
   }
@@ -528,24 +553,24 @@ export async function runMemoryFlushIfNeeded(params: {
     });
     let memoryFlushCompactionCount =
       activeSessionEntry?.compactionCount ??
-      (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.compactionCount : 0) ??
+      (effectiveSessionKey ? activeSessionStore?.[effectiveSessionKey]?.compactionCount : 0) ??
       0;
     if (memoryCompactionCompleted) {
       const nextCount = await incrementCompactionCount({
         sessionEntry: activeSessionEntry,
         sessionStore: activeSessionStore,
-        sessionKey: params.sessionKey,
+        sessionKey: effectiveSessionKey,
         storePath: params.storePath,
       });
       if (typeof nextCount === "number") {
         memoryFlushCompactionCount = nextCount;
       }
     }
-    if (params.storePath && params.sessionKey) {
+    if (params.storePath && effectiveSessionKey) {
       try {
         const updatedEntry = await updateSessionStoreEntry({
           storePath: params.storePath,
-          sessionKey: params.sessionKey,
+          sessionKey: effectiveSessionKey,
           update: async () => ({
             memoryFlushAt: Date.now(),
             memoryFlushCompactionCount,

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -11,6 +11,7 @@ export function createGatewayCloseHandler(params: {
   tailscaleCleanup: (() => Promise<void>) | null;
   canvasHost: CanvasHostHandler | null;
   canvasHostServer: CanvasHostServer | null;
+  releasePluginRouteRegistry?: (() => void) | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
   cron: { stop: () => void };
@@ -33,106 +34,114 @@ export function createGatewayCloseHandler(params: {
   httpServers?: HttpServer[];
 }) {
   return async (opts?: { reason?: string; restartExpectedMs?: number | null }) => {
-    const reasonRaw = typeof opts?.reason === "string" ? opts.reason.trim() : "";
-    const reason = reasonRaw || "gateway stopping";
-    const restartExpectedMs =
-      typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
-        ? Math.max(0, Math.floor(opts.restartExpectedMs))
-        : null;
-    if (params.bonjourStop) {
-      try {
-        await params.bonjourStop();
-      } catch {
-        /* ignore */
-      }
-    }
-    if (params.tailscaleCleanup) {
-      await params.tailscaleCleanup();
-    }
-    if (params.canvasHost) {
-      try {
-        await params.canvasHost.close();
-      } catch {
-        /* ignore */
-      }
-    }
-    if (params.canvasHostServer) {
-      try {
-        await params.canvasHostServer.close();
-      } catch {
-        /* ignore */
-      }
-    }
-    for (const plugin of listChannelPlugins()) {
-      await params.stopChannel(plugin.id);
-    }
-    if (params.pluginServices) {
-      await params.pluginServices.stop().catch(() => {});
-    }
-    await stopGmailWatcher();
-    params.cron.stop();
-    params.heartbeatRunner.stop();
     try {
-      params.updateCheckStop?.();
-    } catch {
-      /* ignore */
-    }
-    for (const timer of params.nodePresenceTimers.values()) {
-      clearInterval(timer);
-    }
-    params.nodePresenceTimers.clear();
-    params.broadcast("shutdown", {
-      reason,
-      restartExpectedMs,
-    });
-    clearInterval(params.tickInterval);
-    clearInterval(params.healthInterval);
-    clearInterval(params.dedupeCleanup);
-    if (params.mediaCleanup) {
-      clearInterval(params.mediaCleanup);
-    }
-    if (params.agentUnsub) {
+      const reasonRaw = typeof opts?.reason === "string" ? opts.reason.trim() : "";
+      const reason = reasonRaw || "gateway stopping";
+      const restartExpectedMs =
+        typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
+          ? Math.max(0, Math.floor(opts.restartExpectedMs))
+          : null;
+      if (params.bonjourStop) {
+        try {
+          await params.bonjourStop();
+        } catch {
+          /* ignore */
+        }
+      }
+      if (params.tailscaleCleanup) {
+        await params.tailscaleCleanup();
+      }
+      if (params.canvasHost) {
+        try {
+          await params.canvasHost.close();
+        } catch {
+          /* ignore */
+        }
+      }
+      if (params.canvasHostServer) {
+        try {
+          await params.canvasHostServer.close();
+        } catch {
+          /* ignore */
+        }
+      }
+      for (const plugin of listChannelPlugins()) {
+        await params.stopChannel(plugin.id);
+      }
+      if (params.pluginServices) {
+        await params.pluginServices.stop().catch(() => {});
+      }
+      await stopGmailWatcher();
+      params.cron.stop();
+      params.heartbeatRunner.stop();
       try {
-        params.agentUnsub();
+        params.updateCheckStop?.();
       } catch {
         /* ignore */
       }
-    }
-    if (params.heartbeatUnsub) {
+      for (const timer of params.nodePresenceTimers.values()) {
+        clearInterval(timer);
+      }
+      params.nodePresenceTimers.clear();
+      params.broadcast("shutdown", {
+        reason,
+        restartExpectedMs,
+      });
+      clearInterval(params.tickInterval);
+      clearInterval(params.healthInterval);
+      clearInterval(params.dedupeCleanup);
+      if (params.mediaCleanup) {
+        clearInterval(params.mediaCleanup);
+      }
+      if (params.agentUnsub) {
+        try {
+          params.agentUnsub();
+        } catch {
+          /* ignore */
+        }
+      }
+      if (params.heartbeatUnsub) {
+        try {
+          params.heartbeatUnsub();
+        } catch {
+          /* ignore */
+        }
+      }
+      params.chatRunState.clear();
+      for (const c of params.clients) {
+        try {
+          c.socket.close(1012, "service restart");
+        } catch {
+          /* ignore */
+        }
+      }
+      params.clients.clear();
+      await params.configReloader.stop().catch(() => {});
+      if (params.browserControl) {
+        await params.browserControl.stop().catch(() => {});
+      }
+      await new Promise<void>((resolve) => params.wss.close(() => resolve()));
+      const servers =
+        params.httpServers && params.httpServers.length > 0
+          ? params.httpServers
+          : [params.httpServer];
+      for (const server of servers) {
+        const httpServer = server as HttpServer & {
+          closeIdleConnections?: () => void;
+        };
+        if (typeof httpServer.closeIdleConnections === "function") {
+          httpServer.closeIdleConnections();
+        }
+        await new Promise<void>((resolve, reject) =>
+          httpServer.close((err) => (err ? reject(err) : resolve())),
+        );
+      }
+    } finally {
       try {
-        params.heartbeatUnsub();
+        params.releasePluginRouteRegistry?.();
       } catch {
         /* ignore */
       }
-    }
-    params.chatRunState.clear();
-    for (const c of params.clients) {
-      try {
-        c.socket.close(1012, "service restart");
-      } catch {
-        /* ignore */
-      }
-    }
-    params.clients.clear();
-    await params.configReloader.stop().catch(() => {});
-    if (params.browserControl) {
-      await params.browserControl.stop().catch(() => {});
-    }
-    await new Promise<void>((resolve) => params.wss.close(() => resolve()));
-    const servers =
-      params.httpServers && params.httpServers.length > 0
-        ? params.httpServers
-        : [params.httpServer];
-    for (const server of servers) {
-      const httpServer = server as HttpServer & {
-        closeIdleConnections?: () => void;
-      };
-      if (typeof httpServer.closeIdleConnections === "function") {
-        httpServer.closeIdleConnections();
-      }
-      await new Promise<void>((resolve, reject) =>
-        httpServer.close((err) => (err ? reject(err) : resolve())),
-      );
     }
   };
 }

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -5,6 +5,11 @@ import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import {
+  getActivePluginHttpRouteRegistry,
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+} from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -70,6 +75,7 @@ export async function createGatewayRuntimeState(params: {
   getReadiness?: ReadinessChecker;
 }): Promise<{
   canvasHost: CanvasHostHandler | null;
+  releasePluginRouteRegistry: () => void;
   httpServer: HttpServer;
   httpServers: HttpServer[];
   httpBindHosts: string[];
@@ -91,147 +97,157 @@ export async function createGatewayRuntimeState(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   toolEventRecipients: ReturnType<typeof createToolEventRecipientRegistry>;
 }> {
-  let canvasHost: CanvasHostHandler | null = null;
-  if (params.canvasHostEnabled) {
-    try {
-      const handler = await createCanvasHostHandler({
-        runtime: params.canvasRuntime,
-        rootDir: params.cfg.canvasHost?.root,
-        basePath: CANVAS_HOST_PATH,
-        allowInTests: params.allowCanvasHostInTests,
-        liveReload: params.cfg.canvasHost?.liveReload,
-      });
-      if (handler.rootDir) {
-        canvasHost = handler;
-        params.logCanvas.info(
-          `canvas host mounted at http://${params.bindHost}:${params.port}${CANVAS_HOST_PATH}/ (root ${handler.rootDir})`,
-        );
+  pinActivePluginHttpRouteRegistry(params.pluginRegistry);
+  try {
+    let canvasHost: CanvasHostHandler | null = null;
+    if (params.canvasHostEnabled) {
+      try {
+        const handler = await createCanvasHostHandler({
+          runtime: params.canvasRuntime,
+          rootDir: params.cfg.canvasHost?.root,
+          basePath: CANVAS_HOST_PATH,
+          allowInTests: params.allowCanvasHostInTests,
+          liveReload: params.cfg.canvasHost?.liveReload,
+        });
+        if (handler.rootDir) {
+          canvasHost = handler;
+          params.logCanvas.info(
+            `canvas host mounted at http://${params.bindHost}:${params.port}${CANVAS_HOST_PATH}/ (root ${handler.rootDir})`,
+          );
+        }
+      } catch (err) {
+        params.logCanvas.warn(`canvas host failed to start: ${String(err)}`);
       }
-    } catch (err) {
-      params.logCanvas.warn(`canvas host failed to start: ${String(err)}`);
     }
-  }
 
-  const clients = new Set<GatewayWsClient>();
-  const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
+    const clients = new Set<GatewayWsClient>();
+    const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
 
-  const handleHooksRequest = createGatewayHooksRequestHandler({
-    deps: params.deps,
-    getHooksConfig: params.hooksConfig,
-    getClientIpConfig: params.getHookClientIpConfig,
-    bindHost: params.bindHost,
-    port: params.port,
-    logHooks: params.logHooks,
-  });
-
-  const handlePluginRequest = createGatewayPluginRequestHandler({
-    registry: params.pluginRegistry,
-    log: params.logPlugins,
-  });
-  const shouldEnforcePluginGatewayAuth = (pathContext: PluginRoutePathContext): boolean => {
-    return shouldEnforceGatewayAuthForPluginPath(params.pluginRegistry, pathContext);
-  };
-
-  const bindHosts = await resolveGatewayListenHosts(params.bindHost);
-  if (!isLoopbackHost(params.bindHost)) {
-    params.log.warn(
-      "⚠️  Gateway is binding to a non-loopback address. " +
-        "Ensure authentication is configured before exposing to public networks.",
-    );
-  }
-  if (params.cfg.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true) {
-    params.log.warn(
-      "⚠️  gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true is enabled. " +
-        "Host-header origin fallback weakens origin checks and should only be used as break-glass.",
-    );
-  }
-  const httpServers: HttpServer[] = [];
-  const httpBindHosts: string[] = [];
-  for (const host of bindHosts) {
-    const httpServer = createGatewayHttpServer({
-      canvasHost,
-      clients,
-      controlUiEnabled: params.controlUiEnabled,
-      controlUiBasePath: params.controlUiBasePath,
-      controlUiRoot: params.controlUiRoot,
-      openAiChatCompletionsEnabled: params.openAiChatCompletionsEnabled,
-      openAiChatCompletionsConfig: params.openAiChatCompletionsConfig,
-      openResponsesEnabled: params.openResponsesEnabled,
-      openResponsesConfig: params.openResponsesConfig,
-      strictTransportSecurityHeader: params.strictTransportSecurityHeader,
-      handleHooksRequest,
-      handlePluginRequest,
-      shouldEnforcePluginGatewayAuth,
-      resolvedAuth: params.resolvedAuth,
-      rateLimiter: params.rateLimiter,
-      getReadiness: params.getReadiness,
-      tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
+    const handleHooksRequest = createGatewayHooksRequestHandler({
+      deps: params.deps,
+      getHooksConfig: params.hooksConfig,
+      getClientIpConfig: params.getHookClientIpConfig,
+      bindHost: params.bindHost,
+      port: params.port,
+      logHooks: params.logHooks,
     });
-    try {
-      await listenGatewayHttpServer({
-        httpServer,
-        bindHost: host,
-        port: params.port,
-      });
-      httpServers.push(httpServer);
-      httpBindHosts.push(host);
-    } catch (err) {
-      if (host === bindHosts[0]) {
-        throw err;
-      }
+
+    const handlePluginRequest = createGatewayPluginRequestHandler({
+      registry: params.pluginRegistry,
+      log: params.logPlugins,
+    });
+    const shouldEnforcePluginGatewayAuth = (pathContext: PluginRoutePathContext): boolean => {
+      return shouldEnforceGatewayAuthForPluginPath(
+        getActivePluginHttpRouteRegistry() ?? params.pluginRegistry,
+        pathContext,
+      );
+    };
+
+    const bindHosts = await resolveGatewayListenHosts(params.bindHost);
+    if (!isLoopbackHost(params.bindHost)) {
       params.log.warn(
-        `gateway: failed to bind loopback alias ${host}:${params.port} (${String(err)})`,
+        "⚠️  Gateway is binding to a non-loopback address. " +
+          "Ensure authentication is configured before exposing to public networks.",
       );
     }
-  }
-  const httpServer = httpServers[0];
-  if (!httpServer) {
-    throw new Error("Gateway HTTP server failed to start");
-  }
+    if (params.cfg.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true) {
+      params.log.warn(
+        "⚠️  gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true is enabled. " +
+          "Host-header origin fallback weakens origin checks and should only be used as break-glass.",
+      );
+    }
+    const httpServers: HttpServer[] = [];
+    const httpBindHosts: string[] = [];
+    for (const host of bindHosts) {
+      const httpServer = createGatewayHttpServer({
+        canvasHost,
+        clients,
+        controlUiEnabled: params.controlUiEnabled,
+        controlUiBasePath: params.controlUiBasePath,
+        controlUiRoot: params.controlUiRoot,
+        openAiChatCompletionsEnabled: params.openAiChatCompletionsEnabled,
+        openAiChatCompletionsConfig: params.openAiChatCompletionsConfig,
+        openResponsesEnabled: params.openResponsesEnabled,
+        openResponsesConfig: params.openResponsesConfig,
+        strictTransportSecurityHeader: params.strictTransportSecurityHeader,
+        handleHooksRequest,
+        handlePluginRequest,
+        shouldEnforcePluginGatewayAuth,
+        resolvedAuth: params.resolvedAuth,
+        rateLimiter: params.rateLimiter,
+        getReadiness: params.getReadiness,
+        tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
+      });
+      try {
+        await listenGatewayHttpServer({
+          httpServer,
+          bindHost: host,
+          port: params.port,
+        });
+        httpServers.push(httpServer);
+        httpBindHosts.push(host);
+      } catch (err) {
+        if (host === bindHosts[0]) {
+          throw err;
+        }
+        params.log.warn(
+          `gateway: failed to bind loopback alias ${host}:${params.port} (${String(err)})`,
+        );
+      }
+    }
+    const httpServer = httpServers[0];
+    if (!httpServer) {
+      throw new Error("Gateway HTTP server failed to start");
+    }
 
-  const wss = new WebSocketServer({
-    noServer: true,
-    maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
-  });
-  for (const server of httpServers) {
-    attachGatewayUpgradeHandler({
-      httpServer: server,
-      wss,
-      canvasHost,
-      clients,
-      resolvedAuth: params.resolvedAuth,
-      rateLimiter: params.rateLimiter,
+    const wss = new WebSocketServer({
+      noServer: true,
+      maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
     });
+    for (const server of httpServers) {
+      attachGatewayUpgradeHandler({
+        httpServer: server,
+        wss,
+        canvasHost,
+        clients,
+        resolvedAuth: params.resolvedAuth,
+        rateLimiter: params.rateLimiter,
+      });
+    }
+
+    const agentRunSeq = new Map<string, number>();
+    const dedupe = new Map<string, DedupeEntry>();
+    const chatRunState = createChatRunState();
+    const chatRunRegistry = chatRunState.registry;
+    const chatRunBuffers = chatRunState.buffers;
+    const chatDeltaSentAt = chatRunState.deltaSentAt;
+    const addChatRun = chatRunRegistry.add;
+    const removeChatRun = chatRunRegistry.remove;
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const toolEventRecipients = createToolEventRecipientRegistry();
+
+    return {
+      canvasHost,
+      releasePluginRouteRegistry: () => releasePinnedPluginHttpRouteRegistry(params.pluginRegistry),
+      httpServer,
+      httpServers,
+      httpBindHosts,
+      wss,
+      clients,
+      broadcast,
+      broadcastToConnIds,
+      agentRunSeq,
+      dedupe,
+      chatRunState,
+      chatRunBuffers,
+      chatDeltaSentAt,
+      addChatRun,
+      removeChatRun,
+      chatAbortControllers,
+      toolEventRecipients,
+    };
+  } catch (err) {
+    releasePinnedPluginHttpRouteRegistry(params.pluginRegistry);
+    throw err;
   }
-
-  const agentRunSeq = new Map<string, number>();
-  const dedupe = new Map<string, DedupeEntry>();
-  const chatRunState = createChatRunState();
-  const chatRunRegistry = chatRunState.registry;
-  const chatRunBuffers = chatRunState.buffers;
-  const chatDeltaSentAt = chatRunState.deltaSentAt;
-  const addChatRun = chatRunRegistry.add;
-  const removeChatRun = chatRunRegistry.remove;
-  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
-  const toolEventRecipients = createToolEventRecipientRegistry();
-
-  return {
-    canvasHost,
-    httpServer,
-    httpServers,
-    httpBindHosts,
-    wss,
-    clients,
-    broadcast,
-    broadcastToConnIds,
-    agentRunSeq,
-    dedupe,
-    chatRunState,
-    chatRunBuffers,
-    chatDeltaSentAt,
-    addChatRun,
-    removeChatRun,
-    chatAbortControllers,
-    toolEventRecipients,
-  };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -583,6 +583,7 @@ export async function startGatewayServer(
   });
   const {
     canvasHost,
+    releasePluginRouteRegistry,
     httpServer,
     httpServers,
     httpBindHosts,
@@ -1022,6 +1023,7 @@ export async function startGatewayServer(
     tailscaleCleanup,
     canvasHost,
     canvasHostServer,
+    releasePluginRouteRegistry,
     stopChannel,
     pluginServices,
     cron,

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -1,5 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
+import { registerPluginHttpRoute } from "../../plugins/http-registry.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "../server-methods/types.js";
 import { makeMockHttpResponse } from "../test-http-response.js";
@@ -290,6 +297,81 @@ describe("createGatewayPluginRequestHandler", () => {
     const handled = await handler({ url: "/API//demo" } as IncomingMessage, res);
     expect(handled).toBe(true);
     expect(routeHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles routes registered into the pinned startup registry after the active registry changes", async () => {
+    const startupRegistry = createTestRegistry();
+    const laterActiveRegistry = createTestRegistry();
+    const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 202;
+      return true;
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    setActivePluginRegistry(laterActiveRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      handler: routeHandler,
+    });
+
+    try {
+      const handler = createGatewayPluginRequestHandler({
+        registry: startupRegistry,
+        log: createPluginLog(),
+      });
+
+      const { res } = makeMockHttpResponse();
+      const handled = await handler({ url: "/bluebubbles-webhook" } as IncomingMessage, res);
+      expect(handled).toBe(true);
+      expect(routeHandler).toHaveBeenCalledTimes(1);
+      expect(laterActiveRegistry.httpRoutes).toHaveLength(0);
+    } finally {
+      unregister();
+      releasePinnedPluginHttpRouteRegistry(startupRegistry);
+      setActivePluginRegistry(createEmptyPluginRegistry());
+    }
+  });
+
+  it("dispatches using the pinned route registry when both startup and active registries are stale", async () => {
+    const startupRegistry = createTestRegistry();
+    const routeRegistry = createTestRegistry();
+    const laterActiveRegistry = createTestRegistry();
+    const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 204;
+      return true;
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(routeRegistry);
+    setActivePluginRegistry(laterActiveRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      handler: routeHandler,
+    });
+
+    try {
+      const handler = createGatewayPluginRequestHandler({
+        registry: startupRegistry,
+        log: createPluginLog(),
+      });
+
+      const { res } = makeMockHttpResponse();
+      const handled = await handler({ url: "/bluebubbles-webhook" } as IncomingMessage, res);
+      expect(handled).toBe(true);
+      expect(routeHandler).toHaveBeenCalledTimes(1);
+      expect(startupRegistry.httpRoutes).toHaveLength(0);
+      expect(laterActiveRegistry.httpRoutes).toHaveLength(0);
+      expect(routeRegistry.httpRoutes).toHaveLength(1);
+    } finally {
+      unregister();
+      releasePinnedPluginHttpRouteRegistry(routeRegistry);
+      setActivePluginRegistry(createEmptyPluginRegistry());
+    }
   });
 
   it("logs and responds with 500 when a route throws", async () => {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
+import { getActivePluginHttpRouteRegistry } from "../../plugins/runtime.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, PAIRING_SCOPE, WRITE_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
@@ -59,12 +60,26 @@ export type PluginHttpRequestHandler = (
   dispatchContext?: { gatewayAuthSatisfied?: boolean },
 ) => Promise<boolean>;
 
+function resolveCurrentPluginRegistry(fallback: PluginRegistry): PluginRegistry {
+  const routeRegistry = getActivePluginHttpRouteRegistry();
+  if (!routeRegistry) {
+    return fallback;
+  }
+  const routeCount = routeRegistry.httpRoutes?.length ?? 0;
+  const fallbackRouteCount = fallback.httpRoutes?.length ?? 0;
+  if (routeCount === 0 && fallbackRouteCount > 0) {
+    return fallback;
+  }
+  return routeRegistry;
+}
+
 export function createGatewayPluginRequestHandler(params: {
   registry: PluginRegistry;
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
-  const { registry, log } = params;
+  const { log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
+    const registry = resolveCurrentPluginRegistry(params.registry);
     const routes = registry.httpRoutes ?? [];
     if (routes.length === 0) {
       return false;

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerPluginHttpRoute } from "./http-registry.js";
 import { createEmptyPluginRegistry } from "./registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  setActivePluginRegistry,
+} from "./runtime.js";
 
 function expectRouteRegistrationDenied(params: {
   replaceExisting: boolean;
@@ -38,6 +43,11 @@ function expectRouteRegistrationDenied(params: {
 }
 
 describe("registerPluginHttpRoute", () => {
+  afterEach(() => {
+    releasePinnedPluginHttpRouteRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
   it("registers route and unregisters it", () => {
     const registry = createEmptyPluginRegistry();
     const handler = vi.fn();
@@ -163,5 +173,27 @@ describe("registerPluginHttpRoute", () => {
 
     unregister();
     expect(registry.httpRoutes).toHaveLength(1);
+  });
+
+  it("uses the pinned route registry when the active registry changes later", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const laterActiveRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    setActivePluginRegistry(laterActiveRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      handler: vi.fn(),
+    });
+
+    expect(startupRegistry.httpRoutes).toHaveLength(1);
+    expect(startupRegistry.httpRoutes[0]?.path).toBe("/bluebubbles-webhook");
+    expect(laterActiveRegistry.httpRoutes).toHaveLength(0);
+
+    unregister();
+    expect(startupRegistry.httpRoutes).toHaveLength(0);
   });
 });

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
 import type { PluginHttpRouteRegistration, PluginRegistry } from "./registry.js";
-import { requireActivePluginRegistry } from "./runtime.js";
+import { requireActivePluginHttpRouteRegistry } from "./runtime.js";
 
 export type PluginHttpRouteHandler = (
   req: IncomingMessage,
@@ -22,7 +22,7 @@ export function registerPluginHttpRoute(params: {
   log?: (message: string) => void;
   registry?: PluginRegistry;
 }): () => void {
-  const registry = params.registry ?? requireActivePluginRegistry();
+  const registry = params.registry ?? requireActivePluginHttpRouteRegistry();
   const routes = registry.httpRoutes ?? [];
   registry.httpRoutes = routes;
 

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -4,6 +4,8 @@ const REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 
 type RegistryState = {
   registry: PluginRegistry | null;
+  httpRouteRegistry: PluginRegistry | null;
+  httpRouteRegistryPinned: boolean;
   key: string | null;
   version: number;
 };
@@ -15,6 +17,8 @@ const state: RegistryState = (() => {
   if (!globalState[REGISTRY_STATE]) {
     globalState[REGISTRY_STATE] = {
       registry: createEmptyPluginRegistry(),
+      httpRouteRegistry: null,
+      httpRouteRegistryPinned: false,
       key: null,
       version: 0,
     };
@@ -24,6 +28,9 @@ const state: RegistryState = (() => {
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
   state.registry = registry;
+  if (!state.httpRouteRegistryPinned) {
+    state.httpRouteRegistry = registry;
+  }
   state.key = cacheKey ?? null;
   state.version += 1;
 }
@@ -35,9 +42,39 @@ export function getActivePluginRegistry(): PluginRegistry | null {
 export function requireActivePluginRegistry(): PluginRegistry {
   if (!state.registry) {
     state.registry = createEmptyPluginRegistry();
+    if (!state.httpRouteRegistryPinned) {
+      state.httpRouteRegistry = state.registry;
+    }
     state.version += 1;
   }
   return state.registry;
+}
+
+export function pinActivePluginHttpRouteRegistry(registry: PluginRegistry) {
+  state.httpRouteRegistry = registry;
+  state.httpRouteRegistryPinned = true;
+}
+
+export function releasePinnedPluginHttpRouteRegistry(registry?: PluginRegistry) {
+  if (registry && state.httpRouteRegistry !== registry) {
+    return;
+  }
+  state.httpRouteRegistryPinned = false;
+  state.httpRouteRegistry = state.registry;
+}
+
+export function getActivePluginHttpRouteRegistry(): PluginRegistry | null {
+  return state.httpRouteRegistry ?? state.registry;
+}
+
+export function requireActivePluginHttpRouteRegistry(): PluginRegistry {
+  const existing = getActivePluginHttpRouteRegistry();
+  if (existing) {
+    return existing;
+  }
+  const created = requireActivePluginRegistry();
+  state.httpRouteRegistry = created;
+  return created;
 }
 
 export function getActivePluginRegistryKey(): string | null {


### PR DESCRIPTION
## Problem

This PR now fixes two restart/runtime regressions:

### 1. Subagent restart recovery

When the gateway restarts (SIGUSR1), in-flight subagent agent turns are killed along with their exec child processes. The subagent registry correctly persists and restores run records to disk, but `resumeSubagentRun()` simply called `waitForSubagentCompletion()` on the original runId. Since no agent turn was actively running after restart, the wait would time out and the subagent would be marked as failed/timed out.

**Observed behavior:**
1. Gateway restarts -> main sessions get reconnected automatically
2. Subagent sessions persist (show as "running" after restart) but their exec processes are killed
3. The subagent hangs forever waiting on a dead runId
4. Eventually times out and is marked as failed

### 2. Gateway plugin webhook routes disappearing

Dynamic plugin webhook routes such as BlueBubbles could disappear from the live gateway process and start returning `404 Not Found`, even though the channel had started successfully and logged that the webhook was listening.

**Observed behavior:**
1. BlueBubbles starts and logs `BlueBubbles webhook listening on /bluebubbles-webhook`
2. Live gateway process later answers `404 Not Found` for `/bluebubbles-webhook`
3. A fresh foreground gateway on another port answers `401 Unauthorized` for the same probe, proving the route exists there
4. BlueBubbles inbound webhooks stop reaching OpenClaw entirely

## Solution

### 1. Retrigger subagents after restart

In `resumeSubagentRun()`, when we detect an incomplete run (no `endedAt`), instead of just waiting on the dead runId, we now call `retriggerSubagentAfterRestart()` which:

1. Sends a continuation message to the subagent's existing session via the `agent` gateway method, informing it that the gateway restarted and any exec processes were terminated
2. Gets a new runId from the fresh agent turn
3. Replaces the old run in the registry via `replaceSubagentRunAfterSteer()` so completion tracking continues seamlessly
4. Falls back gracefully to the old `waitForSubagentCompletion()` if no runId is returned
5. Marks run as errored (not hung) if the retrigger call itself fails

The subagent's conversation history is preserved, so it can pick up where it left off and re-run any terminated processes.

### 2. Pin plugin HTTP routes to the gateway startup registry

Dynamic webhook registration was still tied to the mutable active plugin registry. Other runtime plugin loads could swap that active registry after startup, leaving the gateway HTTP server dispatching against a registry with zero `httpRoutes`.

This follow-up fix:

1. Splits plugin HTTP route registration from the generic active plugin registry state
2. Pins the gateway's HTTP route registry for the lifetime of the gateway runtime
3. Uses the pinned HTTP route registry for route registration and request dispatch
4. Releases the pinned registry during shutdown/startup failure cleanup
5. Adds regression coverage for stale startup registries and active-registry swaps

### 3. Skip subagent pre-compaction memory flush turns

Subagent sessions could still trigger the pre-compaction memory flush turn even though subagent tool policy already treats memory as parent-owned context rather than something workers should write directly.

This follow-up fix:

1. Skips the pre-compaction memory flush run for subagent session keys
2. Resolves the effective session key consistently when checking flush eligibility and persisting derived prompt snapshots
3. Adds direct regression coverage for the memory-flush gate

This keeps subagents focused on their assigned task instead of generating `memory/YYYY-MM-DD.md` writes or related flush prompts inside worker sessions.

## Edge cases handled

- Agent call returns no runId: falls back to waiting (backward compat)
- Agent call throws: run is marked as errored via `completeSubagentRun()` instead of hanging
- Runs with `endedAt` already set: untouched (existing announce/cleanup flows continue)
- Exec processes that died: the continuation message tells the subagent to check and re-run processes as needed
- Dynamic plugin loads after gateway startup: webhook route registration still lands in the pinned gateway route registry
- Startup failures / shutdown: pinned route registry is released so later starts do not inherit stale state
- Subagent sessions: no pre-compaction memory flush turn is injected, even when regular top-level sessions would still flush

## Tests

Added / updated coverage for:

- `src/agents/subagent-registry.restart-recovery.test.ts`
  - Retriggers subagent with continuation message for incomplete runs
  - Marks run as errored when retrigger agent call fails
  - Falls back to wait when retrigger returns no runId
  - Does not retrigger runs that already have `endedAt` set

- `src/plugins/http-registry.test.ts`
  - Registers routes into the pinned HTTP route registry even after the active registry changes

- `src/gateway/server/plugins-http.test.ts`
  - Dispatches using the pinned route registry when startup/active registries go stale

- `src/auto-reply/reply/agent-runner-memory.test.ts`
  - Skips pre-compaction memory flush runs for subagent sessions
  - Keeps heartbeat / CLI skips and regular-session allow behavior covered

- Existing BlueBubbles tests still pass:
  - `extensions/bluebubbles/src/monitor.test.ts`
  - `extensions/bluebubbles/src/monitor.webhook-auth.test.ts`
  - `extensions/bluebubbles/src/send.test.ts`
