### PR TITLE
Fix IRC proactive sends: use monitor's persistent client

### DIFF
--- a/extensions/irc/src/active-clients.ts
+++ b/extensions/irc/src/active-clients.ts
@@ -22,3 +22,14 @@ export function getActiveClient(accountId: string): IrcClient | undefined {
 export function removeActiveClient(accountId: string): void {
   activeClients.delete(accountId);
 }
+
+/**
+ * Only remove the active client if it matches the expected instance.
+ * Prevents a stopping monitor from deregistering a newer monitor's
+ * healthy client during reconnect races.
+ */
+export function removeActiveClientIfMatch(accountId: string, expected: IrcClient): void {
+  if (activeClients.get(accountId) === expected) {
+    activeClients.delete(accountId);
+  }
+}

--- a/extensions/irc/src/active-clients.ts
+++ b/extensions/irc/src/active-clients.ts
@@ -1,0 +1,24 @@
+import type { IrcClient } from "./client.js";
+
+/**
+ * Registry of active IRC clients from the monitor.
+ * Keyed by accountId. Allows sendMessageIrc to use the persistent
+ * monitor client instead of creating a transient connection.
+ */
+const activeClients = new Map<string, IrcClient>();
+
+export function setActiveClient(accountId: string, client: IrcClient): void {
+  activeClients.set(accountId, client);
+}
+
+export function getActiveClient(accountId: string): IrcClient | undefined {
+  const client = activeClients.get(accountId);
+  if (client && client.isReady()) {
+    return client;
+  }
+  return undefined;
+}
+
+export function removeActiveClient(accountId: string): void {
+  activeClients.delete(accountId);
+}

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -1,6 +1,6 @@
 import { resolveLoggerBackedRuntime } from "openclaw/plugin-sdk/extension-shared";
 import { resolveIrcAccount } from "./accounts.js";
-import { setActiveClient, removeActiveClient } from "./active-clients.js";
+import { setActiveClient, removeActiveClientIfMatch } from "./active-clients.js";
 import { connectIrcClient, type IrcClient } from "./client.js";
 import { buildIrcConnectOptions } from "./connect-options.js";
 import { handleIrcInbound } from "./inbound.js";
@@ -141,7 +141,9 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
 
   return {
     stop: () => {
-      removeActiveClient(account.accountId);
+      if (client) {
+        removeActiveClientIfMatch(account.accountId, client);
+      }
       client?.quit("shutdown");
       client = null;
     },

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -1,5 +1,6 @@
 import { resolveLoggerBackedRuntime } from "openclaw/plugin-sdk/extension-shared";
 import { resolveIrcAccount } from "./accounts.js";
+import { setActiveClient, removeActiveClient } from "./active-clients.js";
 import { connectIrcClient, type IrcClient } from "./client.js";
 import { buildIrcConnectOptions } from "./connect-options.js";
 import { handleIrcInbound } from "./inbound.js";
@@ -136,8 +137,11 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
     `[${account.accountId}] connected to ${account.host}:${account.port}${account.tls ? " (tls)" : ""} as ${client.nick}`,
   );
 
+  setActiveClient(account.accountId, client);
+
   return {
     stop: () => {
+      removeActiveClient(account.accountId);
       client?.quit("shutdown");
       client = null;
     },

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -1,4 +1,5 @@
 import { resolveIrcAccount } from "./accounts.js";
+import { getActiveClient } from "./active-clients.js";
 import type { IrcClient } from "./client.js";
 import { connectIrcClient } from "./client.js";
 import { buildIrcConnectOptions } from "./connect-options.js";
@@ -67,13 +68,19 @@ export async function sendMessageIrc(
   if (client?.isReady()) {
     client.sendPrivmsg(target, payload);
   } else {
-    const transient = await connectIrcClient(
-      buildIrcConnectOptions(account, {
-        connectTimeoutMs: 12000,
-      }),
-    );
-    transient.sendPrivmsg(target, payload);
-    transient.quit("sent");
+    // Try the monitor's persistent client first (already connected and joined to channels)
+    const active = getActiveClient(account.accountId);
+    if (active) {
+      active.sendPrivmsg(target, payload);
+    } else {
+      const transient = await connectIrcClient(
+        buildIrcConnectOptions(account, {
+          connectTimeoutMs: 12000,
+        }),
+      );
+      transient.sendPrivmsg(target, payload);
+      transient.quit("sent");
+    }
   }
 
   runtime.channel.activity.record({


### PR DESCRIPTION
## Summary

- `sendMessageIrc` creates transient IRC connections for proactive sends (not replies). These transient clients don't join channels before sending PRIVMSG, so messages to channels silently fail — the function returns success but the message never arrives.
- This adds a lightweight active client registry that the monitor populates when it connects. `sendMessageIrc` checks for an active persistent client first, falling back to transient connections only when no monitor client is available.
- Three files changed in `extensions/irc/src/`: new `active-clients.ts` (Map-based registry), 2 lines added to `monitor.ts` (register/deregister), 5 lines added to `send.ts` (check registry before transient fallback).

## Motivation

When an agent proactively sends a message to an IRC channel (not as a reply to an inbound message), the current code creates a transient connection that connects, sends PRIVMSG, and immediately quits. The IRC server may drop the PRIVMSG because the transient client hasn't joined the target channel. The monitor's persistent client is already connected and joined — this fix lets the send function reuse it.

## Testing

- [x] AI-assisted (Claude Opus 4.6)
- [x] Tested locally with OpenClaw v2026.3.13 + ergo IRC server
- [x] Confirmed proactive sends to IRC channels work after the fix
- [x] Confirmed replies (which use the monitor client via closure) still work
- [x] `pnpm build` passes
- [x] `pnpm test` passes (919/919, 1 pre-existing failure in `plugins/install.test.ts` unrelated)
- [x] No new type errors in `pnpm check`

## Test plan

- [ ] Verify proactive `sendMessageIrc` to a channel delivers the message
- [ ] Verify replies to inbound IRC messages still work
- [ ] Verify behavior when no monitor is running (should fall back to transient client)
- [ ] Verify `stop()` on the monitor removes the active client

🤖 Generated with [Claude Code](https://claude.com/claude-code)