### PR TITLE
fix(gateway): add auth.mode=none and trustedProxy.allowUsers=[] to dangerous-flags

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -711,7 +711,11 @@ export const OpenClawSchema = z
               .optional(),
             trustedProxy: z
               .object({
-                userHeader: z.string().min(1, "userHeader is required for trusted-proxy mode"),
+                userHeader: z
+                  .string()
+                  .min(1, "userHeader is required for trusted-proxy mode")
+                  // [HARDENED] reject whitespace-only values that would bypass min(1).
+                  .refine((v) => v.trim().length > 0, "userHeader cannot be only whitespace"),
                 requiredHeaders: z.array(z.string()).optional(),
                 allowUsers: z.array(z.string()).optional(),
               })

--- a/src/security/dangerous-config-flags.ts
+++ b/src/security/dangerous-config-flags.ts
@@ -34,6 +34,21 @@ export function collectEnabledInsecureOrDangerousFlags(cfg: OpenClawConfig): str
   if (cfg.tools?.exec?.applyPatch?.workspaceOnly === false) {
     enabledFlags.push("tools.exec.applyPatch.workspaceOnly=false");
   }
+  // [HARDENED] mode=none disables authentication entirely — flag as dangerous.
+  if (cfg.gateway?.auth?.mode === "none") {
+    enabledFlags.push("gateway.auth.mode=none (authentication fully disabled)");
+  }
+  // [HARDENED] trusted-proxy with an empty allowUsers list accepts ALL proxy users.
+  if (
+    cfg.gateway?.auth?.mode === "trusted-proxy" &&
+    Array.isArray(cfg.gateway?.auth?.trustedProxy?.allowUsers) &&
+    cfg.gateway.auth.trustedProxy.allowUsers.length === 0
+  ) {
+    enabledFlags.push(
+      "gateway.auth.trustedProxy.allowUsers=[] (all proxy-authenticated users accepted)",
+    );
+  }
+
 
   const pluginEntries = cfg.plugins?.entries;
   if (!isRecord(pluginEntries)) {
@@ -77,5 +92,5 @@ export function collectEnabledInsecureOrDangerousFlags(cfg: OpenClawConfig): str
     }
   }
 
-  return enabledFlags;
+==  return enabledFlags;
 }

--- a/src/security/dangerous-config-flags.ts
+++ b/src/security/dangerous-config-flags.ts
@@ -38,17 +38,15 @@ export function collectEnabledInsecureOrDangerousFlags(cfg: OpenClawConfig): str
   if (cfg.gateway?.auth?.mode === "none") {
     enabledFlags.push("gateway.auth.mode=none (authentication fully disabled)");
   }
-  // [HARDENED] trusted-proxy with an empty allowUsers list accepts ALL proxy users.
+  // [HARDENED] trusted-proxy with an empty or absent allowUsers list accepts ALL proxy users.
   if (
     cfg.gateway?.auth?.mode === "trusted-proxy" &&
-    Array.isArray(cfg.gateway?.auth?.trustedProxy?.allowUsers) &&
-    cfg.gateway.auth.trustedProxy.allowUsers.length === 0
+    (cfg.gateway?.auth?.trustedProxy?.allowUsers ?? []).length === 0
   ) {
     enabledFlags.push(
       "gateway.auth.trustedProxy.allowUsers=[] (all proxy-authenticated users accepted)",
     );
   }
-
 
   const pluginEntries = cfg.plugins?.entries;
   if (!isRecord(pluginEntries)) {
@@ -92,5 +90,5 @@ export function collectEnabledInsecureOrDangerousFlags(cfg: OpenClawConfig): str
     }
   }
 
-==  return enabledFlags;
+  return enabledFlags;
 }


### PR DESCRIPTION
## Summary
Add `gateway.auth.mode=none` and `trustedProxy.allowUsers=[]` to the dangerous-config-flags detector.

Also adds a `.refine()` on `userHeader` in the Zod schema to reject whitespace-only values.

## Motivation
`auth.mode=none` silently disables all authentication. `allowUsers=[]` in trusted-proxy mode allows any user through. Both are logged at startup via the existing dangerous-config-flags mechanism — this PR simply adds them to the list.

## Testing
Tested on self-hosted deployment.

---
- [x] AI-assisted (Claude Code / claude-sonnet-4-6)
- [x] Lightly tested on self-hosted deployment
- [x] Author understands what the code does