### PR TITLE
fix(voicewake): avoid crash on foreign transcript ranges

### DIFF
--- a/Swabble/Sources/SwabbleKit/WakeWordGate.swift
+++ b/Swabble/Sources/SwabbleKit/WakeWordGate.swift
@@ -106,20 +106,14 @@ public enum WakeWordGate {
         triggerEndTime: TimeInterval)
     -> String {
         let threshold = triggerEndTime + 0.001
+        var commandWords: [String] = []
+        commandWords.reserveCapacity(segments.count)
         for segment in segments where segment.start >= threshold {
-            if normalizeToken(segment.text).isEmpty { continue }
-            if let range = segment.range {
-                let slice = transcript[range.lowerBound...]
-                return String(slice).trimmingCharacters(in: Self.whitespaceAndPunctuation)
-            }
-            break
+            let normalized = normalizeToken(segment.text)
+            if normalized.isEmpty { continue }
+            commandWords.append(segment.text)
         }
-
-        let text = segments
-            .filter { $0.start >= threshold && !normalizeToken($0.text).isEmpty }
-            .map(\.text)
-            .joined(separator: " ")
-        return text.trimmingCharacters(in: Self.whitespaceAndPunctuation)
+        return commandWords.joined(separator: " ").trimmingCharacters(in: Self.whitespaceAndPunctuation)
     }
 
     public static func matchesTextOnly(text: String, triggers: [String]) -> Bool {

--- a/Swabble/Tests/SwabbleKitTests/WakeWordGateTests.swift
+++ b/Swabble/Tests/SwabbleKitTests/WakeWordGateTests.swift
@@ -46,6 +46,25 @@ import Testing
         let match = WakeWordGate.match(transcript: transcript, segments: segments, config: config)
         #expect(match?.command == "do it")
     }
+
+    @Test func commandTextHandlesForeignRangeIndices() {
+        let transcript = "hey clawd do thing"
+        let other = "do thing"
+        let foreignRange = other.range(of: "do")
+        let segments = [
+            WakeWordSegment(text: "hey", start: 0.0, duration: 0.1, range: transcript.range(of: "hey")),
+            WakeWordSegment(text: "clawd", start: 0.2, duration: 0.1, range: transcript.range(of: "clawd")),
+            WakeWordSegment(text: "do", start: 0.9, duration: 0.1, range: foreignRange),
+            WakeWordSegment(text: "thing", start: 1.1, duration: 0.1, range: nil),
+        ]
+
+        let command = WakeWordGate.commandText(
+            transcript: transcript,
+            segments: segments,
+            triggerEndTime: 0.3)
+
+        #expect(command == "do thing")
+    }
 }
 
 private func makeSegments(

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeRuntimeTests.swift
@@ -74,4 +74,22 @@ struct VoiceWakeRuntimeTests {
         let config = WakeWordGateConfig(triggers: ["openclaw"], minPostTriggerGap: 0.3)
         #expect(WakeWordGate.match(transcript: transcript, segments: segments, config: config)?.command == "do thing")
     }
+
+    @Test func `gate command text handles foreign string ranges`() {
+        let transcript = "hey openclaw do thing"
+        let other = "do thing"
+        let foreignRange = other.range(of: "do")
+        let segments = [
+            WakeWordSegment(text: "hey", start: 0.0, duration: 0.1, range: transcript.range(of: "hey")),
+            WakeWordSegment(text: "openclaw", start: 0.2, duration: 0.1, range: transcript.range(of: "openclaw")),
+            WakeWordSegment(text: "do", start: 0.9, duration: 0.1, range: foreignRange),
+            WakeWordSegment(text: "thing", start: 1.1, duration: 0.1, range: nil),
+        ]
+
+        #expect(
+            WakeWordGate.commandText(
+                transcript: transcript,
+                segments: segments,
+                triggerEndTime: 0.3) == "do thing")
+    }
 }


### PR DESCRIPTION
## What
- avoid direct string slicing with transcript segment ranges in `WakeWordGate.commandText`
- build command text from post-trigger speech segments only
- add regression coverage for foreign range indices in both Swabble and macOS voice wake tests

## Why
A segment range can be tied to a different transcript instance. Slicing the current transcript with that foreign range can crash in Swift string indexing.

## Validation
- Ran: `swift test --package-path apps/macos --filter VoiceWakeRuntimeTests`
- Result: pass
- Note: `swift test --package-path Swabble --filter WakeWordGateTests` still fails in this environment due the pre-existing availability issue in `Swabble/Sources/SwabbleCore/Support/AttributedString+Sentences.swift`

Supersedes #14458.
