### PR TITLE
fix(auth): refresh auto profile override from lastGood

### DIFF
--- a/src/agents/auth-profiles.markauthprofilegood.test.ts
+++ b/src/agents/auth-profiles.markauthprofilegood.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  ensureAuthProfileStore,
+  markAuthProfileGood,
+  resolveAuthProfileOrder,
+} from "./auth-profiles.js";
+
+describe("markAuthProfileGood", () => {
+  it("stores lastGood under the normalized provider key so fallback success affects future selection", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-lastgood-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const authPath = path.join(agentDir, "auth-profiles.json");
+
+    try {
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        authPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "z-ai:default": {
+                type: "api_key",
+                provider: "z-ai",
+                key: "sk-a",
+              },
+              "z-ai:account2": {
+                type: "api_key",
+                provider: "z-ai",
+                key: "sk-b",
+              },
+            },
+            order: {
+              zai: ["z-ai:default", "z-ai:account2"],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      await markAuthProfileGood({
+        store,
+        provider: "zai",
+        profileId: "z-ai:account2",
+        agentDir,
+      });
+
+      const persisted = JSON.parse(await fs.readFile(authPath, "utf8")) as {
+        lastGood?: Record<string, string>;
+      };
+
+      expect(persisted.lastGood).toEqual({ zai: "z-ai:account2" });
+      expect(
+        resolveAuthProfileOrder({
+          cfg: {},
+          store,
+          provider: "zai",
+          preferredProfile: persisted.lastGood?.zai,
+        }),
+      ).toEqual(["z-ai:account2", "z-ai:default"]);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -91,14 +91,15 @@ export async function markAuthProfileGood(params: {
   agentDir?: string;
 }): Promise<void> {
   const { store, provider, profileId, agentDir } = params;
+  const providerKey = normalizeProviderId(provider);
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (freshStore) => {
       const profile = freshStore.profiles[profileId];
-      if (!profile || profile.provider !== provider) {
+      if (!profile || normalizeProviderId(profile.provider) !== providerKey) {
         return false;
       }
-      freshStore.lastGood = { ...freshStore.lastGood, [provider]: profileId };
+      freshStore.lastGood = { ...freshStore.lastGood, [providerKey]: profileId };
       return true;
     },
   });
@@ -107,9 +108,9 @@ export async function markAuthProfileGood(params: {
     return;
   }
   const profile = store.profiles[profileId];
-  if (!profile || profile.provider !== provider) {
+  if (!profile || normalizeProviderId(profile.provider) !== providerKey) {
     return;
   }
-  store.lastGood = { ...store.lastGood, [provider]: profileId };
+  store.lastGood = { ...store.lastGood, [providerKey]: profileId };
   saveAuthProfileStore(store, agentDir);
 }

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -6,9 +6,9 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import { resolveSessionAuthProfileOverride } from "./session-override.js";
 
-async function writeAuthStore(agentDir: string) {
+async function writeAuthStore(agentDir: string, payload?: unknown) {
   const authPath = path.join(agentDir, "auth-profiles.json");
-  const payload = {
+  const defaultPayload = {
     version: 1,
     profiles: {
       "zai:work": { type: "api_key", provider: "zai", key: "sk-test" },
@@ -17,7 +17,7 @@ async function writeAuthStore(agentDir: string) {
       zai: ["zai:work"],
     },
   };
-  await fs.writeFile(authPath, JSON.stringify(payload), "utf-8");
+  await fs.writeFile(authPath, JSON.stringify(payload ?? defaultPayload), "utf-8");
 }
 
 describe("resolveSessionAuthProfileOverride", () => {
@@ -48,6 +48,101 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       expect(resolved).toBe("zai:work");
       expect(sessionEntry.authProfileOverride).toBe("zai:work");
+    });
+  });
+
+  it("prefers lastGood on a new session", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        version: 1,
+        profiles: {
+          "openai-codex:default": { type: "oauth", provider: "openai-codex", access: "a" },
+          "openai-codex:account2": { type: "oauth", provider: "openai-codex", access: "b" },
+        },
+        lastGood: {
+          "openai-codex": "openai-codex:account2",
+        },
+      });
+
+      const cfg = {
+        auth: {
+          order: {
+            "openai-codex": ["openai-codex:default", "openai-codex:account2"],
+          },
+        },
+      } as OpenClawConfig;
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s2",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { "agent:designer:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:designer:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("openai-codex:account2");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:account2");
+    });
+  });
+
+  it("updates stale auto override to lastGood on existing session", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        version: 1,
+        profiles: {
+          "openai-codex:default": { type: "oauth", provider: "openai-codex", access: "a" },
+          "openai-codex:account2": { type: "oauth", provider: "openai-codex", access: "b" },
+        },
+        lastGood: {
+          "openai-codex": "openai-codex:account2",
+        },
+      });
+
+      const cfg = {
+        auth: {
+          order: {
+            "openai-codex": ["openai-codex:default", "openai-codex:account2"],
+          },
+        },
+      } as OpenClawConfig;
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s3",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 0,
+        compactionCount: 0,
+      };
+      const sessionStore = { "agent:designer:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:designer:main",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("openai-codex:account2");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:account2");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
     });
   });
 });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -85,12 +85,27 @@ export async function resolveSessionAuthProfileOverride(params: {
     return undefined;
   }
 
-  const pickFirstAvailable = () =>
-    order.find((profileId) => !isProfileInCooldown(store, profileId)) ?? order[0];
+  /**
+   * Prefer the last successful profile so sessions do not keep reusing a stale
+   * auto override (for example order[0]) after fallback has already proven that
+   * another profile is healthier.
+   */
+  const pickPreferredAvailableProfile = () => {
+    const lastGoodProfile =
+      store.lastGood?.[provider] ?? store.lastGood?.[normalizeProviderId(provider)];
+    if (
+      lastGoodProfile &&
+      order.includes(lastGoodProfile) &&
+      !isProfileInCooldown(store, lastGoodProfile)
+    ) {
+      return lastGoodProfile;
+    }
+    return order.find((profileId) => !isProfileInCooldown(store, profileId)) ?? order[0];
+  };
   const pickNextAvailable = (active: string) => {
     const startIndex = order.indexOf(active);
     if (startIndex < 0) {
-      return pickFirstAvailable();
+      return pickPreferredAvailableProfile();
     }
     for (let offset = 1; offset <= order.length; offset += 1) {
       const candidate = order[(startIndex + offset) % order.length];
@@ -119,12 +134,15 @@ export async function resolveSessionAuthProfileOverride(params: {
   }
 
   let next = current;
+  const preferredProfile = pickPreferredAvailableProfile();
   if (isNewSession) {
-    next = current ? pickNextAvailable(current) : pickFirstAvailable();
+    next = current ? pickNextAvailable(current) : preferredProfile;
   } else if (current && compactionCount > storedCompaction) {
     next = pickNextAvailable(current);
   } else if (!current || isProfileInCooldown(store, current)) {
-    next = pickFirstAvailable();
+    next = preferredProfile;
+  } else if (source === "auto" && preferredProfile && current !== preferredProfile) {
+    next = preferredProfile;
   }
 
   if (!next) {


### PR DESCRIPTION
## Summary
- prefer `lastGood` when resolving session auth profile overrides
- refresh stale auto-generated session overrides when `lastGood` now points at a healthier profile
- add regression tests for new-session and existing-session sticky fallback behavior

## Problem
A session could keep an auto-generated `authProfileOverride` pinned to the original first profile (for example `openai-codex:default`).

When fallback later proved that another profile was healthier and `lastGood` had already moved, subsequent requests in the same session could still keep starting from the stale override instead of following `lastGood`.

In practice this produced a loop like:
1. request starts from `default`
2. `default` rate-limits
3. fallback rotates to `account2`
4. next request still starts from stale auto override `default`

## Fix
- add `pickPreferredAvailableProfile()` that prefers `lastGood` when available
- use that preferred profile for new sessions
- for existing sessions, if the current override source is `auto` and a better preferred profile exists, update the session override to follow it
- preserve existing behavior for user-pinned overrides

## Tests
- `pnpm vitest run src/agents/auth-profiles/session-override.test.ts`
- added regression coverage for:
  - preferring `lastGood` on a new session
  - updating a stale auto override to `lastGood` on an existing session
