### PR TITLE
fix(doctor): keep security checks alive for channel SecretRefs

### DIFF
--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -197,4 +197,43 @@ describe("noteSecurityWarnings gateway exposure", () => {
     expect(message).not.toContain("Heartbeat defaults");
     expect(message).not.toContain('Heartbeat agent "ops"');
   });
+
+  it("falls back to read-only channel inspection when channel credentials use unresolved SecretRefs", async () => {
+    const resolveDmPolicy = vi.fn(({ account }) => ({
+      policy: account.config.dmPolicy,
+      allowFrom: account.config.allowFrom,
+      allowFromPath: "channels.telegram.",
+      approveHint: "approve",
+    }));
+    pluginRegistry.list = [
+      {
+        id: "telegram",
+        meta: { label: "Telegram" },
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => {
+            throw new Error(
+              'channels.telegram.botToken: unresolved SecretRef "exec:default:telegram-token". Resolve this command against an active gateway runtime snapshot before reading it.',
+            );
+          },
+          inspectAccount: () => ({
+            accountId: "default",
+            enabled: true,
+            configured: true,
+            config: {
+              dmPolicy: "open",
+              allowFrom: ["*"],
+            },
+          }),
+        },
+        security: {
+          resolveDmPolicy,
+        },
+      },
+    ];
+
+    await expect(noteSecurityWarnings({} as OpenClawConfig)).resolves.toBeUndefined();
+    expect(resolveDmPolicy).toHaveBeenCalled();
+    expect(lastMessage()).toContain("Telegram DMs: OPEN");
+  });
 });

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -1,5 +1,7 @@
+import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
+import { inspectReadOnlyChannelAccount } from "../channels/read-only-account-inspect.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig, GatewayBindMode } from "../config/config.js";
 import type { AgentConfig } from "../config/types.agents.js";
@@ -46,6 +48,50 @@ function collectImplicitHeartbeatDirectPolicyWarnings(cfg: OpenClawConfig): stri
   }
 
   return warnings;
+}
+
+function isUnresolvedSecretRefError(error: unknown): boolean {
+  return (error instanceof Error ? error.message : String(error)).includes("unresolved SecretRef");
+}
+
+async function resolveDoctorSecurityAccountContext(params: {
+  plugin: (typeof listChannelPlugins extends () => infer T ? T : never)[number];
+  cfg: OpenClawConfig;
+}) {
+  try {
+    return await resolveDefaultChannelAccountContext(params.plugin, params.cfg);
+  } catch (error) {
+    if (!isUnresolvedSecretRefError(error)) {
+      throw error;
+    }
+  }
+
+  const accountIds = params.plugin.config.listAccountIds(params.cfg);
+  const defaultAccountId = resolveChannelDefaultAccountId({
+    plugin: params.plugin,
+    cfg: params.cfg,
+    accountIds,
+  });
+  const account =
+    params.plugin.config.inspectAccount?.(params.cfg, defaultAccountId) ??
+    inspectReadOnlyChannelAccount({
+      channelId: params.plugin.id,
+      cfg: params.cfg,
+      accountId: defaultAccountId,
+    });
+  if (!account) {
+    return null;
+  }
+  const enabled = params.plugin.config.isEnabled
+    ? params.plugin.config.isEnabled(account, params.cfg)
+    : true;
+  const configured =
+    account && typeof account === "object" && "configured" in account
+      ? Boolean((account as { configured?: unknown }).configured)
+      : params.plugin.config.isConfigured
+        ? await params.plugin.config.isConfigured(account, params.cfg)
+        : true;
+  return { accountIds, defaultAccountId, account, enabled, configured };
 }
 
 export async function noteSecurityWarnings(cfg: OpenClawConfig) {
@@ -189,8 +235,11 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
     if (!plugin.security) {
       continue;
     }
-    const { defaultAccountId, account, enabled, configured } =
-      await resolveDefaultChannelAccountContext(plugin, cfg);
+    const context = await resolveDoctorSecurityAccountContext({ plugin, cfg });
+    if (!context) {
+      continue;
+    }
+    const { defaultAccountId, account, enabled, configured } = context;
     if (!enabled) {
       continue;
     }

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -58,12 +58,14 @@ async function resolveDoctorSecurityAccountContext(params: {
   plugin: (typeof listChannelPlugins extends () => infer T ? T : never)[number];
   cfg: OpenClawConfig;
 }) {
+  let unresolvedSecretRefError: unknown;
   try {
     return await resolveDefaultChannelAccountContext(params.plugin, params.cfg);
   } catch (error) {
     if (!isUnresolvedSecretRefError(error)) {
       throw error;
     }
+    unresolvedSecretRefError = error;
   }
 
   const accountIds = params.plugin.config.listAccountIds(params.cfg);
@@ -80,7 +82,7 @@ async function resolveDoctorSecurityAccountContext(params: {
       accountId: defaultAccountId,
     });
   if (!account) {
-    return null;
+    throw unresolvedSecretRefError;
   }
   const enabled = params.plugin.config.isEnabled
     ? params.plugin.config.isEnabled(account, params.cfg)


### PR DESCRIPTION
## Summary
- add a read-only fallback for doctor security checks when `resolveAccount()` fails on unresolved channel SecretRefs
- keep the fallback scoped to channels that already expose an inspection path so doctor never silently drops DM-policy warnings for unsupported channels
- add regression coverage for unresolved Telegram SecretRefs in the security warning flow

## Test plan
- [x] `codex review --base origin/main`
- [ ] `pnpm build` (fails on current `origin/main` checkout with unrelated TypeScript/module errors in `src/agents/**`, `src/browser/chrome-mcp.ts`, and `src/commands/openai-codex-oauth.ts`)
- [ ] `pnpm check` (not run because `pnpm build` failed first on the current base checkout)
- [ ] `pnpm test` (not run because `pnpm build` failed first on the current base checkout)

## Notes
- AI-assisted
- This keeps existing fail-fast behavior for channels that do not yet have a safe read-only inspection path.

Part of #45416

Made with [Cursor](https://cursor.com)