### PR TITLE
Android: harden permission dialogs across activity teardown

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
@@ -4,6 +4,8 @@ import android.content.pm.PackageManager
 import android.content.Intent
 import android.Manifest
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.provider.Settings
 import androidx.appcompat.app.AlertDialog
 import androidx.activity.ComponentActivity
@@ -24,6 +26,7 @@ import kotlin.coroutines.resume
 class PermissionRequester(private val activity: ComponentActivity) {
   private val mutex = Mutex()
   private var pending: CompletableDeferred<Map<String, Boolean>>? = null
+  private val mainHandler = Handler(Looper.getMainLooper())
 
   private val launcher: ActivityResultLauncher<Array<String>> =
     activity.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
@@ -95,17 +98,24 @@ class PermissionRequester(private val activity: ComponentActivity) {
         val lifecycle = activity.lifecycle
         var dialog: AlertDialog? = null
         var observer: LifecycleEventObserver? = null
-        observer =
+        val removeObserver = {
+          observer?.let(lifecycle::removeObserver)
+          observer = null
+        }
+        val actualObserver =
           LifecycleEventObserver { _, event ->
             if (event != Lifecycle.Event.ON_DESTROY || !cont.isActive) return@LifecycleEventObserver
             dialog?.dismiss()
-            observer?.let(lifecycle::removeObserver)
+            removeObserver()
             cont.resume(false)
           }
-        lifecycle.addObserver(observer)
+        observer = actualObserver
+        lifecycle.addObserver(actualObserver)
         cont.invokeOnCancellation {
-          observer?.let(lifecycle::removeObserver)
-          dialog?.dismiss()
+          mainHandler.post {
+            removeObserver()
+            dialog?.dismiss()
+          }
         }
         dialog =
           AlertDialog.Builder(activity)
@@ -113,40 +123,58 @@ class PermissionRequester(private val activity: ComponentActivity) {
             .setMessage(buildRationaleMessage(permissions))
             .setPositiveButton("Continue") { _, _ ->
               if (!cont.isActive) return@setPositiveButton
-              observer?.let(lifecycle::removeObserver)
+              removeObserver()
               cont.resume(true)
             }
             .setNegativeButton("Not now") { _, _ ->
               if (!cont.isActive) return@setNegativeButton
-              observer?.let(lifecycle::removeObserver)
+              removeObserver()
               cont.resume(false)
             }
             .setOnCancelListener {
               if (!cont.isActive) return@setOnCancelListener
-              observer?.let(lifecycle::removeObserver)
+              removeObserver()
               cont.resume(false)
             }
             .show()
       }
     }
 
-  private fun showSettingsDialog(permissions: List<String>) {
-    if (activity.isFinishing || activity.isDestroyed) return
-    AlertDialog.Builder(activity)
-      .setTitle("Enable permission in Settings")
-      .setMessage(buildSettingsMessage(permissions))
-      .setPositiveButton("Open Settings") { _, _ ->
-        if (activity.isFinishing || activity.isDestroyed) return@setPositiveButton
-        val intent =
-          Intent(
-            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-            Uri.fromParts("package", activity.packageName, null),
-          )
-        activity.startActivity(intent)
+  private suspend fun showSettingsDialog(permissions: List<String>) =
+    withContext(Dispatchers.Main) {
+      if (activity.isFinishing || activity.isDestroyed) return@withContext
+      val lifecycle = activity.lifecycle
+      var dialog: AlertDialog? = null
+      var observer: LifecycleEventObserver? = null
+      val removeObserver = {
+        observer?.let(lifecycle::removeObserver)
+        observer = null
       }
-      .setNegativeButton("Cancel", null)
-      .show()
-  }
+      val actualObserver =
+        LifecycleEventObserver { _, event ->
+          if (event != Lifecycle.Event.ON_DESTROY) return@LifecycleEventObserver
+          removeObserver()
+          dialog?.dismiss()
+        }
+      observer = actualObserver
+      lifecycle.addObserver(actualObserver)
+      dialog =
+        AlertDialog.Builder(activity)
+          .setTitle("Enable permission in Settings")
+          .setMessage(buildSettingsMessage(permissions))
+          .setPositiveButton("Open Settings") { _, _ ->
+            if (activity.isFinishing || activity.isDestroyed) return@setPositiveButton
+            val intent =
+              Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", activity.packageName, null),
+              )
+            activity.startActivity(intent)
+          }
+          .setNegativeButton("Cancel", null)
+          .setOnDismissListener { removeObserver() }
+          .show()
+    }
 
   private fun buildRationaleMessage(permissions: List<String>): String {
     val labels = permissions.map { permissionLabel(it) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
@@ -11,6 +11,8 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.app.ActivityCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -86,22 +88,55 @@ class PermissionRequester(private val activity: ComponentActivity) {
 
   private suspend fun showRationaleDialog(permissions: List<String>): Boolean =
     withContext(Dispatchers.Main) {
+      if (activity.isFinishing || activity.isDestroyed) {
+        return@withContext false
+      }
       suspendCancellableCoroutine { cont ->
-        AlertDialog.Builder(activity)
-          .setTitle("Permission required")
-          .setMessage(buildRationaleMessage(permissions))
-          .setPositiveButton("Continue") { _, _ -> cont.resume(true) }
-          .setNegativeButton("Not now") { _, _ -> cont.resume(false) }
-          .setOnCancelListener { cont.resume(false) }
-          .show()
+        val lifecycle = activity.lifecycle
+        var dialog: AlertDialog? = null
+        var observer: LifecycleEventObserver? = null
+        observer =
+          LifecycleEventObserver { _, event ->
+            if (event != Lifecycle.Event.ON_DESTROY || !cont.isActive) return@LifecycleEventObserver
+            dialog?.dismiss()
+            observer?.let(lifecycle::removeObserver)
+            cont.resume(false)
+          }
+        lifecycle.addObserver(observer)
+        cont.invokeOnCancellation {
+          observer?.let(lifecycle::removeObserver)
+          dialog?.dismiss()
+        }
+        dialog =
+          AlertDialog.Builder(activity)
+            .setTitle("Permission required")
+            .setMessage(buildRationaleMessage(permissions))
+            .setPositiveButton("Continue") { _, _ ->
+              if (!cont.isActive) return@setPositiveButton
+              observer?.let(lifecycle::removeObserver)
+              cont.resume(true)
+            }
+            .setNegativeButton("Not now") { _, _ ->
+              if (!cont.isActive) return@setNegativeButton
+              observer?.let(lifecycle::removeObserver)
+              cont.resume(false)
+            }
+            .setOnCancelListener {
+              if (!cont.isActive) return@setOnCancelListener
+              observer?.let(lifecycle::removeObserver)
+              cont.resume(false)
+            }
+            .show()
       }
     }
 
   private fun showSettingsDialog(permissions: List<String>) {
+    if (activity.isFinishing || activity.isDestroyed) return
     AlertDialog.Builder(activity)
       .setTitle("Enable permission in Settings")
       .setMessage(buildSettingsMessage(permissions))
       .setPositiveButton("Open Settings") { _, _ ->
+        if (activity.isFinishing || activity.isDestroyed) return@setPositiveButton
         val intent =
           Intent(
             Settings.ACTION_APPLICATION_DETAILS_SETTINGS,

--- a/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 
 class PermissionRequester(private val activity: ComponentActivity) {
@@ -98,44 +99,38 @@ class PermissionRequester(private val activity: ComponentActivity) {
         val lifecycle = activity.lifecycle
         var dialog: AlertDialog? = null
         var observer: LifecycleEventObserver? = null
+        val finished = AtomicBoolean(false)
         val removeObserver = {
           observer?.let(lifecycle::removeObserver)
           observer = null
         }
+        fun finish(result: Boolean?) {
+          if (!finished.compareAndSet(false, true)) return
+          removeObserver()
+          dialog?.dismiss()
+          if (result != null) {
+            cont.resume(result)
+          }
+        }
         val actualObserver =
           LifecycleEventObserver { _, event ->
-            if (event != Lifecycle.Event.ON_DESTROY || !cont.isActive) return@LifecycleEventObserver
-            dialog?.dismiss()
-            removeObserver()
-            cont.resume(false)
+            if (event != Lifecycle.Event.ON_DESTROY) return@LifecycleEventObserver
+            finish(false)
           }
         observer = actualObserver
         lifecycle.addObserver(actualObserver)
         cont.invokeOnCancellation {
           mainHandler.post {
-            removeObserver()
-            dialog?.dismiss()
+            finish(null)
           }
         }
         dialog =
           AlertDialog.Builder(activity)
             .setTitle("Permission required")
             .setMessage(buildRationaleMessage(permissions))
-            .setPositiveButton("Continue") { _, _ ->
-              if (!cont.isActive) return@setPositiveButton
-              removeObserver()
-              cont.resume(true)
-            }
-            .setNegativeButton("Not now") { _, _ ->
-              if (!cont.isActive) return@setNegativeButton
-              removeObserver()
-              cont.resume(false)
-            }
-            .setOnCancelListener {
-              if (!cont.isActive) return@setOnCancelListener
-              removeObserver()
-              cont.resume(false)
-            }
+            .setPositiveButton("Continue") { _, _ -> finish(true) }
+            .setNegativeButton("Not now") { _, _ -> finish(false) }
+            .setOnCancelListener { finish(false) }
             .show()
       }
     }


### PR DESCRIPTION
## Summary
- fix a crash path where `PermissionRequester` could try to show a dialog or open app settings after the hosting `Activity` was already finishing or destroyed
- dismiss and complete the rationale coroutine when the `Activity` reaches `ON_DESTROY` so a rotation or teardown cannot leave the permission flow hanging forever
- keep the existing permission UX, but make the rationale/settings dialogs fail closed when the host `Activity` is no longer valid

## Test plan
- [x] Read through the rationale and settings dialog paths to verify they now bail out cleanly on `isFinishing` / `isDestroyed`
- [x] Read through the lifecycle observer path to verify `showRationaleDialog()` now resumes `false` instead of hanging when the host `Activity` is destroyed mid-dialog
- [x] `JAVA_HOME="/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home" ./gradlew --no-daemon :app:assembleDebug :app:testDebugUnitTest -Dorg.gradle.java.home="/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home"`

> This PR was authored with AI assistance.

Made with [Cursor](https://cursor.com)