### PR TITLE
UI: fix oversized context-notice SVG icon hiding chat

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1040,6 +1040,44 @@
   color: var(--ok);
 }
 
+/* ===========================================
+   Context Notice (context window usage warning)
+   =========================================== */
+
+.context-notice {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.2;
+  padding: 6px 14px;
+  margin-bottom: 8px;
+  border-radius: 999px;
+  border: 1px solid var(--ctx-color, var(--danger));
+  background: var(--ctx-bg, var(--danger-subtle));
+  color: var(--ctx-color, var(--danger));
+  white-space: nowrap;
+  user-select: none;
+}
+
+.context-notice__icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.context-notice__detail {
+  opacity: 0.75;
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
 /* Compaction indicator */
 .compaction-indicator {
   align-self: center;


### PR DESCRIPTION
## Summary

- Problem: Missing .context-notice CSS rules caused the context window warning icon to scale infinitely.
- Why it matters: Renders the chat UI completely unusable when context limits are reached.
- What changed: Added missing .context-notice and .context-notice__icon CSS rules to ui/src/styles/components.css.
- What did NOT change: No logic changes to context management or server components.

## Change Type
- [x] Bug fix

## Scope
- [x] UI / DX

## Human Verification
- Verified scenarios: Confirmed that with 100% context used, the alert displays as a small pill at the top and the chat thread/compose box remain fully visible.