### PR TITLE
fix(skills): allow symlinked skills in configured roots

### DIFF
--- a/src/agents/skills.symlink-roots.test.ts
+++ b/src/agents/skills.symlink-roots.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeSkill } from "./skills.e2e-test-helpers.js";
+
+const { warnMock } = vi.hoisted(() => ({
+  warnMock: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => {
+  const makeLogger = () => ({
+    subsystem: "skills",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: () => makeLogger(),
+  });
+  return { createSubsystemLogger: () => makeLogger() };
+});
+
+import { loadWorkspaceSkillEntries } from "./skills.js";
+
+const tempDirs: string[] = [];
+
+async function createTempWorkspaceDir() {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-"));
+  tempDirs.push(workspaceDir);
+  return workspaceDir;
+}
+
+function escapedRootWarnings() {
+  return warnMock.mock.calls.filter(([message]) =>
+    String(message).includes("Skipping skill path that resolves outside its configured root."),
+  );
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+beforeEach(() => {
+  warnMock.mockClear();
+});
+
+describe("skills roots across configured directories", () => {
+  it.runIf(process.platform !== "win32")(
+    "allows workspace skill symlinks that resolve into the project agents skills root without warning",
+    async () => {
+      const workspaceDir = await createTempWorkspaceDir();
+      const projectAgentsSkillDir = path.join(workspaceDir, ".agents", "skills", "slidev");
+      await writeSkill({
+        dir: projectAgentsSkillDir,
+        name: "slidev",
+        description: "Project agents skill",
+      });
+      await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+      await fs.symlink(
+        path.join(workspaceDir, ".agents", "skills", "slidev"),
+        path.join(workspaceDir, "skills", "slidev"),
+        "dir",
+      );
+
+      const entries = loadWorkspaceSkillEntries(workspaceDir, {
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      });
+
+      expect(entries.map((entry) => entry.skill.name)).toContain("slidev");
+      expect(escapedRootWarnings()).toHaveLength(0);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "allows managed skill symlinks that resolve into configured extraDirs without warning",
+    async () => {
+      const workspaceDir = await createTempWorkspaceDir();
+      const managedDir = path.join(workspaceDir, ".managed");
+      const extraDir = await createTempWorkspaceDir();
+      const sharedSkillDir = path.join(extraDir, "shared-skill");
+      await writeSkill({
+        dir: sharedSkillDir,
+        name: "shared-skill",
+        description: "Shared extra-dir skill",
+      });
+      await fs.mkdir(managedDir, { recursive: true });
+      await fs.symlink(sharedSkillDir, path.join(managedDir, "shared-skill"), "dir");
+
+      const entries = loadWorkspaceSkillEntries(workspaceDir, {
+        config: { skills: { load: { extraDirs: [extraDir] } } },
+        managedSkillsDir: managedDir,
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      });
+
+      expect(entries.map((entry) => entry.skill.name)).toContain("shared-skill");
+      expect(escapedRootWarnings()).toHaveLength(0);
+    },
+  );
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -203,12 +203,17 @@ function resolveContainedSkillPath(params: {
   rootDir: string;
   rootRealPath: string;
   candidatePath: string;
+  allowedRootRealPaths?: string[];
 }): string | null {
   const candidateRealPath = tryRealpath(params.candidatePath);
   if (!candidateRealPath) {
     return null;
   }
   if (isPathInside(params.rootRealPath, candidateRealPath)) {
+    return candidateRealPath;
+  }
+  const allowedRoots = params.allowedRootRealPaths ?? [];
+  if (allowedRoots.some((rootRealPath) => isPathInside(rootRealPath, candidateRealPath))) {
     return candidateRealPath;
   }
   warnEscapedSkillPath({
@@ -225,6 +230,7 @@ function filterLoadedSkillsInsideRoot(params: {
   source: string;
   rootDir: string;
   rootRealPath: string;
+  allowedRootRealPaths?: string[];
 }): Skill[] {
   return params.skills.filter((skill) => {
     const baseDirRealPath = resolveContainedSkillPath({
@@ -232,6 +238,7 @@ function filterLoadedSkillsInsideRoot(params: {
       rootDir: params.rootDir,
       rootRealPath: params.rootRealPath,
       candidatePath: skill.baseDir,
+      allowedRootRealPaths: params.allowedRootRealPaths,
     });
     if (!baseDirRealPath) {
       return false;
@@ -241,6 +248,7 @@ function filterLoadedSkillsInsideRoot(params: {
       rootDir: params.rootDir,
       rootRealPath: params.rootRealPath,
       candidatePath: skill.filePath,
+      allowedRootRealPaths: params.allowedRootRealPaths,
     });
     return Boolean(skillFileRealPath);
   });
@@ -311,6 +319,7 @@ function loadSkillEntries(
       rootDir,
       rootRealPath,
       candidatePath: baseDir,
+      allowedRootRealPaths: allowedSkillRootRealPaths,
     });
     if (!baseDirRealPath) {
       return [];
@@ -324,6 +333,7 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: rootSkillMd,
+        allowedRootRealPaths: allowedSkillRootRealPaths,
       });
       if (!rootSkillRealPath) {
         return [];
@@ -349,6 +359,7 @@ function loadSkillEntries(
         source: params.source,
         rootDir,
         rootRealPath: baseDirRealPath,
+        allowedRootRealPaths: allowedSkillRootRealPaths,
       });
     }
 
@@ -385,6 +396,7 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: skillDir,
+        allowedRootRealPaths: allowedSkillRootRealPaths,
       });
       if (!skillDirRealPath) {
         continue;
@@ -398,6 +410,7 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: skillMd,
+        allowedRootRealPaths: allowedSkillRootRealPaths,
       });
       if (!skillMdRealPath) {
         continue;
@@ -424,6 +437,7 @@ function loadSkillEntries(
           source: params.source,
           rootDir,
           rootRealPath: baseDirRealPath,
+          allowedRootRealPaths: allowedSkillRootRealPaths,
         }),
       );
 
@@ -454,6 +468,18 @@ function loadSkillEntries(
     config: opts?.config,
   });
   const mergedExtraDirs = [...extraDirs, ...pluginSkillDirs];
+  const personalAgentsSkillsDir = path.resolve(os.homedir(), ".agents", "skills");
+  const projectAgentsSkillsDir = path.resolve(workspaceDir, ".agents", "skills");
+  const allowedSkillRootRealPaths = [
+    managedSkillsDir,
+    workspaceSkillsDir,
+    bundledSkillsDir,
+    personalAgentsSkillsDir,
+    projectAgentsSkillsDir,
+    ...mergedExtraDirs.map((dir) => resolveUserPath(dir)),
+  ]
+    .filter((dir): dir is string => Boolean(dir))
+    .map((dir) => tryRealpath(path.resolve(dir)) ?? path.resolve(dir));
 
   const bundledSkills = bundledSkillsDir
     ? loadSkills({
@@ -472,12 +498,10 @@ function loadSkillEntries(
     dir: managedSkillsDir,
     source: "openclaw-managed",
   });
-  const personalAgentsSkillsDir = path.resolve(os.homedir(), ".agents", "skills");
   const personalAgentsSkills = loadSkills({
     dir: personalAgentsSkillsDir,
     source: "agents-skills-personal",
   });
-  const projectAgentsSkillsDir = path.resolve(workspaceDir, ".agents", "skills");
   const projectAgentsSkills = loadSkills({
     dir: projectAgentsSkillsDir,
     source: "agents-skills-project",


### PR DESCRIPTION
## Summary
- allow skill symlinks when their real path stays inside another configured skills root such as skills.load.extraDirs, ~/.agents/skills, or <workspace>/.agents/skills
- keep the existing escape warning for real paths that still fall outside every configured skills root
- add regression coverage for workspace and managed skill symlinks that point into configured roots

## Testing
- pnpm exec vitest run src/agents/skills.symlink-roots.test.ts src/agents/skills.loadworkspaceskillentries.test.ts