### PR TITLE
fix(paths): use OPENCLAW_HOME directly as config dir when explicitly set

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -290,6 +290,22 @@ export function resolveConfigDir(
   if (override) {
     return resolveUserPath(override, env, homedir);
   }
+
+  // If OPENCLAW_HOME is explicitly set, use it directly as the config directory.
+  // This prevents nested .openclaw/.openclaw when OPENCLAW_HOME already points to .openclaw.
+  const explicitHome = env.OPENCLAW_HOME?.trim();
+  if (explicitHome) {
+    const resolvedHome = resolveRequiredHomeDir(env, homedir);
+    try {
+      if (fs.existsSync(resolvedHome)) {
+        return resolvedHome;
+      }
+    } catch {
+      // best-effort
+    }
+    return resolvedHome;
+  }
+
   const newDir = path.join(resolveRequiredHomeDir(env, homedir), ".openclaw");
   try {
     const hasNew = fs.existsSync(newDir);


### PR DESCRIPTION
\)\ → \/home/user/.openclaw/.openclaw\

## Solution
When OPENCLAW_HOME is explicitly set, use it directly as the config directory. The \.openclaw\ suffix is only needed as a convention under \$HOME\.

## Test Plan
- Set OPENCLAW_HOME=~/.openclaw
- Run openclaw onboard
- Verify config is written to ~/.openclaw/openclaw.json (not ~/.openclaw/.openclaw/openclaw.json)

## Impact
- Fixes config file location for users who explicitly set OPENCLAW_HOME to ~/.openclaw
- No breaking changes for users who don't set OPENCLAW_HOME or set it to a different path