### PR TITLE
fix(ui): keep dashboard chat image attachments on send

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -572,6 +572,93 @@ describe("sendChatMessage", () => {
       ],
     });
   });
+
+  it("sends attachment-only turns with image payloads", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await sendChatMessage(state, "", [
+      {
+        id: "att-1",
+        mimeType: "image/png",
+        dataUrl: "data:image/png;base64,QUJDRA==",
+      },
+    ]);
+
+    expect(result).toEqual(expect.any(String));
+    expect(request).toHaveBeenCalledWith("chat.send", {
+      sessionKey: "main",
+      message: "",
+      deliver: false,
+      idempotencyKey: expect.any(String),
+      attachments: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          content: "QUJDRA==",
+        },
+      ],
+    });
+  });
+
+  it("keeps image attachments when data URLs include extra metadata parameters", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await sendChatMessage(state, "see attached", [
+      {
+        id: "att-2",
+        mimeType: "image/png",
+        dataUrl: " data:image/png;charset=utf-8;name=clip.png;base64,QUJDRA== ",
+      },
+    ]);
+
+    expect(result).toEqual(expect.any(String));
+    expect(request).toHaveBeenCalledWith("chat.send", {
+      sessionKey: "main",
+      message: "see attached",
+      deliver: false,
+      idempotencyKey: expect.any(String),
+      attachments: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          content: "QUJDRA==",
+        },
+      ],
+    });
+  });
+
+  it("drops malformed attachment data URLs without blocking text sends", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await sendChatMessage(state, "hello", [
+      {
+        id: "att-3",
+        mimeType: "image/png",
+        dataUrl: "data:image/png,not-base64",
+      },
+    ]);
+
+    expect(result).toEqual(expect.any(String));
+    expect(request).toHaveBeenCalledWith("chat.send", {
+      sessionKey: "main",
+      message: "hello",
+      deliver: false,
+      idempotencyKey: expect.any(String),
+      attachments: [],
+    });
+  });
 });
 
 describe("abortChatRun", () => {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -93,12 +93,21 @@ export async function loadChatHistory(state: ChatState) {
   }
 }
 
-function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string } | null {
-  const match = /^data:([^;]+);base64,(.+)$/.exec(dataUrl);
+function dataUrlToBase64(
+  dataUrl: string,
+  mimeTypeHint?: string,
+): { content: string; mimeType: string } | null {
+  const trimmed = dataUrl.trim();
+  const match = /^data:([^,]*?);base64,([\s\S]+)$/i.exec(trimmed);
   if (!match) {
     return null;
   }
-  return { mimeType: match[1], content: match[2] };
+  const mimeType = match[1].split(";")[0]?.trim() || mimeTypeHint;
+  const content = match[2].trim();
+  if (!mimeType || !content) {
+    return null;
+  }
+  return { mimeType, content };
 }
 
 type AssistantMessageNormalizationOptions = {
@@ -201,7 +210,7 @@ export async function sendChatMessage(
   const apiAttachments = hasAttachments
     ? attachments
         .map((att) => {
-          const parsed = dataUrlToBase64(att.dataUrl);
+          const parsed = dataUrlToBase64(att.dataUrl, att.mimeType);
           if (!parsed) {
             return null;
           }


### PR DESCRIPTION
## Summary

Draft for one narrow dashboard-v2 carry-over fix from the recent UI audit backlog Henry called out.

- Fixes #45487
- Scope: keep dashboard-v2 chat image attachments in the `chat.send` payload
- This is one audited regression slice, not a broad v1 -> v2 sync PR

## Problem

Dashboard-v2 chat exposes image attachment affordances, but images can be silently dropped before the `chat.send` RPC is made. That leaves users with a composer that appears to support attachments while the agent receives an empty or text-only turn.

## Current Root-Cause Status

This PR is still Draft because the exact original end-user repro from #45487 is not fully pinned down yet.

What is confirmed in code today:
- the silent-loss point can occur in the dashboard-v2 UI controller
- `ui/src/ui/controllers/chat.ts` converts preview `data:` URLs into `chat.send` attachments
- if `dataUrlToBase64(...)` returns `null`, the attachment is dropped from `apiAttachments` before `state.client.request("chat.send", ...)` runs
- this path does not appear to go through `chat-sanitize.ts`; it is a direct UI -> RPC -> gateway path, so any fix here is dashboard-v2-specific

What is now confirmed in the live UI:
- the paperclip upload path works end-to-end with this change on a running dashboard session
- an uploaded verification PNG survived send and reached the model
- the model correctly answered `481726, red` when asked to read the image contents, confirming the image was actually available to the model after send

What is not yet confirmed:
- whether the original user repro in #45487 was specifically the same `data:` URL parsing failure covered here
- whether clipboard paste and drag/drop hit the same loss point in practice
- or whether another UI-layer loss point still exists in those paths (for example attachment state preservation or pre-send clearing)

Because of that, this change should currently be read as a targeted fix for one confirmed silent-drop path with live picker-upload verification, but not yet as the fully proven fix for every path described in #45487.

## Fix In This Draft

- make the dashboard-v2 data URL parser accept base64 image data URLs with optional extra metadata parameters before `;base64`
- keep the parser base64-specific
- trim input before parsing
- keep using the attachment MIME hint as fallback when needed
- add regression coverage for:
  - attachment-only sends
  - base64 data URLs with extra metadata parameters
  - malformed/non-base64 data URLs being dropped without blocking text sends

## Risk / Compatibility

Low risk.

- restores or hardens existing image-send behavior
- no new API surface
- no gateway contract change
- no expected impact on other channels

## How Tested

Automated:
- `pnpm -C ui exec vitest run src/ui/controllers/chat.test.ts`

Covered scenarios:
- attachment-only send keeps image payloads in `chat.send`
- text + image send keeps image payloads when the data URL contains extra metadata parameters
- malformed/non-base64 attachment data URLs are dropped without blocking text sends

Manual:
- live Control UI paperclip upload on a running dashboard session
- uploaded a verification PNG containing a 6-digit number and colored inner square
- prompt asked the model for the exact number and the inner-square color
- model response was `481726, red`
- confirms the uploaded image survived send and reached the model

Not yet manually verified:
- clipboard paste
- drag/drop

Not tested:
- non-image files, still out of scope

## Review Focus

- Is #45487 still the right audit slice to take first?
- Does the current scope look right: fix the confirmed UI silent-drop path without expanding into generic file support?
- If you have a concrete failing paste or drag/drop repro that still breaks after this patch, please share it so I can move the fix to the actual remaining source-of-loss before marking ready
