### PR TITLE
fix(telegram): keep reaction updates enabled during polling startup

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { monitorTelegramProvider } from "./monitor.js";
 import { tagTelegramNetworkError } from "./network-errors.js";
 
@@ -576,7 +577,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     vi.useRealTimers();
   });
 
-  it("confirms persisted offset with Telegram before starting runner", async () => {
+  it("confirms persisted offset with Telegram before starting runner without dropping reactions", async () => {
     readTelegramUpdateOffsetSpy.mockResolvedValueOnce(549076203);
     const abort = new AbortController();
     const order: string[] = [];
@@ -597,7 +598,12 @@ describe("monitorTelegramProvider (grammY)", () => {
 
     await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
 
-    expect(api.getUpdates).toHaveBeenCalledWith({ offset: 549076204, limit: 1, timeout: 0 });
+    expect(api.getUpdates).toHaveBeenCalledWith({
+      offset: 549076204,
+      limit: 1,
+      timeout: 0,
+      allowed_updates: resolveTelegramAllowedUpdates(),
+    });
     expect(order).toEqual(["deleteWebhook", "getUpdates", "run"]);
   });
 

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -171,8 +171,14 @@ export class TelegramPollingSession {
     if (lastUpdateId === null || lastUpdateId >= Number.MAX_SAFE_INTEGER) {
       return;
     }
+    const allowedUpdates = this.opts.runnerOptions.runner?.fetch?.allowed_updates;
     try {
-      await bot.api.getUpdates({ offset: lastUpdateId + 1, limit: 1, timeout: 0 });
+      await bot.api.getUpdates({
+        offset: lastUpdateId + 1,
+        limit: 1,
+        timeout: 0,
+        ...(allowedUpdates === undefined ? {} : { allowed_updates: allowedUpdates }),
+      });
     } catch {
       // Non-fatal: runner middleware still skips duplicates via shouldSkipUpdate.
     }


### PR DESCRIPTION
## Summary
- keep the persisted-offset confirmation probe from resetting Telegram polling back to default update types
- forward the same `allowed_updates` filter used by the polling runner so `message_reaction` stays subscribed
- add a regression test covering the startup probe path

## Testing
- pnpm exec vitest run src/telegram/monitor.test.ts
- pnpm exec oxlint src/telegram/polling-session.ts src/telegram/monitor.test.ts
- pnpm exec oxfmt --check src/telegram/polling-session.ts src/telegram/monitor.test.ts

Closes #45289
