### PR TITLE
fix: inline Anthropic model aliases to avoid bundler ordering issues

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -31,13 +31,6 @@ export type ModelAliasIndex = {
   byKey: Map<string, string[]>;
 };
 
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
-};
-
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
 }
@@ -151,7 +144,20 @@ function normalizeAnthropicModelId(model: string): string {
     return trimmed;
   }
   const lower = trimmed.toLowerCase();
-  return ANTHROPIC_MODEL_ALIASES[lower] ?? trimmed;
+  // Inline aliases to avoid bundler ordering issues where the constant
+  // might be accessed before it's defined in the bundled output.
+  switch (lower) {
+    case "opus-4.6":
+      return "claude-opus-4-6";
+    case "opus-4.5":
+      return "claude-opus-4-5";
+    case "sonnet-4.6":
+      return "claude-sonnet-4-6";
+    case "sonnet-4.5":
+      return "claude-sonnet-4-5";
+    default:
+      return trimmed;
+  }
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {


### PR DESCRIPTION
## Summary
Fixes a "Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization" error that occurs when the bundler places code that uses `ANTHROPIC_MODEL_ALIASES` before the constant definition in the bundled output.

## Problem
The `ANTHROPIC_MODEL_ALIASES` constant was defined as a `const` in `src/agents/model-selection.ts`. During bundling, the bundler (rolldown via tsdown) would sometimes place code from `src/config/defaults.ts` (which calls `parseModelRef` → `normalizeAnthropicModelId`) before the `ANTHROPIC_MODEL_ALIASES` definition, causing a ReferenceError at runtime:

```
ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization
    at normalizeAnthropicModelId (...)
    at normalizeProviderModelId (...)
    at normalizeModelRef (...)
    at parseModelRef (...)
    at applyContextPruningDefaults (...)
    at Object.loadConfig (...)
```

## Solution
Inline the model aliases directly in the `normalizeAnthropicModelId` function using a `switch` statement. Since `function` declarations are hoisted in JavaScript, this works regardless of where the function appears in the bundled output.

## Changes
- Removed the `ANTHROPIC_MODEL_ALIASES` constant
- Inlined the aliases in `normalizeAnthropicModelId` using a switch statement

## Testing
- Built the project with `pnpm build`
- Verified the bundled output contains the inline switch statement
- Function hoisting ensures the code works regardless of bundler ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)