### PR TITLE
fix(matrix): scope mention matching to the routed agent

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -67,6 +67,9 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
           hasControlCommand: vi.fn().mockReturnValue(false),
           resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
         },
+        mentions: {
+          buildMentionRegexes: vi.fn().mockReturnValue([]),
+        },
       },
       system: {
         enqueueSystemEvent: vi.fn(),
@@ -95,7 +98,6 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
       logVerboseMessage,
       allowFrom: [],
       roomsConfig: undefined,
-      mentionRegexes: [],
       groupPolicy: "open",
       replyToMode: "first",
       threadReplies: "inbound",
@@ -192,5 +194,126 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
         },
       }),
     ).toBe(false);
+  });
+
+  it("does not treat mentions for a different agent as authorized in group rooms", async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const formatInboundEnvelope = vi
+      .fn()
+      .mockImplementation((params: { senderLabel?: string; body: string }) => params.body);
+
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn().mockResolvedValue([]),
+          upsertPairingRequest: vi.fn().mockResolvedValue(undefined),
+        },
+        routing: {
+          buildAgentSessionKey: vi
+            .fn()
+            .mockImplementation(
+              (params: { agentId: string; channel: string; peer?: { kind: string; id: string } }) =>
+                `agent:${params.agentId}:${params.channel}:${params.peer?.kind ?? "direct"}:${params.peer?.id ?? "unknown"}`,
+            ),
+          resolveAgentRoute: vi.fn().mockReturnValue({
+            agentId: "main",
+            accountId: undefined,
+            sessionKey: "agent:main:matrix:channel:!room:example.org",
+            mainSessionKey: "agent:main:main",
+          }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(undefined),
+          recordInboundSession,
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatInboundEnvelope,
+          formatAgentEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+          resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+          createReplyDispatcherWithTyping: vi.fn().mockReturnValue({
+            dispatcher: {},
+            replyOptions: {},
+            markDispatchIdle: vi.fn(),
+          }),
+          withReplyDispatcher: vi
+            .fn()
+            .mockResolvedValue({ queuedFinal: false, counts: { final: 0, partial: 0, tool: 0 } }),
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+        },
+        text: {
+          hasControlCommand: vi.fn().mockReturnValue(false),
+          resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+        },
+        mentions: {
+          // Routed agent is "main" so only @main should count as a mention.
+          buildMentionRegexes: vi
+            .fn()
+            .mockImplementation((_: unknown, agentId?: string) =>
+              agentId === "main" ? [/@main/i] : [/@admin/i],
+            ),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+    } as unknown as PluginRuntime;
+
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as RuntimeLogger;
+
+    const handler = createMatrixRoomMessageHandler({
+      client: {
+        getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+      } as unknown as MatrixClient,
+      core,
+      cfg: {},
+      runtime: { error: vi.fn() } as unknown as RuntimeEnv,
+      logger,
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      groupPolicy: "open",
+      replyToMode: "first",
+      threadReplies: "inbound",
+      dmEnabled: true,
+      dmPolicy: "open",
+      textLimit: 4000,
+      mediaMaxBytes: 5 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(false),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "Dev Room",
+        canonicalAlias: "#dev:matrix.example.org",
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Bu"),
+      accountId: undefined,
+    });
+
+    await handler("!room:example.org", {
+      type: EventType.RoomMessage,
+      event_id: "$event-mention-bypass",
+      sender: "@bu:matrix.example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "@admin please run this",
+      },
+    } as unknown as MatrixRawEvent);
+
+    expect(formatInboundEnvelope).not.toHaveBeenCalled();
+    expect(recordInboundSession).not.toHaveBeenCalled();
   });
 });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -53,7 +53,6 @@ export type MatrixMonitorHandlerParams = {
   logVerboseMessage: (message: string) => void;
   allowFrom: string[];
   roomsConfig: Record<string, MatrixRoomConfig> | undefined;
-  mentionRegexes: ReturnType<PluginRuntime["channel"]["mentions"]["buildMentionRegexes"]>;
   groupPolicy: "open" | "allowlist" | "disabled";
   replyToMode: ReplyToMode;
   threadReplies: "off" | "inbound" | "always";
@@ -137,7 +136,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     logVerboseMessage,
     allowFrom,
     roomsConfig,
-    mentionRegexes,
     groupPolicy,
     replyToMode,
     threadReplies,
@@ -410,6 +408,23 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         return;
       }
 
+      const baseRoute = core.channel.routing.resolveAgentRoute({
+        cfg,
+        channel: "matrix",
+        accountId,
+        peer: {
+          kind: isDirectMessage ? "direct" : "channel",
+          id: isDirectMessage ? senderId : roomId,
+        },
+        // For DMs, pass roomId as parentPeer so the conversation is bindable by room ID
+        // while preserving DM trust semantics (secure 1:1, no group restrictions).
+        parentPeer: isDirectMessage ? { kind: "channel", id: roomId } : undefined,
+      });
+      // Enforce mention-gating with the routed agent's own mention patterns only.
+      // Using global patterns would allow mentions for unrelated agents to unlock
+      // dispatch in this room, bypassing intended routing boundaries.
+      const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, baseRoute.agentId);
+
       const { wasMentioned, hasExplicitMention } = resolveMentions({
         content,
         userId: selfUserId,
@@ -492,18 +507,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         isThreadRoot: false, // @vector-im/matrix-bot-sdk doesn't have this info readily available
       });
 
-      const baseRoute = core.channel.routing.resolveAgentRoute({
-        cfg,
-        channel: "matrix",
-        accountId,
-        peer: {
-          kind: isDirectMessage ? "direct" : "channel",
-          id: isDirectMessage ? senderId : roomId,
-        },
-        // For DMs, pass roomId as parentPeer so the conversation is bindable by room ID
-        // while preserving DM trust semantics (secure 1:1, no group restrictions).
-        parentPeer: isDirectMessage ? { kind: "channel", id: roomId } : undefined,
-      });
       const baseRouteSession = resolveMatrixBaseRouteSession({
         buildAgentSessionKey: core.channel.routing.buildAgentSessionKey,
         baseRoute,

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -295,7 +295,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   });
   setActiveMatrixClient(client, opts.accountId);
 
-  const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg);
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const { groupPolicy: groupPolicyRaw, providerMissingFallbackApplied } =
     resolveAllowlistProviderRuntimeGroupPolicy({
@@ -340,7 +339,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     logVerboseMessage,
     allowFrom,
     roomsConfig,
-    mentionRegexes,
     groupPolicy,
     replyToMode,
     threadReplies,


### PR DESCRIPTION
Problem
In the Matrix monitor, mention detection was not scoped to the routed agent for the current message. This meant mention text for a different agent could incorrectly satisfy the mention gate for the room's routed agent.

Root Cause
The Matrix monitor relied on startup-level/global mentionRegexes instead of resolving mention patterns per message after route resolution. As a result, mention checks were not tightly bound to the resolveAgentRoute(...) result.

Solution
This change resolves the route first and then builds mention regexes for the routed agent with core.channel.mentions.buildMentionRegexes(cfg, baseRoute.agentId). Mention matching therefore only applies to the routed agent for the current message.

Changes
- Build mention regexes after route resolution in extensions/matrix/src/matrix/monitor/handler.ts
- Remove startup-level mentionRegexes usage in extensions/matrix/src/matrix/monitor/index.ts
- Add a regression test in handler.body-for-agent.test.ts

Backward Compatibility
Routing and group allowlist behavior remain unchanged. Only mention detection scope is tightened.