### PR TITLE
feat(web-search): add Brave Search baseUrl config override

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { withEnv } from "../../test-utils/env.js";
+import { BRAVE_SEARCH_ENDPOINT, resolveBraveEndpoint } from "./web-search.js";
 import { __testing } from "./web-search.js";
 
 const {
@@ -33,6 +34,35 @@ const perplexityApiKeyEnv = ["PERPLEXITY_API", "KEY"].join("_");
 const openRouterPerplexityApiKey = ["sk", "or", "v1", "test"].join("-");
 const directPerplexityApiKey = ["pplx", "test"].join("-");
 const enterprisePerplexityApiKey = ["enterprise", "perplexity", "test"].join("-");
+
+describe("resolveBraveEndpoint", () => {
+  it("returns the default endpoint when baseUrl is undefined", () => {
+    expect(resolveBraveEndpoint(undefined)).toBe(BRAVE_SEARCH_ENDPOINT);
+  });
+
+  it("returns the default endpoint when baseUrl is empty or whitespace", () => {
+    expect(resolveBraveEndpoint("")).toBe(BRAVE_SEARCH_ENDPOINT);
+    expect(resolveBraveEndpoint("   ")).toBe(BRAVE_SEARCH_ENDPOINT);
+  });
+
+  it("uses the custom baseUrl when provided", () => {
+    expect(resolveBraveEndpoint("https://proxy.example.com/brave")).toBe(
+      "https://proxy.example.com/brave",
+    );
+  });
+
+  it("strips trailing slash from custom baseUrl", () => {
+    expect(resolveBraveEndpoint("https://proxy.example.com/brave/")).toBe(
+      "https://proxy.example.com/brave",
+    );
+  });
+
+  it("trims whitespace from custom baseUrl", () => {
+    expect(resolveBraveEndpoint("  https://proxy.example.com/brave  ")).toBe(
+      "https://proxy.example.com/brave",
+    );
+  });
+});
 
 describe("web_search perplexity compatibility routing", () => {
   it("detects API key prefixes", () => {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -26,7 +26,12 @@ const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as co
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
-const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
+export const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
+
+/** Resolve the Brave Search API endpoint, falling back to the default. */
+export function resolveBraveEndpoint(baseUrl: string | undefined): string {
+  return (baseUrl?.trim() || BRAVE_SEARCH_ENDPOINT).replace(/\/$/, "");
+}
 const BRAVE_LLM_CONTEXT_ENDPOINT = "https://api.search.brave.com/res/v1/llm/context";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
@@ -1813,8 +1818,7 @@ async function runWebSearch(params: {
     return payload;
   }
 
-  const braveEndpoint = (params.braveBaseUrl?.trim() || BRAVE_SEARCH_ENDPOINT).replace(/\/$/, "");
-  const url = new URL(braveEndpoint);
+  const url = new URL(resolveBraveEndpoint(params.braveBaseUrl));
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -309,6 +309,7 @@ type BraveLlmContextResponse = {
 
 type BraveConfig = {
   mode?: string;
+  baseUrl?: string;
 };
 
 type PerplexityConfig = {
@@ -1603,18 +1604,21 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   braveMode?: "web" | "llm-context";
+  braveBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
   const providerSpecificKey =
-    params.provider === "perplexity"
-      ? `${params.perplexityTransport ?? "search_api"}:${params.perplexityBaseUrl ?? PERPLEXITY_DIRECT_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
-      : params.provider === "grok"
-        ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
-        : params.provider === "gemini"
-          ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
-          : params.provider === "kimi"
-            ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-            : "";
+    params.provider === "brave"
+      ? (params.braveBaseUrl?.trim() ?? "")
+      : params.provider === "perplexity"
+        ? `${params.perplexityTransport ?? "search_api"}:${params.perplexityBaseUrl ?? PERPLEXITY_DIRECT_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
+        : params.provider === "grok"
+          ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
+          : params.provider === "gemini"
+            ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
+            : params.provider === "kimi"
+              ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
+              : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
       ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
@@ -1809,7 +1813,8 @@ async function runWebSearch(params: {
     return payload;
   }
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  const braveEndpoint = (params.braveBaseUrl?.trim() || BRAVE_SEARCH_ENDPOINT).replace(/\/$/, "");
+  const url = new URL(braveEndpoint);
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {
@@ -2186,6 +2191,7 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         braveMode,
+        braveBaseUrl: braveConfig.baseUrl?.trim() || undefined,
       });
       return jsonResult(result);
     },

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -471,6 +471,8 @@ export type ToolsConfig = {
       brave?: {
         /** Brave Search mode: "web" (standard results) or "llm-context" (pre-extracted page content). Default: "web". */
         mode?: "web" | "llm-context";
+        /** Base URL override for Brave Search API (optional; useful for proxies or custom endpoints). */
+        baseUrl?: string;
       };
       /** Gemini-specific configuration (used when provider="gemini"). */
       gemini?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -312,6 +312,7 @@ export const ToolsWebSearchSchema = z
     brave: z
       .object({
         mode: z.union([z.literal("web"), z.literal("llm-context")]).optional(),
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Problem

Closes #45729.

Other web search providers (Kimi, Perplexity) already support `baseUrl` config overrides, but Brave Search is hardcoded to the default API endpoint. Users running self-hosted proxies or custom API gateways have no way to point the Brave provider at a different URL.

## Fix

Added `tools.web.search.brave.baseUrl` config option that overrides the default Brave Search endpoint. The custom URL is included in the cache key to prevent cross-endpoint result collisions. Follows the same pattern as existing Kimi/Perplexity `baseUrl` overrides.

## Changes

- `src/agents/tools/web-search.ts` — plumb `braveBaseUrl` through params, cache key, and fetch URL
- `src/config/types.tools.ts` — add `baseUrl?: string` to brave config type
- `src/config/zod-schema.agent-runtime.ts` — add `baseUrl` to Zod schema

## Test plan

- [x] `pnpm build` and `pnpm check` pass locally
- [x] Default behavior unchanged when `baseUrl` is not set
- [x] Config schema validates with and without `baseUrl`