### PR TITLE
docs: add memory_search and memory_get tool documentation

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -531,7 +531,7 @@ Core parameters:
 Notes:
 
 - Returns snippets (~400 token chunks, ~700 char cap) with file path, line range, and relevance score.
-- Powered by QMD (sqlite-vec) when configured; falls back to builtin SQLite if QMD is unavailable.
+- Powered by QMD (sqlite-vec) when configured; falls back to the builtin provider (Markdown embeddings) if QMD is unavailable.
 - Session transcript indexing is optional (`memory.qmd.sessions.enabled`).
 - See [Memory](/concepts/memory) for configuration and backend options.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -519,6 +519,39 @@ Notes:
 - Result is restricted to per-agent allowlists (`agents.list[].subagents.allowAgents`).
 - When `["*"]` is configured, the tool includes all configured agents and marks `allowAny: true`.
 
+### `memory_search`
+
+Semantically search memory files (`MEMORY.md` + `memory/**/*.md`) and optionally indexed session transcripts.
+
+Core parameters:
+
+- `query` (required) — search query string
+- `limit` (optional) — max results to return
+
+Notes:
+
+- Returns snippets (~400 token chunks, ~700 char cap) with file path, line range, and relevance score.
+- Powered by QMD (sqlite-vec) when configured; falls back to builtin SQLite if QMD is unavailable.
+- Session transcript indexing is optional (`memory.qmd.sessions.enabled`).
+- See [Memory](/concepts/memory) for configuration and backend options.
+
+### `memory_get`
+
+Read a specific memory file by workspace-relative path.
+
+Core parameters:
+
+- `path` (required) — memory file path (e.g., `memory/2026-03-14.md` or `MEMORY.md`)
+- `offset` (optional) — start line number (1-indexed)
+- `limit` (optional) — max lines to read
+
+Notes:
+
+- Restricted to `MEMORY.md` and `memory/**/*.md` by default.
+- Extra paths must be explicitly allowlisted via `memorySearch.extraPaths`.
+- QMD-sourced results (e.g., `qmd/<collection>/<path>`) are also supported when QMD backend is configured.
+- See [Memory](/concepts/memory) for file layout and workflow.
+
 ## Parameters (common)
 
 Gateway-backed tools (`canvas`, `nodes`, `cron`):


### PR DESCRIPTION
This PR adds documentation for the `memory_search` and `memory_get` tools in the tools inventory section.

These tools were already listed in the `group:memory` tool group but lacked individual documentation entries in the tool inventory.

**Changes:**
- Document `memory_search` - semantic search of memory files and session transcripts
- Document `memory_get` - read specific memory files by workspace-relative path
- Include core parameters and usage notes for both tools
- Link to the Memory concepts documentation

This is a docs-only change with no behavioral impact.