### PR TITLE
fix(config): keep default memory slot from blocking updates

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -63,6 +63,13 @@ describe("config plugin validation", () => {
 
   const validateInSuite = (raw: unknown) =>
     validateConfigObjectWithPlugins(raw, { env: suiteEnv() });
+  const warmPluginManifestCache = () =>
+    validateInSuite({
+      plugins: {
+        enabled: false,
+        load: { paths: [badPluginDir, bluebubblesPluginDir, voiceCallSchemaPluginDir] },
+      },
+    });
 
   beforeAll(async () => {
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-plugin-validation-"));
@@ -125,12 +132,7 @@ describe("config plugin validation", () => {
     clearPluginManifestRegistryCache();
     // Warm the plugin manifest cache once so path-based validations can reuse
     // parsed manifests across test cases.
-    validateInSuite({
-      plugins: {
-        enabled: false,
-        load: { paths: [badPluginDir, bluebubblesPluginDir, voiceCallSchemaPluginDir] },
-      },
-    });
+    warmPluginManifestCache();
   });
 
   afterAll(async () => {
@@ -220,29 +222,67 @@ describe("config plugin validation", () => {
     const emptyBundledDir = path.join(suiteHome, "empty-bundled");
     await mkdirSafe(emptyBundledDir);
     clearPluginManifestRegistryCache();
-
-    const res = validateConfigObjectWithPlugins(
-      {
-        agents: { list: [{ id: "pi" }] },
-        plugins: {
-          enabled: true,
+    try {
+      const res = validateConfigObjectWithPlugins(
+        {
+          agents: { list: [{ id: "pi" }] },
+          plugins: {
+            enabled: true,
+          },
         },
-      },
-      {
-        env: {
-          ...suiteEnv(),
-          OPENCLAW_BUNDLED_PLUGINS_DIR: emptyBundledDir,
+        {
+          env: {
+            ...suiteEnv(),
+            OPENCLAW_BUNDLED_PLUGINS_DIR: emptyBundledDir,
+          },
         },
-      },
-    );
+      );
 
-    expect(res.ok).toBe(true);
-    if (res.ok) {
-      expect(res.warnings).toContainEqual({
-        path: "plugins.slots.memory",
-        message:
-          "default bundled memory slot unavailable: memory-core (continuing without fatal validation; check packaged plugin installation)",
-      });
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.warnings).toContainEqual({
+          path: "plugins.slots.memory",
+          message:
+            "default bundled memory slot unavailable: memory-core (continuing without fatal validation; check packaged plugin installation)",
+        });
+      }
+    } finally {
+      clearPluginManifestRegistryCache();
+      warmPluginManifestCache();
+    }
+  });
+
+  it("fails when an explicit default memory slot is undiscoverable", async () => {
+    const emptyBundledDir = path.join(suiteHome, "empty-bundled-explicit");
+    await mkdirSafe(emptyBundledDir);
+    clearPluginManifestRegistryCache();
+    try {
+      const res = validateConfigObjectWithPlugins(
+        {
+          agents: { list: [{ id: "pi" }] },
+          plugins: {
+            enabled: true,
+            slots: { memory: "memory-core" },
+          },
+        },
+        {
+          env: {
+            ...suiteEnv(),
+            OPENCLAW_BUNDLED_PLUGINS_DIR: emptyBundledDir,
+          },
+        },
+      );
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.issues).toContainEqual({
+          path: "plugins.slots.memory",
+          message: "plugin not found: memory-core",
+        });
+      }
+    } finally {
+      clearPluginManifestRegistryCache();
+      warmPluginManifestCache();
     }
   });
 

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -216,6 +216,36 @@ describe("config plugin validation", () => {
     }
   });
 
+  it("warns instead of failing when the default memory slot is temporarily undiscoverable", async () => {
+    const emptyBundledDir = path.join(suiteHome, "empty-bundled");
+    await mkdirSafe(emptyBundledDir);
+    clearPluginManifestRegistryCache();
+
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "pi" }] },
+        plugins: {
+          enabled: true,
+        },
+      },
+      {
+        env: {
+          ...suiteEnv(),
+          OPENCLAW_BUNDLED_PLUGINS_DIR: emptyBundledDir,
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.warnings).toContainEqual({
+        path: "plugins.slots.memory",
+        message:
+          "default bundled memory slot unavailable: memory-core (continuing without fatal validation; check packaged plugin installation)",
+      });
+    }
+  });
+
   it("surfaces plugin config diagnostics", async () => {
     const res = validateInSuite({
       agents: { list: [{ id: "pi" }] },

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -531,7 +531,7 @@ function validateConfigObjectWithPluginsBase(
 
   const memorySlot = normalizedPlugins.slots.memory;
   if (typeof memorySlot === "string" && memorySlot.trim() && !knownIds.has(memorySlot)) {
-    if (memorySlot === defaultSlotIdForKey("memory")) {
+    if (normalizedPlugins.defaultedSlots.memory && memorySlot === defaultSlotIdForKey("memory")) {
       // Keep the default bundled memory slot from aborting update/startup flows
       // when packaged plugin discovery is temporarily unavailable.
       warnings.push({

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -8,6 +8,7 @@ import {
 } from "../plugins/config-state.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
+import { defaultSlotIdForKey } from "../plugins/slots.js";
 import {
   hasAvatarUriScheme,
   isAvatarDataUrl,
@@ -530,7 +531,16 @@ function validateConfigObjectWithPluginsBase(
 
   const memorySlot = normalizedPlugins.slots.memory;
   if (typeof memorySlot === "string" && memorySlot.trim() && !knownIds.has(memorySlot)) {
-    pushMissingPluginIssue("plugins.slots.memory", memorySlot);
+    if (memorySlot === defaultSlotIdForKey("memory")) {
+      // Keep the default bundled memory slot from aborting update/startup flows
+      // when packaged plugin discovery is temporarily unavailable.
+      warnings.push({
+        path: "plugins.slots.memory",
+        message: `default bundled memory slot unavailable: ${memorySlot} (continuing without fatal validation; check packaged plugin installation)`,
+      });
+    } else {
+      pushMissingPluginIssue("plugins.slots.memory", memorySlot);
+    }
   }
 
   let selectedMemoryPluginId: string | null = null;

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -8,6 +8,7 @@ import {
 describe("normalizePluginsConfig", () => {
   it("uses default memory slot when not specified", () => {
     const result = normalizePluginsConfig({});
+    expect(result.defaultedSlots.memory).toBe(true);
     expect(result.slots.memory).toBe("memory-core");
   });
 
@@ -15,7 +16,16 @@ describe("normalizePluginsConfig", () => {
     const result = normalizePluginsConfig({
       slots: { memory: "custom-memory" },
     });
+    expect(result.defaultedSlots.memory).toBe(false);
     expect(result.slots.memory).toBe("custom-memory");
+  });
+
+  it("tracks when the default memory slot was explicitly requested", () => {
+    const result = normalizePluginsConfig({
+      slots: { memory: "memory-core" },
+    });
+    expect(result.defaultedSlots.memory).toBe(false);
+    expect(result.slots.memory).toBe("memory-core");
   });
 
   it("disables memory slot when set to 'none' (case insensitive)", () => {

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -8,6 +8,9 @@ export type NormalizedPluginsConfig = {
   allow: string[];
   deny: string[];
   loadPaths: string[];
+  defaultedSlots: {
+    memory: boolean;
+  };
   slots: {
     memory?: string | null;
   };
@@ -99,6 +102,9 @@ export const normalizePluginsConfig = (
     allow: normalizeList(config?.allow),
     deny: normalizeList(config?.deny),
     loadPaths: normalizeList(config?.load?.paths),
+    defaultedSlots: {
+      memory: memorySlot === undefined,
+    },
     slots: {
       memory: memorySlot === undefined ? defaultSlotIdForKey("memory") : memorySlot,
     },


### PR DESCRIPTION
## Summary

- Problem: `openclaw update` could roll back during post-install doctor/health verification when config validation treated the default `plugins.slots.memory = "memory-core"` slot as a fatal missing plugin.
- Why it matters: a packaged install can temporarily fail bundled plugin discovery during upgrade verification, which should not abort the whole update.
- What changed: config validation now downgrades an undiscoverable default bundled memory slot to a warning, while keeping custom missing memory slot ids as hard errors.
- What did NOT change (scope boundary): plugin discovery/loader behavior and custom plugin-slot validation remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45287
- Related #45255

## User-visible / Behavior Changes

Updates no longer fail config validation solely because the default bundled `memory-core` slot is temporarily undiscoverable during packaged-install verification. OpenClaw now warns and continues instead of rolling back the update.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: Node 24 / Vitest
- Model/provider: N/A
- Integration/channel (if any): packaged plugin discovery + config validation
- Relevant config (redacted): `plugins.enabled: true` with implicit default memory slot

### Steps

1. Validate a config with explicit plugin config but no custom memory slot override.
2. Point bundled plugin discovery at an empty bundled-plugins directory.
3. Confirm validation warns instead of failing, while the existing missing custom slot test still remains strict.

### Expected

- The default bundled `memory-core` slot does not hard-fail update verification when bundled plugin discovery is temporarily unavailable.
- Custom missing slot ids still fail validation.

### Actual

- Added regression coverage for the warning path and kept existing strict custom-slot validation intact.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm exec vitest run src/config/config.plugin-validation.test.ts`
- Edge cases checked: default implicit `memory-core` warns; existing custom missing-slot coverage still fails.
- What you did **not** verify: a full global npm upgrade/rollback cycle on Ubuntu.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/config/validation.ts`, `src/config/config.plugin-validation.test.ts`
- Known bad symptoms reviewers should watch for: validation no longer failing for a genuinely missing custom memory slot id (the existing test should guard this).

## Risks and Mitigations

- Risk: a truly broken packaged install could now continue with memory features unavailable instead of hard-failing during validation.
  - Mitigation: the downgrade is scoped only to the default bundled `memory-core` slot; the runtime loader already emits a warning for a missing memory slot, and custom slot ids still fail validation.
