### PR TITLE
fix(cron): persist payload.fallbacks in cron.update API

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -695,6 +695,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.bestEffortDeliver === "boolean") {
     next.bestEffortDeliver = patch.bestEffortDeliver;
   }
+  if (Array.isArray(patch.fallbacks)) {
+    next.fallbacks = patch.fallbacks;
+  }
   return next;
 }
 
@@ -763,6 +766,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     channel: patch.channel,
     to: patch.to,
     bestEffortDeliver: patch.bestEffortDeliver,
+    fallbacks: Array.isArray(patch.fallbacks) ? patch.fallbacks : undefined,
   };
 }
 

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -52,9 +52,9 @@ vi.mock("undici", () => ({
 }));
 
 import {
+  PROXY_FETCH_PROXY_URL,
   getProxyUrlFromFetch,
   makeProxyFetch,
-  PROXY_FETCH_PROXY_URL,
   resolveProxyFetchFromEnv,
 } from "./proxy-fetch.js";
 
@@ -116,13 +116,10 @@ describe("getProxyUrlFromFetch", () => {
 
   it("returns undefined for plain fetch functions or blank metadata", () => {
     const plainFetch = vi.fn() as unknown as typeof fetch;
-    const blankMetadataFetch = vi.fn() as unknown as typeof fetch;
-    Object.defineProperty(blankMetadataFetch, PROXY_FETCH_PROXY_URL, {
-      value: "   ",
-      enumerable: false,
-      configurable: true,
-      writable: true,
-    });
+    const blankMetadataFetch = vi.fn() as unknown as typeof fetch & {
+      [PROXY_FETCH_PROXY_URL]?: string;
+    };
+    blankMetadataFetch[PROXY_FETCH_PROXY_URL] = "   ";
 
     expect(getProxyUrlFromFetch(plainFetch)).toBeUndefined();
     expect(getProxyUrlFromFetch(blankMetadataFetch)).toBeUndefined();


### PR DESCRIPTION
Fixes issue with cron update API not persisting payload fallbacks correctly.