### PR TITLE
Fix: Control UI model switcher routes to wrong provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,8 @@ ui/src/ui/__screenshots__
 ui/src/ui/views/__screenshots__
 ui/.vitest-attachments
 docs/superpowers
+
+build.log
+clawdbot.log
+openclaw.config.yaml
+qdrant_storage/

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -606,9 +606,24 @@ export function resolveAllowedModelRef(params: {
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
   });
+
+  // When the input has no provider prefix (e.g. "gemini-2.5-flash"), try to
+  // infer the correct provider from the model catalog before falling back to
+  // defaultProvider.  This prevents the UI model switcher from incorrectly
+  // routing a model to the current session's provider when that provider
+  // doesn't actually serve it.
+  let effectiveDefaultProvider = params.defaultProvider;
+  if (!trimmed.includes("/")) {
+    const normalizedModel = trimmed.toLowerCase();
+    const catalogMatch = params.catalog.find((entry) => entry.id.toLowerCase() === normalizedModel);
+    if (catalogMatch) {
+      effectiveDefaultProvider = catalogMatch.provider;
+    }
+  }
+
   const resolved = resolveModelRefFromString({
     raw: trimmed,
-    defaultProvider: params.defaultProvider,
+    defaultProvider: effectiveDefaultProvider,
     aliasIndex,
   });
   if (!resolved) {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -372,7 +372,9 @@ function buildChatModelOptions(
 
   for (const entry of catalog) {
     const provider = entry.provider?.trim();
-    addOption(entry.id, provider ? `${entry.id} · ${provider}` : entry.id);
+    // Send full provider/model to avoid backend defaultProvider mismatch
+    const value = provider ? `${provider}/${entry.id}` : entry.id;
+    addOption(value, provider ? `${entry.id} · ${provider}` : entry.id);
   }
 
   if (currentOverride) {


### PR DESCRIPTION
Ref: #45630

This PR fixes an issue where the Control UI model switcher would incorrectly route a model to the current session's default provider when the model was selected without an explicit provider prefix.

Changes:
1. **Frontend**: Updated `buildChatModelOptions` in `ui/src/ui/app-render.helpers.ts` to use the full `provider/model` ref as the option value.
2. **Backend**: Enhanced `resolveAllowedModelRef` in `src/agents/model-selection.ts` to attempt provider inference from the model catalog when a provider-less model ref is provided.