### PR TITLE
fix(skills): extend skill-scanner to detect dynamic require() and import() calls

### DIFF
--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -175,14 +175,14 @@ const LINE_RULES: LineRule[] = [
     ruleId: "dynamic-require",
     severity: "critical",
     message: "Dynamic require() with variable argument detected",
-    pattern: /\brequire\s*\(\s*(?!['"`])(?!\s*['"`])/,
+    pattern: /\brequire\s*\(\s*(?!['"])/,
   },
-  // R6: détecter l'import() dynamique (expression non-littérale)
+  // R7: détecter l'import() dynamique (expression non-littérale ou template literal dynamique)
   {
     ruleId: "dynamic-import",
     severity: "critical",
     message: "Dynamic import() with non-literal argument detected",
-    pattern: /\bimport\s*\(\s*(?!['"`])(?!\s*['"`])/,
+    pattern: /\bimport\s*\(\s*(?!['"])/,
   },
 ];
 

--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -170,6 +170,20 @@ const LINE_RULES: LineRule[] = [
     message: "WebSocket connection to non-standard port",
     pattern: /new\s+WebSocket\s*\(\s*["']wss?:\/\/[^"']*:(\d+)/,
   },
+  // R6: détecter le chargement dynamique de module via require(variable)
+  {
+    ruleId: "dynamic-require",
+    severity: "critical",
+    message: "Dynamic require() with variable argument detected",
+    pattern: /\brequire\s*\(\s*(?!['"`])(?!\s*['"`])/,
+  },
+  // R6: détecter l'import() dynamique (expression non-littérale)
+  {
+    ruleId: "dynamic-import",
+    severity: "critical",
+    message: "Dynamic import() with non-literal argument detected",
+    pattern: /\bimport\s*\(\s*(?!['"`])(?!\s*['"`])/,
+  },
 ];
 
 const STANDARD_PORTS = new Set([80, 443, 8080, 8443, 3000]);


### PR DESCRIPTION
## Summary
Extend `LINE_RULES` in skill-scanner to detect dynamic `require()` and `import()` calls.

Two new rules added:
- `dynamic-require` (critical): detects `require(` with a non-literal argument
- `dynamic-import` (critical): detects `import(` with a non-literal argument

Uses negative lookahead on quote characters to avoid false positives on static imports.

## Motivation
Dynamic module loading bypasses the static scanner's ability to audit what a skill actually loads at runtime. Adding these rules closes a gap where `require(userControlledVar)` would go undetected.

## Testing
Tested on self-hosted deployment.

---
- [x] AI-assisted (Claude Code / claude-sonnet-4-6)
- [x] Lightly tested on self-hosted deployment
- [x] Author understands what the code does