### PR TITLE
Gateway: restore loopback handshake timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - Dashboard/chat UI: restore the `chat-new-messages` class on the New messages scroll pill so the button uses its existing compact styling instead of rendering as a full-screen SVG overlay. (#44856) Thanks @Astro-Han.
 - Windows/gateway status: reuse the installed service command environment when reading runtime status, so startup-fallback gateways keep reporting the configured port and running state in `gateway status --json` instead of falling back to `gateway port unknown`.
 - Security/device pairing: make bootstrap setup codes single-use so pending device pairing requests cannot be silently replayed and widened to admin before approval. Thanks @tdjackey.
+- Gateway/CLI handshake: restore a 10s pre-auth WebSocket handshake timeout so `openclaw logs --follow` and other loopback CLI RPC commands no longer false-fail on slower hosts after the 3.12 hardening reduction. (#45127)
 
 ## 2026.3.12
 

--- a/src/gateway/server-constants.test.ts
+++ b/src/gateway/server-constants.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_HANDSHAKE_TIMEOUT_MS, getHandshakeTimeoutMs } from "./server-constants.js";
+
+const ORIGINAL_ENV = {
+  VITEST: process.env.VITEST,
+  OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS: process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS,
+};
+
+afterEach(() => {
+  if (ORIGINAL_ENV.VITEST === undefined) {
+    delete process.env.VITEST;
+  } else {
+    process.env.VITEST = ORIGINAL_ENV.VITEST;
+  }
+
+  if (ORIGINAL_ENV.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS === undefined) {
+    delete process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS;
+  } else {
+    process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS =
+      ORIGINAL_ENV.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS;
+  }
+});
+
+describe("server handshake timeout", () => {
+  it("defaults to the loopback-safe handshake timeout", () => {
+    delete process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS;
+    expect(getHandshakeTimeoutMs()).toBe(DEFAULT_HANDSHAKE_TIMEOUT_MS);
+    expect(DEFAULT_HANDSHAKE_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("allows tests to override the handshake timeout budget", () => {
+    process.env.VITEST = "1";
+    process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS = "250";
+    expect(getHandshakeTimeoutMs()).toBe(250);
+  });
+});

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -21,7 +21,9 @@ export const __setMaxChatHistoryMessagesBytesForTest = (value?: number) => {
     maxChatHistoryMessagesBytes = value;
   }
 };
-export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 3_000;
+// Keep the pre-auth retention window long enough for slower CLI/UI connect
+// flows on loopback while payload caps stay enforced separately.
+export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
 export const getHandshakeTimeoutMs = () => {
   if (process.env.VITEST && process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS) {
     const parsed = Number(process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);


### PR DESCRIPTION
## Summary

- Problem: `openclaw logs --follow --local-time` and other loopback CLI RPC flows can hit a false `gateway closed (1000)` / handshake-timeout path after the pre-auth hardening change reduced the default handshake timeout from 10s to 3s.
- Why it matters: `gateway probe` still succeeds, so operators see a healthy gateway while normal CLI RPC commands intermittently fail on slower hosts or under loopback latency.
- What changed: restore the default pre-auth WebSocket handshake timeout to 10s and add a regression test that locks the restored default plus the existing test override path.
- What did NOT change (scope boundary): payload caps, pre-auth close behavior, and the test-only env override remain unchanged.
- AI-assisted: yes. Tested locally with targeted Vitest, Oxlint, and Oxfmt checks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45127
- Related #45222

## User-visible / Behavior Changes

- Loopback CLI commands that connect through the gateway WebSocket handshake keep the pre-3.12 10s budget instead of timing out after 3s.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (local dev environment)
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Gateway loopback WebSocket / CLI
- Relevant config (redacted): default gateway loopback setup

### Steps

1. Start the local gateway and confirm `openclaw gateway probe` succeeds.
2. Run a CLI RPC flow such as `openclaw logs --follow --local-time` against the same loopback gateway.
3. Observe that the pre-auth handshake budget should remain long enough for normal CLI connect/setup on slower hosts.

### Expected

- CLI RPC flows connect reliably over loopback instead of hitting a false handshake timeout.

### Actual

- Before this change, the reduced 3s default could close the socket before connect completed, even while probe succeeded.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

```bash
pnpm vitest run src/gateway/server-constants.test.ts src/gateway/server.preauth-hardening.test.ts src/gateway/server.auth.default-token.suite.ts -t "handshake"
pnpm exec oxlint src/gateway/server-constants.ts src/gateway/server-constants.test.ts CHANGELOG.md
pnpm format:check src/gateway/server-constants.ts src/gateway/server-constants.test.ts CHANGELOG.md
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: restored the default handshake timeout to the pre-hardening 10s value; verified the env override still works; verified the gateway handshake tests pass.
- Edge cases checked: test-only `OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS` override still takes precedence; idle unauthenticated sockets still close after the configured timeout.
- What you did **not** verify: I did not reproduce the original `logs --follow` failure on a separate slow host in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore the 3s default.
- Files/config to restore: `src/gateway/server-constants.ts`
- Known bad symptoms reviewers should watch for: if rejected, unauthenticated sockets would remain open up to 10s instead of 3s before forced close.

## Risks and Mitigations

- Risk: unauthenticated sockets are retained up to 10s again instead of 3s.
  - Mitigation: the 64 KB pre-auth payload cap and forced timeout close still remain in place; this change only restores the handshake budget that shipped before #44089.
- Risk: a future refactor could shrink the default timeout again without noticing the CLI regression.
  - Mitigation: `src/gateway/server-constants.test.ts` now locks the restored default and the override path.
