### PR TITLE
Slack: preserve interactive reply blocks in DMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Docs: https://docs.openclaw.ai
 - Z.AI/onboarding: detect a working default model even for explicit `zai-coding-*` endpoint choices, so Coding Plan setup can keep the selected endpoint while defaulting to `glm-5` when available or `glm-4.7` as fallback. (#45969)
 - Control UI/chat sessions: show human-readable labels in the grouped session dropdown again, keep unique scoped fallbacks when metadata is missing, and disambiguate duplicate labels only when needed. (#45130) thanks @luzhidong.
 
+### Fixes
+
+- Slack/interactive replies: preserve `channelData.slack.blocks` through live DM delivery and preview-finalized edits so Block Kit button and select directives render instead of falling back to raw text. Thanks @vincentkoc.
+
 ## 2026.3.13
 
 ### Changes

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -11,7 +11,7 @@ import { resolveStorePath, updateLastRoute } from "../../../../../src/config/ses
 import { danger, logVerbose, shouldLogVerbose } from "../../../../../src/globals.js";
 import { resolveAgentOutboundIdentity } from "../../../../../src/infra/outbound/identity.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../../../src/security/dm-policy-shared.js";
-import { reactSlackMessage, removeSlackReaction } from "../../actions.js";
+import { editSlackMessage, reactSlackMessage, removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
 import { normalizeSlackOutboundText } from "../../format.js";
 import { recordSlackThreadParticipation } from "../../sent-thread-cache.js";
@@ -24,7 +24,12 @@ import type { SlackStreamSession } from "../../streaming.js";
 import { appendSlackStream, startSlackStream, stopSlackStream } from "../../streaming.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
 import { normalizeSlackAllowOwnerEntry } from "../allow-list.js";
-import { createSlackReplyDeliveryPlan, deliverReplies, resolveSlackThreadTs } from "../replies.js";
+import {
+  createSlackReplyDeliveryPlan,
+  deliverReplies,
+  readSlackReplyBlocks,
+  resolveSlackThreadTs,
+} from "../replies.js";
 import type { PreparedSlackMessage } from "./types.js";
 
 function hasMedia(payload: ReplyPayload): boolean {
@@ -245,7 +250,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   };
 
   const deliverWithStreaming = async (payload: ReplyPayload): Promise<void> => {
-    if (streamFailed || hasMedia(payload) || !payload.text?.trim()) {
+    if (
+      streamFailed ||
+      hasMedia(payload) ||
+      readSlackReplyBlocks(payload)?.length ||
+      !payload.text?.trim()
+    ) {
       await deliverNormally(payload, streamSession?.threadTs);
       return;
     }
@@ -302,28 +312,34 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }
 
       const mediaCount = payload.mediaUrls?.length ?? (payload.mediaUrl ? 1 : 0);
+      const slackBlocks = readSlackReplyBlocks(payload);
       const draftMessageId = draftStream?.messageId();
       const draftChannelId = draftStream?.channelId();
-      const finalText = payload.text;
+      const finalText = payload.text ?? "";
+      const trimmedFinalText = finalText.trim();
       const canFinalizeViaPreviewEdit =
         previewStreamingEnabled &&
         streamMode !== "status_final" &&
         mediaCount === 0 &&
         !payload.isError &&
-        typeof finalText === "string" &&
-        finalText.trim().length > 0 &&
+        (trimmedFinalText.length > 0 || Boolean(slackBlocks?.length)) &&
         typeof draftMessageId === "string" &&
         typeof draftChannelId === "string";
 
       if (canFinalizeViaPreviewEdit) {
         draftStream?.stop();
         try {
-          await ctx.app.client.chat.update({
-            token: ctx.botToken,
-            channel: draftChannelId,
-            ts: draftMessageId,
-            text: normalizeSlackOutboundText(finalText.trim()),
-          });
+          await editSlackMessage(
+            draftChannelId,
+            draftMessageId,
+            normalizeSlackOutboundText(trimmedFinalText),
+            {
+              token: ctx.botToken,
+              accountId: account.accountId,
+              client: ctx.app.client,
+              ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
+            },
+          );
           return;
         } catch (err) {
           logVerbose(

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -53,4 +53,45 @@ describe("deliverReplies identity passthrough", () => {
     expect(sendMock).toHaveBeenCalledOnce();
     expect(sendMock.mock.calls[0][2]).not.toHaveProperty("identity");
   });
+
+  it("delivers block-only replies through to sendMessageSlack", async () => {
+    sendMock.mockResolvedValue(undefined);
+    const blocks = [
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            action_id: "openclaw:reply_button",
+            text: { type: "plain_text", text: "Option A" },
+            value: "reply_1_option_a",
+          },
+        ],
+      },
+    ];
+
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "",
+            channelData: {
+              slack: {
+                blocks,
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock).toHaveBeenCalledWith(
+      "C123",
+      "",
+      expect.objectContaining({
+        blocks,
+      }),
+    );
+  });
 });

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -5,8 +5,21 @@ import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../../src/auto-repl
 import type { ReplyPayload } from "../../../../src/auto-reply/types.js";
 import type { MarkdownTableMode } from "../../../../src/config/types.base.js";
 import type { RuntimeEnv } from "../../../../src/runtime.js";
+import { parseSlackBlocksInput } from "../blocks-input.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { sendMessageSlack, type SlackSendIdentity } from "../send.js";
+
+export function readSlackReplyBlocks(payload: ReplyPayload) {
+  const slackData = payload.channelData?.slack;
+  if (!slackData || typeof slackData !== "object" || Array.isArray(slackData)) {
+    return undefined;
+  }
+  try {
+    return parseSlackBlocksInput((slackData as { blocks?: unknown }).blocks);
+  } catch {
+    return undefined;
+  }
+}
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
@@ -26,19 +39,24 @@ export async function deliverReplies(params: {
     const threadTs = inlineReplyToId ?? params.replyThreadTs;
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const text = payload.text ?? "";
-    if (!text && mediaList.length === 0) {
+    const slackBlocks = readSlackReplyBlocks(payload);
+    if (!text && mediaList.length === 0 && !slackBlocks?.length) {
       continue;
     }
 
     if (mediaList.length === 0) {
       const trimmed = text.trim();
-      if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
+      if (!trimmed && !slackBlocks?.length) {
+        continue;
+      }
+      if (trimmed && isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
         continue;
       }
       await sendMessageSlack(params.target, trimmed, {
         token: params.token,
         threadTs,
         accountId: params.accountId,
+        ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
         ...(params.identity ? { identity: params.identity } : {}),
       });
     } else {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Slack interactive reply directives were parsed into `channelData.slack.blocks`, but live DM delivery ignored those blocks and sent only text.
- Why it matters: Slack DMs rendered raw directive text or plain fallback text instead of Block Kit buttons/selects, breaking interactive replies on the main DM path.
- What changed: forward parsed Slack blocks through `deliverReplies`, preserve them during preview-finalized edits, and add a regression test for block-only DM replies.
- What did NOT change (scope boundary): no changes to Slack directive parsing semantics or non-Slack channel delivery.
- AI-assisted: yes; verified locally with targeted tests and build.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Slack DMs now preserve `channelData.slack.blocks` on the live reply path, so interactive reply directives render as Block Kit buttons/selects instead of raw text or stripped text with no controls.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Slack Socket Mode, DM reply delivery path
- Relevant config (redacted): `channels.slack.capabilities.interactiveReplies=true`, `channels.slack.streaming=partial`, `channels.slack.nativeStreaming=true`

### Steps

1. Enable Slack interactive replies.
2. Send a Slack DM that produces a reply containing `[[slack_buttons:...]]` or `[[slack_select:...]]`.
3. Observe the live DM delivery path or preview-finalized edit.

### Expected

- Slack renders Block Kit interactive controls.

### Actual

- Before this change, the DM delivery path dropped `channelData.slack.blocks` and sent only text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/slack/monitor/replies.test.ts src/auto-reply/reply/route-reply.test.ts src/slack/actions.blocks.test.ts src/slack/send.blocks.test.ts`; `pnpm build`.
- Edge cases checked: block-only replies, normal DM replies with blocks, preview-finalized edit path using Slack `chat.update` semantics via `editSlackMessage`.
- What you did **not** verify: live Slack DM delivery against a real workspace.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: disable `channels.slack.capabilities.interactiveReplies` or revert this branch.
- Files/config to restore: `src/slack/monitor/replies.ts`, `src/slack/monitor/message-handler/dispatch.ts`.
- Known bad symptoms reviewers should watch for: Slack preview edits losing final text or interactive replies failing to render in DMs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: preview-finalized edit path now routes through `editSlackMessage`, so regressions there could affect non-block Slack preview completion.
- Mitigation: reused the existing validated Slack block edit helper and kept targeted send/build coverage green.
