### PR TITLE
Feishu: hint blocked local MEDIA paths and docs

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2780,6 +2780,9 @@ Start the Gateway with `--verbose` to get more console detail. Then inspect the 
 ### My skill generated an imagePDF but nothing was sent
 
 Outbound attachments from the agent must include a `MEDIA:<path-or-url>` line (on its own line). See [OpenClaw assistant setup](/start/openclaw) and [Agent send](/tools/agent-send).
+`MEDIA:<path-or-url>` supports URLs and local paths, but local paths are restricted to allowed OpenClaw media roots.
+Arbitrary absolute paths (for example `MEDIA:/workspace/tmp/screenshot.png`) may be blocked.
+Prefer safe relative paths from the agent workspace (for example `MEDIA:./screenshots/screenshot.png`).
 
 CLI sending:
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -191,6 +191,9 @@ MEDIA:https://example.com/screenshot.png
 ```
 
 OpenClaw extracts these and sends them as media alongside the text.
+`MEDIA:<path-or-url>` supports URLs and local paths, but local paths are restricted to allowed OpenClaw media roots.
+Arbitrary absolute paths (for example `MEDIA:/workspace/tmp/screenshot.png`) may be blocked.
+Prefer safe relative paths inside the agent workspace (for example `MEDIA:./screenshots/screenshot.png`).
 
 ## Operations checklist
 

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -121,6 +121,15 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     return { log: vi.fn(), error: vi.fn() } as never;
   }
 
+  function createBlockedLocalMediaError() {
+    const err = new Error(
+      "Local media path is not under an allowed directory: D:\\study\\openclaw\\workspace\\tmp\\screenshot.png",
+    ) as Error & { code?: string };
+    err.name = "LocalMediaAccessError";
+    err.code = "path-not-allowed";
+    return err;
+  }
+
   function createDispatcherHarness(overrides: Partial<ReplyDispatcherArgs> = {}) {
     const result = createFeishuReplyDispatcher({
       cfg: {} as never,
@@ -509,5 +518,49 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyInThread: true,
       }),
     );
+  });
+
+  it("adds local-media-root hint and sends final fallback once", async () => {
+    const runtime = createRuntimeLogger();
+    const { options } = createDispatcherHarness({
+      runtime,
+      replyToMessageId: "om_parent",
+    });
+    await options.onError?.(createBlockedLocalMediaError(), { kind: "final" });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Hint: Local MEDIA paths must be under allowed OpenClaw media roots.",
+      ),
+    );
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("outside allowed OpenClaw media roots"),
+        replyToMessageId: "om_parent",
+      }),
+    );
+  });
+
+  it("does not send local-media fallback for non-final failures", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    await options.onError?.(createBlockedLocalMediaError(), { kind: "block" });
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("resets local-media fallback guard on reply start", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    await options.onError?.(createBlockedLocalMediaError(), { kind: "final" });
+    await options.onError?.(createBlockedLocalMediaError(), { kind: "final" });
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+
+    await options.onReplyStart?.();
+    await options.onError?.(createBlockedLocalMediaError(), { kind: "final" });
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -521,14 +521,14 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("adds local-media-root hint and sends final fallback once", async () => {
-    const runtime = createRuntimeLogger();
+    const runtimeError = vi.fn();
     const { options } = createDispatcherHarness({
-      runtime,
+      runtime: { log: vi.fn(), error: runtimeError } as never,
       replyToMessageId: "om_parent",
     });
     await options.onError?.(createBlockedLocalMediaError(), { kind: "final" });
 
-    expect(runtime.error).toHaveBeenCalledWith(
+    expect(runtimeError).toHaveBeenCalledWith(
       expect.stringContaining(
         "Hint: Local MEDIA paths must be under allowed OpenClaw media roots.",
       ),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -36,6 +36,38 @@ function normalizeEpochMs(timestamp: number | undefined): number | undefined {
   return timestamp < MS_EPOCH_MIN ? timestamp * 1000 : timestamp;
 }
 
+const LOCAL_MEDIA_PATH_HINT =
+  "Local MEDIA paths must be under allowed OpenClaw media roots. Prefer safe relative paths inside the agent workspace (for example, MEDIA:./screenshot.png).";
+const LOCAL_MEDIA_PATH_USER_FALLBACK =
+  "I could not send that local media file because its path is outside allowed OpenClaw media roots. Use a URL or a safe relative path inside the agent workspace (for example, MEDIA:./screenshot.png).";
+
+type ErrorWithCause = {
+  name?: unknown;
+  code?: unknown;
+  message?: unknown;
+  cause?: unknown;
+};
+
+function isDisallowedLocalMediaPathError(error: unknown): boolean {
+  const visited = new Set<unknown>();
+  let current: unknown = error;
+  while (current && typeof current === "object" && !visited.has(current)) {
+    visited.add(current);
+    const candidate = current as ErrorWithCause;
+    const name = typeof candidate.name === "string" ? candidate.name : "";
+    const code = typeof candidate.code === "string" ? candidate.code : "";
+    const message = typeof candidate.message === "string" ? candidate.message : "";
+    if (
+      (name === "LocalMediaAccessError" && code === "path-not-allowed") ||
+      message.includes("Local media path is not under an allowed directory")
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
 export type CreateFeishuReplyDispatcherParams = {
   cfg: ClawdbotConfig;
   agentId: string;
@@ -144,6 +176,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamText = "";
   let lastPartial = "";
   const deliveredFinalTexts = new Set<string>();
+  let localMediaFallbackSent = false;
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
   type StreamTextUpdateMode = "snapshot" | "delta";
@@ -266,6 +299,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
       onReplyStart: () => {
         deliveredFinalTexts.clear();
+        localMediaFallbackSent = false;
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
@@ -359,10 +393,29 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
       },
       onError: async (error, info) => {
+        const localPathBlocked = isDisallowedLocalMediaPathError(error);
+        const hint = localPathBlocked ? ` Hint: ${LOCAL_MEDIA_PATH_HINT}` : "";
         params.runtime.error?.(
-          `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
+          `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}${hint}`,
         );
         await closeStreaming();
+        if (localPathBlocked && info.kind === "final" && !localMediaFallbackSent) {
+          localMediaFallbackSent = true;
+          try {
+            await sendMessageFeishu({
+              cfg,
+              to: chatId,
+              text: LOCAL_MEDIA_PATH_USER_FALLBACK,
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread: effectiveReplyInThread,
+              accountId,
+            });
+          } catch (fallbackError) {
+            params.runtime.error?.(
+              `feishu[${account.accountId}] final reply local-media fallback failed: ${String(fallbackError)}`,
+            );
+          }
+        }
         typingCallbacks.onIdle?.();
       },
       onIdle: async () => {


### PR DESCRIPTION
## Summary
- add a Feishu-specific hint when outbound local `MEDIA:` paths are blocked by allowed-root checks
- send a one-time plain-text fallback for final Feishu replies that fail with disallowed local media paths
- document outbound `MEDIA:<path-or-url>` local-path restrictions and recommend safe relative workspace paths

## Testing
- `corepack pnpm exec vitest run extensions/feishu/src/reply-dispatcher.test.ts`