### PR TITLE
test: add node-shell command coverage

### DIFF
--- a/src/infra/node-shell.test.ts
+++ b/src/infra/node-shell.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { buildNodeShellCommand } from "./node-shell.js";
+
+describe("buildNodeShellCommand", () => {
+  it("returns sh command for unix platforms", () => {
+    const result = buildNodeShellCommand("echo hello", "linux");
+    expect(result).toEqual(["/bin/sh", "-lc", "echo hello"]);
+  });
+
+  it("returns sh command for darwin", () => {
+    const result = buildNodeShellCommand("echo hello", "darwin");
+    expect(result).toEqual(["/bin/sh", "-lc", "echo hello"]);
+  });
+
+  it("returns sh command for empty string", () => {
+    const result = buildNodeShellCommand("echo hello", "");
+    expect(result).toEqual(["/bin/sh", "-lc", "echo hello"]);
+  });
+
+  it("returns sh command for null", () => {
+    const result = buildNodeShellCommand("echo hello", null);
+    expect(result).toEqual(["/bin/sh", "-lc", "echo hello"]);
+  });
+
+  it("returns sh command for undefined", () => {
+    const result = buildNodeShellCommand("echo hello", undefined);
+    expect(result).toEqual(["/bin/sh", "-lc", "echo hello"]);
+  });
+
+  it("returns cmd command for windows", () => {
+    const result = buildNodeShellCommand("echo hello", "win32");
+    expect(result).toEqual(["cmd.exe", "/d", "/s", "/c", "echo hello"]);
+  });
+
+  it("returns cmd command for windows platform", () => {
+    const result = buildNodeShellCommand("echo hello", "windows");
+    expect(result).toEqual(["cmd.exe", "/d", "/s", "/c", "echo hello"]);
+  });
+
+  it("returns cmd command for win platform", () => {
+    const result = buildNodeShellCommand("echo hello", "win");
+    expect(result).toEqual(["cmd.exe", "/d", "/s", "/c", "echo hello"]);
+  });
+
+  it("handles command with spaces", () => {
+    const result = buildNodeShellCommand("ls -la /tmp", "linux");
+    expect(result).toEqual(["/bin/sh", "-lc", "ls -la /tmp"]);
+  });
+
+  it("trims whitespace from platform", () => {
+    const result = buildNodeShellCommand("echo hello", "  linux  ");
+    expect(result).toEqual(["/bin/sh", "-lc", "echo hello"]);
+  });
+
+  it("case insensitive platform matching", () => {
+    const result = buildNodeShellCommand("echo hello", "LINUX");
+    expect(result).toEqual(["/bin/sh", "-lc", "echo hello"]);
+  });
+
+  it("windows prefix matching is case insensitive", () => {
+    const result = buildNodeShellCommand("echo hello", "WIN32");
+    expect(result).toEqual(["cmd.exe", "/d", "/s", "/c", "echo hello"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Problem: `src/infra/node-shell.ts` lacked test coverage despite being a small utility function.
- Why it matters: Test coverage prevents regressions and documents platform detection behavior.
- What changed: Added `src/infra/node-shell.test.ts` with 12 test cases.
- What did NOT change: No production code modified.
## Change Type
- [x] Chore/infra
## Scope
- [x] CI/CD / infra
## User-visible / Behavior Changes
None
## Security Impact
- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
## Repro + Verification
Run: `pnpm test src/infra/node-shell.test.ts` → All 12 tests pass
## Human Verification
- Verified scenarios: Local test run
- Edge cases: null, undefined, empty string, whitespace, case insensitivity
## Compatibility / Migration
- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
## Risks and Mitigations
None