### PR TITLE
CLI: shorten update dry-run root paths

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/types.openclaw.js";
@@ -362,6 +363,20 @@ describe("update-cli", () => {
     const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
     expect(logs.join("\n")).toContain("Update dry-run");
     expect(logs.join("\n")).toContain("No changes were applied.");
+  });
+
+  it("updateCommand --dry-run shortens home-root paths in human output", async () => {
+    vi.mocked(defaultRuntime.log).mockClear();
+    serviceLoaded.mockResolvedValue(true);
+    const home = os.homedir();
+    mockPackageInstallStatus(`${home}/.local/share/openclaw`);
+
+    await updateCommand({ dryRun: true, channel: "beta" });
+
+    const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    expect(logs.join("\n")).toContain("Root:");
+    expect(logs.join("\n")).toContain("~/.local/share/openclaw");
+    expect(logs.join("\n")).not.toContain(`${home}/.local/share/openclaw`);
   });
 
   it("updateStatusCommand prints table output", async () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -36,7 +36,7 @@ import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { stylePromptMessage } from "../../terminal/prompt-style.js";
 import { theme } from "../../terminal/theme.js";
-import { pathExists } from "../../utils.js";
+import { pathExists, shortenHomePath } from "../../utils.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import { installCompletion } from "../completion-cli.js";
@@ -146,7 +146,7 @@ function printDryRunPreview(preview: UpdateDryRunPreview, jsonMode: boolean): vo
   defaultRuntime.log(theme.heading("Update dry-run"));
   defaultRuntime.log(theme.muted("No changes were applied."));
   defaultRuntime.log("");
-  defaultRuntime.log(`  Root: ${theme.muted(preview.root)}`);
+  defaultRuntime.log(`  Root: ${theme.muted(shortenHomePath(preview.root))}`);
   defaultRuntime.log(`  Install kind: ${theme.muted(preview.installKind)}`);
   defaultRuntime.log(`  Mode: ${theme.muted(preview.mode)}`);
   defaultRuntime.log(`  Channel: ${theme.muted(preview.effectiveChannel)}`);


### PR DESCRIPTION
## Summary
- shorten the install root shown by `openclaw update --dry-run` in human-readable output
- keep JSON output unchanged while aligning the terminal preview with the rest of the CLI's path formatting
- add a regression test that covers home-directory install roots

## Testing
- pnpm test src/cli/update-cli.test.ts
- pnpm exec oxfmt --check src/cli/update-cli/update-command.ts src/cli/update-cli.test.ts
- pnpm build
