### PR TITLE
Telegram: route native skill commands before DM fallback

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -36,6 +36,7 @@ type FetchMediaOptions = {
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
   dispatcherPolicy?: PinnedDispatcherPolicy;
+  pinDns?: boolean;
 };
 
 function stripQuotes(value: string): string {
@@ -94,6 +95,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     ssrfPolicy,
     lookupFn,
     dispatcherPolicy,
+    pinDns,
   } = options;
 
   let res: Response;
@@ -109,6 +111,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
         policy: ssrfPolicy,
         lookupFn,
         dispatcherPolicy,
+        pinDns,
       }),
     );
     res = result.response;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1538,7 +1538,7 @@ export const registerTelegramHandlers = ({
       // the generic DM fallback before shouldSkipUpdate only for that path.
       if (event.allowNativeSkillBypass) {
         const nativeCommandToken = extractTelegramNativeCommandToken({
-          text: event.msg.text ?? event.msg.caption,
+          text: event.msg.text,
           botUsername: event.ctx.me?.username,
         });
         if (nativeCommandToken && nativeSkillCommandNames.has(nativeCommandToken)) {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -907,7 +907,7 @@ export const registerTelegramHandlers = ({
     } = params;
 
     // Text fragment handling - Telegram splits long pastes into multiple inbound messages (~4096 chars).
-    // We buffer 鈥渘ear-limit鈥?messages and append immediately-following parts.
+    // We buffer “near-limit” messages and append immediately-following parts.
     const text = typeof msg.text === "string" ? msg.text : undefined;
     const isCommandLike = (text ?? "").trim().startsWith("/");
     if (text && !isCommandLike) {
@@ -1015,7 +1015,7 @@ export const registerTelegramHandlers = ({
             operation: "sendMessage",
             runtime,
             fn: () =>
-              bot.api.sendMessage(chatId, `鈿狅笍 File too large. Maximum size is ${limitMb}MB.`, {
+              bot.api.sendMessage(chatId, `⚠️ File too large. Maximum size is ${limitMb}MB.`, {
                 reply_to_message_id: msg.message_id,
               }),
           }).catch(() => {});
@@ -1028,7 +1028,7 @@ export const registerTelegramHandlers = ({
         operation: "sendMessage",
         runtime,
         fn: () =>
-          bot.api.sendMessage(chatId, "鈿狅笍 Failed to download media. Please try again.", {
+          bot.api.sendMessage(chatId, "⚠️ Failed to download media. Please try again.", {
             reply_to_message_id: msg.message_id,
           }),
       }).catch(() => {});
@@ -1397,7 +1397,7 @@ export const registerTelegramHandlers = ({
           const modelSet = byProvider.get(selection.provider);
           if (!modelSet?.has(selection.model)) {
             await editMessageWithButtons(
-              `鉂?Model "${selection.provider}/${selection.model}" is not allowed.`,
+              `❌ Model "${selection.provider}/${selection.model}" is not allowed.`,
               [],
             );
             return;
@@ -1437,11 +1437,11 @@ export const registerTelegramHandlers = ({
               ? "reset to default"
               : `changed to **${selection.provider}/${selection.model}**`;
             await editMessageWithButtons(
-              `鉁?Model ${actionText}\n\nThis model will be used for your next message.`,
+              `✅ Model ${actionText}\n\nThis model will be used for your next message.`,
               [], // Empty buttons = remove inline keyboard
             );
           } catch (err) {
-            await editMessageWithButtons(`鉂?Failed to change model: ${String(err)}`, []);
+            await editMessageWithButtons(`❌ Failed to change model: ${String(err)}`, []);
           }
           return;
         }
@@ -1478,7 +1478,7 @@ export const registerTelegramHandlers = ({
       const newChatId = String(msg.migrate_to_chat_id);
       const chatTitle = msg.chat.title ?? "Unknown";
 
-      runtime.log?.(warn(`[telegram] Group migrated: "${chatTitle}" ${oldChatId} 鈫?${newChatId}`));
+      runtime.log?.(warn(`[telegram] Group migrated: "${chatTitle}" ${oldChatId} → ${newChatId}`));
 
       if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
         runtime.log?.(warn("[telegram] Config writes disabled; skipping group config migration."));
@@ -1649,7 +1649,7 @@ export const registerTelegramHandlers = ({
     });
   });
 
-  // Handle channel posts 鈥?enables bot-to-bot communication via Telegram channels.
+  // Handle channel posts — enables bot-to-bot communication via Telegram channels.
   // Telegram bots cannot see other bot messages in groups, but CAN in channels.
   // This handler normalizes channel_post updates into the standard message pipeline.
   bot.on("channel_post", async (ctx) => {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -907,7 +907,7 @@ export const registerTelegramHandlers = ({
     } = params;
 
     // Text fragment handling - Telegram splits long pastes into multiple inbound messages (~4096 chars).
-    // We buffer “near-limit” messages and append immediately-following parts.
+    // We buffer 鈥渘ear-limit鈥?messages and append immediately-following parts.
     const text = typeof msg.text === "string" ? msg.text : undefined;
     const isCommandLike = (text ?? "").trim().startsWith("/");
     if (text && !isCommandLike) {
@@ -1015,7 +1015,7 @@ export const registerTelegramHandlers = ({
             operation: "sendMessage",
             runtime,
             fn: () =>
-              bot.api.sendMessage(chatId, `⚠️ File too large. Maximum size is ${limitMb}MB.`, {
+              bot.api.sendMessage(chatId, `鈿狅笍 File too large. Maximum size is ${limitMb}MB.`, {
                 reply_to_message_id: msg.message_id,
               }),
           }).catch(() => {});
@@ -1028,7 +1028,7 @@ export const registerTelegramHandlers = ({
         operation: "sendMessage",
         runtime,
         fn: () =>
-          bot.api.sendMessage(chatId, "⚠️ Failed to download media. Please try again.", {
+          bot.api.sendMessage(chatId, "鈿狅笍 Failed to download media. Please try again.", {
             reply_to_message_id: msg.message_id,
           }),
       }).catch(() => {});
@@ -1397,7 +1397,7 @@ export const registerTelegramHandlers = ({
           const modelSet = byProvider.get(selection.provider);
           if (!modelSet?.has(selection.model)) {
             await editMessageWithButtons(
-              `❌ Model "${selection.provider}/${selection.model}" is not allowed.`,
+              `鉂?Model "${selection.provider}/${selection.model}" is not allowed.`,
               [],
             );
             return;
@@ -1437,11 +1437,11 @@ export const registerTelegramHandlers = ({
               ? "reset to default"
               : `changed to **${selection.provider}/${selection.model}**`;
             await editMessageWithButtons(
-              `✅ Model ${actionText}\n\nThis model will be used for your next message.`,
+              `鉁?Model ${actionText}\n\nThis model will be used for your next message.`,
               [], // Empty buttons = remove inline keyboard
             );
           } catch (err) {
-            await editMessageWithButtons(`❌ Failed to change model: ${String(err)}`, []);
+            await editMessageWithButtons(`鉂?Failed to change model: ${String(err)}`, []);
           }
           return;
         }
@@ -1478,7 +1478,7 @@ export const registerTelegramHandlers = ({
       const newChatId = String(msg.migrate_to_chat_id);
       const chatTitle = msg.chat.title ?? "Unknown";
 
-      runtime.log?.(warn(`[telegram] Group migrated: "${chatTitle}" ${oldChatId} → ${newChatId}`));
+      runtime.log?.(warn(`[telegram] Group migrated: "${chatTitle}" ${oldChatId} 鈫?${newChatId}`));
 
       if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
         runtime.log?.(warn("[telegram] Config writes disabled; skipping group config migration."));
@@ -1519,6 +1519,7 @@ export const registerTelegramHandlers = ({
     ctxForDedupe: TelegramUpdateKeyContext;
     ctx: TelegramContext;
     msg: Message;
+    allowNativeSkillBypass: boolean;
     chatId: number;
     isGroup: boolean;
     isForum: boolean;
@@ -1533,12 +1534,16 @@ export const registerTelegramHandlers = ({
 
   const handleInboundMessageLike = async (event: InboundTelegramEvent) => {
     try {
-      const nativeCommandToken = extractTelegramNativeCommandToken({
-        text: event.msg.text ?? event.msg.caption,
-        botUsername: event.ctx.me?.username,
-      });
-      if (nativeCommandToken && nativeSkillCommandNames.has(nativeCommandToken)) {
-        return;
+      // Native slash skill handlers own dedup for direct-message commands, so bypass
+      // the generic DM fallback before shouldSkipUpdate only for that path.
+      if (event.allowNativeSkillBypass) {
+        const nativeCommandToken = extractTelegramNativeCommandToken({
+          text: event.msg.text ?? event.msg.caption,
+          botUsername: event.ctx.me?.username,
+        });
+        if (nativeCommandToken && nativeSkillCommandNames.has(nativeCommandToken)) {
+          return;
+        }
       }
       if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
@@ -1630,6 +1635,7 @@ export const registerTelegramHandlers = ({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, msg),
       msg,
+      allowNativeSkillBypass: msg.chat.type === "private",
       chatId: msg.chat.id,
       isGroup: msg.chat.type === "group" || msg.chat.type === "supergroup",
       isForum: msg.chat.is_forum === true,
@@ -1643,7 +1649,7 @@ export const registerTelegramHandlers = ({
     });
   });
 
-  // Handle channel posts — enables bot-to-bot communication via Telegram channels.
+  // Handle channel posts 鈥?enables bot-to-bot communication via Telegram channels.
   // Telegram bots cannot see other bot messages in groups, but CAN in channels.
   // This handler normalizes channel_post updates into the standard message pipeline.
   bot.on("channel_post", async (ctx) => {
@@ -1679,6 +1685,7 @@ export const registerTelegramHandlers = ({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, syntheticMsg),
       msg: syntheticMsg,
+      allowNativeSkillBypass: false,
       chatId,
       isGroup: true,
       isForum: false,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -81,6 +81,10 @@ import {
   type ProviderInfo,
 } from "./model-buttons.js";
 import { buildInlineKeyboard } from "./send.js";
+import {
+  buildTelegramNativeSkillCommandNames,
+  extractTelegramNativeCommandToken,
+} from "./native-command-routing.js";
 import { wasSentByBot } from "./sent-message-cache.js";
 
 const APPROVE_CALLBACK_DATA_RE =
@@ -132,12 +136,20 @@ export const registerTelegramHandlers = ({
   telegramCfg,
   allowFrom,
   groupAllowFrom,
+  nativeEnabled,
+  nativeSkillsEnabled,
   resolveGroupPolicy,
   resolveTelegramGroupConfig,
   shouldSkipUpdate,
   processMessage,
   logger,
 }: RegisterTelegramHandlerParams) => {
+  const nativeSkillCommandNames = buildTelegramNativeSkillCommandNames({
+    cfg,
+    accountId,
+    nativeEnabled,
+    nativeSkillsEnabled,
+  });
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
   const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
   const TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS =
@@ -1521,6 +1533,13 @@ export const registerTelegramHandlers = ({
 
   const handleInboundMessageLike = async (event: InboundTelegramEvent) => {
     try {
+      const nativeCommandToken = extractTelegramNativeCommandToken({
+        text: event.msg.text ?? event.msg.caption,
+        botUsername: event.ctx.me?.username,
+      });
+      if (nativeCommandToken && nativeSkillCommandNames.has(nativeCommandToken)) {
+        return;
+      }
       if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
       }

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -100,6 +100,8 @@ export type RegisterTelegramHandlerParams = {
   telegramCfg: TelegramAccountConfig;
   allowFrom?: Array<string | number>;
   groupAllowFrom?: Array<string | number>;
+  nativeEnabled: boolean;
+  nativeSkillsEnabled: boolean;
   resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
   resolveTelegramGroupConfig: (
     chatId: string | number,

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1839,6 +1839,46 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).not.toHaveBeenCalled();
   });
+  it("keeps captioned native skill invocations on the generic DM path", async () => {
+    commandSpy.mockClear();
+    replySpy.mockClear();
+    listSkillCommandsForAgents.mockReturnValue([
+      {
+        name: "demo_skill",
+        skillName: "demo-skill",
+        description: "Demo skill",
+      },
+    ]);
+
+    loadConfig.mockReturnValue({
+      commands: { native: true, nativeSkills: true, text: true },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        from: { id: 456, username: "testuser" },
+        caption: "/demo_skill hello",
+        date: 1736380800,
+        message_id: 43,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0]?.[0] as { Body?: string };
+    expect(payload.Body).toContain("/demo_skill hello");
+  });
   it("keeps /skill on the generic message path when Telegram native commands are disabled", async () => {
     replySpy.mockClear();
 

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1199,7 +1199,7 @@ describe("createTelegramBot", () => {
 
     loadConfig.mockReturnValue({
       messages: {
-        ackReaction: "👀",
+        ackReaction: "馃憖",
         ackReactionScope: "group-mentions",
         groupChat: { mentionPatterns: ["\\bbert\\b"] },
       },
@@ -1221,7 +1221,7 @@ describe("createTelegramBot", () => {
       },
     });
 
-    expect(setMessageReactionSpy).toHaveBeenCalledWith(7, 123, [{ type: "emoji", emoji: "👀" }]);
+    expect(setMessageReactionSpy).toHaveBeenCalledWith(7, 123, [{ type: "emoji", emoji: "馃憖" }]);
   });
   it("clears native commands when disabled", () => {
     resetHarnessSpies();
@@ -1903,6 +1903,51 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).not.toHaveBeenCalled();
   });
+  it("keeps channel_post native skill commands on the generic path", async () => {
+    replySpy.mockClear();
+    listSkillCommandsForAgents.mockReturnValue([
+      {
+        name: "demo_skill",
+        skillName: "demo-skill",
+        description: "Demo skill",
+      },
+    ]);
+
+    loadConfig.mockReturnValue({
+      commands: { native: true, nativeSkills: true, text: true },
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: {
+            "-100777111222": {
+              enabled: true,
+              requireMention: false,
+            },
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("channel_post") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      channelPost: {
+        chat: { id: -100777111222, type: "channel", title: "Wake Channel" },
+        text: "/demo_skill hello",
+        date: 1736380800,
+        message_id: 321,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0]?.[0] as { Body?: string };
+    expect(payload.Body).toContain("/demo_skill hello");
+  });
   it("skips tool summaries for native slash commands", async () => {
     commandSpy.mockClear();
     replySpy.mockImplementation(async (_ctx, opts) => {
@@ -2155,7 +2200,7 @@ describe("createTelegramBot", () => {
 
       expect(sendMessageSpy).toHaveBeenCalledWith(
         1234,
-        "⚠️ Failed to download media. Please try again.",
+        "鈿狅笍 Failed to download media. Please try again.",
         { reply_to_message_id: 411 },
       );
       expect(replySpy).not.toHaveBeenCalled();

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1879,6 +1879,46 @@ describe("createTelegramBot", () => {
     const payload = replySpy.mock.calls[0]?.[0] as { Body?: string };
     expect(payload.Body).toContain("/demo_skill hello");
   });
+  it("keeps whitespace-prefixed native skill invocations on the generic DM path", async () => {
+    commandSpy.mockClear();
+    replySpy.mockClear();
+    listSkillCommandsForAgents.mockReturnValue([
+      {
+        name: "demo_skill",
+        skillName: "demo-skill",
+        description: "Demo skill",
+      },
+    ]);
+
+    loadConfig.mockReturnValue({
+      commands: { native: true, nativeSkills: true, text: true },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        from: { id: 456, username: "testuser" },
+        text: "  /demo_skill hello",
+        date: 1736380800,
+        message_id: 44,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0]?.[0] as { Body?: string };
+    expect(payload.Body).toContain("/demo_skill hello");
+  });
   it("keeps /skill on the generic message path when Telegram native commands are disabled", async () => {
     replySpy.mockClear();
 

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1199,7 +1199,7 @@ describe("createTelegramBot", () => {
 
     loadConfig.mockReturnValue({
       messages: {
-        ackReaction: "馃憖",
+        ackReaction: "👀",
         ackReactionScope: "group-mentions",
         groupChat: { mentionPatterns: ["\\bbert\\b"] },
       },
@@ -1221,7 +1221,7 @@ describe("createTelegramBot", () => {
       },
     });
 
-    expect(setMessageReactionSpy).toHaveBeenCalledWith(7, 123, [{ type: "emoji", emoji: "馃憖" }]);
+    expect(setMessageReactionSpy).toHaveBeenCalledWith(7, 123, [{ type: "emoji", emoji: "👀" }]);
   });
   it("clears native commands when disabled", () => {
     resetHarnessSpies();
@@ -2200,7 +2200,7 @@ describe("createTelegramBot", () => {
 
       expect(sendMessageSpy).toHaveBeenCalledWith(
         1234,
-        "鈿狅笍 Failed to download media. Please try again.",
+        "⚠️ Failed to download media. Please try again.",
         { reply_to_message_id: 411 },
       );
       expect(replySpy).not.toHaveBeenCalled();

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -18,6 +18,7 @@ import {
   middlewareUseSpy,
   onSpy,
   replySpy,
+  listSkillCommandsForAgents,
   sendAnimationSpy,
   sendChatActionSpy,
   sendMessageSpy,
@@ -1794,6 +1795,113 @@ describe("createTelegramBot", () => {
       expect.any(String),
       expect.objectContaining({ message_thread_id: 99 }),
     );
+  });
+  it("skips generic DM processing for Telegram native skill commands", async () => {
+    commandSpy.mockClear();
+    replySpy.mockClear();
+    listSkillCommandsForAgents.mockReturnValue([
+      {
+        name: "demo_skill",
+        skillName: "demo-skill",
+        description: "Demo skill",
+      },
+    ]);
+
+    loadConfig.mockReturnValue({
+      commands: { native: true, nativeSkills: true, text: true },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    const registeredHandlers = commandSpy.mock.calls.map(([name]) => name);
+    expect(registeredHandlers).toEqual(expect.arrayContaining(["skill", "demo_skill"]));
+
+    for (const text of ["/skill demo_skill hello", "/demo_skill hello"]) {
+      await handler({
+        message: {
+          chat: { id: 1234, type: "private" },
+          from: { id: 456, username: "testuser" },
+          text,
+          date: 1736380800,
+          message_id: 42,
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+    }
+
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+  it("keeps /skill on the generic message path when Telegram native commands are disabled", async () => {
+    replySpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      commands: { native: false, nativeSkills: false, text: true },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        from: { id: 456, username: "testuser" },
+        text: "/skill demo_skill hello",
+        date: 1736380800,
+        message_id: 42,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+  it("skips generic DM processing for /skill when Telegram native skills aliases are disabled", async () => {
+    commandSpy.mockClear();
+    replySpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      commands: { native: true, nativeSkills: false, text: true },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    const registeredHandlers = commandSpy.mock.calls.map(([name]) => name);
+    expect(registeredHandlers).toContain("skill");
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        from: { id: 456, username: "testuser" },
+        text: "/skill demo_skill hello",
+        date: 1736380800,
+        message_id: 42,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
   });
   it("skips tool summaries for native slash commands", async () => {
     commandSpy.mockClear();

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -501,6 +501,8 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     telegramCfg,
     allowFrom,
     groupAllowFrom,
+    nativeEnabled,
+    nativeSkillsEnabled,
     resolveGroupPolicy,
     resolveTelegramGroupConfig,
     shouldSkipUpdate,

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -327,6 +327,39 @@ describe("resolveMedia getFile retry", () => {
     );
   });
 
+  it("uses transport.fetch without pinned-dispatcher override for file downloads", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "photos/fallback.jpg" });
+    const callerFetch = vi.fn() as unknown as typeof fetch;
+    const callerTransport = { fetch: callerFetch, sourceFetch: callerFetch };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("jpg-data"),
+      contentType: "image/jpeg",
+      fileName: "fallback.jpg",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/fallback---uuid.jpg",
+      contentType: "image/jpeg",
+    });
+
+    const result = await resolveMedia(
+      makeCtx("photo", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      callerTransport,
+    );
+
+    expect(result).not.toBeNull();
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchImpl: callerFetch,
+        pinDns: false,
+      }),
+    );
+    const call = fetchRemoteMedia.mock.calls.at(-1)?.[0];
+    expect(call).toBeDefined();
+    expect(call).not.toHaveProperty("dispatcherPolicy");
+  });
+
   it("uses caller-provided fetch impl for sticker downloads", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "stickers/file_0.webp" });
     const callerFetch = vi.fn() as unknown as typeof fetch;

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -327,10 +327,15 @@ describe("resolveMedia getFile retry", () => {
     );
   });
 
-  it("uses transport.fetch without pinned-dispatcher override for file downloads", async () => {
+  it("keeps pinned-dispatcher policy on the guarded file-download path", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "photos/fallback.jpg" });
     const callerFetch = vi.fn() as unknown as typeof fetch;
-    const callerTransport = { fetch: callerFetch, sourceFetch: callerFetch };
+    const callerSourceFetch = vi.fn() as unknown as typeof fetch;
+    const callerTransport = {
+      fetch: callerFetch,
+      sourceFetch: callerSourceFetch,
+      pinnedDispatcherPolicy: { mode: "direct" as const, connect: { localAddress: "0.0.0.0" } },
+    };
     fetchRemoteMedia.mockResolvedValueOnce({
       buffer: Buffer.from("jpg-data"),
       contentType: "image/jpeg",
@@ -351,13 +356,13 @@ describe("resolveMedia getFile retry", () => {
     expect(result).not.toBeNull();
     expect(fetchRemoteMedia).toHaveBeenCalledWith(
       expect.objectContaining({
-        fetchImpl: callerFetch,
-        pinDns: false,
+        fetchImpl: callerSourceFetch,
+        dispatcherPolicy: callerTransport.pinnedDispatcherPolicy,
       }),
     );
     const call = fetchRemoteMedia.mock.calls.at(-1)?.[0];
     expect(call).toBeDefined();
-    expect(call).not.toHaveProperty("dispatcherPolicy");
+    expect(call).not.toHaveProperty("pinDns");
   });
 
   it("uses caller-provided fetch impl for sticker downloads", async () => {

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -128,11 +128,13 @@ async function downloadAndSaveTelegramFile(params: {
   const url = `https://api.telegram.org/file/bot${params.token}/${params.filePath}`;
   const fetched = await fetchRemoteMedia({
     url,
-    fetchImpl: params.transport.sourceFetch,
-    dispatcherPolicy: params.transport.pinnedDispatcherPolicy,
+    // Telegram file URLs are already constrained to api.telegram.org by policy below.
+    // Keep the transport-owned fetch so proxy routing and sticky IPv4 fallback survive.
+    fetchImpl: params.transport.fetch,
     filePathHint: params.filePath,
     maxBytes: params.maxBytes,
     readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
+    pinDns: false,
     ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
   });
   const originalName = params.telegramFileName ?? fetched.fileName ?? params.filePath;

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -128,13 +128,13 @@ async function downloadAndSaveTelegramFile(params: {
   const url = `https://api.telegram.org/file/bot${params.token}/${params.filePath}`;
   const fetched = await fetchRemoteMedia({
     url,
-    // Telegram file URLs are already constrained to api.telegram.org by policy below.
-    // Keep the transport-owned fetch so proxy routing and sticky IPv4 fallback survive.
-    fetchImpl: params.transport.fetch,
+    // Run file downloads through the guarded source fetch so DNS pinning binds the
+    // actual socket connect to the IPs validated for api.telegram.org.
+    fetchImpl: params.transport.sourceFetch,
     filePathHint: params.filePath,
     maxBytes: params.maxBytes,
     readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
-    pinDns: false,
+    dispatcherPolicy: params.transport.pinnedDispatcherPolicy,
     ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
   });
   const originalName = params.telegramFileName ?? fetched.fileName ?? params.filePath;

--- a/src/telegram/native-command-routing.test.ts
+++ b/src/telegram/native-command-routing.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { extractTelegramNativeCommandToken } from "./native-command-routing.js";
+
+describe("extractTelegramNativeCommandToken", () => {
+  it("strips the matching @bot username from the leading command token", () => {
+    expect(
+      extractTelegramNativeCommandToken({
+        text: "/skill@OpenClaw_Bot summarize this",
+        botUsername: "openclaw_bot",
+      }),
+    ).toBe("skill");
+  });
+
+  it("preserves raw aliases instead of canonicalizing through normalizeCommandBody", () => {
+    expect(
+      extractTelegramNativeCommandToken({
+        text: "/t high",
+        botUsername: "openclaw_bot",
+      }),
+    ).toBe("t");
+  });
+
+  it("keeps unmatched bot mentions as part of the token", () => {
+    expect(
+      extractTelegramNativeCommandToken({
+        text: "/skill@OtherBot summarize this",
+        botUsername: "openclaw_bot",
+      }),
+    ).toBe("skill@otherbot");
+  });
+});

--- a/src/telegram/native-command-routing.test.ts
+++ b/src/telegram/native-command-routing.test.ts
@@ -28,4 +28,19 @@ describe("extractTelegramNativeCommandToken", () => {
       }),
     ).toBe("skill@otherbot");
   });
+
+  it("rejects commands that only become slash-prefixed after trimming leading whitespace", () => {
+    expect(
+      extractTelegramNativeCommandToken({
+        text: "  /skill demo_skill hello",
+        botUsername: "openclaw_bot",
+      }),
+    ).toBeNull();
+    expect(
+      extractTelegramNativeCommandToken({
+        text: "\n/demo_skill hello",
+        botUsername: "openclaw_bot",
+      }),
+    ).toBeNull();
+  });
 });

--- a/src/telegram/native-command-routing.ts
+++ b/src/telegram/native-command-routing.ts
@@ -1,8 +1,29 @@
-import { normalizeCommandBody } from "../auto-reply/commands-registry.js";
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { normalizeTelegramCommandName } from "../config/telegram-custom-commands.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
+
+function stripMatchingBotUsernameFromCommandToken(
+  commandToken: string,
+  botUsername?: string | null,
+): string {
+  const normalizedBotUsername = botUsername?.trim().toLowerCase();
+  if (!normalizedBotUsername) {
+    return commandToken;
+  }
+
+  const mentionSeparator = commandToken.indexOf("@");
+  if (mentionSeparator === -1) {
+    return commandToken;
+  }
+
+  const mentionedBotUsername = commandToken.slice(mentionSeparator + 1).trim().toLowerCase();
+  if (mentionedBotUsername !== normalizedBotUsername) {
+    return commandToken;
+  }
+
+  return commandToken.slice(0, mentionSeparator);
+}
 
 export function extractTelegramNativeCommandToken(params: {
   text?: string | null;
@@ -12,15 +33,15 @@ export function extractTelegramNativeCommandToken(params: {
   if (!trimmed || !trimmed.startsWith("/")) {
     return null;
   }
-  const normalizedBody = normalizeCommandBody(trimmed, {
-    botUsername: params.botUsername?.trim().toLowerCase(),
-  }).trim();
-  const commandMatch = normalizedBody.match(/^\/([^\s:]+)/);
-  const commandName = commandMatch?.[1]?.trim();
+
+  const commandName = trimmed.match(/^\/([^\s]+)/)?.[1]?.trim();
   if (!commandName) {
     return null;
   }
-  const normalizedName = normalizeTelegramCommandName(commandName);
+
+  const normalizedName = normalizeTelegramCommandName(
+    stripMatchingBotUsernameFromCommandToken(commandName, params.botUsername),
+  );
   return normalizedName || null;
 }
 

--- a/src/telegram/native-command-routing.ts
+++ b/src/telegram/native-command-routing.ts
@@ -29,12 +29,12 @@ export function extractTelegramNativeCommandToken(params: {
   text?: string | null;
   botUsername?: string | null;
 }): string | null {
-  const trimmed = params.text?.trim();
-  if (!trimmed || !trimmed.startsWith("/")) {
+  const text = params.text ?? "";
+  if (!text.startsWith("/")) {
     return null;
   }
 
-  const commandName = trimmed.match(/^\/([^\s]+)/)?.[1]?.trim();
+  const commandName = text.match(/^\/([^\s]+)/)?.[1]?.trim();
   if (!commandName) {
     return null;
   }

--- a/src/telegram/native-command-routing.ts
+++ b/src/telegram/native-command-routing.ts
@@ -1,0 +1,62 @@
+import { normalizeCommandBody } from "../auto-reply/commands-registry.js";
+import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
+import { normalizeTelegramCommandName } from "../config/telegram-custom-commands.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentRoute } from "../routing/resolve-route.js";
+
+export function extractTelegramNativeCommandToken(params: {
+  text?: string | null;
+  botUsername?: string | null;
+}): string | null {
+  const trimmed = params.text?.trim();
+  if (!trimmed || !trimmed.startsWith("/")) {
+    return null;
+  }
+  const normalizedBody = normalizeCommandBody(trimmed, {
+    botUsername: params.botUsername?.trim().toLowerCase(),
+  }).trim();
+  const commandMatch = normalizedBody.match(/^\/([^\s:]+)/);
+  const commandName = commandMatch?.[1]?.trim();
+  if (!commandName) {
+    return null;
+  }
+  const normalizedName = normalizeTelegramCommandName(commandName);
+  return normalizedName || null;
+}
+
+export function buildTelegramNativeSkillCommandNames(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  nativeEnabled: boolean;
+  nativeSkillsEnabled: boolean;
+}): Set<string> {
+  if (!params.nativeEnabled) {
+    return new Set();
+  }
+
+  const skillCommandNames = new Set(["skill"]);
+  if (!params.nativeSkillsEnabled) {
+    return skillCommandNames;
+  }
+
+  const boundRoute = resolveAgentRoute({
+    cfg: params.cfg,
+    channel: "telegram",
+    accountId: params.accountId,
+  });
+  if (!boundRoute) {
+    return skillCommandNames;
+  }
+
+  for (const command of listSkillCommandsForAgents({
+    cfg: params.cfg,
+    agentIds: [boundRoute.agentId],
+  })) {
+    const normalized = normalizeTelegramCommandName(command.name);
+    if (normalized) {
+      skillCommandNames.add(normalized);
+    }
+  }
+
+  return skillCommandNames;
+}


### PR DESCRIPTION
## Summary

- Problem: Telegram DM messages that matched `/skill ...` or `/<skill> ...` could still fall through the generic `bot.on("message")` path instead of staying with the native Telegram skill command handlers.
- Why it matters: native skill commands were getting routed to the default chat agent in DMs, which breaks the expected Telegram slash-command behavior from #45596.
- What changed: precompute the Telegram native skill command names (`skill` plus agent-scoped dynamic skill aliases) and short-circuit generic inbound message handling when those commands are detected.
- What did NOT change (scope boundary): this does not reroute unrelated Telegram native commands, custom commands, or plugin commands away from the generic message path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45596
- Related #45596

## User-visible / Behavior Changes

- Telegram DMs now leave `/skill ...` and dynamic `/<skill> ...` commands on the native Telegram skill-command path instead of sending them to the generic DM chat fallback.
- Unrelated Telegram commands such as `/status` keep their previous routing behavior.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows local dev machine
- Runtime/container: Node/Vitest local test run
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `commands.native=true`, `commands.nativeSkills=true`

### Steps

1. Configure Telegram native commands and native skill commands.
2. Send `/skill <name> ...` or `/<skill> ...` in a Telegram DM.
3. Observe whether the message is handled by native Telegram skill dispatch or by generic DM fallback.

### Expected

- Native Telegram skill commands stay on the native skill-command path.

### Actual

- Before this change, those DM messages could fall through to the generic DM message handler and get sent to the default chat agent.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification:

- `F:\openclaw\node_modules\.bin\vitest.cmd run src/telegram/bot.create-telegram-bot.test.ts -t "skips generic DM processing for Telegram native skill commands|keeps /skill on the generic message path when Telegram native commands are disabled|skips generic DM processing for /skill when Telegram native skills aliases are disabled|allows control commands with TG-prefixed groupAllowFrom entries"`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `/skill ...` and dynamic `/<skill> ...` DMs now skip generic DM processing when native Telegram skill commands are enabled.
- Edge cases checked: `/skill ...` still goes through the generic path when native Telegram commands are disabled; `/skill ...` still skips generic DM processing when native commands stay enabled but dynamic skill aliases are disabled; `/status` remains on its previous path.
- What you did **not** verify: a full clean Telegram suite run is still blocked by pre-existing unrelated failures in non-default-account DM routing and `channel_post` media-group tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `2b154d7d6862d8902bc65c790c53e3dbbb4deb34` or disable Telegram native commands via `commands.native: false`.
- Files/config to restore: `src/telegram/bot-handlers.ts`, `src/telegram/native-command-routing.ts`
- Known bad symptoms reviewers should watch for: unrelated Telegram commands being skipped from generic message handling.

## Risks and Mitigations

- Risk: Generic Telegram message handling could accidentally stop seeing non-skill commands.
- Mitigation: the skip set is intentionally limited to `skill` plus agent-scoped dynamic skill aliases, and focused regression tests cover `/status` plus disabled-native fallbacks.