### PR TITLE
fix(telegram): use callback message_id as callback message override

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1444,7 +1444,9 @@ export const registerTelegramHandlers = ({
       });
       await processMessage(buildSyntheticContext(ctx, syntheticMessage), [], storeAllowFrom, {
         forceWasMentioned: true,
-        messageIdOverride: callback.id,
+        messageIdOverride: callbackMessage.message_id
+          ? String(callbackMessage.message_id)
+          : undefined,
       });
     } catch (err) {
       runtime.error?.(danger(`callback handler failed: ${String(err)}`));

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -141,6 +141,7 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = replySpy.mock.calls[0][0];
     expect(payload.Body).toContain("cmd:option_a");
+    expect(payload.MessageSid).toBe("10");
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-1");
   });
   it("wraps inbound message with Telegram envelope", async () => {


### PR DESCRIPTION
## Problem

Telegram callback query handling passed `callback.id` as `messageIdOverride`.

But `callback.id` is only the callback-query token used for `answerCallbackQuery`; it is not the originating Telegram message id. That breaks MessageSid continuity and downstream logic that expects a numeric Telegram message id.

## Fix

Use `callback.message.message_id` as the callback message override.

## Tests

Updated callback-query routing coverage to assert the synthetic inbound payload keeps the original Telegram `message_id` as `MessageSid`.

Closes #45638
