### PR TITLE
feat(agents): structured FallbackSummaryError with human-friendly rate limit messages

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -45,6 +45,35 @@ type ModelFallbackRunFn<T> = (
 ) => Promise<T>;
 
 /**
+ * Rich error thrown when all model fallback candidates have been exhausted.
+ * Carries structured attempt metadata and the soonest cooldown expiry so
+ * callers can surface human-friendly "back in X" messaging.
+ */
+export class FallbackSummaryError extends Error {
+  readonly attempts: FallbackAttempt[];
+  /** Unix ms timestamp of the earliest profile cooldown expiry, or null if unknown. */
+  readonly soonestCooldownExpiry: number | null;
+
+  constructor(
+    message: string,
+    params: {
+      attempts: FallbackAttempt[];
+      soonestCooldownExpiry: number | null;
+      cause?: Error;
+    },
+  ) {
+    super(message, { cause: params.cause });
+    this.name = "FallbackSummaryError";
+    this.attempts = params.attempts;
+    this.soonestCooldownExpiry = params.soonestCooldownExpiry;
+  }
+}
+
+export function isFallbackSummaryError(err: unknown): err is FallbackSummaryError {
+  return err instanceof FallbackSummaryError;
+}
+
+/**
  * Fallback abort check. Only treats explicit AbortError names as user aborts.
  * Message-based checks (e.g., "aborted") can mask timeouts and skip fallback.
  */
@@ -189,18 +218,19 @@ function throwFallbackFailureSummary(params: {
   lastError: unknown;
   label: string;
   formatAttempt: (attempt: FallbackAttempt) => string;
+  soonestCooldownExpiry?: number | null;
 }): never {
   if (params.attempts.length <= 1 && params.lastError) {
     throw params.lastError;
   }
   const summary =
     params.attempts.length > 0 ? params.attempts.map(params.formatAttempt).join(" | ") : "unknown";
-  throw new Error(
-    `All ${params.label} failed (${params.attempts.length || params.candidates.length}): ${summary}`,
-    {
-      cause: params.lastError instanceof Error ? params.lastError : undefined,
-    },
-  );
+  const message = `All ${params.label} failed (${params.attempts.length || params.candidates.length}): ${summary}`;
+  throw new FallbackSummaryError(message, {
+    attempts: params.attempts,
+    soonestCooldownExpiry: params.soonestCooldownExpiry ?? null,
+    cause: params.lastError instanceof Error ? params.lastError : undefined,
+  });
 }
 
 function resolveImageFallbackCandidates(params: {
@@ -762,11 +792,29 @@ export async function runWithModelFallback<T>(params: {
     }
   }
 
+  // Compute soonest cooldown expiry across all candidate providers so callers
+  // can show a human-friendly "back in X" estimate.
+  let soonestCooldownExpiry: number | null = null;
+  if (authStore) {
+    for (const candidate of candidates) {
+      const profileIds = resolveAuthProfileOrder({
+        cfg: params.cfg,
+        store: authStore,
+        provider: candidate.provider,
+      });
+      const expiry = getSoonestCooldownExpiry(authStore, profileIds);
+      if (expiry !== null && (soonestCooldownExpiry === null || expiry < soonestCooldownExpiry)) {
+        soonestCooldownExpiry = expiry;
+      }
+    }
+  }
+
   throwFallbackFailureSummary({
     attempts,
     candidates,
     lastError,
     label: "models",
+    soonestCooldownExpiry,
     formatAttempt: (attempt) =>
       `${attempt.provider}/${attempt.model}: ${attempt.error}${
         attempt.reason ? ` (${attempt.reason})` : ""

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -220,8 +220,18 @@ function throwFallbackFailureSummary(params: {
   formatAttempt: (attempt: FallbackAttempt) => string;
   soonestCooldownExpiry?: number | null;
 }): never {
-  if (params.attempts.length <= 1 && params.lastError) {
+  if (params.attempts.length === 0 && params.lastError) {
     throw params.lastError;
+  }
+  if (params.attempts.length === 1 && params.lastError) {
+    throw new FallbackSummaryError(
+      `${params.label} failed: ${params.formatAttempt(params.attempts[0])}`,
+      {
+        attempts: params.attempts,
+        soonestCooldownExpiry: params.soonestCooldownExpiry ?? null,
+        cause: params.lastError instanceof Error ? params.lastError : undefined,
+      },
+    );
   }
   const summary =
     params.attempts.length > 0 ? params.attempts.map(params.formatAttempt).join(" | ") : "unknown";
@@ -866,11 +876,15 @@ export async function runWithImageModelFallback<T>(params: {
     }
   }
 
+  // TODO: Thread authStore into runWithImageModelFallback to compute
+  // soonestCooldownExpiry for image model rate limits (same pattern as
+  // runWithModelFallback). Currently falls back to default "~60 seconds".
   throwFallbackFailureSummary({
     attempts,
     candidates,
     lastError,
     label: "image models",
+    soonestCooldownExpiry: null,
     formatAttempt: (attempt) => `${attempt.provider}/${attempt.model}: ${attempt.error}`,
   });
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -75,6 +75,35 @@ export type AgentRunLoopResult =
     }
   | { kind: "final"; payload: ReplyPayload };
 
+/**
+ * Build a human-friendly rate limit fallback message with model info and time estimate.
+ */
+function buildRateLimitFallbackText(err: unknown): string {
+  let backIn = "~60 seconds";
+  let modelInfo = "";
+  if (isFallbackSummaryError(err)) {
+    if (err.soonestCooldownExpiry !== null) {
+      const secsRemaining = Math.ceil((err.soonestCooldownExpiry - Date.now()) / 1000);
+      if (secsRemaining > 0) {
+        if (secsRemaining < 60) {
+          backIn = `~${secsRemaining}s`;
+        } else if (secsRemaining < 3600) {
+          backIn = `~${Math.ceil(secsRemaining / 60)} min`;
+        } else {
+          backIn = `~${Math.ceil(secsRemaining / 3600)} hr`;
+        }
+      } else {
+        backIn = "any moment";
+      }
+    }
+    const limitedModels = err.attempts.filter((a) => a.reason === "rate_limit").map((a) => a.model);
+    if (limitedModels.length > 0) {
+      modelInfo = ` (${limitedModels.join(", ")} rate limited)`;
+    }
+  }
+  return `⚡ Temporarily unavailable${modelInfo} — back in ${backIn}.`;
+}
+
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -636,36 +665,7 @@ export async function runAgentTurnWithFallback(params: {
           : isRoleOrderingError
             ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
             : isRateLimit
-              ? (() => {
-                  // Build a human-friendly rate limit message with model info and time estimate.
-                  let backIn = "~60 seconds";
-                  let modelInfo = "";
-                  if (isFallbackSummaryError(err)) {
-                    if (err.soonestCooldownExpiry !== null) {
-                      const secsRemaining = Math.ceil(
-                        (err.soonestCooldownExpiry - Date.now()) / 1000,
-                      );
-                      if (secsRemaining > 0) {
-                        if (secsRemaining < 60) {
-                          backIn = `~${secsRemaining}s`;
-                        } else if (secsRemaining < 3600) {
-                          backIn = `~${Math.ceil(secsRemaining / 60)} min`;
-                        } else {
-                          backIn = `~${Math.ceil(secsRemaining / 3600)} hr`;
-                        }
-                      } else {
-                        backIn = "any moment";
-                      }
-                    }
-                    const limitedModels = err.attempts
-                      .filter((a) => a.reason === "rate_limit")
-                      .map((a) => a.model);
-                    if (limitedModels.length > 0) {
-                      modelInfo = ` (${limitedModels.join(", ")} rate limited)`;
-                    }
-                  }
-                  return `⚡ Temporarily unavailable${modelInfo} — back in ${backIn}.`;
-                })()
+              ? buildRateLimitFallbackText(err)
               : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -4,7 +4,7 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { isFallbackSummaryError, runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
@@ -12,6 +12,7 @@ import {
   isContextOverflowError,
   isBillingErrorMessage,
   isLikelyContextOverflowError,
+  isRateLimitErrorMessage,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -536,6 +537,7 @@ export async function runAgentTurnWithFallback(params: {
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
       const isTransientHttp = isTransientHttpError(message);
+      const isRateLimit = isRateLimitErrorMessage(message) || /\(rate_limit\)/i.test(message);
 
       if (
         isCompactionFailure &&
@@ -633,7 +635,38 @@ export async function runAgentTurnWithFallback(params: {
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
           : isRoleOrderingError
             ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+            : isRateLimit
+              ? (() => {
+                  // Build a human-friendly rate limit message with model info and time estimate.
+                  let backIn = "~60 seconds";
+                  let modelInfo = "";
+                  if (isFallbackSummaryError(err)) {
+                    if (err.soonestCooldownExpiry !== null) {
+                      const secsRemaining = Math.ceil(
+                        (err.soonestCooldownExpiry - Date.now()) / 1000,
+                      );
+                      if (secsRemaining > 0) {
+                        if (secsRemaining < 60) {
+                          backIn = `~${secsRemaining}s`;
+                        } else if (secsRemaining < 3600) {
+                          backIn = `~${Math.ceil(secsRemaining / 60)} min`;
+                        } else {
+                          backIn = `~${Math.ceil(secsRemaining / 3600)} hr`;
+                        }
+                      } else {
+                        backIn = "any moment";
+                      }
+                    }
+                    const limitedModels = err.attempts
+                      .filter((a) => a.reason === "rate_limit")
+                      .map((a) => a.model);
+                    if (limitedModels.length > 0) {
+                      modelInfo = ` (${limitedModels.join(", ")} rate limited)`;
+                    }
+                  }
+                  return `⚡ Temporarily unavailable${modelInfo} — back in ${backIn}.`;
+                })()
+              : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",


### PR DESCRIPTION
## Problem
When all model fallback candidates are exhausted due to rate limits, users see raw error dumps like:
```
⚠️ Agent failed before reply: All models failed (3): anthropic/claude-sonnet-4: 429 ...
```
This is confusing and doesn't tell the user when service will resume.

## Solution

### 1. Structured `FallbackSummaryError`
Replace the generic `Error` thrown by `throwFallbackFailureSummary()` with a typed `FallbackSummaryError` that carries:
- `attempts`: structured metadata per attempt (model, reason, error)
- `soonestCooldownExpiry`: Unix ms timestamp of the earliest profile cooldown expiry

### 2. Human-friendly rate limit messages
The agent runner detects rate limit errors (via `isRateLimitErrorMessage` + `/rate_limit/` pattern) and uses the structured error to show:
```
⚡ Temporarily unavailable (sonnet rate limited) — back in ~3 min.
```

Time estimates are derived from actual profile cooldown expiry data, formatted as seconds/minutes/hours as appropriate.

## Impact
- Changes in `model-fallback.ts` and `agent-runner-execution.ts`
- No breaking changes — `FallbackSummaryError` extends `Error`
- Callers not using the typed check continue to work unchanged
- `isFallbackSummaryError()` type guard exported for downstream use