### PR TITLE
feat(anthropic): migrate 1M context from beta to GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
+- Providers/Anthropic: stop sending the retired `context-1m-2025-08-07` beta for `context1m` while preserving OAuth-required Anthropic beta headers. (#45613) Thanks @haoyu-haoyu.
 - Cron/Telegram: preserve explicit `:topic:` delivery targets over stale session-derived thread IDs when isolated cron announces to Telegram forum topics. Carries forward #59069; refs #49704 and #43808. Thanks @roytong9.
 - Build/runtime: write the runtime-postbuild stamp after `pnpm build` writes the build stamp, so the next CLI invocation does not re-sync runtime artifacts after a successful build. Fixes #73151. Thanks @bittoby.
 - CLI/channels: list configured chat channel accounts from read-only setup metadata even when the standalone CLI has not loaded the runtime channel registry, so `openclaw channels list` shows Telegram accounts before auth providers. Fixes #73319 and #73322. Thanks @mlaihk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
-- Providers/Anthropic: stop sending the retired `context-1m-2025-08-07` beta for `context1m` while preserving OAuth-required Anthropic beta headers. (#45613) Thanks @haoyu-haoyu.
+- Providers/Anthropic: migrate 1M context handling to GA by keeping `context1m` as a sizing opt-in, stripping the retired `context-1m-2025-08-07` beta from older configs, and preserving OAuth-required Anthropic beta headers. (#45613) Thanks @haoyu-haoyu.
 - Cron/Telegram: preserve explicit `:topic:` delivery targets over stale session-derived thread IDs when isolated cron announces to Telegram forum topics. Carries forward #59069; refs #49704 and #43808. Thanks @roytong9.
 - Build/runtime: write the runtime-postbuild stamp after `pnpm build` writes the build stamp, so the next CLI invocation does not re-sync runtime artifacts after a successful build. Fixes #73151. Thanks @bittoby.
 - CLI/channels: list configured chat channel accounts from read-only setup metadata even when the standalone CLI has not loaded the runtime channel registry, so `openclaw channels list` shows Telegram accounts before auth providers. Fixes #73319 and #73322. Thanks @mlaihk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 
 - CLI/tasks: reject partially numeric `openclaw tasks audit --limit` values so audit limits must be real positive integers instead of accepting strings like `5abc`. (#84901) Thanks @jbetala7.
 - Status/diagnostics: bound deep Docker audit probes so `openclaw status --deep` reports slow container checks instead of hanging behind unbounded inspection. (#85476) Thanks @giodl73-repo.
+- Providers/Anthropic: migrate 1M context handling to GA-capable Claude 4.x models by sizing eligible models at 1M without the retired `context-1m-2025-08-07` beta, ignoring that retired beta in older configs, and preserving OAuth-required Anthropic beta headers. (#45613) Thanks @haoyu-haoyu.
 - Twitch: keep stale message-handler cleanup callbacks from removing newer handler registrations for the same account, preserving inbound message delivery after reconnects. Fixes #83888. (#85425) Thanks @alkor2000.
 - Memory/LanceDB: expose public memory artifacts through the active memory provider bridge so memory-wiki imports durable memory files, daily notes, dream reports, and event logs without depending on memory-core internals. Fixes #83604. (#85060) Thanks @brokemac79.
 - Docker setup: stop printing the Gateway bearer token in setup logs and printed follow-up commands.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -76,7 +76,7 @@ Look for:
 
 - Selected Anthropic Opus/Sonnet model has `params.context1m: true`.
 - Current Anthropic credential is not eligible for long-context usage.
-- Requests fail only on long sessions/model runs that need the 1M beta path.
+- Requests fail only on long sessions/model runs that need the 1M context path.
 
 Fix options:
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -171,15 +171,16 @@ openclaw config get agents.defaults.models
 
 Look for:
 
-- Selected Anthropic Opus/Sonnet model has `params.context1m: true`.
+- Selected Anthropic model is a GA-capable 1M Claude 4.x model, or the model has legacy `params.context1m: true`.
 - Current Anthropic credential is not eligible for long-context usage.
 - Requests fail only on long sessions/model runs that need the 1M context path.
 
 Fix options:
 
 <Steps>
-  <Step title="Disable context1m">
-    Disable `context1m` for that model to fall back to the normal context window.
+  <Step title="Use a standard context window">
+    Switch to a standard-window model, or remove legacy `context1m` from older
+    model config that is not GA-capable for 1M context.
   </Step>
   <Step title="Use an eligible credential">
     Use an Anthropic credential that is eligible for long-context requests, or switch to an Anthropic API key.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -173,7 +173,7 @@ Look for:
 
 - Selected Anthropic Opus/Sonnet model has `params.context1m: true`.
 - Current Anthropic credential is not eligible for long-context usage.
-- Requests fail only on long sessions/model runs that need the 1M beta path.
+- Requests fail only on long sessions/model runs that need the 1M context path.
 
 Fix options:
 

--- a/docs/help/faq-first-run.md
+++ b/docs/help/faq-first-run.md
@@ -578,7 +578,7 @@ and troubleshooting see the main [FAQ](/help/faq).
 
     If the message is specifically:
     `Extra usage is required for long context requests`, the request is trying to use
-    Anthropic's 1M context beta (`context1m: true`). That only works when your
+    Anthropic's 1M context window (`context1m: true`). That only works when your
     credential is eligible for long-context billing (API key billing or the
     OpenClaw Claude-login path with Extra Usage enabled).
 

--- a/docs/help/faq-first-run.md
+++ b/docs/help/faq-first-run.md
@@ -578,9 +578,10 @@ and troubleshooting see the main [FAQ](/help/faq).
 
     If the message is specifically:
     `Extra usage is required for long context requests`, the request is trying to use
-    Anthropic's 1M context window (`context1m: true`). That only works when your
-    credential is eligible for long-context billing (API key billing or the
-    OpenClaw Claude-login path with Extra Usage enabled).
+    Anthropic's 1M context window (a GA-capable 1M Claude 4.x model or legacy
+    `context1m: true` config). That only works when your credential is eligible
+    for long-context billing (API key billing or the OpenClaw Claude-login path
+    with Extra Usage enabled).
 
     Tip: set a **fallback model** so OpenClaw can keep replying while a provider is rate-limited.
     See [Models](/cli/models), [OAuth](/concepts/oauth), and

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -280,7 +280,7 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
     }
     ```
 
-    OpenClaw uses this for context sizing and no longer sends the retired `context-1m-2025-08-07` beta header.
+    OpenClaw uses this for context sizing and no longer sends the retired `context-1m-2025-08-07` beta header. Older `anthropicBeta` config entries with that value are ignored during request header resolution.
 
     `params.context1m: true` also applies to the Claude CLI backend
     (`claude-cli/*`) for eligible Opus and Sonnet models, expanding the runtime
@@ -293,7 +293,7 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
   </Accordion>
 
   <Accordion title="Claude Opus 4.7 1M context">
-    `anthropic/claude-opus-4.7` and its `claude-cli` variant have a 1M context
+    `anthropic/claude-opus-4-7` and its `claude-cli` variant have a 1M context
     window by default — no `params.context1m: true` needed.
   </Accordion>
 </AccordionGroup>

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -263,8 +263,8 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
 
   </Accordion>
 
-  <Accordion title="1M context window (beta)">
-    Anthropic's 1M context window is beta-gated. Enable it per model:
+  <Accordion title="1M context window">
+    Anthropic's 1M context window is available as an explicit per-model opt-in:
 
     ```json5
     {
@@ -280,14 +280,14 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
     }
     ```
 
-    OpenClaw maps this to `anthropic-beta: context-1m-2025-08-07` on requests.
+    OpenClaw uses this for context sizing and no longer sends the retired `context-1m-2025-08-07` beta header.
 
     `params.context1m: true` also applies to the Claude CLI backend
     (`claude-cli/*`) for eligible Opus and Sonnet models, expanding the runtime
     context window for those CLI sessions to match the direct-API behavior.
 
     <Warning>
-    Requires long-context access on your Anthropic credential. Legacy token auth (`sk-ant-oat-*`) is rejected for 1M context requests — OpenClaw logs a warning and falls back to the standard context window.
+    Requires long-context access on your Anthropic credential. OAuth/subscription token auth keeps its required Anthropic beta headers, but OpenClaw strips the retired 1M beta header if it remains in older config.
     </Warning>
 
   </Accordion>

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -267,8 +267,8 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
 
   </Accordion>
 
-  <Accordion title="1M context window (beta)">
-    Anthropic's 1M context window is beta-gated. Enable it per model:
+  <Accordion title="1M context window">
+    Anthropic's 1M context window is available as an explicit per-model opt-in:
 
     ```json5
     {
@@ -284,14 +284,14 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
     }
     ```
 
-    OpenClaw maps this to `anthropic-beta: context-1m-2025-08-07` on requests.
+    OpenClaw uses this for context sizing and no longer sends the retired `context-1m-2025-08-07` beta header.
 
     `params.context1m: true` also applies to the Claude CLI backend
     (`claude-cli/*`) for eligible Opus and Sonnet models, expanding the runtime
     context window for those CLI sessions to match the direct-API behavior.
 
     <Warning>
-    Requires long-context access on your Anthropic credential. Legacy token auth (`sk-ant-oat-*`) is rejected for 1M context requests — OpenClaw logs a warning and falls back to the standard context window.
+    Requires long-context access on your Anthropic credential. OAuth/subscription token auth keeps its required Anthropic beta headers, but OpenClaw strips the retired 1M beta header if it remains in older config.
     </Warning>
 
   </Accordion>

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -284,7 +284,7 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
     }
     ```
 
-    OpenClaw uses this for context sizing and no longer sends the retired `context-1m-2025-08-07` beta header.
+    OpenClaw uses this for context sizing and no longer sends the retired `context-1m-2025-08-07` beta header. Older `anthropicBeta` config entries with that value are ignored during request header resolution.
 
     `params.context1m: true` also applies to the Claude CLI backend
     (`claude-cli/*`) for eligible Opus and Sonnet models, expanding the runtime
@@ -297,7 +297,7 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
   </Accordion>
 
   <Accordion title="Claude Opus 4.7 1M context">
-    `anthropic/claude-opus-4.7` and its `claude-cli` variant have a 1M context
+    `anthropic/claude-opus-4-7` and its `claude-cli` variant have a 1M context
     window by default — no `params.context1m: true` needed.
   </Accordion>
 </AccordionGroup>

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -268,27 +268,31 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
   </Accordion>
 
   <Accordion title="1M context window">
-    Anthropic's 1M context window is available on GA-capable Claude 4.x models such as Opus 4.6, Opus 4.7, and Sonnet 4.6:
+    Anthropic's 1M context window is available on GA-capable Claude 4.x models
+    such as Opus 4.6, Opus 4.7, and Sonnet 4.6. OpenClaw sizes those models at
+    1M automatically:
 
     ```json5
     {
       agents: {
         defaults: {
           models: {
-            "anthropic/claude-opus-4-6": {
-              params: { context1m: true },
-            },
+            "anthropic/claude-opus-4-6": {},
           },
         },
       },
     }
     ```
 
-    OpenClaw uses this for context sizing on GA-capable 1M models and no longer sends the retired `context-1m-2025-08-07` beta header. Older `anthropicBeta` config entries with that value are ignored during request header resolution.
+    Older configs can keep `params.context1m: true`, but OpenClaw no longer sends
+    the retired `context-1m-2025-08-07` beta header. Older `anthropicBeta` config
+    entries with that value are ignored during request header resolution and
+    unsupported older Claude models stay on their normal context window.
 
     `params.context1m: true` also applies to the Claude CLI backend
-    (`claude-cli/*`) for eligible GA-capable Opus and Sonnet models, expanding the runtime
-    context window for those CLI sessions to match the direct-API behavior.
+    (`claude-cli/*`) for eligible GA-capable Opus and Sonnet models, preserving
+    the runtime context window for those CLI sessions to match the direct-API
+    behavior.
 
     <Warning>
     Requires long-context access on your Anthropic credential. OAuth/subscription token auth keeps its required Anthropic beta headers, but OpenClaw strips the retired 1M beta header if it remains in older config.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -268,7 +268,7 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
   </Accordion>
 
   <Accordion title="1M context window">
-    Anthropic's 1M context window is available as an explicit per-model opt-in:
+    Anthropic's 1M context window is available on GA-capable Claude 4.x models such as Opus 4.6, Opus 4.7, and Sonnet 4.6:
 
     ```json5
     {
@@ -284,10 +284,10 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
     }
     ```
 
-    OpenClaw uses this for context sizing and no longer sends the retired `context-1m-2025-08-07` beta header. Older `anthropicBeta` config entries with that value are ignored during request header resolution.
+    OpenClaw uses this for context sizing on GA-capable 1M models and no longer sends the retired `context-1m-2025-08-07` beta header. Older `anthropicBeta` config entries with that value are ignored during request header resolution.
 
     `params.context1m: true` also applies to the Claude CLI backend
-    (`claude-cli/*`) for eligible Opus and Sonnet models, expanding the runtime
+    (`claude-cli/*`) for eligible GA-capable Opus and Sonnet models, expanding the runtime
     context window for those CLI sessions to match the direct-API behavior.
 
     <Warning>

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -184,11 +184,10 @@ agents:
 `agents.list[].params` merges on top of the selected model's `params`, so you can
 override only `cacheRetention` and inherit other model defaults unchanged.
 
-### Example: enable Anthropic 1M context beta header
+### Example: enable Anthropic 1M context
 
-Anthropic's 1M context window is currently beta-gated. OpenClaw can inject the
-required `anthropic-beta` value when you enable `context1m` on supported Opus
-or Sonnet models.
+OpenClaw can request Anthropic's 1M context window when you enable `context1m`
+on supported Opus or Sonnet models.
 
 ```yaml
 agents:
@@ -199,7 +198,8 @@ agents:
           context1m: true
 ```
 
-This maps to Anthropic's `context-1m-2025-08-07` beta header.
+This keeps the larger context window as an explicit opt-in. OpenClaw no longer
+sends Anthropic's retired `context-1m-2025-08-07` beta header for this setting.
 
 This only applies when `context1m: true` is set on that model entry.
 
@@ -207,8 +207,8 @@ Requirement: the credential must be eligible for long-context usage. If not,
 Anthropic responds with a provider-side rate limit error for that request.
 
 If you authenticate Anthropic with OAuth/subscription tokens (`sk-ant-oat-*`),
-OpenClaw skips the `context-1m-*` beta header because Anthropic currently
-rejects that combination with HTTP 401.
+OpenClaw preserves the OAuth-required Anthropic beta headers while stripping the
+retired `context-1m-*` beta if it remains in older config.
 
 ## Tips for reducing token pressure
 

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -197,7 +197,7 @@ override only `cacheRetention` and inherit other model defaults unchanged.
 ### Example: enable Anthropic 1M context
 
 OpenClaw can request Anthropic's 1M context window when you enable `context1m`
-on supported Opus or Sonnet models.
+on GA-capable Claude 4.x models such as Opus 4.6, Opus 4.7, and Sonnet 4.6.
 
 ```yaml
 agents:
@@ -208,8 +208,9 @@ agents:
           context1m: true
 ```
 
-This keeps the larger context window as an explicit opt-in. OpenClaw no longer
-sends Anthropic's retired `context-1m-2025-08-07` beta header for this setting.
+This keeps the larger context window as an explicit opt-in on eligible models.
+OpenClaw no longer sends Anthropic's retired `context-1m-2025-08-07` beta header
+for this setting.
 
 This only applies when `context1m: true` is set on that model entry.
 

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -194,25 +194,23 @@ agents:
 `agents.list[].params` merges on top of the selected model's `params`, so you can
 override only `cacheRetention` and inherit other model defaults unchanged.
 
-### Example: enable Anthropic 1M context
+### Anthropic 1M context
 
-OpenClaw can request Anthropic's 1M context window when you enable `context1m`
-on GA-capable Claude 4.x models such as Opus 4.6, Opus 4.7, and Sonnet 4.6.
+OpenClaw sizes GA-capable Claude 4.x models such as Opus 4.6, Opus 4.7, and
+Sonnet 4.6 with Anthropic's 1M context window. You do not need
+`params.context1m: true` for those models.
 
 ```yaml
 agents:
   defaults:
     models:
       "anthropic/claude-opus-4-6":
-        params:
-          context1m: true
+        alias: opus
 ```
 
-This keeps the larger context window as an explicit opt-in on eligible models.
-OpenClaw no longer sends Anthropic's retired `context-1m-2025-08-07` beta header
-for this setting.
-
-This only applies when `context1m: true` is set on that model entry.
+Older configs can keep `context1m: true`, but OpenClaw no longer sends
+Anthropic's retired `context-1m-2025-08-07` beta header for this setting and
+does not expand unsupported older Claude models to 1M.
 
 Requirement: the credential must be eligible for long-context usage. If not,
 Anthropic responds with a provider-side rate limit error for that request.

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -194,11 +194,10 @@ agents:
 `agents.list[].params` merges on top of the selected model's `params`, so you can
 override only `cacheRetention` and inherit other model defaults unchanged.
 
-### Example: enable Anthropic 1M context beta header
+### Example: enable Anthropic 1M context
 
-Anthropic's 1M context window is currently beta-gated. OpenClaw can inject the
-required `anthropic-beta` value when you enable `context1m` on supported Opus
-or Sonnet models.
+OpenClaw can request Anthropic's 1M context window when you enable `context1m`
+on supported Opus or Sonnet models.
 
 ```yaml
 agents:
@@ -209,7 +208,8 @@ agents:
           context1m: true
 ```
 
-This maps to Anthropic's `context-1m-2025-08-07` beta header.
+This keeps the larger context window as an explicit opt-in. OpenClaw no longer
+sends Anthropic's retired `context-1m-2025-08-07` beta header for this setting.
 
 This only applies when `context1m: true` is set on that model entry.
 
@@ -217,8 +217,8 @@ Requirement: the credential must be eligible for long-context usage. If not,
 Anthropic responds with a provider-side rate limit error for that request.
 
 If you authenticate Anthropic with OAuth/subscription tokens (`sk-ant-oat-*`),
-OpenClaw skips the `context-1m-*` beta header because Anthropic currently
-rejects that combination with HTTP 401.
+OpenClaw preserves the OAuth-required Anthropic beta headers while stripping the
+retired `context-1m-*` beta if it remains in older config.
 
 ## Tips for reducing token pressure
 

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -546,12 +546,14 @@ describe("anthropic provider replay hooks", () => {
     expect(normalized?.input).toEqual(["text", "image"]);
   });
 
-  it("normalizes exact claude opus 4.7 variants to 1M context", async () => {
+  it("normalizes GA 1M Claude variants to 1M context", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
 
     for (const [runtimeProvider, modelId] of [
       ["anthropic", "claude-opus-4-7"],
       ["claude-cli", "claude-opus-4.7-20260219"],
+      ["anthropic", "claude-opus-4-6"],
+      ["anthropic", "claude-sonnet-4-6"],
     ] as const) {
       expectFields(
         provider.normalizeResolvedModel?.({
@@ -576,6 +578,29 @@ describe("anthropic provider replay hooks", () => {
         },
       );
     }
+  });
+
+  it("does not normalize legacy Claude 4.5 models to 1M context", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    const normalized = provider.normalizeResolvedModel?.({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5",
+      model: {
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        contextTokens: 200_000,
+        maxTokens: 32_000,
+      },
+    } as never);
+
+    expect(normalized).toBeUndefined();
   });
 
   it("resolves claude-cli synthetic oauth auth", async () => {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -48,7 +48,7 @@ type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
 const DEFAULT_ANTHROPIC_MODEL = "anthropic/claude-opus-4-7";
 const ANTHROPIC_OPUS_47_MODEL_ID = "claude-opus-4-7";
 const ANTHROPIC_OPUS_47_DOT_MODEL_ID = "claude-opus-4.7";
-const ANTHROPIC_OPUS_47_CONTEXT_TOKENS = 1_048_576;
+const ANTHROPIC_GA_1M_CONTEXT_TOKENS = 1_048_576;
 const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
 const ANTHROPIC_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
 const ANTHROPIC_OPUS_47_TEMPLATE_MODEL_IDS = [
@@ -61,6 +61,14 @@ const ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS = ["claude-opus-4-5", "claude-opus-4.5"]
 const ANTHROPIC_SONNET_46_MODEL_ID = "claude-sonnet-4-6";
 const ANTHROPIC_SONNET_46_DOT_MODEL_ID = "claude-sonnet-4.6";
 const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet-4.5"] as const;
+const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
+  ANTHROPIC_OPUS_46_MODEL_ID,
+  ANTHROPIC_OPUS_46_DOT_MODEL_ID,
+  ANTHROPIC_OPUS_47_MODEL_ID,
+  ANTHROPIC_OPUS_47_DOT_MODEL_ID,
+  ANTHROPIC_SONNET_46_MODEL_ID,
+  ANTHROPIC_SONNET_46_DOT_MODEL_ID,
+] as const;
 const ANTHROPIC_MODERN_MODEL_PREFIXES = [
   "claude-opus-4-7",
   "claude-opus-4.7",
@@ -294,12 +302,9 @@ function resolveAnthropicForwardCompatModel(
   );
 }
 
-function isAnthropicOpus47Model(modelId: string): boolean {
+function isAnthropicGa1MModel(modelId: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
-  return (
-    normalized.startsWith(ANTHROPIC_OPUS_47_MODEL_ID) ||
-    normalized.startsWith(ANTHROPIC_OPUS_47_DOT_MODEL_ID)
-  );
+  return ANTHROPIC_GA_1M_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
 function hasConfiguredModelContextOverride(
@@ -338,13 +343,13 @@ function hasConfiguredModelContextOverride(
   return false;
 }
 
-function applyAnthropicOpus47ContextWindow(params: {
+function applyAnthropicGa1MContextWindow(params: {
   config?: ProviderNormalizeResolvedModelContext["config"];
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel;
 }): ProviderRuntimeModel | undefined {
-  if (!isAnthropicOpus47Model(params.modelId)) {
+  if (!isAnthropicGa1MModel(params.modelId)) {
     return undefined;
   }
   if (hasConfiguredModelContextOverride(params.config, params.provider, params.modelId)) {
@@ -352,12 +357,12 @@ function applyAnthropicOpus47ContextWindow(params: {
   }
   const nextContextWindow = Math.max(
     params.model.contextWindow ?? 0,
-    ANTHROPIC_OPUS_47_CONTEXT_TOKENS,
+    ANTHROPIC_GA_1M_CONTEXT_TOKENS,
   );
   const nextContextTokens =
     typeof params.model.contextTokens === "number"
-      ? Math.max(params.model.contextTokens, ANTHROPIC_OPUS_47_CONTEXT_TOKENS)
-      : ANTHROPIC_OPUS_47_CONTEXT_TOKENS;
+      ? Math.max(params.model.contextTokens, ANTHROPIC_GA_1M_CONTEXT_TOKENS)
+      : ANTHROPIC_GA_1M_CONTEXT_TOKENS;
   if (
     nextContextWindow === params.model.contextWindow &&
     nextContextTokens === params.model.contextTokens
@@ -407,7 +412,7 @@ function normalizeAnthropicResolvedModel(
 ): ProviderRuntimeModel | undefined {
   const imageCapableModel = applyAnthropicImageInputCapability(ctx) ?? ctx.model;
   const contextWindowModel =
-    applyAnthropicOpus47ContextWindow({
+    applyAnthropicGa1MContextWindow({
       config: ctx.config,
       provider: ctx.provider,
       modelId: ctx.modelId,
@@ -628,7 +633,7 @@ export function buildAnthropicProvider(): ProviderPlugin {
           model,
         }) ?? model;
       return (
-        applyAnthropicOpus47ContextWindow({
+        applyAnthropicGa1MContextWindow({
           config: ctx.config,
           provider: ctx.provider,
           modelId: ctx.modelId,

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -142,6 +142,24 @@ describe("anthropic stream wrappers", () => {
     expect(captured.headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
     expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
   });
+
+  it("preserves OAuth-required betas when legacy context-1m is the only configured beta", () => {
+    const captured: { headers?: Record<string, string> } = {};
+    const wrapped = wrapAnthropicProviderStream({
+      streamFn: createPayloadCapturingBaseStream(captured),
+      modelId: "claude-sonnet-4-6",
+      extraParams: { anthropicBeta: [CONTEXT_1M_BETA] },
+    } as never);
+
+    void wrapped?.(
+      { provider: "anthropic", api: "anthropic-messages", id: "claude-sonnet-4-6" } as never,
+      {} as never,
+      { apiKey: "sk-ant-oat01-oauth-token" } as never,
+    );
+
+    expect(captured.headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
+    expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
+  });
 });
 
 describe("createAnthropicThinkingPrefillWrapper", () => {

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -125,6 +125,15 @@ describe("anthropic stream wrappers", () => {
     ).toEqual(["files-api-2025-04-14"]);
   });
 
+  it("strips legacy context-1m beta from comma-separated string config", () => {
+    expect(
+      resolveAnthropicBetas(
+        { anthropicBeta: `${CONTEXT_1M_BETA},files-api-2025-04-14` },
+        "claude-sonnet-4-6",
+      ),
+    ).toEqual(["files-api-2025-04-14"]);
+  });
+
   it("preserves OAuth-required betas when context1m is the only configured beta trigger", () => {
     const captured: { headers?: Record<string, string> } = {};
     const wrapped = wrapAnthropicProviderStream({

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -6,6 +6,7 @@ import {
   createAnthropicFastModeWrapper,
   createAnthropicServiceTierWrapper,
   createAnthropicThinkingPrefillWrapper,
+  resolveAnthropicBetas,
   wrapAnthropicProviderStream,
 } from "./stream-wrappers.js";
 
@@ -85,20 +86,20 @@ describe("anthropic stream wrappers", () => {
     vi.restoreAllMocks();
   });
 
-  it("strips context-1m for Claude CLI or legacy token auth and warns", () => {
+  it("strips legacy context-1m betas for Claude CLI or legacy token auth", () => {
     const warn = vi.spyOn(__testing.log, "warn").mockImplementation(() => undefined);
     const headers = runWrapper("sk-ant-oat01-123");
     expect(headers?.["anthropic-beta"]).toBeDefined();
     expect(headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
     expect(headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
-    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it("keeps context-1m for API key auth", () => {
+  it("strips legacy context-1m betas for API key auth", () => {
     const warn = vi.spyOn(__testing.log, "warn").mockImplementation(() => undefined);
     const headers = runWrapper("sk-ant-api-123");
     expect(headers?.["anthropic-beta"]).toBeDefined();
-    expect(headers?.["anthropic-beta"]).toContain(CONTEXT_1M_BETA);
+    expect(headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
     expect(warn).not.toHaveBeenCalled();
   });
 
@@ -111,8 +112,35 @@ describe("anthropic stream wrappers", () => {
 
   it("composes the anthropic provider stream chain from extra params", () => {
     const captured = runComposedAnthropicProviderStream("sk-ant-api-123");
-    expect(captured.headers?.["anthropic-beta"]).toContain(CONTEXT_1M_BETA);
+    expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
     expect(captured.payload).toMatchObject({ service_tier: "auto" });
+  });
+
+  it("does not emit the legacy context-1m beta from context1m or explicit config", () => {
+    expect(
+      resolveAnthropicBetas(
+        { context1m: true, anthropicBeta: [CONTEXT_1M_BETA, "files-api-2025-04-14"] },
+        "claude-sonnet-4-6",
+      ),
+    ).toEqual(["files-api-2025-04-14"]);
+  });
+
+  it("preserves OAuth-required betas when context1m is the only configured beta trigger", () => {
+    const captured: { headers?: Record<string, string> } = {};
+    const wrapped = wrapAnthropicProviderStream({
+      streamFn: createPayloadCapturingBaseStream(captured),
+      modelId: "claude-sonnet-4-6",
+      extraParams: { context1m: true },
+    } as never);
+
+    void wrapped?.(
+      { provider: "anthropic", api: "anthropic-messages", id: "claude-sonnet-4-6" } as never,
+      {} as never,
+      { apiKey: "sk-ant-oat01-oauth-token" } as never,
+    );
+
+    expect(captured.headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
+    expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
   });
 });
 

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -154,6 +154,23 @@ describe("anthropic stream wrappers", () => {
     expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
   });
 
+  it("does not add beta headers for context1m-only legacy Sonnet 4.5 configs", () => {
+    const captured: { headers?: Record<string, string> } = {};
+    const wrapped = wrapAnthropicProviderStream({
+      streamFn: createPayloadCapturingBaseStream(captured),
+      modelId: "claude-sonnet-4-5",
+      extraParams: { context1m: true },
+    } as never);
+
+    void wrapped?.(
+      { provider: "anthropic", api: "anthropic-messages", id: "claude-sonnet-4-5" } as never,
+      {} as never,
+      { apiKey: "sk-ant-api-123" } as never,
+    );
+
+    expect(captured.headers?.["anthropic-beta"]).toBeUndefined();
+  });
+
   it("preserves OAuth-required betas when legacy context-1m is the only configured beta", () => {
     const captured: { headers?: Record<string, string> } = {};
     const wrapped = wrapAnthropicProviderStream({

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -127,6 +127,15 @@ describe("anthropic stream wrappers", () => {
     ).toEqual(["files-api-2025-04-14"]);
   });
 
+  it("strips legacy context-1m beta from comma-separated string config", () => {
+    expect(
+      resolveAnthropicBetas(
+        { anthropicBeta: `${CONTEXT_1M_BETA},files-api-2025-04-14` },
+        "claude-sonnet-4-6",
+      ),
+    ).toEqual(["files-api-2025-04-14"]);
+  });
+
   it("preserves OAuth-required betas when context1m is the only configured beta trigger", () => {
     const captured: { headers?: Record<string, string> } = {};
     const wrapped = wrapAnthropicProviderStream({

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -144,6 +144,24 @@ describe("anthropic stream wrappers", () => {
     expect(captured.headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
     expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
   });
+
+  it("preserves OAuth-required betas when legacy context-1m is the only configured beta", () => {
+    const captured: { headers?: Record<string, string> } = {};
+    const wrapped = wrapAnthropicProviderStream({
+      streamFn: createPayloadCapturingBaseStream(captured),
+      modelId: "claude-sonnet-4-6",
+      extraParams: { anthropicBeta: [CONTEXT_1M_BETA] },
+    } as never);
+
+    void wrapped?.(
+      { provider: "anthropic", api: "anthropic-messages", id: "claude-sonnet-4-6" } as never,
+      {} as never,
+      { apiKey: "sk-ant-oat01-oauth-token" } as never,
+    );
+
+    expect(captured.headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
+    expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
+  });
 });
 
 describe("createAnthropicThinkingPrefillWrapper", () => {

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -6,6 +6,7 @@ import {
   createAnthropicFastModeWrapper,
   createAnthropicServiceTierWrapper,
   createAnthropicThinkingPrefillWrapper,
+  resolveAnthropicBetas,
   wrapAnthropicProviderStream,
 } from "./stream-wrappers.js";
 
@@ -88,17 +89,20 @@ describe("anthropic stream wrappers", () => {
     vi.restoreAllMocks();
   });
 
-  it("strips context-1m for Claude CLI or legacy token auth and warns", () => {
+  it("strips legacy context-1m betas for Claude CLI or legacy token auth", () => {
     const warn = vi.spyOn(testing.log, "warn").mockImplementation(() => undefined);
     const headers = runWrapper("sk-ant-oat01-123");
-    expect(headers?.["anthropic-beta"]).toBe(OAUTH_BETA_HEADER);
-    expect(warn).toHaveBeenCalledOnce();
+    expect(headers?.["anthropic-beta"]).toBeDefined();
+    expect(headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
+    expect(headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it("keeps context-1m for API key auth", () => {
+  it("strips legacy context-1m betas for API key auth", () => {
     const warn = vi.spyOn(testing.log, "warn").mockImplementation(() => undefined);
     const headers = runWrapper("sk-ant-api-123");
-    expect(headers?.["anthropic-beta"]).toBe(`${DEFAULT_BETA_HEADER},${CONTEXT_1M_BETA}`);
+    expect(headers?.["anthropic-beta"]).toBeDefined();
+    expect(headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
     expect(warn).not.toHaveBeenCalled();
   });
 
@@ -110,8 +114,35 @@ describe("anthropic stream wrappers", () => {
 
   it("composes the anthropic provider stream chain from extra params", () => {
     const captured = runComposedAnthropicProviderStream("sk-ant-api-123");
-    expect(captured.headers?.["anthropic-beta"]).toBe(`${DEFAULT_BETA_HEADER},${CONTEXT_1M_BETA}`);
-    expect(captured.payload).toEqual({ service_tier: "auto" });
+    expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
+    expect(captured.payload).toMatchObject({ service_tier: "auto" });
+  });
+
+  it("does not emit the legacy context-1m beta from context1m or explicit config", () => {
+    expect(
+      resolveAnthropicBetas(
+        { context1m: true, anthropicBeta: [CONTEXT_1M_BETA, "files-api-2025-04-14"] },
+        "claude-sonnet-4-6",
+      ),
+    ).toEqual(["files-api-2025-04-14"]);
+  });
+
+  it("preserves OAuth-required betas when context1m is the only configured beta trigger", () => {
+    const captured: { headers?: Record<string, string> } = {};
+    const wrapped = wrapAnthropicProviderStream({
+      streamFn: createPayloadCapturingBaseStream(captured),
+      modelId: "claude-sonnet-4-6",
+      extraParams: { context1m: true },
+    } as never);
+
+    void wrapped?.(
+      { provider: "anthropic", api: "anthropic-messages", id: "claude-sonnet-4-6" } as never,
+      {} as never,
+      { apiKey: "sk-ant-oat01-oauth-token" } as never,
+    );
+
+    expect(captured.headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
+    expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
   });
 });
 

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -81,6 +81,17 @@ function normalizeAnthropicServiceTier(value: unknown): AnthropicServiceTier | u
   return undefined;
 }
 
+function hasConfiguredAnthropicBeta(extraParams: Record<string, unknown> | undefined): boolean {
+  const configured = extraParams?.anthropicBeta;
+  if (typeof configured === "string") {
+    return configured.trim().length > 0;
+  }
+  if (!Array.isArray(configured)) {
+    return false;
+  }
+  return configured.some((beta) => typeof beta === "string" && beta.trim().length > 0);
+}
+
 export function resolveAnthropicBetas(
   extraParams: Record<string, unknown> | undefined,
   _modelId: string,
@@ -193,6 +204,7 @@ export function wrapAnthropicProviderStream(
   const anthropicBetas = resolveAnthropicBetas(ctx.extraParams, ctx.modelId);
   const needsAnthropicBetaWrapper =
     anthropicBetas !== undefined ||
+    hasConfiguredAnthropicBeta(ctx.extraParams) ||
     (ctx.extraParams?.context1m === true && isAnthropic1MModel(ctx.modelId));
   const serviceTier = resolveAnthropicServiceTier(ctx.extraParams);
   const fastMode = resolveAnthropicFastMode(ctx.extraParams);

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -99,11 +99,15 @@ export function resolveAnthropicBetas(
   const betas = new Set<string>();
   const configured = extraParams?.anthropicBeta;
   if (typeof configured === "string" && configured.trim()) {
-    betas.add(configured.trim());
+    for (const beta of parseHeaderList(configured)) {
+      betas.add(beta);
+    }
   } else if (Array.isArray(configured)) {
     for (const beta of configured) {
       if (typeof beta === "string" && beta.trim()) {
-        betas.add(beta.trim());
+        for (const betaValue of parseHeaderList(beta)) {
+          betas.add(betaValue);
+        }
       }
     }
   }

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -18,7 +18,7 @@ import {
 
 const log = createSubsystemLogger("anthropic-stream");
 
-const ANTHROPIC_CONTEXT_1M_BETA = "context-1m-2025-08-07";
+const ANTHROPIC_CONTEXT_1M_BETA_LEGACY = "context-1m-2025-08-07";
 const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as const;
 const PI_AI_DEFAULT_ANTHROPIC_BETAS = [
   "fine-grained-tool-streaming-2025-05-14",
@@ -83,7 +83,7 @@ function normalizeAnthropicServiceTier(value: unknown): AnthropicServiceTier | u
 
 export function resolveAnthropicBetas(
   extraParams: Record<string, unknown> | undefined,
-  modelId: string,
+  _modelId: string,
 ): string[] | undefined {
   const betas = new Set<string>();
   const configured = extraParams?.anthropicBeta;
@@ -97,13 +97,9 @@ export function resolveAnthropicBetas(
     }
   }
 
-  if (extraParams?.context1m === true) {
-    if (isAnthropic1MModel(modelId)) {
-      betas.add(ANTHROPIC_CONTEXT_1M_BETA);
-    } else {
-      log.warn(`ignoring context1m for non-opus/sonnet model: anthropic/${modelId}`);
-    }
-  }
+  // 1M context is GA. Keep context1m as a context-sizing opt-in, but do not
+  // send the retired beta even if it remains in older user config.
+  betas.delete(ANTHROPIC_CONTEXT_1M_BETA_LEGACY);
 
   return betas.size > 0 ? [...betas] : undefined;
 }
@@ -115,16 +111,7 @@ export function createAnthropicBetaHeadersWrapper(
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const isOauth = isAnthropicOAuthApiKey(options?.apiKey);
-    const requestedContext1m = betas.includes(ANTHROPIC_CONTEXT_1M_BETA);
-    const effectiveBetas =
-      isOauth && requestedContext1m
-        ? betas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA)
-        : betas;
-    if (isOauth && requestedContext1m) {
-      log.warn(
-        `ignoring context1m for Anthropic Claude CLI or legacy token auth on ${model.provider}/${model.id}; falling back to the standard context window because Anthropic rejects context-1m beta with non-API-key auth`,
-      );
-    }
+    const effectiveBetas = betas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA_LEGACY);
 
     const piAiBetas = isOauth
       ? (PI_AI_OAUTH_ANTHROPIC_BETAS as readonly string[])
@@ -204,12 +191,15 @@ export function wrapAnthropicProviderStream(
   ctx: ProviderWrapStreamFnContext,
 ): StreamFn | undefined {
   const anthropicBetas = resolveAnthropicBetas(ctx.extraParams, ctx.modelId);
+  const needsAnthropicBetaWrapper =
+    anthropicBetas !== undefined ||
+    (ctx.extraParams?.context1m === true && isAnthropic1MModel(ctx.modelId));
   const serviceTier = resolveAnthropicServiceTier(ctx.extraParams);
   const fastMode = resolveAnthropicFastMode(ctx.extraParams);
   return composeProviderStreamWrappers(
     ctx.streamFn,
-    anthropicBetas?.length
-      ? (streamFn) => createAnthropicBetaHeadersWrapper(streamFn, anthropicBetas)
+    needsAnthropicBetaWrapper
+      ? (streamFn) => createAnthropicBetaHeadersWrapper(streamFn, anthropicBetas ?? [])
       : undefined,
     serviceTier
       ? (streamFn) => createAnthropicServiceTierWrapper(streamFn, serviceTier)

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -19,7 +19,14 @@ import {
 const log = createSubsystemLogger("anthropic-stream");
 
 const ANTHROPIC_CONTEXT_1M_BETA_LEGACY = "context-1m-2025-08-07";
-const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as const;
+const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
+  "claude-opus-4-6",
+  "claude-opus-4.6",
+  "claude-opus-4-7",
+  "claude-opus-4.7",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4.6",
+] as const;
 const PI_AI_DEFAULT_ANTHROPIC_BETAS = [
   "fine-grained-tool-streaming-2025-05-14",
   "interleaved-thinking-2025-05-14",
@@ -34,7 +41,7 @@ type AnthropicServiceTier = "auto" | "standard_only";
 
 function isAnthropic1MModel(modelId: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
-  return ANTHROPIC_1M_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+  return ANTHROPIC_GA_1M_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
 function parseHeaderList(value: unknown): string[] {
@@ -112,8 +119,8 @@ export function resolveAnthropicBetas(
     }
   }
 
-  // 1M context is GA. Keep context1m as a context-sizing opt-in, but do not
-  // send the retired beta even if it remains in older user config.
+  // Newer Claude 4.x 1M context is GA. Keep context1m as a context-sizing
+  // opt-in, but do not send the retired beta even if it remains in older config.
   betas.delete(ANTHROPIC_CONTEXT_1M_BETA_LEGACY);
 
   return betas.size > 0 ? [...betas] : undefined;

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -287,7 +287,7 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(16_000);
   });
 
-  it("returns 1M context when anthropic context1m is enabled for opus/sonnet", () => {
+  it("returns 1M context when anthropic context1m is enabled for a GA 1M model", () => {
     const result = resolveContextTokensForModel({
       cfg: {
         models: {
@@ -317,7 +317,7 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
-  it("returns 1M context when claude-cli context1m is enabled for opus/sonnet", () => {
+  it("returns 1M context when claude-cli context1m is enabled for a GA 1M model", () => {
     const result = resolveContextTokensForModel({
       cfg: {
         models: {
@@ -347,7 +347,7 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
-  it("returns 1M context for Anthropic opus/sonnet 4 even without context1m", () => {
+  it("returns 1M context for GA-capable Anthropic 4.x models even without context1m", () => {
     const result = resolveContextTokensForModel({
       cfg: {
         models: {
@@ -396,6 +396,36 @@ describe("resolveContextTokensForModel", () => {
     });
 
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+  });
+
+  it("keeps older Anthropic Sonnet 4.x models at the configured window when context1m is set", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [testModelContextWindow("claude-sonnet-4-5", 200_000)],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-sonnet-4-5": {
+                params: { context1m: true },
+              },
+            },
+          },
+        },
+      },
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(200_000);
   });
 
   it("does not force 1M context for non-opus/sonnet Anthropic models", () => {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -63,17 +63,21 @@ describe("applyDiscoveredContextWindows", () => {
     expect(cache.get("gpt-5.4")).toBe(272_000);
   });
 
-  it("upgrades claude opus 4.7 variants to 1M when discovery still reports 200k", () => {
+  it("upgrades claude-cli GA 1M variants when discovery still reports 200k", () => {
     const cache = new Map<string, number>();
     applyDiscoveredContextWindows({
       cache,
-      models: [{ id: "claude-cli/claude-opus-4.7-20260219", contextWindow: 200_000 }],
+      models: [
+        { id: "claude-cli/claude-opus-4.7-20260219", contextWindow: 200_000 },
+        { id: "claude-cli/claude-sonnet-4-6", contextWindow: 200_000 },
+      ],
     });
 
     expect(cache.get("claude-cli/claude-opus-4.7-20260219")).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+    expect(cache.get("claude-cli/claude-sonnet-4-6")).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
-  it("does not upgrade non-Anthropic opus 4.7 variants from discovery", () => {
+  it("does not upgrade non-Anthropic GA 1M model ids from discovery", () => {
     const cache = new Map<string, number>();
     applyDiscoveredContextWindows({
       cache,
@@ -83,7 +87,7 @@ describe("applyDiscoveredContextWindows", () => {
     expect(cache.get("github-copilot/claude-opus-4.7")).toBe(128_000);
   });
 
-  it("does not upgrade provider-qualified anthropic opus 4.7 discovery ids without verified ownership", () => {
+  it("does not upgrade provider-qualified anthropic GA 1M discovery ids without verified ownership", () => {
     const cache = new Map<string, number>();
     applyDiscoveredContextWindows({
       cache,
@@ -93,7 +97,7 @@ describe("applyDiscoveredContextWindows", () => {
     expect(cache.get("anthropic/claude-opus-4.7-20260219")).toBe(200_000);
   });
 
-  it("upgrades provider-owned anthropic opus 4.7 discovery ids", () => {
+  it("upgrades provider-owned anthropic GA 1M discovery ids", () => {
     const cache = new Map<string, number>();
     applyDiscoveredContextWindows({
       cache,
@@ -109,7 +113,7 @@ describe("applyDiscoveredContextWindows", () => {
     expect(cache.get("anthropic/claude-opus-4.7-20260219")).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
-  it("does not upgrade bare opus 4.7 discovery ids without verified ownership", () => {
+  it("does not upgrade bare GA 1M discovery ids without verified ownership", () => {
     const cache = new Map<string, number>();
     applyDiscoveredContextWindows({
       cache,

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -30,7 +30,14 @@ type ProviderConfigEntry = {
 };
 type ModelsConfig = { providers?: Record<string, ProviderConfigEntry | undefined> };
 
-const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as const;
+const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
+  "claude-opus-4-6",
+  "claude-opus-4.6",
+  "claude-opus-4-7",
+  "claude-opus-4.7",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4.6",
+] as const;
 const CLAUDE_OPUS_47_MODEL_PREFIXES = ["claude-opus-4-7", "claude-opus-4.7"] as const;
 export const ANTHROPIC_CONTEXT_1M_TOKENS = 1_048_576;
 const CONFIG_LOAD_RETRY_POLICY: BackoffPolicy = {
@@ -311,7 +318,7 @@ function isAnthropic1MModel(provider: string, model: string): boolean {
     return false;
   }
   const modelId = resolveModelFamilyId(model);
-  return ANTHROPIC_1M_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
+  return ANTHROPIC_GA_1M_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
 }
 
 function shouldUseAnthropicOpus47ContextWindow(params: {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -38,7 +38,6 @@ const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
   "claude-sonnet-4-6",
   "claude-sonnet-4.6",
 ] as const;
-const CLAUDE_OPUS_47_MODEL_PREFIXES = ["claude-opus-4-7", "claude-opus-4.7"] as const;
 export const ANTHROPIC_CONTEXT_1M_TOKENS = 1_048_576;
 const CONFIG_LOAD_RETRY_POLICY: BackoffPolicy = {
   initialMs: 1_000,
@@ -61,7 +60,7 @@ export function applyDiscoveredContextWindows(params: {
         : typeof model.contextWindow === "number"
           ? Math.trunc(model.contextWindow)
           : undefined;
-    const contextTokens = shouldUseDiscoveredAnthropicOpus47ContextWindow(model)
+    const contextTokens = shouldUseDiscoveredAnthropicGa1MContextWindow(model)
       ? ANTHROPIC_CONTEXT_1M_TOKENS
       : discoveredContextTokens;
     if (!contextTokens || contextTokens <= 0) {
@@ -321,25 +320,20 @@ function isAnthropic1MModel(provider: string, model: string): boolean {
   return ANTHROPIC_GA_1M_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
 }
 
-function shouldUseAnthropicOpus47ContextWindow(params: {
+function shouldUseAnthropicGa1MContextWindow(params: {
   provider?: string;
   model: string;
 }): boolean {
   const provider = params.provider ? normalizeProviderId(params.provider) : "";
-  return (
-    (provider === "anthropic" || provider === "claude-cli") && isClaudeOpus47Model(params.model)
-  );
+  return isAnthropic1MModel(provider, params.model);
 }
 
-function shouldUseDiscoveredAnthropicOpus47ContextWindow(model: ModelEntry): boolean {
+function shouldUseDiscoveredAnthropicGa1MContextWindow(model: ModelEntry): boolean {
   const provider =
     typeof model.provider === "string" ? normalizeProviderId(model.provider) : undefined;
   const modelId = model.id;
-  if (!isClaudeOpus47Model(modelId)) {
-    return false;
-  }
   if (provider) {
-    return provider === "anthropic" || provider === "claude-cli";
+    return isAnthropic1MModel(provider, modelId);
   }
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
   const slash = normalized.indexOf("/");
@@ -347,17 +341,13 @@ function shouldUseDiscoveredAnthropicOpus47ContextWindow(model: ModelEntry): boo
     return false;
   }
   const inferredProvider = normalizeProviderId(normalized.slice(0, slash));
-  return inferredProvider === "claude-cli";
+  const inferredModel = normalized.slice(slash + 1);
+  return inferredProvider === "claude-cli" && isAnthropic1MModel(inferredProvider, inferredModel);
 }
 
 function resolveModelFamilyId(modelId: string): string {
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
   return normalized.includes("/") ? (normalized.split("/").at(-1) ?? normalized) : normalized;
-}
-
-function isClaudeOpus47Model(model: string): boolean {
-  const modelId = resolveModelFamilyId(model);
-  return CLAUDE_OPUS_47_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
 }
 
 export function resolveContextTokensForModel(params: {
@@ -400,7 +390,7 @@ export function resolveContextTokensForModel(params: {
     }
   }
 
-  if (explicitProvider && ref && shouldUseAnthropicOpus47ContextWindow(ref)) {
+  if (explicitProvider && ref && shouldUseAnthropicGa1MContextWindow(ref)) {
     return ANTHROPIC_CONTEXT_1M_TOKENS;
   }
 

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -196,15 +196,12 @@ function createTestToolStreamWrapper(
 
 function resolveAnthropicBetas(
   extraParams: Record<string, unknown> | undefined,
-  modelId: string,
+  _modelId: string,
 ): string[] {
   const configuredBetas = Array.isArray(extraParams?.anthropicBeta)
     ? extraParams.anthropicBeta.filter((value): value is string => typeof value === "string")
     : [];
-  if (!extraParams?.context1m || !/(opus|sonnet)/i.test(modelId)) {
-    return configuredBetas;
-  }
-  return [...ANTHROPIC_DEFAULT_BETAS, ...configuredBetas, ANTHROPIC_CONTEXT_1M_BETA];
+  return configuredBetas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA);
 }
 
 function resolveAnthropicServiceTier(extraParams: Record<string, unknown> | undefined) {
@@ -228,9 +225,10 @@ function isDirectAnthropicModel(model: { provider?: string; baseUrl?: string }):
 function createAnthropicBetaHeadersWrapper(baseStreamFn: StreamFn | undefined, betas: string[]) {
   const underlying = baseStreamFn ?? (() => ({}) as ReturnType<StreamFn>);
   return ((model, context, options) => {
+    const configuredBetas = betas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA);
     const nextBetas = isAnthropicOauthApiKey(options?.apiKey)
-      ? [...ANTHROPIC_OAUTH_BETAS, ...betas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA)]
-      : betas;
+      ? [...ANTHROPIC_OAUTH_BETAS, ...ANTHROPIC_DEFAULT_BETAS, ...configuredBetas]
+      : [...ANTHROPIC_DEFAULT_BETAS, ...configuredBetas];
     const existingBeta =
       typeof options?.headers?.["anthropic-beta"] === "string"
         ? options.headers["anthropic-beta"]
@@ -378,7 +376,11 @@ function installFullProviderRuntimeDepsForTest() {
           params.context.extraParams,
           params.context.modelId,
         );
-        if (anthropicBetas?.length) {
+        if (
+          anthropicBetas.length ||
+          (params.context.extraParams?.context1m === true &&
+            /(opus|sonnet)/i.test(params.context.modelId))
+        ) {
           streamFn = createAnthropicBetaHeadersWrapper(streamFn, anthropicBetas);
         }
         const serviceTier = resolveAnthropicServiceTier(params.context.extraParams);
@@ -2444,7 +2446,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.cacheRetention).toBe("long");
   });
 
-  it("adds Anthropic 1M beta header when context1m is enabled for Opus/Sonnet", () => {
+  it("does not add 1M beta header when context1m is enabled (GA migration)", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = buildAnthropicModelConfig("anthropic/claude-opus-4-6", { context1m: true });
 
@@ -2457,7 +2459,6 @@ describe("applyExtraParamsToAgent", () => {
     } as Model<"anthropic-messages">;
     const context: Context = { messages: [] };
 
-    // Simulate pi-agent-core passing apiKey in options (API key, not OAuth token)
     void agent.streamFn?.(model, context, {
       apiKey: "sk-ant-api03-test", // pragma: allowlist secret
       headers: { "X-Custom": "1" },
@@ -2466,9 +2467,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.headers).toEqual({
       "X-Custom": "1",
-      // Includes pi-ai default betas (preserved to avoid overwrite) + context1m
-      "anthropic-beta":
-        "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,context-1m-2025-08-07",
+      "anthropic-beta": "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14",
     });
   });
 
@@ -2485,7 +2484,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(headers).toEqual({ "X-Custom": "1" });
   });
 
-  it("skips context1m beta for OAuth tokens but preserves OAuth-required betas", () => {
+  it("skips legacy context1m beta for OAuth tokens but preserves OAuth-required betas", () => {
     const calls: Array<SimpleStreamOptions | undefined> = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       calls.push(options);
@@ -2515,7 +2514,6 @@ describe("applyExtraParamsToAgent", () => {
     } as Model<"anthropic-messages">;
     const context: Context = { messages: [] };
 
-    // Simulate pi-agent-core passing an OAuth token (sk-ant-oat-*) as apiKey
     void agent.streamFn?.(model, context, {
       apiKey: "sk-ant-oat01-test-oauth-token", // pragma: allowlist secret
       headers: { "X-Custom": "1" },
@@ -2523,13 +2521,12 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(calls).toHaveLength(1);
     const betaHeader = calls[0]?.headers?.["anthropic-beta"] as string;
-    // Must include the OAuth-required betas so they aren't stripped by pi-ai's mergeHeaders
     expect(betaHeader).toContain("oauth-2025-04-20");
     expect(betaHeader).toContain("claude-code-20250219");
     expect(betaHeader).not.toContain("context-1m-2025-08-07");
   });
 
-  it("merges existing anthropic-beta headers with configured betas", () => {
+  it("merges existing anthropic-beta headers with configured betas (no context-1m)", () => {
     const cfg = buildAnthropicModelConfig("anthropic/claude-sonnet-4-5", {
       context1m: true,
       anthropicBeta: ["files-api-2025-04-14"],
@@ -2543,9 +2540,11 @@ describe("applyExtraParamsToAgent", () => {
       },
     });
 
+    // context1m no longer injects a beta header (GA); only the explicitly
+    // configured anthropicBeta entry should appear alongside pi-ai defaults.
     expect(headers).toEqual({
       "anthropic-beta":
-        "prompt-caching-2024-07-31,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,files-api-2025-04-14,context-1m-2025-08-07",
+        "prompt-caching-2024-07-31,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,files-api-2025-04-14",
     });
   });
 

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -204,15 +204,12 @@ function createTestToolStreamWrapper(
 
 function resolveAnthropicBetas(
   extraParams: Record<string, unknown> | undefined,
-  modelId: string,
+  _modelId: string,
 ): string[] {
   const configuredBetas = Array.isArray(extraParams?.anthropicBeta)
     ? extraParams.anthropicBeta.filter((value): value is string => typeof value === "string")
     : [];
-  if (!extraParams?.context1m || !/(opus|sonnet)/i.test(modelId)) {
-    return configuredBetas;
-  }
-  return [...ANTHROPIC_DEFAULT_BETAS, ...configuredBetas, ANTHROPIC_CONTEXT_1M_BETA];
+  return configuredBetas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA);
 }
 
 function resolveAnthropicServiceTier(extraParams: Record<string, unknown> | undefined) {
@@ -236,9 +233,10 @@ function isDirectAnthropicModel(model: { provider?: string; baseUrl?: string }):
 function createAnthropicBetaHeadersWrapper(baseStreamFn: StreamFn | undefined, betas: string[]) {
   const underlying = baseStreamFn ?? (() => ({}) as ReturnType<StreamFn>);
   return ((model, context, options) => {
+    const configuredBetas = betas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA);
     const nextBetas = isAnthropicOauthApiKey(options?.apiKey)
-      ? [...ANTHROPIC_OAUTH_BETAS, ...betas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA)]
-      : betas;
+      ? [...ANTHROPIC_OAUTH_BETAS, ...ANTHROPIC_DEFAULT_BETAS, ...configuredBetas]
+      : [...ANTHROPIC_DEFAULT_BETAS, ...configuredBetas];
     const existingBeta =
       typeof options?.headers?.["anthropic-beta"] === "string"
         ? options.headers["anthropic-beta"]
@@ -384,7 +382,11 @@ function installFullProviderRuntimeDepsForTest() {
           params.context.extraParams,
           params.context.modelId,
         );
-        if (anthropicBetas?.length) {
+        if (
+          anthropicBetas.length ||
+          (params.context.extraParams?.context1m === true &&
+            /(opus|sonnet)/i.test(params.context.modelId))
+        ) {
           streamFn = createAnthropicBetaHeadersWrapper(streamFn, anthropicBetas);
         }
         const serviceTier = resolveAnthropicServiceTier(params.context.extraParams);
@@ -2687,7 +2689,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.cacheRetention).toBe("long");
   });
 
-  it("adds Anthropic 1M beta header when context1m is enabled for Opus/Sonnet", () => {
+  it("does not add 1M beta header when context1m is enabled (GA migration)", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = buildModelConfig("anthropic/claude-opus-4-6", { context1m: true });
 
@@ -2700,7 +2702,6 @@ describe("applyExtraParamsToAgent", () => {
     } as Model<"anthropic-messages">;
     const context: Context = { messages: [] };
 
-    // Simulate pi-agent-core passing apiKey in options (API key, not OAuth token)
     void agent.streamFn?.(model, context, {
       apiKey: "sk-ant-api03-test", // pragma: allowlist secret
       headers: { "X-Custom": "1" },
@@ -2709,9 +2710,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.headers).toEqual({
       "X-Custom": "1",
-      // Includes pi-ai default betas (preserved to avoid overwrite) + context1m
-      "anthropic-beta":
-        "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,context-1m-2025-08-07",
+      "anthropic-beta": "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14",
     });
   });
 
@@ -2728,7 +2727,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(headers).toEqual({ "X-Custom": "1" });
   });
 
-  it("skips context1m beta for OAuth tokens but preserves OAuth-required betas", () => {
+  it("skips legacy context1m beta for OAuth tokens but preserves OAuth-required betas", () => {
     const calls: Array<SimpleStreamOptions | undefined> = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       calls.push(options);
@@ -2758,7 +2757,6 @@ describe("applyExtraParamsToAgent", () => {
     } as Model<"anthropic-messages">;
     const context: Context = { messages: [] };
 
-    // Simulate pi-agent-core passing an OAuth token (sk-ant-oat-*) as apiKey
     void agent.streamFn?.(model, context, {
       apiKey: "sk-ant-oat01-test-oauth-token", // pragma: allowlist secret
       headers: { "X-Custom": "1" },
@@ -2766,13 +2764,12 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(calls).toHaveLength(1);
     const betaHeader = calls[0]?.headers?.["anthropic-beta"] as string;
-    // Must include the OAuth-required betas so they aren't stripped by pi-ai's mergeHeaders
     expect(betaHeader).toContain("oauth-2025-04-20");
     expect(betaHeader).toContain("claude-code-20250219");
     expect(betaHeader).not.toContain("context-1m-2025-08-07");
   });
 
-  it("merges existing anthropic-beta headers with configured betas", () => {
+  it("merges existing anthropic-beta headers with configured betas (no context-1m)", () => {
     const cfg = buildModelConfig("anthropic/claude-sonnet-4-5", {
       context1m: true,
       anthropicBeta: ["files-api-2025-04-14"],
@@ -2786,9 +2783,11 @@ describe("applyExtraParamsToAgent", () => {
       },
     });
 
+    // context1m no longer injects a beta header (GA); only the explicitly
+    // configured anthropicBeta entry should appear alongside pi-ai defaults.
     expect(headers).toEqual({
       "anthropic-beta":
-        "prompt-caching-2024-07-31,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,files-api-2025-04-14,context-1m-2025-08-07",
+        "prompt-caching-2024-07-31,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,files-api-2025-04-14",
     });
   });
 

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -225,6 +225,10 @@ function isAnthropicOauthApiKey(apiKey: unknown): boolean {
   return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
 }
 
+function isAnthropicGa1MModel(modelId: string): boolean {
+  return /^(claude-opus-4[-.]6|claude-opus-4[-.]7|claude-sonnet-4[-.]6)/i.test(modelId);
+}
+
 function isDirectAnthropicModel(model: { provider?: string; baseUrl?: string }): boolean {
   const baseUrl = typeof model.baseUrl === "string" ? model.baseUrl : "";
   return model.provider === "anthropic" && (!baseUrl || baseUrl.includes("api.anthropic.com"));
@@ -385,7 +389,7 @@ function installFullProviderRuntimeDepsForTest() {
         if (
           anthropicBetas.length ||
           (params.context.extraParams?.context1m === true &&
-            /(opus|sonnet)/i.test(params.context.modelId))
+            isAnthropicGa1MModel(params.context.modelId))
         ) {
           streamFn = createAnthropicBetaHeadersWrapper(streamFn, anthropicBetas);
         }


### PR DESCRIPTION
## Summary

Anthropic has officially graduated the 1M context window from beta to GA. This PR implements Phase 1 of #45550:

- **Stop injecting beta header**: `context-1m-2025-08-07` is no longer added to `anthropic-beta` when `context1m: true`
- **Remove OAuth skip logic**: OAuth tokens (`sk-ant-oat-*`) now support 1M context natively — the special-case filtering that stripped the context-1m beta for OAuth is removed
- **Strip legacy header**: If users still have `context-1m-2025-08-07` in their `anthropicBeta` config, it is silently removed to prevent sending a stale header
- **Remove dead code**: `isAnthropic1MModel()`, `ANTHROPIC_1M_MODEL_PREFIXES`, and the unused `log` import are removed from the stream wrappers

### Backward compatibility

Fully backward compatible:
- `context1m: true` continues to work for context window sizing (`resolveContextTokensForModel` in `context.ts`)
- Existing configs with `context1m: true` will silently stop sending the unnecessary beta header
- No user-facing behavior change — 1M context works the same, just without the beta header

### Files changed

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts` | Remove beta header injection, OAuth skip logic, dead code |
| `src/agents/pi-embedded-runner-extraparams.test.ts` | Update 4 test cases to reflect GA behavior |

## Test plan

- [x] All 79 extraparams tests pass (`pnpm test -- src/agents/pi-embedded-runner-extraparams.test.ts`)
- [x] TypeScript compiles cleanly (no new errors)
- [x] Lint/format pass

Closes #45550 (Phase 1)