### PR TITLE
fix: use local timezone in backup archive names

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -17,13 +17,14 @@ openclaw backup create --dry-run --json
 openclaw backup create --verify
 openclaw backup create --no-include-workspace
 openclaw backup create --only-config
-openclaw backup verify ./2026-03-09T00-00-00.000Z-openclaw-backup.tar.gz
+openclaw backup verify ./2026-03-09T08-00-00.000+08-00-openclaw-backup.tar.gz
 ```
 
 ## Notes
 
 - The archive includes a `manifest.json` file with the resolved source paths and archive layout.
 - Default output is a timestamped `.tar.gz` archive in the current working directory.
+- Timestamped backup filenames use your machine's local timezone and include the UTC offset.
 - If the current working directory is inside a backed-up source tree, OpenClaw falls back to your home directory for the default archive location.
 - Existing archive files are never overwritten.
 - Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -72,7 +72,7 @@ export function registerBackupCommand(program: Command) {
       () =>
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
           [
-            "openclaw backup verify ./2026-03-09T00-00-00.000Z-openclaw-backup.tar.gz",
+            "openclaw backup verify ./2026-03-09T08-00-00.000+08-00-openclaw-backup.tar.gz",
             "Check that the archive structure and manifest are intact.",
           ],
           [

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -6,7 +6,6 @@ import {
   resolveOAuthDir,
   resolveStateDir,
 } from "../config/config.js";
-import { formatSessionArchiveTimestamp } from "../config/sessions/artifacts.js";
 import { pathExists, shortenHomePath } from "../utils.js";
 import { buildCleanupPlan, isPathWithin } from "./cleanup-utils.js";
 
@@ -57,8 +56,28 @@ function backupAssetPriority(kind: BackupAssetKind): number {
   }
 }
 
+export function formatBackupArchiveTimestamp(
+  nowMs = Date.now(),
+  offsetMinutes = -new Date(nowMs).getTimezoneOffset(),
+): string {
+  const shifted = nowMs + offsetMinutes * 60_000;
+  const local = new Date(shifted);
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absOffsetMinutes = Math.abs(offsetMinutes);
+  const offsetHours = String(Math.floor(absOffsetMinutes / 60)).padStart(2, "0");
+  const offsetMins = String(absOffsetMinutes % 60).padStart(2, "0");
+  const year = String(local.getUTCFullYear()).padStart(4, "0");
+  const month = String(local.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(local.getUTCDate()).padStart(2, "0");
+  const hours = String(local.getUTCHours()).padStart(2, "0");
+  const minutes = String(local.getUTCMinutes()).padStart(2, "0");
+  const seconds = String(local.getUTCSeconds()).padStart(2, "0");
+  const millis = String(local.getUTCMilliseconds()).padStart(3, "0");
+  return `${year}-${month}-${day}T${hours}-${minutes}-${seconds}.${millis}${sign}${offsetHours}-${offsetMins}`;
+}
+
 export function buildBackupArchiveRoot(nowMs = Date.now()): string {
-  return `${formatSessionArchiveTimestamp(nowMs)}-openclaw-backup`;
+  return `${formatBackupArchiveTimestamp(nowMs)}-openclaw-backup`;
 }
 
 export function buildBackupArchiveBasename(nowMs = Date.now()): string {

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -8,6 +8,7 @@ import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js"
 import {
   buildBackupArchiveRoot,
   encodeAbsolutePathForBackupArchive,
+  formatBackupArchiveTimestamp,
   resolveBackupPlanFromDisk,
 } from "./backup-shared.js";
 import { backupCreateCommand } from "./backup.js";
@@ -74,6 +75,15 @@ describe("backup commands", () => {
       expect.arrayContaining([expect.objectContaining({ kind: "workspace", reason: "covered" })]),
     );
   }
+
+  it("formats backup archive timestamps in local time with an explicit offset", () => {
+    expect(formatBackupArchiveTimestamp(Date.UTC(2026, 2, 14, 1, 2, 3, 456), 8 * 60)).toBe(
+      "2026-03-14T09-02-03.456+08-00",
+    );
+    expect(formatBackupArchiveTimestamp(Date.UTC(2026, 2, 14, 1, 2, 3, 456), -5 * 60)).toBe(
+      "2026-03-13T20-02-03.456-05-00",
+    );
+  });
 
   it("collapses default config, credentials, and workspace into the state backup root", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");


### PR DESCRIPTION
## Summary
- generate backup archive filenames in the local machine timezone instead of UTC
- include the UTC offset in the generated archive timestamp to keep filenames unambiguous
- update backup docs/examples and add coverage for the new timestamp formatter

## Testing
- npx pnpm exec vitest run src/commands/backup.test.ts src/commands/backup-verify.test.ts src/cli/program/register.backup.test.ts
- npx pnpm exec oxfmt --check src/commands/backup-shared.ts src/commands/backup.test.ts src/cli/program/register.backup.ts docs/cli/backup.md