### PR TITLE
fix(gateway-status): downgrade SecretRef warning when gateway probe succeeds

### DIFF
--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -213,15 +213,66 @@ describe("gateway-status command", () => {
     const parsed = JSON.parse(runtimeLogs.join("\n")) as {
       warnings?: Array<{ code?: string; message?: string; targetIds?: string[] }>;
     };
-    const unresolvedWarning = parsed.warnings?.find(
+    // When the gateway probe succeeds, SecretRef diagnostics are downgraded
+    // to informational notes (auth_secretref_cli_only) instead of errors,
+    // because the secret is resolved at gateway runtime — the CLI just
+    // cannot read it.
+    const cliOnlyNote = parsed.warnings?.find(
       (warning) =>
-        warning.code === "auth_secretref_unresolved" &&
+        warning.code === "auth_secretref_cli_only" &&
         warning.message?.includes("gateway.auth.token SecretRef is unresolved"),
     );
-    expect(unresolvedWarning).toBeTruthy();
-    expect(unresolvedWarning?.targetIds).toContain("localLoopback");
-    expect(unresolvedWarning?.message).toContain("env:default:MISSING_GATEWAY_TOKEN");
-    expect(unresolvedWarning?.message).not.toContain("missing or empty");
+    expect(cliOnlyNote).toBeTruthy();
+    expect(cliOnlyNote?.targetIds).toContain("localLoopback");
+    expect(cliOnlyNote?.message).toContain("env:default:MISSING_GATEWAY_TOKEN");
+    expect(cliOnlyNote?.message).toContain("gateway is healthy");
+    expect(cliOnlyNote?.message).not.toContain("missing or empty");
+  });
+
+  it("keeps auth_secretref_unresolved code when gateway probe fails", async () => {
+    const { runtime, runtimeLogs } = createRuntimeCapture();
+    const previousProbeImpl = probeGateway.getMockImplementation();
+    probeGateway.mockImplementation(async (opts: { url: string }) => ({
+      ok: false,
+      url: opts.url,
+      connectLatencyMs: null,
+      error: "connection refused",
+      close: null,
+      health: null,
+      status: null,
+      presence: [],
+      configSnapshot: null,
+    }));
+
+    try {
+      await withEnvAsync({ MISSING_GATEWAY_TOKEN: undefined }, async () => {
+        mockLocalTokenEnvRefConfig();
+
+        try {
+          await runGatewayStatus(runtime, { timeout: "1000", json: true });
+        } catch (err) {
+          // exit(1) expected when all probes fail
+          if (!(err instanceof Error && err.message.includes("__exit__"))) {
+            throw err;
+          }
+        }
+      });
+
+      const parsed = JSON.parse(runtimeLogs.join("\n")) as {
+        warnings?: Array<{ code?: string; message?: string; targetIds?: string[] }>;
+      };
+      const unresolvedWarning = parsed.warnings?.find(
+        (warning) => warning.code === "auth_secretref_unresolved",
+      );
+      expect(unresolvedWarning).toBeTruthy();
+      expect(unresolvedWarning?.message).not.toContain("gateway is healthy");
+    } finally {
+      if (previousProbeImpl) {
+        probeGateway.mockImplementation(previousProbeImpl);
+      } else {
+        probeGateway.mockReset();
+      }
+    }
   });
 
   it("does not resolve local token SecretRef when OPENCLAW_GATEWAY_TOKEN is set", async () => {

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -229,11 +229,21 @@ export async function gatewayStatusCommand(
       continue;
     }
     for (const diagnostic of result.authDiagnostics) {
-      warnings.push({
-        code: "auth_secretref_unresolved",
-        message: diagnostic,
-        targetIds: [result.target.id],
-      });
+      if (result.probe.ok) {
+        // Gateway is healthy — SecretRef is resolved at runtime but unreadable
+        // from CLI context. Downgrade to informational note instead of warning.
+        warnings.push({
+          code: "auth_secretref_cli_only",
+          message: `${diagnostic} (gateway is healthy; secrets are resolved at runtime)`,
+          targetIds: [result.target.id],
+        });
+      } else {
+        warnings.push({
+          code: "auth_secretref_unresolved",
+          message: diagnostic,
+          targetIds: [result.target.id],
+        });
+      }
     }
   }
 
@@ -304,11 +314,20 @@ export async function gatewayStatusCommand(
   );
   runtime.log(colorize(rich, theme.muted, `Probe budget: ${overallTimeoutMs}ms`));
 
-  if (warnings.length > 0) {
+  const actualWarnings = warnings.filter((w) => w.code !== "auth_secretref_cli_only");
+  const infoNotes = warnings.filter((w) => w.code === "auth_secretref_cli_only");
+  if (actualWarnings.length > 0) {
     runtime.log("");
     runtime.log(colorize(rich, theme.warn, "Warning:"));
-    for (const w of warnings) {
+    for (const w of actualWarnings) {
       runtime.log(`- ${w.message}`);
+    }
+  }
+  if (infoNotes.length > 0) {
+    runtime.log("");
+    runtime.log(colorize(rich, theme.muted, "Note:"));
+    for (const n of infoNotes) {
+      runtime.log(`- ${colorize(rich, theme.muted, n.message)}`);
     }
   }
 


### PR DESCRIPTION
## Problem

When the gateway is running and healthy, `openclaw gateway status` still shows a `Warning:` about unresolved SecretRef for `gateway.auth.token`. This is a false positive — the secret (e.g., `env:GATEWAY_TOKEN`) is resolved at gateway runtime but is not readable from the CLI process context (the env var may only be set in the gateway's LaunchAgent/systemd environment).

This confuses users into thinking their auth config is broken when everything is actually working fine.

## Fix

- When the gateway probe succeeds (`probe.ok === true`), SecretRef diagnostics are downgraded from `auth_secretref_unresolved` (Warning) to `auth_secretref_cli_only` (Note)
- The note message includes `(gateway is healthy; secrets are resolved at runtime)` for clarity
- When the gateway probe fails, the original `auth_secretref_unresolved` warning is preserved — this is a genuine problem
- Warning and Note sections are rendered separately: warnings in warn color, notes in muted color

## Tests

- Updated existing test to verify the downgraded code when probe succeeds
- Added new test: `keeps auth_secretref_unresolved code when gateway probe fails` — verifies warnings are preserved for unhealthy gateways

All 13 gateway-status tests pass locally.