### PR TITLE
fix(voice-call): add fetch timeout to Twilio API and OpenAI TTS calls

### DIFF
--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -138,8 +138,8 @@ export class OpenAITTSProvider {
     }
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`OpenAI TTS failed: ${response.status} - ${error}`);
+      const error = await response.text().catch(() => "");
+      throw new Error(`OpenAI TTS failed: ${response.status}${error ? ` - ${error}` : ""}`);
     }
 
     let arrayBuffer: ArrayBuffer;

--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -119,21 +119,38 @@ export class OpenAITTSProvider {
       body.instructions = effectiveInstructions;
     }
 
-    const response = await fetch("https://api.openai.com/v1/audio/speech", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
+    let response: Response;
+    try {
+      response = await fetch("https://api.openai.com/v1/audio/speech", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(60_000),
+      });
+    } catch (err) {
+      throw new Error(
+        `OpenAI TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
 
     if (!response.ok) {
       const error = await response.text();
       throw new Error(`OpenAI TTS failed: ${response.status} - ${error}`);
     }
 
-    const arrayBuffer = await response.arrayBuffer();
+    let arrayBuffer: ArrayBuffer;
+    try {
+      arrayBuffer = await response.arrayBuffer();
+    } catch (err) {
+      throw new Error(
+        `OpenAI TTS response read failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
     return Buffer.from(arrayBuffer);
   }
 

--- a/extensions/voice-call/src/providers/twilio/api.ts
+++ b/extensions/voice-call/src/providers/twilio/api.ts
@@ -42,8 +42,8 @@ export async function twilioApiRequest<T = unknown>(params: {
     if (params.allowNotFound && response.status === 404) {
       return undefined as T;
     }
-    const errorText = await response.text();
-    throw new Error(`Twilio API error: ${response.status} ${errorText}`);
+    const errorText = await response.text().catch(() => "");
+    throw new Error(`Twilio API error: ${response.status}${errorText ? ` ${errorText}` : ""}`);
   }
 
   let text: string;

--- a/extensions/voice-call/src/providers/twilio/api.ts
+++ b/extensions/voice-call/src/providers/twilio/api.ts
@@ -20,14 +20,23 @@ export async function twilioApiRequest<T = unknown>(params: {
           return acc;
         }, new URLSearchParams());
 
-  const response = await fetch(`${params.baseUrl}${params.endpoint}`, {
-    method: "POST",
-    headers: {
-      Authorization: `Basic ${Buffer.from(`${params.accountSid}:${params.authToken}`).toString("base64")}`,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: bodyParams,
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${params.baseUrl}${params.endpoint}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${params.accountSid}:${params.authToken}`).toString("base64")}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: bodyParams,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Twilio API request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   if (!response.ok) {
     if (params.allowNotFound && response.status === 404) {
@@ -37,6 +46,14 @@ export async function twilioApiRequest<T = unknown>(params: {
     throw new Error(`Twilio API error: ${response.status} ${errorText}`);
   }
 
-  const text = await response.text();
+  let text: string;
+  try {
+    text = await response.text();
+  } catch (err) {
+    throw new Error(
+      `Twilio API response read failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
   return text ? (JSON.parse(text) as T) : (undefined as T);
 }


### PR DESCRIPTION
Both `twilioApiRequest()` and `OpenAITTSProvider.synthesize()` issue bare `fetch()` calls without a cancellation deadline. A stalled connection (DNS hang, idle TCP, unresponsive upstream) blocks the event loop indefinitely.

## Changes

- **`extensions/voice-call/src/providers/twilio/api.ts`**: Add `AbortSignal.timeout(30_000)` to Twilio API POST, wrap fetch + body read in try/catch with `{ cause: err }`
- **`extensions/voice-call/src/providers/tts-openai.ts`**: Add `AbortSignal.timeout(60_000)` to OpenAI TTS request, wrap fetch + `arrayBuffer()` read in try/catch with `{ cause: err }`

lobster-biscuit
