### PR TITLE
test: preserve wrapper behavior for targeted runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@
 - Framework: Vitest with V8 coverage thresholds (70% lines/branches/functions/statements).
 - Naming: match source names with `*.test.ts`; e2e in `*.e2e.test.ts`.
 - Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
+- For targeted/local debugging, keep using the wrapper: `pnpm test -- <path-or-filter> [vitest args...]` (for example `pnpm test -- src/commands/onboard-search.test.ts -t "shows registered plugin providers"`); do not default to raw `pnpm vitest run ...` because it bypasses wrapper config/profile/pool routing.
 - Do not set test workers above 16; tried already.
 - If local Vitest runs cause memory pressure (common on non-Mac-Studio hosts), use `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test` for land/gate runs.
 - Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
+import path from "node:path";
 
 // On Windows, `.cmd` launchers can fail with `spawn EINVAL` when invoked without a shell
 // (especially under GitHub Actions + Git Bash). Use `shell: true` and let the shell resolve pnpm.
@@ -243,12 +244,7 @@ const OPTION_TAKES_VALUE = new Set([
   "--configLoader",
   "--experimental",
 ]);
-const SINGLE_RUN_ONLY_FLAGS = new Set([
-  "--coverage",
-  "--reporter",
-  "--outputFile",
-  "--mergeReports",
-]);
+const SINGLE_RUN_ONLY_FLAGS = new Set(["--coverage", "--outputFile", "--mergeReports"]);
 
 if (shardIndexOverride !== null && shardCount <= 1) {
   console.error(
@@ -309,106 +305,183 @@ const passthroughRequiresSingleRun = passthroughOptionArgs.some((arg) => {
 });
 const channelPrefixes = ["src/telegram/", "src/discord/", "src/web/", "src/browser/", "src/line/"];
 const baseConfigPrefixes = ["src/agents/", "src/auto-reply/", "src/commands/", "test/", "ui/"];
-const inferTargetKind = (fileFilter) => {
+const normalizeRepoPath = (value) => value.split(path.sep).join("/");
+const walkTestFiles = (rootDir) => {
+  if (!fs.existsSync(rootDir)) {
+    return [];
+  }
+  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkTestFiles(fullPath));
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (
+      fullPath.endsWith(".test.ts") ||
+      fullPath.endsWith(".live.test.ts") ||
+      fullPath.endsWith(".e2e.test.ts")
+    ) {
+      files.push(normalizeRepoPath(fullPath));
+    }
+  }
+  return files;
+};
+const allKnownTestFiles = [
+  ...new Set([
+    ...walkTestFiles("src"),
+    ...walkTestFiles("extensions"),
+    ...walkTestFiles("test"),
+    ...walkTestFiles(path.join("ui", "src", "ui")),
+  ]),
+];
+const inferTarget = (fileFilter) => {
+  const isolated = unitIsolatedFiles.includes(fileFilter);
   if (fileFilter.endsWith(".live.test.ts")) {
-    return "live";
+    return { owner: "live", isolated };
   }
   if (fileFilter.endsWith(".e2e.test.ts")) {
-    return "e2e";
+    return { owner: "e2e", isolated };
   }
   if (fileFilter.startsWith("extensions/")) {
-    return "extensions";
+    return { owner: "extensions", isolated };
   }
   if (fileFilter.startsWith("src/gateway/")) {
-    return "gateway";
+    return { owner: "gateway", isolated };
   }
   if (channelPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
-    return "channels";
+    return { owner: "channels", isolated };
   }
   if (baseConfigPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
-    return "base";
+    return { owner: "base", isolated };
   }
   if (fileFilter.startsWith("src/")) {
-    return unitIsolatedFiles.includes(fileFilter) ? "unit-isolated" : "unit";
+    return { owner: "unit", isolated };
   }
-  return "base";
+  return { owner: "base", isolated };
 };
-const createTargetedEntry = (kind, filters) => {
-  if (kind === "unit") {
+const resolveFilterMatches = (fileFilter) => {
+  const normalizedFilter = normalizeRepoPath(fileFilter);
+  if (fs.existsSync(fileFilter)) {
+    const stats = fs.statSync(fileFilter);
+    if (stats.isFile()) {
+      return [normalizedFilter];
+    }
+    if (stats.isDirectory()) {
+      const prefix = normalizedFilter.endsWith("/") ? normalizedFilter : `${normalizedFilter}/`;
+      return allKnownTestFiles.filter((file) => file.startsWith(prefix));
+    }
+  }
+  if (/[*?[\]{}]/.test(normalizedFilter)) {
+    return allKnownTestFiles.filter((file) => path.matchesGlob(file, normalizedFilter));
+  }
+  return allKnownTestFiles.filter((file) => file.includes(normalizedFilter));
+};
+const createTargetedEntry = (owner, isolated, filters) => {
+  const name = isolated ? `${owner}-isolated` : owner;
+  const forceForks = isolated;
+  if (owner === "unit") {
     return {
-      name: "unit",
+      name,
       args: [
         "vitest",
         "run",
         "--config",
         "vitest.unit.config.ts",
-        `--pool=${useVmForks ? "vmForks" : "forks"}`,
+        `--pool=${forceForks ? "forks" : useVmForks ? "vmForks" : "forks"}`,
         ...(disableIsolation ? ["--isolate=false"] : []),
         ...filters,
       ],
     };
   }
-  if (kind === "unit-isolated") {
+  if (owner === "extensions") {
     return {
-      name: "unit-isolated",
-      args: ["vitest", "run", "--config", "vitest.unit.config.ts", "--pool=forks", ...filters],
-    };
-  }
-  if (kind === "extensions") {
-    return {
-      name: "extensions",
+      name,
       args: [
         "vitest",
         "run",
         "--config",
         "vitest.extensions.config.ts",
-        ...(useVmForks ? ["--pool=vmForks"] : []),
+        ...(forceForks ? ["--pool=forks"] : useVmForks ? ["--pool=vmForks"] : []),
         ...filters,
       ],
     };
   }
-  if (kind === "gateway") {
+  if (owner === "gateway") {
     return {
-      name: "gateway",
+      name,
       args: ["vitest", "run", "--config", "vitest.gateway.config.ts", "--pool=forks", ...filters],
     };
   }
-  if (kind === "channels") {
+  if (owner === "channels") {
     return {
-      name: "channels",
-      args: ["vitest", "run", "--config", "vitest.channels.config.ts", ...filters],
+      name,
+      args: [
+        "vitest",
+        "run",
+        "--config",
+        "vitest.channels.config.ts",
+        ...(forceForks ? ["--pool=forks"] : []),
+        ...filters,
+      ],
     };
   }
-  if (kind === "live") {
+  if (owner === "live") {
     return {
-      name: "live",
+      name,
       args: ["vitest", "run", "--config", "vitest.live.config.ts", ...filters],
     };
   }
-  if (kind === "e2e") {
+  if (owner === "e2e") {
     return {
-      name: "e2e",
+      name,
       args: ["vitest", "run", "--config", "vitest.e2e.config.ts", ...filters],
     };
   }
   return {
-    name: "base",
-    args: ["vitest", "run", "--config", "vitest.config.ts", ...filters],
+    name,
+    args: [
+      "vitest",
+      "run",
+      "--config",
+      "vitest.config.ts",
+      ...(forceForks ? ["--pool=forks"] : []),
+      ...filters,
+    ],
   };
 };
-const targetedEntries =
-  passthroughFileFilters.length > 0
-    ? Array.from(
-        passthroughFileFilters.reduce((groups, fileFilter) => {
-          const kind = inferTargetKind(fileFilter);
-          const files = groups.get(kind) ?? [];
-          files.push(fileFilter);
-          groups.set(kind, files);
-          return groups;
-        }, new Map()),
-        ([kind, filters]) => createTargetedEntry(kind, filters),
-      )
-    : [];
+const targetedEntries = (() => {
+  if (passthroughFileFilters.length === 0) {
+    return [];
+  }
+  const groups = passthroughFileFilters.reduce((acc, fileFilter) => {
+    const matchedFiles = resolveFilterMatches(fileFilter);
+    if (matchedFiles.length === 0) {
+      const target = inferTarget(normalizeRepoPath(fileFilter));
+      const key = `${target.owner}:${target.isolated ? "isolated" : "default"}`;
+      const files = acc.get(key) ?? [];
+      files.push(normalizeRepoPath(fileFilter));
+      acc.set(key, files);
+      return acc;
+    }
+    for (const matchedFile of matchedFiles) {
+      const target = inferTarget(matchedFile);
+      const key = `${target.owner}:${target.isolated ? "isolated" : "default"}`;
+      const files = acc.get(key) ?? [];
+      files.push(matchedFile);
+      acc.set(key, files);
+    }
+    return acc;
+  }, new Map());
+  return Array.from(groups, ([key, filters]) => {
+    const [owner, mode] = key.split(":");
+    return createTargetedEntry(owner, mode === "isolated", [...new Set(filters)]);
+  });
+})();
 const topLevelParallelEnabled = testProfile !== "low" && testProfile !== "serial";
 const overrideWorkers = Number.parseInt(process.env.OPENCLAW_TEST_WORKERS ?? "", 10);
 const resolvedOverride =
@@ -491,7 +564,7 @@ const maxWorkersForRun = (name) => {
   if (isCI && isMacOS) {
     return 1;
   }
-  if (name === "unit-isolated") {
+  if (name === "unit-isolated" || name.endsWith("-isolated")) {
     return defaultWorkerBudget.unitIsolated;
   }
   if (name === "extensions") {

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -205,6 +205,50 @@ const shardIndexOverride = (() => {
   const parsed = Number.parseInt(process.env.OPENCLAW_TEST_SHARD_INDEX ?? "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 })();
+const OPTION_TAKES_VALUE = new Set([
+  "-t",
+  "-c",
+  "-r",
+  "--testNamePattern",
+  "--config",
+  "--root",
+  "--dir",
+  "--reporter",
+  "--outputFile",
+  "--pool",
+  "--execArgv",
+  "--vmMemoryLimit",
+  "--maxWorkers",
+  "--environment",
+  "--shard",
+  "--changed",
+  "--sequence",
+  "--inspect",
+  "--inspectBrk",
+  "--testTimeout",
+  "--hookTimeout",
+  "--bail",
+  "--retry",
+  "--diff",
+  "--exclude",
+  "--project",
+  "--slowTestThreshold",
+  "--teardownTimeout",
+  "--attachmentsDir",
+  "--mode",
+  "--api",
+  "--browser",
+  "--maxConcurrency",
+  "--mergeReports",
+  "--configLoader",
+  "--experimental",
+]);
+const SINGLE_RUN_ONLY_FLAGS = new Set([
+  "--coverage",
+  "--reporter",
+  "--outputFile",
+  "--mergeReports",
+]);
 
 if (shardIndexOverride !== null && shardCount <= 1) {
   console.error(
@@ -229,6 +273,142 @@ const silentArgs =
 const rawPassthroughArgs = process.argv.slice(2);
 const passthroughArgs =
   rawPassthroughArgs[0] === "--" ? rawPassthroughArgs.slice(1) : rawPassthroughArgs;
+const parsePassthroughArgs = (args) => {
+  const fileFilters = [];
+  const optionArgs = [];
+  let consumeNextAsOptionValue = false;
+
+  for (const arg of args) {
+    if (consumeNextAsOptionValue) {
+      optionArgs.push(arg);
+      consumeNextAsOptionValue = false;
+      continue;
+    }
+    if (arg === "--") {
+      optionArgs.push(arg);
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      optionArgs.push(arg);
+      consumeNextAsOptionValue = !arg.includes("=") && OPTION_TAKES_VALUE.has(arg);
+      continue;
+    }
+    fileFilters.push(arg);
+  }
+
+  return { fileFilters, optionArgs };
+};
+const { fileFilters: passthroughFileFilters, optionArgs: passthroughOptionArgs } =
+  parsePassthroughArgs(passthroughArgs);
+const passthroughRequiresSingleRun = passthroughOptionArgs.some((arg) => {
+  if (!arg.startsWith("-")) {
+    return false;
+  }
+  const [flag] = arg.split("=", 1);
+  return SINGLE_RUN_ONLY_FLAGS.has(flag);
+});
+const channelPrefixes = ["src/telegram/", "src/discord/", "src/web/", "src/browser/", "src/line/"];
+const baseConfigPrefixes = ["src/agents/", "src/auto-reply/", "src/commands/", "test/", "ui/"];
+const inferTargetKind = (fileFilter) => {
+  if (fileFilter.endsWith(".live.test.ts")) {
+    return "live";
+  }
+  if (fileFilter.endsWith(".e2e.test.ts")) {
+    return "e2e";
+  }
+  if (fileFilter.startsWith("extensions/")) {
+    return "extensions";
+  }
+  if (fileFilter.startsWith("src/gateway/")) {
+    return "gateway";
+  }
+  if (channelPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
+    return "channels";
+  }
+  if (baseConfigPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
+    return "base";
+  }
+  if (fileFilter.startsWith("src/")) {
+    return unitIsolatedFiles.includes(fileFilter) ? "unit-isolated" : "unit";
+  }
+  return "base";
+};
+const createTargetedEntry = (kind, filters) => {
+  if (kind === "unit") {
+    return {
+      name: "unit",
+      args: [
+        "vitest",
+        "run",
+        "--config",
+        "vitest.unit.config.ts",
+        `--pool=${useVmForks ? "vmForks" : "forks"}`,
+        ...(disableIsolation ? ["--isolate=false"] : []),
+        ...filters,
+      ],
+    };
+  }
+  if (kind === "unit-isolated") {
+    return {
+      name: "unit-isolated",
+      args: ["vitest", "run", "--config", "vitest.unit.config.ts", "--pool=forks", ...filters],
+    };
+  }
+  if (kind === "extensions") {
+    return {
+      name: "extensions",
+      args: [
+        "vitest",
+        "run",
+        "--config",
+        "vitest.extensions.config.ts",
+        ...(useVmForks ? ["--pool=vmForks"] : []),
+        ...filters,
+      ],
+    };
+  }
+  if (kind === "gateway") {
+    return {
+      name: "gateway",
+      args: ["vitest", "run", "--config", "vitest.gateway.config.ts", "--pool=forks", ...filters],
+    };
+  }
+  if (kind === "channels") {
+    return {
+      name: "channels",
+      args: ["vitest", "run", "--config", "vitest.channels.config.ts", ...filters],
+    };
+  }
+  if (kind === "live") {
+    return {
+      name: "live",
+      args: ["vitest", "run", "--config", "vitest.live.config.ts", ...filters],
+    };
+  }
+  if (kind === "e2e") {
+    return {
+      name: "e2e",
+      args: ["vitest", "run", "--config", "vitest.e2e.config.ts", ...filters],
+    };
+  }
+  return {
+    name: "base",
+    args: ["vitest", "run", "--config", "vitest.config.ts", ...filters],
+  };
+};
+const targetedEntries =
+  passthroughFileFilters.length > 0
+    ? Array.from(
+        passthroughFileFilters.reduce((groups, fileFilter) => {
+          const kind = inferTargetKind(fileFilter);
+          const files = groups.get(kind) ?? [];
+          files.push(fileFilter);
+          groups.set(kind, files);
+          return groups;
+        }, new Map()),
+        ([kind, filters]) => createTargetedEntry(kind, filters),
+      )
+    : [];
 const topLevelParallelEnabled = testProfile !== "low" && testProfile !== "serial";
 const overrideWorkers = Number.parseInt(process.env.OPENCLAW_TEST_WORKERS ?? "", 10);
 const resolvedOverride =
@@ -397,16 +577,16 @@ const runOnce = (entry, extraArgs = []) =>
     });
   });
 
-const run = async (entry) => {
+const run = async (entry, extraArgs = []) => {
   if (shardCount <= 1) {
-    return runOnce(entry);
+    return runOnce(entry, extraArgs);
   }
   if (shardIndexOverride !== null) {
-    return runOnce(entry, ["--shard", `${shardIndexOverride}/${shardCount}`]);
+    return runOnce(entry, ["--shard", `${shardIndexOverride}/${shardCount}`, ...extraArgs]);
   }
   for (let shardIndex = 1; shardIndex <= shardCount; shardIndex += 1) {
     // eslint-disable-next-line no-await-in-loop
-    const code = await runOnce(entry, ["--shard", `${shardIndex}/${shardCount}`]);
+    const code = await runOnce(entry, ["--shard", `${shardIndex}/${shardCount}`, ...extraArgs]);
     if (code !== 0) {
       return code;
     }
@@ -414,15 +594,15 @@ const run = async (entry) => {
   return 0;
 };
 
-const runEntries = async (entries) => {
+const runEntries = async (entries, extraArgs = []) => {
   if (topLevelParallelEnabled) {
-    const codes = await Promise.all(entries.map(run));
+    const codes = await Promise.all(entries.map((entry) => run(entry, extraArgs)));
     return codes.find((code) => code !== 0);
   }
 
   for (const entry of entries) {
     // eslint-disable-next-line no-await-in-loop
-    const code = await run(entry);
+    const code = await run(entry, extraArgs);
     if (code !== 0) {
       return code;
     }
@@ -440,57 +620,48 @@ const shutdown = (signal) => {
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 
-if (passthroughArgs.length > 0) {
-  const maxWorkers = maxWorkersForRun("unit");
-  const args = maxWorkers
-    ? [
-        "vitest",
-        "run",
-        "--maxWorkers",
-        String(maxWorkers),
-        ...silentArgs,
-        ...windowsCiArgs,
-        ...passthroughArgs,
-      ]
-    : ["vitest", "run", ...silentArgs, ...windowsCiArgs, ...passthroughArgs];
-  const nodeOptions = process.env.NODE_OPTIONS ?? "";
-  const nextNodeOptions = WARNING_SUPPRESSION_FLAGS.reduce(
-    (acc, flag) => (acc.includes(flag) ? acc : `${acc} ${flag}`.trim()),
-    nodeOptions,
-  );
-  const code = await new Promise((resolve) => {
-    let child;
-    try {
-      child = spawn(pnpm, args, {
-        stdio: "inherit",
-        env: { ...process.env, NODE_OPTIONS: nextNodeOptions },
-        shell: isWindows,
-      });
-    } catch (err) {
-      console.error(`[test-parallel] spawn failed: ${String(err)}`);
-      resolve(1);
-      return;
+if (targetedEntries.length > 0) {
+  if (passthroughRequiresSingleRun && targetedEntries.length > 1) {
+    console.error(
+      "[test-parallel] The provided Vitest args require a single run, but the selected test filters span multiple wrapper configs. Run one target/config at a time.",
+    );
+    process.exit(2);
+  }
+  const targetedParallelRuns = keepGatewaySerial
+    ? targetedEntries.filter((entry) => entry.name !== "gateway")
+    : targetedEntries;
+  const targetedSerialRuns = keepGatewaySerial
+    ? targetedEntries.filter((entry) => entry.name === "gateway")
+    : [];
+  const failedTargetedParallel = await runEntries(targetedParallelRuns, passthroughOptionArgs);
+  if (failedTargetedParallel !== undefined) {
+    process.exit(failedTargetedParallel);
+  }
+  for (const entry of targetedSerialRuns) {
+    // eslint-disable-next-line no-await-in-loop
+    const code = await run(entry, passthroughOptionArgs);
+    if (code !== 0) {
+      process.exit(code);
     }
-    children.add(child);
-    child.on("error", (err) => {
-      console.error(`[test-parallel] child error: ${String(err)}`);
-    });
-    child.on("exit", (exitCode, signal) => {
-      children.delete(child);
-      resolve(exitCode ?? (signal ? 1 : 0));
-    });
-  });
-  process.exit(Number(code) || 0);
+  }
+  process.exit(0);
 }
 
-const failedParallel = await runEntries(parallelRuns);
+if (passthroughRequiresSingleRun && passthroughOptionArgs.length > 0) {
+  console.error(
+    "[test-parallel] The provided Vitest args require a single run. Use the dedicated npm script for that workflow (for example `pnpm test:coverage`) or target a single test file/filter.",
+  );
+  process.exit(2);
+}
+
+const failedParallel = await runEntries(parallelRuns, passthroughOptionArgs);
 if (failedParallel !== undefined) {
   process.exit(failedParallel);
 }
 
 for (const entry of serialRuns) {
   // eslint-disable-next-line no-await-in-loop
-  const code = await run(entry);
+  const code = await run(entry, passthroughOptionArgs);
   if (code !== 0) {
     process.exit(code);
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm test -- ...` forwarded passthrough args into a raw `vitest run ...` fallback, bypassing the repo test wrapper’s config/profile/pool routing.
- Why it matters: targeted debugging could behave differently from the repo’s intended test path, including different worker and memory behavior and incorrect config selection for files excluded from `vitest.unit.config.ts`.
- What changed: `scripts/test-parallel.mjs` now parses passthrough args, routes explicit file targets through the correct wrapper-owned config/lane, preserves worker/profile behavior, and rejects single-run-only artifact flags when they would fan out across multiple wrapper lanes.
- What did NOT change (scope boundary): default full-suite wrapper behavior is unchanged, and this does not modify Vitest config contents or test files.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `pnpm test -- <path-or-filter> [vitest args...]` now keeps targeted runs on the repo wrapper instead of falling back to raw Vitest.
- Targeted files excluded from `vitest.unit.config.ts` (for example `src/commands/**`) are routed through the appropriate config.
- Single-run-only flags like `--coverage` now fail fast when they would span multiple wrapper configs, instead of producing incorrect shared artifacts.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local repo config

### Steps

1. Run `pnpm test -- src/commands/onboard-search.test.ts -t "shows registered plugin providers" --passWithNoTests`.
2. Run `pnpm test -- --coverage`.
3. Run `node scripts/test-parallel.mjs -- src/commands/onboard-search.test.ts src/plugins/loader.test.ts --coverage`.

### Expected

- Targeted file runs stay on the wrapper path and honor wrapper config/profile/pool routing.
- Single-run-only artifact flags do not fan out across multiple wrapper lanes/configs.

### Actual

- Targeted wrapper run succeeded and executed the requested file/name filter.
- `--coverage` now fails fast with a clear single-run error instead of producing multi-lane artifact conflicts.
- Multi-config targeted `--coverage` also fails fast with a clear error.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `PATH=/Users/thoffman/openclaw/node_modules/.bin:$PATH node scripts/test-parallel.mjs -- src/commands/onboard-search.test.ts -t "shows registered plugin providers" --passWithNoTests`
  - `pnpm test -- --coverage` now errors before spawning conflicting multi-lane runs
  - `node scripts/test-parallel.mjs -- src/commands/onboard-search.test.ts src/plugins/loader.test.ts --coverage` now errors for multi-config single-run flags
- Edge cases checked:
  - targeted file in `src/commands/**` routes through the wrapper instead of raw Vitest fallback
  - single-run-only flags are blocked for both broad and multi-config targeted runs
- What you did **not** verify:
  - full suite execution
  - CI behavior
  - extension/gateway/live/e2e targeted runs beyond routing logic

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert `scripts/test-parallel.mjs` to restore the prior passthrough behavior
- Files/config to restore: `scripts/test-parallel.mjs`, optionally `AGENTS.md`
- Known bad symptoms reviewers should watch for: targeted wrapper runs selecting the wrong config, or artifact flags unexpectedly running across multiple lanes

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Some uncommon Vitest flags may still need explicit single-run handling if they write shared artifacts.
  - Mitigation:
    - the known artifact-emitting flags are explicitly blocked from multi-lane fanout, and normal targeted file/name filtering was exercised manually.
