### PR TITLE
fix(telegram): use message_id not callback.id as messageIdOverride

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1444,7 +1444,10 @@ export const registerTelegramHandlers = ({
       });
       await processMessage(buildSyntheticContext(ctx, syntheticMessage), [], storeAllowFrom, {
         forceWasMentioned: true,
-        messageIdOverride: callback.id,
+        // Use the originating message's ID, not the callback query UUID.
+        // callback.id is a short-lived opaque token for answerCallbackQuery only;
+        // messageIdOverride feeds MessageSid which must be a numeric Telegram message ID.
+        messageIdOverride: String(callbackMessage.message_id),
       });
     } catch (err) {
       runtime.error?.(danger(`callback handler failed: ${String(err)}`));


### PR DESCRIPTION
## Summary

- `callback.id` (Telegram's callback query UUID) was being passed as `messageIdOverride` instead of `callbackMessage.message_id` (the actual Telegram message ID).
- `messageIdOverride` feeds `MessageSid` in `bot-message-context.session.ts:206`, which is expected to be a numeric Telegram message ID.
- `callback.id` is an opaque token valid only for `answerCallbackQuery` — it is not numeric and not a message ID.

## Impact

1. **`shouldSkipMessageByAbortCutoff`** (`abort-cutoff.ts:86-88`) parses `MessageSid` via `/^\d+$/` for BigInt comparison. A callback UUID fails this regex and falls back to string comparison, breaking abort-cutoff ordering for messages triggered by inline buttons.

2. **Session continuity** — each button press generates a `MessageSid` unrelated to the originating message, preventing session linkage.

## Fix

```ts
// Before (wrong):
messageIdOverride: callback.id,

// After (correct):
messageIdOverride: String(callbackMessage.message_id),
```

This matches the pattern already used correctly at lines 267 and 434 in the same file.

## Verification

- `pnpm build` — clean (no new warnings)
- `pnpm check` — 0 errors, 0 warnings
- Pre-existing test suite failures in `bot.test.ts` (48) are unrelated to this change (confirmed identical failure count before and after)

Closes #45638
Related: #8373, #27309

## Test plan

- [ ] Press inline button in Telegram group — `MessageSid` should now be a numeric message ID matching the originating message
- [ ] `/stop` abort-cutoff after inline button press should correctly compare message IDs numerically