### PR TITLE
fix(feishu): prefer session account over defaultAccount for tools

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -546,15 +546,22 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
 
   type AccountAwareParams = { accountId?: string };
 
-  const getClient = (params: AccountAwareParams | undefined, defaultAccountId?: string) =>
-    createFeishuToolClient({ api, executeParams: params, defaultAccountId });
+  const getClient = (
+    params: AccountAwareParams | undefined,
+    defaultAccountId?: string,
+    messageChannel?: string,
+  ) => createFeishuToolClient({ api, executeParams: params, defaultAccountId, messageChannel });
 
   const registerBitableTool = <TParams extends AccountAwareParams>(params: {
     name: string;
     label: string;
     description: string;
     parameters: unknown;
-    execute: (args: { params: TParams; defaultAccountId?: string }) => Promise<unknown>;
+    execute: (args: {
+      params: TParams;
+      defaultAccountId?: string;
+      messageChannel?: string;
+    }) => Promise<unknown>;
   }) => {
     api.registerTool(
       (ctx) => ({
@@ -568,6 +575,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
               await params.execute({
                 params: rawParams as TParams,
                 defaultAccountId: ctx.agentAccountId,
+                messageChannel: ctx.messageChannel,
               }),
             );
           } catch (err) {
@@ -585,8 +593,8 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     description:
       "Parse a Bitable URL and get app_token, table_id, and table list. Use this first when given a /wiki/ or /base/ URL.",
     parameters: GetMetaSchema,
-    async execute({ params, defaultAccountId }) {
-      return getBitableMeta(getClient(params, defaultAccountId), params.url);
+    async execute({ params, defaultAccountId, messageChannel }) {
+      return getBitableMeta(getClient(params, defaultAccountId, messageChannel), params.url);
     },
   });
 
@@ -595,8 +603,12 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable List Fields",
     description: "List all fields (columns) in a Bitable table with their types and properties",
     parameters: ListFieldsSchema,
-    async execute({ params, defaultAccountId }) {
-      return listFields(getClient(params, defaultAccountId), params.app_token, params.table_id);
+    async execute({ params, defaultAccountId, messageChannel }) {
+      return listFields(
+        getClient(params, defaultAccountId, messageChannel),
+        params.app_token,
+        params.table_id,
+      );
     },
   });
 
@@ -611,9 +623,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable List Records",
     description: "List records (rows) from a Bitable table with pagination support",
     parameters: ListRecordsSchema,
-    async execute({ params, defaultAccountId }) {
+    async execute({ params, defaultAccountId, messageChannel }) {
       return listRecords(
-        getClient(params, defaultAccountId),
+        getClient(params, defaultAccountId, messageChannel),
         params.app_token,
         params.table_id,
         params.page_size,
@@ -632,9 +644,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Get Record",
     description: "Get a single record by ID from a Bitable table",
     parameters: GetRecordSchema,
-    async execute({ params, defaultAccountId }) {
+    async execute({ params, defaultAccountId, messageChannel }) {
       return getRecord(
-        getClient(params, defaultAccountId),
+        getClient(params, defaultAccountId, messageChannel),
         params.app_token,
         params.table_id,
         params.record_id,
@@ -652,9 +664,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Create Record",
     description: "Create a new record (row) in a Bitable table",
     parameters: CreateRecordSchema,
-    async execute({ params, defaultAccountId }) {
+    async execute({ params, defaultAccountId, messageChannel }) {
       return createRecord(
-        getClient(params, defaultAccountId),
+        getClient(params, defaultAccountId, messageChannel),
         params.app_token,
         params.table_id,
         params.fields,
@@ -673,9 +685,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Update Record",
     description: "Update an existing record (row) in a Bitable table",
     parameters: UpdateRecordSchema,
-    async execute({ params, defaultAccountId }) {
+    async execute({ params, defaultAccountId, messageChannel }) {
       return updateRecord(
-        getClient(params, defaultAccountId),
+        getClient(params, defaultAccountId, messageChannel),
         params.app_token,
         params.table_id,
         params.record_id,
@@ -689,11 +701,16 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Create App",
     description: "Create a new Bitable (multidimensional table) application",
     parameters: CreateAppSchema,
-    async execute({ params, defaultAccountId }) {
-      return createApp(getClient(params, defaultAccountId), params.name, params.folder_token, {
-        debug: (msg) => api.logger.debug?.(msg),
-        warn: (msg) => api.logger.warn?.(msg),
-      });
+    async execute({ params, defaultAccountId, messageChannel }) {
+      return createApp(
+        getClient(params, defaultAccountId, messageChannel),
+        params.name,
+        params.folder_token,
+        {
+          debug: (msg) => api.logger.debug?.(msg),
+          warn: (msg) => api.logger.warn?.(msg),
+        },
+      );
     },
   });
 
@@ -709,9 +726,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Create Field",
     description: "Create a new field (column) in a Bitable table",
     parameters: CreateFieldSchema,
-    async execute({ params, defaultAccountId }) {
+    async execute({ params, defaultAccountId, messageChannel }) {
       return createField(
-        getClient(params, defaultAccountId),
+        getClient(params, defaultAccountId, messageChannel),
         params.app_token,
         params.table_id,
         params.field_name,

--- a/extensions/feishu/src/docx.account-selection.test.ts
+++ b/extensions/feishu/src/docx.account-selection.test.ts
@@ -21,11 +21,12 @@ vi.mock("@larksuiteoapi/node-sdk", () => {
 });
 
 describe("feishu_doc account selection", () => {
-  function createDocEnabledConfig(): OpenClawPluginApi["config"] {
+  function createDocEnabledConfig(defaultAccount?: string): OpenClawPluginApi["config"] {
     return {
       channels: {
         feishu: {
           enabled: true,
+          defaultAccount,
           accounts: {
             a: { appId: "app-a", appSecret: "sec-a", tools: { doc: true } }, // pragma: allowlist secret
             b: { appId: "app-b", appSecret: "sec-b", tools: { doc: true } }, // pragma: allowlist secret
@@ -41,8 +42,8 @@ describe("feishu_doc account selection", () => {
     const { api, resolveTool } = createToolFactoryHarness(cfg);
     registerFeishuDocTools(api);
 
-    const docToolA = resolveTool("feishu_doc", { agentAccountId: "a" });
-    const docToolB = resolveTool("feishu_doc", { agentAccountId: "b" });
+    const docToolA = resolveTool("feishu_doc", { agentAccountId: "a", messageChannel: "feishu" });
+    const docToolB = resolveTool("feishu_doc", { agentAccountId: "b", messageChannel: "feishu" });
 
     await docToolA.execute("call-a", { action: "list_blocks", doc_token: "d" });
     await docToolB.execute("call-b", { action: "list_blocks", doc_token: "d" });
@@ -52,13 +53,25 @@ describe("feishu_doc account selection", () => {
     expect(createFeishuClientMock.mock.calls[1]?.[0]?.appId).toBe("app-b");
   });
 
+  test("non-feishu channel falls back to configured defaultAccount", async () => {
+    const cfg = createDocEnabledConfig("b");
+
+    const { api, resolveTool } = createToolFactoryHarness(cfg);
+    registerFeishuDocTools(api);
+
+    const docTool = resolveTool("feishu_doc", { agentAccountId: "a", messageChannel: "slack" });
+    await docTool.execute("call-non-feishu", { action: "list_blocks", doc_token: "d" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
+
   test("explicit accountId param overrides agentAccountId context", async () => {
     const cfg = createDocEnabledConfig();
 
     const { api, resolveTool } = createToolFactoryHarness(cfg);
     registerFeishuDocTools(api);
 
-    const docTool = resolveTool("feishu_doc", { agentAccountId: "b" });
+    const docTool = resolveTool("feishu_doc", { agentAccountId: "b", messageChannel: "feishu" });
     await docTool.execute("call-override", {
       action: "list_blocks",
       doc_token: "d",

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1245,15 +1245,19 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   const registered: string[] = [];
   type FeishuDocExecuteParams = FeishuDocParams & { accountId?: string };
 
-  const getClient = (params: { accountId?: string } | undefined, defaultAccountId?: string) =>
-    createFeishuToolClient({ api, executeParams: params, defaultAccountId });
+  const getClient = (
+    params: { accountId?: string } | undefined,
+    defaultAccountId?: string,
+    messageChannel?: string,
+  ) => createFeishuToolClient({ api, executeParams: params, defaultAccountId, messageChannel });
 
   const getMediaMaxBytes = (
     params: { accountId?: string } | undefined,
     defaultAccountId?: string,
+    messageChannel?: string,
   ) =>
-    (resolveFeishuToolAccount({ api, executeParams: params, defaultAccountId }).config
-      ?.mediaMaxMb ?? 30) *
+    (resolveFeishuToolAccount({ api, executeParams: params, defaultAccountId, messageChannel })
+      .config?.mediaMaxMb ?? 30) *
     1024 *
     1024;
 
@@ -1262,6 +1266,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
     api.registerTool(
       (ctx) => {
         const defaultAccountId = ctx.agentAccountId;
+        const messageChannel = ctx.messageChannel;
         const trustedRequesterOpenId =
           ctx.messageChannel === "feishu" ? ctx.requesterSenderId?.trim() || undefined : undefined;
         return {
@@ -1273,7 +1278,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
           async execute(_toolCallId, params) {
             const p = params as FeishuDocExecuteParams;
             try {
-              const client = getClient(p, defaultAccountId);
+              const client = getClient(p, defaultAccountId, messageChannel);
               switch (p.action) {
                 case "read":
                   return json(await readDoc(client, p.doc_token));
@@ -1283,7 +1288,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       client,
                       p.doc_token,
                       p.content,
-                      getMediaMaxBytes(p, defaultAccountId),
+                      getMediaMaxBytes(p, defaultAccountId, messageChannel),
                       api.logger,
                     ),
                   );
@@ -1293,7 +1298,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       client,
                       p.doc_token,
                       p.content,
-                      getMediaMaxBytes(p, defaultAccountId),
+                      getMediaMaxBytes(p, defaultAccountId, messageChannel),
                       api.logger,
                     ),
                   );
@@ -1304,7 +1309,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       p.doc_token,
                       p.content,
                       p.after_block_id,
-                      getMediaMaxBytes(p, defaultAccountId),
+                      getMediaMaxBytes(p, defaultAccountId, messageChannel),
                       api.logger,
                     ),
                   );
@@ -1355,7 +1360,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                     await uploadImageBlock(
                       client,
                       p.doc_token,
-                      getMediaMaxBytes(p, defaultAccountId),
+                      getMediaMaxBytes(p, defaultAccountId, messageChannel),
                       p.url,
                       p.file_path,
                       p.parent_block_id,
@@ -1369,7 +1374,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                     await uploadFileBlock(
                       client,
                       p.doc_token,
-                      getMediaMaxBytes(p, defaultAccountId),
+                      getMediaMaxBytes(p, defaultAccountId, messageChannel),
                       p.url,
                       p.file_path,
                       p.parent_block_id,
@@ -1442,7 +1447,9 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
         parameters: Type.Object({}),
         async execute() {
           try {
-            const result = await listAppScopes(getClient(undefined, ctx.agentAccountId));
+            const result = await listAppScopes(
+              getClient(undefined, ctx.agentAccountId, ctx.messageChannel),
+            );
             return json(result);
           } catch (err) {
             return json({ error: err instanceof Error ? err.message : String(err) });

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -186,6 +186,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
   api.registerTool(
     (ctx) => {
       const defaultAccountId = ctx.agentAccountId;
+      const messageChannel = ctx.messageChannel;
       return {
         name: "feishu_drive",
         label: "Feishu Drive",
@@ -199,6 +200,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
               api,
               executeParams: p,
               defaultAccountId,
+              messageChannel,
             });
             switch (p.action) {
               case "list":

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -135,6 +135,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
   api.registerTool(
     (ctx) => {
       const defaultAccountId = ctx.agentAccountId;
+      const messageChannel = ctx.messageChannel;
       return {
         name: "feishu_perm",
         label: "Feishu Perm",
@@ -147,6 +148,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
               api,
               executeParams: p,
               defaultAccountId,
+              messageChannel,
             });
             switch (p.action) {
               case "list":

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -147,6 +147,22 @@ describe("feishu tool account routing", () => {
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
   });
 
+  test("wiki tool normalizes inherited Feishu account ids before membership check", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        defaultAccount: "a",
+        toolsA: { wiki: true },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "B" });
+    await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
+
   test("bitable tool routes to agentAccountId and allows explicit accountId override", async () => {
     const { api, resolveTool } = createToolFactoryHarness(createConfig({}));
     registerFeishuBitableTools(api);

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -63,7 +63,7 @@ describe("feishu tool account routing", () => {
     );
     registerFeishuWikiTools(api);
 
-    const tool = resolveTool("feishu_wiki", { agentAccountId: "b" });
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "b", messageChannel: "feishu" });
     await tool.execute("call", { action: "search" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
@@ -79,7 +79,7 @@ describe("feishu tool account routing", () => {
     );
     registerFeishuWikiTools(api);
 
-    const tool = resolveTool("feishu_wiki", { agentAccountId: "a" });
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "a", messageChannel: "feishu" });
     await tool.execute("call", { action: "search" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-a");
@@ -94,7 +94,7 @@ describe("feishu tool account routing", () => {
     );
     registerFeishuDriveTools(api);
 
-    const tool = resolveTool("feishu_drive", { agentAccountId: "b" });
+    const tool = resolveTool("feishu_drive", { agentAccountId: "b", messageChannel: "feishu" });
     await tool.execute("call", { action: "unknown_action" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
@@ -109,7 +109,7 @@ describe("feishu tool account routing", () => {
     );
     registerFeishuPermTools(api);
 
-    const tool = resolveTool("feishu_perm", { agentAccountId: "b" });
+    const tool = resolveTool("feishu_perm", { agentAccountId: "b", messageChannel: "feishu" });
     await tool.execute("call", { action: "unknown_action" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
@@ -141,7 +141,10 @@ describe("feishu tool account routing", () => {
     );
     registerFeishuWikiTools(api);
 
-    const tool = resolveTool("feishu_wiki", { agentAccountId: "slack-main" });
+    const tool = resolveTool("feishu_wiki", {
+      agentAccountId: "slack-main",
+      messageChannel: "feishu",
+    });
     await tool.execute("call", { action: "search" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
@@ -157,7 +160,23 @@ describe("feishu tool account routing", () => {
     );
     registerFeishuWikiTools(api);
 
-    const tool = resolveTool("feishu_wiki", { agentAccountId: "B" });
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "B", messageChannel: "feishu" });
+    await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
+
+  test("wiki tool ignores inherited account context outside Feishu channel", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        defaultAccount: "b",
+        toolsA: { wiki: true },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "a", messageChannel: "slack" });
     await tool.execute("call", { action: "search" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
@@ -167,7 +186,10 @@ describe("feishu tool account routing", () => {
     const { api, resolveTool } = createToolFactoryHarness(createConfig({}));
     registerFeishuBitableTools(api);
 
-    const tool = resolveTool("feishu_bitable_get_meta", { agentAccountId: "b" });
+    const tool = resolveTool("feishu_bitable_get_meta", {
+      agentAccountId: "b",
+      messageChannel: "feishu",
+    });
     await tool.execute("call-ctx", { url: "invalid-url" });
     await tool.execute("call-override", { url: "invalid-url", accountId: "a" });
 

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -115,6 +115,22 @@ describe("feishu tool account routing", () => {
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
   });
 
+  test("wiki tool falls back to configured defaultAccount when no session account is present", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        defaultAccount: "b",
+        toolsA: { wiki: true },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", {});
+    await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
+
   test("bitable tool routes to agentAccountId and allows explicit accountId override", async () => {
     const { api, resolveTool } = createToolFactoryHarness(createConfig({}));
     registerFeishuBitableTools(api);

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -131,6 +131,22 @@ describe("feishu tool account routing", () => {
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
   });
 
+  test("wiki tool falls back to configured defaultAccount when inherited account is not a Feishu account", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        defaultAccount: "b",
+        toolsA: { wiki: true },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "slack-main" });
+    await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
+
   test("bitable tool routes to agentAccountId and allows explicit accountId override", async () => {
     const { api, resolveTool } = createToolFactoryHarness(createConfig({}));
     registerFeishuBitableTools(api);

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -69,7 +69,7 @@ describe("feishu tool account routing", () => {
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
   });
 
-  test("wiki tool prefers configured defaultAccount over inherited default account context", async () => {
+  test("wiki tool prefers inherited account context over configured defaultAccount", async () => {
     const { api, resolveTool } = createToolFactoryHarness(
       createConfig({
         defaultAccount: "b",
@@ -82,7 +82,7 @@ describe("feishu tool account routing", () => {
     const tool = resolveTool("feishu_wiki", { agentAccountId: "a" });
     await tool.execute("call", { action: "search" });
 
-    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-a");
   });
 
   test("drive tool registers when first account disables it and routes to agentAccountId", async () => {

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -1,4 +1,5 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { listFeishuAccountIds, resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
@@ -29,8 +30,9 @@ function readInheritedFeishuAccountId(
   if (!normalized || !config) {
     return undefined;
   }
-  const knownIds = new Set(listFeishuAccountIds(config));
-  return knownIds.has(normalized) ? normalized : undefined;
+  const inheritedAccountId = normalizeAccountId(normalized);
+  const knownIds = new Set(listFeishuAccountIds(config).map((id) => normalizeAccountId(id)));
+  return knownIds.has(inheritedAccountId) ? inheritedAccountId : undefined;
 }
 
 export function resolveFeishuToolAccount(params: {

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -33,8 +33,8 @@ export function resolveFeishuToolAccount(params: {
     cfg: params.api.config,
     accountId:
       normalizeOptionalAccountId(params.executeParams?.accountId) ??
-      readConfiguredDefaultAccountId(params.api.config) ??
-      normalizeOptionalAccountId(params.defaultAccountId),
+      normalizeOptionalAccountId(params.defaultAccountId) ??
+      readConfiguredDefaultAccountId(params.api.config),
   });
 }
 

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
-import { resolveFeishuAccount } from "./accounts.js";
+import { listFeishuAccountIds, resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { resolveToolsConfig } from "./tools-config.js";
 import type { FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
@@ -21,6 +21,18 @@ function readConfiguredDefaultAccountId(config: OpenClawPluginApi["config"]): st
   return normalizeOptionalAccountId(value);
 }
 
+function readInheritedFeishuAccountId(
+  config: OpenClawPluginApi["config"],
+  value: string | undefined,
+): string | undefined {
+  const normalized = normalizeOptionalAccountId(value);
+  if (!normalized || !config) {
+    return undefined;
+  }
+  const knownIds = new Set(listFeishuAccountIds(config));
+  return knownIds.has(normalized) ? normalized : undefined;
+}
+
 export function resolveFeishuToolAccount(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
@@ -33,7 +45,7 @@ export function resolveFeishuToolAccount(params: {
     cfg: params.api.config,
     accountId:
       normalizeOptionalAccountId(params.executeParams?.accountId) ??
-      normalizeOptionalAccountId(params.defaultAccountId) ??
+      readInheritedFeishuAccountId(params.api.config, params.defaultAccountId) ??
       readConfiguredDefaultAccountId(params.api.config),
   });
 }

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -13,6 +13,11 @@ function normalizeOptionalAccountId(value: string | undefined): string | undefin
   return trimmed ? trimmed : undefined;
 }
 
+function normalizeOptionalMessageChannel(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed ? trimmed : undefined;
+}
+
 function readConfiguredDefaultAccountId(config: OpenClawPluginApi["config"]): string | undefined {
   const value = (config?.channels?.feishu as { defaultAccount?: unknown } | undefined)
     ?.defaultAccount;
@@ -39,6 +44,7 @@ export function resolveFeishuToolAccount(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
+  messageChannel?: string;
 }): ResolvedFeishuAccount {
   if (!params.api.config) {
     throw new Error("Feishu config unavailable");
@@ -47,7 +53,9 @@ export function resolveFeishuToolAccount(params: {
     cfg: params.api.config,
     accountId:
       normalizeOptionalAccountId(params.executeParams?.accountId) ??
-      readInheritedFeishuAccountId(params.api.config, params.defaultAccountId) ??
+      (normalizeOptionalMessageChannel(params.messageChannel) === "feishu"
+        ? readInheritedFeishuAccountId(params.api.config, params.defaultAccountId)
+        : undefined) ??
       readConfiguredDefaultAccountId(params.api.config),
   });
 }
@@ -56,6 +64,7 @@ export function createFeishuToolClient(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
+  messageChannel?: string;
 }): Lark.Client {
   return createFeishuClient(resolveFeishuToolAccount(params));
 }

--- a/extensions/feishu/src/tool-factory-test-harness.ts
+++ b/extensions/feishu/src/tool-factory-test-harness.ts
@@ -2,6 +2,8 @@ import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/feishu
 
 type ToolContextLike = {
   agentAccountId?: string;
+  messageChannel?: string;
+  requesterSenderId?: string;
 };
 
 type ToolFactoryLike = (ctx: ToolContextLike) => AnyAgentTool | AnyAgentTool[] | null | undefined;

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -174,6 +174,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
   api.registerTool(
     (ctx) => {
       const defaultAccountId = ctx.agentAccountId;
+      const messageChannel = ctx.messageChannel;
       return {
         name: "feishu_wiki",
         label: "Feishu Wiki",
@@ -187,6 +188,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
               api,
               executeParams: p,
               defaultAccountId,
+              messageChannel,
             });
             switch (p.action) {
               case "spaces":


### PR DESCRIPTION
## Summary

- Problem: In multi-account Feishu setups, tool execution preferred configured `defaultAccount` over the current session account context.
- Why it matters: This can create documents or other resources under the wrong Feishu organization/tenant in personal + company multi-account setups.
- What changed: Feishu tool account resolution now prefers inherited session account context before configured `defaultAccount`.
- What did NOT change (scope boundary): Explicit `accountId` override behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45659
- Related #26066
- Related #15246
- Related #8692

## User-visible / Behavior Changes

In Feishu multi-account setups, tools now default to the account associated with the current session/message before falling back to configured `defaultAccount`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - This changes which existing Feishu account is selected for tool execution in multi-account setups.
  - Mitigation: explicit `accountId` still wins, and a targeted routing test was updated to lock in the safer precedence.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw install
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): multiple `channels.feishu.accounts` entries plus `channels.feishu.defaultAccount`

### Steps

1. Configure multiple Feishu accounts and set `channels.feishu.defaultAccount`.
2. Route an inbound message/session to a non-default Feishu account.
3. Trigger a Feishu tool such as `feishu_doc` or `feishu_wiki`.

### Expected

- Tool uses the current session account unless explicit `accountId` override is provided.

### Actual

- Tool used configured `defaultAccount` even when the current session already had a different Feishu account context.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced the issue in a real multi-account Feishu setup where different accounts mapped to different organizations.
  - Confirmed that removing `channels.feishu.defaultAccount` made tools follow the current session account.
  - Updated and ran `extensions/feishu/src/tool-account-routing.test.ts` successfully.
- Edge cases checked:
  - Explicit `accountId` override test remains unchanged and still passes.
  - Agent-context routing test continues to pass.
- What you did **not** verify:
  - Full repo-wide test/build matrix.
  - Manual verification across every Feishu tool using the shared helper.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Behavior change in multi-account Feishu setups
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit or restore the previous precedence order in `extensions/feishu/src/tool-account.ts`.
- Files/config to restore:
  - `extensions/feishu/src/tool-account.ts`
  - `extensions/feishu/src/tool-account-routing.test.ts`
- Known bad symptoms reviewers should watch for:
  - Tool execution unexpectedly favoring configured `defaultAccount` again.

## Risks and Mitigations

- Risk:
  - Some users may have relied on `defaultAccount` overriding session context.
  - Mitigation:
    - Explicit `accountId` remains available for forced routing.
    - New precedence better matches multi-account channel behavior and avoids cross-tenant resource creation.
