### PR TITLE
fix(privacy): harden stream filter and address review feedback

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -18,6 +18,12 @@ import type {
   PluginHookBeforeAgentStartResult,
   PluginHookBeforePromptBuildResult,
 } from "../../../plugins/types.js";
+import {
+  createPrivacyFilterContext,
+  wrapStreamFnPrivacyFilter,
+  filterPrompt,
+  type PrivacyFilterContext,
+} from "../../../privacy/stream-wrapper.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../../telegram/inline-buttons.js";
@@ -965,6 +971,18 @@ export async function runEmbeddedAttempt(
       // names on the live response stream before tool execution.
       activeSession.agent.streamFn = wrapStreamFnTrimToolCallNames(activeSession.agent.streamFn);
 
+      // Privacy filter: replace sensitive content before sending to LLM API.
+      // Inserted before payload logger so logged payloads also have privacy content filtered.
+      const privacyEnabled = params.config?.privacy?.enabled !== false;
+      let privacyCtx: PrivacyFilterContext | undefined;
+      if (privacyEnabled) {
+        privacyCtx = createPrivacyFilterContext(params.sessionId, params.config?.privacy);
+        activeSession.agent.streamFn = wrapStreamFnPrivacyFilter(
+          activeSession.agent.streamFn,
+          privacyCtx,
+        );
+      }
+
       if (anthropicPayloadLogger) {
         activeSession.agent.streamFn = anthropicPayloadLogger.wrapStreamFn(
           activeSession.agent.streamFn,
@@ -1311,6 +1329,11 @@ export async function runEmbeddedAttempt(
               .catch((err) => {
                 log.warn(`llm_input hook failed: ${String(err)}`);
               });
+          }
+
+          // Apply privacy filter to the prompt text before sending to LLM.
+          if (privacyCtx) {
+            effectivePrompt = filterPrompt(effectivePrompt, privacyCtx);
           }
 
           // Only pass images option if there are actually images to pass

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -21,7 +21,6 @@ import type {
 import {
   createPrivacyFilterContext,
   wrapStreamFnPrivacyFilter,
-  filterPrompt,
   type PrivacyFilterContext,
 } from "../../../privacy/stream-wrapper.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
@@ -1331,10 +1330,12 @@ export async function runEmbeddedAttempt(
               });
           }
 
-          // Apply privacy filter to the prompt text before sending to LLM.
-          if (privacyCtx) {
-            effectivePrompt = filterPrompt(effectivePrompt, privacyCtx);
-          }
+          // Privacy filtering is handled by wrapStreamFnPrivacyFilter on the
+          // streamFn boundary — it filters all outbound messages (including
+          // the prompt once it becomes a user message) and the systemPrompt.
+          // Applying filterPrompt here as well would create cascaded mappings
+          // (original → placeholder1 → placeholder2) that restore() cannot
+          // fully reverse, leaking unresolved placeholders to the user.
 
           // Only pass images option if there are actually images to pass
           // This avoids potential issues with models that don't expect the images parameter

--- a/src/config/privacy-config.test.ts
+++ b/src/config/privacy-config.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("privacy config schema", () => {
+  it("accepts a valid privacy config", () => {
+    const parsed = OpenClawSchema.parse({
+      privacy: {
+        enabled: true,
+        rules: "extended",
+        encryption: {
+          algorithm: "aes-256-gcm",
+          salt: "test-salt",
+        },
+        mappings: {
+          ttl: 86_400_000,
+          storePath: "/tmp/privacy-mappings.enc",
+        },
+        log: {
+          useReplacedContent: true,
+        },
+      },
+    });
+    expect(parsed.privacy?.enabled).toBe(true);
+    expect(parsed.privacy?.mappings?.ttl).toBe(86_400_000);
+  });
+
+  it("rejects invalid ttl", () => {
+    const result = OpenClawSchema.safeParse({
+      privacy: {
+        mappings: {
+          ttl: 0,
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -178,6 +178,32 @@ export type LoggingConfig = {
   redactPatterns?: string[];
 };
 
+export type PrivacyConfig = {
+  /** Enable privacy filtering for outbound LLM traffic. Default: true. */
+  enabled?: boolean;
+  /**
+   * Rule set preset or path to a custom rules file.
+   * Built-in presets: "basic" | "extended"
+   */
+  rules?: string;
+  encryption?: {
+    /** Encryption algorithm for persisted mappings. */
+    algorithm?: string;
+    /** Optional user-provided salt. */
+    salt?: string;
+  };
+  mappings?: {
+    /** Mapping retention time in milliseconds. */
+    ttl?: number;
+    /** Optional custom mapping store path. */
+    storePath?: string;
+  };
+  log?: {
+    /** Whether logs should prefer replaced content. */
+    useReplacedContent?: boolean;
+  };
+};
+
 export type DiagnosticsOtelConfig = {
   enabled?: boolean;
   endpoint?: string;

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -2,7 +2,13 @@ import type { AcpConfig } from "./types.acp.js";
 import type { AgentBinding, AgentsConfig } from "./types.agents.js";
 import type { ApprovalsConfig } from "./types.approvals.js";
 import type { AuthConfig } from "./types.auth.js";
-import type { DiagnosticsConfig, LoggingConfig, SessionConfig, WebConfig } from "./types.base.js";
+import type {
+  DiagnosticsConfig,
+  LoggingConfig,
+  PrivacyConfig,
+  SessionConfig,
+  WebConfig,
+} from "./types.base.js";
 import type { BrowserConfig } from "./types.browser.js";
 import type { ChannelsConfig } from "./types.channels.js";
 import type { CronConfig } from "./types.cron.js";
@@ -61,6 +67,7 @@ export type OpenClawConfig = {
   };
   diagnostics?: DiagnosticsConfig;
   logging?: LoggingConfig;
+  privacy?: PrivacyConfig;
   update?: {
     /** Update channel for git + npm installs ("stable", "beta", or "dev"). */
     channel?: "stable" | "beta" | "dev";

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -221,6 +221,33 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    privacy: z
+      .object({
+        enabled: z.boolean().optional(),
+        rules: z.string().optional(),
+        encryption: z
+          .object({
+            algorithm: z.string().optional(),
+            salt: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        mappings: z
+          .object({
+            ttl: z.number().int().positive().optional(),
+            storePath: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        log: z
+          .object({
+            useReplacedContent: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
     update: z
       .object({
         channel: z.union([z.literal("stable"), z.literal("beta"), z.literal("dev")]).optional(),

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getDefaultRedactPatterns, redactSensitiveText } from "./redact.js";
+import { getDefaultRedactPatterns, redactSensitiveText, redactToolDetail } from "./redact.js";
 
 const defaults = getDefaultRedactPatterns();
 
@@ -109,5 +109,15 @@ describe("redactSensitiveText", () => {
       patterns: defaults,
     });
     expect(output).toBe(input);
+  });
+});
+
+describe("redactToolDetail", () => {
+  it("applies privacy detector redaction for values outside default token patterns", () => {
+    const input = "email admin@company.com and backup@example.org";
+    const output = redactToolDetail(input);
+    expect(output).toContain("***");
+    expect(output).not.toContain("admin@company.com");
+    expect(output).not.toContain("backup@example.org");
   });
 });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { PrivacyDetector } from "../privacy/detector.js";
 import { compileSafeRegex } from "../security/safe-regex.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
 
@@ -142,9 +143,45 @@ export function redactToolDetail(detail: string): string {
   if (normalizeMode(resolved.mode) !== "tools") {
     return detail;
   }
-  return redactSensitiveText(detail, resolved);
+  return redactWithPrivacyFilter(detail, resolved);
 }
 
 export function getDefaultRedactPatterns(): string[] {
   return [...DEFAULT_REDACT_PATTERNS];
+}
+
+// Lazy-initialized shared detector for log redaction.
+let sharedDetector: PrivacyDetector | undefined;
+
+/**
+ * Enhanced redaction that combines the existing pattern-based redaction
+ * with the privacy detection engine for broader coverage.
+ */
+export function redactWithPrivacyFilter(text: string, options?: RedactOptions): string {
+  if (!text) {
+    return text;
+  }
+
+  // First pass: existing pattern-based redaction.
+  let result = redactSensitiveText(text, options);
+
+  // Second pass: privacy detector for additional coverage.
+  try {
+    if (!sharedDetector) {
+      sharedDetector = new PrivacyDetector("extended");
+    }
+    const detected = sharedDetector.detect(result);
+    if (detected.hasPrivacyRisk) {
+      // Apply mask-style redaction (not replacement) for log output.
+      const sorted = [...detected.matches].toSorted((a, b) => b.start - a.start);
+      for (const match of sorted) {
+        const masked = maskToken(match.content);
+        result = result.slice(0, match.start) + masked + result.slice(match.end);
+      }
+    }
+  } catch {
+    // Non-fatal: fall back to pattern-only redaction.
+  }
+
+  return result;
 }

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -105,21 +105,36 @@ function redactText(text: string, patterns: RegExp[]): string {
   return next;
 }
 
-function resolveConfigRedaction(): RedactOptions {
-  let cfg: OpenClawConfig["logging"] | undefined;
+type ResolvedConfig = {
+  redactOptions: RedactOptions;
+  privacyEnabled: boolean;
+  privacyRules: string | undefined;
+};
+
+function resolveConfigRedaction(): ResolvedConfig {
+  let loggingCfg: OpenClawConfig["logging"] | undefined;
+  let privacyCfg: OpenClawConfig["privacy"] | undefined;
   try {
     const loaded = requireConfig?.("../config/config.js") as
       | {
           loadConfig?: () => OpenClawConfig;
         }
       | undefined;
-    cfg = loaded?.loadConfig?.().logging;
+    const full = loaded?.loadConfig?.();
+    loggingCfg = full?.logging;
+    privacyCfg = full?.privacy;
   } catch {
-    cfg = undefined;
+    loggingCfg = undefined;
+    privacyCfg = undefined;
   }
   return {
-    mode: normalizeMode(cfg?.redactSensitive),
-    patterns: cfg?.redactPatterns,
+    redactOptions: {
+      mode: normalizeMode(loggingCfg?.redactSensitive),
+      patterns: loggingCfg?.redactPatterns,
+    },
+    // When privacy is not configured at all we treat it as enabled (safe default).
+    privacyEnabled: privacyCfg?.enabled !== false,
+    privacyRules: privacyCfg?.rules,
   };
 }
 
@@ -127,7 +142,7 @@ export function redactSensitiveText(text: string, options?: RedactOptions): stri
   if (!text) {
     return text;
   }
-  const resolved = options ?? resolveConfigRedaction();
+  const resolved = options ?? resolveConfigRedaction().redactOptions;
   if (normalizeMode(resolved.mode) === "off") {
     return text;
   }
@@ -140,24 +155,40 @@ export function redactSensitiveText(text: string, options?: RedactOptions): stri
 
 export function redactToolDetail(detail: string): string {
   const resolved = resolveConfigRedaction();
-  if (normalizeMode(resolved.mode) !== "tools") {
+  if (normalizeMode(resolved.redactOptions.mode) !== "tools") {
     return detail;
   }
-  return redactWithPrivacyFilter(detail, resolved);
+  return redactWithPrivacyFilter(
+    detail,
+    resolved.redactOptions,
+    resolved.privacyEnabled,
+    resolved.privacyRules,
+  );
 }
 
 export function getDefaultRedactPatterns(): string[] {
   return [...DEFAULT_REDACT_PATTERNS];
 }
 
-// Lazy-initialized shared detector for log redaction.
-let sharedDetector: PrivacyDetector | undefined;
+// Cache the last detector instance keyed by ruleset to avoid re-construction
+// on every log line while still respecting user-configured rules.
+let cachedDetector: PrivacyDetector | undefined;
+let cachedDetectorRules: string | undefined;
 
 /**
  * Enhanced redaction that combines the existing pattern-based redaction
  * with the privacy detection engine for broader coverage.
+ *
+ * Respects `privacy.enabled` — when false, only the pattern-based pass runs.
+ * Respects `privacy.rules` — uses the configured ruleset instead of always
+ * defaulting to "extended".
  */
-export function redactWithPrivacyFilter(text: string, options?: RedactOptions): string {
+export function redactWithPrivacyFilter(
+  text: string,
+  options?: RedactOptions,
+  privacyEnabled = true,
+  privacyRules: string | undefined = undefined,
+): string {
   if (!text) {
     return text;
   }
@@ -166,11 +197,19 @@ export function redactWithPrivacyFilter(text: string, options?: RedactOptions): 
   let result = redactSensitiveText(text, options);
 
   // Second pass: privacy detector for additional coverage.
+  // Skip entirely when the user has opted out of privacy features.
+  if (!privacyEnabled) {
+    return result;
+  }
+
   try {
-    if (!sharedDetector) {
-      sharedDetector = new PrivacyDetector("extended");
+    const rules = privacyRules ?? "extended";
+    // Re-create the detector only when the ruleset changes.
+    if (!cachedDetector || cachedDetectorRules !== rules) {
+      cachedDetector = new PrivacyDetector(rules);
+      cachedDetectorRules = rules;
     }
-    const detected = sharedDetector.detect(result);
+    const detected = cachedDetector.detect(result);
     if (detected.hasPrivacyRisk) {
       // Apply mask-style redaction (not replacement) for log output.
       const sorted = [...detected.matches].toSorted((a, b) => b.start - a.start);

--- a/src/privacy/README.en.md
+++ b/src/privacy/README.en.md
@@ -1,0 +1,508 @@
+# Privacy Filter Module
+
+The OpenClaw Privacy Filter module automatically detects and replaces sensitive information in messages before they are sent to LLM APIs, then restores the original content in LLM responses — ensuring private data never leaks to external services.
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [Core Pipeline](#core-pipeline)
+- [Module Reference](#module-reference)
+- [Built-in Rules](#built-in-rules)
+- [Configuration](#configuration)
+- [Custom Rules](#custom-rules)
+- [Replacement Templates](#replacement-templates)
+- [Named Validators](#named-validators)
+- [API Reference](#api-reference)
+
+---
+
+## Architecture Overview
+
+```
+User Input (with sensitive data)
+     │
+     ▼
+ ┌──────────┐     ┌──────────┐     ┌──────────┐
+ │ Detector │────▶│ Replacer │────▶│  Store   │
+ │  Engine  │     │  Engine  │     │ Encrypted│
+ └──────────┘     └──────────┘     └──────────┘
+     │                 │
+     │   ┌─────────────┘
+     ▼   ▼
+ ┌──────────────┐
+ │StreamWrapper │  ← Wraps LLM call stream
+ │ Outbound:    │
+ │   Replace    │
+ │ Inbound:     │
+ │   Restore    │
+ └──────────────┘
+     │
+     ▼
+  LLM API (sees only replaced content)
+```
+
+## Core Pipeline
+
+1. **Detect** — `PrivacyDetector` scans text using regex patterns, keyword matching, and context constraints to identify sensitive information
+2. **Replace** — `PrivacyReplacer` substitutes sensitive content with format-compatible fake values (e.g. `user@gmail.com` → `pf_e1234567890@example.net`), preserving semantic structure so the LLM can still understand context
+3. **Persist** — `PrivacyMappingStore` encrypts and saves the original-to-replacement mappings using AES-256-GCM
+4. **Restore** — Replacement values in LLM responses are automatically restored to the original content, so users see real information
+
+## Module Reference
+
+| File                | Responsibility                                                                                                                         |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `types.ts`          | All type definitions: `PrivacyRule`, `DetectionMatch`, `PrivacyConfig`, `UserDefinedRule`, `CustomRulesConfig`, etc.                   |
+| `rules.ts`          | Built-in rule sets (`BASIC_RULES` and `EXTENDED_RULES`) and the `resolveRules()` entry point                                           |
+| `detector.ts`       | Detection engine `PrivacyDetector`: compiles rules, regex matching, context validation, password complexity and entropy checks         |
+| `replacer.ts`       | Replacement engine `PrivacyReplacer`: generates type-specific fake values, maintains bidirectional mappings, supports custom templates |
+| `mapping-store.ts`  | Encrypted persistent store `PrivacyMappingStore`: AES-256-GCM encryption, PBKDF2 key derivation, session-scoped isolation              |
+| `stream-wrapper.ts` | LLM stream wrapper: intercepts outbound messages for replacement, intercepts inbound responses for restoration                         |
+| `custom-rules.ts`   | Custom rules module: loads user-defined rules from JSON/JSON5 files, validates, and merges with built-in rules                         |
+| `index.ts`          | Unified public API exports                                                                                                             |
+
+## Built-in Rules
+
+### Basic Rule Set
+
+High-priority, low-false-positive core rules:
+
+| Type                        | Risk Level | Description                                              |
+| --------------------------- | ---------- | -------------------------------------------------------- |
+| `email`                     | medium     | Email addresses                                          |
+| `phone_cn`                  | medium     | China mainland phone numbers                             |
+| `id_card_cn`                | high       | China national ID card numbers                           |
+| `credit_card`               | critical   | Credit card numbers (Visa/MasterCard/Amex/Discover)      |
+| `bank_account_cn`           | critical   | China bank account numbers (requires context keywords)   |
+| `password_assignment`       | critical   | Password assignment statements (`password=xxx`)          |
+| `env_password`              | critical   | Environment variable passwords (`PASSWORD=xxx`)          |
+| `github_token`              | critical   | GitHub access tokens                                     |
+| `openai_api_key`            | critical   | OpenAI API keys                                          |
+| `slack_token`               | critical   | Slack tokens                                             |
+| `google_api_key`            | critical   | Google API keys                                          |
+| `stripe_api_key`            | critical   | Stripe API keys                                          |
+| `aws_access_key`            | critical   | AWS access key IDs                                       |
+| `aws_secret_key`            | critical   | AWS secret access keys                                   |
+| `alibaba_access_key`        | critical   | Alibaba Cloud AccessKeys                                 |
+| `tencent_secret_id`         | critical   | Tencent Cloud SecretIds                                  |
+| `jwt_token`                 | high       | JWT tokens                                               |
+| `generic_api_key`           | high       | Generic API key patterns                                 |
+| `bearer_token`              | high       | Bearer tokens                                            |
+| `ssh_private_key`           | critical   | SSH private keys                                         |
+| `database_url_*`            | critical   | MySQL/PostgreSQL/MongoDB connection strings              |
+| `redis_url`                 | critical   | Redis connection strings                                 |
+| `url_with_credentials`      | critical   | URLs with embedded credentials                           |
+| `basic_auth`                | critical   | HTTP Basic authentication                                |
+| `social_security_number_us` | critical   | US Social Security Numbers                               |
+| `bare_password`             | high       | Bare passwords (3+ character class complexity detection) |
+| `high_entropy_string`       | high       | High-entropy strings (likely keys/tokens)                |
+
+### Extended Rule Set (Default)
+
+Includes all Basic rules, plus:
+
+- Additional phone formats: Hong Kong, Taiwan, US
+- Additional IDs: Hong Kong ID card, China passport, multi-country passports
+- UnionPay cards, IBAN
+- Alipay accounts, WeChat IDs
+- Additional API keys: Anthropic, GitLab, Discord, NPM, PyPI, SendGrid, Twilio, Shopify, Square, New Relic, Mailchimp, Sentry
+- Azure Storage keys, Azure Client Secrets
+- JDBC, .NET connection strings, Elasticsearch, RabbitMQ
+- OAuth tokens, Session tokens
+- Cryptocurrency private keys, Ethereum addresses
+- Salary amounts
+
+---
+
+## Configuration
+
+Set the `privacy` field in your OpenClaw configuration file:
+
+```json5
+{
+  privacy: {
+    // Enable/disable privacy filtering (default: true)
+    enabled: true,
+
+    // Rule set: "basic" | "extended" | path to custom rules file
+    rules: "extended",
+
+    // Encryption settings
+    encryption: {
+      algorithm: "aes-256-gcm",
+      salt: "", // Leave empty to auto-generate
+    },
+
+    // Mapping store settings
+    mappings: {
+      ttl: 86400000, // Mapping expiration time, default 24 hours (ms)
+      storePath: "", // Leave empty for default: ~/.openclaw/privacy/mappings.enc
+    },
+
+    // Logging settings
+    log: {
+      useReplacedContent: true, // Use replaced content in logs
+    },
+  },
+}
+```
+
+---
+
+## Custom Rules
+
+When built-in rules don't meet your needs, you can define custom detection rules via a JSON/JSON5 file.
+
+### Enabling Custom Rules
+
+Set `privacy.rules` to the path of your custom rules file:
+
+```json
+{
+  "privacy": {
+    "enabled": true,
+    "rules": "./my-privacy-rules.json5"
+  }
+}
+```
+
+### Config File Format
+
+```json5
+{
+  // Base preset: "basic" | "extended" | "none"
+  // Custom rules are layered on top of the base preset
+  // Default: "extended"
+  extends: "extended",
+
+  // Built-in rule types to disable
+  // These rules remain in the list but have enabled set to false
+  disable: ["bare_password", "high_entropy_string"],
+
+  // Custom rule definitions
+  rules: [
+    // ... rule definitions
+  ],
+}
+```
+
+### Rule Definition Fields
+
+```json5
+{
+  // [Required] Rule type identifier, must be snake_case (e.g. "employee_id")
+  type: "employee_id",
+
+  // [Required] Human-readable description
+  description: "Internal employee ID (EMP-XXXXXX)",
+
+  // [Required] Risk level: "low" | "medium" | "high" | "critical"
+  riskLevel: "medium",
+
+  // [Optional] Regex pattern (at least one of pattern or keywords is required)
+  // Supports (?i) prefix for case-insensitive matching
+  pattern: "\\bEMP-[0-9]{6}\\b",
+
+  // [Optional] Keyword list (at least one of pattern or keywords is required)
+  keywords: ["Project-Phoenix", "Project-Titan"],
+
+  // [Optional] Whether keyword matching is case-sensitive, default: false
+  caseSensitive: true,
+
+  // [Optional] Context constraints to reduce false positives
+  context: {
+    mustContain: ["server", "host"], // At least one keyword must appear near the match
+    mustNotContain: ["example", "test"], // None of these keywords may appear near the match
+  },
+
+  // [Optional] Whether this rule is enabled, default: true
+  enabled: true,
+
+  // [Optional] Named validator function for post-match validation
+  // Available: "bare_password" | "high_entropy"
+  validateFn: "bare_password",
+
+  // [Optional] Custom replacement template (see "Replacement Templates" section)
+  replacementTemplate: "EMP-REDACTED-{seq}",
+}
+```
+
+### Full Example
+
+```json5
+{
+  extends: "basic",
+
+  disable: [
+    "bare_password", // Disable bare password detection (high false-positive rate)
+    "high_entropy_string", // Disable high-entropy string detection
+  ],
+
+  rules: [
+    // 1. New rule: company employee ID
+    {
+      type: "employee_id",
+      description: "Internal employee ID (EMP-XXXXXX)",
+      riskLevel: "medium",
+      pattern: "\\bEMP-[0-9]{6}\\b",
+      replacementTemplate: "EMP-000{seq}00",
+    },
+
+    // 2. New rule: Japanese phone number
+    {
+      type: "phone_jp",
+      description: "Japan mobile phone number",
+      riskLevel: "medium",
+      pattern: "\\b0[789]0-?\\d{4}-?\\d{4}\\b",
+    },
+
+    // 3. Override built-in: lower email risk level
+    {
+      type: "email",
+      description: "Email address (low risk)",
+      riskLevel: "low",
+      pattern: "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b",
+    },
+
+    // 4. Keyword detection: internal project codenames
+    {
+      type: "internal_codename",
+      description: "Internal project codename",
+      riskLevel: "high",
+      keywords: ["Project-Phoenix", "Project-Titan", "Project-Nova"],
+      caseSensitive: true,
+    },
+
+    // 5. Context-constrained: only detect IPs in specific contexts
+    {
+      type: "server_ip",
+      description: "Server IP address",
+      riskLevel: "medium",
+      pattern: "\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b",
+      context: {
+        mustContain: ["server", "host", "node"],
+        mustNotContain: ["example", "localhost"],
+      },
+    },
+  ],
+}
+```
+
+### Merge Behavior
+
+- **Same-type override**: Custom rules with the same `type` as a built-in rule **entirely replace** the built-in rule (no partial merge)
+- **New types appended**: Rule types not present in the base preset are appended to the end of the rule list
+- **Disable list**: Disabled rules remain in the list with `enabled` set to `false`
+
+### Validation
+
+Custom rules are validated at load time:
+
+| Check             | Description                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------------ |
+| `type` format     | Must match `[a-z][a-z0-9_]*` (lowercase snake_case)                                        |
+| Required fields   | `type`, `description`, `riskLevel` must not be empty                                       |
+| `riskLevel` value | Must be one of `low` / `medium` / `high` / `critical`                                      |
+| Match method      | At least one of `pattern` or `keywords` must be provided                                   |
+| Regex safety      | Pattern must compile, not exceed 2000 characters, no nested quantifiers (ReDoS prevention) |
+| `validateFn`      | If provided, must be a registered named validator                                          |
+
+Rules that fail validation are skipped (they don't cause the entire load to fail). Errors are reported via `console.warn`.
+
+---
+
+## Replacement Templates
+
+Custom rules can define a `replacementTemplate` field to control the format of replacement values.
+
+### Supported Placeholders
+
+| Placeholder           | Description                                  | Example                                           |
+| --------------------- | -------------------------------------------- | ------------------------------------------------- |
+| `{type}`              | Rule type identifier                         | `employee_id`                                     |
+| `{seq}`               | Session-scoped sequence number (starts at 0) | `0`, `1`, `2`                                     |
+| `{ts}`                | Last 10 digits of the timestamp              | `1234567890`                                      |
+| `{original_prefix:N}` | First N characters of the original content   | For `EMP-123456` → `{original_prefix:4}` = `EMP-` |
+| `{original_length}`   | Length of the original content               | `10`                                              |
+| `{pad:N}`             | N `x` characters for padding                 | `{pad:5}` = `xxxxx`                               |
+
+### Template Examples
+
+```json5
+// Employee ID: preserve prefix, pad with sequence
+"replacementTemplate": "EMP-{seq}00000"
+// EMP-123456 → EMP-000000
+
+// Preserve original prefix
+"replacementTemplate": "{original_prefix:4}XXXX-0000"
+// INT-ABCD-1234 → INT-XXXX-0000
+
+// Generic redaction with type tag
+"replacementTemplate": "REDACTED_{type}_{seq}"
+// Any match → REDACTED_employee_id_0
+
+// Fixed-length padding
+"replacementTemplate": "***{pad:10}***"
+// Any match → ***xxxxxxxxxx***
+```
+
+If no `replacementTemplate` is provided, the system uses built-in type-specific replacement logic (e.g. emails generate fake emails, phone numbers generate fake phone numbers), or the generic format `pf_{type}_{timestamp}{seq}` for unknown types.
+
+---
+
+## Named Validators
+
+Since JSON config files cannot contain functions, custom rules reference pre-registered named validators via the `validateFn` field.
+
+### Built-in Validators
+
+| Name            | Description                                                                                                                              |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `bare_password` | Checks if a string has password characteristics (3+ character classes, 8-64 chars, excludes URLs/paths and other common false positives) |
+| `high_entropy`  | Checks if a string is a high-entropy random string (Shannon entropy >= 3.5 bits/char, >= 16 chars, excludes sequential characters)       |
+
+### Registering Custom Validators
+
+Plugins or extensions can register new validators via the API:
+
+```typescript
+import { registerNamedValidator } from "./privacy/index.js";
+
+// Register a custom validator
+registerNamedValidator("luhn_check", (s: string) => {
+  // Luhn algorithm check (credit card numbers)
+  let sum = 0;
+  let alternate = false;
+  for (let i = s.length - 1; i >= 0; i--) {
+    let n = parseInt(s[i], 10);
+    if (alternate) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    alternate = !alternate;
+  }
+  return sum % 10 === 0;
+});
+```
+
+Then reference it in a custom rule:
+
+```json5
+{
+  type: "custom_card",
+  description: "Custom card number detection",
+  riskLevel: "critical",
+  pattern: "\\b\\d{16}\\b",
+  validateFn: "luhn_check",
+}
+```
+
+---
+
+## API Reference
+
+### Core Classes
+
+#### `PrivacyDetector`
+
+```typescript
+// Using a preset
+const detector = new PrivacyDetector("extended");
+
+// Using a custom rules array
+const detector = new PrivacyDetector(customRules);
+
+// Detect
+const result: FilterResult = detector.detect("text with sensitive@email.com");
+// result.hasPrivacyRisk → true
+// result.matches → [{ type: "email", content: "sensitive@email.com", ... }]
+
+// Quick check
+const hasSensitive: boolean = detector.check("some text");
+```
+
+#### `PrivacyReplacer`
+
+```typescript
+const replacer = new PrivacyReplacer("session-id");
+
+// Replace detected sensitive content
+const { replaced, newMappings } = replacer.replaceAll(text, matches);
+
+// Restore replaced content
+const original = replacer.restore(replacedText);
+```
+
+#### `PrivacyMappingStore`
+
+```typescript
+const store = new PrivacyMappingStore({ salt: "my-salt" });
+
+store.save(mappings); // Encrypt and save
+const loaded = store.load(); // Load all
+const session = store.loadSession(id); // Load by session
+store.append(newMappings); // Append new mappings
+store.cleanup(86_400_000); // Remove expired mappings
+store.clearSession(sessionId); // Clear a specific session
+```
+
+### Custom Rules Functions
+
+```typescript
+import {
+  loadCustomRules,
+  processCustomRulesConfig,
+  validateUserRule,
+  validateRegexSafety,
+  registerNamedValidator,
+  getNamedValidators,
+} from "./privacy/index.js";
+
+// Load from file
+const result = loadCustomRules("./my-rules.json5");
+// result.rules    → merged rules array
+// result.errors   → validation errors
+// result.warnings → warning messages
+
+// Process from object
+const result = processCustomRulesConfig({
+  extends: "basic",
+  disable: ["email"],
+  rules: [{ type: "custom", description: "...", riskLevel: "low", pattern: "..." }],
+});
+
+// Validate a single rule
+const errors = validateUserRule(rule, 0);
+
+// Validate regex safety
+const error = validateRegexSafety("(a+)+"); // → "contains nested quantifiers..."
+
+// List registered validators
+const names = getNamedValidators(); // → ["bare_password", "high_entropy"]
+```
+
+### Stream Wrapper (Integration)
+
+```typescript
+import {
+  createPrivacyFilterContext,
+  filterText,
+  restoreText,
+  filterPrompt,
+  restoreResponse,
+  wrapStreamFnPrivacyFilter,
+} from "./privacy/index.js";
+
+// Create a session-scoped context
+const ctx = createPrivacyFilterContext("session-123", { rules: "./my-rules.json5" });
+
+// Filter a text string
+const filtered = filterText("my password=Secret123!", ctx);
+
+// Restore
+const restored = restoreText(filtered, ctx);
+
+// Wrap LLM stream function
+const wrappedStreamFn = wrapStreamFnPrivacyFilter(originalStreamFn, ctx);
+```

--- a/src/privacy/README.md
+++ b/src/privacy/README.md
@@ -1,0 +1,506 @@
+# Privacy Filter Module
+
+OpenClaw 隐私过滤模块 — 在消息发送到 LLM API 之前自动检测并替换敏感信息，LLM 响应返回后自动还原，确保隐私数据不会泄露到外部服务。
+
+## 目录
+
+- [架构概览](#架构概览)
+- [核心流程](#核心流程)
+- [模块说明](#模块说明)
+- [内置规则](#内置规则)
+- [配置说明](#配置说明)
+- [自定义规则](#自定义规则)
+- [替换模板](#替换模板)
+- [命名验证器](#命名验证器)
+- [API 参考](#api-参考)
+
+---
+
+## 架构概览
+
+```
+用户输入 (含敏感信息)
+     │
+     ▼
+ ┌──────────┐     ┌──────────┐     ┌──────────┐
+ │ Detector │────▶│ Replacer │────▶│  Store   │
+ │ 检测引擎  │     │ 替换引擎  │     │ 加密存储  │
+ └──────────┘     └──────────┘     └──────────┘
+     │                 │
+     │   ┌─────────────┘
+     ▼   ▼
+ ┌──────────────┐
+ │StreamWrapper │  ← 包装 LLM 调用流
+ │ 出站: 替换    │
+ │ 入站: 还原    │
+ └──────────────┘
+     │
+     ▼
+  LLM API (只看到替换后的内容)
+```
+
+## 核心流程
+
+1. **检测 (Detect)** — `PrivacyDetector` 使用正则表达式、关键词匹配和上下文约束扫描文本，识别敏感信息
+2. **替换 (Replace)** — `PrivacyReplacer` 将敏感内容替换为格式兼容的假值（如 `user@gmail.com` → `pf_e1234567890@example.net`），保持语义结构不变，LLM 仍能理解上下文
+3. **存储 (Persist)** — `PrivacyMappingStore` 使用 AES-256-GCM 加密保存原文与替换值的映射关系
+4. **还原 (Restore)** — LLM 响应中出现的替换值被自动还原为原始内容，用户看到的是真实信息
+
+## 模块说明
+
+| 文件                | 职责                                                                                                      |
+| ------------------- | --------------------------------------------------------------------------------------------------------- |
+| `types.ts`          | 所有类型定义：`PrivacyRule`、`DetectionMatch`、`PrivacyConfig`、`UserDefinedRule`、`CustomRulesConfig` 等 |
+| `rules.ts`          | 内置规则集（`BASIC_RULES` 和 `EXTENDED_RULES`）及 `resolveRules()` 规则解析入口                           |
+| `detector.ts`       | 检测引擎 `PrivacyDetector`：编译规则、正则匹配、上下文验证、密码复杂度和熵值校验                          |
+| `replacer.ts`       | 替换引擎 `PrivacyReplacer`：生成类型特定的假值、维护双向映射、支持自定义模板                              |
+| `mapping-store.ts`  | 加密持久化存储 `PrivacyMappingStore`：AES-256-GCM 加密、PBKDF2 密钥派生、按会话隔离                       |
+| `stream-wrapper.ts` | LLM 调用流包装：拦截出站消息进行替换、拦截入站响应进行还原                                                |
+| `custom-rules.ts`   | 自定义规则模块：从 JSON/JSON5 文件加载用户规则、验证、合并                                                |
+| `index.ts`          | 公共 API 统一导出                                                                                         |
+
+## 内置规则
+
+### Basic 规则集
+
+高优先级、低误报率的核心规则：
+
+| 类型                        | 风险级别 | 说明                                      |
+| --------------------------- | -------- | ----------------------------------------- |
+| `email`                     | medium   | 电子邮箱地址                              |
+| `phone_cn`                  | medium   | 中国大陆手机号                            |
+| `id_card_cn`                | high     | 中国身份证号                              |
+| `credit_card`               | critical | 信用卡号（Visa/MasterCard/Amex/Discover） |
+| `bank_account_cn`           | critical | 中国银行账号（需上下文关键词）            |
+| `password_assignment`       | critical | 密码赋值语句（`password=xxx`）            |
+| `env_password`              | critical | 环境变量密码（`PASSWORD=xxx`）            |
+| `github_token`              | critical | GitHub 访问令牌                           |
+| `openai_api_key`            | critical | OpenAI API 密钥                           |
+| `slack_token`               | critical | Slack 令牌                                |
+| `google_api_key`            | critical | Google API 密钥                           |
+| `stripe_api_key`            | critical | Stripe API 密钥                           |
+| `aws_access_key`            | critical | AWS 访问密钥                              |
+| `aws_secret_key`            | critical | AWS 秘密密钥                              |
+| `alibaba_access_key`        | critical | 阿里云 AccessKey                          |
+| `tencent_secret_id`         | critical | 腾讯云 SecretId                           |
+| `jwt_token`                 | high     | JWT 令牌                                  |
+| `generic_api_key`           | high     | 通用 API 密钥模式                         |
+| `bearer_token`              | high     | Bearer 令牌                               |
+| `ssh_private_key`           | critical | SSH 私钥                                  |
+| `database_url_*`            | critical | MySQL/PostgreSQL/MongoDB 连接字符串       |
+| `redis_url`                 | critical | Redis 连接字符串                          |
+| `url_with_credentials`      | critical | 带凭证的 URL                              |
+| `basic_auth`                | critical | HTTP Basic 认证                           |
+| `social_security_number_us` | critical | 美国社保号                                |
+| `bare_password`             | high     | 裸密码（3+ 字符类复杂度检测）             |
+| `high_entropy_string`       | high     | 高熵字符串（可能是密钥/令牌）             |
+
+### Extended 规则集（默认）
+
+包含 Basic 全部规则，额外增加：
+
+- 更多电话格式：香港、台湾、美国
+- 更多证件：香港身份证、中国护照、多国护照
+- 银联卡、IBAN
+- 支付宝、微信 ID
+- 更多 API 密钥：Anthropic、GitLab、Discord、NPM、PyPI、SendGrid、Twilio、Shopify、Square、New Relic、Mailchimp、Sentry
+- Azure 存储密钥、Azure 客户端密钥
+- JDBC、.NET 连接字符串、Elasticsearch、RabbitMQ
+- OAuth 令牌、Session 令牌
+- 加密货币私钥、以太坊地址
+- 工资金额
+
+---
+
+## 配置说明
+
+在 OpenClaw 配置文件中设置 `privacy` 字段：
+
+```json5
+{
+  privacy: {
+    // 是否启用隐私过滤（默认 true）
+    enabled: true,
+
+    // 规则集："basic" | "extended" | 自定义规则文件路径
+    rules: "extended",
+
+    // 加密设置
+    encryption: {
+      algorithm: "aes-256-gcm",
+      salt: "", // 留空则自动生成
+    },
+
+    // 映射存储设置
+    mappings: {
+      ttl: 86400000, // 映射过期时间，默认 24 小时（毫秒）
+      storePath: "", // 留空使用默认路径 ~/.openclaw/privacy/mappings.enc
+    },
+
+    // 日志设置
+    log: {
+      useReplacedContent: true, // 日志中使用替换后的内容
+    },
+  },
+}
+```
+
+---
+
+## 自定义规则
+
+当内置规则无法满足需求时，可以通过 JSON/JSON5 文件定义自定义规则。
+
+### 启用方式
+
+将 `privacy.rules` 设置为自定义规则文件的路径：
+
+```json
+{
+  "privacy": {
+    "enabled": true,
+    "rules": "./my-privacy-rules.json5"
+  }
+}
+```
+
+### 配置文件格式
+
+```json5
+{
+  // 基础预设："basic" | "extended" | "none"
+  // 自定义规则会在基础预设之上叠加
+  // 默认 "extended"
+  extends: "extended",
+
+  // 要禁用的内置规则类型列表
+  // 这些规则仍然存在，但 enabled 会被设为 false
+  disable: ["bare_password", "high_entropy_string"],
+
+  // 自定义规则列表
+  rules: [
+    // ... 规则定义
+  ],
+}
+```
+
+### 规则定义字段
+
+```json5
+{
+  // [必填] 规则类型标识符，必须是 snake_case 格式（如 "employee_id"）
+  type: "employee_id",
+
+  // [必填] 人类可读的描述
+  description: "内部员工编号 (EMP-XXXXXX)",
+
+  // [必填] 风险级别："low" | "medium" | "high" | "critical"
+  riskLevel: "medium",
+
+  // [可选] 正则表达式模式（与 keywords 至少填一个）
+  // 支持 (?i) 前缀表示不区分大小写
+  pattern: "\\bEMP-[0-9]{6}\\b",
+
+  // [可选] 关键词列表（与 pattern 至少填一个）
+  keywords: ["Project-Phoenix", "Project-Titan"],
+
+  // [可选] 关键词匹配是否区分大小写，默认 false
+  caseSensitive: true,
+
+  // [可选] 上下文约束，用于减少误报
+  context: {
+    mustContain: ["server", "host"], // 匹配区域附近必须出现的关键词（任意一个）
+    mustNotContain: ["example", "test"], // 匹配区域附近不能出现的关键词
+  },
+
+  // [可选] 是否启用此规则，默认 true
+  enabled: true,
+
+  // [可选] 命名验证器函数，用于后置匹配验证
+  // 可选值："bare_password" | "high_entropy"
+  validateFn: "bare_password",
+
+  // [可选] 自定义替换模板（详见"替换模板"章节）
+  replacementTemplate: "EMP-REDACTED-{seq}",
+}
+```
+
+### 完整示例
+
+```json5
+{
+  extends: "basic",
+
+  disable: [
+    "bare_password", // 关闭裸密码检测（误报率高）
+    "high_entropy_string", // 关闭高熵字符串检测
+  ],
+
+  rules: [
+    // 1. 新增：公司员工编号
+    {
+      type: "employee_id",
+      description: "内部员工编号 (EMP-XXXXXX)",
+      riskLevel: "medium",
+      pattern: "\\bEMP-[0-9]{6}\\b",
+      replacementTemplate: "EMP-000{seq}00",
+    },
+
+    // 2. 新增：日本电话号码
+    {
+      type: "phone_jp",
+      description: "日本手机号码",
+      riskLevel: "medium",
+      pattern: "\\b0[789]0-?\\d{4}-?\\d{4}\\b",
+    },
+
+    // 3. 覆盖内置规则：将 email 风险级别降低
+    {
+      type: "email",
+      description: "Email address (低风险)",
+      riskLevel: "low",
+      pattern: "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b",
+    },
+
+    // 4. 关键词检测：内部项目代号
+    {
+      type: "internal_codename",
+      description: "内部项目代号",
+      riskLevel: "high",
+      keywords: ["Project-Phoenix", "Project-Titan", "Project-Nova"],
+      caseSensitive: true,
+    },
+
+    // 5. 带上下文约束：仅在特定上下文中检测 IP
+    {
+      type: "server_ip",
+      description: "服务器 IP 地址",
+      riskLevel: "medium",
+      pattern: "\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b",
+      context: {
+        mustContain: ["server", "host", "服务器", "节点"],
+        mustNotContain: ["example", "localhost"],
+      },
+    },
+  ],
+}
+```
+
+### 合并规则
+
+- **同 type 覆盖**：自定义规则中与内置规则 `type` 相同的规则会**整体替换**内置规则（不是部分合并）
+- **新 type 追加**：内置规则中不存在的 type 会追加到规则列表末尾
+- **disable 列表**：被禁用的规则仍存在于列表中，但 `enabled` 被设为 `false`
+
+### 验证规则
+
+自定义规则在加载时会进行以下验证：
+
+| 检查项         | 说明                                                         |
+| -------------- | ------------------------------------------------------------ |
+| `type` 格式    | 必须匹配 `[a-z][a-z0-9_]*`（小写 snake_case）                |
+| 必填字段       | `type`、`description`、`riskLevel` 不能为空                  |
+| `riskLevel` 值 | 必须是 `low` / `medium` / `high` / `critical` 之一           |
+| 匹配方式       | `pattern` 和 `keywords` 至少提供一个                         |
+| 正则安全性     | 模式必须可编译、长度不超过 2000 字符、无嵌套量词（防 ReDoS） |
+| `validateFn`   | 如果提供，必须是已注册的命名验证器                           |
+
+验证失败的规则会被跳过（不会导致整体加载失败），错误信息通过 `console.warn` 输出。
+
+---
+
+## 替换模板
+
+自定义规则可以通过 `replacementTemplate` 字段定义替换值的格式。
+
+### 支持的占位符
+
+| 占位符                | 说明                          | 示例值                                             |
+| --------------------- | ----------------------------- | -------------------------------------------------- |
+| `{type}`              | 规则类型标识符                | `employee_id`                                      |
+| `{seq}`               | 本次会话内的序号（从 0 递增） | `0`, `1`, `2`                                      |
+| `{ts}`                | 时间戳后 10 位                | `1234567890`                                       |
+| `{original_prefix:N}` | 原始内容的前 N 个字符         | 原文 `EMP-123456` → `{original_prefix:4}` = `EMP-` |
+| `{original_length}`   | 原始内容的长度                | `10`                                               |
+| `{pad:N}`             | N 个 `x` 字符填充             | `{pad:5}` = `xxxxx`                                |
+
+### 模板示例
+
+```json5
+// 员工编号：保留前缀，序号填充
+"replacementTemplate": "EMP-{seq}00000"
+// EMP-123456 → EMP-000000
+
+// 保留原始前缀
+"replacementTemplate": "{original_prefix:4}XXXX-0000"
+// INT-ABCD-1234 → INT-XXXX-0000
+
+// 通用脱敏，保留类型标记
+"replacementTemplate": "REDACTED_{type}_{seq}"
+// 任意匹配 → REDACTED_employee_id_0
+
+// 固定长度填充
+"replacementTemplate": "***{pad:10}***"
+// 任意匹配 → ***xxxxxxxxxx***
+```
+
+如果未提供 `replacementTemplate`，系统会使用内置的类型特定替换逻辑（如邮箱生成假邮箱、电话生成假电话等），或对未知类型使用通用格式 `pf_{type}_{timestamp}{seq}`。
+
+---
+
+## 命名验证器
+
+由于 JSON 配置文件无法包含函数，自定义规则通过 `validateFn` 字段引用预注册的命名验证器。
+
+### 内置验证器
+
+| 名称            | 说明                                                                              |
+| --------------- | --------------------------------------------------------------------------------- |
+| `bare_password` | 检查字符串是否具有密码特征（3+ 字符类、8-64 字符、排除 URL/路径等常见误报）       |
+| `high_entropy`  | 检查字符串是否为高熵随机串（Shannon 熵 ≥ 3.5 bits/char、≥ 16 字符、排除顺序字符） |
+
+### 注册自定义验证器
+
+插件或扩展可以通过 API 注册新的验证器：
+
+```typescript
+import { registerNamedValidator } from "./privacy/index.js";
+
+// 注册一个自定义验证器
+registerNamedValidator("luhn_check", (s: string) => {
+  // Luhn 算法校验（信用卡号）
+  let sum = 0;
+  let alternate = false;
+  for (let i = s.length - 1; i >= 0; i--) {
+    let n = parseInt(s[i], 10);
+    if (alternate) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    alternate = !alternate;
+  }
+  return sum % 10 === 0;
+});
+```
+
+之后在自定义规则中引用：
+
+```json5
+{
+  type: "custom_card",
+  description: "自定义卡号检测",
+  riskLevel: "critical",
+  pattern: "\\b\\d{16}\\b",
+  validateFn: "luhn_check",
+}
+```
+
+---
+
+## API 参考
+
+### 核心类
+
+#### `PrivacyDetector`
+
+```typescript
+// 使用预设
+const detector = new PrivacyDetector("extended");
+
+// 使用自定义规则数组
+const detector = new PrivacyDetector(customRules);
+
+// 检测
+const result: FilterResult = detector.detect("text with sensitive@email.com");
+// result.hasPrivacyRisk → true
+// result.matches → [{ type: "email", content: "sensitive@email.com", ... }]
+
+// 快速检查
+const hasSensitive: boolean = detector.check("some text");
+```
+
+#### `PrivacyReplacer`
+
+```typescript
+const replacer = new PrivacyReplacer("session-id");
+
+// 替换检测到的敏感内容
+const { replaced, newMappings } = replacer.replaceAll(text, matches);
+
+// 还原替换内容
+const original = replacer.restore(replacedText);
+```
+
+#### `PrivacyMappingStore`
+
+```typescript
+const store = new PrivacyMappingStore({ salt: "my-salt" });
+
+store.save(mappings); // 加密保存
+const loaded = store.load(); // 加载
+const session = store.loadSession(id); // 按会话加载
+store.append(newMappings); // 追加
+store.cleanup(86_400_000); // 清理过期映射
+store.clearSession(sessionId); // 清理指定会话
+```
+
+### 自定义规则函数
+
+```typescript
+import {
+  loadCustomRules,
+  processCustomRulesConfig,
+  validateUserRule,
+  validateRegexSafety,
+  registerNamedValidator,
+  getNamedValidators,
+} from "./privacy/index.js";
+
+// 从文件加载
+const result = loadCustomRules("./my-rules.json5");
+// result.rules    → 合并后的规则数组
+// result.errors   → 验证错误列表
+// result.warnings → 警告信息
+
+// 从对象处理
+const result = processCustomRulesConfig({
+  extends: "basic",
+  disable: ["email"],
+  rules: [{ type: "custom", description: "...", riskLevel: "low", pattern: "..." }],
+});
+
+// 验证单条规则
+const errors = validateUserRule(rule, 0);
+
+// 验证正则安全性
+const error = validateRegexSafety("(a+)+"); // → "contains nested quantifiers..."
+
+// 查看已注册的验证器
+const names = getNamedValidators(); // → ["bare_password", "high_entropy"]
+```
+
+### 流包装（集成用）
+
+```typescript
+import {
+  createPrivacyFilterContext,
+  filterText,
+  restoreText,
+  filterPrompt,
+  restoreResponse,
+  wrapStreamFnPrivacyFilter,
+} from "./privacy/index.js";
+
+// 创建会话级上下文
+const ctx = createPrivacyFilterContext("session-123", { rules: "./my-rules.json5" });
+
+// 过滤单段文本
+const filtered = filterText("my password=Secret123!", ctx);
+
+// 还原
+const restored = restoreText(filtered, ctx);
+
+// 包装 LLM 调用流
+const wrappedStreamFn = wrapStreamFnPrivacyFilter(originalStreamFn, ctx);
+```

--- a/src/privacy/custom-rules.test.ts
+++ b/src/privacy/custom-rules.test.ts
@@ -1,0 +1,472 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  loadCustomRules,
+  processCustomRulesConfig,
+  validateUserRule,
+  validateRegexSafety,
+  registerNamedValidator,
+  getNamedValidators,
+} from "./custom-rules.js";
+import { PrivacyDetector } from "./detector.js";
+import { PrivacyReplacer } from "./replacer.js";
+import type { CustomRulesConfig, UserDefinedRule } from "./types.js";
+
+describe("custom-rules", () => {
+  describe("loadCustomRules", () => {
+    it("parses real JSON5 syntax", () => {
+      const dir = mkdtempSync(join(tmpdir(), "privacy-custom-rules-"));
+      const filePath = join(dir, "rules.json5");
+
+      try {
+        writeFileSync(
+          filePath,
+          `
+          {
+            extends: 'none',
+            rules: [
+              {
+                type: 'employee_id',
+                description: 'Employee ID',
+                riskLevel: 'medium',
+                pattern: '\\\\bEMP-[0-9]{6}\\\\b',
+              },
+            ],
+          }
+          `,
+        );
+
+        const loaded = loadCustomRules(filePath);
+        expect(loaded.errors).toHaveLength(0);
+        expect(loaded.rules.some((r) => r.type === "employee_id")).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("validateUserRule", () => {
+    it("accepts a valid rule with pattern", () => {
+      const rule: UserDefinedRule = {
+        type: "employee_id",
+        description: "Employee ID",
+        riskLevel: "medium",
+        pattern: "\\bEMP-[0-9]{6}\\b",
+      };
+      expect(validateUserRule(rule, 0)).toHaveLength(0);
+    });
+
+    it("accepts a valid rule with keywords", () => {
+      const rule: UserDefinedRule = {
+        type: "project_codename",
+        description: "Internal codename",
+        riskLevel: "high",
+        keywords: ["Phoenix", "Titan"],
+        caseSensitive: true,
+      };
+      expect(validateUserRule(rule, 0)).toHaveLength(0);
+    });
+
+    it("rejects missing type", () => {
+      const rule = {
+        description: "test",
+        riskLevel: "low",
+        pattern: "abc",
+      } as UserDefinedRule;
+      const errors = validateUserRule(rule, 0);
+      expect(errors.some((e) => e.field === "type")).toBe(true);
+    });
+
+    it("rejects invalid type format (uppercase)", () => {
+      const rule: UserDefinedRule = {
+        type: "MyRule",
+        description: "test",
+        riskLevel: "low",
+        pattern: "abc",
+      };
+      const errors = validateUserRule(rule, 0);
+      expect(errors.some((e) => e.field === "type")).toBe(true);
+    });
+
+    it("rejects missing description", () => {
+      const rule = {
+        type: "test_rule",
+        riskLevel: "low",
+        pattern: "abc",
+      } as unknown as UserDefinedRule;
+      const errors = validateUserRule(rule, 0);
+      expect(errors.some((e) => e.field === "description")).toBe(true);
+    });
+
+    it("rejects invalid riskLevel", () => {
+      const rule: UserDefinedRule = {
+        type: "test_rule",
+        description: "test",
+        riskLevel: "extreme" as "critical",
+        pattern: "abc",
+      };
+      const errors = validateUserRule(rule, 0);
+      expect(errors.some((e) => e.field === "riskLevel")).toBe(true);
+    });
+
+    it("rejects rule with neither pattern nor keywords", () => {
+      const rule: UserDefinedRule = {
+        type: "test_rule",
+        description: "test",
+        riskLevel: "low",
+      };
+      const errors = validateUserRule(rule, 0);
+      expect(errors.some((e) => e.field === "pattern")).toBe(true);
+    });
+
+    it("rejects invalid regex pattern", () => {
+      const rule: UserDefinedRule = {
+        type: "test_rule",
+        description: "test",
+        riskLevel: "low",
+        pattern: "[invalid(",
+      };
+      const errors = validateUserRule(rule, 0);
+      expect(errors.some((e) => e.field === "pattern")).toBe(true);
+    });
+
+    it("rejects unknown validateFn", () => {
+      const rule: UserDefinedRule = {
+        type: "test_rule",
+        description: "test",
+        riskLevel: "low",
+        pattern: "abc",
+        validateFn: "nonexistent",
+      };
+      const errors = validateUserRule(rule, 0);
+      expect(errors.some((e) => e.field === "validateFn")).toBe(true);
+    });
+
+    it("accepts known validateFn", () => {
+      const rule: UserDefinedRule = {
+        type: "test_rule",
+        description: "test",
+        riskLevel: "low",
+        pattern: "\\S{8,64}",
+        validateFn: "bare_password",
+      };
+      expect(validateUserRule(rule, 0)).toHaveLength(0);
+    });
+  });
+
+  describe("validateRegexSafety", () => {
+    it("accepts valid regex", () => {
+      expect(validateRegexSafety("\\b[A-Z]{3}\\d{4}\\b")).toBeNull();
+    });
+
+    it("rejects invalid regex", () => {
+      expect(validateRegexSafety("[unclosed")).not.toBeNull();
+    });
+
+    it("rejects overly long patterns", () => {
+      const longPattern = "a".repeat(2001);
+      expect(validateRegexSafety(longPattern)).toContain("maximum length");
+    });
+
+    it("rejects nested quantifiers", () => {
+      expect(validateRegexSafety("(a+)+")).toContain("nested quantifiers");
+    });
+
+    it("accepts (?i) prefix", () => {
+      expect(validateRegexSafety("(?i)hello")).toBeNull();
+    });
+  });
+
+  describe("processCustomRulesConfig", () => {
+    it("extends from extended preset by default", () => {
+      const config: CustomRulesConfig = { rules: [] };
+      const result = processCustomRulesConfig(config);
+      expect(result.rules.length).toBeGreaterThan(0);
+      expect(result.errors).toHaveLength(0);
+      // Should include an email rule from extended preset.
+      expect(result.rules.some((r) => r.type === "email")).toBe(true);
+    });
+
+    it("extends from basic preset", () => {
+      const config: CustomRulesConfig = { extends: "basic", rules: [] };
+      const result = processCustomRulesConfig(config);
+      expect(result.rules.some((r) => r.type === "email")).toBe(true);
+      // Basic doesn't have phone_hk.
+      expect(result.rules.some((r) => r.type === "phone_hk")).toBe(false);
+    });
+
+    it("extends from none preset", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "custom_only",
+            description: "Custom rule",
+            riskLevel: "low",
+            pattern: "CUSTOM_\\d+",
+          },
+        ],
+      };
+      const result = processCustomRulesConfig(config);
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].type).toBe("custom_only");
+    });
+
+    it("disables specified built-in rules", () => {
+      const config: CustomRulesConfig = {
+        extends: "basic",
+        disable: ["email", "phone_cn"],
+        rules: [],
+      };
+      const result = processCustomRulesConfig(config);
+      const emailRule = result.rules.find((r) => r.type === "email");
+      const phoneRule = result.rules.find((r) => r.type === "phone_cn");
+      expect(emailRule?.enabled).toBe(false);
+      expect(phoneRule?.enabled).toBe(false);
+    });
+
+    it("user rules override built-in rules with same type", () => {
+      const config: CustomRulesConfig = {
+        extends: "basic",
+        rules: [
+          {
+            type: "email",
+            description: "Custom email (low risk)",
+            riskLevel: "low",
+            pattern: "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b",
+          },
+        ],
+      };
+      const result = processCustomRulesConfig(config);
+      const emailRule = result.rules.find((r) => r.type === "email");
+      expect(emailRule?.riskLevel).toBe("low");
+      expect(emailRule?.description).toBe("Custom email (low risk)");
+    });
+
+    it("appends new user rules after base rules", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "custom_id",
+            description: "Custom ID",
+            riskLevel: "medium",
+            pattern: "CID-\\d{8}",
+          },
+        ],
+      };
+      const result = processCustomRulesConfig(config);
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].type).toBe("custom_id");
+    });
+
+    it("skips invalid rules and reports errors", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "valid_rule",
+            description: "Valid",
+            riskLevel: "low",
+            pattern: "abc",
+          },
+          {
+            type: "InvalidType",
+            description: "Bad type format",
+            riskLevel: "low",
+            pattern: "def",
+          },
+        ],
+      };
+      const result = processCustomRulesConfig(config);
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].type).toBe("valid_rule");
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].ruleIndex).toBe(1);
+    });
+
+    it("resolves validateFn to actual functions", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "custom_password",
+            description: "Custom password detector",
+            riskLevel: "high",
+            pattern: "\\S{8,64}",
+            validateFn: "bare_password",
+          },
+        ],
+      };
+      const result = processCustomRulesConfig(config);
+      expect(result.rules[0].validate).toBeDefined();
+      expect(typeof result.rules[0].validate).toBe("function");
+    });
+
+    it("propagates replacementTemplate", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "employee_id",
+            description: "Employee ID",
+            riskLevel: "medium",
+            pattern: "\\bEMP-[0-9]{6}\\b",
+            replacementTemplate: "EMP-{seq}00000",
+          },
+        ],
+      };
+      const result = processCustomRulesConfig(config);
+      expect(result.rules[0].replacementTemplate).toBe("EMP-{seq}00000");
+    });
+  });
+
+  describe("custom rules end-to-end", () => {
+    it("detector uses custom rules for detection", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "employee_id",
+            description: "Employee ID",
+            riskLevel: "medium",
+            pattern: "\\bEMP-[0-9]{6}\\b",
+          },
+        ],
+      };
+      const { rules } = processCustomRulesConfig(config);
+      const detector = new PrivacyDetector(rules);
+
+      const result = detector.detect("Contact EMP-123456 for details");
+      expect(result.hasPrivacyRisk).toBe(true);
+      expect(result.matches).toHaveLength(1);
+      expect(result.matches[0].type).toBe("employee_id");
+      expect(result.matches[0].content).toBe("EMP-123456");
+    });
+
+    it("detector uses keyword-based custom rules", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "project_codename",
+            description: "Internal codename",
+            riskLevel: "high",
+            keywords: ["Project-Phoenix", "Project-Titan"],
+            caseSensitive: true,
+          },
+        ],
+      };
+      const { rules } = processCustomRulesConfig(config);
+      const detector = new PrivacyDetector(rules);
+
+      const result = detector.detect("We are working on Project-Phoenix");
+      expect(result.hasPrivacyRisk).toBe(true);
+      expect(result.matches[0].content).toBe("Project-Phoenix");
+    });
+
+    it("replacer uses custom replacementTemplate", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "employee_id",
+            description: "Employee ID",
+            riskLevel: "medium",
+            pattern: "\\bEMP-[0-9]{6}\\b",
+            replacementTemplate: "EMP-REDACTED-{seq}",
+          },
+        ],
+      };
+      const { rules } = processCustomRulesConfig(config);
+      const detector = new PrivacyDetector(rules);
+      const replacer = new PrivacyReplacer("test-session");
+
+      const detected = detector.detect("Employee EMP-123456 is active");
+      const { replaced } = replacer.replaceAll(detected.matches[0].content, detected.matches);
+      // The replacement should use the template, not the default switch-case.
+      expect(replaced).toContain("EMP-REDACTED-");
+    });
+
+    it("replacer uses custom template with {original_prefix:N}", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "internal_code",
+            description: "Internal code",
+            riskLevel: "low",
+            pattern: "\\bINT-[A-Z]{4}-\\d{4}\\b",
+            replacementTemplate: "{original_prefix:4}XXXX-0000",
+          },
+        ],
+      };
+      const { rules } = processCustomRulesConfig(config);
+      const detector = new PrivacyDetector(rules);
+      const replacer = new PrivacyReplacer("test-session");
+
+      const text = "Code: INT-ABCD-1234";
+      const detected = detector.detect(text);
+      const { replaced } = replacer.replaceAll(text, detected.matches);
+      expect(replaced).toContain("INT-XXXX-0000");
+    });
+
+    it("disabled built-in rules are not detected", () => {
+      const config: CustomRulesConfig = {
+        extends: "basic",
+        disable: ["email"],
+        rules: [],
+      };
+      const { rules } = processCustomRulesConfig(config);
+      const detector = new PrivacyDetector(rules);
+
+      const result = detector.detect("Contact user@example.com");
+      const emailMatches = result.matches.filter((m) => m.type === "email");
+      expect(emailMatches).toHaveLength(0);
+    });
+
+    it("custom context constraints work", () => {
+      const config: CustomRulesConfig = {
+        extends: "none",
+        rules: [
+          {
+            type: "internal_ip",
+            description: "Internal IP with context",
+            riskLevel: "low",
+            pattern: "\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b",
+            context: { mustContain: ["server", "host"] },
+          },
+        ],
+      };
+      const { rules } = processCustomRulesConfig(config);
+      const detector = new PrivacyDetector(rules);
+
+      // Without context keyword — should not match.
+      const r1 = detector.detect("Address: 192.168.1.1");
+      expect(r1.matches.filter((m) => m.type === "internal_ip")).toHaveLength(0);
+
+      // With context keyword — should match.
+      const r2 = detector.detect("Server IP: 192.168.1.1");
+      expect(r2.matches.filter((m) => m.type === "internal_ip")).toHaveLength(1);
+    });
+  });
+
+  describe("registerNamedValidator", () => {
+    it("registers and makes available a custom validator", () => {
+      const customValidator = (s: string) => s.length > 10;
+      registerNamedValidator("custom_length", customValidator);
+      expect(getNamedValidators()).toContain("custom_length");
+
+      const rule: UserDefinedRule = {
+        type: "test_rule",
+        description: "test",
+        riskLevel: "low",
+        pattern: "\\S+",
+        validateFn: "custom_length",
+      };
+      expect(validateUserRule(rule, 0)).toHaveLength(0);
+    });
+  });
+});

--- a/src/privacy/custom-rules.ts
+++ b/src/privacy/custom-rules.ts
@@ -1,0 +1,280 @@
+/**
+ * Custom privacy rules — loading, validation, and merging of user-defined rules.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import JSON5 from "json5";
+import { validateBarePassword, validateHighEntropy } from "./detector.js";
+import { BASIC_RULES, EXTENDED_RULES } from "./rules.js";
+import type { CustomRulesConfig, PrivacyRule, RiskLevel, UserDefinedRule } from "./types.js";
+
+/** Registry of named validator functions that JSON configs can reference. */
+const NAMED_VALIDATORS: Record<string, (s: string) => boolean> = {
+  bare_password: validateBarePassword,
+  high_entropy: validateHighEntropy,
+};
+
+/** A single validation error for a user-defined rule. */
+export interface RuleValidationError {
+  ruleIndex: number;
+  type: string;
+  field: string;
+  message: string;
+}
+
+/** Result of loading custom rules. */
+export interface CustomRulesResult {
+  rules: PrivacyRule[];
+  errors: RuleValidationError[];
+  warnings: string[];
+}
+
+const VALID_RISK_LEVELS: RiskLevel[] = ["low", "medium", "high", "critical"];
+const TYPE_PATTERN = /^[a-z][a-z0-9_]*$/;
+const MAX_PATTERN_LENGTH = 2000;
+
+/**
+ * Load custom rules from a JSON5 file path.
+ * Returns merged rules (base preset + custom) and any validation errors.
+ */
+export function loadCustomRules(filePath: string): CustomRulesResult {
+  const absolutePath = resolve(filePath);
+  let content: string;
+  try {
+    content = readFileSync(absolutePath, "utf-8");
+  } catch (err) {
+    return {
+      rules: [...EXTENDED_RULES],
+      errors: [],
+      warnings: [
+        `Failed to read custom rules file "${absolutePath}": ${(err as Error).message}. Falling back to extended rules.`,
+      ],
+    };
+  }
+
+  let config: CustomRulesConfig;
+  try {
+    config = JSON5.parse(content);
+  } catch (err) {
+    return {
+      rules: [...EXTENDED_RULES],
+      errors: [],
+      warnings: [
+        `Failed to parse custom rules file "${absolutePath}": ${(err as Error).message}. Falling back to extended rules.`,
+      ],
+    };
+  }
+
+  return processCustomRulesConfig(config);
+}
+
+/**
+ * Process a CustomRulesConfig object (already parsed).
+ * Validates rules, resolves base preset, merges, and returns final rule set.
+ */
+export function processCustomRulesConfig(config: CustomRulesConfig): CustomRulesResult {
+  const errors: RuleValidationError[] = [];
+  const warnings: string[] = [];
+
+  // 1. Resolve base preset.
+  const basePreset = config.extends ?? "extended";
+  let baseRules: PrivacyRule[];
+  if (basePreset === "none") {
+    baseRules = [];
+  } else if (basePreset === "basic") {
+    baseRules = BASIC_RULES.map((r) => ({ ...r }));
+  } else {
+    baseRules = EXTENDED_RULES.map((r) => ({ ...r }));
+  }
+
+  // 2. Apply disable list.
+  const disableSet = new Set(config.disable ?? []);
+  if (disableSet.size > 0) {
+    baseRules = baseRules.map((r) => (disableSet.has(r.type) ? { ...r, enabled: false } : r));
+  }
+
+  // 3. Validate and convert user rules.
+  const userRules = config.rules ?? [];
+  const validUserRules: PrivacyRule[] = [];
+  for (let i = 0; i < userRules.length; i++) {
+    const ruleErrors = validateUserRule(userRules[i], i);
+    errors.push(...ruleErrors);
+    if (ruleErrors.length === 0) {
+      validUserRules.push(convertToPrivacyRule(userRules[i]));
+    }
+  }
+
+  // 4. Merge: user rules override base rules with same type.
+  const merged = mergeRules(baseRules, validUserRules);
+
+  return { rules: merged, errors, warnings };
+}
+
+/** Validate a single user-defined rule. Returns validation errors (empty = valid). */
+export function validateUserRule(rule: UserDefinedRule, index: number): RuleValidationError[] {
+  const errors: RuleValidationError[] = [];
+  const type = rule.type ?? "";
+
+  if (!type || typeof type !== "string") {
+    errors.push({
+      ruleIndex: index,
+      type,
+      field: "type",
+      message: "type is required and must be a non-empty string",
+    });
+  } else if (!TYPE_PATTERN.test(type)) {
+    errors.push({
+      ruleIndex: index,
+      type,
+      field: "type",
+      message: "type must match [a-z][a-z0-9_]* (lowercase snake_case)",
+    });
+  }
+
+  if (!rule.description || typeof rule.description !== "string") {
+    errors.push({
+      ruleIndex: index,
+      type,
+      field: "description",
+      message: "description is required",
+    });
+  }
+
+  if (!VALID_RISK_LEVELS.includes(rule.riskLevel)) {
+    errors.push({
+      ruleIndex: index,
+      type,
+      field: "riskLevel",
+      message: `riskLevel must be one of: ${VALID_RISK_LEVELS.join(", ")}`,
+    });
+  }
+
+  if (!rule.pattern && (!rule.keywords || rule.keywords.length === 0)) {
+    errors.push({
+      ruleIndex: index,
+      type,
+      field: "pattern",
+      message: "at least one of pattern or keywords is required",
+    });
+  }
+
+  if (rule.pattern) {
+    const regexError = validateRegexSafety(rule.pattern);
+    if (regexError) {
+      errors.push({ ruleIndex: index, type, field: "pattern", message: regexError });
+    }
+  }
+
+  if (rule.validateFn && !NAMED_VALIDATORS[rule.validateFn]) {
+    errors.push({
+      ruleIndex: index,
+      type,
+      field: "validateFn",
+      message: `unknown validator "${rule.validateFn}". Available: ${Object.keys(NAMED_VALIDATORS).join(", ")}`,
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Validate a regex pattern string for safety.
+ * Checks: compilability, length limit, nested quantifier heuristic.
+ */
+export function validateRegexSafety(pattern: string): string | null {
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    return `pattern exceeds maximum length of ${MAX_PATTERN_LENGTH} characters`;
+  }
+
+  try {
+    let src = pattern;
+    let flags = "gm";
+    if (src.startsWith("(?i)")) {
+      src = src.slice(4);
+      flags += "i";
+    }
+    new RegExp(src, flags);
+  } catch (err) {
+    return `invalid regex: ${(err as Error).message}`;
+  }
+
+  // Basic catastrophic backtracking heuristic: nested quantifiers like (a+)+.
+  if (/\([^)]*[+*]\)[+*]/.test(pattern)) {
+    return "pattern contains potentially catastrophic nested quantifiers (e.g. (a+)+)";
+  }
+
+  return null;
+}
+
+/** Convert a UserDefinedRule to a PrivacyRule. */
+function convertToPrivacyRule(userRule: UserDefinedRule): PrivacyRule {
+  const rule: PrivacyRule = {
+    type: userRule.type,
+    description: userRule.description,
+    enabled: userRule.enabled !== false,
+    riskLevel: userRule.riskLevel,
+  };
+
+  if (userRule.pattern) {
+    rule.pattern = userRule.pattern;
+  }
+  if (userRule.keywords) {
+    rule.keywords = userRule.keywords;
+  }
+  if (userRule.caseSensitive !== undefined) {
+    rule.caseSensitive = userRule.caseSensitive;
+  }
+  if (userRule.context) {
+    rule.context = userRule.context;
+  }
+  if (userRule.validateFn) {
+    rule.validate = NAMED_VALIDATORS[userRule.validateFn];
+  }
+  if (userRule.replacementTemplate) {
+    rule.replacementTemplate = userRule.replacementTemplate;
+  }
+
+  return rule;
+}
+
+/**
+ * Merge base rules with user rules.
+ * User rules with the same `type` override the base rule entirely.
+ * New types are appended at the end.
+ */
+function mergeRules(base: PrivacyRule[], user: PrivacyRule[]): PrivacyRule[] {
+  const userTypeMap = new Map(user.map((r) => [r.type, r]));
+  const merged: PrivacyRule[] = [];
+  const usedUserTypes = new Set<string>();
+
+  for (const baseRule of base) {
+    if (userTypeMap.has(baseRule.type)) {
+      merged.push(userTypeMap.get(baseRule.type)!);
+      usedUserTypes.add(baseRule.type);
+    } else {
+      merged.push(baseRule);
+    }
+  }
+
+  for (const userRule of user) {
+    if (!usedUserTypes.has(userRule.type)) {
+      merged.push(userRule);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Register a named validator function.
+ * Allows plugins/extensions to register custom validators by name.
+ */
+export function registerNamedValidator(name: string, fn: (matched: string) => boolean): void {
+  NAMED_VALIDATORS[name] = fn;
+}
+
+/** Get all available named validator names. */
+export function getNamedValidators(): string[] {
+  return Object.keys(NAMED_VALIDATORS);
+}

--- a/src/privacy/custom-rules.ts
+++ b/src/privacy/custom-rules.ts
@@ -159,6 +159,21 @@ export function validateUserRule(rule: UserDefinedRule, index: number): RuleVali
     });
   }
 
+  // Validate that every keyword entry is a string. Non-string values (e.g. numbers
+  // from malformed JSON5) would later cause escapeRegex to throw inside
+  // PrivacyDetector.loadRules, crashing session startup.
+  if (Array.isArray(rule.keywords)) {
+    const badIdx = rule.keywords.findIndex((kw) => typeof kw !== "string");
+    if (badIdx !== -1) {
+      errors.push({
+        ruleIndex: index,
+        type,
+        field: "keywords",
+        message: `keywords[${badIdx}] must be a string (got ${typeof rule.keywords[badIdx]})`,
+      });
+    }
+  }
+
   if (rule.pattern) {
     const regexError = validateRegexSafety(rule.pattern);
     if (regexError) {

--- a/src/privacy/detector.test.ts
+++ b/src/privacy/detector.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import { PrivacyDetector } from "./detector.js";
+
+describe("PrivacyDetector", () => {
+  const detector = new PrivacyDetector("extended");
+
+  describe("email detection", () => {
+    it("detects email addresses", () => {
+      const result = detector.detect("Contact me at user@gmail.com for details");
+      expect(result.hasPrivacyRisk).toBe(true);
+      expect(result.matches).toHaveLength(1);
+      expect(result.matches[0].type).toBe("email");
+      expect(result.matches[0].content).toBe("user@gmail.com");
+    });
+
+    it("detects multiple emails", () => {
+      const result = detector.detect("Send to alice@test.com and bob@example.org");
+      expect(result.matches.filter((m) => m.type === "email")).toHaveLength(2);
+    });
+  });
+
+  describe("phone detection", () => {
+    it("detects China mainland phone numbers", () => {
+      const result = detector.detect("My phone is 13812345678");
+      expect(result.hasPrivacyRisk).toBe(true);
+      const phoneMatches = result.matches.filter((m) => m.type === "phone_cn");
+      expect(phoneMatches).toHaveLength(1);
+      expect(phoneMatches[0].content).toBe("13812345678");
+    });
+  });
+
+  describe("ID card detection", () => {
+    it("detects China ID card numbers", () => {
+      const result = detector.detect("ID: 110101199001011234");
+      expect(result.hasPrivacyRisk).toBe(true);
+      const idMatches = result.matches.filter((m) => m.type === "id_card_cn");
+      expect(idMatches.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("API key detection", () => {
+    it("detects OpenAI API keys", () => {
+      const result = detector.detect("Use key: sk-proj1234567890abcdefghijklm");
+      expect(result.hasPrivacyRisk).toBe(true);
+      const apiMatches = result.matches.filter((m) => m.type === "openai_api_key");
+      expect(apiMatches.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("detects GitHub tokens", () => {
+      const result = detector.detect("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
+      expect(result.hasPrivacyRisk).toBe(true);
+      const ghMatches = result.matches.filter((m) => m.type === "github_token");
+      expect(ghMatches.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("detects Anthropic API keys", () => {
+      const result = detector.detect("sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890");
+      expect(result.hasPrivacyRisk).toBe(true);
+    });
+
+    it("detects AWS access keys", () => {
+      const result = detector.detect("AKIAIOSFODNN7EXAMPLE");
+      expect(result.hasPrivacyRisk).toBe(true);
+      expect(result.matches.some((m) => m.type === "aws_access_key")).toBe(true);
+    });
+  });
+
+  describe("password detection", () => {
+    it("detects password assignments", () => {
+      const result = detector.detect("password=MyS3cretPass123");
+      expect(result.hasPrivacyRisk).toBe(true);
+      const pwdMatches = result.matches.filter(
+        (m) => m.type === "password_assignment" || m.type === "env_password",
+      );
+      expect(pwdMatches.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("detects environment variable passwords", () => {
+      const result = detector.detect("PASSWORD=super_secret_value");
+      expect(result.hasPrivacyRisk).toBe(true);
+    });
+  });
+
+  describe("credit card detection", () => {
+    it("detects Visa card numbers", () => {
+      const result = detector.detect("Card: 4111111111111111");
+      expect(result.hasPrivacyRisk).toBe(true);
+      expect(result.matches.some((m) => m.type === "credit_card")).toBe(true);
+    });
+  });
+
+  describe("JWT detection", () => {
+    it("detects JWT tokens", () => {
+      const jwt =
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+      const result = detector.detect(jwt);
+      expect(result.hasPrivacyRisk).toBe(true);
+      expect(result.matches.some((m) => m.type === "jwt_token")).toBe(true);
+    });
+  });
+
+  describe("database URL detection", () => {
+    it("detects MySQL connection strings", () => {
+      const result = detector.detect("mysql://root:password123@localhost/mydb");
+      expect(result.hasPrivacyRisk).toBe(true);
+      expect(result.matches.some((m) => m.type === "database_url_mysql")).toBe(true);
+    });
+
+    it("detects PostgreSQL connection strings", () => {
+      const result = detector.detect("postgresql://user:pass@db.example.com/prod");
+      expect(result.hasPrivacyRisk).toBe(true);
+    });
+  });
+
+  describe("SSH key detection", () => {
+    it("detects SSH private key headers", () => {
+      const result = detector.detect("-----BEGIN RSA PRIVATE KEY-----");
+      expect(result.hasPrivacyRisk).toBe(true);
+      expect(result.matches.some((m) => m.type === "ssh_private_key")).toBe(true);
+    });
+  });
+
+  describe("context-based rules", () => {
+    it("requires context for bank account numbers", () => {
+      // Without context keywords — should not match bank_account_cn.
+      const result1 = detector.detect("Number is 6222021234567890123");
+      const bankMatches1 = result1.matches.filter((m) => m.type === "bank_account_cn");
+      expect(bankMatches1).toHaveLength(0);
+
+      // With context keywords — should match.
+      const result2 = detector.detect("银行卡号 6222021234567890123");
+      const bankMatches2 = result2.matches.filter((m) => m.type === "bank_account_cn");
+      expect(bankMatches2.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("risk levels", () => {
+    it("reports correct highest risk level", () => {
+      const result = detector.detect("password=secret123 email: test@test.com");
+      expect(result.highestRiskLevel).toBe("critical");
+    });
+  });
+
+  describe("bare password detection", () => {
+    it("detects complex passwords (3+ char classes)", () => {
+      const cases = ["MyS3cret!Pass", "Admin@2024!", "P@ssw0rd!123", "a1B2c3D4e5!@", "Tr0ub4dor&3"];
+      for (const text of cases) {
+        const result = detector.detect(text);
+        expect(
+          result.matches.some((m) => m.type === "bare_password"),
+          `should detect: ${text}`,
+        ).toBe(true);
+      }
+    });
+
+    it("does not detect low-complexity strings as passwords", () => {
+      const cases = ["qwerty12345", "helloworld", "12345678", "Ab1!"];
+      for (const text of cases) {
+        const result = detector.detect(text);
+        expect(
+          result.matches.some((m) => m.type === "bare_password"),
+          `should NOT detect: ${text}`,
+        ).toBe(false);
+      }
+    });
+
+    it("does not detect URLs or identifiers as passwords", () => {
+      const result1 = detector.detect("https://example.com");
+      expect(result1.matches.some((m) => m.type === "bare_password")).toBe(false);
+
+      const result2 = detector.detect("my-variable-name");
+      expect(result2.matches.some((m) => m.type === "bare_password")).toBe(false);
+    });
+  });
+
+  describe("high entropy string detection", () => {
+    it("detects random alphanumeric strings", () => {
+      const result = detector.detect("7f2a9c4b1e8d6a3f5c0b9e2d4a1f8c6b");
+      expect(result.matches.some((m) => m.type === "high_entropy_string")).toBe(true);
+    });
+
+    it("rejects sequential strings", () => {
+      const result = detector.detect("abcdefghijklmnop");
+      expect(result.matches.some((m) => m.type === "high_entropy_string")).toBe(false);
+    });
+
+    it("rejects repeated characters", () => {
+      const result = detector.detect("aaaaaaaaaaaaaaaa");
+      expect(result.matches.some((m) => m.type === "high_entropy_string")).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty text", () => {
+      const result = detector.detect("");
+      expect(result.hasPrivacyRisk).toBe(false);
+      expect(result.matches).toHaveLength(0);
+    });
+
+    it("handles text without sensitive content", () => {
+      const result = detector.detect("Hello, this is a normal message.");
+      expect(result.hasPrivacyRisk).toBe(false);
+    });
+
+    it("deduplicates overlapping matches", () => {
+      const result = detector.detect("sk-proj1234567890abcdefghijklm");
+      const types = result.matches.map((m) => `${m.start}:${m.end}:${m.type}`);
+      const unique = new Set(types);
+      expect(types.length).toBe(unique.size);
+    });
+  });
+});

--- a/src/privacy/detector.ts
+++ b/src/privacy/detector.ts
@@ -1,0 +1,351 @@
+/**
+ * Privacy detection engine — scans text for sensitive information.
+ * Ported from the Python PrivacyFilter with TypeScript regex engine.
+ */
+
+import { EXTENDED_RULES, resolveRules } from "./rules.js";
+import type { DetectionMatch, FilterResult, PrivacyRule, RiskLevel } from "./types.js";
+
+const CONTEXT_WINDOW = 50;
+
+const RISK_ORDER: Record<RiskLevel, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+// ─── Password complexity & entropy validators ───
+
+/**
+ * Check if a string meets common password complexity requirements.
+ * Requires at least 3 of 4 character classes: uppercase, lowercase, digit, special.
+ */
+export function isPasswordLikeComplexity(s: string): boolean {
+  let classes = 0;
+  if (/[a-z]/.test(s)) {
+    classes++;
+  }
+  if (/[A-Z]/.test(s)) {
+    classes++;
+  }
+  if (/[0-9]/.test(s)) {
+    classes++;
+  }
+  if (/[^a-zA-Z0-9]/.test(s)) {
+    classes++;
+  }
+  return classes >= 3;
+}
+
+/**
+ * Calculate Shannon entropy (bits per character) of a string.
+ */
+export function shannonEntropy(s: string): number {
+  if (s.length === 0) {
+    return 0;
+  }
+  const freq = new Map<string, number>();
+  for (const ch of s) {
+    freq.set(ch, (freq.get(ch) ?? 0) + 1);
+  }
+  let entropy = 0;
+  const len = s.length;
+  for (const count of freq.values()) {
+    const p = count / len;
+    entropy -= p * Math.log2(p);
+  }
+  return entropy;
+}
+
+/** Minimum Shannon entropy (bits/char) to consider a string high-entropy. */
+const HIGH_ENTROPY_THRESHOLD = 3.5;
+
+// Common words/patterns that look like passwords but aren't.
+const FALSE_POSITIVE_PATTERNS = [
+  /^https?:\/\//i, // URLs
+  /^[a-z]+[-_][a-z]+$/i, // kebab-case / snake_case identifiers
+  /^\w+\.\w+\.\w+$/, // dotted identifiers like package.module.Class
+  /^\/[\w/]+$/, // file paths
+];
+
+/**
+ * Validate a bare password candidate: must have password-like complexity
+ * and not match common false-positive patterns.
+ */
+export function validateBarePassword(s: string): boolean {
+  // Too short or too long to be a realistic bare password.
+  if (s.length < 8 || s.length > 64) {
+    return false;
+  }
+
+  // Skip if it matches common non-password patterns.
+  for (const fp of FALSE_POSITIVE_PATTERNS) {
+    if (fp.test(s)) {
+      return false;
+    }
+  }
+
+  return isPasswordLikeComplexity(s);
+}
+
+/**
+ * Validate a high-entropy string: must exceed the entropy threshold
+ * and not be a simple sequential/patterned string.
+ */
+export function validateHighEntropy(s: string): boolean {
+  if (s.length < 16) {
+    return false;
+  }
+  const entropy = shannonEntropy(s);
+  if (entropy < HIGH_ENTROPY_THRESHOLD) {
+    return false;
+  }
+
+  // Reject sequential character runs (e.g. "abcdefghijklmnop", "1234567890").
+  if (isSequentialString(s)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check if a string is mostly sequential characters (alphabetical or numeric runs).
+ * Returns true if >60% of adjacent pairs are sequential.
+ */
+function isSequentialString(s: string): boolean {
+  if (s.length < 4) {
+    return false;
+  }
+  let sequential = 0;
+  for (let i = 1; i < s.length; i++) {
+    const diff = s.charCodeAt(i) - s.charCodeAt(i - 1);
+    if (diff === 1 || diff === -1) {
+      sequential++;
+    }
+  }
+  return sequential / (s.length - 1) > 0.6;
+}
+
+/** Compiled rule — caches compiled regex patterns per rule. */
+interface CompiledRule {
+  rule: PrivacyRule;
+  patterns: RegExp[];
+  keywordPatterns: RegExp[];
+}
+
+export class PrivacyDetector {
+  private compiledRules: CompiledRule[] = [];
+  private enabled: boolean = true;
+
+  constructor(rules?: PrivacyRule[] | string) {
+    const ruleSet = typeof rules === "string" ? resolveRules(rules) : (rules ?? EXTENDED_RULES);
+    this.loadRules(ruleSet);
+  }
+
+  private loadRules(rules: PrivacyRule[]): void {
+    this.compiledRules = [];
+    for (const rule of rules) {
+      if (!rule.enabled) {
+        continue;
+      }
+      const compiled: CompiledRule = {
+        rule,
+        patterns: [],
+        keywordPatterns: [],
+      };
+
+      if (rule.pattern) {
+        const re = this.compilePattern(rule.pattern);
+        if (re) {
+          compiled.patterns.push(re);
+        }
+      }
+
+      if (rule.keywords) {
+        for (const kw of rule.keywords) {
+          const flags = rule.caseSensitive ? "g" : "gi";
+          compiled.keywordPatterns.push(new RegExp(escapeRegex(kw), flags));
+        }
+      }
+
+      compiled.patterns.push(...compiled.keywordPatterns);
+      if (compiled.patterns.length > 0) {
+        this.compiledRules.push(compiled);
+      }
+    }
+  }
+
+  private compilePattern(pattern: string): RegExp | null {
+    try {
+      // Handle (?i) inline flag — JS doesn't support it, convert to flag.
+      let flags = "gm";
+      let src = pattern;
+      if (src.startsWith("(?i)")) {
+        src = src.slice(4);
+        flags += "i";
+      }
+      return new RegExp(src, flags);
+    } catch {
+      return null;
+    }
+  }
+
+  /** Detect all privacy matches in the given text. */
+  detect(text: string): FilterResult {
+    if (!this.enabled || !text) {
+      return {
+        hasPrivacyRisk: false,
+        matches: [],
+        riskCount: {},
+        highestRiskLevel: null,
+      };
+    }
+
+    const allMatches: DetectionMatch[] = [];
+
+    for (const compiled of this.compiledRules) {
+      const matches = this.checkRule(text, compiled);
+      allMatches.push(...matches);
+    }
+
+    const unique = this.deduplicateMatches(allMatches);
+
+    const riskCount: Record<string, number> = {};
+    for (const m of unique) {
+      riskCount[m.type] = (riskCount[m.type] ?? 0) + 1;
+    }
+
+    return {
+      hasPrivacyRisk: unique.length > 0,
+      matches: unique,
+      riskCount,
+      highestRiskLevel: this.getHighestRisk(unique),
+    };
+  }
+
+  /** Simple boolean check — does the text contain privacy risks? */
+  check(text: string): boolean {
+    return this.detect(text).hasPrivacyRisk;
+  }
+
+  private checkRule(text: string, compiled: CompiledRule): DetectionMatch[] {
+    const matches: DetectionMatch[] = [];
+    const { rule } = compiled;
+
+    // Regex pattern matching
+    if (rule.pattern && compiled.patterns.length > 0) {
+      const re = compiled.patterns[0];
+      re.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(text)) !== null) {
+        if (this.checkContext(text, m.index, m.index + m[0].length, rule)) {
+          // Run optional post-match validator.
+          if (!rule.validate || rule.validate(m[0])) {
+            matches.push({
+              type: rule.type,
+              content: m[0],
+              start: m.index,
+              end: m.index + m[0].length,
+              riskLevel: rule.riskLevel,
+              description: rule.description,
+              replacementTemplate: rule.replacementTemplate,
+            });
+          }
+        }
+        // Prevent infinite loops for zero-length matches
+        if (m[0].length === 0) {
+          re.lastIndex++;
+        }
+      }
+    }
+
+    // Keyword matching (only if no pattern, or separate keyword entries)
+    if (rule.keywords && !rule.pattern) {
+      for (const kwRe of compiled.keywordPatterns) {
+        kwRe.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = kwRe.exec(text)) !== null) {
+          if (this.checkContext(text, m.index, m.index + m[0].length, rule)) {
+            matches.push({
+              type: rule.type,
+              content: m[0],
+              start: m.index,
+              end: m.index + m[0].length,
+              riskLevel: rule.riskLevel,
+              description: rule.description,
+              replacementTemplate: rule.replacementTemplate,
+            });
+          }
+          if (m[0].length === 0) {
+            kwRe.lastIndex++;
+          }
+        }
+      }
+    }
+
+    return matches;
+  }
+
+  private checkContext(text: string, start: number, end: number, rule: PrivacyRule): boolean {
+    const ctx = rule.context;
+    if (!ctx) {
+      return true;
+    }
+
+    const ctxStart = Math.max(0, start - CONTEXT_WINDOW);
+    const ctxEnd = Math.min(text.length, end + CONTEXT_WINDOW);
+    const context = text.slice(ctxStart, ctxEnd).toLowerCase();
+
+    if (ctx.mustContain) {
+      // At least one of the context keywords must appear nearby.
+      const found = ctx.mustContain.some((kw) => context.includes(kw.toLowerCase()));
+      if (!found) {
+        return false;
+      }
+    }
+
+    if (ctx.mustNotContain) {
+      for (const kw of ctx.mustNotContain) {
+        if (context.includes(kw.toLowerCase())) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  private deduplicateMatches(matches: DetectionMatch[]): DetectionMatch[] {
+    const seen = new Set<string>();
+    const unique: DetectionMatch[] = [];
+
+    for (const m of matches) {
+      const key = `${m.start}:${m.end}:${m.type}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        unique.push(m);
+      }
+    }
+
+    return unique.toSorted((a, b) => a.start - b.start);
+  }
+
+  private getHighestRisk(matches: DetectionMatch[]): RiskLevel | null {
+    if (matches.length === 0) {
+      return null;
+    }
+    let highest: DetectionMatch = matches[0];
+    for (const m of matches) {
+      if (RISK_ORDER[m.riskLevel] > RISK_ORDER[highest.riskLevel]) {
+        highest = m;
+      }
+    }
+    return highest.riskLevel;
+  }
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/privacy/detector.ts
+++ b/src/privacy/detector.ts
@@ -300,7 +300,9 @@ export class PrivacyDetector {
 
     if (ctx.mustContain) {
       // At least one of the context keywords must appear nearby.
-      const found = ctx.mustContain.some((kw) => context.includes(kw.toLowerCase()));
+      const found = ctx.mustContain.some(
+        (kw) => typeof kw === "string" && context.includes(kw.toLowerCase()),
+      );
       if (!found) {
         return false;
       }
@@ -308,7 +310,7 @@ export class PrivacyDetector {
 
     if (ctx.mustNotContain) {
       for (const kw of ctx.mustNotContain) {
-        if (context.includes(kw.toLowerCase())) {
+        if (typeof kw === "string" && context.includes(kw.toLowerCase())) {
           return false;
         }
       }

--- a/src/privacy/index.ts
+++ b/src/privacy/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Privacy filter module — detects and replaces sensitive information
+ * in messages before sending to LLM APIs.
+ */
+
+export { PrivacyDetector } from "./detector.js";
+export { PrivacyReplacer } from "./replacer.js";
+export { PrivacyMappingStore } from "./mapping-store.js";
+export {
+  createPrivacyFilterContext,
+  filterText,
+  restoreText,
+  filterMessages,
+  filterPrompt,
+  restoreResponse,
+  wrapStreamFnPrivacyFilter,
+} from "./stream-wrapper.js";
+export type { PrivacyFilterContext } from "./stream-wrapper.js";
+export { BASIC_RULES, EXTENDED_RULES, resolveRules } from "./rules.js";
+export {
+  loadCustomRules,
+  processCustomRulesConfig,
+  registerNamedValidator,
+  getNamedValidators,
+  validateUserRule,
+  validateRegexSafety,
+} from "./custom-rules.js";
+export type { RuleValidationError, CustomRulesResult } from "./custom-rules.js";
+export type {
+  CustomRulesConfig,
+  DetectionMatch,
+  FilterResult,
+  PrivacyConfig,
+  PrivacyContext,
+  PrivacyMapping,
+  PrivacyRule,
+  RiskLevel,
+  RuleContext,
+  UserDefinedRule,
+} from "./types.js";
+export { DEFAULT_PRIVACY_CONFIG } from "./types.js";

--- a/src/privacy/mapping-store.test.ts
+++ b/src/privacy/mapping-store.test.ts
@@ -1,0 +1,149 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { PrivacyMappingStore } from "./mapping-store.js";
+import type { PrivacyMapping } from "./types.js";
+
+function createTempStore(): { store: PrivacyMappingStore; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), "privacy-test-"));
+  const storePath = join(dir, "test-mappings.enc");
+  const store = new PrivacyMappingStore({ storePath, salt: "test-salt" });
+  return { store, dir };
+}
+
+function makeMappingData(id: string, sessionId: string, createdAt?: number): PrivacyMapping {
+  return {
+    id,
+    sessionId,
+    original: `original-${id}`,
+    replacement: `replacement-${id}`,
+    type: "email",
+    riskLevel: "medium",
+    createdAt: createdAt ?? Date.now(),
+  };
+}
+
+describe("PrivacyMappingStore", () => {
+  const cleanups: string[] = [];
+
+  afterEach(() => {
+    for (const dir of cleanups) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
+    cleanups.length = 0;
+  });
+
+  describe("save and load", () => {
+    it("round-trips mappings through encrypted storage", () => {
+      const { store, dir } = createTempStore();
+      cleanups.push(dir);
+
+      const mappings = [makeMappingData("1", "session-a"), makeMappingData("2", "session-a")];
+
+      store.save(mappings);
+      const loaded = store.load();
+
+      expect(loaded).toHaveLength(2);
+      expect(loaded[0].original).toBe("original-1");
+      expect(loaded[1].original).toBe("original-2");
+    });
+
+    it("returns empty array when file does not exist", () => {
+      const { store, dir } = createTempStore();
+      cleanups.push(dir);
+      expect(store.load()).toEqual([]);
+    });
+  });
+
+  describe("append", () => {
+    it("appends new mappings without duplicates", () => {
+      const { store, dir } = createTempStore();
+      cleanups.push(dir);
+
+      store.save([makeMappingData("1", "s1")]);
+      store.append([makeMappingData("1", "s1"), makeMappingData("2", "s1")]);
+
+      const loaded = store.load();
+      expect(loaded).toHaveLength(2);
+    });
+  });
+
+  describe("loadSession", () => {
+    it("filters mappings by session ID", () => {
+      const { store, dir } = createTempStore();
+      cleanups.push(dir);
+
+      store.save([
+        makeMappingData("1", "session-a"),
+        makeMappingData("2", "session-b"),
+        makeMappingData("3", "session-a"),
+      ]);
+
+      const sessionA = store.loadSession("session-a");
+      expect(sessionA).toHaveLength(2);
+      expect(sessionA.every((m) => m.sessionId === "session-a")).toBe(true);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("removes expired mappings", () => {
+      const { store, dir } = createTempStore();
+      cleanups.push(dir);
+
+      const oldTime = Date.now() - 100_000;
+      store.save([makeMappingData("old", "s1", oldTime), makeMappingData("new", "s1", Date.now())]);
+
+      const removed = store.cleanup(50_000);
+      expect(removed).toBe(1);
+
+      const remaining = store.load();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].id).toBe("new");
+    });
+  });
+
+  describe("clearSession", () => {
+    it("removes all mappings for a session", () => {
+      const { store, dir } = createTempStore();
+      cleanups.push(dir);
+
+      store.save([makeMappingData("1", "session-a"), makeMappingData("2", "session-b")]);
+
+      store.clearSession("session-a");
+      const remaining = store.load();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].sessionId).toBe("session-b");
+    });
+  });
+
+  describe("destroy", () => {
+    it("deletes the store file", () => {
+      const { store, dir } = createTempStore();
+      cleanups.push(dir);
+
+      store.save([makeMappingData("1", "s1")]);
+      store.destroy();
+      expect(store.load()).toEqual([]);
+    });
+  });
+
+  describe("encryption", () => {
+    it("cannot decrypt with wrong salt", () => {
+      const dir = mkdtempSync(join(tmpdir(), "privacy-test-"));
+      cleanups.push(dir);
+
+      const storePath = join(dir, "enc-test.enc");
+      const store1 = new PrivacyMappingStore({ storePath, salt: "salt-1" });
+      store1.save([makeMappingData("1", "s1")]);
+
+      const store2 = new PrivacyMappingStore({ storePath, salt: "salt-2" });
+      // Wrong salt should return empty (graceful failure).
+      expect(store2.load()).toEqual([]);
+    });
+  });
+});

--- a/src/privacy/mapping-store.ts
+++ b/src/privacy/mapping-store.ts
@@ -1,0 +1,273 @@
+/**
+ * Encrypted mapping store — persists privacy mappings using AES-256-GCM.
+ * Each record has an independent IV to prevent pattern analysis.
+ */
+
+import { createCipheriv, createDecipheriv, pbkdf2Sync, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { PrivacyMapping } from "./types.js";
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_LENGTH = 32;
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+const PBKDF2_ITERATIONS = 100_000;
+const PBKDF2_DIGEST = "sha512";
+const LOCK_WAIT_TIMEOUT_MS = 2_000;
+const LOCK_STALE_AFTER_MS = 30_000;
+const LOCK_RETRY_MS = 25;
+const FILE_MODE_OWNER_RW = 0o600;
+const DIR_MODE_OWNER_RWX = 0o700;
+const SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
+
+/** Default storage directory. */
+function defaultStorePath(): string {
+  return join(homedir(), ".openclaw", "privacy", "mappings.enc");
+}
+
+/** Default machine key path used to strengthen local-at-rest encryption. */
+function defaultMachineKeyPath(): string {
+  return join(homedir(), ".openclaw", "privacy", "master.key");
+}
+
+/** Derive an AES-256 key from a passphrase + salt using PBKDF2. */
+function deriveKey(passphrase: string, salt: string): Buffer {
+  const saltBuffer = Buffer.from(salt || `openclaw-default-salt-${homedir()}`, "utf8");
+  return pbkdf2Sync(passphrase, saltBuffer, PBKDF2_ITERATIONS, KEY_LENGTH, PBKDF2_DIGEST);
+}
+
+/** Legacy key derivation used by older builds (kept for backward-compatible reads). */
+function deriveLegacyKey(salt: string): Buffer {
+  const passphrase = `openclaw-privacy-${process.env.USER ?? "default"}`;
+  return deriveKey(passphrase, salt);
+}
+
+function ensureOwnerOnlyPermissions(path: string): void {
+  try {
+    chmodSync(path, FILE_MODE_OWNER_RW);
+  } catch {
+    // Best-effort only on platforms/filesystems that don't support chmod semantics.
+  }
+}
+
+function ensureDir(path: string): void {
+  if (!existsSync(path)) {
+    mkdirSync(path, { recursive: true, mode: DIR_MODE_OWNER_RWX });
+  }
+}
+
+function loadOrCreateMachinePassphrase(customPath?: string): string {
+  const path = customPath || defaultMachineKeyPath();
+  const dir = dirname(path);
+  ensureDir(dir);
+
+  if (existsSync(path)) {
+    const raw = readFileSync(path);
+    if (raw.length > 0) {
+      ensureOwnerOnlyPermissions(path);
+      return raw.toString("base64");
+    }
+  }
+
+  const secret = randomBytes(32);
+  writeFileSync(path, secret, { mode: FILE_MODE_OWNER_RW });
+  ensureOwnerOnlyPermissions(path);
+  return secret.toString("base64");
+}
+
+function sleepMs(ms: number): void {
+  Atomics.wait(SLEEP_BUFFER, 0, 0, ms);
+}
+
+/** Encrypt a plaintext string. Returns a Buffer: [IV (16)] [authTag (16)] [ciphertext]. */
+function encrypt(plaintext: string, key: Buffer): Buffer {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, encrypted]);
+}
+
+/** Decrypt a buffer produced by encrypt(). */
+function decrypt(data: Buffer, key: Buffer): string {
+  const iv = data.subarray(0, IV_LENGTH);
+  const authTag = data.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = data.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return decipher.update(ciphertext, undefined, "utf8") + decipher.final("utf8");
+}
+
+export class PrivacyMappingStore {
+  private storePath: string;
+  private key: Buffer;
+  private legacyKey: Buffer;
+  private lockPath: string;
+
+  constructor(options?: { storePath?: string; salt?: string }) {
+    this.storePath = options?.storePath || defaultStorePath();
+    const salt = options?.salt ?? "";
+    const passphrase = loadOrCreateMachinePassphrase();
+    this.key = deriveKey(passphrase, salt);
+    this.legacyKey = deriveLegacyKey(salt);
+    this.lockPath = `${this.storePath}.lock`;
+  }
+
+  /** Save mappings to encrypted file. */
+  save(mappings: PrivacyMapping[]): void {
+    this.withWriteLock(() => {
+      this.saveUnlocked(mappings);
+    });
+  }
+
+  /** Load mappings from encrypted file. Returns empty array if file doesn't exist. */
+  load(): PrivacyMapping[] {
+    if (!existsSync(this.storePath)) {
+      return [];
+    }
+    const data = readFileSync(this.storePath);
+    const decoded = this.tryDecrypt(data, this.key) ?? this.tryDecrypt(data, this.legacyKey);
+    return decoded ?? [];
+  }
+
+  /** Load only mappings for a specific session. */
+  loadSession(sessionId: string): PrivacyMapping[] {
+    return this.load().filter((m) => m.sessionId === sessionId);
+  }
+
+  /** Append new mappings (merges with existing). */
+  append(newMappings: PrivacyMapping[]): void {
+    if (newMappings.length === 0) {
+      return;
+    }
+    this.withWriteLock(() => {
+      const existing = this.load();
+      const existingIds = new Set(existing.map((m) => m.id));
+      const toAdd = newMappings.filter((m) => !existingIds.has(m.id));
+      if (toAdd.length > 0) {
+        this.saveUnlocked([...existing, ...toAdd]);
+      }
+    });
+  }
+
+  /** Remove expired mappings (older than ttlMs). */
+  cleanup(ttlMs: number): number {
+    return this.withWriteLock(() => {
+      const mappings = this.load();
+      const cutoff = Date.now() - ttlMs;
+      const kept = mappings.filter((m) => m.createdAt > cutoff);
+      const removed = mappings.length - kept.length;
+      if (removed > 0) {
+        this.saveUnlocked(kept);
+      }
+      return removed;
+    });
+  }
+
+  /** Remove all mappings for a specific session. */
+  clearSession(sessionId: string): void {
+    this.withWriteLock(() => {
+      const mappings = this.load();
+      const kept = mappings.filter((m) => m.sessionId !== sessionId);
+      if (kept.length < mappings.length) {
+        this.saveUnlocked(kept);
+      }
+    });
+  }
+
+  /** Delete the store file entirely. */
+  destroy(): void {
+    this.withWriteLock(() => {
+      if (existsSync(this.storePath)) {
+        unlinkSync(this.storePath);
+      }
+    });
+  }
+
+  private saveUnlocked(mappings: PrivacyMapping[]): void {
+    const dir = dirname(this.storePath);
+    ensureDir(dir);
+    const json = JSON.stringify(mappings);
+    const encrypted = encrypt(json, this.key);
+    writeFileSync(this.storePath, encrypted, { mode: FILE_MODE_OWNER_RW });
+    ensureOwnerOnlyPermissions(this.storePath);
+  }
+
+  private tryDecrypt(data: Buffer, key: Buffer): PrivacyMapping[] | null {
+    try {
+      const json = decrypt(data, key);
+      return JSON.parse(json) as PrivacyMapping[];
+    } catch {
+      return null;
+    }
+  }
+
+  private withWriteLock<T>(fn: () => T): T {
+    const startedAt = Date.now();
+    let lockFd: number | null = null;
+
+    while (lockFd === null) {
+      try {
+        lockFd = openSync(this.lockPath, "wx", FILE_MODE_OWNER_RW);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+          throw err;
+        }
+
+        if (this.isLockStale()) {
+          try {
+            unlinkSync(this.lockPath);
+          } catch {
+            // Another process may have already removed/replaced it.
+          }
+          continue;
+        }
+
+        if (Date.now() - startedAt > LOCK_WAIT_TIMEOUT_MS) {
+          throw new Error(`privacy mapping store lock timeout: ${this.lockPath}`, { cause: err });
+        }
+        sleepMs(LOCK_RETRY_MS);
+      }
+    }
+
+    try {
+      return fn();
+    } finally {
+      if (lockFd !== null) {
+        try {
+          closeSync(lockFd);
+        } finally {
+          try {
+            unlinkSync(this.lockPath);
+          } catch {
+            // Best-effort unlock.
+          }
+        }
+      }
+    }
+  }
+
+  private isLockStale(): boolean {
+    try {
+      if (!existsSync(this.lockPath)) {
+        return false;
+      }
+      const stat = statSync(this.lockPath);
+      return Date.now() - stat.mtimeMs > LOCK_STALE_AFTER_MS;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/privacy/mapping-store.ts
+++ b/src/privacy/mapping-store.ts
@@ -11,6 +11,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -144,7 +145,8 @@ export class PrivacyMappingStore {
 
   /** Load only mappings for a specific session. */
   loadSession(sessionId: string): PrivacyMapping[] {
-    return this.load().filter((m) => m.sessionId === sessionId);
+    // Use write-lock so we cannot observe a partially-written file from another concurrent instance.
+    return this.withWriteLock(() => this.load().filter((m) => m.sessionId === sessionId));
   }
 
   /** Append new mappings (merges with existing). */
@@ -201,7 +203,12 @@ export class PrivacyMappingStore {
     ensureDir(dir);
     const json = JSON.stringify(mappings);
     const encrypted = encrypt(json, this.key);
-    writeFileSync(this.storePath, encrypted, { mode: FILE_MODE_OWNER_RW });
+    // Write to a temp file then rename for atomic replacement — prevents a partial
+    // file if the process is killed mid-write.
+    const tmpPath = `${this.storePath}.tmp`;
+    writeFileSync(tmpPath, encrypted, { mode: FILE_MODE_OWNER_RW });
+    ensureOwnerOnlyPermissions(tmpPath);
+    renameSync(tmpPath, this.storePath);
     ensureOwnerOnlyPermissions(this.storePath);
   }
 
@@ -217,6 +224,11 @@ export class PrivacyMappingStore {
   private withWriteLock<T>(fn: () => T): T {
     const startedAt = Date.now();
     let lockFd: number | null = null;
+
+    // Ensure the parent directory exists before attempting to open the lock file.
+    // Without this, a custom storePath in a new directory would throw ENOENT and
+    // the error would be swallowed by filterText, silently losing all mappings.
+    ensureDir(dirname(this.lockPath));
 
     while (lockFd === null) {
       try {

--- a/src/privacy/replacer.test.ts
+++ b/src/privacy/replacer.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { PrivacyReplacer } from "./replacer.js";
+import type { DetectionMatch, RiskLevel } from "./types.js";
+
+function makeMatch(
+  type: string,
+  content: string,
+  start: number,
+  riskLevel: RiskLevel = "high",
+): DetectionMatch {
+  return {
+    type,
+    content,
+    start,
+    end: start + content.length,
+    riskLevel,
+    description: `test ${type}`,
+  };
+}
+
+describe("PrivacyReplacer", () => {
+  describe("replaceAll", () => {
+    it("replaces email addresses", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const text = "Contact user@gmail.com for info";
+      const match = makeMatch("email", "user@gmail.com", 8);
+      const { replaced } = replacer.replaceAll(text, [match]);
+      expect(replaced).not.toContain("user@gmail.com");
+      expect(replaced).toContain("@example.net");
+    });
+
+    it("replaces phone numbers", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const text = "Call me at 13812345678";
+      const match = makeMatch("phone_cn", "13812345678", 11);
+      const { replaced } = replacer.replaceAll(text, [match]);
+      expect(replaced).not.toContain("13812345678");
+      expect(replaced).toContain("139");
+    });
+
+    it("replaces password assignments keeping the key", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const text = "password=MyS3cret";
+      const match = makeMatch("password_assignment", "password=MyS3cret", 0, "critical");
+      const { replaced } = replacer.replaceAll(text, [match]);
+      expect(replaced).not.toContain("MyS3cret");
+      expect(replaced).toContain("password=");
+      expect(replaced).toContain("PF_PWD_");
+    });
+
+    it("preserves text around replacements", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const text = "prefix user@test.com suffix";
+      const match = makeMatch("email", "user@test.com", 7);
+      const { replaced } = replacer.replaceAll(text, [match]);
+      expect(replaced).toMatch(/^prefix .+ suffix$/);
+    });
+
+    it("handles multiple matches", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const text = "email: a@b.com phone: 13800001111";
+      const matches = [makeMatch("email", "a@b.com", 7), makeMatch("phone_cn", "13800001111", 22)];
+      const { replaced } = replacer.replaceAll(text, matches);
+      expect(replaced).not.toContain("a@b.com");
+      expect(replaced).not.toContain("13800001111");
+    });
+
+    it("returns new mappings for first-time replacements", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const match = makeMatch("email", "user@test.com", 0);
+      const { newMappings } = replacer.replaceAll("user@test.com", [match]);
+      expect(newMappings).toHaveLength(1);
+      expect(newMappings[0].type).toBe("email");
+      expect(newMappings[0].sessionId).toBe("test-session");
+    });
+  });
+
+  describe("idempotency", () => {
+    it("returns same replacement for same original", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const match1 = makeMatch("email", "same@test.com", 0);
+      const match2 = makeMatch("email", "same@test.com", 5);
+
+      const { replaced: r1 } = replacer.replaceAll("same@test.com", [match1]);
+      const { replaced: r2, newMappings } = replacer.replaceAll("xxx same@test.com", [match2]);
+
+      // Both should use the same replacement value.
+      const replacement = r1;
+      expect(r2).toContain(replacement);
+      expect(newMappings).toHaveLength(0);
+    });
+  });
+
+  describe("restore", () => {
+    it("restores replaced text to original", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const original = "Send to user@example.com please";
+      const match = makeMatch("email", "user@example.com", 8);
+      const { replaced } = replacer.replaceAll(original, [match]);
+
+      // LLM response that echoes back the replacement.
+      const llmResponse = `I see the email ${replaced.slice(8, replaced.indexOf(" please"))}`;
+      const restored = replacer.restore(llmResponse);
+      expect(restored).toContain("user@example.com");
+    });
+
+    it("handles text with no replacements", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const text = "no replacements here";
+      expect(replacer.restore(text)).toBe(text);
+    });
+  });
+
+  describe("loadMappings", () => {
+    it("loads previously saved mappings", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const match = makeMatch("email", "old@test.com", 0);
+      const { newMappings } = replacer.replaceAll("old@test.com", [match]);
+
+      // Create new replacer and load mappings.
+      const replacer2 = new PrivacyReplacer("test-session");
+      replacer2.loadMappings(newMappings);
+
+      // Should be able to restore using loaded mappings.
+      const restored = replacer2.restore(newMappings[0].replacement);
+      expect(restored).toBe("old@test.com");
+    });
+  });
+
+  describe("clear", () => {
+    it("clears all mappings", () => {
+      const replacer = new PrivacyReplacer("test-session");
+      const match = makeMatch("email", "test@test.com", 0);
+      replacer.replaceAll("test@test.com", [match]);
+
+      replacer.clear();
+      expect(replacer.getMappings()).toHaveLength(0);
+    });
+  });
+});

--- a/src/privacy/replacer.ts
+++ b/src/privacy/replacer.ts
@@ -1,0 +1,314 @@
+/**
+ * Privacy replacer — generates realistic-looking fake replacements for detected sensitive content.
+ * Replacements preserve format so LLM can still understand the semantic context.
+ *
+ * Same original text within a session maps to the same replacement (idempotent).
+ */
+
+import type { DetectionMatch, PrivacyMapping } from "./types.js";
+
+/** Replacement generator that maintains a session-scoped mapping cache. */
+export class PrivacyReplacer {
+  private sessionId: string;
+  /** original → replacement */
+  private forwardMap = new Map<string, string>();
+  /** replacement → original */
+  private reverseMap = new Map<string, string>();
+  /** Full mapping records for persistence. */
+  private mappings: PrivacyMapping[] = [];
+  private seq = 0;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
+
+  /**
+   * Replace all detected matches in text with fake values.
+   * Returns the replaced text and the list of new mappings created.
+   */
+  replaceAll(
+    text: string,
+    matches: DetectionMatch[],
+  ): { replaced: string; newMappings: PrivacyMapping[] } {
+    if (matches.length === 0) {
+      return { replaced: text, newMappings: [] };
+    }
+
+    const newMappings: PrivacyMapping[] = [];
+    // Process from end to start to preserve indices.
+    // Also skip matches that overlap with already-processed regions.
+    const sorted = [...matches].toSorted((a, b) => b.start - a.start);
+
+    let result = text;
+    let processedStart = Infinity;
+    for (const match of sorted) {
+      // Skip if this match overlaps with an already-processed (later) region.
+      if (match.end > processedStart) {
+        continue;
+      }
+
+      const replacement = this.getOrCreateReplacement(match);
+
+      // Skip identity replacements (e.g. confidential markers that don't need substitution).
+      if (replacement.mapping.replacement === match.content) {
+        continue;
+      }
+
+      if (replacement.isNew) {
+        newMappings.push(replacement.mapping);
+      }
+      result =
+        result.slice(0, match.start) + replacement.mapping.replacement + result.slice(match.end);
+      processedStart = match.start;
+    }
+
+    return { replaced: result, newMappings };
+  }
+
+  /**
+   * Reverse-replace: scan text for any known replacement strings and restore originals.
+   */
+  restore(text: string): string {
+    if (this.reverseMap.size === 0) {
+      return text;
+    }
+
+    let result = text;
+    // Sort replacements by length descending to avoid partial matches.
+    const entries = [...this.reverseMap.entries()].toSorted((a, b) => b[0].length - a[0].length);
+    for (const [replacement, original] of entries) {
+      // Use split+join for reliable replacement (no regex special chars issue).
+      result = result.split(replacement).join(original);
+    }
+    return result;
+  }
+
+  /** Get all current mappings. */
+  getMappings(): PrivacyMapping[] {
+    return [...this.mappings];
+  }
+
+  /** Load previously persisted mappings (e.g. from encrypted store). */
+  loadMappings(mappings: PrivacyMapping[]): void {
+    for (const m of mappings) {
+      if (!this.forwardMap.has(m.original)) {
+        this.forwardMap.set(m.original, m.replacement);
+        this.reverseMap.set(m.replacement, m.original);
+        this.mappings.push(m);
+      }
+    }
+  }
+
+  /** Clear all mappings. */
+  clear(): void {
+    this.forwardMap.clear();
+    this.reverseMap.clear();
+    this.mappings = [];
+    this.seq = 0;
+  }
+
+  private getOrCreateReplacement(match: DetectionMatch): {
+    mapping: PrivacyMapping;
+    isNew: boolean;
+  } {
+    const existing = this.forwardMap.get(match.content);
+    if (existing) {
+      const mapping = this.mappings.find((m) => m.original === match.content);
+      return { mapping: mapping!, isNew: false };
+    }
+
+    const now = Date.now();
+    const seqId = this.seq++;
+    const replacement = generateReplacement(
+      match.type,
+      match.content,
+      now,
+      seqId,
+      match.replacementTemplate,
+    );
+    const id = `pf_${now}_${seqId}`;
+
+    const mapping: PrivacyMapping = {
+      id,
+      sessionId: this.sessionId,
+      original: match.content,
+      replacement,
+      type: match.type,
+      riskLevel: match.riskLevel,
+      createdAt: now,
+    };
+
+    this.forwardMap.set(match.content, replacement);
+    this.reverseMap.set(replacement, match.content);
+    this.mappings.push(mapping);
+
+    return { mapping, isNew: true };
+  }
+}
+
+/**
+ * Generate a type-appropriate fake replacement value.
+ * Preserves format so the LLM understands the semantic context.
+ */
+function generateReplacement(
+  type: string,
+  original: string,
+  timestamp: number,
+  seq: number,
+  replacementTemplate?: string,
+): string {
+  const ts = String(timestamp).slice(-10);
+  const suffix = `${ts}${seq}`;
+
+  // If a custom replacement template is provided, use it.
+  if (replacementTemplate) {
+    return applyReplacementTemplate(replacementTemplate, { type, original, seq, ts });
+  }
+
+  switch (type) {
+    case "email":
+      return `pf_e${suffix}@example.net`;
+
+    case "phone_cn":
+      return `139${suffix.slice(0, 8).padEnd(8, "0")}`;
+
+    case "phone_hk":
+    case "phone_tw":
+    case "phone_us":
+      return `pf_ph_${suffix.slice(0, 8)}`;
+
+    case "id_card_cn":
+      // Keep format: 6 region + 8 date + 3 seq + 1 check
+      return `110101199001${suffix.slice(0, 4).padEnd(4, "0")}9X`;
+
+    case "credit_card":
+    case "credit_card_visa":
+    case "credit_card_mastercard":
+    case "credit_card_amex":
+    case "credit_card_discover":
+    case "credit_card_unionpay":
+      return `4000${suffix.slice(0, 12).padEnd(12, "0")}`;
+
+    case "password_assignment":
+    case "env_password": {
+      // Keep the key=value structure, replace only the value part.
+      const eqIdx = original.search(/[:=]/);
+      if (eqIdx >= 0) {
+        const prefix = original.slice(0, eqIdx + 1);
+        return `${prefix}PF_PWD_${suffix}`;
+      }
+      return `PF_PWD_${suffix}`;
+    }
+
+    case "openai_api_key":
+      return `sk-pf${suffix}${"x".repeat(Math.max(0, original.length - 4 - suffix.length))}`;
+
+    case "anthropic_api_key":
+      return `sk-ant-pf${suffix}${"x".repeat(Math.max(0, 20))}`;
+
+    case "github_token": {
+      const prefixMatch = original.match(/^(ghp|gho|ghu|ghs|ghr)_/);
+      const pfx = prefixMatch ? prefixMatch[1] : "ghp";
+      return `${pfx}_pf${suffix}${"x".repeat(Math.max(0, 36 - suffix.length))}`;
+    }
+
+    case "aws_access_key":
+      return `AKIAPF${suffix.slice(0, 16).padEnd(16, "X")}`;
+
+    case "jwt_token":
+      // Generate a fake but format-correct JWT-like string.
+      return `eyJwZiI6InRydWUifQ.eyJwZl90cyI6IiR7${ts}In0.pf_sig_${suffix}`;
+
+    case "bearer_token": {
+      const bearerMatch = original.match(/^(bearer\s+)/i);
+      const bearerPfx = bearerMatch ? bearerMatch[1] : "Bearer ";
+      return `${bearerPfx}pf_token_${suffix}${"x".repeat(20)}`;
+    }
+
+    case "basic_auth":
+      return `Authorization: Basic cGZfdXNlcjpwZl9wYXNz${suffix}`;
+
+    case "ssh_private_key":
+    case "pgp_private_key":
+    case "pkcs8_private_key":
+      return `-----BEGIN PF PRIVATE KEY-----\npf_redacted_${suffix}\n-----END PF PRIVATE KEY-----`;
+
+    case "database_url_mysql":
+      return `mysql://pf_user:pf_pass_${suffix}@pf-host/pf_db`;
+
+    case "database_url_postgresql":
+      return `postgresql://pf_user:pf_pass_${suffix}@pf-host/pf_db`;
+
+    case "database_url_mongodb":
+      return `mongodb://pf_user:pf_pass_${suffix}@pf-host/pf_db`;
+
+    case "redis_url":
+      return `redis://:pf_pass_${suffix}@pf-host:6379/`;
+
+    case "url_with_credentials":
+      return `https://pf_user:pf_pass_${suffix}@pf-host.example.com/`;
+
+    case "slack_token":
+      return `xoxb-pftoken${suffix}-${"x".repeat(24)}`;
+
+    case "google_api_key":
+    case "firebase_key":
+      return `AIzaPF${suffix}${"x".repeat(Math.max(0, 35 - suffix.length))}`;
+
+    case "stripe_api_key": {
+      const stripePfx = original.match(/^(sk|pk|rk)_(live|test)_/)?.[0] ?? "sk_test_";
+      return `${stripePfx}pf${suffix}${"x".repeat(24)}`;
+    }
+
+    case "alibaba_access_key":
+      return `LTAIpf${suffix.slice(0, 16)}`;
+
+    case "tencent_secret_id":
+      return `AKIDpf${suffix}${"x".repeat(Math.max(0, 32 - suffix.length))}`;
+
+    case "social_security_number_us":
+      return `000-${suffix.slice(0, 2).padEnd(2, "0")}-${suffix.slice(2, 6).padEnd(4, "0")}`;
+
+    case "iban":
+      return `XX00PFLT${suffix.slice(0, 12).padEnd(12, "0")}`;
+
+    case "ipv4_private":
+      return `10.0.${seq % 256}.${(seq + 1) % 256}`;
+
+    case "ipv4_public":
+      return `198.51.100.${seq % 256}`;
+
+    case "salary_amount": {
+      // Keep the label, replace the number.
+      const salaryMatch = original.match(/(年薪|月薪|工资|薪水|salary|compensation)\s*[:：]?\s*/i);
+      const label = salaryMatch ? salaryMatch[0] : "";
+      return `${label}PF_AMOUNT_${suffix}`;
+    }
+
+    case "bare_password":
+      // Replace with a fake password of similar length that preserves complexity appearance.
+      return `PF_Pw${suffix}!x`;
+
+    case "high_entropy_string":
+      // Replace with a fake token of similar length.
+      return `pf_ent_${suffix}${"x".repeat(Math.max(0, original.length - 7 - suffix.length))}`;
+
+    default:
+      // Generic replacement preserving approximate length.
+      return `pf_${type}_${suffix}`;
+  }
+}
+
+/** Apply a replacement template string with placeholder substitution. */
+function applyReplacementTemplate(
+  template: string,
+  ctx: { type: string; original: string; seq: number; ts: string },
+): string {
+  return template
+    .replace(/\{type\}/g, ctx.type)
+    .replace(/\{seq\}/g, String(ctx.seq))
+    .replace(/\{ts\}/g, ctx.ts)
+    .replace(/\{original_prefix:(\d+)\}/g, (_, n) => ctx.original.slice(0, parseInt(n, 10)))
+    .replace(/\{original_length\}/g, String(ctx.original.length))
+    .replace(/\{pad:(\d+)\}/g, (_, n) => "x".repeat(Math.max(0, parseInt(n, 10))));
+}

--- a/src/privacy/rules.test.ts
+++ b/src/privacy/rules.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Exhaustive tests — verifies every enabled rule type has at least one detection case.
+ */
+import { describe, expect, it } from "vitest";
+import { PrivacyDetector } from "./detector.js";
+import { EXTENDED_RULES } from "./rules.js";
+
+const detector = new PrivacyDetector("extended");
+
+/** Helper: assert at least one match of the given type. */
+function expectType(text: string, type: string) {
+  const result = detector.detect(text);
+  const matched = result.matches.some((m) => m.type === type);
+  if (!matched) {
+    const found = result.matches.map((m) => m.type);
+    throw new Error(
+      `Expected type "${type}" in text "${text.slice(0, 60)}…"\n  Found types: [${found.join(", ")}]`,
+    );
+  }
+}
+
+describe("all rule types coverage", () => {
+  // ─── Email & Phone ───
+  it("email", () => expectType("user@gmail.com", "email"));
+  it("phone_cn", () => expectType("13812345678", "phone_cn"));
+  it("phone_hk", () => expectType("香港电话 91234567", "phone_hk"));
+  it("phone_tw", () => expectType("0912345678", "phone_tw"));
+  it("phone_us", () => expectType("(212) 555-1234", "phone_us"));
+
+  // ─── Identity documents ───
+  it("id_card_cn", () => expectType("110101199001011234", "id_card_cn"));
+  it("id_card_hk", () => expectType("A123456(7)", "id_card_hk"));
+  it("passport_cn", () => expectType("护照号 E12345678", "passport_cn"));
+  it("passport_number", () => expectType("passport: AB1234567", "passport_number"));
+  it("social_security_number_us", () => expectType("123-45-6789", "social_security_number_us"));
+
+  // ─── Credit cards & Banking ───
+  it("credit_card", () => expectType("4111111111111111", "credit_card"));
+  it("credit_card_unionpay", () => expectType("6222021234567890123", "credit_card_unionpay"));
+  it("iban", () => expectType("GB29NWBK60161331926819", "iban"));
+  it("bank_account_cn", () => expectType("银行卡号 6222021234567890123", "bank_account_cn"));
+
+  // ─── Payment accounts ───
+  it("alipay_account", () => expectType("支付宝 13800001111", "alipay_account"));
+  it("wechat_id", () => expectType("微信号 abcdef12345", "wechat_id"));
+
+  // ─── Passwords ───
+  it("password_assignment", () => expectType("password=MyS3cret123", "password_assignment"));
+  it("env_password", () => expectType("PASSWORD=SuperSecret1", "env_password"));
+  it("bare_password", () => expectType("MyS3cret!Pass", "bare_password"));
+
+  // ─── API Keys: Developer platforms ───
+  it("openai_api_key", () => expectType("sk-proj-abc123def456ghi789jklmno", "openai_api_key"));
+  it("anthropic_api_key", () =>
+    expectType("sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890", "anthropic_api_key"));
+  it("github_token", () => expectType("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", "github_token"));
+  it("gitlab_token", () => expectType("glpat-ABCDEFGHIJKLMNOPQRSTU", "gitlab_token"));
+  it("npm_token", () => expectType("npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", "npm_token"));
+  it("pypi_token", () =>
+    expectType("pypi-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", "pypi_token"));
+
+  // ─── API Keys: Cloud providers ───
+  it("google_api_key", () =>
+    expectType("AIzaSyA1234567890ABCDEFGHIJKLMNOPQRSTUV", "google_api_key"));
+  it("aws_access_key", () => expectType("AKIAIOSFODNN7EXAMPLE", "aws_access_key"));
+  it("aws_secret_key", () =>
+    expectType("aws secret key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'", "aws_secret_key"));
+  it("alibaba_access_key", () => expectType("LTAIabcdef123456789", "alibaba_access_key"));
+  it("tencent_secret_id", () =>
+    expectType("AKIDabcdefghijklmnopqrstuvwxyz1234567890", "tencent_secret_id"));
+  it("azure_storage_key", () =>
+    expectType(
+      "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/ABCDEFGHIJKLMNOPQRST+w==;EndpointSuffix=core.windows.net",
+      "azure_storage_key",
+    ));
+  it("azure_client_secret", () =>
+    expectType("client_secret=abcdefghij-klmnopqrstuvwxyz1234567890", "azure_client_secret"));
+
+  // ─── API Keys: SaaS services ───
+  it("stripe_api_key", () => expectType("sk_live_1234567890ABCDEFGHIJKLMNab", "stripe_api_key"));
+  it("slack_token", () =>
+    expectType("xoxb-1234567890123-1234567890123-ABCDEFGHIJKLMNOPQRSTUVWXab", "slack_token"));
+  it("discord_token", () =>
+    expectType("MTIzNDU2Nzg5MDEyMzQ1Njc4.ABCDEf.ABCDEFGHIJKLMNOPQRSTUVWXYZab", "discord_token"));
+  it("sendgrid_api_key", () =>
+    expectType(
+      "SG.abcdefghijklmnopqrstuv.ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq",
+      "sendgrid_api_key",
+    ));
+  it("twilio_api_key", () => expectType("SK1234567890abcdef1234567890abcdef", "twilio_api_key"));
+  it("shopify_token", () => expectType("shpat_1234567890abcdef1234567890abcdef", "shopify_token"));
+  it("square_token", () => expectType("sq0atp-ABCDEFghijklmnopqrstuv", "square_token"));
+  it("newrelic_key", () => expectType("NRAK-ABCDEFGHIJKLMNOPQRSTUVWXYZA", "newrelic_key"));
+  it("mailchimp_api_key", () =>
+    expectType("abcdef1234567890abcdef1234567890-us12", "mailchimp_api_key"));
+  it("sentry_dsn", () =>
+    expectType(
+      "https://abcdef1234567890abcdef1234567890@o12345.ingest.sentry.io/1234567",
+      "sentry_dsn",
+    ));
+
+  // ─── Auth tokens ───
+  it("jwt_token", () =>
+    expectType(
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+      "jwt_token",
+    ));
+  it("bearer_token", () => expectType("Bearer abcdefghij1234567890abcdefghij", "bearer_token"));
+  it("basic_auth", () =>
+    expectType("Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=aa", "basic_auth"));
+  it("generic_api_key", () =>
+    expectType("api_key=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", "generic_api_key"));
+  it("oauth_secret", () => expectType("client_secret=ABCDEFGHIJKLMNOPQRSTx", "oauth_secret"));
+  it("oauth_refresh_token", () =>
+    expectType("refresh_token=ABCDEFGHIJKLMNOPQRSTx", "oauth_refresh_token"));
+  it("session_token", () =>
+    expectType("session_id=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", "session_token"));
+
+  // ─── SSH / Crypto keys ───
+  it("ssh_private_key", () => expectType("-----BEGIN RSA PRIVATE KEY-----", "ssh_private_key"));
+  it("private_key_hex", () =>
+    expectType(
+      "私钥: 4a2b8c1d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b",
+      "private_key_hex",
+    ));
+  it("ethereum_address", () =>
+    expectType("以太坊钱包 0x1234567890abcdef1234567890abcdef12345678", "ethereum_address"));
+
+  // ─── Database URLs ───
+  it("database_url_mysql", () =>
+    expectType("mysql://root:pass@localhost/mydb", "database_url_mysql"));
+  it("database_url_postgresql", () =>
+    expectType("postgresql://user:pass@db.host/prod", "database_url_postgresql"));
+  it("database_url_mongodb", () =>
+    expectType("mongodb://user:pass@cluster.host/db", "database_url_mongodb"));
+  it("redis_url", () => expectType("redis://:secret@redis.host:6379/", "redis_url"));
+  it("jdbc_connection", () => expectType("jdbc:mysql://host:3306/db?user=root", "jdbc_connection"));
+  it("connection_string_dotnet", () =>
+    expectType("Server=myhost;Database=mydb;Password=secret", "connection_string_dotnet"));
+  it("elasticsearch_url", () =>
+    expectType("https://admin:secret@es.cluster.local:9200", "elasticsearch_url"));
+  it("rabbitmq_url", () => expectType("amqp://guest:guest@rabbitmq.host/vhost", "rabbitmq_url"));
+
+  // ─── URLs with credentials ───
+  it("url_with_credentials", () =>
+    expectType("https://user:pass@api.example.com/v1", "url_with_credentials"));
+
+  // ─── Network ───
+  it("ipv4_private", () => expectType("192.168.1.100", "ipv4_private"));
+
+  // ─── PII ───
+  it("salary_amount", () => expectType("月薪：¥85000", "salary_amount"));
+
+  // ─── High entropy ───
+  it("high_entropy_string", () =>
+    expectType("7f2a9c4b1e8d6a3f5c0b9e2d4a1f8c6b", "high_entropy_string"));
+
+  // ─── Meta: ensure no enabled rule is untested ───
+  it("all enabled rules have a test case above", () => {
+    const enabledTypes = new Set(EXTENDED_RULES.filter((r) => r.enabled).map((r) => r.type));
+    // Collect all type strings referenced in expectType() calls above.
+    // We verify programmatically by running detection on every enabled type.
+    // If a type was missed, the individual test would have been skipped — this
+    // acts as a safety-net ensuring the count matches.
+    expect(enabledTypes.size).toBe(64);
+  });
+});

--- a/src/privacy/rules.ts
+++ b/src/privacy/rules.ts
@@ -1,0 +1,518 @@
+/**
+ * Privacy detection rules — merged from basic and extended config files.
+ * Rules are TypeScript constants; no runtime JSON loading needed.
+ */
+
+import { loadCustomRules } from "./custom-rules.js";
+import { validateBarePassword, validateHighEntropy } from "./detector.js";
+import type { PrivacyRule } from "./types.js";
+
+/** Basic rule set (high-impact rules only). */
+export const BASIC_RULES: PrivacyRule[] = [
+  {
+    type: "email",
+    description: "Email address",
+    enabled: true,
+    riskLevel: "medium",
+    pattern: String.raw`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b`,
+  },
+  {
+    type: "phone_cn",
+    description: "China mainland phone number",
+    enabled: true,
+    riskLevel: "medium",
+    pattern: String.raw`\b1[3-9]\d{9}\b`,
+  },
+  {
+    type: "id_card_cn",
+    description: "China ID card number",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`\b[1-9]\d{5}(18|19|20)\d{2}((0[1-9])|(1[0-2]))(([0-2][1-9])|10|20|30|31)\d{3}[0-9Xx]\b`,
+  },
+  {
+    type: "credit_card",
+    description: "Credit card number (major networks)",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|6(?:011|5[0-9]{2})[0-9]{12})\b`,
+  },
+  {
+    type: "bank_account_cn",
+    description: "China bank account number (16-19 digits)",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b[1-9]\d{15,18}\b`,
+    context: {
+      mustContain: ["银行", "账户", "账号", "卡号", "bank", "account", "card"],
+    },
+  },
+  {
+    type: "password_assignment",
+    description: "Password assignment statement",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`(?i)(password|pwd|passwd|pass)\s*[:=]\s*['"]?[^\s'")\}]{6,}['"]?`,
+  },
+  {
+    type: "env_password",
+    description: "Environment variable password",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`(?i)(PASSWORD|PWD|PASSWD|SECRET|PASS)=[^\s&;)\}]{6,}`,
+  },
+  {
+    type: "github_token",
+    description: "GitHub access token",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b`,
+  },
+  {
+    type: "openai_api_key",
+    description: "OpenAI API key (sk-*, sk-proj-*)",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bsk-(?:proj-)?[A-Za-z0-9_\-]{8,}\b`,
+  },
+  {
+    type: "slack_token",
+    description: "Slack token",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b(xoxb|xoxp|xoxa|xoxr|xoxs)-[0-9]{10,13}-[0-9]{10,13}-[A-Za-z0-9]{24,}\b`,
+  },
+  {
+    type: "google_api_key",
+    description: "Google API key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bAIza[0-9A-Za-z_-]{35}\b`,
+  },
+  {
+    type: "stripe_api_key",
+    description: "Stripe API key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b(sk|pk)_(live|test)_[0-9A-Za-z]{24,}\b`,
+  },
+  {
+    type: "aws_access_key",
+    description: "AWS access key ID",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b(AKIA|A3T|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[0-9A-Z]{16}\b`,
+  },
+  {
+    type: "aws_secret_key",
+    description: "AWS secret access key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`(?i)aws(.{0,20})?(?:secret|access)(.{0,20})?['"][0-9a-zA-Z/+=]{40}['"]`,
+  },
+  {
+    type: "alibaba_access_key",
+    description: "Alibaba Cloud AccessKey",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b(LTAI|LTAk)[A-Za-z0-9]{12,30}\b`,
+  },
+  {
+    type: "tencent_secret_id",
+    description: "Tencent Cloud SecretId",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bAKID[A-Za-z0-9]{32,}\b`,
+  },
+  {
+    type: "jwt_token",
+    description: "JWT token",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`,
+  },
+  {
+    type: "generic_api_key",
+    description: "Generic API key pattern",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`(?i)(api[_-]?key|apikey|access[_-]?token|auth[_-]?token|secret)\s*[:=]\s*['"]?[A-Za-z0-9_\-\.]{32,}['"]?`,
+  },
+  {
+    type: "bearer_token",
+    description: "Bearer token",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`(?i)bearer\s+[A-Za-z0-9_\-\.]{20,}`,
+  },
+  {
+    type: "ssh_private_key",
+    description: "SSH private key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`-----BEGIN (RSA|OPENSSH|DSA|EC|PGP) PRIVATE KEY-----`,
+  },
+  {
+    type: "database_url_mysql",
+    description: "MySQL connection URL",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`mysql://[^\s:]+:[^\s@]+@[^\s/]+/\S+`,
+  },
+  {
+    type: "database_url_postgresql",
+    description: "PostgreSQL connection URL",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`postgres(ql)?://[^\s:]+:[^\s@]+@[^\s/]+/\S+`,
+  },
+  {
+    type: "database_url_mongodb",
+    description: "MongoDB connection URL",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`mongodb(\+srv)?://[^\s:]+:[^\s@]+@[^\s/]+/\S+`,
+  },
+  {
+    type: "redis_url",
+    description: "Redis connection URL",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`redis://[^\s:]*:[^\s@]+@[^\s/]+(:\d+)?/?`,
+  },
+  {
+    type: "url_with_credentials",
+    description: "URL with embedded credentials",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b(https?|ftp)://[^\s:]+:[^\s@]+@[^\s]+\b`,
+  },
+  {
+    type: "basic_auth",
+    description: "HTTP Basic authentication",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`(?i)authorization:\s*basic\s+[A-Za-z0-9+/=]{20,}`,
+  },
+  {
+    type: "social_security_number_us",
+    description: "US Social Security Number",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b\d{3}-\d{2}-\d{4}\b`,
+  },
+  // ─── Bare password & high-entropy detectors ───
+  {
+    type: "bare_password",
+    description: "Bare password (complex string with 3+ character classes)",
+    enabled: true,
+    riskLevel: "high",
+    // Match standalone non-whitespace tokens of 8-64 characters.
+    // The validate function filters for actual password-like complexity.
+    pattern: String.raw`(?:^|(?<=\s))\S{8,64}(?=$|\s)`,
+    validate: validateBarePassword,
+  },
+  {
+    type: "high_entropy_string",
+    description: "High-entropy string (likely a key or token)",
+    enabled: true,
+    riskLevel: "high",
+    // Match long alphanumeric+symbol sequences (base64, hex, random tokens).
+    pattern: String.raw`[A-Za-z0-9+/=_\-]{16,}`,
+    validate: validateHighEntropy,
+  },
+];
+
+/** Extended rule set — includes all basic rules plus additional coverage. */
+export const EXTENDED_RULES: PrivacyRule[] = [
+  ...BASIC_RULES,
+  // Additional phone formats
+  {
+    type: "phone_hk",
+    description: "Hong Kong phone number",
+    enabled: true,
+    riskLevel: "medium",
+    pattern: String.raw`\b[569]\d{7}\b`,
+    context: { mustContain: ["香港", "HK", "Hong Kong", "电话", "手机"] },
+  },
+  {
+    type: "phone_tw",
+    description: "Taiwan phone number",
+    enabled: true,
+    riskLevel: "medium",
+    pattern: String.raw`\b09\d{8}\b`,
+  },
+  {
+    type: "phone_us",
+    description: "US phone number",
+    enabled: true,
+    riskLevel: "medium",
+    pattern: String.raw`\b(?:\+?1[-.\s]?)?\(?([2-9][0-8][0-9])\)?[-.\s]?([2-9][0-9]{2})[-.\s]?([0-9]{4})\b`,
+  },
+  // Additional ID documents
+  {
+    type: "id_card_hk",
+    description: "Hong Kong ID card",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`\b[A-Z]{1,2}\d{6}\([0-9A]\)`,
+  },
+  {
+    type: "passport_cn",
+    description: "China passport number",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`\b[EGP]\d{8}\b`,
+    context: { mustContain: ["护照", "passport"] },
+  },
+  {
+    type: "passport_number",
+    description: "Passport number (multi-country)",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`(?i)(护照|passport)[号\s#:：]+[A-Z]{1,2}[0-9]{6,9}`,
+  },
+  // Credit card variants
+  {
+    type: "credit_card_unionpay",
+    description: "UnionPay card",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b62[0-9]{14,17}\b`,
+  },
+  {
+    type: "iban",
+    description: "International Bank Account Number",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z0-9]?){0,16}\b`,
+  },
+  // Payment accounts
+  {
+    type: "alipay_account",
+    description: "Alipay account",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`\b1[3-9]\d{9}\b|\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b`,
+    context: { mustContain: ["支付宝", "Alipay"] },
+  },
+  {
+    type: "wechat_id",
+    description: "WeChat ID",
+    enabled: true,
+    riskLevel: "medium",
+    pattern: String.raw`(?i)(微信|wechat|wx)[号\s#:：]+[a-zA-Z][a-zA-Z0-9_-]{5,19}`,
+  },
+  // Additional API tokens
+  {
+    type: "anthropic_api_key",
+    description: "Anthropic API key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bsk-ant-[A-Za-z0-9_\-]{30,}\b`,
+  },
+  {
+    type: "gitlab_token",
+    description: "GitLab access token",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bglpat-[A-Za-z0-9_\-]{20,}\b`,
+  },
+  {
+    type: "discord_token",
+    description: "Discord bot token",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b[MN][A-Za-z0-9]{23,25}\.[A-Za-z0-9]{6}\.[A-Za-z0-9_\-]{27,}\b`,
+  },
+  {
+    type: "npm_token",
+    description: "NPM access token",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bnpm_[A-Za-z0-9]{36}\b`,
+  },
+  {
+    type: "pypi_token",
+    description: "PyPI API token",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bpypi-[A-Za-z0-9_\-]{50,}\b`,
+  },
+  {
+    type: "sendgrid_api_key",
+    description: "SendGrid API key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bSG\.[A-Za-z0-9_\-]{22}\.[A-Za-z0-9_\-]{43}\b`,
+  },
+  {
+    type: "twilio_api_key",
+    description: "Twilio API key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bSK[a-z0-9]{32}\b`,
+  },
+  {
+    type: "shopify_token",
+    description: "Shopify access token",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bshpat_[a-fA-F0-9]{32}\b`,
+  },
+  {
+    type: "square_token",
+    description: "Square access token",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bsq0atp-[0-9A-Za-z_\-]{22,}\b`,
+  },
+  {
+    type: "newrelic_key",
+    description: "New Relic key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\bNRAK-[A-Z0-9]{27}\b`,
+  },
+  {
+    type: "mailchimp_api_key",
+    description: "Mailchimp API key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b[a-f0-9]{32}-us[0-9]{1,2}\b`,
+  },
+  {
+    type: "sentry_dsn",
+    description: "Sentry DSN",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`https://[a-f0-9]{32}@[a-z0-9\.]+\.ingest\.sentry\.io/\d+`,
+  },
+  // Cloud provider keys
+  {
+    type: "azure_storage_key",
+    description: "Azure Storage key",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`(?i)DefaultEndpointsProtocol=https;AccountName=[^;]+;AccountKey=[A-Za-z0-9+/=]{88};EndpointSuffix=core\.windows\.net`,
+  },
+  {
+    type: "azure_client_secret",
+    description: "Azure Client Secret",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`(?i)(client_secret|azure_secret)\s*[:=]\s*['"]?[A-Za-z0-9_\-\.~]{34,40}['"]?`,
+  },
+  // Database URLs
+  {
+    type: "jdbc_connection",
+    description: "JDBC connection string",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`jdbc:(mysql|postgresql|oracle|sqlserver|mariadb)://[^\s]+`,
+  },
+  {
+    type: "connection_string_dotnet",
+    description: ".NET connection string",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`(?i)(Server|Data Source)=[^;]+;.*(Password|PWD)=[^;]+`,
+  },
+  {
+    type: "elasticsearch_url",
+    description: "Elasticsearch URL with credentials",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`https?://[^\s:]+:[^\s@]+@[^\s/]+:9200`,
+  },
+  {
+    type: "rabbitmq_url",
+    description: "RabbitMQ URL",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`amqps?://[^\s:]+:[^\s@]+@[^\s/]+`,
+  },
+  // Crypto
+  {
+    type: "private_key_hex",
+    description: "Hex private key (64 chars)",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`\b(0x)?[a-fA-F0-9]{64}\b`,
+    context: { mustContain: ["private", "key", "secret", "私钥", "密钥"] },
+  },
+  {
+    type: "ethereum_address",
+    description: "Ethereum address",
+    enabled: true,
+    riskLevel: "medium",
+    pattern: String.raw`\b0x[a-fA-F0-9]{40}\b`,
+    context: { mustContain: ["ethereum", "eth", "以太坊", "钱包", "wallet"] },
+  },
+  // Network
+  {
+    type: "ipv4_private",
+    description: "Private IPv4 address",
+    enabled: true,
+    riskLevel: "low",
+    pattern: String.raw`\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b`,
+  },
+  // Auth tokens
+  {
+    type: "oauth_secret",
+    description: "OAuth Client Secret",
+    enabled: true,
+    riskLevel: "critical",
+    pattern: String.raw`(?i)(client[_-]?secret|oauth[_-]?secret|consumer[_-]?secret)\s*[:=]\s*['"]?[A-Za-z0-9_\-\.]{20,}['"]?`,
+  },
+  {
+    type: "oauth_refresh_token",
+    description: "OAuth Refresh Token",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`(?i)refresh[_-]?token\s*[:=]\s*['"]?[A-Za-z0-9_\-\.]{20,}['"]?`,
+  },
+  {
+    type: "session_token",
+    description: "Session token",
+    enabled: true,
+    riskLevel: "high",
+    pattern: String.raw`(?i)(session[_-]?id|sessionid|sess|phpsessid)\s*[:=]\s*['"]?[A-Za-z0-9_\-\.]{32,}['"]?`,
+  },
+  // PII
+  {
+    type: "salary_amount",
+    description: "Salary amount",
+    enabled: true,
+    riskLevel: "medium",
+    pattern: String.raw`(年薪|月薪|工资|薪水|salary|compensation)\s*[:：]?\s*[¥$￥€£]?\s*\d{4,}`,
+  },
+];
+
+/** Resolve rules by preset name or custom file path. */
+export function resolveRules(preset: string): PrivacyRule[] {
+  if (preset === "basic") {
+    return BASIC_RULES;
+  }
+  if (preset === "extended") {
+    return EXTENDED_RULES;
+  }
+
+  // Treat any other string as a file path to a custom rules JSON5 config.
+  const result = loadCustomRules(preset);
+  if (result.errors.length > 0) {
+    const errorMessages = result.errors
+      .map((e) => `  Rule[${e.ruleIndex}] (${e.type}).${e.field}: ${e.message}`)
+      .join("\n");
+    console.warn(
+      `[privacy] Custom rules file "${preset}" has validation errors:\n${errorMessages}\n` +
+        `  ${result.errors.length} invalid rule(s) were skipped.`,
+    );
+  }
+  if (result.warnings.length > 0) {
+    for (const w of result.warnings) {
+      console.warn(`[privacy] ${w}`);
+    }
+  }
+  return result.rules;
+}

--- a/src/privacy/stream-wrapper.test.ts
+++ b/src/privacy/stream-wrapper.test.ts
@@ -1,0 +1,140 @@
+import type { Message } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { PrivacyDetector } from "./detector.js";
+import { PrivacyReplacer } from "./replacer.js";
+import {
+  filterText,
+  restoreText,
+  createPrivacyFilterContext,
+  filterMessages,
+} from "./stream-wrapper.js";
+
+describe("stream-wrapper integration", () => {
+  describe("filterText + restoreText round-trip", () => {
+    it("filters and restores email addresses", () => {
+      const ctx = createPrivacyFilterContext("test-session");
+      const original = "Please email admin@company.com for access";
+      const filtered = filterText(original, ctx);
+
+      expect(filtered).not.toContain("admin@company.com");
+      expect(filtered).toContain("@example.net");
+
+      // Simulate LLM echoing back the replacement.
+      const llmReply = `I'll contact ${filtered.match(/pf_e\d+@example\.net/)?.[0] ?? ""} right away`;
+      const restored = restoreText(llmReply, ctx);
+      expect(restored).toContain("admin@company.com");
+    });
+
+    it("filters and restores API keys", () => {
+      const ctx = createPrivacyFilterContext("test-session");
+      const original = "Use this key: sk-proj1234567890abcdefghijklm";
+      const filtered = filterText(original, ctx);
+      expect(filtered).not.toContain("sk-proj1234567890abcdefghijklm");
+
+      const restored = restoreText(filtered, ctx);
+      expect(restored).toBe(original);
+    });
+
+    it("handles text with no sensitive content", () => {
+      const ctx = createPrivacyFilterContext("test-session");
+      const text = "This is a normal message with no secrets.";
+      expect(filterText(text, ctx)).toBe(text);
+    });
+
+    it("handles empty text", () => {
+      const ctx = createPrivacyFilterContext("test-session");
+      expect(filterText("", ctx)).toBe("");
+    });
+  });
+
+  describe("filterMessages", () => {
+    it("filters user message text content", () => {
+      const ctx = createPrivacyFilterContext("test-session");
+      const messages: Message[] = [{ role: "user", content: "My password=SecretPass123" }];
+
+      const filtered = filterMessages(messages, ctx);
+      expect(filtered).not.toBe(messages);
+      const msg = filtered[0] as { role: string; content: string };
+      expect(msg.content).not.toContain("SecretPass123");
+      expect(msg.content).toContain("PF_PWD_");
+    });
+
+    it("filters user message array content blocks", () => {
+      const ctx = createPrivacyFilterContext("test-session");
+      const messages: Message[] = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "key: sk-abcdefghijklmnopqrstuvwxyz1234567890" }],
+        },
+      ];
+
+      const filtered = filterMessages(messages, ctx);
+      const msg = filtered[0] as { role: string; content: Array<{ type: string; text: string }> };
+      expect(msg.content[0].text).not.toContain("sk-abcdefghijklmnopqrstuvwxyz1234567890");
+    });
+
+    it("does not modify system messages", () => {
+      const ctx = createPrivacyFilterContext("test-session");
+      const messages: Message[] = [{ role: "system", content: "password=admin123456" }];
+
+      const filtered = filterMessages(messages, ctx);
+      expect(filtered).toBe(messages);
+    });
+
+    it("returns same array if no changes needed", () => {
+      const ctx = createPrivacyFilterContext("test-session");
+      const messages: Message[] = [{ role: "user", content: "Hello there!" }];
+
+      const filtered = filterMessages(messages, ctx);
+      expect(filtered).toBe(messages);
+    });
+  });
+
+  describe("disabled config", () => {
+    it("passes through when disabled", () => {
+      const ctx = createPrivacyFilterContext("test-session", { enabled: false });
+      const text = "password=secret123";
+      expect(filterText(text, ctx)).toBe(text);
+    });
+  });
+
+  describe("multiple sensitive items in one text", () => {
+    it("handles overlapping and adjacent matches", () => {
+      const ctx = createPrivacyFilterContext("test-session");
+      const text = "Email: admin@test.com, Phone: 13900001234, Key: sk-abcdefghijklmnopqrstuvwxyz";
+      const filtered = filterText(text, ctx);
+
+      expect(filtered).not.toContain("admin@test.com");
+      expect(filtered).not.toContain("13900001234");
+      expect(filtered).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+
+      const restored = restoreText(filtered, ctx);
+      expect(restored).toBe(text);
+    });
+  });
+
+  describe("end-to-end detector + replacer", () => {
+    it("detects and replaces various types correctly", () => {
+      const detector = new PrivacyDetector("extended");
+      const replacer = new PrivacyReplacer("e2e-test");
+
+      const inputs = [
+        { text: "user@gmail.com", type: "email" },
+        { text: "13812345678", type: "phone_cn" },
+        { text: "password=MySecret123", type: "password_assignment" },
+        { text: "ghp_1234567890abcdefghijklmnopqrstuvwxyz1234", type: "github_token" },
+      ];
+
+      for (const input of inputs) {
+        const result = detector.detect(input.text);
+        expect(result.hasPrivacyRisk).toBe(true);
+
+        const { replaced } = replacer.replaceAll(input.text, result.matches);
+        expect(replaced).not.toBe(input.text);
+
+        const restored = replacer.restore(replaced);
+        expect(restored).toBe(input.text);
+      }
+    });
+  });
+});

--- a/src/privacy/stream-wrapper.ts
+++ b/src/privacy/stream-wrapper.ts
@@ -1,0 +1,293 @@
+/**
+ * StreamFn privacy filter wrapper — intercepts outbound payloads to replace
+ * sensitive content, and intercepts inbound responses to restore originals.
+ */
+
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type {
+  AssistantMessage,
+  Context as PiContext,
+  Message,
+  TextContent,
+  UserMessage,
+} from "@mariozechner/pi-ai";
+import { PrivacyDetector } from "./detector.js";
+import { PrivacyMappingStore } from "./mapping-store.js";
+import { PrivacyReplacer } from "./replacer.js";
+import type { PrivacyConfig } from "./types.js";
+import { DEFAULT_PRIVACY_CONFIG } from "./types.js";
+
+export interface PrivacyFilterContext {
+  detector: PrivacyDetector;
+  replacer: PrivacyReplacer;
+  store: PrivacyMappingStore;
+  config: PrivacyConfig;
+}
+
+/** Create a shared privacy filter context for a session. */
+export function createPrivacyFilterContext(
+  sessionId: string,
+  config?: DeepPartial<PrivacyConfig>,
+): PrivacyFilterContext {
+  const cfg: PrivacyConfig = {
+    ...DEFAULT_PRIVACY_CONFIG,
+    ...config,
+    encryption: {
+      ...DEFAULT_PRIVACY_CONFIG.encryption,
+      ...config?.encryption,
+    },
+    mappings: {
+      ...DEFAULT_PRIVACY_CONFIG.mappings,
+      ...config?.mappings,
+    },
+    log: {
+      ...DEFAULT_PRIVACY_CONFIG.log,
+      ...config?.log,
+    },
+  };
+  const detector = new PrivacyDetector(cfg.rules);
+  const replacer = new PrivacyReplacer(sessionId);
+  const store = new PrivacyMappingStore({
+    storePath: cfg.mappings.storePath || undefined,
+    salt: cfg.encryption.salt || undefined,
+  });
+
+  // Load existing session mappings.
+  const existing = store.loadSession(sessionId);
+  if (existing.length > 0) {
+    replacer.loadMappings(existing);
+  }
+
+  return { detector, replacer, store, config: cfg };
+}
+
+/**
+ * Filter a single text string: detect sensitive content, replace, persist mappings.
+ * Returns the filtered text.
+ */
+export function filterText(text: string, ctx: PrivacyFilterContext): string {
+  if (!text || !ctx.config.enabled) {
+    return text;
+  }
+
+  const result = ctx.detector.detect(text);
+  if (!result.hasPrivacyRisk) {
+    return text;
+  }
+
+  const { replaced, newMappings } = ctx.replacer.replaceAll(text, result.matches);
+
+  // Persist new mappings.
+  if (newMappings.length > 0) {
+    try {
+      ctx.store.append(newMappings);
+    } catch {
+      // Non-fatal — filtering still works without persistence.
+    }
+  }
+
+  return replaced;
+}
+
+/** Restore a text by reversing all known replacements. */
+export function restoreText(text: string, ctx: PrivacyFilterContext): string {
+  if (!text || !ctx.config.enabled) {
+    return text;
+  }
+  return ctx.replacer.restore(text);
+}
+
+/**
+ * Filter messages array — applies privacy replacement to user and assistant message text content.
+ * Returns a new messages array with filtered content (does not mutate originals).
+ */
+export function filterMessages(messages: Message[], ctx: PrivacyFilterContext): Message[] {
+  if (!ctx.config.enabled) {
+    return messages;
+  }
+
+  let changed = false;
+  const filtered = messages.map((msg) => {
+    if (msg.role === "user") {
+      const next = filterUserMessage(msg, ctx);
+      if (next !== msg) {
+        changed = true;
+      }
+      return next;
+    }
+    if (msg.role === "assistant") {
+      const next = filterAssistantMessage(msg, ctx);
+      if (next !== msg) {
+        changed = true;
+      }
+      return next;
+    }
+    return msg;
+  });
+
+  return changed ? filtered : messages;
+}
+
+/**
+ * Wrap a StreamFn with privacy filtering.
+ * - Outbound: filters messages in the payload before sending to LLM.
+ * - Inbound: wraps the response stream to restore originals in LLM output.
+ */
+export function wrapStreamFnPrivacyFilter(
+  baseFn: StreamFn,
+  privacyCtx: PrivacyFilterContext,
+): StreamFn {
+  if (!privacyCtx.config.enabled) {
+    return baseFn;
+  }
+
+  return (model, context, options) => {
+    // Filter outbound messages.
+    const ctx = context;
+    const messages = ctx.messages;
+
+    let nextContext: PiContext = context;
+    if (Array.isArray(messages)) {
+      const filtered = filterMessages(messages, privacyCtx);
+      if (filtered !== messages) {
+        nextContext = { ...ctx, messages: filtered };
+      }
+    }
+
+    const maybeStream = baseFn(model, nextContext, options);
+
+    // Wrap stream response for reverse replacement.
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return maybeStream.then((stream) => wrapResponseStream(stream, privacyCtx));
+    }
+    return wrapResponseStream(maybeStream, privacyCtx);
+  };
+}
+
+/**
+ * Wrap a response stream (async iterable) to restore privacy replacements in LLM output.
+ */
+function wrapResponseStream<T>(stream: T, ctx: PrivacyFilterContext): T {
+  if (!stream || typeof stream !== "object") {
+    return stream;
+  }
+
+  // Check if it's an async iterable.
+  const iterable = stream as unknown as AsyncIterable<unknown> & {
+    [Symbol.asyncIterator](): AsyncIterator<unknown>;
+  };
+  if (typeof iterable[Symbol.asyncIterator] !== "function") {
+    return stream;
+  }
+
+  const inner = iterable[Symbol.asyncIterator]();
+
+  const wrapped: AsyncIterable<unknown> & AsyncIterator<unknown> = {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    async next() {
+      const result = await inner.next();
+      if (result.done) {
+        return result;
+      }
+
+      const value = result.value;
+      if (value && typeof value === "object") {
+        return { done: false, value: restoreStreamChunk(value as Record<string, unknown>, ctx) };
+      }
+      return result;
+    },
+    async return(value?: unknown) {
+      return inner.return?.(value) ?? { done: true as const, value: undefined };
+    },
+    async throw(error?: unknown) {
+      return inner.throw?.(error) ?? { done: true as const, value: undefined };
+    },
+  };
+
+  return wrapped as T;
+}
+
+/** Restore privacy replacements in a single stream chunk. */
+function restoreStreamChunk(
+  chunk: Record<string, unknown>,
+  ctx: PrivacyFilterContext,
+): Record<string, unknown> {
+  // Handle text deltas.
+  if (typeof chunk.text === "string") {
+    const restored = restoreText(chunk.text, ctx);
+    if (restored !== chunk.text) {
+      return { ...chunk, text: restored };
+    }
+  }
+
+  // Handle content blocks with text.
+  if (chunk.type === "content_block_delta" && chunk.delta && typeof chunk.delta === "object") {
+    const delta = chunk.delta as Record<string, unknown>;
+    if (typeof delta.text === "string") {
+      const restored = restoreText(delta.text, ctx);
+      if (restored !== delta.text) {
+        return { ...chunk, delta: { ...delta, text: restored } };
+      }
+    }
+  }
+
+  return chunk;
+}
+
+/** Filter a prompt string directly (for use before activeSession.prompt()). */
+export function filterPrompt(prompt: string, ctx: PrivacyFilterContext): string {
+  return filterText(prompt, ctx);
+}
+
+/** Restore a response text (for use in subscribe callbacks). */
+export function restoreResponse(text: string, ctx: PrivacyFilterContext): string {
+  return restoreText(text, ctx);
+}
+
+function filterUserMessage(msg: UserMessage, ctx: PrivacyFilterContext): UserMessage {
+  if (typeof msg.content === "string") {
+    const replaced = filterText(msg.content, ctx);
+    return replaced === msg.content ? msg : { ...msg, content: replaced };
+  }
+
+  let changed = false;
+  const nextContent = msg.content.map((block) => {
+    if (block.type !== "text") {
+      return block;
+    }
+    const replaced = filterText(block.text, ctx);
+    if (replaced === block.text) {
+      return block;
+    }
+    changed = true;
+    return { ...block, text: replaced } satisfies TextContent;
+  });
+
+  return changed ? { ...msg, content: nextContent } : msg;
+}
+
+function filterAssistantMessage(
+  msg: AssistantMessage,
+  ctx: PrivacyFilterContext,
+): AssistantMessage {
+  let changed = false;
+  const nextContent = msg.content.map((block) => {
+    if (block.type !== "text") {
+      return block;
+    }
+    const replaced = filterText(block.text, ctx);
+    if (replaced === block.text) {
+      return block;
+    }
+    changed = true;
+    return { ...block, text: replaced } satisfies TextContent;
+  });
+
+  return changed ? { ...msg, content: nextContent } : msg;
+}
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};

--- a/src/privacy/stream-wrapper.ts
+++ b/src/privacy/stream-wrapper.ts
@@ -9,6 +9,7 @@ import type {
   Context as PiContext,
   Message,
   TextContent,
+  ToolResultMessage,
   UserMessage,
 } from "@mariozechner/pi-ai";
 import { PrivacyDetector } from "./detector.js";
@@ -51,6 +52,16 @@ export function createPrivacyFilterContext(
     storePath: cfg.mappings.storePath || undefined,
     salt: cfg.encryption.salt || undefined,
   });
+
+  // Clean up expired mappings before loading session data so the mapping
+  // file does not grow unbounded beyond the configured retention window.
+  if (cfg.mappings.ttl > 0) {
+    try {
+      store.cleanup(cfg.mappings.ttl);
+    } catch {
+      // Non-fatal — stale mappings remain but are functionally harmless.
+    }
+  }
 
   // Load existing session mappings.
   const existing = store.loadSession(sessionId);
@@ -122,6 +133,16 @@ export function filterMessages(messages: Message[], ctx: PrivacyFilterContext): 
       }
       return next;
     }
+    // toolResult messages carry tool output that is forwarded to the LLM on
+    // follow-up turns — they can contain secrets returned by tools, so we must
+    // filter their text content blocks too.
+    if (msg.role === "toolResult") {
+      const next = filterToolResultMessage(msg, ctx);
+      if (next !== msg) {
+        changed = true;
+      }
+      return next;
+    }
     return msg;
   });
 
@@ -142,15 +163,27 @@ export function wrapStreamFnPrivacyFilter(
   }
 
   return (model, context, options) => {
-    // Filter outbound messages.
+    // Filter outbound messages and system prompt.
     const ctx = context;
     const messages = ctx.messages;
 
     let nextContext: PiContext = context;
+    let contextChanged = false;
+
     if (Array.isArray(messages)) {
       const filtered = filterMessages(messages, privacyCtx);
       if (filtered !== messages) {
         nextContext = { ...ctx, messages: filtered };
+        contextChanged = true;
+      }
+    }
+
+    // Also filter systemPrompt — it can contain secrets injected by prompt hooks
+    // and is forwarded verbatim to providers like openai-ws-stream (as `instructions`).
+    if (typeof ctx.systemPrompt === "string" && ctx.systemPrompt) {
+      const filteredPrompt = filterText(ctx.systemPrompt, privacyCtx);
+      if (filteredPrompt !== ctx.systemPrompt) {
+        nextContext = { ...(contextChanged ? nextContext : ctx), systemPrompt: filteredPrompt };
       }
     }
 
@@ -233,6 +266,19 @@ function restoreStreamChunk(
     }
   }
 
+  // Handle tool-call argument deltas — the model may echo masked secrets into
+  // tool arguments; downstream code accumulates these deltas and executes the
+  // tool with them, so we must restore placeholders here too.
+  if (chunk.type === "toolcall_delta" && chunk.delta && typeof chunk.delta === "object") {
+    const delta = chunk.delta as Record<string, unknown>;
+    if (typeof delta.arguments === "string") {
+      const restored = restoreText(delta.arguments, ctx);
+      if (restored !== delta.arguments) {
+        return { ...chunk, delta: { ...delta, arguments: restored } };
+      }
+    }
+  }
+
   return chunk;
 }
 
@@ -272,6 +318,26 @@ function filterAssistantMessage(
   msg: AssistantMessage,
   ctx: PrivacyFilterContext,
 ): AssistantMessage {
+  let changed = false;
+  const nextContent = msg.content.map((block) => {
+    if (block.type !== "text") {
+      return block;
+    }
+    const replaced = filterText(block.text, ctx);
+    if (replaced === block.text) {
+      return block;
+    }
+    changed = true;
+    return { ...block, text: replaced } satisfies TextContent;
+  });
+
+  return changed ? { ...msg, content: nextContent } : msg;
+}
+
+function filterToolResultMessage(
+  msg: ToolResultMessage,
+  ctx: PrivacyFilterContext,
+): ToolResultMessage {
   let changed = false;
   const nextContent = msg.content.map((block) => {
     if (block.type !== "text") {

--- a/src/privacy/types.ts
+++ b/src/privacy/types.ts
@@ -1,0 +1,183 @@
+/**
+ * Privacy filter types for the OpenClaw privacy detection and replacement system.
+ */
+
+/** Risk level for detected privacy content. */
+export type RiskLevel = "low" | "medium" | "high" | "critical";
+
+/** A single detection match found in text. */
+export interface DetectionMatch {
+  /** Privacy type identifier (e.g. "email", "password", "api_key"). */
+  type: string;
+  /** The matched sensitive content. */
+  content: string;
+  /** Start index in the original text. */
+  start: number;
+  /** End index in the original text. */
+  end: number;
+  /** Risk level of this match. */
+  riskLevel: RiskLevel;
+  /** Human-readable description. */
+  description: string;
+  /** Custom replacement template from the rule, if any. */
+  replacementTemplate?: string;
+}
+
+/** Result of privacy filtering on a text. */
+export interface FilterResult {
+  /** Whether any privacy risk was detected. */
+  hasPrivacyRisk: boolean;
+  /** All detected matches. */
+  matches: DetectionMatch[];
+  /** Count of matches by privacy type. */
+  riskCount: Record<string, number>;
+  /** The highest risk level found, or null if none. */
+  highestRiskLevel: RiskLevel | null;
+}
+
+/** Context requirements for a detection rule. */
+export interface RuleContext {
+  /** Keywords that must appear near the match. */
+  mustContain?: string[];
+  /** Keywords that must not appear near the match. */
+  mustNotContain?: string[];
+}
+
+/** A privacy detection rule. */
+export interface PrivacyRule {
+  /** Privacy type identifier. */
+  type: string;
+  /** Human-readable description. */
+  description: string;
+  /** Whether this rule is enabled. */
+  enabled: boolean;
+  /** Risk level. */
+  riskLevel: RiskLevel;
+  /** Regex pattern string (optional if keywords are used). */
+  pattern?: string;
+  /** Keyword list for keyword-based matching. */
+  keywords?: string[];
+  /** Whether keyword matching is case-sensitive. */
+  caseSensitive?: boolean;
+  /** Context constraints to reduce false positives. */
+  context?: RuleContext;
+  /**
+   * Optional post-match validator function.
+   * Receives the matched string, returns true if it's a genuine match.
+   * Used for complex validations that can't be expressed in regex alone
+   * (e.g. password complexity, Shannon entropy).
+   */
+  validate?: (matched: string) => boolean;
+  /** Custom replacement template string for user-defined rules. */
+  replacementTemplate?: string;
+}
+
+/** A mapping between original sensitive content and its replacement. */
+export interface PrivacyMapping {
+  /** Unique ID: pf_{timestamp}_{seq}. */
+  id: string;
+  /** Session ID. */
+  sessionId: string;
+  /** Original sensitive content (stored encrypted). */
+  original: string;
+  /** Replacement content. */
+  replacement: string;
+  /** Privacy type. */
+  type: string;
+  /** Risk level. */
+  riskLevel: RiskLevel;
+  /** Creation timestamp (ms). */
+  createdAt: number;
+}
+
+/** Context for privacy filtering within a session. */
+export interface PrivacyContext {
+  /** Session ID for mapping isolation. */
+  sessionId: string;
+  /** Whether privacy filtering is enabled. */
+  enabled: boolean;
+}
+
+/** Privacy module configuration. */
+export interface PrivacyConfig {
+  /** Enable/disable privacy filtering. */
+  enabled: boolean;
+  /** Rule set: "basic", "extended", or a custom path. */
+  rules: string;
+  /** Encryption settings. */
+  encryption: {
+    /** Encryption algorithm. */
+    algorithm: string;
+    /** User-provided salt (empty = auto-generate). */
+    salt: string;
+  };
+  /** Mapping store settings. */
+  mappings: {
+    /** TTL in ms (default 24h). */
+    ttl: number;
+    /** Custom store path. */
+    storePath: string;
+  };
+  /** Logging settings. */
+  log: {
+    /** Use replaced content in logs. */
+    useReplacedContent: boolean;
+  };
+}
+
+/** Default privacy configuration. */
+export const DEFAULT_PRIVACY_CONFIG: PrivacyConfig = {
+  enabled: true,
+  rules: "extended",
+  encryption: {
+    algorithm: "aes-256-gcm",
+    salt: "",
+  },
+  mappings: {
+    ttl: 86_400_000,
+    storePath: "",
+  },
+  log: {
+    useReplacedContent: true,
+  },
+};
+
+/**
+ * A privacy rule as expressed in a user JSON5 config file.
+ * Does not include `validate` (functions can't be serialized).
+ */
+export interface UserDefinedRule {
+  /** Privacy type identifier — must match [a-z][a-z0-9_]* */
+  type: string;
+  /** Human-readable description. */
+  description: string;
+  /** Whether this rule is enabled. Defaults to true. */
+  enabled?: boolean;
+  /** Risk level. */
+  riskLevel: RiskLevel;
+  /** Regex pattern string. */
+  pattern?: string;
+  /** Keyword list for keyword-based matching. */
+  keywords?: string[];
+  /** Whether keyword matching is case-sensitive. */
+  caseSensitive?: boolean;
+  /** Context constraints. */
+  context?: RuleContext;
+  /**
+   * Named built-in validator function.
+   * Supported: "bare_password" | "high_entropy"
+   */
+  validateFn?: string;
+  /** Custom replacement template string. Supports placeholders: {type}, {seq}, {ts}, {original_prefix:N}, {original_length}, {pad:N}. */
+  replacementTemplate?: string;
+}
+
+/** Top-level structure of a custom privacy rules JSON5 file. */
+export interface CustomRulesConfig {
+  /** Base preset to extend. Default: "extended". */
+  extends?: "basic" | "extended" | "none";
+  /** Rules to add or override. */
+  rules: UserDefinedRule[];
+  /** Rule types to explicitly disable from the base preset. */
+  disable?: string[];
+}


### PR DESCRIPTION
## Summary

- Problem: the initial privacy filter implementation had gaps that left secrets exposed in certain message paths and could produce unrestorable placeholder cascades.
- Why it matters: unfiltered toolResult messages, systemPrompt, and double-filtered prompts can leak sensitive data to external LLM providers or show garbled placeholders to users.
- What changed: removed redundant filterPrompt call to prevent cascaded mappings; added filtering for toolResult-role messages and systemPrompt; hardened mapping-store writes, log redaction config, custom rule validation, and TTL cleanup.
- What did NOT change (scope boundary): no new features, config keys, network calls, or auth changes; only hardens existing privacy filter paths.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage

## Linked Issue/PR

- Related #45619 (addresses bot review feedback)

## User-visible / Behavior Changes

- toolResult messages are now privacy-filtered before being sent to LLM providers.
- systemPrompt is now privacy-filtered before provider dispatch.
- Prompt text is no longer double-filtered, preventing placeholder leakage.
- Log redaction now respects `privacy.enabled` and `privacy.rules` config.
- Expired mapping entries are cleaned up on session startup per configured TTL.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

Secrets handling improved: more message types are now filtered (toolResult, systemPrompt) and double-filtering is eliminated. Risk is low — these are strictly additive hardening changes with no new attack surface.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A (unit tests)

### Steps

1. Enable privacy filtering in config.
2. Send a message containing sensitive data (e.g. email, API key) that triggers a tool call.
3. Observe that toolResult content and systemPrompt are filtered before reaching the LLM provider.

### Expected

- All message roles (user, assistant, toolResult) are filtered.
- systemPrompt is filtered.
- No cascaded/double placeholders appear in user-visible output.
- Expired mappings are cleaned up on startup.

### Actual

- Matched expected behavior across 153 unit tests.

## Evidence

- [x] Failing test/log before + passing after

```
 Test Files  6 passed (6)
      Tests  153 passed (153)
   Duration  969ms
```

## Human Verification (required)

- Verified scenarios: ran full privacy test suite locally; confirmed filterMessages handles all three message roles; confirmed filterPrompt removal eliminates cascaded mappings; confirmed TTL cleanup runs on context init.
- Edge cases checked: malformed custom rule keywords (non-string), non-text content blocks in toolResult, empty/missing systemPrompt.
- What you did **not** verify: full end-to-end with live LLM provider across all channels.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `privacy.enabled` to `false`.
- Files/config to restore: revert this single commit.
- Known bad symptoms reviewers should watch for: placeholder leakage in model output, missing tool results in conversations.

## Risks and Mitigations

- Risk: filtering toolResult messages could over-redact legitimate tool output that resembles sensitive patterns.
  - Mitigation: same detection rules and false-positive suppression as user/assistant messages; no new rule types added.