### PR TITLE
fix(ui): restore scrollbar visibility and fix Firefox support

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -107,11 +107,18 @@
   --duration-normal: 180ms;
   --duration-slow: 300ms;
 
+  /* Scrollbar thumb */
+  --scrollbar-thumb: rgba(255, 255, 255, 0.12);
+  --scrollbar-thumb-hover: rgba(255, 255, 255, 0.2);
+
   color-scheme: dark;
 }
 
 /* Light theme tokens apply to every light-mode family. */
 :root[data-theme-mode="light"] {
+  --scrollbar-thumb: rgba(0, 0, 0, 0.12);
+  --scrollbar-thumb-hover: rgba(0, 0, 0, 0.2);
+
   --bg: #f8f9fa;
   --bg-accent: #f1f3f5;
   --bg-elevated: #ffffff;
@@ -311,8 +318,8 @@ select {
 
 /* Scrollbar styling - Minimal, barely visible */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
@@ -320,12 +327,18 @@ select {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--scrollbar-thumb);
   border-radius: var(--radius-full);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.14);
+  background: var(--scrollbar-thumb-hover);
+}
+
+/* Firefox support */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 
 /* Animations - Polished with spring feel */

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -336,7 +336,7 @@ select {
 }
 
 /* Firefox support */
-* {
+:root {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) transparent;
 }

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -13,7 +13,6 @@
   border: 1px solid var(--border);
   background: var(--panel);
   overflow: hidden;
-  overflow: clip;
   animation: config-enter 0.3s var(--ease-out);
 }
 
@@ -177,8 +176,6 @@
   min-width: 0;
   background: var(--panel);
   overflow: hidden;
-  /* fallback for older browsers */
-  overflow: clip;
 }
 
 /* Actions Bar */


### PR DESCRIPTION
## Summary
This PR fixes the issue where scrollbars were missing or invisible in the v3 UI (#45695).

### Changes:
- **Visibility**: Increased scrollbar width to 8px and improved thumb color visibility in both Light and Dark modes.
- **Firefox Support**: Added global Firefox support using 'scrollbar-width: thin' and 'scrollbar-color'.
- **Layout Fix**: Replaced 'overflow: clip' with 'overflow: hidden' in the config layout. 'overflow: clip' was preventing scrolling mechanisms on some containers.

Fixes #45695