### PR TITLE
test(infra): fix baseline typing and path assertions

### DIFF
--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -64,7 +64,7 @@ describe("formatBackupCreateSummary", () => {
             displayPath: "~/.openclaw/config.json",
           },
           {
-            kind: "oauth",
+            kind: "credentials",
             sourcePath: "/oauth",
             archivePath: "archive/oauth",
             displayPath: "~/.openclaw/oauth",
@@ -77,7 +77,7 @@ describe("formatBackupCreateSummary", () => {
       "Backup archive: /tmp/openclaw-backup.tar.gz",
       "Included 2 paths:",
       "- config: ~/.openclaw/config.json",
-      "- oauth: ~/.openclaw/oauth",
+      "- credentials: ~/.openclaw/oauth",
       "Dry run only; archive was not written.",
     ]);
   });

--- a/src/infra/pairing-files.test.ts
+++ b/src/infra/pairing-files.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   pruneExpiredPending,
@@ -7,10 +8,11 @@ import {
 
 describe("pairing file helpers", () => {
   it("resolves pairing file paths from explicit base dirs", () => {
+    const dir = path.join("/tmp/openclaw-state", "devices");
     expect(resolvePairingPaths("/tmp/openclaw-state", "devices")).toEqual({
-      dir: "/tmp/openclaw-state/devices",
-      pendingPath: "/tmp/openclaw-state/devices/pending.json",
-      pairedPath: "/tmp/openclaw-state/devices/paired.json",
+      dir,
+      pendingPath: path.join(dir, "pending.json"),
+      pairedPath: path.join(dir, "paired.json"),
     });
   });
 

--- a/src/infra/pairing-pending.test.ts
+++ b/src/infra/pairing-pending.test.ts
@@ -24,6 +24,8 @@ describe("rejectPendingPairingRequest", () => {
         keep: { accountId: "keep-me" },
         reject: { accountId: "acct-42" },
       },
+    } satisfies {
+      pendingById: Record<string, { accountId: string }>;
     };
     const persistState = vi.fn(async () => undefined);
 
@@ -33,7 +35,7 @@ describe("rejectPendingPairingRequest", () => {
         idKey: "accountId",
         loadState: async () => state,
         persistState,
-        getId: (pending) => pending.accountId,
+        getId: (pending: { accountId: string }) => pending.accountId,
       }),
     ).resolves.toEqual({
       requestId: "reject",


### PR DESCRIPTION
## Summary
- fix the backup summary test to use the current `credentials` asset kind
- add an explicit pending request type in the pairing rejection test
- make the explicit pairing path assertion use platform-aware path joins

## Testing
- pnpm exec vitest run src/infra/pairing-pending.test.ts src/infra/pairing-files.test.ts
- pnpm tsgo _(still fails on unrelated mainline `chrome-mcp` and `ws` errors, but no longer reports the three infra failures this PR fixes)_
- pnpm exec oxlint src/infra/backup-create.test.ts src/infra/pairing-pending.test.ts src/infra/pairing-files.test.ts
- pnpm exec oxfmt --check src/infra/backup-create.test.ts src/infra/pairing-pending.test.ts src/infra/pairing-files.test.ts
