### PR TITLE
fix: avoid ANTHROPIC_MODEL_ALIASES init-time ReferenceError

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -31,12 +31,14 @@ export type ModelAliasIndex = {
   byKey: Map<string, string[]>;
 };
 
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
-};
+function getAnthropicModelAliases(): Record<string, string> {
+  return {
+    "opus-4.6": "claude-opus-4-6",
+    "opus-4.5": "claude-opus-4-5",
+    "sonnet-4.6": "claude-sonnet-4-6",
+    "sonnet-4.5": "claude-sonnet-4-5",
+  };
+}
 
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
@@ -151,7 +153,7 @@ function normalizeAnthropicModelId(model: string): string {
     return trimmed;
   }
   const lower = trimmed.toLowerCase();
-  return ANTHROPIC_MODEL_ALIASES[lower] ?? trimmed;
+  return getAnthropicModelAliases()[lower] ?? trimmed;
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {


### PR DESCRIPTION
## Summary
- fix a module initialization ordering bug that can throw `ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization`
- switch Anthropic alias lookup to a lazy accessor so lookup is safe even when called during cyclic module initialization
- preserve existing Anthropic model alias behavior (no functional change to mappings)

## Repro
Using `v2026.3.12` with config:
- `agents.defaults.model.primary = anthropic/claude-sonnet-4-6`
- `agents.defaults.contextPruning = { mode: "cache-ttl", ttl: "1h" }`

Before this patch:
- `openclaw status` prints `ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization`
- `openclaw gateway restart` prints the same error

After this patch:
- both commands run without that ReferenceError

## Validation
- manual repro commands above on this branch
- `pnpm vitest run src/config/config.pruning-defaults.test.ts`
