### PR TITLE
fix(ci): restore latest check coverage

### DIFF
--- a/src/cli/daemon-cli/status.test.ts
+++ b/src/cli/daemon-cli/status.test.ts
@@ -1,19 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
+import type { DaemonStatus } from "./status.gather.js";
 
-const gatherDaemonStatus = vi.fn(async (_opts?: unknown) => ({
-  service: {
-    label: "LaunchAgent",
-    loaded: true,
-    loadedText: "loaded",
-    notLoadedText: "not loaded",
-  },
-  rpc: {
-    ok: true,
-    url: "ws://127.0.0.1:18789",
-  },
-  extraServices: [],
-}));
+const gatherDaemonStatus = vi.fn(
+  async (_opts?: unknown): Promise<DaemonStatus> => ({
+    service: {
+      label: "LaunchAgent",
+      loaded: true,
+      loadedText: "loaded",
+      notLoadedText: "not loaded",
+    },
+    rpc: {
+      ok: true,
+      url: "ws://127.0.0.1:18789",
+    },
+    extraServices: [],
+  }),
+);
 const printDaemonStatus = vi.fn();
 
 const { runtimeErrors, defaultRuntime, resetRuntimeCapture } = createCliRuntimeCapture();

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -15,7 +15,12 @@ const gatewayClientCalls: Array<{
 }> = [];
 const ensureWorkspaceAndSessionsMock = vi.fn(async (..._args: unknown[]) => {});
 const installGatewayDaemonNonInteractiveMock = vi.hoisted(() =>
-  vi.fn(async () => ({ installed: true as const })),
+  vi.fn(
+    async (): Promise<{
+      installed: boolean;
+      skippedReason?: "systemd-user-unavailable";
+    }> => ({ installed: true }),
+  ),
 );
 const gatewayServiceMock = vi.hoisted(() => ({
   label: "LaunchAgent",

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -149,11 +149,16 @@ export async function runNonInteractiveOnboardingLocal(params: {
       runtime,
       port: gatewayResult.port,
     });
-    daemonInstallStatus = {
-      requested: true,
-      installed: daemonInstall.installed,
-      skippedReason: daemonInstall.skippedReason,
-    };
+    daemonInstallStatus = daemonInstall.installed
+      ? {
+          requested: true,
+          installed: true,
+        }
+      : {
+          requested: true,
+          installed: false,
+          skippedReason: daemonInstall.skippedReason,
+        };
     if (!daemonInstall.installed && !opts.skipHealth) {
       logNonInteractiveOnboardingFailure({
         opts,

--- a/src/infra/outbound/deliver.test-helpers.ts
+++ b/src/infra/outbound/deliver.test-helpers.ts
@@ -8,7 +8,39 @@ import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/c
 import { createIMessageTestPlugin } from "../../test-utils/imessage-test-plugin.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
 
-export const deliverMocks = {
+type AsyncUnknownFn<TReturn> = (...args: unknown[]) => Promise<TReturn>;
+type SyncUnknownFn<TReturn> = (...args: unknown[]) => TReturn;
+type DeliverOutboundPayloads = typeof import("./deliver.js").deliverOutboundPayloads;
+type DeliverOutboundResults = Awaited<ReturnType<DeliverOutboundPayloads>>;
+
+export const deliverMocks: {
+  sessions: {
+    appendAssistantMessageToSessionTranscript: AsyncUnknownFn<{
+      ok: true;
+      sessionFile: string;
+    }>;
+  };
+  hooks: {
+    runner: {
+      hasHooks: SyncUnknownFn<boolean>;
+      runMessageSent: AsyncUnknownFn<void>;
+    };
+  };
+  internalHooks: {
+    createInternalHookEvent: (
+      ...args: Parameters<typeof createInternalHookEventPayload>
+    ) => ReturnType<typeof createInternalHookEventPayload>;
+    triggerInternalHook: AsyncUnknownFn<void>;
+  };
+  queue: {
+    enqueueDelivery: AsyncUnknownFn<string>;
+    ackDelivery: AsyncUnknownFn<void>;
+    failDelivery: AsyncUnknownFn<void>;
+  };
+  log: {
+    warn: SyncUnknownFn<void>;
+  };
+} = {
   sessions: {
     appendAssistantMessageToSessionTranscript: async () => ({ ok: true, sessionFile: "x" }),
   },
@@ -33,35 +65,51 @@ export const deliverMocks = {
 };
 
 const _mocks = vi.hoisted(() => ({
-  appendAssistantMessageToSessionTranscript: vi.fn(async () =>
-    deliverMocks.sessions.appendAssistantMessageToSessionTranscript(),
+  appendAssistantMessageToSessionTranscript: vi.fn(
+    async (
+      ...args: Parameters<typeof deliverMocks.sessions.appendAssistantMessageToSessionTranscript>
+    ) => await deliverMocks.sessions.appendAssistantMessageToSessionTranscript(...args),
   ),
 }));
 const _hookMocks = vi.hoisted(() => ({
   runner: {
-    hasHooks: vi.fn(() => deliverMocks.hooks.runner.hasHooks()),
+    hasHooks: vi.fn((...args: Parameters<typeof deliverMocks.hooks.runner.hasHooks>) =>
+      deliverMocks.hooks.runner.hasHooks(...args),
+    ),
     runMessageSent: vi.fn(
-      async (...args: unknown[]) => await deliverMocks.hooks.runner.runMessageSent(...args),
+      async (...args: Parameters<typeof deliverMocks.hooks.runner.runMessageSent>) =>
+        await deliverMocks.hooks.runner.runMessageSent(...args),
     ),
   },
 }));
 const _internalHookMocks = vi.hoisted(() => ({
-  createInternalHookEvent: vi.fn((...args: unknown[]) =>
-    deliverMocks.internalHooks.createInternalHookEvent(...args),
+  createInternalHookEvent: vi.fn(
+    (...args: Parameters<typeof deliverMocks.internalHooks.createInternalHookEvent>) =>
+      deliverMocks.internalHooks.createInternalHookEvent(...args),
   ),
   triggerInternalHook: vi.fn(
-    async (...args: unknown[]) => await deliverMocks.internalHooks.triggerInternalHook(...args),
+    async (...args: Parameters<typeof deliverMocks.internalHooks.triggerInternalHook>) =>
+      await deliverMocks.internalHooks.triggerInternalHook(...args),
   ),
 }));
 const _queueMocks = vi.hoisted(() => ({
   enqueueDelivery: vi.fn(
-    async (...args: unknown[]) => await deliverMocks.queue.enqueueDelivery(...args),
+    async (...args: Parameters<typeof deliverMocks.queue.enqueueDelivery>) =>
+      await deliverMocks.queue.enqueueDelivery(...args),
   ),
-  ackDelivery: vi.fn(async (...args: unknown[]) => await deliverMocks.queue.ackDelivery(...args)),
-  failDelivery: vi.fn(async (...args: unknown[]) => await deliverMocks.queue.failDelivery(...args)),
+  ackDelivery: vi.fn(
+    async (...args: Parameters<typeof deliverMocks.queue.ackDelivery>) =>
+      await deliverMocks.queue.ackDelivery(...args),
+  ),
+  failDelivery: vi.fn(
+    async (...args: Parameters<typeof deliverMocks.queue.failDelivery>) =>
+      await deliverMocks.queue.failDelivery(...args),
+  ),
 }));
 const _logMocks = vi.hoisted(() => ({
-  warn: vi.fn((...args: unknown[]) => deliverMocks.log.warn(...args)),
+  warn: vi.fn((...args: Parameters<typeof deliverMocks.log.warn>) =>
+    deliverMocks.log.warn(...args),
+  ),
 }));
 
 export const mocks = _mocks;
@@ -177,16 +225,12 @@ export function resetDeliverTestMocks(params?: { includeSessionMocks?: boolean }
 }
 
 export async function runChunkedWhatsAppDelivery(params: {
-  deliverOutboundPayloads: (params: {
-    cfg: OpenClawConfig;
-    channel: string;
-    to: string;
-    payloads: Array<{ text: string }>;
-    deps: { sendWhatsApp: ReturnType<typeof vi.fn> };
-    mirror?: unknown;
-  }) => Promise<Array<{ messageId?: string; toJid?: string }>>;
-  mirror?: unknown;
-}) {
+  deliverOutboundPayloads: DeliverOutboundPayloads;
+  mirror?: Parameters<DeliverOutboundPayloads>[0]["mirror"];
+}): Promise<{
+  sendWhatsApp: unknown;
+  results: DeliverOutboundResults;
+}> {
   const sendWhatsApp = vi
     .fn()
     .mockResolvedValueOnce({ messageId: "w1", toJid: "jid" })


### PR DESCRIPTION
## Summary
- restore the daemon status `--require-rpc` path and its CLI tests
- carry the non-interactive daemon install status through onboarding JSON and diagnostics
- extract deliver lifecycle test helpers and tighten their types so `check` can typecheck the updated tests again

## Testing
- `node node_modules/vitest/vitest.mjs run src/infra/outbound/deliver.lifecycle.test.ts src/commands/onboard-non-interactive.gateway.test.ts src/cli/daemon-cli/status.test.ts src/cli/daemon-cli/register-service-commands.test.ts`
- `npm exec --yes pnpm@10.23.0 format`
- `./node_modules/.bin/oxlint src/commands/onboard-non-interactive/local.ts src/commands/onboard-non-interactive/local/output.ts src/commands/onboard-non-interactive/local/daemon-install.ts src/commands/onboard-non-interactive.gateway.test.ts src/cli/daemon-cli/types.ts src/cli/daemon-cli/status.ts src/cli/daemon-cli/status.test.ts src/cli/daemon-cli/register-service-commands.ts src/cli/daemon-cli/register-service-commands.test.ts src/infra/outbound/deliver.test-helpers.ts src/infra/outbound/deliver.lifecycle.test.ts`
- `npm exec --yes pnpm@10.23.0 tsgo` still fails on pre-existing unrelated `TS2883` errors outside this patch; no remaining matches in the touched files
