### PR TITLE
feat(hooks): expose external-data provenance in before_tool_call HookContext

### DIFF
--- a/src/agents/pi-tools.before-tool-call.external-data.test.ts
+++ b/src/agents/pi-tools.before-tool-call.external-data.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import {
+  __testing as beforeToolCallTesting,
+  wrapToolWithBeforeToolCallHook,
+  type HookContext,
+} from "./pi-tools.before-tool-call.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+vi.mock("../plugins/hook-runner-global.js");
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+type HookRunnerMock = {
+  hasHooks: ReturnType<typeof vi.fn>;
+  runBeforeToolCall: ReturnType<typeof vi.fn>;
+};
+
+function installMockHookRunner(hasHooksReturn = true) {
+  const hookRunner: HookRunnerMock = {
+    hasHooks: vi.fn(() => hasHooksReturn),
+    runBeforeToolCall: vi.fn().mockResolvedValue(undefined),
+  };
+  mockGetGlobalHookRunner.mockReturnValue(
+    hookRunner as unknown as ReturnType<typeof getGlobalHookRunner>,
+  );
+  return hookRunner;
+}
+
+function createWrappedTool(name: string, ctx: HookContext) {
+  const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+  return wrapToolWithBeforeToolCallHook({ name, execute } as unknown as AnyAgentTool, ctx);
+}
+
+describe("before_tool_call external data tracking", () => {
+  let hookRunner: HookRunnerMock;
+
+  beforeEach(() => {
+    hookRunner = installMockHookRunner(true);
+    beforeToolCallTesting.externalDataSourcesByScope.clear();
+  });
+
+  it("sets hasExternalData=false when no external tools have been called", async () => {
+    const ctx: HookContext = { runId: "run-none" };
+    const tool = createWrappedTool("read", ctx);
+
+    await tool.execute("call-none", { path: "/tmp/a.txt" }, undefined, undefined);
+
+    expect(hookRunner.runBeforeToolCall).toHaveBeenCalledTimes(1);
+    const [, toolContext] = hookRunner.runBeforeToolCall.mock.calls[0] as [unknown, HookContext];
+    expect(toolContext.hasExternalData).toBe(false);
+  });
+
+  it("sets hasExternalData=true after web_fetch is called", async () => {
+    const ctx: HookContext = { runId: "run-web-fetch" };
+    const fetchTool = createWrappedTool("web_fetch", ctx);
+    const readTool = createWrappedTool("read", ctx);
+
+    await fetchTool.execute("call-fetch", { url: "https://example.com" }, undefined, undefined);
+    await readTool.execute("call-read", { path: "/tmp/a.txt" }, undefined, undefined);
+
+    const [, toolContext] = hookRunner.runBeforeToolCall.mock.calls.at(-1) as [
+      unknown,
+      HookContext,
+    ];
+    expect(toolContext.hasExternalData).toBe(true);
+  });
+
+  it("sets hasExternalData=true after web_search is called", async () => {
+    const ctx: HookContext = { runId: "run-web-search" };
+    const searchTool = createWrappedTool("web_search", ctx);
+    const readTool = createWrappedTool("read", ctx);
+
+    await searchTool.execute("call-search", { query: "openclaw" }, undefined, undefined);
+    await readTool.execute("call-read", { path: "/tmp/a.txt" }, undefined, undefined);
+
+    const [, toolContext] = hookRunner.runBeforeToolCall.mock.calls.at(-1) as [
+      unknown,
+      HookContext,
+    ];
+    expect(toolContext.hasExternalData).toBe(true);
+  });
+
+  it("sets hasExternalData=true after browser is called", async () => {
+    const ctx: HookContext = { runId: "run-browser" };
+    const browserTool = createWrappedTool("browser", ctx);
+    const readTool = createWrappedTool("read", ctx);
+
+    await browserTool.execute("call-browser", { action: "open" }, undefined, undefined);
+    await readTool.execute("call-read", { path: "/tmp/a.txt" }, undefined, undefined);
+
+    const [, toolContext] = hookRunner.runBeforeToolCall.mock.calls.at(-1) as [
+      unknown,
+      HookContext,
+    ];
+    expect(toolContext.hasExternalData).toBe(true);
+  });
+
+  it("keeps hasExternalData=false after read is called", async () => {
+    const ctx: HookContext = { runId: "run-read" };
+    const readTool = createWrappedTool("read", ctx);
+
+    await readTool.execute("call-read-1", { path: "/tmp/a.txt" }, undefined, undefined);
+    await readTool.execute("call-read-2", { path: "/tmp/b.txt" }, undefined, undefined);
+
+    const [, toolContext] = hookRunner.runBeforeToolCall.mock.calls.at(-1) as [
+      unknown,
+      HookContext,
+    ];
+    expect(toolContext.hasExternalData).toBe(false);
+  });
+
+  it("keeps hasExternalData=false after exec is called", async () => {
+    const ctx: HookContext = { runId: "run-exec" };
+    const execTool = createWrappedTool("exec", ctx);
+    const readTool = createWrappedTool("read", ctx);
+
+    await execTool.execute("call-exec", { cmd: "ls" }, undefined, undefined);
+    await readTool.execute("call-read", { path: "/tmp/a.txt" }, undefined, undefined);
+
+    const [, toolContext] = hookRunner.runBeforeToolCall.mock.calls.at(-1) as [
+      unknown,
+      HookContext,
+    ];
+    expect(toolContext.hasExternalData).toBe(false);
+  });
+
+  it("keeps hasExternalData=false when external tool execution fails", async () => {
+    const ctx: HookContext = { sessionId: "sess-failing-external" };
+    const failingFetchExecute = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    const failingFetchTool = wrapToolWithBeforeToolCallHook(
+      { name: "web_fetch", execute: failingFetchExecute } as unknown as AnyAgentTool,
+      ctx,
+    );
+    const readTool = createWrappedTool("read", ctx);
+
+    await expect(
+      failingFetchTool.execute(
+        "call-fetch-fail",
+        { url: "https://example.com" },
+        undefined,
+        undefined,
+      ),
+    ).rejects.toThrow("fetch failed");
+    await readTool.execute("call-read-after-fail", { path: "/tmp/a.txt" }, undefined, undefined);
+
+    const [, toolContext] = hookRunner.runBeforeToolCall.mock.calls.at(-1) as [
+      unknown,
+      HookContext,
+    ];
+    expect(toolContext.hasExternalData).toBe(false);
+  });
+
+  it("keeps external-data state isolated across scopes", async () => {
+    const ctxA: HookContext = { runId: "run-a" };
+    const ctxB: HookContext = { runId: "run-b" };
+    const fetchToolA = createWrappedTool("web_fetch", ctxA);
+    const readToolA = createWrappedTool("read", ctxA);
+    const readToolB = createWrappedTool("read", ctxB);
+
+    await fetchToolA.execute("call-fetch-a", { url: "https://example.com" }, undefined, undefined);
+    await readToolB.execute("call-read-b", { path: "/tmp/b.txt" }, undefined, undefined);
+    await readToolA.execute("call-read-a", { path: "/tmp/a.txt" }, undefined, undefined);
+
+    const [, contextForB] = hookRunner.runBeforeToolCall.mock.calls[1] as [unknown, HookContext];
+    const [, contextForA] = hookRunner.runBeforeToolCall.mock.calls[2] as [unknown, HookContext];
+    expect(contextForB.hasExternalData).toBe(false);
+    expect(contextForA.hasExternalData).toBe(true);
+  });
+
+  it("evicts oldest scopes when tracked external-data scopes exceed cap", async () => {
+    installMockHookRunner(false);
+    const maxScopes = beforeToolCallTesting.MAX_TRACKED_EXTERNAL_DATA_SCOPES;
+    const totalScopes = maxScopes + 1;
+
+    for (let i = 0; i < totalScopes; i += 1) {
+      const ctx: HookContext = { runId: `run-${i}` };
+      const fetchTool = createWrappedTool("web_fetch", ctx);
+      await fetchTool.execute(
+        `call-${i}`,
+        { url: `https://example.com/${i}` },
+        undefined,
+        undefined,
+      );
+    }
+
+    const oldestKey = beforeToolCallTesting.buildHookContextScopeKey({ runId: "run-0" });
+    const newestKey = beforeToolCallTesting.buildHookContextScopeKey({
+      runId: `run-${totalScopes - 1}`,
+    });
+    expect(beforeToolCallTesting.externalDataSourcesByScope.size).toBe(maxScopes);
+    expect(oldestKey).toBeDefined();
+    expect(newestKey).toBeDefined();
+    expect(beforeToolCallTesting.externalDataSourcesByScope.has(oldestKey!)).toBe(false);
+    expect(beforeToolCallTesting.externalDataSourcesByScope.has(newestKey!)).toBe(true);
+  });
+
+  it("passes turnSource fields through to runBeforeToolCall tool context", async () => {
+    const ctx: HookContext = {
+      sessionId: "sess-turn-source",
+      turnSourceChannel: "whatsapp",
+      turnSourceTo: "channel-123",
+      turnSourceAccountId: "account-abc",
+      turnSourceThreadId: 42,
+    };
+    const tool = createWrappedTool("read", ctx);
+
+    await tool.execute("call-turn-source", { path: "/tmp/a.txt" }, undefined, undefined);
+
+    const [, toolContext] = hookRunner.runBeforeToolCall.mock.calls[0] as [unknown, HookContext];
+    expect(toolContext.turnSourceChannel).toBe("whatsapp");
+    expect(toolContext.turnSourceTo).toBe("channel-123");
+    expect(toolContext.turnSourceAccountId).toBe("account-abc");
+    expect(toolContext.turnSourceThreadId).toBe(42);
+  });
+});

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -13,6 +13,11 @@ export type HookContext = {
   sessionId?: string;
   runId?: string;
   loopDetection?: ToolLoopDetectionConfig;
+  /** Channel routing context — available when the turn originated from a messaging surface. */
+  turnSourceChannel?: string;
+  turnSourceTo?: string;
+  turnSourceAccountId?: string;
+  turnSourceThreadId?: string | number;
 };
 
 type HookOutcome = { blocked: true; reason: string } | { blocked: false; params: unknown };
@@ -21,6 +26,9 @@ const log = createSubsystemLogger("agents/tools");
 const BEFORE_TOOL_CALL_WRAPPED = Symbol("beforeToolCallWrapped");
 const adjustedParamsByToolCallId = new Map<string, unknown>();
 const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
+const EXTERNAL_DATA_SOURCE_TOOL_NAMES = new Set(["web_fetch", "web_search", "browser"]);
+const MAX_TRACKED_EXTERNAL_DATA_SCOPES = 1024;
+const externalDataSourcesByScope = new Map<string, Set<string>>();
 const LOOP_WARNING_BUCKET_SIZE = 10;
 const MAX_LOOP_WARNING_KEYS = 256;
 let beforeToolCallRuntimePromise: Promise<
@@ -37,6 +45,50 @@ function buildAdjustedParamsKey(params: { runId?: string; toolCallId: string }):
     return `${params.runId}:${params.toolCallId}`;
   }
   return params.toolCallId;
+}
+
+function buildHookContextScopeKey(ctx?: HookContext): string | undefined {
+  const sessionId = ctx?.sessionId?.trim();
+  if (sessionId) {
+    return `session:${sessionId}`;
+  }
+  const sessionKey = ctx?.sessionKey?.trim();
+  if (sessionKey) {
+    return `session_key:${sessionKey}`;
+  }
+  const runId = ctx?.runId?.trim();
+  if (runId) {
+    return `run:${runId}`;
+  }
+  return undefined;
+}
+
+function hasTrackedExternalDataForContext(ctx?: HookContext): boolean {
+  const scopeKey = buildHookContextScopeKey(ctx);
+  if (!scopeKey) {
+    return false;
+  }
+  const sources = externalDataSourcesByScope.get(scopeKey);
+  return (sources?.size ?? 0) > 0;
+}
+
+function trackExternalDataSourceForContext(ctx: HookContext | undefined, toolName: string): void {
+  if (!EXTERNAL_DATA_SOURCE_TOOL_NAMES.has(toolName)) {
+    return;
+  }
+  const scopeKey = buildHookContextScopeKey(ctx);
+  if (!scopeKey) {
+    return;
+  }
+  const sources = externalDataSourcesByScope.get(scopeKey) ?? new Set<string>();
+  sources.add(toolName);
+  externalDataSourcesByScope.set(scopeKey, sources);
+  if (externalDataSourcesByScope.size > MAX_TRACKED_EXTERNAL_DATA_SCOPES) {
+    const oldest = externalDataSourcesByScope.keys().next().value;
+    if (oldest) {
+      externalDataSourcesByScope.delete(oldest);
+    }
+  }
 }
 
 function shouldEmitLoopWarning(state: SessionState, warningKey: string, count: number): boolean {
@@ -160,6 +212,15 @@ export async function runBeforeToolCallHook(args: {
       ...(args.ctx?.sessionKey ? { sessionKey: args.ctx.sessionKey } : {}),
       ...(args.ctx?.sessionId ? { sessionId: args.ctx.sessionId } : {}),
       ...(args.ctx?.runId ? { runId: args.ctx.runId } : {}),
+      hasExternalData: hasTrackedExternalDataForContext(args.ctx),
+      ...(args.ctx?.turnSourceChannel ? { turnSourceChannel: args.ctx.turnSourceChannel } : {}),
+      ...(args.ctx?.turnSourceTo ? { turnSourceTo: args.ctx.turnSourceTo } : {}),
+      ...(args.ctx?.turnSourceAccountId
+        ? { turnSourceAccountId: args.ctx.turnSourceAccountId }
+        : {}),
+      ...(args.ctx?.turnSourceThreadId !== undefined
+        ? { turnSourceThreadId: args.ctx.turnSourceThreadId }
+        : {}),
       ...(args.toolCallId ? { toolCallId: args.toolCallId } : {}),
     };
     const hookResult = await hookRunner.runBeforeToolCall(
@@ -227,6 +288,7 @@ export function wrapToolWithBeforeToolCallHook(
       const normalizedToolName = normalizeToolName(toolName || "tool");
       try {
         const result = await execute(toolCallId, outcome.params, signal, onUpdate);
+        trackExternalDataSourceForContext(ctx, normalizedToolName);
         await recordLoopOutcome({
           ctx,
           toolName: normalizedToolName,
@@ -269,7 +331,10 @@ export function consumeAdjustedParamsForToolCall(toolCallId: string, runId?: str
 export const __testing = {
   BEFORE_TOOL_CALL_WRAPPED,
   buildAdjustedParamsKey,
+  buildHookContextScopeKey,
   adjustedParamsByToolCallId,
+  externalDataSourcesByScope,
+  MAX_TRACKED_EXTERNAL_DATA_SCOPES,
   runBeforeToolCallHook,
   isPlainObject,
 };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -702,6 +702,13 @@ export type PluginHookToolContext = {
   /** Stable run identifier for this agent invocation. */
   runId?: string;
   toolName: string;
+  /** True when the session has consumed data from external sources (web_fetch, web_search, browser). */
+  hasExternalData?: boolean;
+  /** Channel routing context — available when the turn originated from a messaging surface. */
+  turnSourceChannel?: string;
+  turnSourceTo?: string;
+  turnSourceAccountId?: string;
+  turnSourceThreadId?: string | number;
   /** Provider-specific tool call ID when available. */
   toolCallId?: string;
 };


### PR DESCRIPTION
## Problem

Plugin authors using `before_tool_call` hooks currently have no visibility into whether the session has consumed external data. This makes it impossible to build informed tool-gating logic (e.g., requiring confirmation before side-effect tools when untrusted web content has entered the session).

## Changes

Extend the `before_tool_call` hook context with read-only provenance metadata:

- **`hasExternalData: boolean`** — true when the session has successfully called `web_fetch`, `web_search`, or `browser`
- **Channel routing fields** — `turnSourceChannel`, `turnSourceTo`, `turnSourceAccountId`, `turnSourceThreadId` for plugin-initiated notifications

Implementation details:
- Session-scoped tracking (`sessionId > sessionKey > runId`); no global fallback
- Bounded memory (1024 scope cap with oldest-eviction)
- Tracking fires only on successful tool execution (failed calls do not flip the boolean)
- Matching fields added to `PluginHookToolContext` in `src/plugins/types.ts` for typed consumers

## Files changed

| File | Change |
|------|--------|
| `src/agents/pi-tools.before-tool-call.ts` | HookContext type + tracking logic |
| `src/plugins/types.ts` | PluginHookToolContext type |
| `src/agents/pi-tools.before-tool-call.external-data.test.ts` | New: 10 tests |

## Test plan

```bash
pnpm exec vitest run src/agents/pi-tools.before-tool-call
```

10 tests covering:
- `hasExternalData` false by default
- Flips true after `web_fetch` / `web_search` / `browser`
- Stays false after `read` / `exec`
- Stays false when external tool execution fails
- Scope isolation across sessions
- Eviction when scope cap is exceeded
- `turnSource*` field passthrough

## Compatibility

- All new `HookContext` fields are optional — existing hook consumers are unaffected
- No behavior change for any existing functionality
- No new config surface
- `pnpm build` passes cleanly

## Known limitations

- Tracking covers the primary agent tool loop (`wrapToolWithBeforeToolCallHook`). HTTP-invoked tools via `tools-invoke-http` call `runBeforeToolCallHook` directly and are not tracked in this pass.
