### PR TITLE
fix(memory-flush): restore HH-MM timestamped auto-flush path

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1691,7 +1691,7 @@ describe("runReplyAgent memory flush", () => {
       expect(flushCall?.extraSystemPrompt).toContain("extra system");
       expect(flushCall?.extraSystemPrompt).toContain("Flush memory now.");
       expect(flushCall?.extraSystemPrompt).toContain("NO_REPLY");
-      expect(flushCall?.extraSystemPrompt).toContain("memory/YYYY-MM-DD.md");
+      expect(flushCall?.extraSystemPrompt).toContain("memory/YYYY-MM-DD-HH-MM.md");
       expect(flushCall?.extraSystemPrompt).toContain("MEMORY.md");
       expect(calls[1]?.prompt).toBe("hello");
     });
@@ -1819,7 +1819,7 @@ describe("runReplyAgent memory flush", () => {
       expect(calls[0]?.prompt).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
       expect(calls[0]?.prompt).toContain("MEMORY.md");
       expect(calls[0]?.memoryFlushWritePath).toMatch(/^memory\/\d{4}-\d{2}-\d{2}\.md$/);
-      expect(calls[0]?.extraSystemPrompt).toContain("memory/YYYY-MM-DD.md");
+      expect(calls[0]?.extraSystemPrompt).toContain("memory/YYYY-MM-DD-HH-MM.md");
       expect(calls[0]?.extraSystemPrompt).toContain("MEMORY.md");
       expect(calls[1]?.prompt).toBe("hello");
 

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -16,14 +16,14 @@ describe("resolveMemoryFlushPromptForRun", () => {
     },
   } as OpenClawConfig;
 
-  it("replaces YYYY-MM-DD using user timezone and appends current time", () => {
+  it("replaces YYYY-MM-DD using user timezone with HH-MM and appends current time", () => {
     const prompt = resolveMemoryFlushPromptForRun({
-      prompt: "Store durable notes in memory/YYYY-MM-DD.md",
+      prompt: "Store durable notes in memory/YYYY-MM-DD-HH-MM.md",
       cfg,
       nowMs: Date.UTC(2026, 1, 16, 15, 0, 0),
     });
 
-    expect(prompt).toContain("memory/2026-02-16.md");
+    expect(prompt).toContain("memory/2026-02-16-10-00.md");
     expect(prompt).toContain(
       "Current time: Monday, February 16th, 2026 — 10:00 AM (America/New_York) / 2026-02-16 15:00 UTC",
     );
@@ -40,13 +40,13 @@ describe("resolveMemoryFlushPromptForRun", () => {
     expect((prompt.match(/Current time:/g) ?? []).length).toBe(1);
   });
 
-  it("resolves the canonical relative memory path using user timezone", () => {
+  it("resolves the timestamped relative memory path using user timezone", () => {
     const relativePath = resolveMemoryFlushRelativePathForRun({
       cfg,
       nowMs: Date.UTC(2026, 1, 16, 15, 0, 0),
     });
 
-    expect(relativePath).toBe("memory/2026-02-16.md");
+    expect(relativePath).toBe("memory/2026-02-16-10-00.md");
   });
 });
 
@@ -56,9 +56,8 @@ describe("DEFAULT_MEMORY_FLUSH_PROMPT", () => {
     expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("do not overwrite");
   });
 
-  it("includes anti-fragmentation instruction to prevent timestamped variant files (#34919)", () => {
-    // Agents must not create YYYY-MM-DD-HHMM.md variants alongside the canonical file
-    expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("timestamped variant");
-    expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("YYYY-MM-DD.md");
+  it("includes instruction to use timestamped memory files (#34919)", () => {
+    expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("timestamped memory files");
+    expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("YYYY-MM-DD-HH-MM.md");
   });
 });

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -11,9 +11,9 @@ export const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4000;
 export const DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES = 2 * 1024 * 1024;
 
 const MEMORY_FLUSH_TARGET_HINT =
-  "Store durable memories only in memory/YYYY-MM-DD.md (create memory/ if needed).";
+  "Store durable memories in memory/YYYY-MM-DD-HH-MM.md (create memory/ if needed).";
 const MEMORY_FLUSH_APPEND_ONLY_HINT =
-  "If memory/YYYY-MM-DD.md already exists, APPEND new content only and do not overwrite existing entries.";
+  "If memory/YYYY-MM-DD-HH-MM.md already exists, APPEND new content only and do not overwrite existing entries.";
 const MEMORY_FLUSH_READ_ONLY_HINT =
   "Treat workspace bootstrap/reference files such as MEMORY.md, SOUL.md, TOOLS.md, and AGENTS.md as read-only during this flush; never overwrite, replace, or edit them.";
 const MEMORY_FLUSH_REQUIRED_HINTS = [
@@ -27,7 +27,7 @@ export const DEFAULT_MEMORY_FLUSH_PROMPT = [
   MEMORY_FLUSH_TARGET_HINT,
   MEMORY_FLUSH_READ_ONLY_HINT,
   MEMORY_FLUSH_APPEND_ONLY_HINT,
-  "Do NOT create timestamped variant files (e.g., YYYY-MM-DD-HHMM.md); always use the canonical YYYY-MM-DD.md filename.",
+  "Use timestamped memory files in the format YYYY-MM-DD-HH-MM.md for this flush.",
   `If nothing to store, reply with ${SILENT_REPLY_TOKEN}.`,
 ].join(" ");
 
@@ -40,20 +40,25 @@ export const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
   `You may reply, but usually ${SILENT_REPLY_TOKEN} is correct.`,
 ].join(" ");
 
-function formatDateStampInTimezone(nowMs: number, timezone: string): string {
+function formatDateTimeStampInTimezone(nowMs: number, timezone: string): string {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
   }).formatToParts(new Date(nowMs));
   const year = parts.find((part) => part.type === "year")?.value;
   const month = parts.find((part) => part.type === "month")?.value;
   const day = parts.find((part) => part.type === "day")?.value;
-  if (year && month && day) {
-    return `${year}-${month}-${day}`;
+  const hour = parts.find((part) => part.type === "hour")?.value;
+  const minute = parts.find((part) => part.type === "minute")?.value;
+  if (year && month && day && hour && minute) {
+    return `${year}-${month}-${day}-${hour}-${minute}`;
   }
-  return new Date(nowMs).toISOString().slice(0, 10);
+  return new Date(nowMs).toISOString().slice(0, 16).replace("T", "-").replace(":", "-");
 }
 
 export function resolveMemoryFlushRelativePathForRun(params: {
@@ -62,8 +67,8 @@ export function resolveMemoryFlushRelativePathForRun(params: {
 }): string {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   const { userTimezone } = resolveCronStyleNow(params.cfg ?? {}, nowMs);
-  const dateStamp = formatDateStampInTimezone(nowMs, userTimezone);
-  return `memory/${dateStamp}.md`;
+  const dateTimeStamp = formatDateTimeStampInTimezone(nowMs, userTimezone);
+  return `memory/${dateTimeStamp}.md`;
 }
 
 export function resolveMemoryFlushPromptForRun(params: {
@@ -79,7 +84,10 @@ export function resolveMemoryFlushPromptForRun(params: {
   })
     .replace(/^memory\//, "")
     .replace(/\.md$/, "");
-  const withDate = params.prompt.replaceAll("YYYY-MM-DD", dateStamp).trimEnd();
+  const withDate = params.prompt
+    .replaceAll("YYYY-MM-DD-HH-MM", dateStamp)
+    .replaceAll("YYYY-MM-DD", dateStamp)
+    .trimEnd();
   if (!withDate) {
     return timeLine;
   }

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -203,9 +203,9 @@ describe("memory flush settings", () => {
     expect(settings?.forceFlushTranscriptBytes).toBe(DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES);
     expect(settings?.prompt.length).toBeGreaterThan(0);
     expect(settings?.systemPrompt.length).toBeGreaterThan(0);
-    expect(settings?.prompt).toContain("memory/YYYY-MM-DD.md");
+    expect(settings?.prompt).toContain("memory/YYYY-MM-DD-HH-MM.md");
     expect(settings?.prompt).toContain("MEMORY.md");
-    expect(settings?.systemPrompt).toContain("memory/YYYY-MM-DD.md");
+    expect(settings?.systemPrompt).toContain("memory/YYYY-MM-DD-HH-MM.md");
     expect(settings?.systemPrompt).toContain("MEMORY.md");
   });
 
@@ -234,9 +234,9 @@ describe("memory flush settings", () => {
     });
     expect(settings?.prompt).toContain("NO_REPLY");
     expect(settings?.systemPrompt).toContain("NO_REPLY");
-    expect(settings?.prompt).toContain("memory/YYYY-MM-DD.md");
+    expect(settings?.prompt).toContain("memory/YYYY-MM-DD-HH-MM.md");
     expect(settings?.prompt).toContain("MEMORY.md");
-    expect(settings?.systemPrompt).toContain("memory/YYYY-MM-DD.md");
+    expect(settings?.systemPrompt).toContain("memory/YYYY-MM-DD-HH-MM.md");
     expect(settings?.systemPrompt).toContain("MEMORY.md");
   });
 


### PR DESCRIPTION
## Summary
- switch auto memory-flush write path to `memory/YYYY-MM-DD-HH-MM.md`
- align default/system memory-flush hints with timestamped HH-MM format
- update tests and path expectations accordingly

## Validation
- `pnpm exec vitest run src/auto-reply/reply/memory-flush.test.ts src/auto-reply/reply/reply-state.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
