### PR TITLE
fix: enable updateLastRoute for group chats to persist sessions

### DIFF
--- a/src/telegram/bot-message-context.session.ts
+++ b/src/telegram/bot-message-context.session.ts
@@ -262,27 +262,27 @@ export async function buildTelegramInboundContextPayload(params: {
     storePath,
     sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
     ctx: ctxPayload,
-    updateLastRoute: !isGroup
-      ? {
-          sessionKey: updateLastRouteSessionKey,
-          channel: "telegram",
-          to: `telegram:${chatId}`,
-          accountId: route.accountId,
-          threadId: dmThreadId != null ? String(dmThreadId) : undefined,
-          mainDmOwnerPin:
-            updateLastRouteSessionKey === route.mainSessionKey && pinnedMainDmOwner && senderId
-              ? {
-                  ownerRecipient: pinnedMainDmOwner,
-                  senderRecipient: senderId,
-                  onSkip: ({ ownerRecipient, senderRecipient }) => {
-                    logVerbose(
-                      `telegram: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
-                    );
-                  },
-                }
-              : undefined,
-        }
-      : undefined,
+    updateLastRoute: {
+      sessionKey: updateLastRouteSessionKey,
+      channel: "telegram",
+      to: `telegram:${chatId}`,
+      accountId: route.accountId,
+      threadId: isGroup
+        ? (resolvedThreadId != null ? String(resolvedThreadId) : undefined)
+        : (dmThreadId != null ? String(dmThreadId) : undefined),
+      mainDmOwnerPin:
+        !isGroup && updateLastRouteSessionKey === route.mainSessionKey && pinnedMainDmOwner && senderId
+          ? {
+              ownerRecipient: pinnedMainDmOwner,
+              senderRecipient: senderId,
+              onSkip: ({ ownerRecipient, senderRecipient }) => {
+                logVerbose(
+                  `telegram: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
+                );
+              },
+            }
+          : undefined,
+    },
     onRecordError: (err) => {
       logVerbose(`telegram: failed updating session meta: ${String(err)}`);
     },


### PR DESCRIPTION
## Summary

- Enable `updateLastRoute` for Telegram group chats (was previously DM-only)
- Use `resolvedThreadId` for group thread tracking, `dmThreadId` for DMs
- Keep `mainDmOwnerPin` DM-only with `!isGroup &&` guard

## Problem

Group chat sessions are not persisted properly. All messages in a group generate the same session key (`telegram:group:<chatId>`), and because `updateLastRoute` was set to `undefined` for groups, delivery context was never updated. Each new message overwrites the previous session entry.

**Result**: A group with 166 messages (including 107 bot responses) shows only 1 session in `paw-monitor session list`.

DM sessions work correctly because they have `updateLastRoute` enabled.

## Root Cause

In `src/telegram/bot-message-context.session.ts` line 265:

```typescript
updateLastRoute: !isGroup ? { ... } : undefined,
```

Groups were explicitly excluded from delivery context tracking. The `!isGroup` guard was applied at too coarse a granularity — only `mainDmOwnerPin` (which pins session ownership for DMs) truly needs to be DM-only, but the entire `updateLastRoute` block was wrapped in `!isGroup`.

This causes `recordInboundSession()` in `src/channels/session.ts` to early-return at line 61:

```typescript
const update = params.updateLastRoute;
if (!update) {
  return;  // ← groups always hit this, skipping updateLastRoute() entirely
}
```

Without `updateLastRoute`, the session store only runs `recordSessionMetaFromInbound()`, which overwrites the single group session key on every message instead of properly tracking delivery context.

## Fix

Move the `!isGroup` guard down to only wrap `mainDmOwnerPin` (the DM-specific feature), instead of the entire `updateLastRoute` block:

- **Before**: `updateLastRoute: !isGroup ? { sessionKey, channel, to, threadId, mainDmOwnerPin } : undefined`
- **After**: `updateLastRoute: { sessionKey, channel, to, threadId, mainDmOwnerPin: !isGroup ? {...} : undefined }`

The `threadId` field uses `resolvedThreadId` for groups (supports Telegram forum topics) and `dmThreadId` for DMs.

## Test plan

- [ ] Verify group messages create/update session entries in the store
- [ ] Verify DM behavior is unchanged (regression check)
- [ ] Verify `mainDmOwnerPin` is still DM-only
- [ ] Verify forum topic threads use `resolvedThreadId` correctly

Fixes #45573