### PR TITLE
Android: guard ElevenLabs AudioTrack cleanup races

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/ElevenLabsStreamingTts.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/ElevenLabsStreamingTts.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 import okhttp3.*
 import org.json.JSONObject
 import kotlin.math.max
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Streams text chunks to ElevenLabs WebSocket API and plays audio in real-time.
@@ -58,7 +59,7 @@ class ElevenLabsStreamingTts(
   val isPlaying: StateFlow<Boolean> = _isPlaying
 
   private var webSocket: WebSocket? = null
-  private var audioTrack: AudioTrack? = null
+  private val audioTrack = AtomicReference<AudioTrack?>(null)
   private var trackStarted = false
   private var client: OkHttpClient? = null
   @Volatile private var stopped = false
@@ -112,7 +113,7 @@ class ElevenLabsStreamingTts(
       Log.e(TAG, "AudioTrack init failed")
       return
     }
-    audioTrack = track
+    audioTrack.set(track)
     _isPlaying.value = true
 
     // Open WebSocket
@@ -268,8 +269,7 @@ class ElevenLabsStreamingTts(
     drainJob = null
     webSocket?.cancel()
     webSocket = null
-    val track = audioTrack
-    audioTrack = null
+    val track = audioTrack.getAndSet(null)
     if (track != null) {
       try {
         track.pause()
@@ -283,20 +283,35 @@ class ElevenLabsStreamingTts(
   }
 
   private fun writeToTrack(pcmBytes: ByteArray) {
-    val track = audioTrack ?: return
+    val track = audioTrack.get() ?: return
     if (stopped) return
 
     // Start playback on first audio chunk — avoids underrun
     if (!trackStarted) {
-      track.play()
-      trackStarted = true
-      hasReceivedAudio = true
-      Log.d(TAG, "AudioTrack started on first chunk")
+      try {
+        track.play()
+        trackStarted = true
+        hasReceivedAudio = true
+        Log.d(TAG, "AudioTrack started on first chunk")
+      } catch (err: IllegalStateException) {
+        if (!stopped) {
+          Log.w(TAG, "AudioTrack play failed: ${err.message}")
+        }
+        return
+      }
     }
 
     var offset = 0
     while (offset < pcmBytes.size && !stopped) {
-      val wrote = track.write(pcmBytes, offset, pcmBytes.size - offset)
+      val wrote =
+        try {
+          track.write(pcmBytes, offset, pcmBytes.size - offset)
+        } catch (err: IllegalStateException) {
+          if (!stopped) {
+            Log.w(TAG, "AudioTrack write failed: ${err.message}")
+          }
+          return
+        }
       if (wrote <= 0) {
         if (stopped) return
         Log.w(TAG, "AudioTrack write returned $wrote")
@@ -312,8 +327,14 @@ class ElevenLabsStreamingTts(
     val deadline = System.currentTimeMillis() + 10_000
     while (!stopped && System.currentTimeMillis() < deadline) {
       // Check if track is still playing
-      val track = audioTrack ?: return
-      if (track.playState != AudioTrack.PLAYSTATE_PLAYING) return
+      val track = audioTrack.get() ?: return
+      val playState =
+        try {
+          track.playState
+        } catch (_: IllegalStateException) {
+          return
+        }
+      if (playState != AudioTrack.PLAYSTATE_PLAYING) return
       try {
         Thread.sleep(100)
       } catch (_: InterruptedException) {
@@ -323,8 +344,7 @@ class ElevenLabsStreamingTts(
   }
 
   private fun cleanup() {
-    val track = audioTrack
-    audioTrack = null
+    val track = audioTrack.getAndSet(null)
     if (track != null) {
       try {
         track.stop()


### PR DESCRIPTION
## Summary
- fix a race where `stop()`/`cleanup()` could release the same `AudioTrack` while a delayed WebSocket audio chunk was still trying to play or write
- store the active `AudioTrack` in an `AtomicReference` so cleanup paths atomically take ownership before releasing it
- catch `IllegalStateException` around delayed `play()`/`write()`/`playState` access so late chunks fail safely instead of crashing the TTS stream

## Test plan
- [x] Read through `stop()`, `cleanup()`, `onClosed()`, and `writeToTrack()` to verify only one path can now release the current `AudioTrack`
- [x] `JAVA_HOME="/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home" ./gradlew --no-daemon :app:assembleDebug :app:testDebugUnitTest -Dorg.gradle.java.home="/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home"`

> This PR was authored with AI assistance.

Made with [Cursor](https://cursor.com)