### PR TITLE
fix(agents): expand ~ in tool file paths to OS home directory

### DIFF
--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 
 export type RequiredParamGroup = {
@@ -95,6 +97,13 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   if ("file_path" in normalized && !("path" in normalized)) {
     normalized.path = normalized.file_path;
     delete normalized.file_path;
+  }
+  // Expand ~ to the OS account home dir. Must use OS home (HOME/USERPROFILE/os.homedir)
+  // rather than resolveEffectiveHomeDir, which prefers OPENCLAW_HOME and would send
+  // tool file paths into the app-state directory instead of the user's home.
+  if (typeof normalized.path === "string" && normalized.path.startsWith("~")) {
+    const osHome = process.env.HOME || process.env.USERPROFILE || os.homedir();
+    normalized.path = expandHomePrefix(normalized.path, { home: osHome });
   }
   // old_string → oldText (edit)
   if ("old_string" in normalized && !("oldText" in normalized)) {

--- a/src/agents/tilde-expansion.test.ts
+++ b/src/agents/tilde-expansion.test.ts
@@ -1,0 +1,31 @@
+import os from "node:os";
+import { describe, expect, it } from "vitest";
+import { normalizeToolParams } from "./pi-tools.params.js";
+
+describe("normalizeToolParams tilde expansion", () => {
+  it("expands ~ in path parameter", () => {
+    const home = os.homedir();
+    const params = { path: "~/.ssh/config" };
+    const normalized = normalizeToolParams(params);
+    expect(normalized?.path).toBe(`${home}/.ssh/config`);
+  });
+
+  it("expands ~ in file_path parameter (aliased to path)", () => {
+    const home = os.homedir();
+    const params = { file_path: "~/Documents/notes.txt" };
+    const normalized = normalizeToolParams(params);
+    expect(normalized?.path).toBe(`${home}/Documents/notes.txt`);
+  });
+
+  it("does not expand ~ if it is not at the start of the path", () => {
+    const params = { path: "/some/path/~middle" };
+    const normalized = normalizeToolParams(params);
+    expect(normalized?.path).toBe("/some/path/~middle");
+  });
+
+  it("handles paths without tilde", () => {
+    const params = { path: "/etc/hosts" };
+    const normalized = normalizeToolParams(params);
+    expect(normalized?.path).toBe("/etc/hosts");
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #30669.

When an AI model emits tool calls with `~/...` file paths (e.g. `path: "~/.ssh/config"`), the Edit/Write/Read tools receive the literal `~` and fail to resolve it. Users see "file not found" errors for paths that clearly exist.

## Fix

`normalizeToolParams` now expands a leading `~` in `path`/`file_path` parameters to the OS account home directory using `HOME`/`USERPROFILE`/`os.homedir()`. Deliberately avoids `resolveEffectiveHomeDir` which prefers `OPENCLAW_HOME` (used for app-state isolation) — tool file paths should resolve to the user's actual home.

## Test plan

- [x] `pnpm test` — 4 cases in `tilde-expansion.test.ts` (path, file_path alias, non-leading ~, plain path)
- [x] `pnpm build` and `pnpm check` pass locally