### PR TITLE
Android: make current-location callback cancellation-safe

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
@@ -10,11 +10,9 @@ import androidx.core.content.ContextCompat
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlinx.coroutines.suspendCancellableCoroutine
 
 class LocationCaptureManager(private val context: Context) {
   data class Payload(val payloadJson: String)
@@ -101,17 +99,15 @@ class LocationCaptureManager(private val context: Context) {
       providers.firstOrNull { manager.isProviderEnabled(it) }
         ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no providers available")
     return withTimeout(timeoutMs.coerceAtLeast(1)) {
-      suspendCancellableCoroutine { cont ->
+      val location =
+        suspendCancellableCoroutine<Location?> { cont ->
         val signal = CancellationSignal()
         cont.invokeOnCancellation { signal.cancel() }
         manager.getCurrentLocation(resolved, signal, context.mainExecutor) { location ->
-          if (location != null) {
-            cont.resume(location)
-          } else {
-            cont.resumeWithException(IllegalStateException("LOCATION_UNAVAILABLE: no fix"))
-          }
+            cont.resume(location) { _, _, _ -> }
         }
       }
+      location ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no fix")
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix a timeout race in `LocationCaptureManager.requestCurrent()` where `getCurrentLocation()` could still invoke its callback after `withTimeout()` had already cancelled the continuation
- switch the callback to return a nullable `Location` through `CancellableContinuation.resume(value) { ... }`, so delayed callbacks are safely dropped instead of crashing with `Already resumed`
- keep the existing `LOCATION_UNAVAILABLE: no fix` behavior by converting `null` into the same exception after the suspension point rather than from inside the callback

## Test plan
- [x] Read through the timeout + cancellation path to verify delayed callbacks now use cancellation-safe completion
- [x] Read through the `null` location path to verify it still returns `LOCATION_UNAVAILABLE: no fix`
- [x] `JAVA_HOME="/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home" ./gradlew --no-daemon :app:assembleDebug :app:testDebugUnitTest -Dorg.gradle.java.home="/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home"`

> This PR was authored with AI assistance.

Made with [Cursor](https://cursor.com)