### PR TITLE
fix(macos): align minimum Node.js version with runtime guard (22.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Control UI: restore the operator-only device-auth bypass and classify browser connect failures so origin and device-identity problems no longer show up as auth errors in the Control UI and web chat. (#45512) thanks @sallyom.
 - macOS/voice wake: stop crashing wake-word command extraction when speech segment ranges come from a different transcript instance.
 - Discord/allowlists: honor raw `guild_id` when hydrated guild objects are missing so allowlisted channels and threads like `#maintainers` no longer get false-dropped before channel allowlist checks.
+- macOS/runtime locator: require Node >=22.16.0 during macOS runtime discovery so the app no longer accepts Node versions that the main runtime guard rejects later. Thanks @sumleo.
 
 ## 2026.3.12
 

--- a/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
+++ b/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
@@ -54,7 +54,7 @@ enum RuntimeResolutionError: Error {
 
 enum RuntimeLocator {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "runtime")
-    private static let minNode = RuntimeVersion(major: 22, minor: 12, patch: 0)
+    private static let minNode = RuntimeVersion(major: 22, minor: 16, patch: 0)
 
     static func resolve(
         searchPaths: [String] = CommandResolver.preferredPaths()) -> Result<RuntimeResolution, RuntimeResolutionError>
@@ -91,7 +91,7 @@ enum RuntimeLocator {
         switch error {
         case let .notFound(searchPaths):
             [
-                "openclaw needs Node >=22.12.0 but found no runtime.",
+                "openclaw needs Node >=22.16.0 but found no runtime.",
                 "PATH searched: \(searchPaths.joined(separator: ":"))",
                 "Install Node: https://nodejs.org/en/download",
             ].joined(separator: "\n")
@@ -105,7 +105,7 @@ enum RuntimeLocator {
             [
                 "Could not parse \(kind.rawValue) version output \"\(raw)\" from \(path).",
                 "PATH searched: \(searchPaths.joined(separator: ":"))",
-                "Try reinstalling or pinning a supported version (Node >=22.12.0).",
+                "Try reinstalling or pinning a supported version (Node >=22.16.0).",
             ].joined(separator: "\n")
         }
     }

--- a/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
+++ b/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
@@ -54,7 +54,7 @@ enum RuntimeResolutionError: Error {
 
 enum RuntimeLocator {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "runtime")
-    private static let minNode = RuntimeVersion(major: 22, minor: 0, patch: 0)
+    private static let minNode = RuntimeVersion(major: 22, minor: 12, patch: 0)
 
     static func resolve(
         searchPaths: [String] = CommandResolver.preferredPaths()) -> Result<RuntimeResolution, RuntimeResolutionError>
@@ -91,7 +91,7 @@ enum RuntimeLocator {
         switch error {
         case let .notFound(searchPaths):
             [
-                "openclaw needs Node >=22.0.0 but found no runtime.",
+                "openclaw needs Node >=22.12.0 but found no runtime.",
                 "PATH searched: \(searchPaths.joined(separator: ":"))",
                 "Install Node: https://nodejs.org/en/download",
             ].joined(separator: "\n")
@@ -105,7 +105,7 @@ enum RuntimeLocator {
             [
                 "Could not parse \(kind.rawValue) version output \"\(raw)\" from \(path).",
                 "PATH searched: \(searchPaths.joined(separator: ":"))",
-                "Try reinstalling or pinning a supported version (Node >=22.0.0).",
+                "Try reinstalling or pinning a supported version (Node >=22.12.0).",
             ].joined(separator: "\n")
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/RuntimeLocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RuntimeLocatorTests.swift
@@ -16,7 +16,7 @@ struct RuntimeLocatorTests {
     @Test func `resolve succeeds with valid node`() throws {
         let script = """
         #!/bin/sh
-        echo v22.5.0
+        echo v22.12.0
         """
         let node = try self.makeTempExecutable(contents: script)
         let result = RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
@@ -25,7 +25,23 @@ struct RuntimeLocatorTests {
             return
         }
         #expect(res.path == node.path)
-        #expect(res.version == RuntimeVersion(major: 22, minor: 5, patch: 0))
+        #expect(res.version == RuntimeVersion(major: 22, minor: 12, patch: 0))
+    }
+
+    @Test func `resolve fails on boundary below minimum`() throws {
+        let script = """
+        #!/bin/sh
+        echo v22.11.9
+        """
+        let node = try self.makeTempExecutable(contents: script)
+        let result = RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
+        guard case let .failure(.unsupported(_, found, required, path, _)) = result else {
+            Issue.record("Expected unsupported error, got \(result)")
+            return
+        }
+        #expect(found == RuntimeVersion(major: 22, minor: 11, patch: 9))
+        #expect(required == RuntimeVersion(major: 22, minor: 12, patch: 0))
+        #expect(path == node.path)
     }
 
     @Test func `resolve fails when too old`() throws {
@@ -60,6 +76,7 @@ struct RuntimeLocatorTests {
 
     @Test func `describe failure includes paths`() {
         let msg = RuntimeLocator.describeFailure(.notFound(searchPaths: ["/tmp/a", "/tmp/b"]))
+        #expect(msg.contains("Node >=22.12.0"))
         #expect(msg.contains("PATH searched: /tmp/a:/tmp/b"))
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/RuntimeLocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RuntimeLocatorTests.swift
@@ -16,7 +16,7 @@ struct RuntimeLocatorTests {
     @Test func `resolve succeeds with valid node`() throws {
         let script = """
         #!/bin/sh
-        echo v22.12.0
+        echo v22.16.0
         """
         let node = try self.makeTempExecutable(contents: script)
         let result = RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
@@ -25,13 +25,13 @@ struct RuntimeLocatorTests {
             return
         }
         #expect(res.path == node.path)
-        #expect(res.version == RuntimeVersion(major: 22, minor: 12, patch: 0))
+        #expect(res.version == RuntimeVersion(major: 22, minor: 16, patch: 0))
     }
 
     @Test func `resolve fails on boundary below minimum`() throws {
         let script = """
         #!/bin/sh
-        echo v22.11.9
+        echo v22.15.9
         """
         let node = try self.makeTempExecutable(contents: script)
         let result = RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
@@ -39,8 +39,8 @@ struct RuntimeLocatorTests {
             Issue.record("Expected unsupported error, got \(result)")
             return
         }
-        #expect(found == RuntimeVersion(major: 22, minor: 11, patch: 9))
-        #expect(required == RuntimeVersion(major: 22, minor: 12, patch: 0))
+        #expect(found == RuntimeVersion(major: 22, minor: 15, patch: 9))
+        #expect(required == RuntimeVersion(major: 22, minor: 16, patch: 0))
         #expect(path == node.path)
     }
 
@@ -76,8 +76,17 @@ struct RuntimeLocatorTests {
 
     @Test func `describe failure includes paths`() {
         let msg = RuntimeLocator.describeFailure(.notFound(searchPaths: ["/tmp/a", "/tmp/b"]))
-        #expect(msg.contains("Node >=22.12.0"))
+        #expect(msg.contains("Node >=22.16.0"))
         #expect(msg.contains("PATH searched: /tmp/a:/tmp/b"))
+
+        let parseMsg = RuntimeLocator.describeFailure(
+            .versionParse(
+                kind: .node,
+                raw: "garbage",
+                path: "/usr/local/bin/node",
+                searchPaths: ["/usr/local/bin"],
+            ))
+        #expect(parseMsg.contains("Node >=22.16.0"))
     }
 
     @Test func `runtime version parses with leading V and metadata`() {


### PR DESCRIPTION
## Summary

- Problem: the macOS runtime locator accepted Node 22.0.0+, while the runtime guard and engines policy require 22.16.0+.
- Why it matters: users could be told their Node runtime was acceptable by the macOS app, then fail later in the actual runtime guard.
- What changed: updated the macOS runtime minimum and user-facing messages to 22.16.0, and updated macOS tests to cover the new accept/reject boundary plus the `versionParse` message path.
- What did NOT change (scope boundary): this replacement PR intentionally excludes the broad SwiftFormat churn from #14666.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #14666
- Related #14666

## User-visible / Behavior Changes

- The macOS app now requires Node.js >=22.16.0 during runtime discovery, matching the runtime guard.
- The macOS error strings now point users to the correct minimum version.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Swift Package Manager + Node 25 host for repo tooling
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build a temp `node` executable returning `v22.15.9` or `v22.16.0`.
2. Run `RuntimeLocator.resolve(searchPaths:)` through the macOS tests.
3. Confirm 22.15.9 rejects and 22.16.0 accepts.

### Expected

- Node <22.16.0 is rejected.
- Node >=22.16.0 is accepted.
- Failure copy references 22.16.0.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `cd apps/macos && swift test --filter RuntimeLocatorTests`; `pnpm protocol:check`
- Edge cases checked: 22.15.9 reject boundary; 22.16.0 accept boundary; failure text includes 22.16.0 in both `notFound` and `versionParse` paths
- What you did **not** verify: full repo test suite; macOS app manual UI flow

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`No`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or restore the old runtime minimum in `apps/macos/Sources/OpenClaw/RuntimeLocator.swift`
- Files/config to restore: `apps/macos/Sources/OpenClaw/RuntimeLocator.swift`, `apps/macos/Tests/OpenClawIPCTests/RuntimeLocatorTests.swift`
- Known bad symptoms reviewers should watch for: macOS accepting unsupported Node versions again, or incorrectly rejecting 22.16.0+

## Risks and Mitigations

- Risk: boundary expectation differs from other runtime checks in the future.
  - Mitigation: tests now explicitly pin the 22.16.0 boundary and cover both user-facing failure strings.

Credit to @sumleo for the original report and patch direction in #14666. This PR supersedes #14666 with the same functional fix on a clean branch.
