### PR TITLE
feat(config): add agents.defaults.reasoningDefault config option

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -512,7 +512,8 @@ export function buildStatusMessage(args: StatusArgs): string {
   const verboseLevel =
     args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
   const fastMode = args.resolvedFast ?? args.sessionEntry?.fastMode ?? false;
-  const reasoningLevel = args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? "off";
+  const reasoningLevel =
+    args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? args.agent?.reasoningDefault ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import { resolveContextTokensForModel } from "../agents/context.js";
-import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import {
+  DEFAULT_CONTEXT_TOKENS,
+  DEFAULT_MODEL,
+  DEFAULT_PROVIDER,
+} from "../agents/defaults.js";
 import { resolveModelAuthMode } from "../agents/model-auth.js";
 import {
   buildModelAliasIndex,
@@ -9,7 +13,11 @@ import {
 } from "../agents/model-selection.js";
 import { resolveSandboxRuntimeStatus } from "../agents/sandbox.js";
 import type { SkillCommandSpec } from "../agents/skills.js";
-import { derivePromptTokens, normalizeUsage, type UsageLike } from "../agents/usage.js";
+import {
+  derivePromptTokens,
+  normalizeUsage,
+  type UsageLike,
+} from "../agents/usage.js";
 import { resolveChannelModelOverride } from "../channels/model-overrides.js";
 import { isCommandFlagEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -47,10 +55,20 @@ import {
 } from "./commands-registry.js";
 import type { CommandCategory } from "./commands-registry.types.js";
 import { resolveActiveFallbackState } from "./fallback-state.js";
-import { formatProviderModelRef, resolveSelectedAndActiveModel } from "./model-runtime.js";
-import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
+import {
+  formatProviderModelRef,
+  resolveSelectedAndActiveModel,
+} from "./model-runtime.js";
+import type {
+  ElevatedLevel,
+  ReasoningLevel,
+  ThinkLevel,
+  VerboseLevel,
+} from "./thinking.js";
 
-type AgentDefaults = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>;
+type AgentDefaults = NonNullable<
+  NonNullable<OpenClawConfig["agents"]>["defaults"]
+>;
 type AgentConfig = Partial<AgentDefaults> & {
   model?: AgentDefaults["model"] | string;
 };
@@ -92,7 +110,13 @@ type StatusArgs = {
   now?: number;
 };
 
-type NormalizedAuthMode = "api-key" | "oauth" | "token" | "aws-sdk" | "mixed" | "unknown";
+type NormalizedAuthMode =
+  | "api-key"
+  | "oauth"
+  | "token"
+  | "aws-sdk"
+  | "mixed"
+  | "unknown";
 
 function normalizeAuthMode(value?: string): NormalizedAuthMode | undefined {
   const normalized = value?.trim().toLowerCase();
@@ -133,7 +157,11 @@ function resolveRuntimeLabel(
     if (sandboxMode === "off") {
       return "direct";
     }
-    const runtime = runtimeStatus.sandboxed ? "docker" : sessionKey ? "direct" : "unknown";
+    const runtime = runtimeStatus.sandboxed
+      ? "docker"
+      : sessionKey
+        ? "direct"
+        : "unknown";
     return `${runtime}/${sandboxMode}`;
   }
 
@@ -164,7 +192,10 @@ function resolveRuntimeLabel(
   return `${runtime}/${sandboxMode}`;
 }
 
-const formatTokens = (total: number | null | undefined, contextTokens: number | null) => {
+const formatTokens = (
+  total: number | null | undefined,
+  contextTokens: number | null,
+) => {
   const ctx = contextTokens ?? null;
   if (total == null) {
     const ctxLabel = ctx ? formatTokenCount(ctx) : "?";
@@ -196,7 +227,9 @@ const formatQueueDetails = (queue?: QueueStatus) => {
   if (typeof queue.debounceMs === "number") {
     const ms = Math.max(0, Math.round(queue.debounceMs));
     const label =
-      ms >= 1000 ? `${ms % 1000 === 0 ? ms / 1000 : (ms / 1000).toFixed(1)}s` : `${ms}ms`;
+      ms >= 1000
+        ? `${ms % 1000 === 0 ? ms / 1000 : (ms / 1000).toFixed(1)}s`
+        : `${ms}ms`;
     detailParts.push(`debounce ${label}`);
   }
   if (typeof queue.cap === "number") {
@@ -230,7 +263,8 @@ const readUsageFromSessionLog = (
   let logPath: string;
   try {
     const resolvedAgentId =
-      agentId ?? (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined);
+      agentId ??
+      (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined);
     logPath = resolveSessionFilePath(
       sessionId,
       sessionEntry,
@@ -256,7 +290,9 @@ const readUsageFromSessionLog = (
       fs.closeSync(fd);
     }
     const tail = buf.toString("utf-8");
-    const lines = (offset > 0 ? tail.slice(tail.indexOf("\n") + 1) : tail).split(/\n+/);
+    const lines = (
+      offset > 0 ? tail.slice(tail.indexOf("\n") + 1) : tail
+    ).split(/\n+/);
 
     let input = 0;
     let output = 0;
@@ -293,7 +329,8 @@ const readUsageFromSessionLog = (
     }
     input = lastUsage.input ?? 0;
     output = lastUsage.output ?? 0;
-    promptTokens = derivePromptTokens(lastUsage) ?? lastUsage.total ?? input + output;
+    promptTokens =
+      derivePromptTokens(lastUsage) ?? lastUsage.total ?? input + output;
     const total = lastUsage.total ?? promptTokens + output;
     if (promptTokens === 0 && total === 0) {
       return undefined;
@@ -309,7 +346,8 @@ const formatUsagePair = (input?: number | null, output?: number | null) => {
     return null;
   }
   const inputLabel = typeof input === "number" ? formatTokenCount(input) : "?";
-  const outputLabel = typeof output === "number" ? formatTokenCount(output) : "?";
+  const outputLabel =
+    typeof output === "number" ? formatTokenCount(output) : "?";
   return `🧮 Tokens: ${inputLabel} in / ${outputLabel} out`;
 };
 
@@ -328,8 +366,10 @@ const formatCacheLine = (
     return null;
   }
 
-  const cachedLabel = typeof cacheRead === "number" ? formatTokenCount(cacheRead) : "0";
-  const newLabel = typeof cacheWrite === "number" ? formatTokenCount(cacheWrite) : "0";
+  const cachedLabel =
+    typeof cacheRead === "number" ? formatTokenCount(cacheRead) : "0";
+  const newLabel =
+    typeof cacheWrite === "number" ? formatTokenCount(cacheWrite) : "0";
 
   const totalInput =
     (typeof cacheRead === "number" ? cacheRead : 0) +
@@ -343,7 +383,9 @@ const formatCacheLine = (
   return `🗄️ Cache: ${hitRate}% hit · ${cachedLabel} cached, ${newLabel} new`;
 };
 
-const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandingDecision>) => {
+const formatMediaUnderstandingLine = (
+  decisions?: ReadonlyArray<MediaUnderstandingDecision>,
+) => {
   if (!decisions || decisions.length === 0) {
     return null;
   }
@@ -352,10 +394,16 @@ const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandi
       const count = decision.attachments.length;
       const countLabel = count > 1 ? ` x${count}` : "";
       if (decision.outcome === "success") {
-        const chosen = decision.attachments.find((entry) => entry.chosen)?.chosen;
+        const chosen = decision.attachments.find(
+          (entry) => entry.chosen,
+        )?.chosen;
         const provider = chosen?.provider?.trim();
         const model = chosen?.model?.trim();
-        const modelLabel = provider ? (model ? `${provider}/${model}` : provider) : null;
+        const modelLabel = provider
+          ? model
+            ? `${provider}/${model}`
+            : provider
+          : null;
         return `${decision.capability}${countLabel} ok${modelLabel ? ` (${modelLabel})` : ""}`;
       }
       if (decision.outcome === "no-attachment") {
@@ -369,7 +417,9 @@ const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandi
       }
       if (decision.outcome === "skipped") {
         const reason = decision.attachments
-          .flatMap((entry) => entry.attempts.map((attempt) => attempt.reason).filter(Boolean))
+          .flatMap((entry) =>
+            entry.attempts.map((attempt) => attempt.reason).filter(Boolean),
+          )
           .find(Boolean);
         const shortReason = reason ? reason.split(":")[0]?.trim() : undefined;
         return `${decision.capability} skipped${shortReason ? ` (${shortReason})` : ""}`;
@@ -438,7 +488,8 @@ export function buildStatusMessage(args: StatusArgs): string {
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const selectedProvider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
+  const selectedProvider =
+    entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
   const selectedModel = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
   const modelRefs = resolveSelectedAndActiveModel({
     selectedProvider,
@@ -460,7 +511,9 @@ export function buildStatusMessage(args: StatusArgs): string {
   let outputTokens = entry?.outputTokens;
   let cacheRead = entry?.cacheRead;
   let cacheWrite = entry?.cacheWrite;
-  let totalTokens = entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
+  let totalTokens =
+    entry?.totalTokens ??
+    (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
 
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).
@@ -508,12 +561,21 @@ export function buildStatusMessage(args: StatusArgs): string {
   }
 
   const thinkLevel =
-    args.resolvedThink ?? args.sessionEntry?.thinkingLevel ?? args.agent?.thinkingDefault ?? "off";
+    args.resolvedThink ??
+    args.sessionEntry?.thinkingLevel ??
+    args.agent?.thinkingDefault ??
+    "off";
   const verboseLevel =
-    args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
+    args.resolvedVerbose ??
+    args.sessionEntry?.verboseLevel ??
+    args.agent?.verboseDefault ??
+    "off";
   const fastMode = args.resolvedFast ?? args.sessionEntry?.fastMode ?? false;
   const reasoningLevel =
-    args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? args.agent?.reasoningDefault ?? "off";
+    args.resolvedReasoning ??
+    args.sessionEntry?.reasoningLevel ??
+    args.agent?.reasoningDefault ??
+    "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??
@@ -525,7 +587,9 @@ export function buildStatusMessage(args: StatusArgs): string {
   const updatedAt = entry?.updatedAt;
   const sessionLine = [
     `Session: ${args.sessionKey ?? "unknown"}`,
-    typeof updatedAt === "number" ? `updated ${formatTimeAgo(now - updatedAt)}` : "no activity",
+    typeof updatedAt === "number"
+      ? `updated ${formatTimeAgo(now - updatedAt)}`
+      : "no activity",
   ]
     .filter(Boolean)
     .join(" • ");
@@ -549,7 +613,11 @@ export function buildStatusMessage(args: StatusArgs): string {
   const queueMode = args.queue?.mode ?? "unknown";
   const queueDetails = formatQueueDetails(args.queue);
   const verboseLabel =
-    verboseLevel === "full" ? "verbose:full" : verboseLevel === "on" ? "verbose" : null;
+    verboseLevel === "full"
+      ? "verbose:full"
+      : verboseLevel === "on"
+        ? "verbose"
+        : null;
   const elevatedLabel =
     elevatedLevel && elevatedLevel !== "off"
       ? elevatedLevel === "on"
@@ -572,17 +640,24 @@ export function buildStatusMessage(args: StatusArgs): string {
   const activationLine = activationParts.filter(Boolean).join(" · ");
 
   const selectedAuthMode =
-    normalizeAuthMode(args.modelAuth) ?? resolveModelAuthMode(selectedProvider, args.config);
+    normalizeAuthMode(args.modelAuth) ??
+    resolveModelAuthMode(selectedProvider, args.config);
   const selectedAuthLabelValue =
     args.modelAuth ??
-    (selectedAuthMode && selectedAuthMode !== "unknown" ? selectedAuthMode : undefined);
+    (selectedAuthMode && selectedAuthMode !== "unknown"
+      ? selectedAuthMode
+      : undefined);
   const activeAuthMode =
-    normalizeAuthMode(args.activeModelAuth) ?? resolveModelAuthMode(activeProvider, args.config);
+    normalizeAuthMode(args.activeModelAuth) ??
+    resolveModelAuthMode(activeProvider, args.config);
   const activeAuthLabelValue =
     args.activeModelAuth ??
-    (activeAuthMode && activeAuthMode !== "unknown" ? activeAuthMode : undefined);
+    (activeAuthMode && activeAuthMode !== "unknown"
+      ? activeAuthMode
+      : undefined);
   const selectedModelLabel = modelRefs.selected.label || "unknown";
-  const activeModelLabel = formatProviderModelRef(activeProvider, activeModel) || "unknown";
+  const activeModelLabel =
+    formatProviderModelRef(activeProvider, activeModel) || "unknown";
   const fallbackState = resolveActiveFallbackState({
     selectedModelRef: selectedModelLabel,
     activeModelRef: activeModelLabel,
@@ -591,7 +666,8 @@ export function buildStatusMessage(args: StatusArgs): string {
   const effectiveCostAuthMode = fallbackState.active
     ? activeAuthMode
     : (selectedAuthMode ?? activeAuthMode);
-  const showCost = effectiveCostAuthMode === "api-key" || effectiveCostAuthMode === "mixed";
+  const showCost =
+    effectiveCostAuthMode === "api-key" || effectiveCostAuthMode === "mixed";
   const costConfig = showCost
     ? resolveModelCostConfig({
         provider: activeProvider,
@@ -599,7 +675,8 @@ export function buildStatusMessage(args: StatusArgs): string {
         config: args.config,
       })
     : undefined;
-  const hasUsage = typeof inputTokens === "number" || typeof outputTokens === "number";
+  const hasUsage =
+    typeof inputTokens === "number" || typeof outputTokens === "number";
   const cost =
     showCost && hasUsage
       ? estimateUsageCost({
@@ -612,7 +689,9 @@ export function buildStatusMessage(args: StatusArgs): string {
       : undefined;
   const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
 
-  const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
+  const selectedAuthLabel = selectedAuthLabelValue
+    ? ` · 🔑 ${selectedAuthLabelValue}`
+    : "";
   const channelModelNote = (() => {
     if (!args.config || !entry) {
       return undefined;
@@ -653,7 +732,8 @@ export function buildStatusMessage(args: StatusArgs): string {
   })();
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
-  const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
+  const showFallbackAuth =
+    activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
   const fallbackLine = fallbackState.active
     ? `↪️ Fallback: ${activeModelLabel}${
         showFallbackAuth ? ` · 🔑 ${activeAuthLabelValue}` : ""
@@ -665,7 +745,9 @@ export function buildStatusMessage(args: StatusArgs): string {
   const cacheLine = formatCacheLine(inputTokens, cacheRead, cacheWrite);
   const costLine = costLabel ? `💵 Cost: ${costLabel}` : null;
   const usageCostLine =
-    usagePair && costLine ? `${usagePair} · ${costLine}` : (usagePair ?? costLine);
+    usagePair && costLine
+      ? `${usagePair} · ${costLine}`
+      : (usagePair ?? costLine);
   const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
   const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry);
 
@@ -732,7 +814,12 @@ export function buildHelpMessage(cfg?: OpenClawConfig): string {
   lines.push("  /new  |  /reset  |  /compact [instructions]  |  /stop");
   lines.push("");
 
-  const optionParts = ["/think <level>", "/model <id>", "/fast on|off", "/verbose on|off"];
+  const optionParts = [
+    "/think <level>",
+    "/model <id>",
+    "/fast on|off",
+    "/verbose on|off",
+  ];
   if (isCommandFlagEnabled(cfg, "config")) {
     optionParts.push("/config");
   }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -187,6 +187,8 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
+  /** Default reasoning level when no /reasoning directive is present. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -148,6 +148,7 @@ export const AgentDefaultsSchema = z
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),


### PR DESCRIPTION
Fixes #45880

## Problem
OpenClaw supports config defaults for thinking and verbose:
- `agents.defaults.thinkingDefault`
- `agents.defaults.verboseDefault`

But there's no equivalent for reasoning visibility:
- ❌ `agents.defaults.reasoningDefault` — **does not exist**

Users who want reasoning stream visible by default currently have to manually send `/reasoning stream` in every new conversation.

## Solution
Add `agents.defaults.reasoningDefault` config option with the same pattern:
- Accept values: `"off"` | `"on"` | `"stream"`
- Resolution: `resolvedReasoning ?? sessionEntry?.reasoningLevel ?? agent?.reasoningDefault ?? "off"`

## Changes
1. `src/config/types.agent-defaults.ts` - Add `reasoningDefault` type definition
2. `src/config/zod-schema.agent-defaults.ts` - Add Zod validation schema
3. `src/auto-reply/status.ts` - Add fallback chain for reasoning level resolution

## Use Case
Users on Telegram who want reasoning stream visible by default can now set this once globally instead of manually sending `/reasoning stream` in every new conversation.
