### PR TITLE
fix(skills): resolve symlinks via realpathSync before scanning skill directories

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -152,6 +152,8 @@ function listChildDirectories(dir: string): string[] {
   try {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
     const dirs: string[] = [];
+    // R4: résoudre le realpath de dir une seule fois avant la boucle
+    const resolvedDir = fs.realpathSync(dir);
     for (const entry of entries) {
       if (entry.name.startsWith(".")) continue;
       if (entry.name === "node_modules") continue;
@@ -165,7 +167,6 @@ function listChildDirectories(dir: string): string[] {
           // R4: résoudre le realpath du symlink et vérifier qu'il reste dans dir
           // pour éviter qu'un lien symbolique ne permette de sortir de la racine.
           const realTarget = fs.realpathSync(fullPath);
-          const resolvedDir = fs.realpathSync(dir);
           if (
             fs.statSync(realTarget).isDirectory() &&
             (realTarget === resolvedDir || realTarget.startsWith(resolvedDir + path.sep))

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -162,11 +162,18 @@ function listChildDirectories(dir: string): string[] {
       }
       if (entry.isSymbolicLink()) {
         try {
-          if (fs.statSync(fullPath).isDirectory()) {
+          // R4: résoudre le realpath du symlink et vérifier qu'il reste dans dir
+          // pour éviter qu'un lien symbolique ne permette de sortir de la racine.
+          const realTarget = fs.realpathSync(fullPath);
+          const resolvedDir = fs.realpathSync(dir);
+          if (
+            fs.statSync(realTarget).isDirectory() &&
+            (realTarget === resolvedDir || realTarget.startsWith(resolvedDir + path.sep))
+          ) {
             dirs.push(entry.name);
           }
         } catch {
-          // ignore broken symlinks
+          // ignore broken symlinks or paths outside root
         }
       }
     }


### PR DESCRIPTION
## Summary
Resolve symlinks via `realpathSync` before scanning skill directories, and filter entries whose resolved path falls outside the declared `rootDir`.

## Motivation
`listChildDirectories()` followed symlinks into arbitrary host directories before the final `filterLoadedSkillsInsideRoot()` check, meaning `SKILL.md` content was read from symlink targets outside the intended boundary. Resolving the realpath early closes this window.

## Testing
Tested on self-hosted deployment.

---
- [x] AI-assisted (Claude Code / claude-sonnet-4-6)
- [x] Lightly tested on self-hosted deployment
- [x] Author understands what the code does