### PR TITLE
fix(models): preserve stream usage compat opt-ins

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -295,6 +295,17 @@ describe("normalizeModelCompat", () => {
     expect(supportsUsageInStreaming(normalized)).toBe(true);
   });
 
+  it("preserves explicit supportsUsageInStreaming false on non-native endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-cpa",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: { supportsUsageInStreaming: false },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsUsageInStreaming(normalized)).toBe(false);
+  });
+
   it("still forces flags off when not explicitly set by user", () => {
     const model = {
       ...baseModel(),
@@ -347,6 +358,32 @@ describe("normalizeModelCompat", () => {
     expect(supportsDeveloperRole(normalized)).toBe(false);
     expect(supportsUsageInStreaming(normalized)).toBe(false);
     expect(supportsStrictMode(normalized)).toBe(false);
+  });
+
+  it("leaves fully explicit non-native compat untouched", () => {
+    const model = baseModel();
+    model.baseUrl = "https://proxy.example.com/v1";
+    model.compat = {
+      supportsDeveloperRole: false,
+      supportsUsageInStreaming: true,
+      supportsStrictMode: true,
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized).toBe(model);
+  });
+
+  it("preserves explicit usage compat when developer role is explicitly enabled", () => {
+    const model = baseModel();
+    model.baseUrl = "https://proxy.example.com/v1";
+    model.compat = {
+      supportsDeveloperRole: true,
+      supportsUsageInStreaming: true,
+      supportsStrictMode: true,
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsDeveloperRole(normalized)).toBe(true);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
+    expect(supportsStrictMode(normalized)).toBe(true);
   });
 });
 

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -66,11 +66,11 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     return model;
   }
   const forcedDeveloperRole = compat?.supportsDeveloperRole === true;
-  const forcedUsageStreaming = compat?.supportsUsageInStreaming === true;
+  const hasStreamingUsageOverride = compat?.supportsUsageInStreaming !== undefined;
   const targetStrictMode = compat?.supportsStrictMode ?? false;
   if (
     compat?.supportsDeveloperRole !== undefined &&
-    compat?.supportsUsageInStreaming !== undefined &&
+    hasStreamingUsageOverride &&
     compat?.supportsStrictMode !== undefined
   ) {
     return model;
@@ -83,7 +83,7 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
       ? {
           ...compat,
           supportsDeveloperRole: forcedDeveloperRole || false,
-          supportsUsageInStreaming: forcedUsageStreaming || false,
+          ...(hasStreamingUsageOverride ? {} : { supportsUsageInStreaming: false }),
           supportsStrictMode: targetStrictMode,
         }
       : {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -6,6 +6,7 @@ import {
   type ExistingProviderConfig,
 } from "./models-config.merge.js";
 import {
+  applyNativeStreamingUsageCompat,
   enforceSourceManagedProviderSecrets,
   normalizeProviders,
   resolveImplicitProviders,
@@ -126,7 +127,8 @@ export async function planOpenClawModelsJson(params: {
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? mergedProviders;
-  const nextContents = `${JSON.stringify({ providers: secretEnforcedProviders }, null, 2)}\n`;
+  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };

--- a/src/agents/models-config.providers.modelstudio.test.ts
+++ b/src/agents/models-config.providers.modelstudio.test.ts
@@ -1,32 +1,36 @@
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { withEnvAsync } from "../test-utils/env.js";
-import { resolveImplicitProvidersForTest } from "./models-config.e2e-harness.js";
-import { buildModelStudioProvider } from "./models-config.providers.js";
-
-const modelStudioApiKeyEnv = ["MODELSTUDIO_API", "KEY"].join("_");
+import {
+  applyNativeStreamingUsageCompat,
+  buildModelStudioProvider,
+} from "./models-config.providers.js";
 
 describe("Model Studio implicit provider", () => {
-  it("should include modelstudio when MODELSTUDIO_API_KEY is configured", async () => {
-    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
-    const modelStudioApiKey = "test-key"; // pragma: allowlist secret
-    await withEnvAsync({ [modelStudioApiKeyEnv]: modelStudioApiKey }, async () => {
-      const providers = await resolveImplicitProvidersForTest({ agentDir });
-      expect(providers?.modelstudio).toBeDefined();
-      expect(providers?.modelstudio?.apiKey).toBe("MODELSTUDIO_API_KEY");
-      expect(providers?.modelstudio?.baseUrl).toBe("https://coding-intl.dashscope.aliyuncs.com/v1");
+  it("should opt native Model Studio baseUrls into streaming usage", () => {
+    const providers = applyNativeStreamingUsageCompat({
+      modelstudio: buildModelStudioProvider(),
     });
+    expect(providers?.modelstudio).toBeDefined();
+    expect(providers?.modelstudio?.baseUrl).toBe("https://coding-intl.dashscope.aliyuncs.com/v1");
+    expect(
+      providers?.modelstudio?.models?.every(
+        (model) => model.compat?.supportsUsageInStreaming === true,
+      ),
+    ).toBe(true);
   });
 
-  it("should build the static Model Studio provider catalog", () => {
-    const provider = buildModelStudioProvider();
-    const modelIds = provider.models.map((model) => model.id);
-    expect(provider.api).toBe("openai-completions");
-    expect(provider.baseUrl).toBe("https://coding-intl.dashscope.aliyuncs.com/v1");
-    expect(modelIds).toContain("qwen3.5-plus");
-    expect(modelIds).toContain("qwen3-coder-plus");
-    expect(modelIds).toContain("kimi-k2.5");
+  it("should keep streaming usage opt-in disabled for custom Model Studio-compatible baseUrls", () => {
+    const providers = applyNativeStreamingUsageCompat({
+      modelstudio: {
+        ...buildModelStudioProvider(),
+        baseUrl: "https://proxy.example.com/v1",
+      },
+    });
+    expect(providers?.modelstudio).toBeDefined();
+    expect(providers?.modelstudio?.baseUrl).toBe("https://proxy.example.com/v1");
+    expect(
+      providers?.modelstudio?.models?.some(
+        (model) => model.compat?.supportsUsageInStreaming === true,
+      ),
+    ).toBe(false);
   });
 });

--- a/src/agents/models-config.providers.moonshot.test.ts
+++ b/src/agents/models-config.providers.moonshot.test.ts
@@ -7,7 +7,11 @@ import {
   MOONSHOT_CN_BASE_URL,
 } from "../commands/onboard-auth.models.js";
 import { captureEnv } from "../test-utils/env.js";
-import { resolveImplicitProviders } from "./models-config.providers.js";
+import {
+  applyNativeStreamingUsageCompat,
+  resolveImplicitProviders,
+} from "./models-config.providers.js";
+import { buildMoonshotProvider } from "./models-config.providers.static.js";
 
 describe("moonshot implicit provider (#33637)", () => {
   it("uses explicit CN baseUrl when provided", async () => {
@@ -39,6 +43,31 @@ describe("moonshot implicit provider (#33637)", () => {
       expect(providers?.moonshot).toBeDefined();
       expect(providers?.moonshot?.baseUrl).toBe(MOONSHOT_CN_BASE_URL);
       expect(providers?.moonshot?.apiKey).toBeDefined();
+      expect(providers?.moonshot?.models?.[0]?.compat?.supportsUsageInStreaming).toBeUndefined();
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("keeps streaming usage opt-in unset before the final compat pass", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    process.env.MOONSHOT_API_KEY = "sk-test-custom";
+
+    try {
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          moonshot: {
+            baseUrl: "https://proxy.example.com/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      });
+      expect(providers?.moonshot).toBeDefined();
+      expect(providers?.moonshot?.baseUrl).toBe("https://proxy.example.com/v1");
+      expect(providers?.moonshot?.models?.[0]?.compat?.supportsUsageInStreaming).toBeUndefined();
     } finally {
       envSnapshot.restore();
     }
@@ -53,8 +82,32 @@ describe("moonshot implicit provider (#33637)", () => {
       const providers = await resolveImplicitProviders({ agentDir });
       expect(providers?.moonshot).toBeDefined();
       expect(providers?.moonshot?.baseUrl).toBe(MOONSHOT_AI_BASE_URL);
+      expect(providers?.moonshot?.models?.[0]?.compat?.supportsUsageInStreaming).toBeUndefined();
     } finally {
       envSnapshot.restore();
     }
+  });
+
+  it("opts native Moonshot baseUrls into streaming usage only after the final compat pass", () => {
+    const defaultProviders = applyNativeStreamingUsageCompat({
+      moonshot: buildMoonshotProvider(),
+    });
+    expect(defaultProviders.moonshot?.models?.[0]?.compat?.supportsUsageInStreaming).toBe(true);
+
+    const cnProviders = applyNativeStreamingUsageCompat({
+      moonshot: {
+        ...buildMoonshotProvider(),
+        baseUrl: MOONSHOT_CN_BASE_URL,
+      },
+    });
+    expect(cnProviders.moonshot?.models?.[0]?.compat?.supportsUsageInStreaming).toBe(true);
+
+    const customProviders = applyNativeStreamingUsageCompat({
+      moonshot: {
+        ...buildMoonshotProvider(),
+        baseUrl: "https://proxy.example.com/v1",
+      },
+    });
+    expect(customProviders.moonshot?.models?.[0]?.compat?.supportsUsageInStreaming).toBeUndefined();
   });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -81,12 +81,80 @@ type SecretDefaults = {
   exec?: string;
 };
 
+const MOONSHOT_NATIVE_BASE_URLS = new Set([
+  "https://api.moonshot.ai/v1",
+  "https://api.moonshot.cn/v1",
+]);
+const MODELSTUDIO_NATIVE_BASE_URLS = new Set([
+  "https://coding-intl.dashscope.aliyuncs.com/v1",
+  "https://coding.dashscope.aliyuncs.com/v1",
+]);
+
 const ENV_VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
 
 function normalizeApiKeyConfig(value: string): string {
   const trimmed = value.trim();
   const match = /^\$\{([A-Z0-9_]+)\}$/.exec(trimmed);
   return match?.[1] ?? trimmed;
+}
+
+function normalizeProviderBaseUrl(baseUrl: string | undefined): string {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    const url = new URL(trimmed);
+    url.hash = "";
+    url.search = "";
+    return url.toString().replace(/\/+$/, "").toLowerCase();
+  } catch {
+    return trimmed.replace(/\/+$/, "").toLowerCase();
+  }
+}
+
+function withStreamingUsageCompat(provider: ProviderConfig): ProviderConfig {
+  if (!Array.isArray(provider.models) || provider.models.length === 0) {
+    return provider;
+  }
+
+  let changed = false;
+  const models = provider.models.map((model) => {
+    if (model.compat?.supportsUsageInStreaming !== undefined) {
+      return model;
+    }
+    changed = true;
+    return {
+      ...model,
+      compat: {
+        ...model.compat,
+        supportsUsageInStreaming: true,
+      },
+    };
+  });
+
+  return changed ? { ...provider, models } : provider;
+}
+
+export function applyNativeStreamingUsageCompat(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  let changed = false;
+  const nextProviders: Record<string, ProviderConfig> = {};
+
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    const normalizedBaseUrl = normalizeProviderBaseUrl(provider.baseUrl);
+    const isNativeMoonshot =
+      providerKey === "moonshot" && MOONSHOT_NATIVE_BASE_URLS.has(normalizedBaseUrl);
+    const isNativeModelStudio =
+      providerKey === "modelstudio" && MODELSTUDIO_NATIVE_BASE_URLS.has(normalizedBaseUrl);
+    const nextProvider =
+      isNativeMoonshot || isNativeModelStudio ? withStreamingUsageCompat(provider) : provider;
+    nextProviders[providerKey] = nextProvider;
+    changed ||= nextProvider !== provider;
+  }
+
+  return changed ? nextProviders : providers;
 }
 
 function resolveEnvApiKeyVarName(
@@ -684,7 +752,16 @@ const SIMPLE_IMPLICIT_PROVIDER_LOADERS: ImplicitProviderLoader[] = [
     apiKey,
   })),
   withApiKey("qianfan", async ({ apiKey }) => ({ ...buildQianfanProvider(), apiKey })),
-  withApiKey("modelstudio", async ({ apiKey }) => ({ ...buildModelStudioProvider(), apiKey })),
+  withApiKey("modelstudio", async ({ apiKey, explicitProvider }) => {
+    const explicitBaseUrl = explicitProvider?.baseUrl;
+    return {
+      ...buildModelStudioProvider(),
+      ...(typeof explicitBaseUrl === "string" && explicitBaseUrl.trim()
+        ? { baseUrl: explicitBaseUrl.trim() }
+        : {}),
+      apiKey,
+    };
+  }),
   withApiKey("openrouter", async ({ apiKey }) => ({ ...buildOpenrouterProvider(), apiKey })),
   withApiKey("nvidia", async ({ apiKey }) => ({ ...buildNvidiaProvider(), apiKey })),
   withApiKey("kilocode", async ({ apiKey }) => ({


### PR DESCRIPTION
## Summary

This fixes a `model-compat` policy bug for non-native `openai-completions` endpoints.

OpenClaw currently forces both `supportsDeveloperRole` and `supportsUsageInStreaming` to `false` for any non-native OpenAI-compatible base URL. That is too broad for streaming usage: built-in catalogs and user config can already declare explicit compat opt-ins, but the normalizer overwrites them.

Bailian/DashScope is a concrete repro. It can return streaming token usage, but OpenClaw suppresses `stream_options.include_usage` before the request is sent, so `usage` / `lastCallUsage` never shows up in the final result.

## Root cause

This is not a Bailian-specific parser bug in this repo.

The issue is that `normalizeModelCompat()` treats streaming usage as a blanket "non-native OpenAI" incompatibility, even when a provider model or user config has already opted in explicitly. That makes the compat schema inconsistent: callers can set `supportsUsageInStreaming`, but the normalizer silently discards it.

There is one important constraint here: `@mariozechner/pi-ai` enables `stream_options.include_usage` unless `compat.supportsUsageInStreaming === false`. So removing the default-off behavior entirely would reopen unknown custom proxies by default, which would be too risky.

## What this changes

This PR keeps the conservative default for unknown non-native endpoints, but preserves explicit streaming-usage opt-ins.

Specifically:

- non-native `openai-completions` endpoints still force `supportsDeveloperRole = false`
- `supportsUsageInStreaming = false` is only injected when the flag is unspecified
- explicit `supportsUsageInStreaming: true` and `false` now survive normalization
- built-in Moonshot and Model Studio catalogs now explicitly opt in to streaming usage support

This means known compatible providers can expose token usage, while unknown custom proxies stay on the current safe default.

## Scope boundary

This PR does not change `pi-ai` parsing or retry behavior.

It also does not enable streaming usage for arbitrary custom OpenAI-compatible endpoints by default. Those remain opt-in.

## Validation

Checks run from this branch:

- `CI=1 pnpm exec vitest run --maxWorkers=1 --reporter=verbose src/agents/model-compat.test.ts`
- `CI=1 pnpm exec vitest run --maxWorkers=1 --reporter=verbose src/agents/models-config.providers.moonshot.test.ts`
- `CI=1 pnpm exec vitest run --maxWorkers=1 --reporter=verbose src/agents/models-config.providers.modelstudio.test.ts -t 'should build the static Model Studio provider catalog'`
- `pnpm build`
- `pnpm check`
- `codex review --base openclaw-upstream/main`

Manual verification:

- built the upstream checkout locally and ran a real Bailian-backed `openclaw agent --local --json` request
- confirmed `usage` and `lastCallUsage` were present in the result
- observed `usage.input=16571`, `usage.output=76`, `usage.total=16647`

This keeps the implementation generic while using Bailian as the motivating repro and validation case.
