### PR TITLE
fix: load pierre themes without json module imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/mentions: recognize `matrix.to` mentions whose visible label uses the bot's room display name, so `requireMention: true` rooms respond correctly in modern Matrix clients. (#55393) thanks @nickludlam.
 - Ollama/thinking off: route `thinkingLevel=off` through the live Ollama extension request path so thinking-capable Ollama models now receive top-level `think: false` instead of silently generating hidden reasoning tokens. (#53200) Thanks @BruceMacD.
 - Plugins/diffs: stage bundled `@pierre/diffs` runtime dependencies during packaged updates so the bundled diff viewer keeps loading after global installs and updates. (#56077) Thanks @gumadeiras.
+- Plugins/diffs: load bundled Pierre themes without JSON module imports so diff rendering keeps working on newer Node builds. (#45869) thanks @NickHood1984.
 
 ## 2026.3.24
 

--- a/extensions/diffs/src/config.test.ts
+++ b/extensions/diffs/src/config.test.ts
@@ -1,4 +1,10 @@
 import fs from "node:fs";
+import {
+  disposeHighlighter,
+  RegisteredCustomThemes,
+  ResolvedThemes,
+  ResolvingThemes,
+} from "@pierre/diffs";
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_DIFFS_PLUGIN_SECURITY,
@@ -308,6 +314,56 @@ describe("renderDiffDocument", () => {
     expect(rendered.fileCount).toBe(2);
     expect(rendered.html).toContain("Workspace patch");
     expect(rendered.imageHtml).toContain("max-width: 1180px;");
+  });
+
+  it("re-registers pierre theme loaders before rendering", async () => {
+    await disposeHighlighter();
+
+    const originalLightLoader = RegisteredCustomThemes.get("pierre-light");
+    const originalDarkLoader = RegisteredCustomThemes.get("pierre-dark");
+    const brokenLoader = async () => {
+      throw new Error("broken pierre theme loader");
+    };
+
+    RegisteredCustomThemes.set("pierre-light", brokenLoader);
+    RegisteredCustomThemes.set("pierre-dark", brokenLoader);
+    ResolvedThemes.delete("pierre-light");
+    ResolvedThemes.delete("pierre-dark");
+    ResolvingThemes.delete("pierre-light");
+    ResolvingThemes.delete("pierre-dark");
+
+    try {
+      const rendered = await renderDiffDocument(
+        {
+          kind: "before_after",
+          before: "const value = 1;\n",
+          after: "const value = 2;\n",
+          path: "src/example.ts",
+        },
+        {
+          presentation: DEFAULT_DIFFS_TOOL_DEFAULTS,
+          image: resolveDiffImageRenderOptions({ defaults: DEFAULT_DIFFS_TOOL_DEFAULTS }),
+          expandUnchanged: false,
+        },
+      );
+
+      expect(rendered.fileCount).toBe(1);
+      expect(rendered.html).toContain("src/example.ts");
+      expect(RegisteredCustomThemes.get("pierre-light")).not.toBe(brokenLoader);
+      expect(RegisteredCustomThemes.get("pierre-dark")).not.toBe(brokenLoader);
+    } finally {
+      if (originalLightLoader) {
+        RegisteredCustomThemes.set("pierre-light", originalLightLoader);
+      } else {
+        RegisteredCustomThemes.delete("pierre-light");
+      }
+      if (originalDarkLoader) {
+        RegisteredCustomThemes.set("pierre-dark", originalDarkLoader);
+      } else {
+        RegisteredCustomThemes.delete("pierre-dark");
+      }
+      await disposeHighlighter();
+    }
   });
 
   it("rejects patches that exceed file-count limits", async () => {

--- a/extensions/diffs/src/pierre-themes.ts
+++ b/extensions/diffs/src/pierre-themes.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { RegisteredCustomThemes, ResolvedThemes, ResolvingThemes } from "@pierre/diffs";
+
+let pierreThemesRegistration: Promise<void> | null = null;
+
+async function loadPierreTheme(themeFileName: string, themeName: string): Promise<unknown> {
+  const diffsPackageRoot = await fs.realpath(
+    fileURLToPath(new URL("../node_modules/@pierre/diffs", import.meta.url)),
+  );
+  const themePath = path.join(diffsPackageRoot, "..", "theme", "themes", themeFileName);
+  return {
+    ...(JSON.parse(await fs.readFile(themePath, "utf8")) as Record<string, unknown>),
+    name: themeName,
+  };
+}
+
+export async function ensurePierreThemesRegistered(): Promise<void> {
+  pierreThemesRegistration ??= Promise.resolve().then(() => {
+    RegisteredCustomThemes.set("pierre-light", () =>
+      loadPierreTheme("pierre-light.json", "pierre-light"),
+    );
+    RegisteredCustomThemes.set("pierre-dark", () =>
+      loadPierreTheme("pierre-dark.json", "pierre-dark"),
+    );
+    ResolvedThemes.delete("pierre-light");
+    ResolvedThemes.delete("pierre-dark");
+    ResolvingThemes.delete("pierre-light");
+    ResolvingThemes.delete("pierre-dark");
+  });
+  await pierreThemesRegistration;
+}

--- a/extensions/diffs/src/pierre-themes.ts
+++ b/extensions/diffs/src/pierre-themes.ts
@@ -1,33 +1,58 @@
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
+import type { ThemeRegistrationResolved } from "@pierre/diffs";
 import { RegisteredCustomThemes, ResolvedThemes, ResolvingThemes } from "@pierre/diffs";
 
-type RegisteredThemeLoader = NonNullable<ReturnType<typeof RegisteredCustomThemes.get>>;
-type RegisteredTheme = Awaited<ReturnType<RegisteredThemeLoader>>;
-const require = createRequire(import.meta.url);
+type PierreThemeName = "pierre-dark" | "pierre-light";
+const diffsRequire = createRequire(import.meta.resolve("@pierre/diffs"));
+const PIERRE_THEME_SPECS = [
+  ["pierre-dark", "@pierre/theme/themes/pierre-dark.json"],
+  ["pierre-light", "@pierre/theme/themes/pierre-light.json"],
+] as const satisfies ReadonlyArray<readonly [PierreThemeName, string]>;
 
-async function loadPierreTheme(
+function createThemeLoader(
+  themeName: PierreThemeName,
   themeSpecifier: string,
-  themeName: string,
-): Promise<RegisteredTheme> {
-  const themePath = require.resolve(themeSpecifier);
-  return {
-    ...(JSON.parse(await fs.readFile(themePath, "utf8")) as Record<string, unknown>),
-    name: themeName,
+): () => Promise<ThemeRegistrationResolved> {
+  let cachedTheme: ThemeRegistrationResolved | undefined;
+  return async () => {
+    if (cachedTheme) {
+      return cachedTheme;
+    }
+    const themePath = diffsRequire.resolve(themeSpecifier);
+    cachedTheme = {
+      ...(JSON.parse(await fs.readFile(themePath, "utf8")) as Record<string, unknown>),
+      name: themeName,
+    } as ThemeRegistrationResolved;
+    return cachedTheme;
   };
 }
 
-export async function ensurePierreThemesRegistered(): Promise<void> {
-  // Always overwrite the upstream loaders so the Node-safe path wins even if
-  // @pierre/diffs registered its JSON-import loaders earlier in this process.
-  RegisteredCustomThemes.set("pierre-light", () =>
-    loadPierreTheme("@pierre/theme/themes/pierre-light.json", "pierre-light"),
-  );
-  RegisteredCustomThemes.set("pierre-dark", () =>
-    loadPierreTheme("@pierre/theme/themes/pierre-dark.json", "pierre-dark"),
-  );
-  ResolvedThemes.delete("pierre-light");
-  ResolvedThemes.delete("pierre-dark");
-  ResolvingThemes.delete("pierre-light");
-  ResolvingThemes.delete("pierre-dark");
+const PIERRE_THEME_LOADERS = new Map(
+  PIERRE_THEME_SPECS.map(([themeName, themeSpecifier]) => [
+    themeName,
+    createThemeLoader(themeName, themeSpecifier),
+  ]),
+);
+
+export function ensurePierreThemesRegistered(): void {
+  let replacedThemeLoader = false;
+
+  for (const [themeName, loader] of PIERRE_THEME_LOADERS) {
+    if (RegisteredCustomThemes.get(themeName) !== loader) {
+      RegisteredCustomThemes.set(themeName, loader);
+      replacedThemeLoader = true;
+    }
+  }
+
+  if (!replacedThemeLoader) {
+    return;
+  }
+
+  // If another path swapped these loaders, clear the resolver caches so the
+  // next render rehydrates the highlighter with the Node-safe theme source.
+  for (const [themeName] of PIERRE_THEME_LOADERS) {
+    ResolvedThemes.delete(themeName);
+    ResolvingThemes.delete(themeName);
+  }
 }

--- a/extensions/diffs/src/pierre-themes.ts
+++ b/extensions/diffs/src/pierre-themes.ts
@@ -4,8 +4,10 @@ import { fileURLToPath } from "node:url";
 import { RegisteredCustomThemes, ResolvedThemes, ResolvingThemes } from "@pierre/diffs";
 
 let pierreThemesRegistration: Promise<void> | null = null;
+type RegisteredThemeLoader = NonNullable<ReturnType<typeof RegisteredCustomThemes.get>>;
+type RegisteredTheme = Awaited<ReturnType<RegisteredThemeLoader>>;
 
-async function loadPierreTheme(themeFileName: string, themeName: string): Promise<unknown> {
+async function loadPierreTheme(themeFileName: string, themeName: string): Promise<RegisteredTheme> {
   const diffsPackageRoot = await fs.realpath(
     fileURLToPath(new URL("../node_modules/@pierre/diffs", import.meta.url)),
   );

--- a/extensions/diffs/src/pierre-themes.ts
+++ b/extensions/diffs/src/pierre-themes.ts
@@ -1,17 +1,16 @@
 import fs from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 import { RegisteredCustomThemes, ResolvedThemes, ResolvingThemes } from "@pierre/diffs";
 
-let pierreThemesRegistration: Promise<void> | null = null;
 type RegisteredThemeLoader = NonNullable<ReturnType<typeof RegisteredCustomThemes.get>>;
 type RegisteredTheme = Awaited<ReturnType<RegisteredThemeLoader>>;
+const require = createRequire(import.meta.url);
 
-async function loadPierreTheme(themeFileName: string, themeName: string): Promise<RegisteredTheme> {
-  const diffsPackageRoot = await fs.realpath(
-    fileURLToPath(new URL("../node_modules/@pierre/diffs", import.meta.url)),
-  );
-  const themePath = path.join(diffsPackageRoot, "..", "theme", "themes", themeFileName);
+async function loadPierreTheme(
+  themeSpecifier: string,
+  themeName: string,
+): Promise<RegisteredTheme> {
+  const themePath = require.resolve(themeSpecifier);
   return {
     ...(JSON.parse(await fs.readFile(themePath, "utf8")) as Record<string, unknown>),
     name: themeName,
@@ -19,17 +18,16 @@ async function loadPierreTheme(themeFileName: string, themeName: string): Promis
 }
 
 export async function ensurePierreThemesRegistered(): Promise<void> {
-  pierreThemesRegistration ??= Promise.resolve().then(() => {
-    RegisteredCustomThemes.set("pierre-light", () =>
-      loadPierreTheme("pierre-light.json", "pierre-light"),
-    );
-    RegisteredCustomThemes.set("pierre-dark", () =>
-      loadPierreTheme("pierre-dark.json", "pierre-dark"),
-    );
-    ResolvedThemes.delete("pierre-light");
-    ResolvedThemes.delete("pierre-dark");
-    ResolvingThemes.delete("pierre-light");
-    ResolvingThemes.delete("pierre-dark");
-  });
-  await pierreThemesRegistration;
+  // Always overwrite the upstream loaders so the Node-safe path wins even if
+  // @pierre/diffs registered its JSON-import loaders earlier in this process.
+  RegisteredCustomThemes.set("pierre-light", () =>
+    loadPierreTheme("@pierre/theme/themes/pierre-light.json", "pierre-light"),
+  );
+  RegisteredCustomThemes.set("pierre-dark", () =>
+    loadPierreTheme("@pierre/theme/themes/pierre-dark.json", "pierre-dark"),
+  );
+  ResolvedThemes.delete("pierre-light");
+  ResolvedThemes.delete("pierre-dark");
+  ResolvingThemes.delete("pierre-light");
+  ResolvingThemes.delete("pierre-dark");
 }

--- a/extensions/diffs/src/render.ts
+++ b/extensions/diffs/src/render.ts
@@ -8,6 +8,7 @@ import type {
 } from "@pierre/diffs";
 import { RegisteredCustomThemes, parsePatchFiles } from "@pierre/diffs";
 import { preloadFileDiff, preloadMultiFileDiff } from "@pierre/diffs/ssr";
+import { ensurePierreThemesRegistered } from "./pierre-themes.js";
 import type {
   DiffInput,
   DiffRenderOptions,
@@ -375,6 +376,8 @@ async function renderBeforeAfterDiff(
   input: Extract<DiffInput, { kind: "before_after" }>,
   options: DiffRenderOptions,
 ): Promise<{ viewerBodyHtml: string; imageBodyHtml: string; fileCount: number }> {
+  await ensurePierreThemesRegistered();
+
   const fileName = resolveBeforeAfterFileName(input);
   const lang = normalizeSupportedLanguage(input.lang);
   const oldFile: FileContents = {
@@ -433,6 +436,8 @@ async function renderPatchDiff(
   input: Extract<DiffInput, { kind: "patch" }>,
   options: DiffRenderOptions,
 ): Promise<{ viewerBodyHtml: string; imageBodyHtml: string; fileCount: number }> {
+  await ensurePierreThemesRegistered();
+
   const files = parsePatchFiles(input.patch).flatMap((entry) => entry.files ?? []);
   if (files.length === 0) {
     throw new Error("Patch input did not contain any file diffs.");

--- a/extensions/diffs/src/render.ts
+++ b/extensions/diffs/src/render.ts
@@ -14,7 +14,6 @@ import { VIEWER_LOADER_PATH } from "./viewer-assets.js";
 const DEFAULT_FILE_NAME = "diff.txt";
 const MAX_PATCH_FILE_COUNT = 128;
 const MAX_PATCH_TOTAL_LINES = 120_000;
-ensurePierreThemesRegistered();
 
 function escapeCssString(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');

--- a/extensions/diffs/src/render.ts
+++ b/extensions/diffs/src/render.ts
@@ -1,12 +1,5 @@
-import fs from "node:fs/promises";
-import { createRequire } from "node:module";
-import type {
-  FileContents,
-  FileDiffMetadata,
-  SupportedLanguages,
-  ThemeRegistrationResolved,
-} from "@pierre/diffs";
-import { RegisteredCustomThemes, parsePatchFiles } from "@pierre/diffs";
+import type { FileContents, FileDiffMetadata, SupportedLanguages } from "@pierre/diffs";
+import { parsePatchFiles } from "@pierre/diffs";
 import { preloadFileDiff, preloadMultiFileDiff } from "@pierre/diffs/ssr";
 import { ensurePierreThemesRegistered } from "./pierre-themes.js";
 import type {
@@ -21,45 +14,7 @@ import { VIEWER_LOADER_PATH } from "./viewer-assets.js";
 const DEFAULT_FILE_NAME = "diff.txt";
 const MAX_PATCH_FILE_COUNT = 128;
 const MAX_PATCH_TOTAL_LINES = 120_000;
-const diffsRequire = createRequire(import.meta.resolve("@pierre/diffs"));
-
-let pierreThemesPatched = false;
-
-function createThemeLoader(
-  themeName: "pierre-dark" | "pierre-light",
-  themePath: string,
-): () => Promise<ThemeRegistrationResolved> {
-  let cachedTheme: ThemeRegistrationResolved | undefined;
-  return async () => {
-    if (cachedTheme) {
-      return cachedTheme;
-    }
-    const raw = await fs.readFile(themePath, "utf8");
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    cachedTheme = {
-      ...parsed,
-      name: themeName,
-    } as ThemeRegistrationResolved;
-    return cachedTheme;
-  };
-}
-
-function patchPierreThemeLoadersForNode24(): void {
-  if (pierreThemesPatched) {
-    return;
-  }
-  try {
-    const darkThemePath = diffsRequire.resolve("@pierre/theme/themes/pierre-dark.json");
-    const lightThemePath = diffsRequire.resolve("@pierre/theme/themes/pierre-light.json");
-    RegisteredCustomThemes.set("pierre-dark", createThemeLoader("pierre-dark", darkThemePath));
-    RegisteredCustomThemes.set("pierre-light", createThemeLoader("pierre-light", lightThemePath));
-    pierreThemesPatched = true;
-  } catch {
-    // Keep upstream loaders if theme files cannot be resolved.
-  }
-}
-
-patchPierreThemeLoadersForNode24();
+ensurePierreThemesRegistered();
 
 function escapeCssString(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
@@ -376,7 +331,7 @@ async function renderBeforeAfterDiff(
   input: Extract<DiffInput, { kind: "before_after" }>,
   options: DiffRenderOptions,
 ): Promise<{ viewerBodyHtml: string; imageBodyHtml: string; fileCount: number }> {
-  await ensurePierreThemesRegistered();
+  ensurePierreThemesRegistered();
 
   const fileName = resolveBeforeAfterFileName(input);
   const lang = normalizeSupportedLanguage(input.lang);
@@ -436,7 +391,7 @@ async function renderPatchDiff(
   input: Extract<DiffInput, { kind: "patch" }>,
   options: DiffRenderOptions,
 ): Promise<{ viewerBodyHtml: string; imageBodyHtml: string; fileCount: number }> {
-  await ensurePierreThemesRegistered();
+  ensurePierreThemesRegistered();
 
   const files = parsePatchFiles(input.patch).flatMap((entry) => entry.files ?? []);
   if (files.length === 0) {


### PR DESCRIPTION
## Summary
- preload the bundled pierre themes without relying on JSON module imports
- override the pre-registered theme entries used by `@pierre/diffs` so the extension can resolve them on newer Node builds
- keep the change scoped to `extensions/diffs`

## Why
The `checks (node, extensions, pnpm test:extensions)` failure inherited by [#40791](https://github.com/openclaw/openclaw/pull/40791) includes `extensions/diffs` tests breaking when Node requires `type: "json"` for those bundled theme imports. This PR isolates that fix so it can be reviewed independently.

## Validation
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/diffs/index.test.ts extensions/diffs/src/render.test.ts extensions/diffs/src/tool.test.ts`