### PR TITLE
fix: forward Ollama think flag when thinking is disabled

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -434,6 +434,37 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
+  it("includes top-level think=false and temperature for Ollama-native requests", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          options: { temperature: 0.2, thinking: "off" },
+        });
+
+        const events = await collectStreamEvents(stream);
+        expect(events.at(-1)?.type).toBe("done");
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+
+        const requestBody = JSON.parse(requestInit.body) as {
+          think?: boolean;
+          options: { temperature?: number };
+        };
+        expect(requestBody.think).toBe(false);
+        expect(requestBody.options.temperature).toBe(0.2);
+      },
+    );
+  });
+
   it("preserves an explicit Authorization header when apiKey is a local marker", async () => {
     await withMockNdjsonFetch(
       [

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -43,6 +43,7 @@ interface OllamaChatRequest {
   stream: boolean;
   tools?: OllamaTool[];
   options?: Record<string, unknown>;
+  think?: boolean;
 }
 
 interface OllamaChatMessage {
@@ -465,6 +466,12 @@ export function createOllamaStreamFn(
           ...(ollamaTools.length > 0 ? { tools: ollamaTools } : {}),
           options: ollamaOptions,
         };
+        if (options?.thinking === false || options?.thinking === "off") {
+          body.think = false;
+        } else if (options?.thinking === true || options?.thinking === "on") {
+          body.think = true;
+        }
+        options?.onPayload?.(body);
 
         const headers: Record<string, string> = {
           "Content-Type": "application/json",

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -412,6 +412,53 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]).not.toHaveProperty("reasoning_effort");
   });
 
+  it("applies thinking=false for Ollama when thinkingLevel is off", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+
+    applyExtraParamsToAgent(agent, undefined, "ollama", "qwen35-opus-q4km", undefined, "off");
+
+    const model = {
+      api: "ollama-chat",
+      provider: "ollama",
+      id: "qwen35-opus-q4km",
+    } as unknown as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.thinking).toBe(false);
+  });
+
+  it("applies configured thinking=false for Ollama model params", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "ollama/qwen35-opus-q4km": {
+              params: {
+                thinking: "off",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "ollama", "qwen35-opus-q4km");
+
+    const model = {
+      api: "ollama-chat",
+      provider: "ollama",
+      id: "qwen35-opus-q4km",
+    } as unknown as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.thinking).toBe(false);
+  });
+
   it("injects parallel_tool_calls for openai-completions payloads when configured", () => {
     const payload = runParallelToolCallsPayloadMutationCase({
       applyProvider: "nvidia-nim",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -152,6 +152,48 @@ function createStreamFnWithExtraParams(
   return wrappedStreamFn;
 }
 
+function normalizeOllamaThinkFlag(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (["off", "false", "disabled", "disable", "none"].includes(normalized)) {
+    return false;
+  }
+  if (["on", "true", "enabled", "enable"].includes(normalized)) {
+    return true;
+  }
+  return undefined;
+}
+
+function resolveOllamaThinkingFlag(params: {
+  configuredThinking?: unknown;
+  thinkingLevel?: ThinkLevel;
+}): boolean | undefined {
+  if (params.thinkingLevel === "off") {
+    return false;
+  }
+  return normalizeOllamaThinkFlag(params.configuredThinking);
+}
+
+function createOllamaThinkingWrapper(
+  baseStreamFn: StreamFn | undefined,
+  thinkValue: boolean,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) =>
+    underlying(model, context, {
+      ...options,
+      ...(options?.thinking === undefined ? { thinking: thinkValue } : {}),
+    });
+}
+
 function isGemini31Model(modelId: string): boolean {
   const normalized = modelId.toLowerCase();
   return normalized.includes("gemini-3.1-pro") || normalized.includes("gemini-3.1-flash");
@@ -392,6 +434,17 @@ export function applyExtraParamsToAgent(
   }
 
   agent.streamFn = createAnthropicToolPayloadCompatibilityWrapper(agent.streamFn);
+
+  if (provider === "ollama") {
+    const ollamaThinkingFlag = resolveOllamaThinkingFlag({
+      configuredThinking: merged?.thinking,
+      thinkingLevel,
+    });
+    if (ollamaThinkingFlag !== undefined) {
+      log.debug(`applying Ollama think=${ollamaThinkingFlag} for ${provider}/${modelId}`);
+      agent.streamFn = createOllamaThinkingWrapper(agent.streamFn, ollamaThinkingFlag);
+    }
+  }
 
   if (provider === "openrouter") {
     log.debug(`applying OpenRouter app attribution headers for ${provider}/${modelId}`);


### PR DESCRIPTION
## Summary
- forward OpenClaw's disabled thinking state to native Ollama `/api/chat` requests via top-level `think: false`
- preserve the existing payload mutation flow by mutating the request body in `onPayload` instead of replacing it
- propagate configured Ollama `thinking` params through `applyExtraParamsToAgent(...)`
- add regression coverage for both the native request body and extra-params wrapper behavior

## Testing
- `corepack pnpm vitest run src/agents/ollama-stream.test.ts`
- `corepack pnpm vitest run src/agents/pi-embedded-runner-extraparams.test.ts`
