### PR TITLE
fix: pass meta argument through RuntimeLogger methods in createRuntimeLogging

### DIFF
--- a/src/plugins/runtime/runtime-logging.test.ts
+++ b/src/plugins/runtime/runtime-logging.test.ts
@@ -8,7 +8,7 @@ describe("createRuntimeLogging", () => {
     vi.restoreAllMocks();
   });
 
-  it("passes meta through RuntimeLogger methods", () => {
+  it("passes structured meta as the first logger argument", () => {
     const debug = vi.fn();
     const info = vi.fn();
     const warn = vi.fn();
@@ -30,10 +30,37 @@ describe("createRuntimeLogging", () => {
     logger.warn("warn message", meta);
     logger.error("error message", meta);
 
-    expect(debug).toHaveBeenCalledWith("debug message", meta);
-    expect(info).toHaveBeenCalledWith("info message", meta);
-    expect(warn).toHaveBeenCalledWith("warn message", meta);
-    expect(error).toHaveBeenCalledWith("error message", meta);
+    expect(debug).toHaveBeenCalledWith(meta, "debug message");
+    expect(info).toHaveBeenCalledWith(meta, "info message");
+    expect(warn).toHaveBeenCalledWith(meta, "warn message");
+    expect(error).toHaveBeenCalledWith(meta, "error message");
+  });
+
+  it("omits the meta argument when no structured fields are provided", () => {
+    const debug = vi.fn();
+    const info = vi.fn();
+    const warn = vi.fn();
+    const error = vi.fn();
+
+    vi.spyOn(loggingModule, "getChildLogger").mockReturnValue({
+      debug,
+      info,
+      warn,
+      error,
+    } as unknown as ReturnType<typeof loggingModule.getChildLogger>);
+
+    const runtimeLogging = createRuntimeLogging();
+    const logger = runtimeLogging.getChildLogger({ plugin: "demo" });
+
+    logger.debug?.("debug message");
+    logger.info("info message", {});
+    logger.warn("warn message");
+    logger.error("error message", {});
+
+    expect(debug).toHaveBeenCalledWith("debug message");
+    expect(info).toHaveBeenCalledWith("info message");
+    expect(warn).toHaveBeenCalledWith("warn message");
+    expect(error).toHaveBeenCalledWith("error message");
   });
 
   it("re-exports shouldLogVerbose", () => {

--- a/src/plugins/runtime/runtime-logging.test.ts
+++ b/src/plugins/runtime/runtime-logging.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as globalsModule from "../../globals.js";
+import * as loggingModule from "../../logging.js";
+import { createRuntimeLogging } from "./runtime-logging.js";
+
+describe("createRuntimeLogging", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes meta through RuntimeLogger methods", () => {
+    const debug = vi.fn();
+    const info = vi.fn();
+    const warn = vi.fn();
+    const error = vi.fn();
+    const meta = { runId: "run-1", attempt: 2 };
+
+    vi.spyOn(loggingModule, "getChildLogger").mockReturnValue({
+      debug,
+      info,
+      warn,
+      error,
+    } as unknown as ReturnType<typeof loggingModule.getChildLogger>);
+
+    const runtimeLogging = createRuntimeLogging();
+    const logger = runtimeLogging.getChildLogger({ plugin: "demo" });
+
+    logger.debug?.("debug message", meta);
+    logger.info("info message", meta);
+    logger.warn("warn message", meta);
+    logger.error("error message", meta);
+
+    expect(debug).toHaveBeenCalledWith("debug message", meta);
+    expect(info).toHaveBeenCalledWith("info message", meta);
+    expect(warn).toHaveBeenCalledWith("warn message", meta);
+    expect(error).toHaveBeenCalledWith("error message", meta);
+  });
+
+  it("re-exports shouldLogVerbose", () => {
+    const runtimeLogging = createRuntimeLogging();
+    expect(runtimeLogging.shouldLogVerbose).toBe(globalsModule.shouldLogVerbose);
+  });
+});

--- a/src/plugins/runtime/runtime-logging.ts
+++ b/src/plugins/runtime/runtime-logging.ts
@@ -11,10 +11,10 @@ export function createRuntimeLogging(): PluginRuntime["logging"] {
         level: opts?.level ? normalizeLogLevel(opts.level) : undefined,
       });
       return {
-        debug: (message) => logger.debug?.(message),
-        info: (message) => logger.info(message),
-        warn: (message) => logger.warn(message),
-        error: (message) => logger.error(message),
+        debug: (message, meta) => logger.debug?.(message, meta),
+        info: (message, meta) => logger.info(message, meta),
+        warn: (message, meta) => logger.warn(message, meta),
+        error: (message, meta) => logger.error(message, meta),
       };
     },
   };

--- a/src/plugins/runtime/runtime-logging.ts
+++ b/src/plugins/runtime/runtime-logging.ts
@@ -3,6 +3,25 @@ import { getChildLogger } from "../../logging.js";
 import { normalizeLogLevel } from "../../logging/levels.js";
 import type { PluginRuntime } from "./types.js";
 
+function hasStructuredMeta(
+  meta: Record<string, unknown> | undefined,
+): meta is Record<string, unknown> {
+  return Boolean(meta && Object.keys(meta).length > 0);
+}
+
+function writeRuntimeLog(params: {
+  message: string;
+  meta: Record<string, unknown> | undefined;
+  writeMessage: (message: string) => void;
+  writeMeta: (meta: Record<string, unknown>, message: string) => void;
+}): void {
+  if (hasStructuredMeta(params.meta)) {
+    params.writeMeta(params.meta, params.message);
+    return;
+  }
+  params.writeMessage(params.message);
+}
+
 export function createRuntimeLogging(): PluginRuntime["logging"] {
   return {
     shouldLogVerbose,
@@ -11,10 +30,34 @@ export function createRuntimeLogging(): PluginRuntime["logging"] {
         level: opts?.level ? normalizeLogLevel(opts.level) : undefined,
       });
       return {
-        debug: (message, meta) => logger.debug?.(message, meta),
-        info: (message, meta) => logger.info(message, meta),
-        warn: (message, meta) => logger.warn(message, meta),
-        error: (message, meta) => logger.error(message, meta),
+        debug: (message, meta) =>
+          writeRuntimeLog({
+            message,
+            meta,
+            writeMessage: (m) => logger.debug?.(m),
+            writeMeta: (m, text) => logger.debug?.(m, text),
+          }),
+        info: (message, meta) =>
+          writeRuntimeLog({
+            message,
+            meta,
+            writeMessage: (m) => logger.info(m),
+            writeMeta: (m, text) => logger.info(m, text),
+          }),
+        warn: (message, meta) =>
+          writeRuntimeLog({
+            message,
+            meta,
+            writeMessage: (m) => logger.warn(m),
+            writeMeta: (m, text) => logger.warn(m, text),
+          }),
+        error: (message, meta) =>
+          writeRuntimeLog({
+            message,
+            meta,
+            writeMessage: (m) => logger.error(m),
+            writeMeta: (m, text) => logger.error(m, text),
+          }),
       };
     },
   };


### PR DESCRIPTION
## Problem

`createRuntimeLogging()` in `src/plugins/runtime/runtime-logging.ts` implements the `RuntimeLogger` interface but silently drops the `meta` argument from all four logger methods:

```ts
// Before (broken)
debug: (message) => logger.debug?.(message),
info:  (message) => logger.info(message),
warn:  (message) => logger.warn(message),
error: (message) => logger.error(message),
```

The `RuntimeLogger` type signature declares:

```ts
error: (message: string, meta?: Record<string, unknown>) => void;
```

So any structured metadata passed by plugins (e.g. error objects serialized as `{ err: ... }`) was silently discarded, making error diagnosis in plugin code impossible.

## Fix

Forward the `meta` argument to the underlying logger for all four methods:

```ts
// After (fixed)
debug: (message, meta) => logger.debug?.(message, meta),
info:  (message, meta) => logger.info(message, meta),
warn:  (message, meta) => logger.warn(message, meta),
error: (message, meta) => logger.error(message, meta),
```

## Impact

- No API change — `RuntimeLogger` interface is unchanged
- Plugins calling `logger.error("webhook failed", { err, statusCode })` will now see the metadata in logs
- Discovered while debugging a Teams channel `webhook failed` error where the actual `AADSTS7000229` cause was invisible in logs