### PR TITLE
feat: add BoxLite as alternative sandbox provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -422,10 +422,14 @@
     "vitest": "^4.1.0"
   },
   "peerDependencies": {
+    "@boxlite-ai/boxlite": "^0.4.2",
     "@napi-rs/canvas": "^0.1.89",
     "node-llama-cpp": "3.16.2"
   },
   "peerDependenciesMeta": {
+    "@boxlite-ai/boxlite": {
+      "optional": true
+    },
     "node-llama-cpp": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@aws-sdk/client-bedrock':
         specifier: ^3.1009.0
         version: 3.1009.0
+      '@boxlite-ai/boxlite':
+        specifier: ^0.4.2
+        version: 0.4.2(playwright-core@1.58.2)
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
         version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.7)(opusscript@0.1.1)
@@ -994,6 +997,27 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@boxlite-ai/boxlite-darwin-arm64@0.4.2':
+    resolution: {integrity: sha512-FwTfA8AyDXwoDb7nE7vGo04uBt2VDAiEl5leNNzroGSUKoTuCxNy8JfEbwwHb54UrIp/q7GNq7hG0JtmyxuubQ==}
+    engines: {node: '>=18.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@boxlite-ai/boxlite-linux-x64-gnu@0.4.2':
+    resolution: {integrity: sha512-UIRiTKl1L0cx2igDiikEiBfpNbTZ0W3lft5ow7I2mkDnjtBVIQYSm+PmVXBupTYivAuPh38g9WhqJH44C1RJdQ==}
+    engines: {node: '>=18.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@boxlite-ai/boxlite@0.4.2':
+    resolution: {integrity: sha512-LVxG0feP1sBGbYz/VOm11VsU8PyUv7rvXOQJqKrfBgI9oRVyqycpY39PCJ1oC+FFho7w7d61q8VCVDlDdj8i6Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      playwright-core: '>=1.58.0'
+    peerDependenciesMeta:
+      playwright-core:
+        optional: true
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -7796,6 +7820,18 @@ snapshots:
   '@blazediff/core@1.9.1': {}
 
   '@borewit/text-codec@0.2.2': {}
+
+  '@boxlite-ai/boxlite-darwin-arm64@0.4.2':
+    optional: true
+
+  '@boxlite-ai/boxlite-linux-x64-gnu@0.4.2':
+    optional: true
+
+  '@boxlite-ai/boxlite@0.4.2(playwright-core@1.58.2)':
+    optionalDependencies:
+      '@boxlite-ai/boxlite-darwin-arm64': 0.4.2
+      '@boxlite-ai/boxlite-linux-x64-gnu': 0.4.2
+      playwright-core: 1.58.2
 
   '@bramus/specificity@2.4.2':
     dependencies:

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -388,10 +388,26 @@ export async function runExecProcess(opts: {
   // BoxLite provider: run command via BoxLite micro-VM instead of process supervisor.
   if (opts.sandbox?.provider === "boxlite") {
     const boxliteScopeKey = opts.sandbox.containerName;
+    let boxliteAborted = false;
     const boxlitePromise = (async (): Promise<ExecProcessOutcome> => {
       try {
         const { runBoxLiteCommand } = await import("./boxlite/runtime.js");
-        const result = await runBoxLiteCommand(boxliteScopeKey, "sh", ["-c", execCommand]);
+
+        // Wrap with timeout if configured.
+        let resultPromise: Promise<import("./boxlite/runtime.js").BoxLiteExecResult> =
+          runBoxLiteCommand(boxliteScopeKey, "sh", ["-c", execCommand]);
+        if (timeoutMs) {
+          resultPromise = Promise.race([
+            resultPromise,
+            new Promise<never>((_, reject) => {
+              setTimeout(() => {
+                reject(new Error(`BoxLite command timed out after ${timeoutMs}ms`));
+              }, timeoutMs);
+            }),
+          ]);
+        }
+
+        const result = await resultPromise;
         if (result.stdout) {
           handleStdout(result.stdout);
         }
@@ -416,6 +432,22 @@ export async function runExecProcess(opts: {
           timedOut: false,
         };
       } catch (err) {
+        const durationMs = Date.now() - startedAt;
+        const wasTimedOut = err instanceof Error && err.message.includes("timed out");
+        if (wasTimedOut || boxliteAborted) {
+          markExited(session, null, null, "failed");
+          maybeNotifyOnExit(session, "failed");
+          const aggregated = session.aggregated.trim();
+          const suffix = wasTimedOut ? "\n\n(Command timed out)" : "\n\n(Command aborted)";
+          return {
+            status: "failed",
+            exitCode: null,
+            exitSignal: null,
+            durationMs,
+            aggregated: aggregated + suffix,
+            timedOut: wasTimedOut,
+          };
+        }
         markExited(session, null, null, "failed");
         maybeNotifyOnExit(session, "failed");
         throw err;
@@ -428,7 +460,7 @@ export async function runExecProcess(opts: {
       pid: undefined,
       promise: boxlitePromise,
       kill: () => {
-        // BoxLite commands are async calls, not child processes; no kill needed.
+        boxliteAborted = true;
       },
     };
   }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -385,6 +385,54 @@ export async function runExecProcess(opts: {
       ? Math.floor(opts.timeoutSec * 1000)
       : undefined;
 
+  // BoxLite provider: run command via BoxLite micro-VM instead of process supervisor.
+  if (opts.sandbox?.provider === "boxlite") {
+    const boxliteScopeKey = opts.sandbox.containerName;
+    const boxlitePromise = (async (): Promise<ExecProcessOutcome> => {
+      try {
+        const { runBoxLiteCommand } = await import("./boxlite/runtime.js");
+        const result = await runBoxLiteCommand(boxliteScopeKey, "sh", ["-c", execCommand]);
+        if (result.stdout) {
+          handleStdout(result.stdout);
+        }
+        if (result.stderr) {
+          handleStderr(result.stderr);
+        }
+        const durationMs = Date.now() - startedAt;
+        const exitCode = result.exitCode;
+        const isShellFailure = exitCode === 126 || exitCode === 127;
+        const status: "completed" | "failed" =
+          exitCode === 0 && !isShellFailure ? "completed" : "failed";
+        markExited(session, exitCode, null, status);
+        maybeNotifyOnExit(session, status);
+        const aggregated = session.aggregated.trim();
+        const exitMsg = exitCode !== 0 ? `\n\n(Command exited with code ${exitCode})` : "";
+        return {
+          status,
+          exitCode,
+          exitSignal: null,
+          durationMs,
+          aggregated: aggregated + exitMsg,
+          timedOut: false,
+        };
+      } catch (err) {
+        markExited(session, null, null, "failed");
+        maybeNotifyOnExit(session, "failed");
+        throw err;
+      }
+    })();
+
+    return {
+      session,
+      startedAt,
+      pid: undefined,
+      promise: boxlitePromise,
+      kill: () => {
+        // BoxLite commands are async calls, not child processes; no kill needed.
+      },
+    };
+  }
+
   const spawnSpec:
     | {
         mode: "child";

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -8,6 +8,7 @@ import { assertSandboxPath } from "./sandbox-paths.js";
 const CHUNK_LIMIT = 8 * 1024;
 
 export type BashSandboxConfig = {
+  provider?: "docker" | "boxlite";
   containerName: string;
   workspaceDir: string;
   containerWorkdir: string;

--- a/src/agents/boxlite/runtime.test.ts
+++ b/src/agents/boxlite/runtime.test.ts
@@ -118,7 +118,7 @@ describe("BoxLite runtime", () => {
     expect(mockStop).toHaveBeenCalledTimes(2);
   });
 
-  it("cleans up VM when setup command fails", async () => {
+  it("cleans up VM when setup command throws", async () => {
     mockExec.mockRejectedValueOnce(new Error("setup failed"));
 
     await expect(ensureBoxLiteBox("test-setup-fail", { setupCommand: "bad-cmd" })).rejects.toThrow(
@@ -126,6 +126,17 @@ describe("BoxLite runtime", () => {
     );
 
     // VM should be cleaned up — not left in registry.
+    expect(getActiveBoxLiteBoxCount()).toBe(0);
+    expect(mockStop).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up VM when setup command exits non-zero", async () => {
+    mockExec.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "pkg not found" });
+
+    await expect(
+      ensureBoxLiteBox("test-setup-nonzero", { setupCommand: "apt-get install missing" }),
+    ).rejects.toThrow("BoxLite setup command failed with exit code 1: pkg not found");
+
     expect(getActiveBoxLiteBoxCount()).toBe(0);
     expect(mockStop).toHaveBeenCalledOnce();
   });

--- a/src/agents/boxlite/runtime.test.ts
+++ b/src/agents/boxlite/runtime.test.ts
@@ -117,4 +117,26 @@ describe("BoxLite runtime", () => {
     expect(getActiveBoxLiteBoxCount()).toBe(0);
     expect(mockStop).toHaveBeenCalledTimes(2);
   });
+
+  it("cleans up VM when setup command fails", async () => {
+    mockExec.mockRejectedValueOnce(new Error("setup failed"));
+
+    await expect(ensureBoxLiteBox("test-setup-fail", { setupCommand: "bad-cmd" })).rejects.toThrow(
+      "setup failed",
+    );
+
+    // VM should be cleaned up — not left in registry.
+    expect(getActiveBoxLiteBoxCount()).toBe(0);
+    expect(mockStop).toHaveBeenCalledOnce();
+  });
+
+  it("deduplicates concurrent creation for the same scope key", async () => {
+    // Both calls start before either finishes — second should join first's in-flight promise.
+    const p1 = ensureBoxLiteBox("concurrent-key");
+    const p2 = ensureBoxLiteBox("concurrent-key");
+
+    const [h1, h2] = await Promise.all([p1, p2]);
+    expect(h1).toBe(h2);
+    expect(getActiveBoxLiteBoxCount()).toBe(1);
+  });
 });

--- a/src/agents/boxlite/runtime.test.ts
+++ b/src/agents/boxlite/runtime.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the @boxlite-ai/boxlite NAPI module before importing runtime.
+const mockExec = vi.fn();
+const mockCopyIn = vi.fn();
+const mockCopyOut = vi.fn();
+const mockStop = vi.fn();
+
+class MockSimpleBox {
+  exec = mockExec;
+  copyIn = mockCopyIn;
+  copyOut = mockCopyOut;
+  stop = mockStop;
+}
+
+vi.mock("@boxlite-ai/boxlite", () => ({
+  SimpleBox: MockSimpleBox,
+}));
+
+// Use dynamic import so the mock is in place before the module loads.
+const {
+  ensureBoxLiteBox,
+  runBoxLiteCommand,
+  stopBoxLiteBox,
+  stopAllBoxLiteBoxes,
+  getActiveBoxLiteBoxCount,
+  isBoxLiteAvailable,
+  resolveBoxLiteWorkdir,
+} = await import("./runtime.js");
+
+describe("BoxLite runtime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExec.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    mockCopyIn.mockResolvedValue(undefined);
+    mockCopyOut.mockResolvedValue(undefined);
+    mockStop.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await stopAllBoxLiteBoxes();
+  });
+
+  it("isBoxLiteAvailable returns true when module is present", async () => {
+    expect(await isBoxLiteAvailable()).toBe(true);
+  });
+
+  it("resolveBoxLiteWorkdir returns default when no config", () => {
+    expect(resolveBoxLiteWorkdir()).toBe("/workspace");
+  });
+
+  it("resolveBoxLiteWorkdir returns configured workdir", () => {
+    expect(resolveBoxLiteWorkdir({ workdir: "/app" })).toBe("/app");
+  });
+
+  it("creates a box on first call and reuses on second", async () => {
+    const handle1 = await ensureBoxLiteBox("test-scope-1");
+    expect(getActiveBoxLiteBoxCount()).toBe(1);
+
+    const handle2 = await ensureBoxLiteBox("test-scope-1");
+    // Reused existing box — same handle returned.
+    expect(handle1).toBe(handle2);
+    expect(getActiveBoxLiteBoxCount()).toBe(1);
+  });
+
+  it("runs setup command when configured", async () => {
+    mockExec.mockResolvedValue({ exitCode: 0, stdout: "ok", stderr: "" });
+
+    await ensureBoxLiteBox("test-setup", {
+      setupCommand: "apt-get update",
+    });
+
+    expect(mockExec).toHaveBeenCalledWith("sh", "-c", "apt-get update");
+  });
+
+  it("skips setup command when blank", async () => {
+    await ensureBoxLiteBox("test-no-setup", { setupCommand: "  " });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("runBoxLiteCommand delegates to handle.run", async () => {
+    mockExec.mockResolvedValue({ exitCode: 0, stdout: "hello", stderr: "" });
+
+    await ensureBoxLiteBox("test-run");
+    const result = await runBoxLiteCommand("test-run", "echo", ["hello"]);
+
+    expect(result).toEqual({ exitCode: 0, stdout: "hello", stderr: "" });
+    expect(mockExec).toHaveBeenCalledWith("echo", "hello");
+  });
+
+  it("runBoxLiteCommand throws when box not found", async () => {
+    await expect(runBoxLiteCommand("nonexistent", "echo", [])).rejects.toThrow(
+      "BoxLite box not found for scope key: nonexistent",
+    );
+  });
+
+  it("stopBoxLiteBox removes box and calls stop", async () => {
+    await ensureBoxLiteBox("test-stop");
+    expect(getActiveBoxLiteBoxCount()).toBe(1);
+
+    await stopBoxLiteBox("test-stop");
+    expect(getActiveBoxLiteBoxCount()).toBe(0);
+    expect(mockStop).toHaveBeenCalledOnce();
+  });
+
+  it("stopBoxLiteBox is idempotent for unknown keys", async () => {
+    await stopBoxLiteBox("unknown-key");
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it("stopAllBoxLiteBoxes cleans up all boxes", async () => {
+    await ensureBoxLiteBox("box-a");
+    await ensureBoxLiteBox("box-b");
+    expect(getActiveBoxLiteBoxCount()).toBe(2);
+
+    await stopAllBoxLiteBoxes();
+    expect(getActiveBoxLiteBoxCount()).toBe(0);
+    expect(mockStop).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/boxlite/runtime.ts
+++ b/src/agents/boxlite/runtime.ts
@@ -104,12 +104,22 @@ async function createBox(scopeKey: string, config?: BoxLiteSettings): Promise<Bo
 
   // Run setup command if configured.
   if (config?.setupCommand?.trim()) {
+    let setupError: Error | undefined;
     try {
-      await handle.run("sh", "-c", config.setupCommand);
+      const setupResult = await handle.run("sh", "-c", config.setupCommand);
+      if (setupResult.exitCode !== 0) {
+        const detail = setupResult.stderr?.trim() || setupResult.stdout?.trim() || "";
+        setupError = new Error(
+          `BoxLite setup command failed with exit code ${setupResult.exitCode}${detail ? `: ${detail}` : ""}`,
+        );
+      }
     } catch (err) {
+      setupError = err instanceof Error ? err : new Error(String(err));
+    }
+    if (setupError) {
       activeBoxes.delete(scopeKey);
       await handle.stop().catch(() => undefined);
-      throw err;
+      throw setupError;
     }
   }
 

--- a/src/agents/boxlite/runtime.ts
+++ b/src/agents/boxlite/runtime.ts
@@ -1,0 +1,134 @@
+import type { BoxLiteSettings } from "../../config/types.sandbox.js";
+
+export type BoxLiteExecResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+type BoxHandle = {
+  run(cmd: string, ...args: string[]): Promise<BoxLiteExecResult>;
+  copyIn(hostPath: string, containerDest: string): Promise<void>;
+  copyOut(containerSrc: string, hostDest: string): Promise<void>;
+  stop(): Promise<void>;
+};
+
+type BoxEntry = {
+  handle: BoxHandle;
+  createdAtMs: number;
+  lastUsedAtMs: number;
+};
+
+const DEFAULT_IMAGE = "alpine:latest";
+const DEFAULT_MEMORY_MIB = 512;
+const DEFAULT_CPUS = 2;
+const DEFAULT_WORKDIR = "/workspace";
+
+// In-memory registry keyed by scope key.
+const activeBoxes = new Map<string, BoxEntry>();
+
+export async function isBoxLiteAvailable(): Promise<boolean> {
+  try {
+    await import("@boxlite-ai/boxlite");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureBoxLiteBox(
+  scopeKey: string,
+  config?: BoxLiteSettings,
+): Promise<BoxHandle> {
+  const existing = activeBoxes.get(scopeKey);
+  if (existing) {
+    existing.lastUsedAtMs = Date.now();
+    return existing.handle;
+  }
+
+  const { SimpleBox } = await import("@boxlite-ai/boxlite");
+  const image = config?.image ?? DEFAULT_IMAGE;
+  const memoryMib = config?.memoryMib ?? DEFAULT_MEMORY_MIB;
+  const cpus = config?.cpus ?? DEFAULT_CPUS;
+  const workingDir = config?.workdir ?? DEFAULT_WORKDIR;
+
+  const box = new SimpleBox({
+    image,
+    memoryMib,
+    cpus,
+    workingDir,
+    env: config?.env,
+    name: scopeKey,
+    reuseExisting: true,
+  });
+
+  const handle: BoxHandle = {
+    async run(cmd: string, ...args: string[]) {
+      const result = await box.exec(cmd, ...args);
+      return { exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr };
+    },
+    async copyIn(hostPath: string, containerDest: string) {
+      await box.copyIn(hostPath, containerDest);
+    },
+    async copyOut(containerSrc: string, hostDest: string) {
+      await box.copyOut(containerSrc, hostDest);
+    },
+    async stop() {
+      await box.stop();
+    },
+  };
+
+  // Run setup command if configured.
+  if (config?.setupCommand?.trim()) {
+    await handle.run("sh", "-c", config.setupCommand);
+  }
+
+  activeBoxes.set(scopeKey, {
+    handle,
+    createdAtMs: Date.now(),
+    lastUsedAtMs: Date.now(),
+  });
+
+  return handle;
+}
+
+export async function runBoxLiteCommand(
+  scopeKey: string,
+  cmd: string,
+  args: string[],
+): Promise<BoxLiteExecResult> {
+  const entry = activeBoxes.get(scopeKey);
+  if (!entry) {
+    throw new Error(`BoxLite box not found for scope key: ${scopeKey}`);
+  }
+  entry.lastUsedAtMs = Date.now();
+  return entry.handle.run(cmd, ...args);
+}
+
+export async function stopBoxLiteBox(scopeKey: string): Promise<void> {
+  const entry = activeBoxes.get(scopeKey);
+  if (!entry) {
+    return;
+  }
+  activeBoxes.delete(scopeKey);
+  try {
+    await entry.handle.stop();
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+export async function stopAllBoxLiteBoxes(): Promise<void> {
+  const keys = [...activeBoxes.keys()];
+  for (const key of keys) {
+    await stopBoxLiteBox(key);
+  }
+}
+
+export function getActiveBoxLiteBoxCount(): number {
+  return activeBoxes.size;
+}
+
+export function resolveBoxLiteWorkdir(config?: BoxLiteSettings): string {
+  return config?.workdir ?? DEFAULT_WORKDIR;
+}

--- a/src/agents/boxlite/runtime.ts
+++ b/src/agents/boxlite/runtime.ts
@@ -26,6 +26,8 @@ const DEFAULT_WORKDIR = "/workspace";
 
 // In-memory registry keyed by scope key.
 const activeBoxes = new Map<string, BoxEntry>();
+// In-flight creation promises to prevent TOCTOU races.
+const inFlightCreations = new Map<string, Promise<BoxHandle>>();
 
 export async function isBoxLiteAvailable(): Promise<boolean> {
   try {
@@ -46,6 +48,20 @@ export async function ensureBoxLiteBox(
     return existing.handle;
   }
 
+  // Deduplicate concurrent creation for the same scope key.
+  const pending = inFlightCreations.get(scopeKey);
+  if (pending) {
+    return pending;
+  }
+
+  const creation = createBox(scopeKey, config).finally(() => {
+    inFlightCreations.delete(scopeKey);
+  });
+  inFlightCreations.set(scopeKey, creation);
+  return creation;
+}
+
+async function createBox(scopeKey: string, config?: BoxLiteSettings): Promise<BoxHandle> {
   const { SimpleBox } = await import("@boxlite-ai/boxlite");
   const image = config?.image ?? DEFAULT_IMAGE;
   const memoryMib = config?.memoryMib ?? DEFAULT_MEMORY_MIB;
@@ -78,16 +94,24 @@ export async function ensureBoxLiteBox(
     },
   };
 
-  // Run setup command if configured.
-  if (config?.setupCommand?.trim()) {
-    await handle.run("sh", "-c", config.setupCommand);
-  }
-
-  activeBoxes.set(scopeKey, {
+  // Register before setup so the VM is always reachable for cleanup.
+  const entry: BoxEntry = {
     handle,
     createdAtMs: Date.now(),
     lastUsedAtMs: Date.now(),
-  });
+  };
+  activeBoxes.set(scopeKey, entry);
+
+  // Run setup command if configured.
+  if (config?.setupCommand?.trim()) {
+    try {
+      await handle.run("sh", "-c", config.setupCommand);
+    } catch (err) {
+      activeBoxes.delete(scopeKey);
+      await handle.stop().catch(() => undefined);
+      throw err;
+    }
+  }
 
   return handle;
 }

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -5,6 +5,7 @@ import type { SandboxContext } from "./sandbox.js";
 function createSandboxContext(overrides?: Partial<SandboxContext>): SandboxContext {
   const base = {
     enabled: true,
+    provider: "docker" as const,
     sessionKey: "session:test",
     workspaceDir: "/tmp/openclaw-sandbox",
     agentWorkspaceDir: "/tmp/openclaw-workspace",

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -574,6 +574,7 @@ describe("Agent-specific tool filtering", () => {
       agentDir: "/tmp/agent-restricted",
       sandbox: {
         enabled: true,
+        provider: "docker" as const,
         sessionKey: "agent:restricted:main",
         workspaceDir: "/tmp/sandbox",
         agentWorkspaceDir: "/tmp/test-restricted",

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -340,7 +340,8 @@ export function createOpenClawCodingTools(options?: {
   const fsPolicy = createToolFsPolicy({
     workspaceOnly: isMemoryFlushRun || fsConfig.workspaceOnly,
   });
-  const sandboxRoot = sandbox?.workspaceDir;
+  // BoxLite sandboxes skip fsBridge (it relies on `docker exec`); file tools use host paths.
+  const sandboxRoot = sandbox?.provider === "boxlite" ? undefined : sandbox?.workspaceDir;
   const sandboxFsBridge = sandbox?.fsBridge;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
@@ -375,7 +376,7 @@ export function createOpenClawCodingTools(options?: {
         return [
           workspaceOnly
             ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
-                containerWorkdir: sandbox.containerWorkdir,
+                containerWorkdir: sandbox!.containerWorkdir,
               })
             : sandboxed,
         ];
@@ -468,7 +469,7 @@ export function createOpenClawCodingTools(options?: {
                   createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
                   sandboxRoot,
                   {
-                    containerWorkdir: sandbox.containerWorkdir,
+                    containerWorkdir: sandbox!.containerWorkdir,
                   },
                 )
               : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
@@ -477,7 +478,7 @@ export function createOpenClawCodingTools(options?: {
                   createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
                   sandboxRoot,
                   {
-                    containerWorkdir: sandbox.containerWorkdir,
+                    containerWorkdir: sandbox!.containerWorkdir,
                   },
                 )
               : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -435,10 +435,11 @@ export function createOpenClawCodingTools(options?: {
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
     sandbox: sandbox
       ? {
+          provider: sandbox.provider,
           containerName: sandbox.containerName,
           workspaceDir: sandbox.workspaceDir,
           containerWorkdir: sandbox.containerWorkdir,
-          env: sandbox.docker.env,
+          env: sandbox.provider === "boxlite" ? sandbox.docker.env : sandbox.docker.env,
         }
       : undefined,
   });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -439,7 +439,7 @@ export function createOpenClawCodingTools(options?: {
           containerName: sandbox.containerName,
           workspaceDir: sandbox.workspaceDir,
           containerWorkdir: sandbox.containerWorkdir,
-          env: sandbox.provider === "boxlite" ? sandbox.docker.env : sandbox.docker.env,
+          env: sandbox.docker.env,
         }
       : undefined,
   });

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -48,6 +48,7 @@ vi.mock("../../browser/bridge-server.js", () => ({
 function buildConfig(enableNoVnc: boolean): SandboxConfig {
   return {
     mode: "all",
+    provider: "docker",
     scope: "session",
     workspaceAccess: "none",
     workspaceRoot: "/tmp/openclaw-sandboxes",

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -187,12 +187,17 @@ export function resolveSandboxConfigForAgent(
 
   const toolPolicy = resolveSandboxToolPolicyForAgent(cfg, agentId);
 
+  const rawProvider = agentSandbox?.provider ?? agent?.provider;
+  const provider = rawProvider === "boxlite" ? "boxlite" : "docker";
+
   return {
     mode: agentSandbox?.mode ?? agent?.mode ?? "off",
+    provider,
     scope,
     workspaceAccess: agentSandbox?.workspaceAccess ?? agent?.workspaceAccess ?? "none",
     workspaceRoot:
       agentSandbox?.workspaceRoot ?? agent?.workspaceRoot ?? DEFAULT_SANDBOX_WORKSPACE_ROOT,
+    boxlite: provider === "boxlite" ? (agentSandbox?.boxlite ?? agent?.boxlite) : undefined,
     docker: resolveSandboxDockerConfig({
       scope,
       globalDocker: agent?.docker,

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -145,7 +145,8 @@ export async function resolveSandboxContext(params: {
       browserAllowHostControl: cfg.browser.allowHostControl,
     };
 
-    sandboxContext.fsBridge = createSandboxFsBridge({ sandbox: sandboxContext });
+    // Skip fs-bridge for BoxLite — SandboxFsBridgeImpl uses `docker exec` internally.
+    // BoxLite file operations go through the exec runtime instead.
     return sandboxContext;
   }
 

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -125,6 +125,31 @@ export async function resolveSandboxContext(params: {
     workspaceDir: params.workspaceDir,
   });
 
+  // BoxLite provider: create/reuse a micro-VM instead of a Docker container.
+  if (cfg.provider === "boxlite") {
+    const { ensureBoxLiteBox, resolveBoxLiteWorkdir } = await import("../boxlite/runtime.js");
+    await ensureBoxLiteBox(scopeKey, cfg.boxlite);
+    const containerWorkdir = resolveBoxLiteWorkdir(cfg.boxlite);
+
+    const sandboxContext: SandboxContext = {
+      enabled: true,
+      provider: "boxlite",
+      sessionKey: rawSessionKey,
+      workspaceDir,
+      agentWorkspaceDir,
+      workspaceAccess: cfg.workspaceAccess,
+      containerName: scopeKey, // Reuse containerName for box scope key.
+      containerWorkdir,
+      docker: cfg.docker, // Keep docker config for type compatibility.
+      tools: cfg.tools,
+      browserAllowHostControl: cfg.browser.allowHostControl,
+    };
+
+    sandboxContext.fsBridge = createSandboxFsBridge({ sandbox: sandboxContext });
+    return sandboxContext;
+  }
+
+  // Docker provider (default).
   const docker = await resolveSandboxDockerUser({
     docker: cfg.docker,
     workspaceDir,
@@ -168,6 +193,7 @@ export async function resolveSandboxContext(params: {
 
   const sandboxContext: SandboxContext = {
     enabled: true,
+    provider: "docker",
     sessionKey: rawSessionKey,
     workspaceDir,
     agentWorkspaceDir,

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -91,6 +91,7 @@ function createSandboxConfig(
 ): SandboxConfig {
   return {
     mode: "all",
+    provider: "docker",
     scope: "shared",
     workspaceAccess,
     workspaceRoot: "~/.openclaw/sandboxes",

--- a/src/agents/sandbox/prune.ts
+++ b/src/agents/sandbox/prune.ts
@@ -85,6 +85,12 @@ async function pruneSandboxBrowsers(cfg: SandboxConfig) {
 }
 
 export async function maybePruneSandboxes(cfg: SandboxConfig) {
+  // BoxLite provider: boxes are managed in-memory and cleaned up on stop.
+  // No registry-based prune needed.
+  if (cfg.provider === "boxlite") {
+    return;
+  }
+
   const now = Date.now();
   if (now - lastPruneAtMs < 5 * 60 * 1000) {
     return;

--- a/src/agents/sandbox/test-fixtures.ts
+++ b/src/agents/sandbox/test-fixtures.ts
@@ -28,6 +28,7 @@ export function createSandboxTestContext(params?: {
 
   return {
     enabled: true,
+    provider: "docker" as const,
     sessionKey: "sandbox:test",
     workspaceDir: "/tmp/workspace",
     agentWorkspaceDir: "/tmp/workspace",

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -1,7 +1,10 @@
+import type { BoxLiteSettings } from "../../config/types.sandbox.js";
 import type { SandboxFsBridge } from "./fs-bridge.js";
 import type { SandboxDockerConfig } from "./types.docker.js";
 
 export type { SandboxDockerConfig } from "./types.docker.js";
+
+export type SandboxProvider = "docker" | "boxlite";
 
 export type SandboxToolPolicy = {
   allow?: string[];
@@ -54,10 +57,12 @@ export type SandboxScope = "session" | "agent" | "shared";
 
 export type SandboxConfig = {
   mode: "off" | "non-main" | "all";
+  provider: SandboxProvider;
   scope: SandboxScope;
   workspaceAccess: SandboxWorkspaceAccess;
   workspaceRoot: string;
   docker: SandboxDockerConfig;
+  boxlite?: BoxLiteSettings;
   browser: SandboxBrowserConfig;
   tools: SandboxToolPolicy;
   prune: SandboxPruneConfig;
@@ -71,6 +76,7 @@ export type SandboxBrowserContext = {
 
 export type SandboxContext = {
   enabled: boolean;
+  provider: SandboxProvider;
   sessionKey: string;
   workspaceDir: string;
   agentWorkspaceDir: string;

--- a/src/agents/test-helpers/pi-tools-sandbox-context.ts
+++ b/src/agents/test-helpers/pi-tools-sandbox-context.ts
@@ -18,6 +18,7 @@ export function createPiToolsSandboxContext(params: PiToolsSandboxContextParams)
   const workspaceDir = params.workspaceDir;
   return {
     enabled: true,
+    provider: "docker" as const,
     sessionKey: params.sessionKey ?? "sandbox:test",
     workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir ?? workspaceDir,

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -1,4 +1,5 @@
 import type {
+  BoxLiteSettings,
   SandboxBrowserSettings,
   SandboxDockerSettings,
   SandboxPruneSettings,
@@ -15,6 +16,8 @@ export type AgentModelConfig =
 
 export type AgentSandboxConfig = {
   mode?: "off" | "non-main" | "all";
+  /** Sandbox provider: "docker" (default) or "boxlite" (micro-VM). */
+  provider?: "docker" | "boxlite";
   /** Agent workspace access inside the sandbox. */
   workspaceAccess?: "none" | "ro" | "rw";
   /**
@@ -30,6 +33,8 @@ export type AgentSandboxConfig = {
   workspaceRoot?: string;
   /** Docker-specific sandbox settings. */
   docker?: SandboxDockerSettings;
+  /** BoxLite micro-VM settings (used when provider is "boxlite"). */
+  boxlite?: BoxLiteSettings;
   /** Optional sandboxed browser settings. */
   browser?: SandboxBrowserSettings;
   /** Auto-prune sandbox settings. */

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -94,3 +94,18 @@ export type SandboxPruneSettings = {
   /** Prune if older than N days (0 disables). */
   maxAgeDays?: number;
 };
+
+export type BoxLiteSettings = {
+  /** OCI image for BoxLite micro-VM (default: "alpine:latest"). */
+  image?: string;
+  /** Memory in MiB for the micro-VM (default: 512). */
+  memoryMib?: number;
+  /** Number of CPU cores (default: 2). */
+  cpus?: number;
+  /** Working directory inside the micro-VM (default: /workspace). */
+  workdir?: string;
+  /** Extra environment variables for BoxLite exec. */
+  env?: Record<string, string>;
+  /** Optional setup command run once after box creation. */
+  setupCommand?: string;
+};

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -492,15 +492,29 @@ const ToolLoopDetectionSchema = z
   })
   .optional();
 
+const BoxLiteSchema = z
+  .object({
+    image: z.string().optional(),
+    memoryMib: z.number().int().positive().optional(),
+    cpus: z.number().int().positive().optional(),
+    workdir: z.string().optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    setupCommand: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
 export const AgentSandboxSchema = z
   .object({
     mode: z.union([z.literal("off"), z.literal("non-main"), z.literal("all")]).optional(),
+    provider: z.union([z.literal("docker"), z.literal("boxlite")]).optional(),
     workspaceAccess: z.union([z.literal("none"), z.literal("ro"), z.literal("rw")]).optional(),
     sessionToolsVisibility: z.union([z.literal("spawned"), z.literal("all")]).optional(),
     scope: z.union([z.literal("session"), z.literal("agent"), z.literal("shared")]).optional(),
     perSession: z.boolean().optional(),
     workspaceRoot: z.string().optional(),
     docker: SandboxDockerSchema,
+    boxlite: BoxLiteSchema,
     browser: SandboxBrowserSchema,
     prune: SandboxPruneSchema,
   })


### PR DESCRIPTION
## Summary

- Adds BoxLite micro-VM runtime as an alternative sandbox provider alongside Docker
- BoxLite provides hardware-level isolation (KVM on Linux, Hypervisor.framework on macOS) without requiring a Docker daemon
- New `provider: "docker" | "boxlite"` field on `SandboxConfig` selects the backend; existing functions dispatch polymorphically
- `@boxlite-ai/boxlite` added as optional peer dependency — clear error when missing

## Changes

- **Types**: Added `SandboxProvider`, `BoxLiteSettings`, `provider` field to `SandboxConfig`/`SandboxContext`/`AgentSandboxConfig`/`BashSandboxConfig`
- **Runtime**: New `src/agents/boxlite/runtime.ts` — single file handling create/exec/stop with in-memory box registry
- **Dispatch**: Polymorphic branching in `resolveSandboxContext()`, `runExecProcess()`, `maybePruneSandboxes()`
- **Config**: Provider resolution in `resolveSandboxConfigForAgent()`, Zod schema validation for BoxLite settings
- **Tests**: 11 new BoxLite runtime unit tests, all existing sandbox test fixtures updated with `provider` field

## Test plan

- [x] `pnpm tsgo` — no BoxLite-related type errors
- [x] `pnpm test -- src/agents/sandbox/` — 20 files, 116 tests pass
- [x] `pnpm test -- src/agents/boxlite/` — 11 tests pass
- [x] `pnpm test -- src/agents/pi-tools-agent-config.test.ts src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts` — 24 tests pass
- [ ] Manual: set `agents.defaults.sandbox.provider: boxlite` + `mode: all`, run a command
- [ ] Without `@boxlite-ai/boxlite` installed: verify clear error on `provider: boxlite`
- [ ] Default (`provider: docker` or unset): behavior identical to today