### PR TITLE
fix(ui): restore health status to overview dashboard

### DIFF
--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -12,6 +12,7 @@ export const de: TranslationMap = {
     enabled: "Aktiviert",
     disabled: "Deaktiviert",
     na: "k. A.",
+    issues: "Probleme",
     docs: "Dokumentation",
     resources: "Ressourcen",
   },

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -3,7 +3,7 @@ import type { TranslationMap } from "../lib/types.ts";
 export const de: TranslationMap = {
   common: {
     version: "Version",
-    health: "Status",
+    health: "Gateway-Zustand",
     ok: "OK",
     online: "Online",
     offline: "Offline",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -11,6 +11,7 @@ export const en: TranslationMap = {
     enabled: "Enabled",
     disabled: "Disabled",
     na: "n/a",
+    issues: "Issues",
     version: "Version",
     docs: "Docs",
     theme: "Theme",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -12,6 +12,7 @@ export const es: TranslationMap = {
     enabled: "Habilitado",
     disabled: "Deshabilitado",
     na: "n/a",
+    issues: "Problemas",
     docs: "Docs",
     resources: "Recursos",
   },

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -11,6 +11,7 @@ export const pt_BR: TranslationMap = {
     enabled: "Ativado",
     disabled: "Desativado",
     na: "n/a",
+    issues: "Problemas",
     version: "Versão",
     docs: "Docs",
     resources: "Recursos",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -11,6 +11,7 @@ export const zh_CN: TranslationMap = {
     enabled: "已启用",
     disabled: "已禁用",
     na: "不适用",
+    issues: "异常",
     version: "版本",
     docs: "文档",
     resources: "资源",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -11,6 +11,7 @@ export const zh_TW: TranslationMap = {
     enabled: "已啟用",
     disabled: "已禁用",
     na: "不適用",
+    issues: "異常",
     version: "版本",
     docs: "文檔",
     resources: "資源",

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -624,6 +624,7 @@ export function renderApp(state: AppViewState) {
                 cronEnabled: state.cronStatus?.enabled ?? null,
                 cronNext,
                 lastChannelsRefresh: state.channelsLastSuccess,
+                health: state.healthResult,
                 usageResult: state.usageResult,
                 sessionsResult: state.sessionsResult,
                 skillsReport: state.skillsReport,

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -351,8 +351,8 @@ export function renderOverview(props: OverviewProps) {
           </div>
           <div class="stat">
             <div class="stat-label">${t("common.health")}</div>
-            <div class="stat-value ${props.health?.ok ? "ok" : props.health ? "warn" : ""}">
-              ${props.health == null ? t("common.na") : props.health.ok ? t("common.ok") : t("common.issues")}
+            <div class="stat-value ${!props.connected || props.health == null ? "" : props.health.ok ? "ok" : "warn"}">
+              ${!props.connected || props.health == null ? t("common.na") : props.health.ok ? t("common.ok") : t("common.issues")}
             </div>
           </div>
           <div class="stat">

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -10,6 +10,7 @@ import type {
   AttentionItem,
   CronJob,
   CronStatus,
+  HealthSummary,
   SessionsListResult,
   SessionsUsageResult,
   SkillStatusReport,
@@ -36,6 +37,7 @@ export type OverviewProps = {
   cronEnabled: boolean | null;
   cronNext: number | null;
   lastChannelsRefresh: number | null;
+  health: HealthSummary | null;
   // New dashboard data
   usageResult: SessionsUsageResult | null;
   sessionsResult: SessionsListResult | null;
@@ -345,6 +347,12 @@ export function renderOverview(props: OverviewProps) {
             <div class="stat-label">${t("overview.snapshot.status")}</div>
             <div class="stat-value ${props.connected ? "ok" : "warn"}">
               ${props.connected ? t("common.ok") : t("common.offline")}
+            </div>
+          </div>
+          <div class="stat">
+            <div class="stat-label">${t("common.health")}</div>
+            <div class="stat-value ${props.health?.ok ? "ok" : props.health ? "warn" : ""}">
+              ${props.health == null ? t("common.na") : props.health.ok ? t("common.ok") : "Issues"}
             </div>
           </div>
           <div class="stat">

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -352,7 +352,7 @@ export function renderOverview(props: OverviewProps) {
           <div class="stat">
             <div class="stat-label">${t("common.health")}</div>
             <div class="stat-value ${props.health?.ok ? "ok" : props.health ? "warn" : ""}">
-              ${props.health == null ? t("common.na") : props.health.ok ? t("common.ok") : "Issues"}
+              ${props.health == null ? t("common.na") : props.health.ok ? t("common.ok") : t("common.issues")}
             </div>
           </div>
           <div class="stat">


### PR DESCRIPTION
## Summary

Fixes #45848

The health indicator was lost during the dashboard-v2 refactor. This restores it to the stat grid in the overview tab.

- **What changed:** Added `health` prop to `OverviewProps` and `renderOverview()`, then rendered it in the stat grid
- **Display logic:**
  - `OK` (green) when `health.ok` is true
  - `Issues` (amber) when `health.ok` is false
  - `n/a` when health data isn't loaded yet

## Test plan

1. Open Control UI → Overview tab
2. Verify "Health" stat appears in the snapshot grid
3. Should show OK/Issues based on gateway health state