### PR TITLE
Fix Ollama provider to stream tokens incrementally instead of buffering entire response

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -562,6 +562,9 @@ describe("createOllamaStreamFn", () => {
         expect(events[0]?.type).toBe("start");
         expect((events[0] as { partial: { content: unknown[] } }).partial.content).toEqual([]);
 
+        // `partial` is a single mutable reference shared across all text_delta events;
+        // only `delta` reliably reflects the per-chunk value. See the
+        // "text_delta partial accumulates content across chunks" test for details.
         expect(events[1]).toMatchObject({ type: "text_delta", delta: "hello", contentIndex: 0 });
         expect(events[2]).toMatchObject({ type: "text_delta", delta: " world", contentIndex: 0 });
 

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -620,6 +620,36 @@ describe("createOllamaStreamFn", () => {
       },
     );
   });
+
+  it("emits start and text_delta for mixed content + tool_call responses", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Let me check."},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":3}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        // start → text_delta → done
+        expect(events).toHaveLength(3);
+
+        expect(events[0]?.type).toBe("start");
+        expect((events[0] as { partial: { content: unknown[] } }).partial.content).toEqual([]);
+
+        expect(events[1]).toMatchObject({
+          type: "text_delta",
+          delta: "Let me check.",
+          contentIndex: 0,
+        });
+
+        const doneEvent = events[2] as { type: string; message: { stopReason: string } };
+        expect(doneEvent.type).toBe("done");
+        expect(doneEvent.message.stopReason).toBe("toolUse");
+      },
+    );
+  });
 });
 
 describe("resolveOllamaBaseUrlForRun", () => {

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -544,6 +544,79 @@ describe("createOllamaStreamFn", () => {
       [{ type: "text", text: "final answer" }],
     );
   });
+
+  it("emits start with empty content, then text_delta per chunk, then done", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"hello"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":" world"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        // start → text_delta → text_delta → done
+        expect(events).toHaveLength(4);
+
+        expect(events[0]?.type).toBe("start");
+        expect((events[0] as { partial: { content: unknown[] } }).partial.content).toEqual([]);
+
+        expect(events[1]).toMatchObject({ type: "text_delta", delta: "hello", contentIndex: 0 });
+        expect(events[2]).toMatchObject({ type: "text_delta", delta: " world", contentIndex: 0 });
+
+        expect(events[3]?.type).toBe("done");
+      },
+    );
+  });
+
+  it("does not emit start or text_delta for tool-call-only responses", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        // Only the final done event — no start or text_delta
+        expect(events).toHaveLength(1);
+        expect(events[0]?.type).toBe("done");
+        expect((events[0] as { message: { stopReason: string } }).message.stopReason).toBe(
+          "toolUse",
+        );
+      },
+    );
+  });
+
+  it("text_delta partial accumulates content across chunks", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"a"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"b"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"c"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":3}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        const deltas = events.filter(
+          (
+            e,
+          ): e is { type: "text_delta"; partial: { content: { type: string; text: string }[] } } =>
+            e.type === "text_delta",
+        );
+        expect(deltas).toHaveLength(3);
+
+        // The partial's content text should reflect accumulated state
+        // (using a single mutable object, so the final value wins)
+        const lastPartialText = deltas[2].partial.content[0]?.text;
+        expect(lastPartialText).toBe("abc");
+      },
+    );
+  });
 });
 
 describe("resolveOllamaBaseUrlForRun", () => {

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -562,9 +562,6 @@ describe("createOllamaStreamFn", () => {
         expect(events[0]?.type).toBe("start");
         expect((events[0] as { partial: { content: unknown[] } }).partial.content).toEqual([]);
 
-        // `partial` is a single mutable reference shared across all text_delta events;
-        // only `delta` reliably reflects the per-chunk value. See the
-        // "text_delta partial accumulates content across chunks" test for details.
         expect(events[1]).toMatchObject({ type: "text_delta", delta: "hello", contentIndex: 0 });
         expect(events[2]).toMatchObject({ type: "text_delta", delta: " world", contentIndex: 0 });
 
@@ -593,7 +590,7 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
-  it("text_delta partial accumulates content across chunks", async () => {
+  it("text_delta partial carries only the current chunk delta", async () => {
     await withMockNdjsonFetch(
       [
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":"a"},"done":false}',
@@ -613,10 +610,11 @@ describe("createOllamaStreamFn", () => {
         );
         expect(deltas).toHaveLength(3);
 
-        // The partial's content text should reflect accumulated state
-        // (using a single mutable object, so the final value wins)
-        const lastPartialText = deltas[2].partial.content[0]?.text;
-        expect(lastPartialText).toBe("abc");
+        // partial.content carries only the current chunk's delta text,
+        // matching the OpenAI WebSocket provider contract
+        expect(deltas[0].partial.content[0]?.text).toBe("a");
+        expect(deltas[1].partial.content[0]?.text).toBe("b");
+        expect(deltas[2].partial.content[0]?.text).toBe("c");
       },
     );
   });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -498,21 +498,30 @@ export function createOllamaStreamFn(
         const reader = response.body.getReader();
         let accumulatedContent = "";
         let emittedStart = false;
+        const partialContent: AssistantMessage["content"] = [{ type: "text", text: "" }];
+        const partial = buildAssistantMessageWithZeroUsage({
+          model,
+          content: partialContent,
+          stopReason: "stop",
+        });
         const accumulatedToolCalls: OllamaToolCall[] = [];
         let finalResponse: OllamaChatResponse | undefined;
 
         for await (const chunk of parseNdjsonStream(reader)) {
           if (chunk.message?.content) {
-            accumulatedContent += chunk.message.content;
-            const partial = buildAssistantMessageWithZeroUsage({
-              model,
-              content: [{ type: "text", text: accumulatedContent }],
-              stopReason: "stop",
-            });
             if (!emittedStart) {
               emittedStart = true;
-              stream.push({ type: "start", partial });
+              stream.push({
+                type: "start",
+                partial: buildAssistantMessageWithZeroUsage({
+                  model,
+                  content: [],
+                  stopReason: "stop",
+                }),
+              });
             }
+            accumulatedContent += chunk.message.content;
+            (partialContent[0] as { type: "text"; text: string }).text = accumulatedContent;
             stream.push({
               type: "text_delta",
               contentIndex: 0,

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -498,12 +498,6 @@ export function createOllamaStreamFn(
         const reader = response.body.getReader();
         let accumulatedContent = "";
         let emittedStart = false;
-        const partialTextNode = { type: "text" as const, text: "" };
-        const partial = buildAssistantMessageWithZeroUsage({
-          model,
-          content: [partialTextNode],
-          stopReason: "stop",
-        });
         const accumulatedToolCalls: OllamaToolCall[] = [];
         let finalResponse: OllamaChatResponse | undefined;
 
@@ -521,12 +515,15 @@ export function createOllamaStreamFn(
               });
             }
             accumulatedContent += chunk.message.content;
-            partialTextNode.text = accumulatedContent;
             stream.push({
               type: "text_delta",
               contentIndex: 0,
               delta: chunk.message.content,
-              partial,
+              partial: buildAssistantMessageWithZeroUsage({
+                model,
+                content: [{ type: "text", text: chunk.message.content }],
+                stopReason: "stop",
+              }),
             });
           }
 

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -498,10 +498,10 @@ export function createOllamaStreamFn(
         const reader = response.body.getReader();
         let accumulatedContent = "";
         let emittedStart = false;
-        const partialContent: AssistantMessage["content"] = [{ type: "text", text: "" }];
+        const partialTextNode = { type: "text" as const, text: "" };
         const partial = buildAssistantMessageWithZeroUsage({
           model,
-          content: partialContent,
+          content: [partialTextNode],
           stopReason: "stop",
         });
         const accumulatedToolCalls: OllamaToolCall[] = [];
@@ -521,7 +521,7 @@ export function createOllamaStreamFn(
               });
             }
             accumulatedContent += chunk.message.content;
-            (partialContent[0] as { type: "text"; text: string }).text = accumulatedContent;
+            partialTextNode.text = accumulatedContent;
             stream.push({
               type: "text_delta",
               contentIndex: 0,

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -12,6 +12,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   buildAssistantMessage as buildStreamAssistantMessage,
+  buildAssistantMessageWithZeroUsage,
   buildStreamErrorAssistantMessage,
   buildUsageWithNoCost,
 } from "./stream-message-shared.js";
@@ -496,12 +497,28 @@ export function createOllamaStreamFn(
 
         const reader = response.body.getReader();
         let accumulatedContent = "";
+        let emittedStart = false;
         const accumulatedToolCalls: OllamaToolCall[] = [];
         let finalResponse: OllamaChatResponse | undefined;
 
         for await (const chunk of parseNdjsonStream(reader)) {
           if (chunk.message?.content) {
             accumulatedContent += chunk.message.content;
+            const partial = buildAssistantMessageWithZeroUsage({
+              model,
+              content: [{ type: "text", text: accumulatedContent }],
+              stopReason: "stop",
+            });
+            if (!emittedStart) {
+              emittedStart = true;
+              stream.push({ type: "start", partial });
+            }
+            stream.push({
+              type: "text_delta",
+              contentIndex: 0,
+              delta: chunk.message.content,
+              partial,
+            });
           }
 
           // Ollama sends tool_calls in intermediate (done:false) chunks,


### PR DESCRIPTION
## Summary

- The Ollama stream function requested `stream: true` from the API but accumulated all content chunks internally, emitting only a single `done` event at the end
- This prevented downstream consumers (`onPartialReply`, block streaming pipeline, draft stream) from receiving incremental text updates during generation
- Emit a `start` event before the first content token and a `text_delta` event for each content chunk, matching the contract used by other streaming providers (e.g. Anthropic, OpenAI WebSocket)
- The final `done` event with the complete `AssistantMessage` is still emitted unchanged after the stream ends

## Motivation

Without incremental events, features like Telegram draft streaming (`TelegramDraftStream`), `onPartialReply` callbacks, and block streaming coalescing cannot function with Ollama models. The response appears all-at-once instead of progressively — defeating the purpose of requesting `stream: true` from the Ollama API.

## Test plan

- [x] Verify Ollama streaming responses emit `start` → `text_delta` (per token) → `done` events
- [x] Verify `onPartialReply` fires during Ollama streaming in gateway plugins
- [x] Verify Telegram messages update progressively with Ollama models
- [ ] Verify tool-call responses (no content tokens) still work correctly (no `start` emitted, `done` handles via `!addedPartial` path)
- [x] Verify thinking-only models (content arrives after thinking phase) emit events only for content tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)