### PR TITLE
fix: robust token usage normalization for OpenAI-compatible providers

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -116,15 +116,38 @@ export function normalizeCliModel(modelId: string, backend: CliBackendConfig): s
 }
 
 function toUsage(raw: Record<string, unknown>): CliUsage | undefined {
-  const pick = (key: string) =>
-    typeof raw[key] === "number" && raw[key] > 0 ? raw[key] : undefined;
-  const input = pick("input_tokens") ?? pick("inputTokens");
-  const output = pick("output_tokens") ?? pick("outputTokens");
-  const cacheRead =
-    pick("cache_read_input_tokens") ?? pick("cached_input_tokens") ?? pick("cacheRead");
-  const cacheWrite = pick("cache_write_input_tokens") ?? pick("cacheWrite");
-  const total = pick("total_tokens") ?? pick("total");
-  if (!input && !output && !cacheRead && !cacheWrite && !total) {
+  const pick = (...keys: string[]) => {
+    for (const key of keys) {
+      const val = raw[key];
+      if (typeof val === "number" && val > 0) {
+        return val;
+      }
+    }
+    for (const key of keys) {
+      const val = raw[key];
+      if (typeof val === "number") {
+        return val;
+      }
+    }
+    return undefined;
+  };
+  const input = pick("input_tokens", "inputTokens", "prompt_tokens", "promptTokens");
+  const output = pick("output_tokens", "outputTokens", "completion_tokens", "completionTokens");
+  const cacheRead = pick(
+    "cache_read_input_tokens",
+    "cached_input_tokens",
+    "cacheRead",
+    "cached_tokens",
+  );
+  const cacheWrite = pick("cache_write_input_tokens", "cacheWrite");
+  const total = pick("total_tokens", "total");
+  if (
+    input === undefined &&
+    output === undefined &&
+    cacheRead === undefined &&
+    cacheWrite === undefined &&
+    total === undefined
+  ) {
     return undefined;
   }
   return { input, output, cacheRead, cacheWrite, total };

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -90,31 +90,49 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     return undefined;
   }
 
+  const pick = (...args: unknown[]) => {
+    for (const arg of args) {
+      const val = asFiniteNumber(arg);
+      if (val !== undefined && val > 0) {
+        return val;
+      }
+    }
+    for (const arg of args) {
+      const val = asFiniteNumber(arg);
+      if (val !== undefined) {
+        return val;
+      }
+    }
+    return undefined;
+  };
+
   // Some providers (pi-ai OpenAI-format) pre-subtract cached_tokens from
   // prompt_tokens upstream.  When cached_tokens > prompt_tokens the result is
   // negative, which is nonsensical.  Clamp to 0.
-  const rawInput = asFiniteNumber(
-    raw.input ?? raw.inputTokens ?? raw.input_tokens ?? raw.promptTokens ?? raw.prompt_tokens,
+  const rawInput = pick(
+    raw.input,
+    raw.inputTokens,
+    raw.input_tokens,
+    raw.promptTokens,
+    raw.prompt_tokens,
   );
   const input = rawInput !== undefined && rawInput < 0 ? 0 : rawInput;
-  const output = asFiniteNumber(
-    raw.output ??
-      raw.outputTokens ??
-      raw.output_tokens ??
-      raw.completionTokens ??
-      raw.completion_tokens,
+  const output = pick(
+    raw.output,
+    raw.outputTokens,
+    raw.output_tokens,
+    raw.completionTokens,
+    raw.completion_tokens,
   );
-  const cacheRead = asFiniteNumber(
-    raw.cacheRead ??
-      raw.cache_read ??
-      raw.cache_read_input_tokens ??
-      raw.cached_tokens ??
-      raw.prompt_tokens_details?.cached_tokens,
+  const cacheRead = pick(
+    raw.cacheRead,
+    raw.cache_read,
+    raw.cache_read_input_tokens,
+    raw.cached_tokens,
+    raw.prompt_tokens_details?.cached_tokens,
   );
-  const cacheWrite = asFiniteNumber(
-    raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,
-  );
-  const total = asFiniteNumber(raw.total ?? raw.totalTokens ?? raw.total_tokens);
+  const cacheWrite = pick(raw.cacheWrite, raw.cache_write, raw.cache_creation_input_tokens);
+  const total = pick(raw.total, raw.totalTokens, raw.total_tokens);
 
   if (
     input === undefined &&


### PR DESCRIPTION
Fixes token usage being reported as 0 for Alibaba Bailian and other OpenAI-compatible providers that may return both `input_tokens: 0` and `prompt_tokens: N`.

Also adds missing `prompt_tokens` and `completion_tokens` support to the CLI runner usage helper.

Fixes #45038
Fixes #45061