### PR TITLE
fix(reply): populate template variables for early aborts and commands

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1954,4 +1954,992 @@ describe("Response Prefix Template Interpolation", () => {
       thinkLevel: "off",
     });
   });
+
+  it("calls onModelSelected for fast-abort path", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({
+      handled: true,
+      aborted: true,
+      stoppedSubagents: 0,
+    });
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValueOnce({
+      "test-session-key": {
+        sessionId: "sid",
+        createdAt: 123,
+        modelOverride: "openai/gpt-5.2-20260205",
+        providerOverride: "openai",
+        thinkingLevel: "high",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx(),
+      SessionKey: "test-session-key",
+    };
+
+    const onModelSelected = vi.fn();
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyOptions: { onModelSelected },
+    });
+
+    // Date suffix stripped via stripModelSuffixes for consistent modelFull downstream
+    expect(onModelSelected).toHaveBeenCalledWith({
+      provider: "openai",
+      model: "gpt-5.2",
+      thinkLevel: "high",
+    });
+  });
+
+  it("resolves provider from model string when providerOverride is absent (fast-abort path)", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({
+      handled: true,
+      aborted: true,
+      stoppedSubagents: 0,
+    });
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValueOnce({
+      "test-session-key": {
+        sessionId: "sid",
+        updatedAt: 123,
+        modelOverride: "openai/gpt-5.2-20260205",
+        // providerOverride intentionally absent
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx(),
+      SessionKey: "test-session-key",
+    };
+
+    const onModelSelected = vi.fn();
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyOptions: { onModelSelected },
+    });
+
+    // Provider should be extracted from the model string prefix, not fall back to "unknown".
+    // Date suffix stripped via stripModelSuffixes for consistent modelFull downstream.
+    expect(onModelSelected).toHaveBeenCalledWith({
+      provider: "openai",
+      model: "gpt-5.2",
+      thinkLevel: "off",
+    });
+  });
+
+  it("falls back to 'unknown' provider when model has no slash and providerOverride is absent (fast-abort path)", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({
+      handled: true,
+      aborted: true,
+      stoppedSubagents: 0,
+    });
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValueOnce({
+      "test-session-key": {
+        sessionId: "sid",
+        updatedAt: 123,
+        modelOverride: "gpt-5.2",
+        // providerOverride intentionally absent; model has no slash prefix
+        thinkingLevel: "low",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx(),
+      SessionKey: "test-session-key",
+    };
+
+    const onModelSelected = vi.fn();
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyOptions: { onModelSelected },
+    });
+
+    // No slash in model string and no providerOverride → provider should be "unknown"
+    expect(onModelSelected).toHaveBeenCalledWith({
+      provider: "unknown",
+      model: "gpt-5.2",
+      thinkLevel: "low",
+    });
+  });
+
+  it("resolves provider from model string and uses fresh session entry in !modelSelected fallback", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+
+    // First load (captured before replyResolver): stale — no providerOverride, old thinkingLevel
+    vi.spyOn(sessionStore, "loadSessionStore")
+      .mockReturnValueOnce({
+        "test-session-key": {
+          sessionId: "sid",
+          updatedAt: 123,
+          modelOverride: "anthropic/claude-sonnet-4-6",
+          thinkingLevel: "off",
+        },
+      })
+      // Second load (re-read after replyResolver): fresh — /think changed thinkingLevel to "high"
+      .mockReturnValueOnce({
+        "test-session-key": {
+          sessionId: "sid",
+          updatedAt: 456,
+          modelOverride: "anthropic/claude-sonnet-4-6",
+          thinkingLevel: "high",
+        },
+      });
+
+    const ctx = {
+      ...buildTestCtx(),
+      SessionKey: "test-session-key",
+    };
+
+    // Simulate a command reply (/think) that does not trigger onModelSelected itself
+    const replyResolver = vi.fn().mockResolvedValue([{ text: "Thinking mode: high" }]);
+    const onModelSelected = vi.fn();
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected },
+    });
+
+    // Should use fresh entry (thinkingLevel "high") and extracted provider, not stale entry
+    expect(onModelSelected).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      thinkLevel: "high",
+    });
+  });
+
+  it("passes correct responsePrefixContext to routeReply for routed final replies", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValueOnce({
+      "test-session-key": {
+        sessionId: "sid",
+        createdAt: 123,
+        modelOverride: "openai/gpt-5.2-20260205",
+        providerOverride: "openai",
+        thinkingLevel: "high",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    // Simulate a command reply (no onModelSelected trigger) that routes to originating
+    const replyResolver = vi.fn().mockResolvedValue([{ text: "Done." }]);
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+    });
+
+    // Should route to originating channel, not use dispatcher
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "telegram:999",
+        responsePrefixContext: expect.objectContaining({
+          provider: "openai",
+          model: "gpt-5.2",
+          modelFull: "openai/gpt-5.2",
+          thinkingLevel: "high",
+        }),
+      }),
+    );
+  });
+
+  it("passes fresh session entry to routeReply responsePrefixContext after command mutations", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+
+    // First load (before replyResolver): stale thinkingLevel
+    vi.spyOn(sessionStore, "loadSessionStore")
+      .mockReturnValueOnce({
+        "test-session-key": {
+          sessionId: "sid",
+          updatedAt: 123,
+          modelOverride: "anthropic/claude-sonnet-4-6",
+          providerOverride: "anthropic",
+          thinkingLevel: "off",
+        },
+      })
+      // Second load (after replyResolver): /think changed thinkingLevel to "high"
+      .mockReturnValueOnce({
+        "test-session-key": {
+          sessionId: "sid",
+          updatedAt: 456,
+          modelOverride: "anthropic/claude-sonnet-4-6",
+          providerOverride: "anthropic",
+          thinkingLevel: "high",
+        },
+      });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    const replyResolver = vi.fn().mockResolvedValue([{ text: "Thinking mode: high" }]);
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+    });
+
+    // Should use fresh entry with thinkingLevel "high", not stale "off"
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responsePrefixContext: expect.objectContaining({
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          modelFull: "anthropic/claude-sonnet-4-6",
+          thinkingLevel: "high",
+        }),
+      }),
+    );
+  });
+
+  // Exercises the !modelSelected fallback (~line 591 in dispatch-from-config.ts)
+  // where the reply resolver never triggered onModelSelected (e.g. /stop, /status).
+  it("preserves nested model IDs in onModelSelected fallback for command replies", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValueOnce({
+      "test-session-key": {
+        sessionId: "sid",
+        createdAt: 123,
+        modelOverride: "hf:moonshotai/Kimi-K2.5",
+        providerOverride: "synthetic",
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx(),
+      SessionKey: "test-session-key",
+    };
+
+    const replyResolver = vi.fn().mockResolvedValue([{ text: "Done." }]);
+    const onModelSelected = vi.fn();
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected },
+    });
+
+    // Full path "hf:moonshotai/Kimi-K2.5" preserved so downstream
+    // createReplyPrefixContext can build correct modelFull
+    expect(onModelSelected).toHaveBeenCalledWith({
+      provider: "synthetic",
+      model: "hf:moonshotai/Kimi-K2.5",
+      thinkLevel: "off",
+    });
+  });
+
+  it("preserves nested model IDs in modelFull for routed replies", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValueOnce({
+      "test-session-key": {
+        sessionId: "sid",
+        createdAt: 123,
+        modelOverride: "hf:moonshotai/Kimi-K2.5",
+        providerOverride: "synthetic",
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    const replyResolver = vi.fn().mockResolvedValue([{ text: "Done." }]);
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+    });
+
+    // modelFull should preserve the nested path "hf:moonshotai/Kimi-K2.5"
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responsePrefixContext: expect.objectContaining({
+          provider: "synthetic",
+          model: "Kimi-K2.5",
+          modelFull: "synthetic/hf:moonshotai/Kimi-K2.5",
+          thinkingLevel: "off",
+        }),
+      }),
+    );
+  });
+
+  it("infers provider from nested model string when providerOverride is absent", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValueOnce({
+      "test-session-key": {
+        sessionId: "sid",
+        updatedAt: 123,
+        modelOverride: "hf:moonshotai/Kimi-K2.5",
+        // providerOverride intentionally absent — provider inferred from model prefix
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    const replyResolver = vi.fn().mockResolvedValue([{ text: "Done." }]);
+    const onModelSelected = vi.fn();
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected },
+    });
+
+    // Provider inferred as "hf:moonshotai" from model prefix; matching prefix
+    // stripped by stripMatchingProviderPrefix, leaving "Kimi-K2.5".
+    expect(onModelSelected).toHaveBeenCalledWith({
+      provider: "hf:moonshotai",
+      model: "Kimi-K2.5",
+      thinkLevel: "off",
+    });
+
+    // Routed reply should have consistent modelFull
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responsePrefixContext: expect.objectContaining({
+          provider: "hf:moonshotai",
+          model: "Kimi-K2.5",
+          modelFull: "hf:moonshotai/Kimi-K2.5",
+        }),
+      }),
+    );
+  });
+
+  it("routed final reply uses captured model from onModelSelected over session overrides", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValue({
+      "test-session-key": {
+        sessionId: "sid",
+        updatedAt: 123,
+        modelOverride: "openai/gpt-5.2",
+        providerOverride: "openai",
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    // Simulate the run selecting a different model (fallback/override)
+    const replyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions, _cfg?: OpenClawConfig) => {
+        opts?.onModelSelected?.({
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          thinkLevel: "high",
+        });
+        return [{ text: "Hi from Claude." }] satisfies ReplyPayload[];
+      },
+    );
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected: vi.fn() },
+    });
+
+    // Should use the actual model selected during the run, not session overrides
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responsePrefixContext: expect.objectContaining({
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          modelFull: "anthropic/claude-sonnet-4-6",
+          thinkingLevel: "high",
+        }),
+      }),
+    );
+  });
+
+  it("routed block/tool payloads include responsePrefixContext from onModelSelected", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValue({
+      "test-session-key": {
+        sessionId: "sid",
+        updatedAt: 123,
+        modelOverride: "openai/gpt-5.2",
+        providerOverride: "openai",
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    const replyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions, _cfg?: OpenClawConfig) => {
+        opts?.onModelSelected?.({
+          provider: "openai",
+          model: "gpt-5.2",
+          thinkLevel: "low",
+        });
+        await opts?.onToolResult?.({ text: "🔧 ran tool" });
+        await opts?.onBlockReply?.({ text: "block content" });
+        return undefined;
+      },
+    );
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected: vi.fn() },
+    });
+
+    // Both tool result and block reply should include responsePrefixContext
+    expect(mocks.routeReply).toHaveBeenCalledTimes(2);
+    for (const call of mocks.routeReply.mock.calls) {
+      const params = call[0] as { responsePrefixContext?: Record<string, unknown> };
+      expect(params.responsePrefixContext).toEqual(
+        expect.objectContaining({
+          provider: "openai",
+          model: "gpt-5.2",
+          modelFull: "openai/gpt-5.2",
+          thinkingLevel: "low",
+        }),
+      );
+    }
+  });
+
+  it("routed block payloads use session prefix context when onModelSelected never fires", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValue({
+      "test-session-key": {
+        sessionId: "sid",
+        updatedAt: 123,
+        modelOverride: "anthropic/claude-opus-4-6",
+        providerOverride: "anthropic",
+        thinkingLevel: "high",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    // No onModelSelected call — simulates command-only path
+    const replyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions, _cfg?: OpenClawConfig) => {
+        await opts?.onBlockReply?.({ text: "streaming block" });
+        return undefined;
+      },
+    );
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+    });
+
+    // Falls back to session-based prefix context
+    expect(mocks.routeReply).toHaveBeenCalledTimes(1);
+    const params = mocks.routeReply.mock.calls[0]?.[0] as {
+      responsePrefixContext?: Record<string, unknown>;
+    };
+    expect(params.responsePrefixContext).toEqual(
+      expect.objectContaining({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        modelFull: "anthropic/claude-opus-4-6",
+        thinkingLevel: "high",
+      }),
+    );
+  });
+
+  it("routed modelFull avoids double-prefix when mctx.model is fully-qualified", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValue({
+      "test-session-key": {
+        sessionId: "sid",
+        updatedAt: 123,
+        modelOverride: "openai/gpt-5.2",
+        providerOverride: "openai",
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    // Simulate onModelSelected with a fully-qualified model string
+    const replyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions, _cfg?: OpenClawConfig) => {
+        opts?.onModelSelected?.({
+          provider: "anthropic",
+          model: "anthropic/claude-sonnet-4-6",
+          thinkLevel: "high",
+        });
+        return [{ text: "response" }] satisfies ReplyPayload[];
+      },
+    );
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected: vi.fn() },
+    });
+
+    // modelFull must NOT be "anthropic/anthropic/claude-sonnet-4-6"
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responsePrefixContext: expect.objectContaining({
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          modelFull: "anthropic/claude-sonnet-4-6",
+          thinkingLevel: "high",
+        }),
+      }),
+    );
+  });
+
+  it("routed block payloads before onModelSelected use session-fallback context", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    // Capture deep-copied snapshots of responsePrefixContext at each call,
+    // since the mutable streamingPrefixContext object is passed by reference.
+    const capturedContexts: Record<string, unknown>[] = [];
+    mocks.routeReply.mockImplementation(async (params: unknown) => {
+      const p = params as Record<string, unknown>;
+      if (p.responsePrefixContext && typeof p.responsePrefixContext === "object") {
+        capturedContexts.push({ ...p.responsePrefixContext } as Record<string, unknown>);
+      }
+      return { ok: true as boolean, messageId: "mock" };
+    });
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValue({
+      "test-session-key": {
+        sessionId: "sid",
+        updatedAt: 123,
+        modelOverride: "openai/gpt-5.2",
+        providerOverride: "openai",
+        thinkingLevel: "low",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    // Simulate block/tool arriving BEFORE onModelSelected fires
+    const replyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions, _cfg?: OpenClawConfig) => {
+        // Block fires first — no model selected yet
+        await opts?.onBlockReply?.({ text: "early block" });
+        // Then model is selected
+        opts?.onModelSelected?.({
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          thinkLevel: "high",
+        });
+        // Another block fires after model selection
+        await opts?.onBlockReply?.({ text: "late block" });
+        return undefined;
+      },
+    );
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected: vi.fn() },
+    });
+
+    // Two block payloads routed
+    expect(capturedContexts).toHaveLength(2);
+
+    // First block (before onModelSelected) should use session-fallback context
+    expect(capturedContexts[0]).toEqual(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.2",
+        modelFull: "openai/gpt-5.2",
+        thinkingLevel: "low",
+      }),
+    );
+
+    // Second block (after onModelSelected) should use updated model context
+    expect(capturedContexts[1]).toEqual(
+      expect.objectContaining({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        modelFull: "anthropic/claude-sonnet-4-6",
+        thinkingLevel: "high",
+      }),
+    );
+  });
+
+  it("fast-abort routed reply has correct responsePrefixContext without modelFull double-prefix", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({
+      handled: true,
+      aborted: true,
+      stoppedSubagents: 0,
+    });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValueOnce({
+      "test-session-key": {
+        sessionId: "sid",
+        createdAt: 123,
+        modelOverride: "openai/gpt-5.2-20260205",
+        providerOverride: "openai",
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+    });
+
+    // Should route to originating channel with correct prefix context
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "telegram:999",
+        responsePrefixContext: expect.objectContaining({
+          provider: "openai",
+          // model should be short (no provider prefix) — no double "openai/openai/gpt-5.2"
+          model: "gpt-5.2",
+          modelFull: "openai/gpt-5.2",
+          thinkingLevel: "off",
+        }),
+      }),
+    );
+  });
+
+  it("cross-provider model prefix does not produce triple-segment modelFull", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+    mocks.routeReply.mockClear();
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValue({
+      "test-session-key": {
+        sessionId: "sid",
+        updatedAt: 123,
+        modelOverride: "openai/gpt-5.2",
+        providerOverride: "openai",
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx({
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+      }),
+      SessionKey: "test-session-key",
+    };
+
+    // Simulate onModelSelected with a model whose prefix differs from provider
+    // (e.g. provider="openai" but model="azure/gpt-4o")
+    const replyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions, _cfg?: OpenClawConfig) => {
+        opts?.onModelSelected?.({
+          provider: "openai",
+          model: "azure/gpt-4o",
+          thinkLevel: "off",
+        });
+        return [{ text: "response" }] satisfies ReplyPayload[];
+      },
+    );
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected: vi.fn() },
+    });
+
+    // modelFull must be "openai/gpt-4o", NOT "openai/azure/gpt-4o"
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responsePrefixContext: expect.objectContaining({
+          provider: "openai",
+          model: "gpt-4o",
+          modelFull: "openai/gpt-4o",
+          thinkingLevel: "off",
+        }),
+      }),
+    );
+  });
 });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1906,3 +1906,52 @@ describe("dispatchReplyFromConfig", () => {
     expect(blockReplySentTexts).toContain("The answer is 42");
   });
 });
+
+describe("Response Prefix Template Interpolation", () => {
+  it("calls onModelSelected with session fallback for command replies like /stop", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValueOnce({ handled: false, aborted: false });
+
+    const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+    const sessionStore = await import("../../config/sessions.js");
+    vi.spyOn(sessionStore, "loadSessionStore").mockReturnValueOnce({
+      "test-session-key": {
+        sessionId: "sid",
+        createdAt: 123,
+        modelOverride: "kimi-k2.5",
+        providerOverride: "kimi",
+        thinkingLevel: "off",
+      },
+    });
+
+    const ctx = {
+      ...buildTestCtx(),
+      SessionKey: "test-session-key",
+    };
+
+    const replyResolver = vi.fn().mockResolvedValue([{ text: "⚙️ Agent was aborted." }]);
+    const onModelSelected = vi.fn();
+
+    const dispatcher = {
+      sendFinalReply: vi.fn().mockReturnValue(true),
+      sendBlockReply: vi.fn().mockReturnValue(true),
+      sendToolResult: vi.fn().mockReturnValue(true),
+      getQueuedCounts: vi.fn().mockReturnValue({ final: 0, block: 0, tool: 0 }),
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {},
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected },
+    });
+
+    expect(onModelSelected).toHaveBeenCalledWith({
+      provider: "kimi",
+      model: "kimi-k2.5",
+      thinkLevel: "off",
+    });
+  });
+});

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -29,15 +29,41 @@ import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { GetReplyOptions, ModelSelectedContext, ReplyPayload } from "../types.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
 import { shouldBypassAcpDispatchForCommand, tryDispatchAcpReply } from "./dispatch-acp.js";
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { shouldSuppressReasoningPayload } from "./reply-payloads.js";
-import { extractShortModelName, type ResponsePrefixContext } from "./response-prefix-template.js";
+import {
+  extractShortModelName,
+  stripModelSuffixes,
+  type ResponsePrefixContext,
+} from "./response-prefix-template.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
+
+/**
+ * Resolve provider from explicit override or by extracting the prefix before
+ * the first "/" in the model string. Falls back to "unknown" when neither is
+ * available.
+ */
+function resolveProviderFallback(rawProvider: string | undefined, rawModel: string): string {
+  return rawProvider || (rawModel.includes("/") ? rawModel.split("/")[0] : "unknown");
+}
+
+/**
+ * Strip the provider-prefix segment from a model string only when it matches
+ * the resolved provider. Preserves internal path segments for nested model
+ * IDs like "hf:moonshotai/Kimi-K2.5".
+ */
+function stripMatchingProviderPrefix(rawModel: string, provider: string): string {
+  const firstSlash = rawModel.indexOf("/");
+  if (firstSlash >= 0 && rawModel.slice(0, firstSlash) === provider) {
+    return rawModel.slice(firstSlash + 1);
+  }
+  return rawModel;
+}
 
 const AUDIO_PLACEHOLDER_RE = /^<media:audio>(\s*\([^)]*\))?$/i;
 const AUDIO_HEADER_RE = /^\[Audio\b/i;
@@ -107,12 +133,28 @@ export type DispatchFromConfigResult = {
 };
 
 /**
- * Build a ResponsePrefixContext for an abort reply from the session entry and
- * config. Template variables like `{model}` and `{thinkingLevel}` in
- * responsePrefix are resolved from the session's persisted overrides so the
- * abort message is prefixed consistently with normal replies.
+ * Apply model-selected context onto a ResponsePrefixContext.
+ * Used by both the streaming (trackedOnModelSelected) and final prefix
+ * context paths to ensure consistent provider/model/modelFull/thinkingLevel
+ * derivation from the actual model chosen for a turn.
  */
-function buildAbortPrefixContext(params: {
+function applyModelSelectedContext(ctx: ResponsePrefixContext, mctx: ModelSelectedContext): void {
+  ctx.provider = mctx.provider;
+  ctx.model = extractShortModelName(mctx.model);
+  // Use extractShortModelName for modelFull too — consistent with ctx.model
+  // and avoids asymmetry when mctx.model has a provider prefix that doesn't
+  // match mctx.provider (e.g. "azure/gpt-4o" with provider "openai").
+  ctx.modelFull = `${mctx.provider}/${ctx.model}`;
+  ctx.thinkingLevel = mctx.thinkLevel ?? "off";
+}
+
+/**
+ * Build a ResponsePrefixContext from the session entry and config.
+ * Template variables like `{model}` and `{thinkingLevel}` in responsePrefix
+ * are resolved from the session's persisted overrides so abort messages and
+ * routed replies are prefixed consistently with normal replies.
+ */
+function buildSessionPrefixContext(params: {
   cfg: OpenClawConfig;
   sessionKey: string | undefined;
   sessionEntry: SessionEntry | undefined;
@@ -125,12 +167,24 @@ function buildAbortPrefixContext(params: {
 
   const rawModel = sessionEntry?.modelOverride?.trim();
   const rawProvider = sessionEntry?.providerOverride?.trim();
+  const provider = rawModel ? resolveProviderFallback(rawProvider, rawModel) : rawProvider;
+  const shortModel = rawModel ? extractShortModelName(rawModel) : undefined;
+
+  // Build the model segment for modelFull. Strip the first "/" segment only
+  // when it matches the resolved provider to avoid duplication (e.g.
+  // "openai/gpt-5.2" → "gpt-5.2"). Otherwise keep the full rawModel so
+  // nested model IDs like "hf:moonshotai/Kimi-K2.5" are preserved intact.
+  // Uses shared stripModelSuffixes to stay aligned with extractShortModelName.
+  const modelSegmentForFull =
+    rawModel && provider
+      ? stripModelSuffixes(stripMatchingProviderPrefix(rawModel, provider))
+      : undefined;
 
   return {
     identityName,
-    model: rawModel ? extractShortModelName(rawModel) : undefined,
-    modelFull: rawModel && rawProvider ? `${rawProvider}/${rawModel}` : undefined,
-    provider: rawProvider,
+    model: shortModel,
+    modelFull: provider && modelSegmentForFull ? `${provider}/${modelSegmentForFull}` : undefined,
+    provider,
     thinkingLevel: sessionEntry?.thinkingLevel ?? "off",
   };
 }
@@ -205,6 +259,18 @@ export async function dispatchReplyFromConfig(params: {
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
+
+  // Mutable prefix context for streaming payloads (block/tool results routed
+  // via sendPayloadAsync). Initialized from session overrides; updated by
+  // onModelSelected with the actual model used for this turn.
+  // NOTE: intentional asymmetry — this uses the pre-run session entry so it's
+  // available immediately for streaming, while finalPrefixContext (below) uses
+  // a fresh session re-read after the run to pick up command-mutated overrides.
+  const streamingPrefixContext: ResponsePrefixContext = buildSessionPrefixContext({
+    cfg,
+    sessionKey: ctx.SessionKey,
+    sessionEntry: sessionStoreEntry.entry,
+  });
   const hookRunner = getGlobalHookRunner();
 
   // Extract message context for hooks (plugin and internal)
@@ -297,6 +363,7 @@ export async function dispatchReplyFromConfig(params: {
       mirror,
       isGroup,
       groupId,
+      responsePrefixContext: streamingPrefixContext,
     });
     if (!result.ok) {
       logVerbose(`dispatch-from-config: route-reply failed: ${result.error ?? "unknown error"}`);
@@ -312,9 +379,13 @@ export async function dispatchReplyFromConfig(params: {
       // from session overrides so responsePrefix templates like {model} can interpolate.
       const rawModel = sessionStoreEntry.entry?.modelOverride?.trim();
       if (rawModel && params.replyOptions?.onModelSelected) {
+        const rawProvider = sessionStoreEntry.entry?.providerOverride?.trim();
+        const provider = resolveProviderFallback(rawProvider, rawModel);
+        // Strip date/latest suffixes so downstream modelFull is consistent
+        // with buildSessionPrefixContext (both use stripModelSuffixes).
         params.replyOptions.onModelSelected({
-          provider: sessionStoreEntry.entry?.providerOverride?.trim() ?? "unknown",
-          model: rawModel,
+          provider,
+          model: stripModelSuffixes(stripMatchingProviderPrefix(rawModel, provider)),
           thinkLevel: sessionStoreEntry.entry?.thinkingLevel ?? "off",
         });
       }
@@ -335,7 +406,7 @@ export async function dispatchReplyFromConfig(params: {
           cfg,
           isGroup,
           groupId,
-          responsePrefixContext: buildAbortPrefixContext({
+          responsePrefixContext: buildSessionPrefixContext({
             cfg,
             sessionKey: ctx.SessionKey,
             sessionEntry: sessionStoreEntry.entry,
@@ -454,8 +525,13 @@ export async function dispatchReplyFromConfig(params: {
     // If it didn't (e.g. commands like /stop or /status), we provide a fallback
     // so responsePrefix templates like {model} still resolve.
     let modelSelected = false;
-    const trackedOnModelSelected = (mctx: import("../types.js").ModelSelectedContext) => {
+    let capturedModelCtx: ModelSelectedContext | undefined;
+    const trackedOnModelSelected = (mctx: ModelSelectedContext) => {
       modelSelected = true;
+      capturedModelCtx = mctx;
+      // Update streaming prefix context with actual model so block/tool
+      // payloads routed via sendPayloadAsync interpolate correctly.
+      applyModelSelectedContext(streamingPrefixContext, mctx);
       params.replyOptions?.onModelSelected?.(mctx);
     };
 
@@ -550,18 +626,39 @@ export async function dispatchReplyFromConfig(params: {
       }
     }
 
+    // Re-read session entry — commands like /think and /model mutate session fields during
+    // directive handling, so the entry captured before replyResolver may be stale.
+    const freshEntry = resolveSessionStoreLookup(ctx, cfg).entry ?? sessionStoreEntry.entry;
+
     if (!modelSelected && params.replyOptions?.onModelSelected) {
-      const rawModel = sessionStoreEntry.entry?.modelOverride?.trim();
+      const rawModel = freshEntry?.modelOverride?.trim();
       if (rawModel) {
+        const rawProvider = freshEntry?.providerOverride?.trim();
+        const provider = resolveProviderFallback(rawProvider, rawModel);
+        // Strip date/latest suffixes so downstream modelFull is consistent
+        // with buildSessionPrefixContext (both use stripModelSuffixes).
         params.replyOptions.onModelSelected({
-          provider: sessionStoreEntry.entry?.providerOverride?.trim() ?? "unknown",
-          model: rawModel,
-          thinkLevel: sessionStoreEntry.entry?.thinkingLevel ?? "off",
+          provider,
+          model: stripModelSuffixes(stripMatchingProviderPrefix(rawModel, provider)),
+          thinkLevel: freshEntry?.thinkingLevel ?? "off",
         });
       }
     }
 
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
+
+    // Build final prefix context from fresh session entry, overlaying with
+    // the actual model selected during this turn when available. This ensures
+    // routed replies use the real model (from onModelSelected) rather than
+    // stale session overrides when model fallback/select happened.
+    const finalPrefixContext = buildSessionPrefixContext({
+      cfg,
+      sessionKey: ctx.SessionKey,
+      sessionEntry: freshEntry,
+    });
+    if (capturedModelCtx) {
+      applyModelSelectedContext(finalPrefixContext, capturedModelCtx);
+    }
 
     let queuedFinal = false;
     let routedFinalCount = 0;
@@ -591,13 +688,7 @@ export async function dispatchReplyFromConfig(params: {
           cfg,
           isGroup,
           groupId,
-          // Ensure we provide prefix context for replies bypassing the dispatcher
-          // (like /stop command aborts) so {model} templates interpolate correctly
-          responsePrefixContext: buildAbortPrefixContext({
-            cfg,
-            sessionKey: ctx.SessionKey,
-            sessionEntry: sessionStoreEntry.entry,
-          }),
+          responsePrefixContext: finalPrefixContext,
         });
         if (!result.ok) {
           logVerbose(

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,4 +1,5 @@
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveIdentityName } from "../../agents/identity.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   loadSessionStore,
@@ -34,6 +35,7 @@ import { shouldBypassAcpDispatchForCommand, tryDispatchAcpReply } from "./dispat
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { shouldSuppressReasoningPayload } from "./reply-payloads.js";
+import { extractShortModelName, type ResponsePrefixContext } from "./response-prefix-template.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 
@@ -103,6 +105,35 @@ export type DispatchFromConfigResult = {
   queuedFinal: boolean;
   counts: Record<ReplyDispatchKind, number>;
 };
+
+/**
+ * Build a ResponsePrefixContext for an abort reply from the session entry and
+ * config. Template variables like `{model}` and `{thinkingLevel}` in
+ * responsePrefix are resolved from the session's persisted overrides so the
+ * abort message is prefixed consistently with normal replies.
+ */
+function buildAbortPrefixContext(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string | undefined;
+  sessionEntry: SessionEntry | undefined;
+}): ResponsePrefixContext {
+  const { cfg, sessionKey, sessionEntry } = params;
+  const agentId = sessionKey
+    ? resolveSessionAgentId({ sessionKey, config: cfg })
+    : resolveSessionAgentId({ config: cfg });
+  const identityName = resolveIdentityName(cfg, agentId);
+
+  const rawModel = sessionEntry?.modelOverride?.trim();
+  const rawProvider = sessionEntry?.providerOverride?.trim();
+
+  return {
+    identityName,
+    model: rawModel ? extractShortModelName(rawModel) : undefined,
+    modelFull: rawModel && rawProvider ? `${rawProvider}/${rawModel}` : undefined,
+    provider: rawProvider,
+    thinkingLevel: sessionEntry?.thinkingLevel ?? "off",
+  };
+}
 
 export async function dispatchReplyFromConfig(params: {
   ctx: FinalizedMsgContext;
@@ -277,6 +308,17 @@ export async function dispatchReplyFromConfig(params: {
   try {
     const fastAbort = await tryFastAbortFromMessage({ ctx, cfg });
     if (fastAbort.handled) {
+      // For fast aborts, model selection never happens. Populate the dispatcher's context
+      // from session overrides so responsePrefix templates like {model} can interpolate.
+      const rawModel = sessionStoreEntry.entry?.modelOverride?.trim();
+      if (rawModel && params.replyOptions?.onModelSelected) {
+        params.replyOptions.onModelSelected({
+          provider: sessionStoreEntry.entry?.providerOverride?.trim() ?? "unknown",
+          model: rawModel,
+          thinkLevel: sessionStoreEntry.entry?.thinkingLevel ?? "off",
+        });
+      }
+
       const payload = {
         text: formatAbortReplyText(fastAbort.stoppedSubagents),
       } satisfies ReplyPayload;
@@ -293,6 +335,11 @@ export async function dispatchReplyFromConfig(params: {
           cfg,
           isGroup,
           groupId,
+          responsePrefixContext: buildAbortPrefixContext({
+            cfg,
+            sessionKey: ctx.SessionKey,
+            sessionEntry: sessionStoreEntry.entry,
+          }),
         });
         queuedFinal = result.ok;
         if (result.ok) {
@@ -403,10 +450,20 @@ export async function dispatchReplyFromConfig(params: {
       systemEvent: shouldRouteToOriginating,
     });
 
+    // Wrap onModelSelected to track whether the run actually picked a model.
+    // If it didn't (e.g. commands like /stop or /status), we provide a fallback
+    // so responsePrefix templates like {model} still resolve.
+    let modelSelected = false;
+    const trackedOnModelSelected = (mctx: import("../types.js").ModelSelectedContext) => {
+      modelSelected = true;
+      params.replyOptions?.onModelSelected?.(mctx);
+    };
+
     const replyResult = await (params.replyResolver ?? getReplyFromConfig)(
       ctx,
       {
         ...params.replyOptions,
+        onModelSelected: trackedOnModelSelected,
         typingPolicy: typing.typingPolicy,
         suppressTyping: typing.suppressTyping,
         onToolResult: (payload: ReplyPayload) => {
@@ -493,6 +550,17 @@ export async function dispatchReplyFromConfig(params: {
       }
     }
 
+    if (!modelSelected && params.replyOptions?.onModelSelected) {
+      const rawModel = sessionStoreEntry.entry?.modelOverride?.trim();
+      if (rawModel) {
+        params.replyOptions.onModelSelected({
+          provider: sessionStoreEntry.entry?.providerOverride?.trim() ?? "unknown",
+          model: rawModel,
+          thinkLevel: sessionStoreEntry.entry?.thinkingLevel ?? "off",
+        });
+      }
+    }
+
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
 
     let queuedFinal = false;
@@ -523,6 +591,13 @@ export async function dispatchReplyFromConfig(params: {
           cfg,
           isGroup,
           groupId,
+          // Ensure we provide prefix context for replies bypassing the dispatcher
+          // (like /stop command aborts) so {model} templates interpolate correctly
+          responsePrefixContext: buildAbortPrefixContext({
+            cfg,
+            sessionKey: ctx.SessionKey,
+            sessionEntry: sessionStoreEntry.entry,
+          }),
         });
         if (!result.ok) {
           logVerbose(

--- a/src/auto-reply/reply/response-prefix-template.ts
+++ b/src/auto-reply/reply/response-prefix-template.ts
@@ -67,6 +67,15 @@ export function resolveResponsePrefixTemplate(
 }
 
 /**
+ * Strip date-stamp (`-YYYYMMDD`) and `-latest` suffixes from a model name.
+ * Shared by {@link extractShortModelName} and callers that need suffix
+ * stripping without provider-prefix removal.
+ */
+export function stripModelSuffixes(model: string): string {
+  return model.replace(/-\d{8}$/, "").replace(/-latest$/, "");
+}
+
+/**
  * Extract short model name from a full model string.
  *
  * Strips:
@@ -84,8 +93,7 @@ export function extractShortModelName(fullModel: string): string {
   const slash = fullModel.lastIndexOf("/");
   const modelPart = slash >= 0 ? fullModel.slice(slash + 1) : fullModel;
 
-  // Strip date suffixes (YYYYMMDD format)
-  return modelPart.replace(/-\d{8}$/, "").replace(/-latest$/, "");
+  return stripModelSuffixes(modelPart);
 }
 
 /**

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -19,6 +19,7 @@ import type { OriginatingChannelType } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import { shouldSuppressReasoningPayload } from "./reply-payloads.js";
+import type { ResponsePrefixContext } from "./response-prefix-template.js";
 
 let deliverRuntimePromise: Promise<
   typeof import("../../infra/outbound/deliver-runtime.js")
@@ -52,6 +53,12 @@ export type RouteReplyParams = {
   isGroup?: boolean;
   /** Group or channel identifier for correlation with received events */
   groupId?: string;
+  /**
+   * Optional context for interpolating template variables in responsePrefix.
+   * When provided, placeholders like `{model}` and `{thinkingLevel}` in
+   * responsePrefix are replaced with the supplied values.
+   */
+  responsePrefixContext?: ResponsePrefixContext;
 };
 
 export type RouteReplyResult = {
@@ -96,6 +103,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       : cfg.messages?.responsePrefix;
   const normalized = normalizeReplyPayload(payload, {
     responsePrefix,
+    responsePrefixContext: params.responsePrefixContext,
     enableSlackInteractiveReplies:
       channel === "slack" ? isSlackInteractiveRepliesEnabled({ cfg, accountId }) : false,
   });


### PR DESCRIPTION
Fixes #45314

### Summary
Fixes a bug where `responsePrefix` templates like `{model}` and `{thinkingLevel}` were not interpolated when returning replies from early aborts (e.g. `/stop`) or other slash commands.

### Changes
- Added a fallback in `dispatchReplyFromConfig` to invoke `onModelSelected` using the session entry's override if a model was never naturally selected during the turn (e.g. command paths).
- Added `responsePrefixContext` to `routeReply` params to support direct-routed replies (fast-abort path) where the dispatcher context is bypassed.
- Added `buildAbortPrefixContext` to derive the prefix context from `SessionEntry`.

### Testing
- Added tests verifying `onModelSelected` is invoked properly as a fallback for command replies.