### PR TITLE
fix(gateway): bound unanswered client requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,7 @@ Docs: https://docs.openclaw.ai
 
 - Dashboard/chat UI: stop reloading full chat history on every live tool result in dashboard v2 so tool-heavy runs no longer trigger UI freeze/re-render storms while the final event still refreshes persisted history. (#45541) Thanks @BunsDev.
 - Gateway/client requests: reject unanswered gateway RPC calls after a bounded timeout and clear their pending state, so stalled connections no longer leak hanging `GatewayClient.request()` promises indefinitely.
-- Telegram/webhook auth: validate the Telegram webhook secret before reading or parsing request bodies, so unauthenticated requests are rejected immediately instead of consuming up to 1 MB first. Thanks @space08.
 - Build/plugin-sdk bundling: bundle plugin-sdk subpath entries in one shared build pass so published packages stop duplicating shared chunks and avoid the recent plugin-sdk memory blow-up. (#45426) Thanks @TarasShyn.
-- Browser/existing-session: accept text-only `list_pages` and `new_page` responses from Chrome DevTools MCP so live-session tab discovery and new-tab open flows keep working when the server omits structured page metadata.
 - Ollama/reasoning visibility: stop promoting native `thinking` and `reasoning` fields into final assistant text so local reasoning models no longer leak internal thoughts in normal replies. (#45330) Thanks @xi7ang.
 - Android/onboarding QR scan: switch setup QR scanning to Google Code Scanner so onboarding uses a more reliable scanner instead of the legacy embedded ZXing flow. (#45021) Thanks @obviyus.
 - Browser/existing-session: accept text-only `list_pages` and `new_page` responses from Chrome DevTools MCP so live-session tab discovery and new-tab open flows keep working when the server omits structured page metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Dashboard/chat UI: stop reloading full chat history on every live tool result in dashboard v2 so tool-heavy runs no longer trigger UI freeze/re-render storms while the final event still refreshes persisted history. (#45541) Thanks @BunsDev.
+- Gateway/client requests: reject unanswered gateway RPC calls after a bounded timeout and clear their pending state, so stalled connections no longer leak hanging `GatewayClient.request()` promises indefinitely.
+- Telegram/webhook auth: validate the Telegram webhook secret before reading or parsing request bodies, so unauthenticated requests are rejected immediately instead of consuming up to 1 MB first. Thanks @space08.
+- Build/plugin-sdk bundling: bundle plugin-sdk subpath entries in one shared build pass so published packages stop duplicating shared chunks and avoid the recent plugin-sdk memory blow-up. (#45426) Thanks @TarasShyn.
+- Browser/existing-session: accept text-only `list_pages` and `new_page` responses from Chrome DevTools MCP so live-session tab discovery and new-tab open flows keep working when the server omits structured page metadata.
 - Ollama/reasoning visibility: stop promoting native `thinking` and `reasoning` fields into final assistant text so local reasoning models no longer leak internal thoughts in normal replies. (#45330) Thanks @xi7ang.
 - Android/onboarding QR scan: switch setup QR scanning to Google Code Scanner so onboarding uses a more reliable scanner instead of the legacy embedded ZXing flow. (#45021) Thanks @obviyus.
 - Browser/existing-session: accept text-only `list_pages` and `new_page` responses from Chrome DevTools MCP so live-session tab discovery and new-tab open flows keep working when the server omits structured page metadata.

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -18,6 +18,11 @@ let lastClientOptions: {
   onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
   onClose?: (code: number, reason: string) => void;
 } | null = null;
+let lastRequestOptions: {
+  method?: string;
+  params?: unknown;
+  opts?: { expectFinal?: boolean; timeoutMs?: number | null };
+} | null = null;
 type StartMode = "hello" | "close" | "silent";
 let startMode: StartMode = "hello";
 let closeCode = 1006;
@@ -45,7 +50,12 @@ vi.mock("./client.js", () => ({
     }) {
       lastClientOptions = opts;
     }
-    async request() {
+    async request(
+      method: string,
+      params: unknown,
+      opts?: { expectFinal?: boolean; timeoutMs?: number | null },
+    ) {
+      lastRequestOptions = { method, params, opts };
       return { ok: true };
     }
     start() {
@@ -72,6 +82,7 @@ function resetGatewayCallMocks() {
   pickPrimaryTailnetIPv4.mockClear();
   pickPrimaryLanIPv4.mockClear();
   lastClientOptions = null;
+  lastRequestOptions = null;
   startMode = "hello";
   closeCode = 1006;
   closeReason = "";
@@ -572,6 +583,15 @@ describe("callGateway error details", () => {
     await promise;
 
     expect(errMessage).toContain("gateway closed (1006");
+  });
+
+  it("forwards caller timeout to client requests", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    await callGateway({ method: "health", timeoutMs: 45_000 });
+
+    expect(lastRequestOptions?.method).toBe("health");
+    expect(lastRequestOptions?.opts?.timeoutMs).toBe(45_000);
   });
 
   it("fails fast when remote mode is missing remote url", async () => {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -594,6 +594,16 @@ describe("callGateway error details", () => {
     expect(lastRequestOptions?.opts?.timeoutMs).toBe(45_000);
   });
 
+  it("does not inject wrapper timeout defaults into expectFinal requests", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    await callGateway({ method: "health", expectFinal: true });
+
+    expect(lastRequestOptions?.method).toBe("health");
+    expect(lastRequestOptions?.opts?.expectFinal).toBe(true);
+    expect(lastRequestOptions?.opts?.timeoutMs).toBeUndefined();
+  });
+
   it("fails fast when remote mode is missing remote url", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -848,6 +848,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
           });
           const result = await client.request<T>(opts.method, opts.params, {
             expectFinal: opts.expectFinal,
+            timeoutMs,
           });
           ignoreClose = true;
           stop(undefined, result);

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -848,7 +848,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
           });
           const result = await client.request<T>(opts.method, opts.params, {
             expectFinal: opts.expectFinal,
-            timeoutMs,
+            timeoutMs: opts.timeoutMs,
           });
           ignoreClose = true;
           stop(undefined, result);

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -710,7 +710,7 @@ export class GatewayClient {
   async request<T = Record<string, unknown>>(
     method: string,
     params?: unknown,
-    opts?: { expectFinal?: boolean },
+    opts?: { expectFinal?: boolean; timeoutMs?: number | null },
   ): Promise<T> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new Error("gateway not connected");
@@ -723,11 +723,22 @@ export class GatewayClient {
       );
     }
     const expectFinal = opts?.expectFinal === true;
+    const timeoutMs =
+      opts?.timeoutMs === null
+        ? null
+        : typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
+          ? Math.max(1, opts.timeoutMs)
+          : expectFinal
+            ? null
+            : this.requestTimeoutMs;
     const p = new Promise<T>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`gateway request timeout for ${method}`));
-      }, this.requestTimeoutMs);
+      const timeout =
+        timeoutMs === null
+          ? null
+          : setTimeout(() => {
+              this.pending.delete(id);
+              reject(new Error(`gateway request timeout for ${method}`));
+            }, timeoutMs);
       this.pending.set(id, {
         resolve: (value) => resolve(value as T),
         reject,

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -44,6 +44,7 @@ type Pending = {
   resolve: (value: unknown) => void;
   reject: (err: unknown) => void;
   expectFinal: boolean;
+  timeout: NodeJS.Timeout | null;
 };
 
 type GatewayClientErrorShape = {
@@ -78,6 +79,7 @@ export type GatewayClientOptions = {
   url?: string; // ws://127.0.0.1:18789
   connectDelayMs?: number;
   tickWatchMinIntervalMs?: number;
+  requestTimeoutMs?: number;
   token?: string;
   bootstrapToken?: string;
   deviceToken?: string;
@@ -136,6 +138,7 @@ export class GatewayClient {
   private lastTick: number | null = null;
   private tickIntervalMs = 30_000;
   private tickTimer: NodeJS.Timeout | null = null;
+  private readonly requestTimeoutMs: number;
 
   constructor(opts: GatewayClientOptions) {
     this.opts = {
@@ -145,6 +148,10 @@ export class GatewayClient {
           ? undefined
           : (opts.deviceIdentity ?? loadOrCreateDeviceIdentity()),
     };
+    this.requestTimeoutMs =
+      typeof opts.requestTimeoutMs === "number" && Number.isFinite(opts.requestTimeoutMs)
+        ? Math.max(1, opts.requestTimeoutMs)
+        : 30_000;
   }
 
   start() {
@@ -586,6 +593,9 @@ export class GatewayClient {
           return;
         }
         this.pending.delete(parsed.id);
+        if (pending.timeout) {
+          clearTimeout(pending.timeout);
+        }
         if (parsed.ok) {
           pending.resolve(parsed.payload);
         } else {
@@ -638,6 +648,9 @@ export class GatewayClient {
 
   private flushPendingErrors(err: Error) {
     for (const [, p] of this.pending) {
+      if (p.timeout) {
+        clearTimeout(p.timeout);
+      }
       p.reject(err);
     }
     this.pending.clear();
@@ -711,10 +724,15 @@ export class GatewayClient {
     }
     const expectFinal = opts?.expectFinal === true;
     const p = new Promise<T>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`gateway request timeout for ${method}`));
+      }, this.requestTimeoutMs);
       this.pending.set(id, {
         resolve: (value) => resolve(value as T),
         reject,
         expectFinal,
+        timeout,
       });
     });
     this.ws.send(JSON.stringify(frame));

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -727,7 +727,7 @@ export class GatewayClient {
       opts?.timeoutMs === null
         ? null
         : typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
-          ? Math.max(1, opts.timeoutMs)
+          ? Math.max(1, Math.min(Math.floor(opts.timeoutMs), 2_147_483_647))
           : expectFinal
             ? null
             : this.requestTimeoutMs;

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -150,7 +150,7 @@ export class GatewayClient {
     };
     this.requestTimeoutMs =
       typeof opts.requestTimeoutMs === "number" && Number.isFinite(opts.requestTimeoutMs)
-        ? Math.max(1, opts.requestTimeoutMs)
+        ? Math.max(1, Math.min(Math.floor(opts.requestTimeoutMs), 2_147_483_647))
         : 30_000;
   }
 

--- a/src/gateway/client.watchdog.test.ts
+++ b/src/gateway/client.watchdog.test.ts
@@ -1,7 +1,7 @@
 import { createServer as createHttpsServer } from "node:https";
 import { createServer } from "node:net";
-import { afterEach, describe, expect, test } from "vitest";
-import { WebSocketServer } from "ws";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
 import { rawDataToString } from "../infra/ws.js";
 import { GatewayClient } from "./client.js";
 
@@ -84,6 +84,34 @@ describe("GatewayClient", () => {
       expect(res.reason).toContain("tick timeout");
     }
   }, 4000);
+
+  test("times out unresolved requests and clears pending state", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new GatewayClient({
+        requestTimeoutMs: 25,
+      });
+      const send = vi.fn();
+      (client as unknown as { ws: WebSocket | { readyState: number; send: () => void } }).ws = {
+        readyState: WebSocket.OPEN,
+        send,
+      };
+
+      const requestPromise = client.request("status");
+      const requestExpectation = expect(requestPromise).rejects.toThrow(
+        "gateway request timeout for status",
+      );
+      expect(send).toHaveBeenCalledTimes(1);
+      expect((client as unknown as { pending: Map<string, unknown> }).pending.size).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      await requestExpectation;
+      expect((client as unknown as { pending: Map<string, unknown> }).pending.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   test("rejects mismatched tls fingerprint", async () => {
     const key = [

--- a/src/gateway/client.watchdog.test.ts
+++ b/src/gateway/client.watchdog.test.ts
@@ -113,6 +113,47 @@ describe("GatewayClient", () => {
     }
   });
 
+  test("does not auto-timeout expectFinal requests", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new GatewayClient({
+        requestTimeoutMs: 25,
+      });
+      const send = vi.fn();
+      (
+        client as unknown as {
+          ws: WebSocket | { readyState: number; send: () => void; close: () => void };
+        }
+      ).ws = {
+        readyState: WebSocket.OPEN,
+        send,
+        close: vi.fn(),
+      };
+
+      let settled = false;
+      const requestPromise = client.request("chat.send", undefined, { expectFinal: true });
+      void requestPromise.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      expect(send).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      expect(settled).toBe(false);
+      expect((client as unknown as { pending: Map<string, unknown> }).pending.size).toBe(1);
+
+      client.stop();
+      await expect(requestPromise).rejects.toThrow("gateway client stopped");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("rejects mismatched tls fingerprint", async () => {
     const key = [
       "-----BEGIN PRIVATE KEY-----", // pragma: allowlist secret

--- a/src/gateway/client.watchdog.test.ts
+++ b/src/gateway/client.watchdog.test.ts
@@ -92,9 +92,14 @@ describe("GatewayClient", () => {
         requestTimeoutMs: 25,
       });
       const send = vi.fn();
-      (client as unknown as { ws: WebSocket | { readyState: number; send: () => void } }).ws = {
+      (
+        client as unknown as {
+          ws: WebSocket | { readyState: number; send: () => void; close: () => void };
+        }
+      ).ws = {
         readyState: WebSocket.OPEN,
         send,
+        close: vi.fn(),
       };
 
       const requestPromise = client.request("status");
@@ -143,6 +148,46 @@ describe("GatewayClient", () => {
       expect(send).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(25);
+
+      expect(settled).toBe(false);
+      expect((client as unknown as { pending: Map<string, unknown> }).pending.size).toBe(1);
+
+      client.stop();
+      await expect(requestPromise).rejects.toThrow("gateway client stopped");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("clamps oversized explicit request timeouts before scheduling", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new GatewayClient({
+        requestTimeoutMs: 25,
+      });
+      const send = vi.fn();
+      (
+        client as unknown as {
+          ws: WebSocket | { readyState: number; send: () => void; close: () => void };
+        }
+      ).ws = {
+        readyState: WebSocket.OPEN,
+        send,
+        close: vi.fn(),
+      };
+
+      let settled = false;
+      const requestPromise = client.request("status", undefined, { timeoutMs: 2_592_010_000 });
+      void requestPromise.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(1);
 
       expect(settled).toBe(false);
       expect((client as unknown as { pending: Map<string, unknown> }).pending.size).toBe(1);

--- a/src/gateway/client.watchdog.test.ts
+++ b/src/gateway/client.watchdog.test.ts
@@ -199,6 +199,46 @@ describe("GatewayClient", () => {
     }
   });
 
+  test("clamps oversized default request timeouts before scheduling", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new GatewayClient({
+        requestTimeoutMs: 2_592_010_000,
+      });
+      const send = vi.fn();
+      (
+        client as unknown as {
+          ws: WebSocket | { readyState: number; send: () => void; close: () => void };
+        }
+      ).ws = {
+        readyState: WebSocket.OPEN,
+        send,
+        close: vi.fn(),
+      };
+
+      let settled = false;
+      const requestPromise = client.request("status");
+      void requestPromise.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(settled).toBe(false);
+      expect((client as unknown as { pending: Map<string, unknown> }).pending.size).toBe(1);
+
+      client.stop();
+      await expect(requestPromise).rejects.toThrow("gateway client stopped");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("rejects mismatched tls fingerprint", async () => {
     const key = [
       "-----BEGIN PRIVATE KEY-----", // pragma: allowlist secret


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `GatewayClient.request()` could hang forever when the gateway never returned a response, leaving pending entries stuck indefinitely.
- Why it matters: stalled gateway RPCs can leak pending state and block higher-level flows that expect bounded failure instead of permanent hangs.
- What changed: added bounded timeout handling for normal request/response RPCs, clear pending timers on response and bulk flush paths, and added focused regression coverage for timeout cleanup and `expectFinal` behavior.
- What did NOT change (scope boundary): this PR does not change tick-timeout flushing or reconnect retry policy; those remain follow-up issues.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45466
- Related #45468
- Related #45469

## User-visible / Behavior Changes

- Unanswered non-`expectFinal` gateway RPCs now fail with a timeout instead of hanging forever.
- `expectFinal: true` flows remain unbounded by default unless a caller explicitly opts into a timeout.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/vitest in repo worktree
- Model/provider: n/a
- Integration/channel (if any): gateway client
- Relevant config (redacted): default `GatewayClient` options plus test-only `requestTimeoutMs`

### Steps

1. Create a `GatewayClient` with an open socket stub and issue a request that never receives a response.
2. Advance fake timers past the configured request timeout.
3. Verify the request rejects and the pending entry is removed.
4. Issue an `expectFinal: true` request under the same default timeout and verify it does not auto-timeout.

### Expected

- Normal unanswered requests reject after a bounded timeout and clear pending state.
- `expectFinal` requests are not implicitly capped by the default timeout.

### Actual

- Verified with focused regression tests after the patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted watchdog tests for timed-out unanswered requests and non-timeout `expectFinal` requests.
- Edge cases checked: pending-map cleanup on timeout; timer cleanup on forced `client.stop()` after an `expectFinal` request remains pending.
- What you did **not** verify: full repo CI triage, tick-timeout disconnect behavior, and reconnect policy changes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert PR #45689 or set a caller-specific `timeoutMs: null`/`expectFinal: true` where unbounded waiting is required.
- Files/config to restore: `src/gateway/client.ts`, `src/gateway/client.watchdog.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: legitimate non-`expectFinal` RPCs timing out too aggressively if a caller relies on the 30s default and actually needs a longer timeout.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some normal RPCs may legitimately need longer than the default timeout.
  - Mitigation: callers can pass an explicit `timeoutMs`, and `expectFinal` requests are no longer implicitly capped.
