### PR TITLE
feat(slack): per-agent display names via chat:write.customize

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -283,7 +283,7 @@ describe("slackPlugin agentPrompt", () => {
     });
 
     expect(hints).toEqual([
-      "- Slack interactive replies are disabled. If needed, ask to set `channels.slack.capabilities.interactiveReplies=true` (or the same under `channels.slack.accounts.<account>.capabilities`).",
+      '- Slack interactive replies are disabled. If needed, ask to add `"interactiveReplies"` to `channels.slack.capabilities` (or `channels.slack.accounts.<account>.capabilities`).',
     ]);
   });
 

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/slack";
 import { describe, expect, it, vi } from "vitest";
+import { mapOutboundIdentityToSlack } from "./channel.js";
 import { createRuntimeEnv } from "../../../test/helpers/extensions/runtime-env.js";
 import { slackOutbound } from "./outbound-adapter.js";
 
@@ -389,5 +390,70 @@ describe("slackPlugin config", () => {
     expect(snapshot?.configured).toBe(true);
     expect(snapshot?.botTokenStatus).toBe("available");
     expect(snapshot?.signingSecretStatus).toBe("configured_unavailable");
+  });
+});
+
+describe("mapOutboundIdentityToSlack", () => {
+  it("returns undefined for undefined identity", () => {
+    expect(mapOutboundIdentityToSlack(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for empty identity", () => {
+    expect(mapOutboundIdentityToSlack({})).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only fields", () => {
+    expect(mapOutboundIdentityToSlack({ name: "  ", avatarUrl: " ", emoji: " " })).toBeUndefined();
+  });
+
+  it("maps name to username", () => {
+    expect(mapOutboundIdentityToSlack({ name: "Levy" })).toEqual({
+      username: "Levy",
+      iconUrl: undefined,
+      iconEmoji: undefined,
+    });
+  });
+
+  it("maps avatarUrl to iconUrl", () => {
+    expect(mapOutboundIdentityToSlack({ avatarUrl: "https://example.com/avatar.png" })).toEqual({
+      username: undefined,
+      iconUrl: "https://example.com/avatar.png",
+      iconEmoji: undefined,
+    });
+  });
+
+  it("maps colon-wrapped emoji to iconEmoji when no avatarUrl", () => {
+    expect(mapOutboundIdentityToSlack({ emoji: ":robot_face:" })).toEqual({
+      username: undefined,
+      iconUrl: undefined,
+      iconEmoji: ":robot_face:",
+    });
+  });
+
+  it("prefers avatarUrl over emoji for icon", () => {
+    const result = mapOutboundIdentityToSlack({
+      avatarUrl: "https://example.com/avatar.png",
+      emoji: ":robot_face:",
+    });
+    expect(result?.iconUrl).toBe("https://example.com/avatar.png");
+    expect(result?.iconEmoji).toBeUndefined();
+  });
+
+  it("ignores non-colon-wrapped emoji", () => {
+    expect(mapOutboundIdentityToSlack({ emoji: "🤖" })).toBeUndefined();
+  });
+
+  it("maps all fields together", () => {
+    expect(
+      mapOutboundIdentityToSlack({
+        name: "Byte",
+        avatarUrl: "https://example.com/byte.png",
+        emoji: ":gear:",
+      }),
+    ).toEqual({
+      username: "Byte",
+      iconUrl: "https://example.com/byte.png",
+      iconEmoji: undefined, // avatarUrl takes precedence
+    });
   });
 });

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -82,6 +82,11 @@ function getTokenForOperation(
   if (operation === "read") {
     return userToken ?? botToken;
   }
+  if (!allowUserWrites) {
+    return botToken;
+  }
+  return botToken ?? userToken;
+}
 
 /**
  * Maps an OutboundIdentity (name/avatarUrl/emoji) to the SlackSendIdentity
@@ -110,12 +115,6 @@ export function mapOutboundIdentityToSlack(identity?: {
     return undefined;
   }
   return { username, iconUrl, iconEmoji };
-}
-
-  if (!allowUserWrites) {
-    return botToken;
-  }
-  return botToken ?? userToken;
 }
 
 type SlackSendFn = ReturnType<typeof getSlackRuntime>["channel"]["slack"]["sendMessageSlack"];
@@ -526,7 +525,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
     textChunkLimit: 4000,
     ...createAttachedChannelResultAdapter({
       channel: "slack",
-      sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg , identity}\) => {
+      sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg, identity }) => {
         const { send, threadTsValue, tokenOverride } = resolveSlackSendContext({
           cfg,
           accountId: accountId ?? undefined,

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -82,6 +82,36 @@ function getTokenForOperation(
   if (operation === "read") {
     return userToken ?? botToken;
   }
+
+/**
+ * Maps an OutboundIdentity (name/avatarUrl/emoji) to the SlackSendIdentity
+ * shape (username/iconUrl/iconEmoji) expected by sendMessageSlack.
+ *
+ * When the agent has `identity.name` and/or `identity.emoji` configured,
+ * these are passed as `username` and `icon_emoji` in chat.postMessage calls,
+ * enabling per-agent display names via the `chat:write.customize` Slack scope.
+ * Falls back gracefully if the scope is missing (handled in send.ts).
+ */
+export function mapOutboundIdentityToSlack(identity?: {
+  name?: string;
+  avatarUrl?: string;
+  emoji?: string;
+}): { username?: string; iconUrl?: string; iconEmoji?: string } | undefined {
+  if (!identity) {
+    return undefined;
+  }
+  const username = identity.name?.trim() || undefined;
+  const iconUrl = identity.avatarUrl?.trim() || undefined;
+  // Only use emoji as icon when no avatar URL is present and the emoji is in
+  // Slack's colon-wrapped format (e.g. ":robot_face:").
+  const rawEmoji = identity.emoji?.trim();
+  const iconEmoji = !iconUrl && rawEmoji && /^:[^:\s]+:$/.test(rawEmoji) ? rawEmoji : undefined;
+  if (!username && !iconUrl && !iconEmoji) {
+    return undefined;
+  }
+  return { username, iconUrl, iconEmoji };
+}
+
   if (!allowUserWrites) {
     return botToken;
   }
@@ -396,6 +426,17 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       threadId: null,
     }),
   },
+  agentPrompt: {
+    messageToolHints: ({ cfg, accountId }) =>
+      isSlackInteractiveRepliesEnabled({ cfg, accountId })
+        ? [
+            "- Slack interactive replies: use `[[slack_buttons: Label:value, Other:other]]` to add action buttons that route clicks back as Slack interaction system events.",
+            "- Slack selects: use `[[slack_select: Placeholder | Label:value, Other:other]]` to add a static select menu that routes the chosen value back as a Slack interaction system event.",
+          ]
+        : [
+            '- Slack interactive replies are disabled. If needed, ask to add `"interactiveReplies"` to `channels.slack.capabilities` (or `channels.slack.accounts.<account>.capabilities`).',
+          ],
+  },
   messaging: {
     normalizeTarget: normalizeSlackMessagingTarget,
     resolveSessionTarget: ({ id }) => normalizeSlackMessagingTarget(`channel:${id}`),
@@ -485,7 +526,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
     textChunkLimit: 4000,
     ...createAttachedChannelResultAdapter({
       channel: "slack",
-      sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg }) => {
+      sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg , identity}\) => {
         const { send, threadTsValue, tokenOverride } = resolveSlackSendContext({
           cfg,
           accountId: accountId ?? undefined,
@@ -493,11 +534,13 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
           replyToId,
           threadId,
         });
+        const slackIdentity = mapOutboundIdentityToSlack(identity);
         return await send(to, text, {
           cfg,
           threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
           accountId: accountId ?? undefined,
           ...(tokenOverride ? { token: tokenOverride } : {}),
+          ...(slackIdentity ? { identity: slackIdentity } : {}),
         });
       },
       sendMedia: async ({
@@ -510,6 +553,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         replyToId,
         threadId,
         cfg,
+        identity,
       }) => {
         const { send, threadTsValue, tokenOverride } = resolveSlackSendContext({
           cfg,
@@ -518,6 +562,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
           replyToId,
           threadId,
         });
+        const slackIdentity = mapOutboundIdentityToSlack(identity);
         return await send(to, text, {
           cfg,
           mediaUrl,
@@ -525,6 +570,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
           threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
           accountId: accountId ?? undefined,
           ...(tokenOverride ? { token: tokenOverride } : {}),
+          ...(slackIdentity ? { identity: slackIdentity } : {}),
         });
       },
     }),


### PR DESCRIPTION
## Closing — Superseded by upstream

All functionality from this PR has been natively implemented in upstream:
- Identity mapping → `outbound-adapter.ts` (`resolveSlackSendIdentity`)
- Agent prompt hints → `shared.ts` (`agentPrompt.messageToolHints`)
- `chat:write.customize` support → wired through the outbound pipeline

No further action needed. Thank you to the maintainers for incorporating this.