### PR TITLE
Guard updater service refresh against missing invocation cwd

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -668,6 +668,54 @@ describe("update-cli", () => {
     expect(runDaemonInstall).not.toHaveBeenCalled();
   });
 
+  it("updateCommand reuses the captured invocation cwd when process.cwd later fails", async () => {
+    const root = createCaseDir("openclaw-updated-root");
+    const entryPath = path.join(root, "dist", "entry.js");
+    pathExists.mockImplementation(async (candidate: string) => candidate === entryPath);
+
+    const originalCwd = process.cwd();
+    let restoreCwd: (() => void) | undefined;
+    vi.mocked(runGatewayUpdate).mockImplementation(async () => {
+      const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+        throw new Error("ENOENT: current working directory is gone");
+      });
+      restoreCwd = () => cwdSpy.mockRestore();
+      return {
+        status: "ok",
+        mode: "npm",
+        root,
+        steps: [],
+        durationMs: 100,
+      };
+    });
+    serviceLoaded.mockResolvedValue(true);
+
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: "./state",
+        },
+        async () => {
+          await updateCommand({});
+        },
+      );
+    } finally {
+      restoreCwd?.();
+    }
+
+    expect(runCommandWithTimeout).toHaveBeenCalledWith(
+      [expect.stringMatching(/node/), entryPath, "gateway", "install", "--force"],
+      expect.objectContaining({
+        cwd: root,
+        env: expect.objectContaining({
+          OPENCLAW_STATE_DIR: path.resolve(originalCwd, "./state"),
+        }),
+        timeoutMs: 60_000,
+      }),
+    );
+    expect(runDaemonInstall).not.toHaveBeenCalled();
+  });
+
   it("updateCommand falls back to restart when env refresh install fails", async () => {
     await runRestartFallbackScenario({ daemonInstall: "fail" });
   });

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -124,9 +124,17 @@ function formatCommandFailure(stdout: string, stderr: string): string {
   return detail.split("\n").slice(-3).join("\n");
 }
 
+function tryResolveInvocationCwd(): string | undefined {
+  try {
+    return process.cwd();
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveServiceRefreshEnv(
   env: NodeJS.ProcessEnv,
-  invocationCwd: string = process.cwd(),
+  invocationCwd?: string,
 ): NodeJS.ProcessEnv {
   const resolvedEnv: NodeJS.ProcessEnv = { ...env };
   for (const key of SERVICE_REFRESH_PATH_ENV_KEYS) {
@@ -135,6 +143,10 @@ function resolveServiceRefreshEnv(
       continue;
     }
     if (rawValue.startsWith("~") || path.isAbsolute(rawValue) || path.win32.isAbsolute(rawValue)) {
+      resolvedEnv[key] = rawValue;
+      continue;
+    }
+    if (!invocationCwd) {
       resolvedEnv[key] = rawValue;
       continue;
     }
@@ -205,6 +217,7 @@ function printDryRunPreview(preview: UpdateDryRunPreview, jsonMode: boolean): vo
 async function refreshGatewayServiceEnv(params: {
   result: UpdateRunResult;
   jsonMode: boolean;
+  invocationCwd?: string;
 }): Promise<void> {
   const args = ["gateway", "install", "--force"];
   if (params.jsonMode) {
@@ -217,7 +230,7 @@ async function refreshGatewayServiceEnv(params: {
     }
     const res = await runCommandWithTimeout([resolveNodeRunner(), candidate, ...args], {
       cwd: params.result.root,
-      env: resolveServiceRefreshEnv(process.env),
+      env: resolveServiceRefreshEnv(process.env, params.invocationCwd),
       timeoutMs: SERVICE_REFRESH_TIMEOUT_MS,
     });
     if (res.code === 0) {
@@ -547,6 +560,7 @@ async function maybeRestartService(params: {
   refreshServiceEnv: boolean;
   gatewayPort: number;
   restartScriptPath?: string | null;
+  invocationCwd?: string;
 }): Promise<void> {
   if (params.shouldRestart) {
     if (!params.opts.json) {
@@ -562,6 +576,7 @@ async function maybeRestartService(params: {
           await refreshGatewayServiceEnv({
             result: params.result,
             jsonMode: Boolean(params.opts.json),
+            invocationCwd: params.invocationCwd,
           });
         } catch (err) {
           if (!params.opts.json) {
@@ -667,6 +682,7 @@ async function maybeRestartService(params: {
 
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   suppressDeprecations();
+  const invocationCwd = tryResolveInvocationCwd();
 
   const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
   const shouldRestart = opts.restart !== false;
@@ -949,6 +965,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     refreshServiceEnv: refreshGatewayServiceEnv,
     gatewayPort,
     restartScriptPath,
+    invocationCwd,
   });
 
   if (!opts.json) {


### PR DESCRIPTION
## Summary

- Problem: `resolveServiceRefreshEnv` defaulted `invocationCwd` to `process.cwd()`, which can throw `ENOENT` after an update replaces or removes the caller's original directory.
- Why it matters: that exception aborts the service env refresh path before `runCommandWithTimeout` can use the safe `cwd: params.result.root`, so `gateway install --force` may never refresh the installed service environment.
- What changed: capture a stable invocation cwd at the start of `updateCommand`, thread it into the service refresh helper, and only rebase relative env overrides when that captured cwd is available.
- What did NOT change (scope boundary): the refresh still runs from the updated install root, and absolute or `~`-prefixed overrides still keep their existing behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #45452

## User-visible / Behavior Changes

Relative service env path overrides continue to resolve against the original invocation directory even if that directory disappears during update.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): gateway updater
- Relevant config (redacted): `OPENCLAW_STATE_DIR=./state`

### Steps

1. Start `openclaw update` from a directory that may be replaced or removed during update.
2. Ensure the refresh path uses the updated install root and a relative service env override such as `OPENCLAW_STATE_DIR=./state`.
3. Let the original invocation cwd become unavailable before the refresh helper resolves env overrides.

### Expected

- Service env refresh still runs and preserves relative overrides using the originally captured cwd.

### Actual

- Before this change, `process.cwd()` could throw during env rebasing and skip the refresh path entirely.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/cli/update-cli.test.ts`; updater refresh path with relative env overrides; updater refresh path after `process.cwd()` starts throwing.
- Edge cases checked: no captured cwd available leaves relative overrides unchanged instead of throwing; absolute and `~`-prefixed overrides remain untouched.
- What you did **not** verify: full end-to-end service reinstall against a real removed working directory outside the unit test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR's two commits.
- Files/config to restore: `src/cli/update-cli/update-command.ts`, `src/cli/update-cli.test.ts`
- Known bad symptoms reviewers should watch for: relative refresh overrides resolving against the install root or refresh path being skipped when cwd disappears.

## Risks and Mitigations

- Risk: another call site might invoke the refresh helper without a captured cwd.
  - Mitigation: the helper now degrades by leaving relative overrides unchanged instead of throwing.
