### PR TITLE
feat(memory): add heading-aware chunking option for improved search

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -337,7 +337,11 @@ function mergeConfig(
     outputDimensionality,
     local,
     store,
-    chunking: { tokens: Math.max(1, chunking.tokens), overlap: chunking.overlap, headingAware: chunking.headingAware },
+    chunking: {
+      tokens: Math.max(1, chunking.tokens),
+      overlap: chunking.overlap,
+      headingAware: chunking.headingAware,
+    },
     sync: {
       ...sync,
       sessions: {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -230,6 +230,7 @@ function mergeConfig(
   const chunking = {
     tokens: overrides?.chunking?.tokens ?? defaults?.chunking?.tokens ?? DEFAULT_CHUNK_TOKENS,
     overlap: overrides?.chunking?.overlap ?? defaults?.chunking?.overlap ?? DEFAULT_CHUNK_OVERLAP,
+    headingAware: overrides?.chunking?.headingAware ?? defaults?.chunking?.headingAware ?? false,
   };
   const sync = {
     onSessionStart: overrides?.sync?.onSessionStart ?? defaults?.sync?.onSessionStart ?? true,
@@ -336,7 +337,7 @@ function mergeConfig(
     outputDimensionality,
     local,
     store,
-    chunking: { tokens: Math.max(1, chunking.tokens), overlap },
+    chunking: { tokens: Math.max(1, chunking.tokens), overlap: chunking.overlap, headingAware: chunking.headingAware },
     sync: {
       ...sync,
       sessions: {

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -399,13 +399,13 @@ export function chunkMarkdown(
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
     const lineNo = i + 1;
-    
+
     // Heading-aware: flush on heading (unless it's the first heading)
     if (headingAware && isHeading(line) && current.length > 0) {
       flush();
       carryOverlap();
     }
-    
+
     const segments: string[] = [];
     if (line.length === 0) {
       segments.push("");
@@ -416,7 +416,7 @@ export function chunkMarkdown(
     }
     for (const segment of segments) {
       const lineSize = segment.length + 1;
-      
+
       // Enforce cumulative size limit to avoid giant chunks
       if (currentChars + lineSize > maxChars && current.length > 0) {
         flush();

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -333,7 +333,7 @@ export async function buildMultimodalChunkForIndexing(
 
 export function chunkMarkdown(
   content: string,
-  chunking: { tokens: number; overlap: number },
+  chunking: { tokens: number; overlap: number; headingAware?: boolean },
 ): MemoryChunk[] {
   const lines = content.split("\n");
   if (lines.length === 0) {
@@ -342,9 +342,22 @@ export function chunkMarkdown(
   const maxChars = Math.max(32, chunking.tokens * 4);
   const overlapChars = Math.max(0, chunking.overlap * 4);
   const chunks: MemoryChunk[] = [];
+  const headingAware = chunking.headingAware ?? false;
+
+  // Helper to detect markdown headings
+  const isHeading = (line: string): boolean => {
+    return /^#{1,6}\s+/.test(line.trim());
+  };
+
+  // Get heading level (1-6) or 0 if not a heading
+  const getHeadingLevel = (line: string): number => {
+    const match = line.trim().match(/^(#{1,6})\s+/);
+    return match ? match[1].length : 0;
+  };
 
   let current: Array<{ line: string; lineNo: number }> = [];
   let currentChars = 0;
+  let currentSectionStart = 0;
 
   const flush = () => {
     if (current.length === 0) {
@@ -393,6 +406,13 @@ export function chunkMarkdown(
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
     const lineNo = i + 1;
+    
+    // Heading-aware: flush on heading (unless it's the first heading)
+    if (headingAware && isHeading(line) && current.length > 0) {
+      flush();
+      carryOverlap();
+    }
+    
     const segments: string[] = [];
     if (line.length === 0) {
       segments.push("");
@@ -403,9 +423,18 @@ export function chunkMarkdown(
     }
     for (const segment of segments) {
       const lineSize = segment.length + 1;
-      if (currentChars + lineSize > maxChars && current.length > 0) {
-        flush();
-        carryOverlap();
+      
+      // In heading-aware mode, only flush if segment exceeds maxChars (otherwise keep accumulating)
+      if (headingAware) {
+        if (lineSize > maxChars && current.length > 0) {
+          flush();
+          carryOverlap();
+        }
+      } else {
+        if (currentChars + lineSize > maxChars && current.length > 0) {
+          flush();
+          carryOverlap();
+        }
       }
       current.push({ line: segment, lineNo });
       currentChars += lineSize;

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -349,15 +349,8 @@ export function chunkMarkdown(
     return /^#{1,6}\s+/.test(line.trim());
   };
 
-  // Get heading level (1-6) or 0 if not a heading
-  const getHeadingLevel = (line: string): number => {
-    const match = line.trim().match(/^(#{1,6})\s+/);
-    return match ? match[1].length : 0;
-  };
-
   let current: Array<{ line: string; lineNo: number }> = [];
   let currentChars = 0;
-  let currentSectionStart = 0;
 
   const flush = () => {
     if (current.length === 0) {
@@ -424,17 +417,10 @@ export function chunkMarkdown(
     for (const segment of segments) {
       const lineSize = segment.length + 1;
       
-      // In heading-aware mode, only flush if segment exceeds maxChars (otherwise keep accumulating)
-      if (headingAware) {
-        if (lineSize > maxChars && current.length > 0) {
-          flush();
-          carryOverlap();
-        }
-      } else {
-        if (currentChars + lineSize > maxChars && current.length > 0) {
-          flush();
-          carryOverlap();
-        }
+      // Enforce cumulative size limit to avoid giant chunks
+      if (currentChars + lineSize > maxChars && current.length > 0) {
+        flush();
+        carryOverlap();
       }
       current.push({ line: segment, lineNo });
       currentChars += lineSize;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -59,6 +59,7 @@ type MemoryIndexMeta = {
   scopeHash?: string;
   chunkTokens: number;
   chunkOverlap: number;
+  chunkHeadingAware?: boolean;
   vectorDims?: number;
 };
 
@@ -999,6 +1000,7 @@ export abstract class MemoryManagerSyncOps {
       meta.scopeHash !== configuredScopeHash ||
       meta.chunkTokens !== this.settings.chunking.tokens ||
       meta.chunkOverlap !== this.settings.chunking.overlap ||
+      meta.chunkHeadingAware !== this.settings.chunking.headingAware ||
       (vectorReady && !meta?.vectorDims);
     try {
       if (needsFullReindex) {
@@ -1218,6 +1220,7 @@ export abstract class MemoryManagerSyncOps {
         scopeHash: this.resolveConfiguredScopeHash(),
         chunkTokens: this.settings.chunking.tokens,
         chunkOverlap: this.settings.chunking.overlap,
+        chunkHeadingAware: this.settings.chunking.headingAware ?? false,
       };
       if (!nextMeta) {
         throw new Error("Failed to compute memory index metadata for reindexing.");
@@ -1290,6 +1293,7 @@ export abstract class MemoryManagerSyncOps {
       scopeHash: this.resolveConfiguredScopeHash(),
       chunkTokens: this.settings.chunking.tokens,
       chunkOverlap: this.settings.chunking.overlap,
+      chunkHeadingAware: this.settings.chunking.headingAware ?? false,
     };
     if (this.vector.available && this.vector.dims) {
       nextMeta.vectorDims = this.vector.dims;


### PR DESCRIPTION

Summary:

• Problem: Memory search splits large files arbitrarily, reducing context relevance
• Why it matters: Heading-aware chunks preserve semantic structure, improving search relevance
• What changed: Added headingAware option to chunkMarkdown() - splits on ## and ### headings as natural boundaries
• What did NOT change: Files without headings work exactly as before (backward compatible)

Change Type: Feature

Scope: Memory / storage

Linked Issue: Closes #44395

User-visible Changes:

• New optional config: headingAware in memory chunking options
• MemoryIndexMeta tracks headingAware for reindex detection on config change

Security Impact: All No

Human Verification: Verified files with/without headings work correctly

Compatibility: Backward compatible
