### PR TITLE
fix(failover): classify api_error internal server errors as overloaded for proper cooldown

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -865,11 +865,18 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("key has been disabled")).toBe("auth_permanent");
     expect(classifyFailoverReason("account has been deactivated")).toBe("auth_permanent");
   });
-  it("classifies JSON api_error internal server failures as timeout", () => {
+  it("classifies api_error internal server failures as overloaded regardless of format", () => {
+    // JSON format (raw API response body)
     expect(
       classifyFailoverReason(
         '{"type":"error","error":{"type":"api_error","message":"Internal server error"}}',
       ),
-    ).toBe("timeout");
+    ).toBe("overloaded");
+    // SDK format (after describeUnknownError)
+    expect(classifyFailoverReason("LLM error api_error: Internal server error")).toBe("overloaded");
+  });
+  it("preserves timeout classification for raw HTTP 500 without api_error", () => {
+    // Raw HTTP format should still go through isTransientHttpError → "timeout"
+    expect(classifyFailoverReason("500 Internal Server Error")).toBe("timeout");
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -853,7 +853,7 @@ function isJsonApiInternalServerError(raw: string): boolean {
   const value = raw.toLowerCase();
   // Anthropic often wraps transient 500s in JSON payloads like:
   // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  return value.includes("api_error") && value.includes("internal server error");
 }
 
 export function parseImageDimensionError(raw: string): {
@@ -1007,7 +1007,7 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     return "timeout";
   }
   if (isJsonApiInternalServerError(raw)) {
-    return "timeout";
+    return "overloaded";
   }
   if (isCloudCodeAssistFormatError(raw)) {
     return "format";


### PR DESCRIPTION
## What
Widen `isJsonApiInternalServerError` to match the SDK error format and reclassify as `"overloaded"` instead of `"timeout"`.

## Why
Fixes #45494 — Cron agent jobs silently time out during sustained LLM API outages instead of fast-failing on definitive errors.

### Root Cause

When Anthropic returns HTTP 500, the Pi SDK surfaces it as `"api_error: Internal server error"` (plain text). `isJsonApiInternalServerError` only matched JSON format (`"\"type\":\"api_error\""`), so `classifyFailoverReason` returned `null` for the SDK format.

This null classification breaks cooldown: profiles keep rotating with full SDK retry cycles (~22s each), exhausting the entire cron timeout on a single fallback candidate. Cross-provider fallback never reached.

### Why `"overloaded"` not `"timeout"`

`resolveAuthProfileFailureReason("timeout")` returns `null` — timeouts explicitly skip cooldown to avoid poisoning fallback models. HTTP 500 is a server-side error; classifying as `"overloaded"` triggers proper cooldown via `resolveAuthProfileFailureReason("overloaded")`, so same-provider profiles are skipped and cross-provider fallback proceeds.

## How
Two changes in `errors.ts`:
1. `isJsonApiInternalServerError`: remove JSON quote requirement (`"\"type\":\"api_error\""` → `"api_error"`) so both JSON and SDK formats match
2. `classifyFailoverReason`: return `"overloaded"` instead of `"timeout"` when `isJsonApiInternalServerError` matches

The `"api_error"` token limits the match to Anthropic-style errors. Raw HTTP `"500 Internal Server Error"` (no `api_error`) still routes through `isTransientHttpError` → `"timeout"` (unchanged behavior).

## Testing
- [x] Updated test: JSON format → `"overloaded"` (was `"timeout"`)
- [x] Added test: SDK format `"LLM error api_error: Internal server error"` → `"overloaded"`
- [x] Added test: raw HTTP `"500 Internal Server Error"` → `"timeout"` (preserves existing behavior)
- [x] 72/72 tests pass
- [x] AI-assisted (Claude, fully tested)