### PR TITLE
CLI: shorten update result root paths

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/types.openclaw.js";
@@ -362,6 +363,20 @@ describe("update-cli", () => {
     const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
     expect(logs.join("\n")).toContain("Update dry-run");
     expect(logs.join("\n")).toContain("No changes were applied.");
+  });
+
+  it("updateCommand --dry-run shortens home-root paths in human output", async () => {
+    vi.mocked(defaultRuntime.log).mockClear();
+    serviceLoaded.mockResolvedValue(true);
+    const home = os.homedir();
+    mockPackageInstallStatus(`${home}/.local/share/openclaw`);
+
+    await updateCommand({ dryRun: true, channel: "beta" });
+
+    const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    expect(logs.join("\n")).toContain("Root:");
+    expect(logs.join("\n")).toContain("~/.local/share/openclaw");
+    expect(logs.join("\n")).not.toContain(`${home}/.local/share/openclaw`);
   });
 
   it("updateStatusCommand prints table output", async () => {

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from "vitest";
+import os from "node:os";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
-import { inferUpdateFailureHints } from "./progress.js";
+
+const runtimeLog = vi.fn();
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: runtimeLog,
+  },
+}));
+
+const { inferUpdateFailureHints, printResult } = await import("./progress.js");
 
 function makeResult(
   stepName: string,
@@ -26,6 +36,10 @@ function makeResult(
 }
 
 describe("inferUpdateFailureHints", () => {
+  beforeEach(() => {
+    runtimeLog.mockReset();
+  });
+
   it("returns EACCES hint for global update permission failures", () => {
     const result = makeResult(
       "global update",
@@ -49,5 +63,24 @@ describe("inferUpdateFailureHints", () => {
       "pnpm",
     );
     expect(inferUpdateFailureHints(result)).toEqual([]);
+  });
+
+  it("shortens result root paths in human output", () => {
+    const home = os.homedir();
+    printResult(
+      {
+        status: "ok",
+        mode: "npm",
+        root: `${home}/.local/share/openclaw`,
+        steps: [],
+        durationMs: 1,
+      },
+      { json: false },
+    );
+
+    const lines = runtimeLog.mock.calls.map((call) => String(call[0]));
+    expect(lines.join("\n")).toContain("Root:");
+    expect(lines.join("\n")).toContain("~/.local/share/openclaw");
+    expect(lines.join("\n")).not.toContain(`${home}/.local/share/openclaw`);
   });
 });

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
 import { theme } from "../../terminal/theme.js";
+import { shortenHomePath } from "../../utils.js";
 import type { UpdateCommandOptions } from "./shared.js";
 
 const STEP_LABELS: Record<string, string> = {
@@ -150,7 +151,7 @@ export function printResult(result: UpdateRunResult, opts: PrintResultOptions): 
     `${theme.heading("Update Result:")} ${statusColor(result.status.toUpperCase())}`,
   );
   if (result.root) {
-    defaultRuntime.log(`  Root: ${theme.muted(result.root)}`);
+    defaultRuntime.log(`  Root: ${theme.muted(shortenHomePath(result.root))}`);
   }
   if (result.reason) {
     defaultRuntime.log(`  Reason: ${theme.muted(result.reason)}`);

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -36,7 +36,7 @@ import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { stylePromptMessage } from "../../terminal/prompt-style.js";
 import { theme } from "../../terminal/theme.js";
-import { pathExists } from "../../utils.js";
+import { pathExists, shortenHomePath } from "../../utils.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import { installCompletion } from "../completion-cli.js";
@@ -146,7 +146,7 @@ function printDryRunPreview(preview: UpdateDryRunPreview, jsonMode: boolean): vo
   defaultRuntime.log(theme.heading("Update dry-run"));
   defaultRuntime.log(theme.muted("No changes were applied."));
   defaultRuntime.log("");
-  defaultRuntime.log(`  Root: ${theme.muted(preview.root)}`);
+  defaultRuntime.log(`  Root: ${theme.muted(shortenHomePath(preview.root))}`);
   defaultRuntime.log(`  Install kind: ${theme.muted(preview.installKind)}`);
   defaultRuntime.log(`  Mode: ${theme.muted(preview.mode)}`);
   defaultRuntime.log(`  Channel: ${theme.muted(preview.effectiveChannel)}`);


### PR DESCRIPTION
## Summary
- shorten the install root shown in human-readable `openclaw update` result summaries
- keep JSON output unchanged while aligning the post-update summary with the dry-run preview path formatting
- add a regression test for home-directory result roots in `printResult()`

## Testing
- pnpm test src/cli/update-cli/progress.test.ts
- pnpm exec oxfmt --check src/cli/update-cli/progress.ts src/cli/update-cli/progress.test.ts
- pnpm build
