### PR TITLE
fix(ui): improve light sidebar contrast

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -332,6 +332,8 @@
 }
 
 :root[data-theme-mode="light"] .sidebar {
+  /* Raise muted contrast within the sidebar without changing global light theme tokens. */
+  --muted: var(--muted-strong);
   background: color-mix(in srgb, var(--panel) 98%, white 2%);
 }
 


### PR DESCRIPTION
## Summary
- raise the light-mode sidebar's local `--muted` token to `--muted-strong` so nav labels and other sidebar text stop rendering as low-contrast grey-on-grey
- keep the fix scoped to `.sidebar` so other light-mode surfaces do not change
- fixes #45654

## Test plan
- [x] `pnpm --dir ui build`
- [x] `pnpm --dir ui test`
- [x] verified the updated light-mode sidebar locally in the control UI against a live gateway session
- [ ] `pnpm check` currently fails on unrelated pre-existing TypeScript errors outside this change

## Notes
- AI-assisted: yes
- Before screenshot: see #45654
- After screenshot: verified locally in Cursor during this change
- Local `codex review --base origin/main` could not be run because the `codex` CLI is not installed in this environment

Made with [Cursor](https://cursor.com)