### PR TITLE
feat: install Google Workspace CLI (gws) in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -224,6 +224,9 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
  && chmod 755 /app/openclaw.mjs
 
+# Install Google Workspace CLI (gws)
+RUN npm install -g @googleworkspace/cli
+
 ENV NODE_ENV=production
 
 # Security hardening: Run as non-root user


### PR DESCRIPTION
Install `@googleworkspace/cli` inside the runtime image to enable native Google Workspace support (gws/gog). See: https://github.com/googleworkspace/cli