### PR TITLE
fix(mmr): add CJK tokenization and exclude katakana prolonged sound mark (U+30FC)

### DIFF
--- a/src/memory/mmr.ts
+++ b/src/memory/mmr.ts
@@ -31,7 +31,16 @@ export const DEFAULT_MMR_CONFIG: MMRConfig = {
  */
 export function tokenize(text: string): Set<string> {
   const tokens = text.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
-  return new Set(tokens);
+  // Extract individual CJK characters as tokens so Jaccard similarity
+  // works correctly for Chinese, Japanese, and Korean text. Without this,
+  // pure-CJK strings always tokenize to an empty Set, causing every pair
+  // to have jaccardSimilarity === 1 and breaking MMR diversity re-ranking.
+  //
+  // U+30FC (KATAKANA-HIRAGANA PROLONGED SOUND MARK, "ー") is intentionally
+  // excluded: it is a modifier that elongates the preceding vowel and carries
+  // no independent semantic meaning, so it should not become a token.
+  const cjkTokens = text.match(/[一-鿿぀-ゟ゠-・ヽ-ヿ가-힯]/g) ?? [];
+  return new Set([...tokens, ...cjkTokens]);
 }
 
 /**


### PR DESCRIPTION
## Problem

`tokenize()` in `src/memory/mmr.ts` only extracts ASCII alphanumeric tokens via `/[a-z0-9_]+/g`. For pure CJK text this produces an **empty `Set`**, causing:

1. `jaccardSimilarity(Set{}, Set{}) === 1` for any two CJK strings → MMR treats all CJK memories as identical and breaks diversity re-ranking entirely for Chinese/Japanese/Korean content.

2. The Katakana range `\u30a0-\u30ff` would include **U+30FC** (KATAKANA-HIRAGANA PROLONGED SOUND MARK, "ー") — a modifier that merely elongates the preceding vowel with no independent semantic meaning.

### Failing test

```
FAIL  src/memory/mmr.test.ts > tokenize > extracts individual CJK characters as tokens
AssertionError: CJK Katakana: expected Set{ 'コ', 'ン', 'ピ', 'ュ', 'ー', 'タ' } to deeply equal Set{ 'コ', 'ン', 'ピ', 'ュ', 'タ' }
```

## Fix

Add a secondary regex for individual CJK character extraction, with the Katakana range split to exclude U+30FC:

```diff
 export function tokenize(text: string): Set<string> {
   const tokens = text.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
-  return new Set(tokens);
+  // Extract individual CJK characters as tokens so Jaccard similarity
+  // works correctly for Chinese, Japanese, and Korean text. Without this,
+  // pure-CJK strings always tokenize to an empty Set, causing every pair
+  // to have jaccardSimilarity === 1 and breaking MMR diversity re-ranking.
+  //
+  // U+30FC (KATAKANA-HIRAGANA PROLONGED SOUND MARK, "ー") is intentionally
+  // excluded: it is a modifier that elongates the preceding vowel and carries
+  // no independent semantic meaning, so it should not become a token.
+  const cjkTokens = text.match(/[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30fb\u30fd-\u30ff\uac00-\ud7af]/g) ?? [];
+  return new Set([...tokens, ...cjkTokens]);
 }
```

## Unicode ranges

| Range | Script | Note |
|---|---|---|
| U+4E00–9FFF | CJK Unified Ideographs | Chinese, Japanese Kanji |
| U+3040–309F | Hiragana | Japanese |
| U+30A0–30FB, U+30FD–30FF | Katakana | Japanese (U+30FC excluded) |
| U+AC00–D7AF | Hangul Syllables | Korean |

## All tokenize tests pass

| Test case | Input | Expected tokens | Status |
|---|---|---|---|
| CJK Chinese | 机器学习 | {机,器,学,习} | ✓ |
| CJK Hiragana | にほんご | {に,ほ,ん,ご} | ✓ |
| CJK Katakana | コンピュータ | {コ,ン,ピ,ュ,タ} | ✓ (was failing) |
| Mixed CJK+ASCII | hello 机器 | {hello,机,器} | ✓ |