### PR TITLE
ACP: recover parent relay output from gateway state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - macOS/runtime locator: require Node >=22.16.0 during macOS runtime discovery so the app no longer accepts Node versions that the main runtime guard rejects later. Thanks @sumleo.
 - Agents/custom providers: preserve blank API keys for loopback OpenAI-compatible custom providers by clearing the synthetic Authorization header at runtime, while keeping explicit apiKey and oauth/token config from silently downgrading into fake bearer auth. (#45631) Thanks @xinhuagu.
 - Models/google-vertex Gemini flash-lite normalization: apply existing bare-ID preview normalization to `google-vertex` model refs and provider configs so `google-vertex/gemini-3.1-flash-lite` resolves as `gemini-3.1-flash-lite-preview`. (#42435) thanks @scoootscooob.
+- ACP/parent streaming: backfill missing child assistant output and terminal completion from gateway `chat.history` and `agent.wait` when ACP relay events do not reach the local parent emitter, so `sessions_spawn` with `streamTo: "parent"` no longer gets stuck on start/stall-only updates. (#45205)
 
 ## 2026.3.12
 

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -5,11 +5,16 @@ import {
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
 
+const callGatewayMock = vi.fn();
 const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatNowMock = vi.fn();
 const readAcpSessionEntryMock = vi.fn();
 const resolveSessionFilePathMock = vi.fn();
 const resolveSessionFilePathOptionsMock = vi.fn();
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (...args: unknown[]) => callGatewayMock(...args),
+}));
 
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
@@ -19,14 +24,23 @@ vi.mock("../infra/heartbeat-wake.js", () => ({
   requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
 }));
 
-vi.mock("../acp/runtime/session-meta.js", () => ({
-  readAcpSessionEntry: (...args: unknown[]) => readAcpSessionEntryMock(...args),
-}));
+vi.mock("../acp/runtime/session-meta.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../acp/runtime/session-meta.js")>();
+  return {
+    ...actual,
+    readAcpSessionEntry: (...args: unknown[]) => readAcpSessionEntryMock(...args),
+  };
+});
 
-vi.mock("../config/sessions/paths.js", () => ({
-  resolveSessionFilePath: (...args: unknown[]) => resolveSessionFilePathMock(...args),
-  resolveSessionFilePathOptions: (...args: unknown[]) => resolveSessionFilePathOptionsMock(...args),
-}));
+vi.mock("../config/sessions/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/paths.js")>();
+  return {
+    ...actual,
+    resolveSessionFilePath: (...args: unknown[]) => resolveSessionFilePathMock(...args),
+    resolveSessionFilePathOptions: (...args: unknown[]) =>
+      resolveSessionFilePathOptionsMock(...args),
+  };
+});
 
 function collectedTexts() {
   return enqueueSystemEventMock.mock.calls.map((call) => String(call[0] ?? ""));
@@ -34,6 +48,16 @@ function collectedTexts() {
 
 describe("startAcpSpawnParentStreamRelay", () => {
   beforeEach(() => {
+    callGatewayMock.mockReset();
+    callGatewayMock.mockImplementation(async (opts?: { method?: string }) => {
+      if (opts?.method === "chat.history") {
+        return { messages: [] };
+      }
+      if (opts?.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      throw new Error(`Unexpected method: ${String(opts?.method)}`);
+    });
     enqueueSystemEventMock.mockClear();
     requestHeartbeatNowMock.mockClear();
     readAcpSessionEntryMock.mockReset();
@@ -206,6 +230,148 @@ describe("startAcpSpawnParentStreamRelay", () => {
 
     const texts = collectedTexts();
     expect(texts.some((text) => text.includes("codex: hello world"))).toBe(true);
+    relay.dispose();
+  });
+
+  it("falls back to child history and gateway wait when local events never arrive", async () => {
+    callGatewayMock.mockImplementation(async (opts?: { method?: string }) => {
+      if (opts?.method === "chat.history") {
+        const isPrimingRead =
+          callGatewayMock.mock.calls.filter(([call]) => call?.method === "chat.history").length ===
+          1;
+        return isPrimingRead
+          ? { messages: [] }
+          : {
+              messages: [
+                {
+                  role: "assistant",
+                  content: [{ type: "text", text: "READY_FROM_HISTORY" }],
+                },
+              ],
+            };
+      }
+      if (opts?.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      throw new Error(`Unexpected method: ${String(opts?.method)}`);
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-6",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-6",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 120_000,
+      noOutputPollMs: 250,
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    const texts = collectedTexts();
+    expect(texts.some((text) => text.includes("codex: READY_FROM_HISTORY"))).toBe(true);
+    expect(texts.some((text) => text.includes("codex run completed."))).toBe(true);
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "chat.history",
+        params: expect.objectContaining({
+          sessionKey: "agent:codex:acp:child-6",
+        }),
+      }),
+    );
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent.wait",
+        params: expect.objectContaining({
+          runId: "run-6",
+          timeoutMs: 1,
+        }),
+      }),
+    );
+    relay.dispose();
+  });
+
+  it("falls back to gateway wait when assistant deltas arrive but lifecycle completion is missing", async () => {
+    callGatewayMock.mockImplementation(async (opts?: { method?: string }) => {
+      if (opts?.method === "chat.history") {
+        return { messages: [] };
+      }
+      if (opts?.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      throw new Error(`Unexpected method: ${String(opts?.method)}`);
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-7",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-7",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 120_000,
+      noOutputPollMs: 250,
+    });
+
+    emitAgentEvent({
+      runId: "run-7",
+      stream: "assistant",
+      data: {
+        delta: "READY_FROM_LOCAL",
+      },
+    });
+    await vi.advanceTimersByTimeAsync(250);
+
+    const texts = collectedTexts();
+    expect(texts.some((text) => text.includes("codex: READY_FROM_LOCAL"))).toBe(true);
+    expect(texts.some((text) => text.includes("codex run completed."))).toBe(true);
+    relay.dispose();
+  });
+
+  it("hydrates missing assistant output from history before a local lifecycle end completes", async () => {
+    callGatewayMock.mockImplementation(async (opts?: { method?: string }) => {
+      if (opts?.method === "chat.history") {
+        const isPrimingRead =
+          callGatewayMock.mock.calls.filter(([call]) => call?.method === "chat.history").length ===
+          1;
+        return isPrimingRead
+          ? { messages: [] }
+          : {
+              messages: [
+                {
+                  role: "assistant",
+                  content: [{ type: "text", text: "READY_BEFORE_LOCAL_END" }],
+                },
+              ],
+            };
+      }
+      if (opts?.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      throw new Error(`Unexpected method: ${String(opts?.method)}`);
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-8",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-8",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 120_000,
+      noOutputPollMs: 250,
+    });
+
+    emitAgentEvent({
+      runId: "run-8",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+      },
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    const texts = collectedTexts();
+    expect(texts.some((text) => text.includes("codex: READY_BEFORE_LOCAL_END"))).toBe(true);
+    expect(texts.some((text) => text.includes("codex run completed."))).toBe(true);
     relay.dispose();
   });
 

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -2,10 +2,12 @@ import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
+import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { extractAssistantText, stripToolMessages } from "./tools/sessions-helpers.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
@@ -205,8 +207,15 @@ export function startAcpSpawnParentStreamRelay(params: {
   let pendingText = "";
   let lastProgressAt = Date.now();
   let stallNotified = false;
+  let sawLocalAssistantEvent = false;
+  let sawLocalTerminalEvent = false;
+  let fallbackPollInFlight = false;
+  let historyBaselineReady = false;
+  let historyOutputRelayed = false;
+  let lastHistoryAssistant = "";
   let flushTimer: NodeJS.Timeout | undefined;
   let relayLifetimeTimer: NodeJS.Timeout | undefined;
+  let fallbackPollTimer: NodeJS.Timeout | undefined;
 
   const clearFlushTimer = () => {
     if (!flushTimer) {
@@ -246,6 +255,152 @@ export function startAcpSpawnParentStreamRelay(params: {
     flushTimer.unref?.();
   };
 
+  const recordAssistantOutput = (delta: string | undefined, kind: string) => {
+    if (!delta || !delta.trim()) {
+      return false;
+    }
+    logEvent(kind, { delta });
+
+    if (stallNotified) {
+      stallNotified = false;
+      emit(`${relayLabel} resumed output.`, `${contextPrefix}:resumed`);
+    }
+
+    lastProgressAt = Date.now();
+    pendingText += delta;
+    if (pendingText.length > STREAM_BUFFER_MAX_CHARS) {
+      pendingText = pendingText.slice(-STREAM_BUFFER_MAX_CHARS);
+    }
+    if (pendingText.length >= STREAM_SNIPPET_MAX_CHARS || delta.includes("\n\n")) {
+      flushPending();
+      return true;
+    }
+    scheduleFlush();
+    return true;
+  };
+
+  const readLatestAssistantFromChildHistory = async (): Promise<string | undefined> => {
+    const history = await callGateway<{ messages?: unknown[] }>({
+      method: "chat.history",
+      params: {
+        sessionKey: params.childSessionKey,
+        limit: 24,
+      },
+      timeoutMs: 10_000,
+    }).catch(() => null);
+    const filtered = stripToolMessages(Array.isArray(history?.messages) ? history.messages : []);
+    const assistantMessages = filtered.filter(
+      (msg) => (msg as { role?: unknown } | undefined)?.role === "assistant",
+    );
+    const last =
+      assistantMessages.length > 0 ? assistantMessages[assistantMessages.length - 1] : undefined;
+    return toTrimmedString(extractAssistantText(last));
+  };
+
+  const primeHistoryBaseline = async () => {
+    if (historyBaselineReady || disposed) {
+      return;
+    }
+    const reply = await readLatestAssistantFromChildHistory();
+    if (disposed) {
+      return;
+    }
+    historyBaselineReady = true;
+    lastHistoryAssistant = reply ?? "";
+  };
+
+  const maybeRelayHistoryAssistant = async (force = false) => {
+    const reply = await readLatestAssistantFromChildHistory();
+    if (disposed) {
+      return false;
+    }
+    if (!historyBaselineReady) {
+      historyBaselineReady = true;
+      lastHistoryAssistant = reply ?? "";
+      if (!force || !reply || sawLocalAssistantEvent) {
+        return false;
+      }
+      const relayed = recordAssistantOutput(reply, "assistant_history");
+      if (relayed) {
+        historyOutputRelayed = true;
+      }
+      return relayed;
+    }
+    if (!reply) {
+      return false;
+    }
+    const changed = reply !== lastHistoryAssistant;
+    lastHistoryAssistant = reply;
+    if (sawLocalAssistantEvent) {
+      return false;
+    }
+    if (!force && !changed) {
+      return false;
+    }
+    if (historyOutputRelayed && !changed) {
+      return false;
+    }
+    const relayed = recordAssistantOutput(reply, "assistant_history");
+    if (relayed) {
+      historyOutputRelayed = true;
+    }
+    return relayed;
+  };
+
+  const maybeFinalizeFromGateway = async () => {
+    if (disposed || sawLocalTerminalEvent) {
+      return false;
+    }
+    const wait = await callGateway<{ status?: unknown; error?: unknown }>({
+      method: "agent.wait",
+      params: {
+        runId,
+        timeoutMs: 1,
+      },
+      timeoutMs: 5_000,
+    }).catch(() => null);
+    const status = toTrimmedString(wait?.status);
+    if (disposed || !status || status === "timeout") {
+      return false;
+    }
+    if (status !== "ok" && status !== "error") {
+      return false;
+    }
+    sawLocalTerminalEvent = true;
+    if (status === "error") {
+      flushPending();
+      const errorText = toTrimmedString(wait?.error);
+      if (errorText) {
+        emit(`${relayLabel} run failed: ${errorText}`, `${contextPrefix}:error`);
+      } else {
+        emit(`${relayLabel} run failed.`, `${contextPrefix}:error`);
+      }
+      dispose();
+      return true;
+    }
+    await maybeRelayHistoryAssistant(true);
+    flushPending();
+    emit(`${relayLabel} run completed.`, `${contextPrefix}:done`);
+    dispose();
+    return true;
+  };
+
+  const fallbackPollIntervalMs = Math.min(noOutputPollMs, 5_000);
+  const runFallbackPoll = async () => {
+    if (disposed || fallbackPollInFlight) {
+      return;
+    }
+    fallbackPollInFlight = true;
+    try {
+      if (!sawLocalAssistantEvent) {
+        await maybeRelayHistoryAssistant(false);
+      }
+      await maybeFinalizeFromGateway();
+    } finally {
+      fallbackPollInFlight = false;
+    }
+  };
+
   const noOutputWatcherTimer = setInterval(() => {
     if (disposed || noOutputNoticeMs <= 0) {
       return;
@@ -276,6 +431,15 @@ export function startAcpSpawnParentStreamRelay(params: {
   }, maxRelayLifetimeMs);
   relayLifetimeTimer.unref?.();
 
+  if (fallbackPollIntervalMs > 0) {
+    fallbackPollTimer = setInterval(() => {
+      void runFallbackPoll();
+    }, fallbackPollIntervalMs);
+    fallbackPollTimer.unref?.();
+  }
+
+  void primeHistoryBaseline();
+
   if (params.emitStartNotice !== false) {
     emitStartNotice();
   }
@@ -286,31 +450,13 @@ export function startAcpSpawnParentStreamRelay(params: {
     }
 
     if (event.stream === "assistant") {
+      sawLocalAssistantEvent = true;
       const data = event.data;
       const deltaCandidate =
         (data as { delta?: unknown } | undefined)?.delta ??
         (data as { text?: unknown } | undefined)?.text;
       const delta = typeof deltaCandidate === "string" ? deltaCandidate : undefined;
-      if (!delta || !delta.trim()) {
-        return;
-      }
-      logEvent("assistant_delta", { delta });
-
-      if (stallNotified) {
-        stallNotified = false;
-        emit(`${relayLabel} resumed output.`, `${contextPrefix}:resumed`);
-      }
-
-      lastProgressAt = Date.now();
-      pendingText += delta;
-      if (pendingText.length > STREAM_BUFFER_MAX_CHARS) {
-        pendingText = pendingText.slice(-STREAM_BUFFER_MAX_CHARS);
-      }
-      if (pendingText.length >= STREAM_SNIPPET_MAX_CHARS || delta.includes("\n\n")) {
-        flushPending();
-        return;
-      }
-      scheduleFlush();
+      recordAssistantOutput(delta, "assistant_delta");
       return;
     }
 
@@ -321,7 +467,6 @@ export function startAcpSpawnParentStreamRelay(params: {
     const phase = toTrimmedString((event.data as { phase?: unknown } | undefined)?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
     if (phase === "end") {
-      flushPending();
       const startedAt = toFiniteNumber(
         (event.data as { startedAt?: unknown } | undefined)?.startedAt,
       );
@@ -330,19 +475,27 @@ export function startAcpSpawnParentStreamRelay(params: {
         startedAt != null && endedAt != null && endedAt >= startedAt
           ? endedAt - startedAt
           : undefined;
-      if (durationMs != null) {
-        emit(
-          `${relayLabel} run completed in ${Math.max(1, Math.round(durationMs / 1000))}s.`,
-          `${contextPrefix}:done`,
-        );
-      } else {
-        emit(`${relayLabel} run completed.`, `${contextPrefix}:done`);
-      }
-      dispose();
+      sawLocalTerminalEvent = true;
+      void (async () => {
+        if (!sawLocalAssistantEvent) {
+          await maybeRelayHistoryAssistant(true);
+        }
+        flushPending();
+        if (durationMs != null) {
+          emit(
+            `${relayLabel} run completed in ${Math.max(1, Math.round(durationMs / 1000))}s.`,
+            `${contextPrefix}:done`,
+          );
+        } else {
+          emit(`${relayLabel} run completed.`, `${contextPrefix}:done`);
+        }
+        dispose();
+      })();
       return;
     }
 
     if (phase === "error") {
+      sawLocalTerminalEvent = true;
       flushPending();
       const errorText = toTrimmedString((event.data as { error?: unknown } | undefined)?.error);
       if (errorText) {
@@ -363,6 +516,9 @@ export function startAcpSpawnParentStreamRelay(params: {
     clearRelayLifetimeTimer();
     flushLogBuffer();
     clearInterval(noOutputWatcherTimer);
+    if (fallbackPollTimer) {
+      clearInterval(fallbackPollTimer);
+    }
     unsubscribe();
   };
 


### PR DESCRIPTION
## Summary

- Problem: ACP child runs can finish successfully while the parent `streamTo: "parent"` relay only sees synthetic `start`/`stall` notices because it depends on local `onAgentEvent(...)` delivery.
- Why it matters: orchestration from the parent session loses child progress and terminal completion, so `sessions_spawn` looks hung even when the ACP child actually replied or finished work.
- What changed: the parent relay now backfills child assistant output from gateway `chat.history` and terminal state from `agent.wait`, while still preferring local assistant/lifecycle events when they arrive.
- What did NOT change (scope boundary): ACP spawn semantics, child execution, and the normal local event path are unchanged; this only adds a best-effort fallback when relay events do not cross the process boundary.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45205
- Related #45205

## User-visible / Behavior Changes

- ACP parent relays now recover missing child assistant output and completion from gateway state when local relay events do not arrive, so parent sessions stop getting stuck on `start`/`stall`-only updates.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  - The relay now makes best-effort gateway calls to `chat.history` and `agent.wait` for the spawned child session/run.
  - Mitigation: calls are scoped to the known child session key / run ID, use short timeouts, and only supplement the existing local event path.

## Repro + Verification

### Environment

- OS: macOS host for source tests; live repro previously validated against Debian 13 install from issue pattern
- Runtime/container: Node v25.6.0, pnpm 10.23.0
- Model/provider: ACP child via Codex during manual smoke; issue originally reported with Claude/OpenRouter
- Integration/channel (if any): ACP `sessions_spawn` with `streamTo: "parent"`
- Relevant config (redacted): ACP enabled with backend `acpx`, parent streaming enabled

### Steps

1. Start an ACP-capable parent session and spawn a child with `sessions_spawn`, `runtime: "acp"`, and `streamTo: "parent"`.
2. Use a task that produces visible assistant output quickly.
3. Observe the parent relay output and child transcript / ACP stream log.

### Expected

- Parent relay receives child assistant progress and terminal completion.

### Actual

- Before the fix, affected runs could emit only synthetic `start`/`stall` notices even though the child transcript already contained assistant output and the child had completed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/agents/acp-spawn-parent-stream.test.ts src/commands/agent.acp.test.ts`
  - New relay regression cases cover:
    - missing local assistant + terminal events recovered via `chat.history` + `agent.wait`
    - missing local terminal event with assistant deltas still present
    - missing local assistant output recovered before a local lifecycle `end`
  - Manual live smoke on the installed 2026.3.12 runtime: 5 repeated real ACP spawns with unique markers all produced assistant output plus terminal completion in the generated `.acp-stream.jsonl` relay logs.
- Edge cases checked:
  - start notice behavior unchanged
  - no-output stall / resume behavior unchanged
  - max relay lifetime timeout unchanged
  - local whitespace-preserving delta aggregation unchanged
- What you did **not** verify:
  - I did not rely on `src/agents/acp-spawn.test.ts` for this fix because that suite fully mocks `acp-spawn-parent-stream.js` and, in this tarball snapshot, currently fails during unrelated mock-hoisting/module-load setup before exercising the relay path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit or temporarily remove the fallback poll / gateway backfill from `src/agents/acp-spawn-parent-stream.ts`.
- Files/config to restore:
  - `src/agents/acp-spawn-parent-stream.ts`
  - `src/agents/acp-spawn-parent-stream.test.ts`
  - `CHANGELOG.md`
- Known bad symptoms reviewers should watch for:
  - duplicated child progress relays
  - parent relay completion firing before child output is flushed
  - relay logs missing `assistant_history` / terminal backfill in the missing-event path

## Risks and Mitigations

- Risk: fallback history polling could duplicate output when local assistant events already arrived.
  - Mitigation: the fallback path bails once local assistant events have been seen and tracks whether history output was already relayed.
- Risk: extra gateway lookups could introduce relay noise or hangs.
  - Mitigation: calls are short-timeout, best-effort, and capped to the relay lifetime / poll interval already used by the stall watcher.
