### PR TITLE
fix(memory): resolve global node-llama installs

### DIFF
--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -3,6 +3,7 @@ import * as authModule from "../agents/model-auth.js";
 import { DEFAULT_GEMINI_EMBEDDING_MODEL } from "./embeddings-gemini.js";
 import { createEmbeddingProvider, DEFAULT_LOCAL_MODEL } from "./embeddings.js";
 import { mockPublicPinnedHostname } from "./test-helpers/ssrf.js";
+import { resolveNodeLlamaCppInstallTarget } from "./node-llama.js";
 
 vi.mock("../agents/model-auth.js", async () => {
   const { createModelAuthMockModule } = await import("../test-utils/model-auth-mock.js");
@@ -10,9 +11,13 @@ vi.mock("../agents/model-auth.js", async () => {
 });
 
 const importNodeLlamaCppMock = vi.fn();
-vi.mock("./node-llama.js", () => ({
-  importNodeLlamaCpp: (...args: unknown[]) => importNodeLlamaCppMock(...args),
-}));
+vi.mock("./node-llama.js", async () => {
+  const actual = await vi.importActual<typeof import("./node-llama.js")>("./node-llama.js");
+  return {
+    ...actual,
+    importNodeLlamaCpp: (...args: unknown[]) => importNodeLlamaCppMock(...args),
+  };
+});
 
 const createFetchMock = () =>
   vi.fn(async (_input?: unknown, _init?: unknown) => ({
@@ -402,7 +407,10 @@ describe("embedding provider local fallback", () => {
 
   it("mentions npm global install recovery when node-llama-cpp is missing", async () => {
     mockMissingLocalEmbeddingDependency();
-    await expect(createLocalProvider()).rejects.toThrow(/npm i -g node-llama-cpp@3\.16\.2/i);
+    const installTarget = resolveNodeLlamaCppInstallTarget().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    await expect(createLocalProvider()).rejects.toThrow(
+      new RegExp(`npm i -g ${installTarget}`, "i"),
+    );
   });
 });
 

--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -399,6 +399,11 @@ describe("embedding provider local fallback", () => {
     await expect(createLocalProvider()).rejects.toThrow(/provider = "gemini"/i);
     await expect(createLocalProvider()).rejects.toThrow(/provider = "mistral"/i);
   });
+
+  it("mentions npm global install recovery when node-llama-cpp is missing", async () => {
+    mockMissingLocalEmbeddingDependency();
+    await expect(createLocalProvider()).rejects.toThrow(/npm i -g node-llama-cpp@3\.16\.2/i);
+  });
 });
 
 describe("local embedding normalization", () => {

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -312,7 +312,7 @@ function formatLocalSetupError(err: unknown): string {
     "To enable local embeddings:",
     "1) Use Node 24 (recommended for installs/updates; Node 22 LTS, currently 22.16+, remains supported)",
     missing
-      ? "2) Reinstall OpenClaw (this should install node-llama-cpp): npm i -g openclaw@latest"
+      ? "2) Install node-llama-cpp next to OpenClaw (for npm globals: npm i -g node-llama-cpp@3.16.2)"
       : null,
     "3) If you use pnpm: pnpm approve-builds (select node-llama-cpp), then pnpm rebuild node-llama-cpp",
     ...REMOTE_EMBEDDING_PROVIDER_IDS.map(

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -18,7 +18,11 @@ import {
 import { createOllamaEmbeddingProvider, type OllamaEmbeddingClient } from "./embeddings-ollama.js";
 import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./embeddings-openai.js";
 import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embeddings-voyage.js";
-import { importNodeLlamaCpp } from "./node-llama.js";
+import {
+  importNodeLlamaCpp,
+  isNodeLlamaMissingError,
+  resolveNodeLlamaCppInstallTarget,
+} from "./node-llama.js";
 
 export type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
 export type { MistralEmbeddingClient } from "./embeddings-mistral.js";
@@ -291,20 +295,9 @@ export async function createEmbeddingProvider(
   }
 }
 
-function isNodeLlamaCppMissing(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-  const code = (err as Error & { code?: unknown }).code;
-  if (code === "ERR_MODULE_NOT_FOUND") {
-    return err.message.includes("node-llama-cpp");
-  }
-  return false;
-}
-
 function formatLocalSetupError(err: unknown): string {
   const detail = formatErrorMessage(err);
-  const missing = isNodeLlamaCppMissing(err);
+  const missing = isNodeLlamaMissingError(err);
   return [
     "Local embeddings unavailable.",
     missing
@@ -316,7 +309,7 @@ function formatLocalSetupError(err: unknown): string {
     "To enable local embeddings:",
     "1) Use Node 24 (recommended for installs/updates; Node 22 LTS, currently 22.16+, remains supported)",
     missing
-      ? "2) Install node-llama-cpp next to OpenClaw (for npm globals: npm i -g node-llama-cpp@3.16.2)"
+      ? `2) Install node-llama-cpp next to OpenClaw (for npm globals: npm i -g ${resolveNodeLlamaCppInstallTarget()})`
       : null,
     "3) If you use pnpm: pnpm approve-builds (select node-llama-cpp), then pnpm rebuild node-llama-cpp",
     ...REMOTE_EMBEDDING_PROVIDER_IDS.map(

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -129,8 +129,12 @@ async function createLocalEmbeddingProvider(
           llama = await getLlama({ logLevel: LlamaLogLevel.error });
         }
         if (!embeddingModel) {
+          const activeLlama = llama;
+          if (!activeLlama) {
+            throw new Error("Failed to initialize local embedding runtime");
+          }
           const resolved = await resolveModelFile(modelPath, modelCacheDir || undefined);
-          embeddingModel = await llama.loadModel({ modelPath: resolved });
+          embeddingModel = await activeLlama.loadModel({ modelPath: resolved });
         }
         if (!embeddingContext) {
           embeddingContext = await embeddingModel.createEmbeddingContext();

--- a/src/memory/node-llama.test.ts
+++ b/src/memory/node-llama.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { importNodeLlamaCpp } from "./node-llama.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("importNodeLlamaCpp", () => {
+  it("falls back to a resolved package entry when bare global import is unavailable", async () => {
+    const prefix = await makeTempDir("openclaw-node-llama-prefix-");
+    const globalRoot = path.join(prefix, "lib", "node_modules");
+    const fakeOpenClawDist = path.join(globalRoot, "openclaw", "dist");
+    const fakeNodeLlama = path.join(globalRoot, "node-llama-cpp");
+
+    await fs.mkdir(fakeOpenClawDist, { recursive: true });
+    await fs.mkdir(fakeNodeLlama, { recursive: true });
+    await fs.writeFile(
+      path.join(fakeNodeLlama, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "node-llama-cpp",
+          type: "module",
+          exports: "./index.js",
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(fakeNodeLlama, "index.js"),
+      'export const marker = "resolved-global-node-llama";\n',
+      "utf-8",
+    );
+
+    const importer = async (specifier: string) => {
+      if (specifier === "node-llama-cpp") {
+        throw Object.assign(new Error("Cannot find package 'node-llama-cpp'"), {
+          code: "ERR_MODULE_NOT_FOUND",
+        });
+      }
+      return import(specifier);
+    };
+
+    const mod = (await importNodeLlamaCpp({
+      metaUrl: pathToFileURL(path.join(fakeOpenClawDist, "auth-profiles.mjs")).href,
+      env: { npm_config_prefix: prefix },
+      globalPaths: [],
+      importer,
+    })) as { marker?: string };
+
+    expect(mod.marker).toBe("resolved-global-node-llama");
+  });
+});

--- a/src/memory/node-llama.ts
+++ b/src/memory/node-llama.ts
@@ -1,3 +1,119 @@
-export async function importNodeLlamaCpp() {
-  return import("node-llama-cpp");
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+type NodeLlamaImporter = (specifier: string) => Promise<unknown>;
+
+function isNodeLlamaMissingError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const code = (err as Error & { code?: unknown }).code;
+  return code === "ERR_MODULE_NOT_FOUND" && err.message.includes("node-llama-cpp");
+}
+
+function readModuleGlobalPaths(): string[] {
+  try {
+    const require = createRequire(import.meta.url);
+    const moduleNs = require("node:module") as { globalPaths?: string[] };
+    return Array.isArray(moduleNs.globalPaths)
+      ? moduleNs.globalPaths.filter((value): value is string => typeof value === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function resolveNodeModuleRoots(params: {
+  metaUrl: string;
+  env?: NodeJS.ProcessEnv;
+  globalPaths?: readonly string[];
+}): string[] {
+  const roots = new Set<string>();
+
+  try {
+    let current = path.dirname(fileURLToPath(params.metaUrl));
+    while (current) {
+      if (path.basename(current) === "node_modules") {
+        roots.add(current);
+      }
+      const parent = path.dirname(current);
+      if (parent === current) {
+        break;
+      }
+      current = parent;
+    }
+  } catch {
+    // Ignore invalid/non-file meta URLs.
+  }
+
+  const prefix = params.env?.["npm_config_prefix"]?.trim();
+  if (prefix) {
+    roots.add(path.resolve(prefix, "lib", "node_modules"));
+    roots.add(path.resolve(prefix, "node_modules"));
+  }
+
+  for (const globalPath of params.globalPaths ?? readModuleGlobalPaths()) {
+    const trimmed = globalPath.trim();
+    if (trimmed) {
+      roots.add(path.resolve(trimmed));
+    }
+  }
+
+  return [...roots];
+}
+
+function resolveNodeLlamaImportCandidates(params: {
+  metaUrl: string;
+  env?: NodeJS.ProcessEnv;
+  globalPaths?: readonly string[];
+}): string[] {
+  const candidates = new Set<string>();
+  const baseRequire = createRequire(params.metaUrl);
+
+  const tryResolve = (request: NodeJS.Require, specifier: string) => {
+    try {
+      candidates.add(pathToFileURL(request.resolve(specifier)).href);
+    } catch {
+      // Ignore missing candidates and keep searching.
+    }
+  };
+
+  tryResolve(baseRequire, "node-llama-cpp");
+
+  for (const root of resolveNodeModuleRoots(params)) {
+    tryResolve(createRequire(path.join(root, "__openclaw-node-llama__.cjs")), "node-llama-cpp");
+  }
+
+  return [...candidates];
+}
+
+export async function importNodeLlamaCpp(params?: {
+  metaUrl?: string;
+  env?: NodeJS.ProcessEnv;
+  globalPaths?: readonly string[];
+  importer?: NodeLlamaImporter;
+}) {
+  const importer = params?.importer ?? ((specifier: string) => import(specifier));
+  try {
+    return await importer("node-llama-cpp");
+  } catch (err) {
+    if (!isNodeLlamaMissingError(err)) {
+      throw err;
+    }
+    for (const candidate of resolveNodeLlamaImportCandidates({
+      metaUrl: params?.metaUrl ?? import.meta.url,
+      env: params?.env,
+      globalPaths: params?.globalPaths,
+    })) {
+      try {
+        return await importer(candidate);
+      } catch (candidateErr) {
+        if (!isNodeLlamaMissingError(candidateErr)) {
+          throw candidateErr;
+        }
+      }
+    }
+    throw err;
+  }
 }

--- a/src/memory/node-llama.ts
+++ b/src/memory/node-llama.ts
@@ -4,7 +4,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 type NodeLlamaImporter = (specifier: string) => Promise<unknown>;
 
-function isNodeLlamaMissingError(err: unknown): boolean {
+export function isNodeLlamaMissingError(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false;
   }
@@ -12,6 +12,24 @@ function isNodeLlamaMissingError(err: unknown): boolean {
   return code === "ERR_MODULE_NOT_FOUND" && err.message.includes("node-llama-cpp");
 }
 
+export function resolveNodeLlamaCppInstallTarget(moduleUrl = import.meta.url): string {
+  try {
+    const require = createRequire(moduleUrl);
+    const pkg = require("../../package.json") as {
+      dependencies?: Record<string, unknown>;
+      optionalDependencies?: Record<string, unknown>;
+    };
+    const version =
+      typeof pkg.dependencies?.["node-llama-cpp"] === "string"
+        ? pkg.dependencies["node-llama-cpp"].trim()
+        : typeof pkg.optionalDependencies?.["node-llama-cpp"] === "string"
+          ? pkg.optionalDependencies["node-llama-cpp"].trim()
+          : "";
+    return version ? `node-llama-cpp@${version}` : "node-llama-cpp";
+  } catch {
+    return "node-llama-cpp";
+  }
+}
 function readModuleGlobalPaths(): string[] {
   try {
     const require = createRequire(import.meta.url);

--- a/src/memory/node-llama.ts
+++ b/src/memory/node-llama.ts
@@ -18,13 +18,16 @@ export function resolveNodeLlamaCppInstallTarget(moduleUrl = import.meta.url): s
     const pkg = require("../../package.json") as {
       dependencies?: Record<string, unknown>;
       optionalDependencies?: Record<string, unknown>;
+      peerDependencies?: Record<string, unknown>;
     };
     const version =
       typeof pkg.dependencies?.["node-llama-cpp"] === "string"
         ? pkg.dependencies["node-llama-cpp"].trim()
         : typeof pkg.optionalDependencies?.["node-llama-cpp"] === "string"
           ? pkg.optionalDependencies["node-llama-cpp"].trim()
-          : "";
+          : typeof pkg.peerDependencies?.["node-llama-cpp"] === "string"
+            ? pkg.peerDependencies["node-llama-cpp"].trim()
+            : "";
     return version ? `node-llama-cpp@${version}` : "node-llama-cpp";
   } catch {
     return "node-llama-cpp";


### PR DESCRIPTION
## Summary
- retry `node-llama-cpp` loading through resolved install roots when the bare import is missing
- cover the global-install recovery path with a regression test that simulates a standalone npm-global `node-llama-cpp`
- update the local-embeddings error guidance to point users at the supported npm-global recovery command instead of the stale reinstall advice

## Testing
- pnpm exec vitest run src/memory/node-llama.test.ts src/memory/embeddings.test.ts
- pnpm exec oxlint src/memory/node-llama.ts src/memory/node-llama.test.ts src/memory/embeddings.ts src/memory/embeddings.test.ts
- pnpm exec oxfmt --check src/memory/node-llama.ts src/memory/node-llama.test.ts src/memory/embeddings.ts src/memory/embeddings.test.ts

Closes #45364
