### PR TITLE
fix(line): use configured field in collectStatusIssues instead of raw token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - macOS/local gateway: stop OpenClaw.app from killing healthy local gateway listeners after startup by recognizing the current `openclaw-gateway` process title and using the current `openclaw gateway` launch shape.
 - Memory/QMD: resolve slugified `memory_search` file hints back to the indexed filesystem path before returning search hits, so `memory_get` works again for mixed-case and spaced paths. (#50313) Thanks @erra9x.
 - Security/LINE: make webhook signature validation run the timing-safe compare even when the supplied signature length is wrong, closing a small timing side-channel. (#55663) Thanks @gavyngong.
+- LINE/status: stop `openclaw status` from warning about missing credentials when sanitized LINE snapshots are already configured, while still surfacing whether the missing field is the token or secret. (#45701) Thanks @tamaosamu.
 
 ## 2026.3.28-beta.1
 

--- a/extensions/line/src/channel.status.test.ts
+++ b/extensions/line/src/channel.status.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { ChannelAccountSnapshot } from "../api.js";
+import { linePlugin } from "./channel.js";
+
+function collectIssues(accounts: ChannelAccountSnapshot[]) {
+  const collect = linePlugin.status?.collectStatusIssues;
+  if (!collect) {
+    throw new Error("LINE plugin status collector is unavailable");
+  }
+  return collect(accounts);
+}
+
+describe("linePlugin status.collectStatusIssues", () => {
+  it("does not warn when a sanitized snapshot is configured", () => {
+    expect(
+      collectIssues([
+        {
+          accountId: "default",
+          configured: true,
+          tokenSource: "env",
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("reports missing access token when the snapshot is unconfigured and tokenSource is none", () => {
+    expect(
+      collectIssues([
+        {
+          accountId: "default",
+          configured: false,
+          tokenSource: "none",
+        },
+      ]),
+    ).toEqual([
+      {
+        channel: "line",
+        accountId: "default",
+        kind: "config",
+        message: "LINE channel access token not configured",
+      },
+    ]);
+  });
+
+  it("reports missing secret when the snapshot is unconfigured but a token source exists", () => {
+    expect(
+      collectIssues([
+        {
+          accountId: "default",
+          configured: false,
+          tokenSource: "env",
+        },
+      ]),
+    ).toEqual([
+      {
+        channel: "line",
+        accountId: "default",
+        kind: "config",
+        message: "LINE channel secret not configured",
+      },
+    ]);
+  });
+});

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -83,20 +83,15 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = createChatChannelP
         const issues: ChannelStatusIssue[] = [];
         for (const account of accounts) {
           const accountId = account.accountId ?? DEFAULT_ACCOUNT_ID;
-          if (!account.channelAccessToken?.trim()) {
+          if (account.configured === false) {
+            const hasToken = account.tokenSource != null && account.tokenSource !== "none";
             issues.push({
               channel: "line",
               accountId,
               kind: "config",
-              message: "LINE channel access token not configured",
-            });
-          }
-          if (!account.channelSecret?.trim()) {
-            issues.push({
-              channel: "line",
-              accountId,
-              kind: "config",
-              message: "LINE channel secret not configured",
+              message: hasToken
+                ? "LINE channel secret not configured"
+                : "LINE channel access token not configured",
             });
           }
         }
@@ -520,5 +515,4 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = createChatChannelP
           accountId: accountId ?? undefined,
         }),
     }),
-  },
 });

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -515,4 +515,5 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = createChatChannelP
           accountId: accountId ?? undefined,
         }),
     }),
+  },
 });


### PR DESCRIPTION
## Summary

Fix `openclaw status` always showing LINE as WARN with "LINE channel access token not configured" even when the token is valid.

## Root Cause

`collectStatusIssues` checked `account.channelAccessToken?.trim()` on the snapshot object, but `projectSafeChannelAccountSnapshotFields` intentionally strips sensitive fields like `channelAccessToken` from snapshots for security. This means `channelAccessToken` was always `undefined` in the snapshot, causing a false WARN.

## Fix

Replace the raw `channelAccessToken` / `channelSecret` checks with `account.configured === false`, which is already computed by `buildChannelAccountSnapshot` and correctly reflects whether credentials are present. This is consistent with how other channels (e.g. Telegram via `resolveEnabledConfiguredAccountId`) implement their status checks.

## Before
```
│ LINE │ ON │ WARN │ LINE channel access token not configured │
```
(even with valid token, successful API probe, and working bot)

## After
LINE shows OK when credentials are properly configured.

Fixes #45693