### PR TITLE
fix(agents): forward threadId in sessions_send announce delivery

### DIFF
--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -127,6 +127,7 @@ export async function runSessionsSendA2AFlow(params: {
             message: announceReply.trim(),
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
+            threadId: announceTarget.threadId,
             idempotencyKey: crypto.randomUUID(),
           },
           timeoutMs: 10_000,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -31,6 +31,7 @@ vi.mock("../../config/config.js", async (importOriginal) => {
 });
 
 import { createSessionsListTool } from "./sessions-list-tool.js";
+import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
 import { createSessionsSendTool } from "./sessions-send-tool.js";
 
 let resolveAnnounceTarget: (typeof import("./sessions-announce-target.js"))["resolveAnnounceTarget"];
@@ -208,6 +209,30 @@ describe("extractAssistantText", () => {
       content: [{ type: "text", text: "Handle payment required errors in your API." }],
     };
     expect(extractAssistantText(message)).toBe("Handle payment required errors in your API.");
+  });
+});
+
+describe("resolveAnnounceTargetFromKey — Telegram forum topic", () => {
+  beforeEach(async () => {
+    await installRegistry();
+  });
+
+  it("extracts threadId from Telegram group:topic session key", () => {
+    const target = resolveAnnounceTargetFromKey(
+      "agent:coder:telegram:group:-1003525386997:topic:2",
+    );
+    expect(target).toMatchObject({
+      channel: "telegram",
+      threadId: "2",
+    });
+    // `to` should contain the group ID without the :topic:N suffix
+    expect(target?.to).not.toContain("topic");
+  });
+
+  it("returns no threadId for plain group session keys", () => {
+    const target = resolveAnnounceTargetFromKey("agent:main:telegram:group:-100123456");
+    expect(target).toMatchObject({ channel: "telegram" });
+    expect(target?.threadId).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

When `sessions_send` delivers an announce message to a Telegram forum topic, the delivery fails with "Telegram recipient must be a numeric chat ID". The `resolveAnnounceTargetFromKey` helper correctly extracts the `threadId` from topic-style session keys (`agent:coder:telegram:group:-100xxx:topic:2`), but `runSessionsSendA2AFlow` never forwards it in the `callGateway("send")` params.

- `src/agents/tools/sessions-send-tool.a2a.ts` — add `threadId: announceTarget.threadId` to the send params
- `src/agents/tools/sessions.test.ts` — add 2 tests for `resolveAnnounceTargetFromKey` topic/thread extraction

Fixes #45878

## Test plan

- [x] New unit tests pass (threadId extraction from topic key, no threadId for plain keys)
- [x] All existing passing tests unaffected (14/14 pass; 5 pre-existing failures in unrelated `transcriptPath` suite)
- [ ] CI green