### PR TITLE
fix(cron): prevent isolated cron nested lane deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 - Browser/existing-session: accept text-only `list_pages` and `new_page` responses from Chrome DevTools MCP so live-session tab discovery and new-tab open flows keep working when the server omits structured page metadata.
 - Ollama/reasoning visibility: stop promoting native `thinking` and `reasoning` fields into final assistant text so local reasoning models no longer leak internal thoughts in normal replies. (#45330) Thanks @xi7ang.
+- Cron/isolated sessions: route nested cron-triggered embedded runner work onto the nested lane so isolated cron jobs no longer deadlock when compaction or other queued inner work runs. Thanks @vincentkoc.
 - Windows/gateway install: bound `schtasks` calls and fall back to the Startup-folder login item when task creation hangs, so native `openclaw gateway install` fails fast instead of wedging forever on broken Scheduled Task setups.
 - Windows/gateway auth: stop attaching device identity on local loopback shared-token and password gateway calls, so native Windows agent replies no longer log stale `device signature expired` fallback noise before succeeding.
 - Telegram/media downloads: thread the same direct or proxy transport policy into SSRF-guarded file fetches so inbound attachments keep working when Telegram falls back between env-proxy and direct networking. (#44639) Thanks @obviyus.

--- a/src/agents/pi-embedded-runner/lanes.test.ts
+++ b/src/agents/pi-embedded-runner/lanes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { CommandLane } from "../../process/lanes.js";
+import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
+
+describe("resolveGlobalLane", () => {
+  it("defaults to main lane when no lane is provided", () => {
+    expect(resolveGlobalLane()).toBe(CommandLane.Main);
+    expect(resolveGlobalLane("")).toBe(CommandLane.Main);
+    expect(resolveGlobalLane("  ")).toBe(CommandLane.Main);
+  });
+
+  it("maps cron lane to nested lane to prevent deadlocks", () => {
+    // When cron jobs trigger nested agent runs, the outer execution holds
+    // the cron lane slot. Inner work must use a separate lane to avoid
+    // deadlock. See: https://github.com/openclaw/openclaw/issues/44805
+    expect(resolveGlobalLane("cron")).toBe(CommandLane.Nested);
+    expect(resolveGlobalLane("  cron  ")).toBe(CommandLane.Nested);
+  });
+
+  it("preserves other lanes as-is", () => {
+    expect(resolveGlobalLane("main")).toBe(CommandLane.Main);
+    expect(resolveGlobalLane("subagent")).toBe(CommandLane.Subagent);
+    expect(resolveGlobalLane("nested")).toBe(CommandLane.Nested);
+    expect(resolveGlobalLane("custom-lane")).toBe("custom-lane");
+    expect(resolveGlobalLane(" custom ")).toBe("custom");
+  });
+});
+
+describe("resolveSessionLane", () => {
+  it("defaults to main lane and prefixes with session:", () => {
+    expect(resolveSessionLane("")).toBe("session:main");
+    expect(resolveSessionLane("  ")).toBe("session:main");
+  });
+
+  it("adds session: prefix if not present", () => {
+    expect(resolveSessionLane("abc123")).toBe("session:abc123");
+    expect(resolveSessionLane(" xyz ")).toBe("session:xyz");
+  });
+
+  it("preserves existing session: prefix", () => {
+    expect(resolveSessionLane("session:abc")).toBe("session:abc");
+    expect(resolveSessionLane("session:main")).toBe("session:main");
+  });
+});

--- a/src/agents/pi-embedded-runner/lanes.ts
+++ b/src/agents/pi-embedded-runner/lanes.ts
@@ -7,6 +7,10 @@ export function resolveSessionLane(key: string) {
 
 export function resolveGlobalLane(lane?: string) {
   const cleaned = lane?.trim();
+  // Cron jobs hold the cron lane slot; inner operations must use nested to avoid deadlock.
+  if (cleaned === CommandLane.Cron) {
+    return CommandLane.Nested;
+  }
   return cleaned ? cleaned : CommandLane.Main;
 }
 


### PR DESCRIPTION
## Summary

- Problem: isolated cron jobs can deadlock when nested embedded-runner work tries to enqueue back onto the same cron lane.
- Why it matters: `sessionTarget: "isolated"` cron jobs can time out before the agent session even comes online when compaction or other queued inner work is triggered.
- What changed:
  - map `cron` to `nested` inside `resolveGlobalLane()` for embedded runner global-lane resolution
  - add unit coverage for the cron-to-nested mapping and the existing session-lane behavior
  - add an Unreleased changelog note
- What did NOT change (scope boundary): this does not change main-session cron execution or non-cron nested agent lane resolution.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44805
- Related #44998

## User-visible / Behavior Changes

- Isolated cron jobs no longer reuse the outer cron lane for nested embedded-runner work.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22 / pnpm
- Model/provider: n/a
- Integration/channel (if any): cron / embedded runner lanes
- Relevant config (redacted): default test harness config

### Steps

1. Run `pnpm test -- src/agents/pi-embedded-runner/lanes.test.ts`
2. Run `pnpm test -- src/agents/lanes.test.ts`

### Expected

- cron global lanes resolve to nested lanes for embedded runner inner work
- existing nested-agent lane expectations continue to pass

### Actual

- Matches expected in the focused lane tests above.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - new embedded-runner lane unit tests pass
  - existing nested-agent lane unit tests still pass
- Edge cases checked:
  - blank / whitespace lanes still default correctly
  - non-cron lanes preserve their current values
- What you did **not** verify:
  - full cron suite
  - full end-to-end isolated cron reproduction locally

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert `a4a14a7ec5` and `de17cdea69`
- Files/config to restore: `src/agents/pi-embedded-runner/lanes.ts`, `src/agents/pi-embedded-runner/lanes.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: isolated cron runs timing out before a session is created, or unexpected lane routing for non-cron callers

## Risks and Mitigations

- Risk: lane remapping could accidentally change non-cron behavior.
  - Mitigation: the mapping is scoped to the explicit `CommandLane.Cron` case and the test covers preserved behavior for other lanes.
