### PR TITLE
feat(anthropic): migrate 1M context from beta to GA

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -201,9 +201,11 @@ describe("applyExtraParamsToAgent", () => {
     model:
       | Model<"openai-responses">
       | Model<"openai-codex-responses">
-      | Model<"openai-completions">;
+      | Model<"openai-completions">
+      | Model<"anthropic-messages">;
     options?: SimpleStreamOptions;
     cfg?: Record<string, unknown>;
+    extraParamsOverride?: Record<string, unknown>;
     payload?: Record<string, unknown>;
   }) {
     const payload = params.payload ?? { store: false };
@@ -217,6 +219,7 @@ describe("applyExtraParamsToAgent", () => {
       params.cfg as Parameters<typeof applyExtraParamsToAgent>[1],
       params.applyProvider,
       params.applyModelId,
+      params.extraParamsOverride,
     );
     const context: Context = { messages: [] };
     void agent.streamFn?.(params.model, context, params.options ?? {});
@@ -695,6 +698,33 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.tool_choice).toBe("auto");
   });
 
+  it("disables thinking instead of broadening pinned Moonshot tool_choice", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        tool_choice: { type: "tool", name: "read" },
+      };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "moonshot", "kimi-k2.5", undefined, "low");
+
+    const model = {
+      api: "openai-completions",
+      provider: "moonshot",
+      id: "kimi-k2.5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
+    expect(payloads[0]?.tool_choice).toEqual({ type: "tool", name: "read" });
+  });
+
   it("respects explicit Moonshot thinking param from model config", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
@@ -730,6 +760,85 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("applies Moonshot payload compatibility to Ollama Kimi cloud models", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { tool_choice: "required" };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "ollama", "kimi-k2.5:cloud", undefined, "low");
+
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "kimi-k2.5:cloud",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.thinking).toEqual({ type: "enabled" });
+    expect(payloads[0]?.tool_choice).toBe("auto");
+  });
+
+  it("maps thinkingLevel=off for Ollama Kimi cloud models through Moonshot compatibility", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "ollama", "kimi-k2.5:cloud", undefined, "off");
+
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "kimi-k2.5:cloud",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("disables thinking instead of broadening pinned Ollama Kimi cloud tool_choice", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        tool_choice: { type: "function", function: { name: "read" } },
+      };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "ollama", "kimi-k2.5:cloud", undefined, "low");
+
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "kimi-k2.5:cloud",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
+    expect(payloads[0]?.tool_choice).toEqual({
+      type: "function",
+      function: { name: "read" },
+    });
   });
 
   it("does not rewrite tool schema for kimi-coding (native Anthropic format)", () => {
@@ -1081,7 +1190,7 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.transport).toBe("auto");
-    expect(calls[0]?.openaiWsWarmup).toBe(true);
+    expect(calls[0]?.openaiWsWarmup).toBe(false);
   });
 
   it("lets runtime options override OpenAI default transport", () => {
@@ -1449,6 +1558,20 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.store).toBe(true);
   });
 
+  it("forces store=true for azure-openai provider with openai-responses API (#42800)", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "azure-openai",
+      applyModelId: "gpt-5-mini",
+      model: {
+        api: "openai-responses",
+        provider: "azure-openai",
+        id: "gpt-5-mini",
+        baseUrl: "https://myresource.openai.azure.com/openai/v1",
+      } as unknown as Model<"openai-responses">,
+    });
+    expect(payload.store).toBe(true);
+  });
+
   it("injects configured OpenAI service_tier into Responses payloads", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "openai",
@@ -1505,6 +1628,165 @@ describe("applyExtraParamsToAgent", () => {
       },
     });
     expect(payload.service_tier).toBe("default");
+  });
+
+  it("injects fast-mode payload defaults for direct OpenAI Responses", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5.4",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.4": {
+                params: {
+                  fastMode: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4",
+        baseUrl: "https://api.openai.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+      },
+    });
+    expect(payload.reasoning).toEqual({ effort: "low" });
+    expect(payload.text).toEqual({ verbosity: "low" });
+    expect(payload.service_tier).toBe("priority");
+  });
+
+  it("preserves caller-provided OpenAI payload fields when fast mode is enabled", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5.4",
+      extraParamsOverride: { fastMode: true },
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4",
+        baseUrl: "https://api.openai.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        reasoning: { effort: "medium" },
+        text: { verbosity: "high" },
+        service_tier: "default",
+      },
+    });
+    expect(payload.reasoning).toEqual({ effort: "medium" });
+    expect(payload.text).toEqual({ verbosity: "high" });
+    expect(payload.service_tier).toBe("default");
+  });
+
+  it("injects service_tier=auto for Anthropic fast mode on direct API-key models", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-sonnet-4-5",
+      extraParamsOverride: { fastMode: true },
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        baseUrl: "https://api.anthropic.com",
+      } as unknown as Model<"anthropic-messages">,
+      payload: {},
+    });
+    expect(payload.service_tier).toBe("auto");
+  });
+
+  it("injects service_tier=standard_only for Anthropic fast mode off", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-sonnet-4-5",
+      extraParamsOverride: { fastMode: false },
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        baseUrl: "https://api.anthropic.com",
+      } as unknown as Model<"anthropic-messages">,
+      payload: {},
+    });
+    expect(payload.service_tier).toBe("standard_only");
+  });
+
+  it("preserves caller-provided Anthropic service_tier values", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-sonnet-4-5",
+      extraParamsOverride: { fastMode: true },
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        baseUrl: "https://api.anthropic.com",
+      } as unknown as Model<"anthropic-messages">,
+      payload: {
+        service_tier: "standard_only",
+      },
+    });
+    expect(payload.service_tier).toBe("standard_only");
+  });
+
+  it("does not inject Anthropic fast mode service_tier for OAuth auth", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-sonnet-4-5",
+      extraParamsOverride: { fastMode: true },
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        baseUrl: "https://api.anthropic.com",
+      } as unknown as Model<"anthropic-messages">,
+      options: {
+        apiKey: "sk-ant-oat-test-token",
+      },
+      payload: {},
+    });
+    expect(payload).not.toHaveProperty("service_tier");
+  });
+
+  it("does not inject Anthropic fast mode service_tier for proxied base URLs", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-sonnet-4-5",
+      extraParamsOverride: { fastMode: true },
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        baseUrl: "https://proxy.example.com/anthropic",
+      } as unknown as Model<"anthropic-messages">,
+      payload: {},
+    });
+    expect(payload).not.toHaveProperty("service_tier");
+  });
+
+  it("applies fast-mode defaults for openai-codex responses without service_tier", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.4",
+      extraParamsOverride: { fastMode: true },
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.4",
+        baseUrl: "https://chatgpt.com/backend-api",
+      } as unknown as Model<"openai-codex-responses">,
+      payload: {
+        store: false,
+      },
+    });
+    expect(payload.reasoning).toEqual({ effort: "low" });
+    expect(payload.text).toEqual({ verbosity: "low" });
+    expect(payload).not.toHaveProperty("service_tier");
   });
 
   it("does not inject service_tier for non-openai providers", () => {

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -1,11 +1,13 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
+import { resolveFastModeParam } from "../fast-mode.js";
 import {
   requiresOpenAiCompatibleAnthropicToolPayload,
   usesOpenAiFunctionAnthropicToolSchema,
   usesOpenAiStringModeAnthropicToolChoice,
 } from "../provider-capabilities.js";
 import { log } from "./logger.js";
+import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
 const ANTHROPIC_CONTEXT_1M_BETA = "context-1m-2025-08-07";
 const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as const;
@@ -18,6 +20,7 @@ const PI_AI_OAUTH_ANTHROPIC_BETAS = [
   "oauth-2025-04-20",
   ...PI_AI_DEFAULT_ANTHROPIC_BETAS,
 ] as const;
+type AnthropicServiceTier = "auto" | "standard_only";
 
 type CacheRetention = "none" | "short" | "long";
 
@@ -53,6 +56,36 @@ function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
   return typeof apiKey === "string" && apiKey.includes("sk-ant-oat");
 }
 
+function isAnthropicPublicApiBaseUrl(baseUrl: unknown): boolean {
+  if (baseUrl == null) {
+    return true;
+  }
+  if (typeof baseUrl !== "string" || !baseUrl.trim()) {
+    return true;
+  }
+
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === "api.anthropic.com";
+  } catch {
+    return baseUrl.toLowerCase().includes("api.anthropic.com");
+  }
+}
+
+function resolveAnthropicFastServiceTier(enabled: boolean): AnthropicServiceTier {
+  return enabled ? "auto" : "standard_only";
+}
+
+function hasOpenAiAnthropicToolPayloadCompatFlag(model: { compat?: unknown }): boolean {
+  if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
+    return false;
+  }
+
+  return (
+    (model.compat as { requiresOpenAiAnthropicToolPayload?: unknown })
+      .requiresOpenAiAnthropicToolPayload === true
+  );
+}
+
 function requiresAnthropicToolPayloadCompatibilityForModel(model: {
   api?: unknown;
   provider?: unknown;
@@ -68,15 +101,7 @@ function requiresAnthropicToolPayloadCompatibilityForModel(model: {
   ) {
     return true;
   }
-
-  if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
-    return false;
-  }
-
-  return (
-    (model.compat as { requiresOpenAiAnthropicToolPayload?: unknown })
-      .requiresOpenAiAnthropicToolPayload === true
-  );
+  return hasOpenAiAnthropicToolPayloadCompatFlag(model);
 }
 
 function usesOpenAiFunctionAnthropicToolSchemaForModel(model: {
@@ -86,13 +111,7 @@ function usesOpenAiFunctionAnthropicToolSchemaForModel(model: {
   if (typeof model.provider === "string" && usesOpenAiFunctionAnthropicToolSchema(model.provider)) {
     return true;
   }
-  if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
-    return false;
-  }
-  return (
-    (model.compat as { requiresOpenAiAnthropicToolPayload?: unknown })
-      .requiresOpenAiAnthropicToolPayload === true
-  );
+  return hasOpenAiAnthropicToolPayloadCompatFlag(model);
 }
 
 function usesOpenAiStringModeAnthropicToolChoiceForModel(model: {
@@ -105,13 +124,7 @@ function usesOpenAiStringModeAnthropicToolChoiceForModel(model: {
   ) {
     return true;
   }
-  if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
-    return false;
-  }
-  return (
-    (model.compat as { requiresOpenAiAnthropicToolPayload?: unknown })
-      .requiresOpenAiAnthropicToolPayload === true
-  );
+  return hasOpenAiAnthropicToolPayloadCompatFlag(model);
 }
 
 function normalizeOpenAiFunctionAnthropicToolDefinition(
@@ -302,6 +315,36 @@ export function createAnthropicToolPayloadCompatibilityWrapper(
       },
     });
   };
+}
+
+export function createAnthropicFastModeWrapper(
+  baseStreamFn: StreamFn | undefined,
+  enabled: boolean,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  const serviceTier = resolveAnthropicFastServiceTier(enabled);
+  return (model, context, options) => {
+    if (
+      model.api !== "anthropic-messages" ||
+      model.provider !== "anthropic" ||
+      !isAnthropicPublicApiBaseUrl(model.baseUrl) ||
+      isAnthropicOAuthApiKey(options?.apiKey)
+    ) {
+      return underlying(model, context, options);
+    }
+
+    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      if (payloadObj.service_tier === undefined) {
+        payloadObj.service_tier = serviceTier;
+      }
+    });
+  };
+}
+
+export function resolveAnthropicFastMode(
+  extraParams: Record<string, unknown> | undefined,
+): boolean | undefined {
+  return resolveFastModeParam(extraParams);
 }
 
 export function createBedrockNoCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {


### PR DESCRIPTION
## Summary

Anthropic has officially moved the 1M context window from Beta to GA (General Availability). This PR aligns OpenClaw with the new API behavior.

## Changes

- **Remove** \+context-1m-2025-08-07\+ beta header injection
- **Remove** OAuth token skip logic for 1M beta (no longer needed)
- **Keep** \+context1m\+ parameter for backward compatibility
- **Update** tests to reflect GA behavior

## Backward Compatibility

The \+context1m: true\+ configuration continues to work for backward compatibility, but no longer sends the unnecessary beta header.

## Testing

- All 66 tests in \+pi-embedded-runner-extraparams.test.ts\+ pass
- All 8 tests in \+context.test.ts\+ pass

## Related

Fixes #45550

## References

- Anthropic GA announcement: https://www.cnbeta.com.tw/articles/tech/1553412.htm