### PR TITLE
ACPX: add a built-in Chrome DevTools MCP preset for live Chrome sessions

### DIFF
--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -143,6 +143,16 @@ Per-session `mcpServers` are not supported in bridge mode. If an ACP client
 sends them during `newSession` or `loadSession`, the bridge returns a clear
 error instead of silently ignoring them.
 
+If you want ACPX-backed OpenClaw sessions to use a live Chrome session, enable
+the ACPX plugin preset instead:
+
+```bash
+openclaw config set plugins.entries.acpx.config.chromeDevtoolsMcp.enabled true
+```
+
+That setting affects ACPX-backed agent sessions only. It does not add
+per-session `mcpServers` support to `openclaw acp`.
+
 ## Use from `acpx` (Codex, Claude, other ACP clients)
 
 If you want a coding agent such as Codex or Claude Code to talk to your

--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -153,6 +153,10 @@ openclaw config set plugins.entries.acpx.config.chromeDevtoolsMcp.enabled true
 That setting affects ACPX-backed agent sessions only. It does not add
 per-session `mcpServers` support to `openclaw acp`.
 
+ACPX applies that preset through its existing MCP proxy path when it launches
+the target agent. The `openclaw acp` bridge itself still rejects per-session
+`mcpServers`.
+
 ## Use from `acpx` (Codex, Claude, other ACP clients)
 
 If you want a coding agent such as Codex or Claude Code to talk to your

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -565,6 +565,37 @@ Notes:
 
 See [Plugins](/tools/plugin).
 
+### Chrome live session preset
+
+If you want ACPX-backed agent sessions to reuse your live Chrome session
+through Chrome DevTools MCP, enable the built-in ACPX preset:
+
+```bash
+openclaw config set plugins.entries.acpx.config.chromeDevtoolsMcp.enabled true
+```
+
+When enabled, ACPX injects this MCP server definition into ACPX-backed
+sessions:
+
+```json
+{
+  "chrome-devtools": {
+    "command": "npx",
+    "args": ["-y", "chrome-devtools-mcp@0.20.0", "--autoConnect", "--experimental-page-id-routing"]
+  }
+}
+```
+
+Notes:
+
+- This affects ACPX-backed sessions only.
+- It does not change the browser tool, `existing-session` browser profiles, or
+  the `openclaw acp` bridge.
+- If `plugins.entries.acpx.config.mcpServers.chrome-devtools` is already set,
+  the explicit entry wins and the preset is skipped.
+- If `browser.evaluateEnabled=false`, the built-in preset is suppressed as a
+  conservative safety boundary.
+
 ## Permission configuration
 
 ACP sessions run non-interactively — there is no TTY to approve or deny file-write and shell-exec permission prompts. The acpx plugin provides two config keys that control how permissions are handled:

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -591,10 +591,19 @@ Notes:
 - This affects ACPX-backed sessions only.
 - It does not change the browser tool, `existing-session` browser profiles, or
   the `openclaw acp` bridge.
+- ACPX applies this through its existing MCP proxy path. It does not add a new
+  `acpx` CLI flag for Chrome DevTools MCP.
 - If `plugins.entries.acpx.config.mcpServers.chrome-devtools` is already set,
   the explicit entry wins and the preset is skipped.
 - If `browser.evaluateEnabled=false`, the built-in preset is suppressed as a
   conservative safety boundary.
+- Because the preset uses `npx -y`, the first run needs npm registry access
+  unless `chrome-devtools-mcp@0.20.0` is already cached locally.
+- The `chrome-devtools-mcp` version is pinned by OpenClaw. Future version bumps
+  happen in later OpenClaw PRs and releases.
+- If you need offline packaging, a custom channel, or a different version, set
+  `plugins.entries.acpx.config.mcpServers.chrome-devtools` explicitly instead
+  of using the built-in preset.
 
 ## Permission configuration
 

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -35,6 +35,15 @@
         "type": "number",
         "minimum": 0
       },
+      "chromeDevtoolsMcp": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      },
       "mcpServers": {
         "type": "object",
         "additionalProperties": {
@@ -94,6 +103,11 @@
     "queueOwnerTtlSeconds": {
       "label": "Queue Owner TTL Seconds",
       "help": "Idle queue-owner TTL for acpx prompt turns. Keep this short in OpenClaw to avoid delayed completion after each turn.",
+      "advanced": true
+    },
+    "chromeDevtoolsMcp.enabled": {
+      "label": "Enable Chrome DevTools MCP Preset",
+      "help": "Inject the built-in chrome-devtools-mcp live-session preset into ACPX-backed agent sessions. This affects ACPX only, not the browser tool or openclaw acp bridge.",
       "advanced": true
     },
     "mcpServers": {

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -127,6 +127,38 @@ describe("acpx plugin config parsing", () => {
     expect(resolved.strictWindowsCmdWrapper).toBe(true);
   });
 
+  it("accepts chromeDevtoolsMcp enablement and preserves mcpServers", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        chromeDevtoolsMcp: { enabled: true },
+        mcpServers: {
+          example: {
+            command: "npx",
+            args: ["example-mcp"],
+          },
+        },
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.chromeDevtoolsMcp.enabled).toBe(true);
+    expect(resolved.mcpServers.example).toEqual({
+      command: "npx",
+      args: ["example-mcp"],
+    });
+  });
+
+  it("rejects invalid chromeDevtoolsMcp config", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          chromeDevtoolsMcp: { enabled: "yes" },
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("chromeDevtoolsMcp must be an object with an optional boolean enabled field");
+  });
+
   it("rejects non-boolean strictWindowsCmdWrapper", () => {
     expect(() =>
       resolveAcpxPluginConfig({

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -31,6 +31,14 @@ export type AcpxMcpServer = {
   env: Array<{ name: string; value: string }>;
 };
 
+export type AcpxChromeDevtoolsMcpConfig = {
+  enabled?: boolean;
+};
+
+export type ResolvedAcpxChromeDevtoolsMcpConfig = {
+  enabled: boolean;
+};
+
 export type AcpxPluginConfig = {
   command?: string;
   expectedVersion?: string;
@@ -40,6 +48,7 @@ export type AcpxPluginConfig = {
   strictWindowsCmdWrapper?: boolean;
   timeoutSeconds?: number;
   queueOwnerTtlSeconds?: number;
+  chromeDevtoolsMcp?: AcpxChromeDevtoolsMcpConfig;
   mcpServers?: Record<string, McpServerConfig>;
 };
 
@@ -55,6 +64,7 @@ export type ResolvedAcpxPluginConfig = {
   strictWindowsCmdWrapper: boolean;
   timeoutSeconds?: number;
   queueOwnerTtlSeconds: number;
+  chromeDevtoolsMcp: ResolvedAcpxChromeDevtoolsMcpConfig;
   mcpServers: Record<string, McpServerConfig>;
 };
 
@@ -111,6 +121,19 @@ function isMcpServerConfig(value: unknown): value is McpServerConfig {
   return true;
 }
 
+function isChromeDevtoolsMcpConfig(value: unknown): value is AcpxChromeDevtoolsMcpConfig {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const allowedKeys = new Set(["enabled"]);
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      return false;
+    }
+  }
+  return value.enabled === undefined || typeof value.enabled === "boolean";
+}
+
 function parseAcpxPluginConfig(value: unknown): ParseResult {
   if (value === undefined) {
     return { ok: true, value: undefined };
@@ -127,6 +150,7 @@ function parseAcpxPluginConfig(value: unknown): ParseResult {
     "strictWindowsCmdWrapper",
     "timeoutSeconds",
     "queueOwnerTtlSeconds",
+    "chromeDevtoolsMcp",
     "mcpServers",
   ]);
   for (const key of Object.keys(value)) {
@@ -199,6 +223,14 @@ function parseAcpxPluginConfig(value: unknown): ParseResult {
     return { ok: false, message: "queueOwnerTtlSeconds must be a non-negative number" };
   }
 
+  const chromeDevtoolsMcp = value.chromeDevtoolsMcp;
+  if (chromeDevtoolsMcp !== undefined && !isChromeDevtoolsMcpConfig(chromeDevtoolsMcp)) {
+    return {
+      ok: false,
+      message: "chromeDevtoolsMcp must be an object with an optional boolean enabled field",
+    };
+  }
+
   const mcpServers = value.mcpServers;
   if (mcpServers !== undefined) {
     if (!isRecord(mcpServers)) {
@@ -228,6 +260,7 @@ function parseAcpxPluginConfig(value: unknown): ParseResult {
       timeoutSeconds: typeof timeoutSeconds === "number" ? timeoutSeconds : undefined,
       queueOwnerTtlSeconds:
         typeof queueOwnerTtlSeconds === "number" ? queueOwnerTtlSeconds : undefined,
+      chromeDevtoolsMcp: chromeDevtoolsMcp as AcpxChromeDevtoolsMcpConfig | undefined,
       mcpServers: mcpServers as Record<string, McpServerConfig> | undefined,
     },
   };
@@ -282,6 +315,13 @@ export function createAcpxPluginConfigSchema(): OpenClawPluginConfigSchema {
         strictWindowsCmdWrapper: { type: "boolean" },
         timeoutSeconds: { type: "number", minimum: 0.001 },
         queueOwnerTtlSeconds: { type: "number", minimum: 0 },
+        chromeDevtoolsMcp: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            enabled: { type: "boolean" },
+          },
+        },
         mcpServers: {
           type: "object",
           additionalProperties: {
@@ -355,6 +395,9 @@ export function resolveAcpxPluginConfig(params: {
       normalized.strictWindowsCmdWrapper ?? DEFAULT_STRICT_WINDOWS_CMD_WRAPPER,
     timeoutSeconds: normalized.timeoutSeconds,
     queueOwnerTtlSeconds: normalized.queueOwnerTtlSeconds ?? DEFAULT_QUEUE_OWNER_TTL_SECONDS,
+    chromeDevtoolsMcp: {
+      enabled: normalized.chromeDevtoolsMcp?.enabled === true,
+    },
     mcpServers: normalized.mcpServers ?? {},
   };
 }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -26,6 +26,7 @@ beforeAll(async () => {
       nonInteractivePermissions: "fail",
       strictWindowsCmdWrapper: true,
       queueOwnerTtlSeconds: 0.1,
+      chromeDevtoolsMcp: { enabled: false },
       mcpServers: {},
     },
     { logger: NOOP_LOGGER },

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -7,7 +7,7 @@ import {
   requireAcpRuntimeBackend,
 } from "../../../src/acp/runtime/registry.js";
 import { ACPX_BUNDLED_BIN, ACPX_PINNED_VERSION } from "./config.js";
-import { createAcpxRuntimeService } from "./service.js";
+import { buildChromeDevtoolsMcpPreset, createAcpxRuntimeService } from "./service.js";
 
 const { ensureAcpxSpy } = vi.hoisted(() => ({
   ensureAcpxSpy: vi.fn(async () => {}),
@@ -158,6 +158,138 @@ describe("createAcpxRuntimeService", () => {
       expect.objectContaining({
         queueOwnerTtlSeconds: 0.1,
       }),
+    );
+  });
+
+  it("builds the chrome-devtools-mcp preset with pinned args", () => {
+    expect(buildChromeDevtoolsMcpPreset()).toEqual({
+      command: "npx",
+      args: ["-y", "chrome-devtools-mcp@0.20.0", "--autoConnect", "--experimental-page-id-routing"],
+    });
+  });
+
+  it("injects the chrome-devtools-mcp preset when enabled", async () => {
+    const { runtime } = createRuntimeStub(true);
+    const runtimeFactory = vi.fn(() => runtime);
+    const service = createAcpxRuntimeService({
+      runtimeFactory,
+      pluginConfig: {
+        chromeDevtoolsMcp: { enabled: true },
+      },
+    });
+    const context = createServiceContext();
+
+    await service.start(context);
+
+    expect(runtimeFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginConfig: expect.objectContaining({
+          mcpServers: {
+            "chrome-devtools": buildChromeDevtoolsMcpPreset(),
+          },
+        }),
+      }),
+    );
+    expect(context.logger.info).toHaveBeenCalledWith(
+      "chrome-devtools-mcp preset injected from acpx plugin config",
+    );
+  });
+
+  it("does not override an explicit chrome-devtools mcpServers entry", async () => {
+    const { runtime } = createRuntimeStub(true);
+    const runtimeFactory = vi.fn(() => runtime);
+    const userDefined = { command: "custom-chrome-mcp", args: ["--custom"] };
+    const service = createAcpxRuntimeService({
+      runtimeFactory,
+      pluginConfig: {
+        chromeDevtoolsMcp: { enabled: true },
+        mcpServers: { "chrome-devtools": userDefined },
+      },
+    });
+    const context = createServiceContext();
+
+    await service.start(context);
+
+    expect(runtimeFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginConfig: expect.objectContaining({
+          mcpServers: { "chrome-devtools": userDefined },
+        }),
+      }),
+    );
+    expect(context.logger.info).toHaveBeenCalledWith(
+      "chrome-devtools-mcp preset skipped: existing mcpServers entry takes precedence",
+    );
+  });
+
+  it("does not leak the injected preset into later restarts", async () => {
+    const { runtime } = createRuntimeStub(true);
+    const runtimeFactory = vi.fn(() => runtime);
+    const service = createAcpxRuntimeService({
+      runtimeFactory,
+      pluginConfig: {
+        chromeDevtoolsMcp: { enabled: true },
+        mcpServers: { canva: { command: "npx", args: ["canva-mcp"] } },
+      },
+    });
+    const enabledContext = createServiceContext();
+
+    await service.start(enabledContext);
+    await service.stop?.(enabledContext);
+
+    const disabledContext = createServiceContext({
+      config: {
+        browser: {
+          evaluateEnabled: false,
+        },
+      },
+    });
+
+    await service.start(disabledContext);
+
+    expect(runtimeFactory).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        pluginConfig: expect.objectContaining({
+          mcpServers: {
+            canva: { command: "npx", args: ["canva-mcp"] },
+          },
+        }),
+      }),
+    );
+    expect(disabledContext.logger.warn).toHaveBeenCalledWith(
+      "chrome-devtools-mcp preset blocked: browser.evaluateEnabled=false disables the built-in ACPX preset",
+    );
+  });
+
+  it("blocks the built-in preset when browser.evaluateEnabled is false", async () => {
+    const { runtime } = createRuntimeStub(true);
+    const runtimeFactory = vi.fn(() => runtime);
+    const service = createAcpxRuntimeService({
+      runtimeFactory,
+      pluginConfig: {
+        chromeDevtoolsMcp: { enabled: true },
+      },
+    });
+    const context = createServiceContext({
+      config: {
+        browser: {
+          evaluateEnabled: false,
+        },
+      },
+    });
+
+    await service.start(context);
+
+    expect(runtimeFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginConfig: expect.objectContaining({
+          mcpServers: {},
+        }),
+      }),
+    );
+    expect(context.logger.warn).toHaveBeenCalledWith(
+      "chrome-devtools-mcp preset blocked: browser.evaluateEnabled=false disables the built-in ACPX preset",
     );
   });
 

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -5,9 +5,17 @@ import type {
   PluginLogger,
 } from "openclaw/plugin-sdk/acpx";
 import { registerAcpRuntimeBackend, unregisterAcpRuntimeBackend } from "openclaw/plugin-sdk/acpx";
-import { resolveAcpxPluginConfig, type ResolvedAcpxPluginConfig } from "./config.js";
+import {
+  resolveAcpxPluginConfig,
+  type McpServerConfig,
+  type ResolvedAcpxPluginConfig,
+} from "./config.js";
 import { ensureAcpx } from "./ensure.js";
 import { ACPX_BACKEND_ID, AcpxRuntime } from "./runtime.js";
+
+const CHROME_DEVTOOLS_MCP_SERVER_NAME = "chrome-devtools";
+const CHROME_DEVTOOLS_MCP_PINNED_VERSION = "0.20.0";
+const CHROME_DEVTOOLS_MCP_PACKAGE = `chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_PINNED_VERSION}`;
 
 type AcpxRuntimeLike = AcpRuntime & {
   probeAvailability(): Promise<void>;
@@ -32,6 +40,33 @@ function createDefaultRuntime(params: AcpxRuntimeFactoryParams): AcpxRuntimeLike
   });
 }
 
+export function buildChromeDevtoolsMcpPreset(): McpServerConfig {
+  return {
+    command: "npx",
+    args: ["-y", CHROME_DEVTOOLS_MCP_PACKAGE, "--autoConnect", "--experimental-page-id-routing"],
+  };
+}
+
+function resolveChromeDevtoolsPresetAction(params: {
+  config: OpenClawPluginServiceContext["config"];
+  pluginConfig: ResolvedAcpxPluginConfig;
+}):
+  | { kind: "disabled" }
+  | { kind: "override" }
+  | { kind: "blocked" }
+  | { kind: "inject"; preset: McpServerConfig } {
+  if (!params.pluginConfig.chromeDevtoolsMcp.enabled) {
+    return { kind: "disabled" };
+  }
+  if (params.pluginConfig.mcpServers[CHROME_DEVTOOLS_MCP_SERVER_NAME]) {
+    return { kind: "override" };
+  }
+  if (params.config.browser?.evaluateEnabled === false) {
+    return { kind: "blocked" };
+  }
+  return { kind: "inject", preset: buildChromeDevtoolsMcpPreset() };
+}
+
 export function createAcpxRuntimeService(
   params: CreateAcpxRuntimeServiceParams = {},
 ): OpenClawPluginService {
@@ -41,10 +76,33 @@ export function createAcpxRuntimeService(
   return {
     id: "acpx-runtime",
     async start(ctx: OpenClawPluginServiceContext): Promise<void> {
-      const pluginConfig = resolveAcpxPluginConfig({
+      let pluginConfig = resolveAcpxPluginConfig({
         rawConfig: params.pluginConfig,
         workspaceDir: ctx.workspaceDir,
       });
+      const chromeDevtoolsPresetAction = resolveChromeDevtoolsPresetAction({
+        config: ctx.config,
+        pluginConfig,
+      });
+      if (chromeDevtoolsPresetAction.kind === "inject") {
+        pluginConfig = {
+          ...pluginConfig,
+          // Keep user-supplied plugin config immutable across service restarts.
+          mcpServers: {
+            ...pluginConfig.mcpServers,
+            [CHROME_DEVTOOLS_MCP_SERVER_NAME]: chromeDevtoolsPresetAction.preset,
+          },
+        };
+        ctx.logger.info("chrome-devtools-mcp preset injected from acpx plugin config");
+      } else if (chromeDevtoolsPresetAction.kind === "override") {
+        ctx.logger.info(
+          "chrome-devtools-mcp preset skipped: existing mcpServers entry takes precedence",
+        );
+      } else if (chromeDevtoolsPresetAction.kind === "blocked") {
+        ctx.logger.warn(
+          "chrome-devtools-mcp preset blocked: browser.evaluateEnabled=false disables the built-in ACPX preset",
+        );
+      }
       const runtimeFactory = params.runtimeFactory ?? createDefaultRuntime;
       runtime = runtimeFactory({
         pluginConfig,

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -335,6 +335,7 @@ export async function createMockRuntimeFixture(params?: {
     nonInteractivePermissions: "fail",
     strictWindowsCmdWrapper: true,
     queueOwnerTtlSeconds: params?.queueOwnerTtlSeconds ?? 0.1,
+    chromeDevtoolsMcp: { enabled: false },
     mcpServers: params?.mcpServers ?? {},
   };
 


### PR DESCRIPTION
## Summary

- Problem: ACPX-backed agent sessions can already use `chrome-devtools-mcp`, but only through verbose manual `plugins.entries.acpx.config.mcpServers` configuration.
- Root cause: the ACPX plugin already supports MCP server injection, but it has no small preset for the supported Chrome live-session attach flow.
- Fix: add `plugins.entries.acpx.config.chromeDevtoolsMcp.enabled` to inject a pinned `chrome-devtools` MCP server with `--autoConnect` and `--experimental-page-id-routing`.
- Scope boundary: ACPX-only. No changes to the browser tool, `existing-session` browser profiles, or the separate `openclaw acp` bridge path.

## Why now

This workflow has been surfacing upstream across recent `chrome-devtools-mcp` releases, not in a single Chrome 146 release-note entry.

- `0.12.0` on December 9, 2025 added `--auto-connect` support for attaching to a Chrome instance.
- `0.18.0` on February 24, 2026 added `--slim` mode.
- `0.19.0` on March 5, 2026 added pageId routing for parallel multi-agent workflows.
- `0.20.0` on March 11, 2026 added the experimental `chrome-devtools` CLI.

This PR does not claim to introduce a brand-new Chrome capability. It turns a recently surfaced upstream Chrome DevTools MCP workflow into a small ACPX preset instead of requiring users to hand-author `mcpServers` config.

Upstream reference: [chrome-devtools-mcp changelog](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/CHANGELOG.md)

## Behavior

- Default: off.
- If enabled, ACPX injects:
  - `npx -y chrome-devtools-mcp@0.20.0 --autoConnect --experimental-page-id-routing`
- ACPX applies that preset through its existing MCP proxy path. This PR does not add a new direct `acpx` CLI flag.
- If `plugins.entries.acpx.config.mcpServers.chrome-devtools` already exists, explicit config wins and the preset is skipped.
- If `browser.evaluateEnabled=false`, the preset is suppressed and a warning is logged.

## Why this config lives under ACPX

- The ACPX plugin is the component that already owns `mcpServers` parsing and runtime injection.
- Putting this under `browser.*` would imply browser-tool behavior changes that this PR does not make.

## Risk / compatibility

- Additive and backward compatible.
- Main risk is widening access to a user's live Chrome session.
- Operational note: because the preset uses `npx -y`, first use needs npm registry access unless the package is already cached locally.
- Versioning note: `chrome-devtools-mcp` is pinned in OpenClaw and future bumps happen in later OpenClaw PRs.
- Mitigations:
  - default-off
  - explicit manual override wins
  - conservative suppression when `browser.evaluateEnabled` is disabled
  - manual `mcpServers.chrome-devtools` config remains available for offline packaging or custom versions

## How tested

- ACPX config parser tests for the new flag and invalid values
- ACPX service tests for inject / skip / blocked / restart behavior
- Targeted ACPX runtime tests
- `pnpm test extensions/acpx/src/config.test.ts extensions/acpx/src/service.test.ts extensions/acpx/src/runtime.test.ts`
- `pnpm tsgo` (currently fails on unrelated existing errors in `src/infra/outbound/outbound-send-service.test.ts`)
- `pnpm check` (currently fails for the same unrelated existing errors after formatting passes)
- Local real-browser smoke on macOS with Google Chrome `146.0.7680.76`
  - enabled `chrome://inspect/#remote-debugging`
  - ran the exact built-in preset path via ACPX (`chrome-devtools-mcp@0.20.0 --autoConnect --experimental-page-id-routing`)
  - Codex successfully called `chrome-devtools/list_pages`, `chrome-devtools/select_page`, and `chrome-devtools/evaluate_script`
  - Codex returned the live tab title from a real Chrome page: `OpenClaw Smoke 2026-03-13 12-01 HST`

## Not tested

- multi-profile Chrome autoConnect behavior
- offline first-run install path for `npx -y`

## Review focus

- sanity check on ACPX-only scope
- config placement under `plugins.entries.acpx.config.*`
- conservative `browser.evaluateEnabled` guard
