### PR TITLE
fix(ui): restore usage tab custom header layout

### DIFF
--- a/ui/src/ui/app-render.test.ts
+++ b/ui/src/ui/app-render.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { __test as appRenderTest } from "./app-render.ts";
+
+describe("shouldRenderSharedPageHeader", () => {
+  it("renders the shared header for standard non-chat tabs", () => {
+    expect(appRenderTest.shouldRenderSharedPageHeader("overview", false)).toBe(true);
+    expect(appRenderTest.shouldRenderSharedPageHeader("sessions", false)).toBe(true);
+  });
+
+  it("keeps usage on its dedicated in-view header", () => {
+    expect(appRenderTest.shouldRenderSharedPageHeader("usage", false)).toBe(false);
+  });
+
+  it("skips the shared header for chat and config special cases", () => {
+    expect(appRenderTest.shouldRenderSharedPageHeader("chat", true)).toBe(false);
+    expect(appRenderTest.shouldRenderSharedPageHeader("config", false)).toBe(false);
+  });
+});

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -179,7 +179,7 @@ function uniquePreserveOrder(values: string[]): string[] {
 }
 
 function shouldRenderSharedPageHeader(tab: Tab, isChat: boolean): boolean {
-  // Keep Usage on its dedicated in-view hero header to match the v2026.3.11 layout.
+  // Usage owns its in-view hero header; chat and config already use custom header paths.
   return !isChat && tab !== "config" && tab !== "usage";
 }
 
@@ -614,7 +614,10 @@ export function renderApp(state: AppViewState) {
             : isChat
               ? html`<section class="content-header">
                   <div>${renderChatSessionSelect(state)}</div>
-                  <div class="page-meta">${renderChatControls(state)}</div>
+                  <div class="page-meta">
+                    ${state.lastError ? html`<div class="pill danger">${state.lastError}</div>` : nothing}
+                    ${renderChatControls(state)}
+                  </div>
                 </section>`
               : nothing
         }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -78,7 +78,13 @@ import {
 import "./components/dashboard-header.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
-import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import {
+  normalizeBasePath,
+  TAB_GROUPS,
+  subtitleForTab,
+  titleForTab,
+  type Tab,
+} from "./navigation.ts";
 import { agentLogoUrl } from "./views/agents-utils.ts";
 import {
   resolveAgentConfig,
@@ -171,6 +177,15 @@ function uniquePreserveOrder(values: string[]): string[] {
   }
   return output;
 }
+
+function shouldRenderSharedPageHeader(tab: Tab, isChat: boolean): boolean {
+  // Keep Usage on its dedicated in-view hero header to match the v2026.3.11 layout.
+  return !isChat && tab !== "config" && tab !== "usage";
+}
+
+export const __test = {
+  shouldRenderSharedPageHeader,
+};
 
 type DismissedUpdateBanner = {
   latestVersion: string;
@@ -586,22 +601,22 @@ export function renderApp(state: AppViewState) {
             : nothing
         }
         ${
-          state.tab === "config"
-            ? nothing
-            : html`<section class="content-header">
+          shouldRenderSharedPageHeader(state.tab, isChat)
+            ? html`<section class="content-header">
               <div>
-                ${
-                  isChat
-                    ? renderChatSessionSelect(state)
-                    : html`<div class="page-title">${titleForTab(state.tab)}</div>`
-                }
-                ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
+                <div class="page-title">${titleForTab(state.tab)}</div>
+                <div class="page-sub">${subtitleForTab(state.tab)}</div>
               </div>
               <div class="page-meta">
                 ${state.lastError ? html`<div class="pill danger">${state.lastError}</div>` : nothing}
-                ${isChat ? renderChatControls(state) : nothing}
               </div>
             </section>`
+            : isChat
+              ? html`<section class="content-header">
+                  <div>${renderChatSessionSelect(state)}</div>
+                  <div class="page-meta">${renderChatControls(state)}</div>
+                </section>`
+              : nothing
         }
 
         ${

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { __test as appRenderTest } from "../app-render.ts";
 import {
   agentLogoUrl,
   resolveConfiguredCronModelSuggestions,
@@ -130,21 +129,5 @@ describe("resolveAgentAvatarUrl", () => {
   it("returns null for initials or emoji avatar values without a URL", () => {
     expect(resolveAgentAvatarUrl({ identity: { avatar: "A" } })).toBeNull();
     expect(resolveAgentAvatarUrl({ identity: { avatar: "🦞" } })).toBeNull();
-  });
-});
-
-describe("shouldRenderSharedPageHeader", () => {
-  it("renders the shared header for standard non-chat tabs", () => {
-    expect(appRenderTest.shouldRenderSharedPageHeader("overview", false)).toBe(true);
-    expect(appRenderTest.shouldRenderSharedPageHeader("sessions", false)).toBe(true);
-  });
-
-  it("keeps usage on its dedicated in-view header", () => {
-    expect(appRenderTest.shouldRenderSharedPageHeader("usage", false)).toBe(false);
-  });
-
-  it("skips the shared header for chat and config special cases", () => {
-    expect(appRenderTest.shouldRenderSharedPageHeader("chat", true)).toBe(false);
-    expect(appRenderTest.shouldRenderSharedPageHeader("config", false)).toBe(false);
   });
 });

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { __test as appRenderTest } from "../app-render.ts";
 import {
   agentLogoUrl,
   resolveConfiguredCronModelSuggestions,
@@ -129,5 +130,21 @@ describe("resolveAgentAvatarUrl", () => {
   it("returns null for initials or emoji avatar values without a URL", () => {
     expect(resolveAgentAvatarUrl({ identity: { avatar: "A" } })).toBeNull();
     expect(resolveAgentAvatarUrl({ identity: { avatar: "🦞" } })).toBeNull();
+  });
+});
+
+describe("shouldRenderSharedPageHeader", () => {
+  it("renders the shared header for standard non-chat tabs", () => {
+    expect(appRenderTest.shouldRenderSharedPageHeader("overview", false)).toBe(true);
+    expect(appRenderTest.shouldRenderSharedPageHeader("sessions", false)).toBe(true);
+  });
+
+  it("keeps usage on its dedicated in-view header", () => {
+    expect(appRenderTest.shouldRenderSharedPageHeader("usage", false)).toBe(false);
+  });
+
+  it("skips the shared header for chat and config special cases", () => {
+    expect(appRenderTest.shouldRenderSharedPageHeader("chat", true)).toBe(false);
+    expect(appRenderTest.shouldRenderSharedPageHeader("config", false)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: `v2026.3.12` started rendering the shared shell page header on the Usage tab again, so the tab showed both the shell `Usage` title/subtitle and the existing in-view Usage hero.
- Why it matters: the duplicated header regressed the v2 Usage page layout reported in #45709.
- What changed: restore the `v2026.3.11` behavior by skipping the shared shell header on the Usage tab while keeping the existing Usage view header, and add a regression test for that special case.
- What did NOT change (scope boundary): no new Usage layout was introduced; this is only reverting the shared header behavior for `usage` back to what `v2026.3.11` already did.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45709
- Related #41503

## User-visible / Behavior Changes

- The Usage tab no longer shows the duplicated `Usage` title/subtitle introduced in `v2026.3.12`.
- The page now matches the pre-regression `v2026.3.11` behavior, where only the Usage view's own header is shown.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS Sequoia 15 / darwin 25.3.0
- Runtime/container: Node 22+, pnpm 10.23.0
- Model/provider: n/a
- Integration/channel (if any): Control UI / v2 Usage tab
- Relevant config (redacted): n/a

### Steps

1. Open the v2 Control UI Usage tab.
2. Compare the top-of-page header rendering in `v2026.3.12` vs the prior `v2026.3.11` behavior described in #45709.
3. Confirm the shared shell `page-title/page-sub` header is suppressed for `usage`, leaving only the Usage view header.

### Expected

- The Usage tab renders a single header, matching the pre-regression layout.

### Actual

- Before this fix, `v2026.3.12` rendered both the shared shell header and the Usage view header, duplicating the title/subtitle.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted regression test added in `ui/src/ui/views/agents-utils.test.ts`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the `v2026.3.11` and `v2026.3.12` render paths locally, restored the old Usage special-case in `ui/src/ui/app-render.ts`, and ran `pnpm test -- ui/src/ui/views/agents-utils.test.ts`.
- Edge cases checked: chat still uses its session selector header path; config still omits the shared shell header.
- What you did **not** verify: I did not capture a fresh browser screenshot for the PR; this change intentionally restores the existing `v2026.3.11` behavior already reflected by the issue report.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to return to the `v2026.3.12` shared-header behavior.
- Files/config to restore: `ui/src/ui/app-render.ts`
- Known bad symptoms reviewers should watch for: the Usage tab title/subtitle appearing twice again.

## Risks and Mitigations

- Risk: the shared header special-case could accidentally affect another tab's header handling.
- Mitigation: the logic is limited to `usage`, and the regression test also covers the existing `chat` and `config` special cases.

AI-assisted: yes.
Testing: targeted test passed; `pnpm build` passed. `pnpm check` and `pnpm test` currently fail in this branch due unrelated existing repo issues outside this change (for example `src/infra/outbound/deliver.test.ts`, `extensions/irc/src/config-schema.ts`, `src/cli/daemon-cli/status.test.ts`).
Codex review: `codex` CLI is not installed in this environment, so that step could not be run.

Made with [Cursor](https://cursor.com)