### PR TITLE
fix(agents): preserve thinking/redacted_thinking blocks in stripThoughtSignatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/streaming: add `onReasoningStream` and `onReasoningEnd` support to streaming cards, so `/reasoning stream` renders thinking tokens as markdown blockquotes in the same card — matching the Telegram channel's reasoning lane behavior.
 - Feishu/cards: add identity-aware structured card headers and note footers for Feishu replies and direct sends, while keeping that presentation wired through the shared outbound identity path. (#29938) Thanks @nszhsl.
 - Gateway/health monitor: add configurable stale-event thresholds and restart limits, plus per-channel and per-account `healthMonitor.enabled` overrides, while keeping the existing global disable path on `gateway.channelHealthCheckMinutes=0`. (#42107) Thanks @rstar327.
+- Android/mobile: add a system-aware dark theme across onboarding and post-onboarding screens so the app follows the device theme through setup, chat, and voice flows. (#46249) Thanks @sibbl.
 
 ### Fixes
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.ui.mobileCardSurface
 
 private enum class ConnectInputMode {
   SetupCode,
@@ -144,7 +145,7 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
     Surface(
       modifier = Modifier.fillMaxWidth(),
       shape = RoundedCornerShape(14.dp),
-      color = Color.White,
+      color = mobileCardSurface,
       border = BorderStroke(1.dp, mobileBorder),
     ) {
       Column {
@@ -205,7 +206,7 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
         shape = RoundedCornerShape(14.dp),
         colors =
           ButtonDefaults.buttonColors(
-            containerColor = Color.White,
+            containerColor = mobileCardSurface,
             contentColor = mobileDanger,
           ),
         border = BorderStroke(1.dp, mobileDanger.copy(alpha = 0.4f)),
@@ -298,7 +299,7 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
       Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(14.dp),
-        color = Color.White,
+        color = mobileCardSurface,
         border = BorderStroke(1.dp, mobileBorder),
       ) {
         Column(
@@ -480,7 +481,7 @@ private fun MethodChip(label: String, active: Boolean, onClick: () -> Unit) {
         containerColor = if (active) mobileAccent else mobileSurface,
         contentColor = if (active) Color.White else mobileText,
       ),
-    border = BorderStroke(1.dp, if (active) Color(0xFF184DAF) else mobileBorderStrong),
+    border = BorderStroke(1.dp, if (active) mobileAccentBorderStrong else mobileBorderStrong),
   ) {
     Text(label, style = mobileCaption1.copy(fontWeight = FontWeight.Bold))
   }
@@ -509,10 +510,10 @@ private fun CommandBlock(command: String) {
     modifier = Modifier.fillMaxWidth(),
     shape = RoundedCornerShape(12.dp),
     color = mobileCodeBg,
-    border = BorderStroke(1.dp, Color(0xFF2B2E35)),
+    border = BorderStroke(1.dp, mobileCodeBorder),
   ) {
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-      Box(modifier = Modifier.width(3.dp).height(42.dp).background(Color(0xFF3FC97A)))
+      Box(modifier = Modifier.width(3.dp).height(42.dp).background(mobileCodeAccent))
       Text(
         text = command,
         modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/MobileUiTokens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/MobileUiTokens.kt
@@ -1,5 +1,7 @@
 package ai.openclaw.app.ui
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -9,32 +11,147 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import ai.openclaw.app.R
 
-internal val mobileBackgroundGradient =
-  Brush.verticalGradient(
-    listOf(
-      Color(0xFFFFFFFF),
-      Color(0xFFF7F8FA),
-      Color(0xFFEFF1F5),
-    ),
+// ---------------------------------------------------------------------------
+// MobileColors – semantic color tokens with light + dark variants
+// ---------------------------------------------------------------------------
+
+internal data class MobileColors(
+  val surface: Color,
+  val surfaceStrong: Color,
+  val cardSurface: Color,
+  val border: Color,
+  val borderStrong: Color,
+  val text: Color,
+  val textSecondary: Color,
+  val textTertiary: Color,
+  val accent: Color,
+  val accentSoft: Color,
+  val accentBorderStrong: Color,
+  val success: Color,
+  val successSoft: Color,
+  val warning: Color,
+  val warningSoft: Color,
+  val danger: Color,
+  val dangerSoft: Color,
+  val codeBg: Color,
+  val codeText: Color,
+  val codeBorder: Color,
+  val codeAccent: Color,
+  val chipBorderConnected: Color,
+  val chipBorderConnecting: Color,
+  val chipBorderWarning: Color,
+  val chipBorderError: Color,
+)
+
+internal fun lightMobileColors() =
+  MobileColors(
+    surface = Color(0xFFF6F7FA),
+    surfaceStrong = Color(0xFFECEEF3),
+    cardSurface = Color(0xFFFFFFFF),
+    border = Color(0xFFE5E7EC),
+    borderStrong = Color(0xFFD6DAE2),
+    text = Color(0xFF17181C),
+    textSecondary = Color(0xFF5D6472),
+    textTertiary = Color(0xFF99A0AE),
+    accent = Color(0xFF1D5DD8),
+    accentSoft = Color(0xFFECF3FF),
+    accentBorderStrong = Color(0xFF184DAF),
+    success = Color(0xFF2F8C5A),
+    successSoft = Color(0xFFEEF9F3),
+    warning = Color(0xFFC8841A),
+    warningSoft = Color(0xFFFFF8EC),
+    danger = Color(0xFFD04B4B),
+    dangerSoft = Color(0xFFFFF2F2),
+    codeBg = Color(0xFF15171B),
+    codeText = Color(0xFFE8EAEE),
+    codeBorder = Color(0xFF2B2E35),
+    codeAccent = Color(0xFF3FC97A),
+    chipBorderConnected = Color(0xFFCFEBD8),
+    chipBorderConnecting = Color(0xFFD5E2FA),
+    chipBorderWarning = Color(0xFFEED8B8),
+    chipBorderError = Color(0xFFF3C8C8),
   )
 
-internal val mobileSurface = Color(0xFFF6F7FA)
-internal val mobileSurfaceStrong = Color(0xFFECEEF3)
-internal val mobileBorder = Color(0xFFE5E7EC)
-internal val mobileBorderStrong = Color(0xFFD6DAE2)
-internal val mobileText = Color(0xFF17181C)
-internal val mobileTextSecondary = Color(0xFF5D6472)
-internal val mobileTextTertiary = Color(0xFF99A0AE)
-internal val mobileAccent = Color(0xFF1D5DD8)
-internal val mobileAccentSoft = Color(0xFFECF3FF)
-internal val mobileSuccess = Color(0xFF2F8C5A)
-internal val mobileSuccessSoft = Color(0xFFEEF9F3)
-internal val mobileWarning = Color(0xFFC8841A)
-internal val mobileWarningSoft = Color(0xFFFFF8EC)
-internal val mobileDanger = Color(0xFFD04B4B)
-internal val mobileDangerSoft = Color(0xFFFFF2F2)
-internal val mobileCodeBg = Color(0xFF15171B)
-internal val mobileCodeText = Color(0xFFE8EAEE)
+internal fun darkMobileColors() =
+  MobileColors(
+    surface = Color(0xFF1A1C20),
+    surfaceStrong = Color(0xFF24262B),
+    cardSurface = Color(0xFF1E2024),
+    border = Color(0xFF2E3038),
+    borderStrong = Color(0xFF3A3D46),
+    text = Color(0xFFE4E5EA),
+    textSecondary = Color(0xFFA0A6B4),
+    textTertiary = Color(0xFF6B7280),
+    accent = Color(0xFF6EA8FF),
+    accentSoft = Color(0xFF1A2A44),
+    accentBorderStrong = Color(0xFF5B93E8),
+    success = Color(0xFF5FBB85),
+    successSoft = Color(0xFF152E22),
+    warning = Color(0xFFE8A844),
+    warningSoft = Color(0xFF2E2212),
+    danger = Color(0xFFE87070),
+    dangerSoft = Color(0xFF2E1616),
+    codeBg = Color(0xFF111317),
+    codeText = Color(0xFFE8EAEE),
+    codeBorder = Color(0xFF2B2E35),
+    codeAccent = Color(0xFF3FC97A),
+    chipBorderConnected = Color(0xFF1E4A30),
+    chipBorderConnecting = Color(0xFF1E3358),
+    chipBorderWarning = Color(0xFF3E3018),
+    chipBorderError = Color(0xFF3E1E1E),
+  )
+
+internal val LocalMobileColors = staticCompositionLocalOf { lightMobileColors() }
+
+internal object MobileColorsAccessor {
+  val current: MobileColors
+    @Composable get() = LocalMobileColors.current
+}
+
+// ---------------------------------------------------------------------------
+// Backward-compatible top-level accessors (composable getters)
+// ---------------------------------------------------------------------------
+// These allow existing call sites to keep using `mobileSurface`, `mobileText`, etc.
+// without converting every file at once. Each resolves to the themed value.
+
+internal val mobileSurface: Color @Composable get() = LocalMobileColors.current.surface
+internal val mobileSurfaceStrong: Color @Composable get() = LocalMobileColors.current.surfaceStrong
+internal val mobileCardSurface: Color @Composable get() = LocalMobileColors.current.cardSurface
+internal val mobileBorder: Color @Composable get() = LocalMobileColors.current.border
+internal val mobileBorderStrong: Color @Composable get() = LocalMobileColors.current.borderStrong
+internal val mobileText: Color @Composable get() = LocalMobileColors.current.text
+internal val mobileTextSecondary: Color @Composable get() = LocalMobileColors.current.textSecondary
+internal val mobileTextTertiary: Color @Composable get() = LocalMobileColors.current.textTertiary
+internal val mobileAccent: Color @Composable get() = LocalMobileColors.current.accent
+internal val mobileAccentSoft: Color @Composable get() = LocalMobileColors.current.accentSoft
+internal val mobileAccentBorderStrong: Color @Composable get() = LocalMobileColors.current.accentBorderStrong
+internal val mobileSuccess: Color @Composable get() = LocalMobileColors.current.success
+internal val mobileSuccessSoft: Color @Composable get() = LocalMobileColors.current.successSoft
+internal val mobileWarning: Color @Composable get() = LocalMobileColors.current.warning
+internal val mobileWarningSoft: Color @Composable get() = LocalMobileColors.current.warningSoft
+internal val mobileDanger: Color @Composable get() = LocalMobileColors.current.danger
+internal val mobileDangerSoft: Color @Composable get() = LocalMobileColors.current.dangerSoft
+internal val mobileCodeBg: Color @Composable get() = LocalMobileColors.current.codeBg
+internal val mobileCodeText: Color @Composable get() = LocalMobileColors.current.codeText
+internal val mobileCodeBorder: Color @Composable get() = LocalMobileColors.current.codeBorder
+internal val mobileCodeAccent: Color @Composable get() = LocalMobileColors.current.codeAccent
+
+// Background gradient – light fades white→gray, dark fades near-black→dark-gray
+internal val mobileBackgroundGradient: Brush
+  @Composable get() {
+    val colors = LocalMobileColors.current
+    return Brush.verticalGradient(
+      listOf(
+        colors.surface,
+        colors.surfaceStrong,
+        colors.surfaceStrong,
+      ),
+    )
+  }
+
+// ---------------------------------------------------------------------------
+// Typography tokens (theme-independent)
+// ---------------------------------------------------------------------------
 
 internal val mobileFontFamily =
   FontFamily(
@@ -42,6 +159,15 @@ internal val mobileFontFamily =
     Font(resId = R.font.manrope_500_medium, weight = FontWeight.Medium),
     Font(resId = R.font.manrope_600_semibold, weight = FontWeight.SemiBold),
     Font(resId = R.font.manrope_700_bold, weight = FontWeight.Bold),
+  )
+
+internal val mobileDisplay =
+  TextStyle(
+    fontFamily = mobileFontFamily,
+    fontWeight = FontWeight.Bold,
+    fontSize = 34.sp,
+    lineHeight = 40.sp,
+    letterSpacing = (-0.8).sp,
   )
 
 internal val mobileTitle1 =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -81,7 +81,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -94,7 +93,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
-import ai.openclaw.app.R
 import ai.openclaw.app.node.DeviceNotificationListenerService
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
@@ -129,95 +127,80 @@ private enum class SpecialAccessToggle {
   NotificationListener,
 }
 
-private val onboardingBackgroundGradient =
-  listOf(
-    Color(0xFFFFFFFF),
-    Color(0xFFF7F8FA),
-    Color(0xFFEFF1F5),
-  )
-private val onboardingSurface = Color(0xFFF6F7FA)
-private val onboardingBorder = Color(0xFFE5E7EC)
-private val onboardingBorderStrong = Color(0xFFD6DAE2)
-private val onboardingText = Color(0xFF17181C)
-private val onboardingTextSecondary = Color(0xFF4D5563)
-private val onboardingTextTertiary = Color(0xFF8A92A2)
-private val onboardingAccent = Color(0xFF1D5DD8)
-private val onboardingAccentSoft = Color(0xFFECF3FF)
-private val onboardingSuccess = Color(0xFF2F8C5A)
-private val onboardingWarning = Color(0xFFC8841A)
-private val onboardingCommandBg = Color(0xFF15171B)
-private val onboardingCommandBorder = Color(0xFF2B2E35)
-private val onboardingCommandAccent = Color(0xFF3FC97A)
-private val onboardingCommandText = Color(0xFFE8EAEE)
+private val onboardingBackgroundGradient: Brush
+  @Composable get() = mobileBackgroundGradient
 
-private val onboardingFontFamily =
-  FontFamily(
-    Font(resId = R.font.manrope_400_regular, weight = FontWeight.Normal),
-    Font(resId = R.font.manrope_500_medium, weight = FontWeight.Medium),
-    Font(resId = R.font.manrope_600_semibold, weight = FontWeight.SemiBold),
-    Font(resId = R.font.manrope_700_bold, weight = FontWeight.Bold),
-  )
+private val onboardingSurface: Color
+  @Composable get() = mobileCardSurface
 
-private val onboardingDisplayStyle =
-  TextStyle(
-    fontFamily = onboardingFontFamily,
-    fontWeight = FontWeight.Bold,
-    fontSize = 34.sp,
-    lineHeight = 40.sp,
-    letterSpacing = (-0.8).sp,
-  )
+private val onboardingBorder: Color
+  @Composable get() = mobileBorder
 
-private val onboardingTitle1Style =
-  TextStyle(
-    fontFamily = onboardingFontFamily,
-    fontWeight = FontWeight.SemiBold,
-    fontSize = 24.sp,
-    lineHeight = 30.sp,
-    letterSpacing = (-0.5).sp,
-  )
+private val onboardingBorderStrong: Color
+  @Composable get() = mobileBorderStrong
 
-private val onboardingHeadlineStyle =
-  TextStyle(
-    fontFamily = onboardingFontFamily,
-    fontWeight = FontWeight.SemiBold,
-    fontSize = 16.sp,
-    lineHeight = 22.sp,
-    letterSpacing = (-0.1).sp,
-  )
+private val onboardingText: Color
+  @Composable get() = mobileText
 
-private val onboardingBodyStyle =
-  TextStyle(
-    fontFamily = onboardingFontFamily,
-    fontWeight = FontWeight.Medium,
-    fontSize = 15.sp,
-    lineHeight = 22.sp,
-  )
+private val onboardingTextSecondary: Color
+  @Composable get() = mobileTextSecondary
 
-private val onboardingCalloutStyle =
-  TextStyle(
-    fontFamily = onboardingFontFamily,
-    fontWeight = FontWeight.Medium,
-    fontSize = 14.sp,
-    lineHeight = 20.sp,
-  )
+private val onboardingTextTertiary: Color
+  @Composable get() = mobileTextTertiary
 
-private val onboardingCaption1Style =
-  TextStyle(
-    fontFamily = onboardingFontFamily,
-    fontWeight = FontWeight.Medium,
-    fontSize = 12.sp,
-    lineHeight = 16.sp,
-    letterSpacing = 0.2.sp,
-  )
+private val onboardingAccent: Color
+  @Composable get() = mobileAccent
 
-private val onboardingCaption2Style =
-  TextStyle(
-    fontFamily = onboardingFontFamily,
-    fontWeight = FontWeight.Medium,
-    fontSize = 11.sp,
-    lineHeight = 14.sp,
-    letterSpacing = 0.4.sp,
-  )
+private val onboardingAccentSoft: Color
+  @Composable get() = mobileAccentSoft
+
+private val onboardingAccentBorderStrong: Color
+  @Composable get() = mobileAccentBorderStrong
+
+private val onboardingSuccess: Color
+  @Composable get() = mobileSuccess
+
+private val onboardingSuccessSoft: Color
+  @Composable get() = mobileSuccessSoft
+
+private val onboardingWarning: Color
+  @Composable get() = mobileWarning
+
+private val onboardingWarningSoft: Color
+  @Composable get() = mobileWarningSoft
+
+private val onboardingCommandBg: Color
+  @Composable get() = mobileCodeBg
+
+private val onboardingCommandBorder: Color
+  @Composable get() = mobileCodeBorder
+
+private val onboardingCommandAccent: Color
+  @Composable get() = mobileCodeAccent
+
+private val onboardingCommandText: Color
+  @Composable get() = mobileCodeText
+
+private val onboardingDisplayStyle: TextStyle
+  get() = mobileDisplay
+
+private val onboardingTitle1Style: TextStyle
+  get() = mobileTitle1
+
+private val onboardingHeadlineStyle: TextStyle
+  get() = mobileHeadline
+
+private val onboardingBodyStyle: TextStyle
+  get() = mobileBody
+
+private val onboardingCalloutStyle: TextStyle
+  get() = mobileCallout
+
+private val onboardingCaption1Style: TextStyle
+  get() = mobileCaption1
+
+private val onboardingCaption2Style: TextStyle
+  get() = mobileCaption2
 
 @Composable
 fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
@@ -495,7 +478,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
     modifier =
       modifier
         .fillMaxSize()
-        .background(Brush.verticalGradient(onboardingBackgroundGradient)),
+        .background(onboardingBackgroundGradient),
   ) {
     Column(
       modifier =
@@ -755,13 +738,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               onClick = { step = OnboardingStep.Gateway },
               modifier = Modifier.weight(1f).height(52.dp),
               shape = RoundedCornerShape(14.dp),
-              colors =
-                ButtonDefaults.buttonColors(
-                  containerColor = onboardingAccent,
-                  contentColor = Color.White,
-                  disabledContainerColor = onboardingAccent.copy(alpha = 0.45f),
-                  disabledContentColor = Color.White,
-                ),
+              colors = onboardingPrimaryButtonColors(),
             ) {
               Text("Next", style = onboardingHeadlineStyle.copy(fontWeight = FontWeight.Bold))
             }
@@ -807,13 +784,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               },
               modifier = Modifier.weight(1f).height(52.dp),
               shape = RoundedCornerShape(14.dp),
-              colors =
-                ButtonDefaults.buttonColors(
-                  containerColor = onboardingAccent,
-                  contentColor = Color.White,
-                  disabledContainerColor = onboardingAccent.copy(alpha = 0.45f),
-                  disabledContentColor = Color.White,
-                ),
+              colors = onboardingPrimaryButtonColors(),
             ) {
               Text("Next", style = onboardingHeadlineStyle.copy(fontWeight = FontWeight.Bold))
             }
@@ -827,13 +798,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               },
               modifier = Modifier.weight(1f).height(52.dp),
               shape = RoundedCornerShape(14.dp),
-              colors =
-                ButtonDefaults.buttonColors(
-                  containerColor = onboardingAccent,
-                  contentColor = Color.White,
-                  disabledContainerColor = onboardingAccent.copy(alpha = 0.45f),
-                  disabledContentColor = Color.White,
-                ),
+              colors = onboardingPrimaryButtonColors(),
             ) {
               Text("Next", style = onboardingHeadlineStyle.copy(fontWeight = FontWeight.Bold))
             }
@@ -844,13 +809,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                 onClick = { viewModel.setOnboardingCompleted(true) },
                 modifier = Modifier.weight(1f).height(52.dp),
                 shape = RoundedCornerShape(14.dp),
-                colors =
-                  ButtonDefaults.buttonColors(
-                    containerColor = onboardingAccent,
-                    contentColor = Color.White,
-                    disabledContainerColor = onboardingAccent.copy(alpha = 0.45f),
-                    disabledContentColor = Color.White,
-                  ),
+                colors = onboardingPrimaryButtonColors(),
               ) {
                 Text("Finish", style = onboardingHeadlineStyle.copy(fontWeight = FontWeight.Bold))
               }
@@ -883,13 +842,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                 },
                 modifier = Modifier.weight(1f).height(52.dp),
                 shape = RoundedCornerShape(14.dp),
-                colors =
-                  ButtonDefaults.buttonColors(
-                    containerColor = onboardingAccent,
-                    contentColor = Color.White,
-                    disabledContainerColor = onboardingAccent.copy(alpha = 0.45f),
-                    disabledContentColor = Color.White,
-                  ),
+                colors = onboardingPrimaryButtonColors(),
               ) {
                 Text("Connect", style = onboardingHeadlineStyle.copy(fontWeight = FontWeight.Bold))
               }
@@ -900,6 +853,36 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
     }
   }
 }
+
+@Composable
+private fun onboardingPrimaryButtonColors() =
+  ButtonDefaults.buttonColors(
+    containerColor = onboardingAccent,
+    contentColor = Color.White,
+    disabledContainerColor = onboardingAccent.copy(alpha = 0.45f),
+    disabledContentColor = Color.White.copy(alpha = 0.9f),
+  )
+
+@Composable
+private fun onboardingTextFieldColors() =
+  OutlinedTextFieldDefaults.colors(
+    focusedContainerColor = onboardingSurface,
+    unfocusedContainerColor = onboardingSurface,
+    focusedBorderColor = onboardingAccent,
+    unfocusedBorderColor = onboardingBorder,
+    focusedTextColor = onboardingText,
+    unfocusedTextColor = onboardingText,
+    cursorColor = onboardingAccent,
+  )
+
+@Composable
+private fun onboardingSwitchColors() =
+  SwitchDefaults.colors(
+    checkedTrackColor = onboardingAccent,
+    uncheckedTrackColor = onboardingBorderStrong,
+    checkedThumbColor = Color.White,
+    uncheckedThumbColor = Color.White,
+  )
 
 @Composable
 private fun StepRail(current: OnboardingStep) {
@@ -1005,11 +988,7 @@ private fun GatewayStep(
       onClick = onScanQrClick,
       modifier = Modifier.fillMaxWidth().height(48.dp),
       shape = RoundedCornerShape(12.dp),
-      colors =
-        ButtonDefaults.buttonColors(
-          containerColor = onboardingAccent,
-          contentColor = Color.White,
-        ),
+      colors = onboardingPrimaryButtonColors(),
     ) {
       Text("Scan QR code", style = onboardingHeadlineStyle.copy(fontWeight = FontWeight.Bold))
     }
@@ -1059,15 +1038,7 @@ private fun GatewayStep(
             textStyle = onboardingBodyStyle.copy(fontFamily = FontFamily.Monospace, color = onboardingText),
             shape = RoundedCornerShape(14.dp),
             colors =
-              OutlinedTextFieldDefaults.colors(
-                focusedContainerColor = onboardingSurface,
-                unfocusedContainerColor = onboardingSurface,
-                focusedBorderColor = onboardingAccent,
-                unfocusedBorderColor = onboardingBorder,
-                focusedTextColor = onboardingText,
-                unfocusedTextColor = onboardingText,
-                cursorColor = onboardingAccent,
-              ),
+              onboardingTextFieldColors(),
           )
           if (!resolvedEndpoint.isNullOrBlank()) {
             ResolvedEndpoint(endpoint = resolvedEndpoint)
@@ -1097,15 +1068,7 @@ private fun GatewayStep(
             textStyle = onboardingBodyStyle.copy(color = onboardingText),
             shape = RoundedCornerShape(14.dp),
             colors =
-              OutlinedTextFieldDefaults.colors(
-                focusedContainerColor = onboardingSurface,
-                unfocusedContainerColor = onboardingSurface,
-                focusedBorderColor = onboardingAccent,
-                unfocusedBorderColor = onboardingBorder,
-                focusedTextColor = onboardingText,
-                unfocusedTextColor = onboardingText,
-                cursorColor = onboardingAccent,
-              ),
+              onboardingTextFieldColors(),
           )
 
           Text("PORT", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
@@ -1119,15 +1082,7 @@ private fun GatewayStep(
             textStyle = onboardingBodyStyle.copy(fontFamily = FontFamily.Monospace, color = onboardingText),
             shape = RoundedCornerShape(14.dp),
             colors =
-              OutlinedTextFieldDefaults.colors(
-                focusedContainerColor = onboardingSurface,
-                unfocusedContainerColor = onboardingSurface,
-                focusedBorderColor = onboardingAccent,
-                unfocusedBorderColor = onboardingBorder,
-                focusedTextColor = onboardingText,
-                unfocusedTextColor = onboardingText,
-                cursorColor = onboardingAccent,
-              ),
+              onboardingTextFieldColors(),
           )
 
           Row(
@@ -1143,12 +1098,7 @@ private fun GatewayStep(
               checked = manualTls,
               onCheckedChange = onManualTlsChange,
               colors =
-                SwitchDefaults.colors(
-                  checkedTrackColor = onboardingAccent,
-                  uncheckedTrackColor = onboardingBorderStrong,
-                  checkedThumbColor = Color.White,
-                  uncheckedThumbColor = Color.White,
-                ),
+                onboardingSwitchColors(),
             )
           }
 
@@ -1163,15 +1113,7 @@ private fun GatewayStep(
             textStyle = onboardingBodyStyle.copy(color = onboardingText),
             shape = RoundedCornerShape(14.dp),
             colors =
-              OutlinedTextFieldDefaults.colors(
-                focusedContainerColor = onboardingSurface,
-                unfocusedContainerColor = onboardingSurface,
-                focusedBorderColor = onboardingAccent,
-                unfocusedBorderColor = onboardingBorder,
-                focusedTextColor = onboardingText,
-                unfocusedTextColor = onboardingText,
-                cursorColor = onboardingAccent,
-              ),
+              onboardingTextFieldColors(),
           )
 
           Text("PASSWORD (OPTIONAL)", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
@@ -1185,15 +1127,7 @@ private fun GatewayStep(
             textStyle = onboardingBodyStyle.copy(color = onboardingText),
             shape = RoundedCornerShape(14.dp),
             colors =
-              OutlinedTextFieldDefaults.colors(
-                focusedContainerColor = onboardingSurface,
-                unfocusedContainerColor = onboardingSurface,
-                focusedBorderColor = onboardingAccent,
-                unfocusedBorderColor = onboardingBorder,
-                focusedTextColor = onboardingText,
-                unfocusedTextColor = onboardingText,
-                cursorColor = onboardingAccent,
-              ),
+              onboardingTextFieldColors(),
           )
 
           if (!manualResolvedEndpoint.isNullOrBlank()) {
@@ -1261,7 +1195,7 @@ private fun GatewayModeChip(
         containerColor = if (active) onboardingAccent else onboardingSurface,
         contentColor = if (active) Color.White else onboardingText,
       ),
-    border = androidx.compose.foundation.BorderStroke(1.dp, if (active) Color(0xFF184DAF) else onboardingBorderStrong),
+    border = androidx.compose.foundation.BorderStroke(1.dp, if (active) onboardingAccentBorderStrong else onboardingBorderStrong),
   ) {
     Text(
       text = label,
@@ -1524,13 +1458,7 @@ private fun PermissionToggleRow(
       checked = checked,
       onCheckedChange = onCheckedChange,
       enabled = enabled,
-      colors =
-        SwitchDefaults.colors(
-          checkedTrackColor = onboardingAccent,
-          uncheckedTrackColor = onboardingBorderStrong,
-          checkedThumbColor = Color.White,
-          uncheckedThumbColor = Color.White,
-        ),
+      colors = onboardingSwitchColors(),
     )
   }
 }
@@ -1605,7 +1533,7 @@ private fun FinalStep(
       Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(14.dp),
-        color = Color(0xFFEEF9F3),
+        color = onboardingSuccessSoft,
         border = androidx.compose.foundation.BorderStroke(1.dp, onboardingSuccess.copy(alpha = 0.2f)),
       ) {
         Row(
@@ -1641,7 +1569,7 @@ private fun FinalStep(
       Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(14.dp),
-        color = Color(0xFFFFF8EC),
+        color = onboardingWarningSoft,
         border = androidx.compose.foundation.BorderStroke(1.dp, onboardingWarning.copy(alpha = 0.2f)),
       ) {
         Column(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OpenClawTheme.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OpenClawTheme.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
@@ -13,8 +14,11 @@ fun OpenClawTheme(content: @Composable () -> Unit) {
   val context = LocalContext.current
   val isDark = isSystemInDarkTheme()
   val colorScheme = if (isDark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+  val mobileColors = if (isDark) darkMobileColors() else lightMobileColors()
 
-  MaterialTheme(colorScheme = colorScheme, content = content)
+  CompositionLocalProvider(LocalMobileColors provides mobileColors) {
+    MaterialTheme(colorScheme = colorScheme, content = content)
+  }
 }
 
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/PostOnboardingTabs.kt
@@ -159,28 +159,28 @@ private fun TopStatusBar(
           mobileSuccessSoft,
           mobileSuccess,
           mobileSuccess,
-          Color(0xFFCFEBD8),
+          LocalMobileColors.current.chipBorderConnected,
         )
       StatusVisual.Connecting ->
         listOf(
           mobileAccentSoft,
           mobileAccent,
           mobileAccent,
-          Color(0xFFD5E2FA),
+          LocalMobileColors.current.chipBorderConnecting,
         )
       StatusVisual.Warning ->
         listOf(
           mobileWarningSoft,
           mobileWarning,
           mobileWarning,
-          Color(0xFFEED8B8),
+          LocalMobileColors.current.chipBorderWarning,
         )
       StatusVisual.Error ->
         listOf(
           mobileDangerSoft,
           mobileDanger,
           mobileDanger,
-          Color(0xFFF3C8C8),
+          LocalMobileColors.current.chipBorderError,
         )
       StatusVisual.Offline ->
         listOf(
@@ -249,7 +249,7 @@ private fun BottomTabBar(
   ) {
     Surface(
       modifier = Modifier.fillMaxWidth(),
-      color = Color.White.copy(alpha = 0.97f),
+      color = mobileCardSurface.copy(alpha = 0.97f),
       shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
       border = BorderStroke(1.dp, mobileBorder),
       shadowElevation = 6.dp,
@@ -270,7 +270,7 @@ private fun BottomTabBar(
             modifier = Modifier.weight(1f).heightIn(min = 58.dp),
             shape = RoundedCornerShape(16.dp),
             color = if (active) mobileAccentSoft else Color.Transparent,
-            border = if (active) BorderStroke(1.dp, Color(0xFFD5E2FA)) else null,
+            border = if (active) BorderStroke(1.dp, LocalMobileColors.current.chipBorderConnecting) else null,
             shadowElevation = 0.dp,
           ) {
             Column(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -736,11 +736,12 @@ private fun settingsTextFieldColors() =
     cursorColor = mobileAccent,
   )
 
+@Composable
 private fun Modifier.settingsRowModifier() =
   this
     .fillMaxWidth()
     .border(width = 1.dp, color = mobileBorder, shape = RoundedCornerShape(14.dp))
-    .background(Color.White, RoundedCornerShape(14.dp))
+    .background(mobileCardSurface, RoundedCornerShape(14.dp))
 
 @Composable
 private fun settingsPrimaryButtonColors() =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceTabScreen.kt
@@ -363,7 +363,7 @@ private fun VoiceTurnBubble(entry: VoiceConversationEntry) {
     Surface(
       modifier = Modifier.fillMaxWidth(0.90f),
       shape = RoundedCornerShape(12.dp),
-      color = if (isUser) mobileAccentSoft else Color.White,
+      color = if (isUser) mobileAccentSoft else mobileCardSurface,
       border = BorderStroke(1.dp, if (isUser) mobileAccent else mobileBorderStrong),
     ) {
       Column(
@@ -391,7 +391,7 @@ private fun VoiceThinkingBubble() {
     Surface(
       modifier = Modifier.fillMaxWidth(0.68f),
       shape = RoundedCornerShape(12.dp),
-      color = Color.White,
+      color = mobileCardSurface,
       border = BorderStroke(1.dp, mobileBorderStrong),
     ) {
       Row(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
@@ -46,11 +46,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ai.openclaw.app.ui.mobileAccent
+import ai.openclaw.app.ui.mobileAccentBorderStrong
 import ai.openclaw.app.ui.mobileAccentSoft
 import ai.openclaw.app.ui.mobileBorder
 import ai.openclaw.app.ui.mobileBorderStrong
 import ai.openclaw.app.ui.mobileCallout
 import ai.openclaw.app.ui.mobileCaption1
+import ai.openclaw.app.ui.mobileCardSurface
 import ai.openclaw.app.ui.mobileHeadline
 import ai.openclaw.app.ui.mobileSurface
 import ai.openclaw.app.ui.mobileText
@@ -110,7 +112,7 @@ fun ChatComposer(
         Surface(
           onClick = { showThinkingMenu = true },
           shape = RoundedCornerShape(14.dp),
-          color = Color.White,
+          color = mobileCardSurface,
           border = BorderStroke(1.dp, mobileBorderStrong),
         ) {
           Row(
@@ -177,7 +179,7 @@ fun ChatComposer(
             disabledContainerColor = mobileBorderStrong,
             disabledContentColor = mobileTextTertiary,
           ),
-        border = BorderStroke(1.dp, if (canSend) Color(0xFF154CAD) else mobileBorderStrong),
+        border = BorderStroke(1.dp, if (canSend) mobileAccentBorderStrong else mobileBorderStrong),
       ) {
         if (sendBusy) {
           CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = Color.White)
@@ -211,9 +213,9 @@ private fun SecondaryActionButton(
     shape = RoundedCornerShape(14.dp),
     colors =
       ButtonDefaults.buttonColors(
-        containerColor = Color.White,
+        containerColor = mobileCardSurface,
         contentColor = mobileTextSecondary,
-        disabledContainerColor = Color.White,
+        disabledContainerColor = mobileCardSurface,
         disabledContentColor = mobileTextTertiary,
       ),
     border = BorderStroke(1.dp, mobileBorderStrong),
@@ -303,7 +305,7 @@ private fun AttachmentChip(fileName: String, onRemove: () -> Unit) {
       Surface(
         onClick = onRemove,
         shape = RoundedCornerShape(999.dp),
-        color = Color.White,
+        color = mobileCardSurface,
         border = BorderStroke(1.dp, mobileBorderStrong),
       ) {
         Text(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
@@ -94,7 +94,7 @@ private val markdownParser: Parser by lazy {
 @Composable
 fun ChatMarkdown(text: String, textColor: Color) {
   val document = remember(text) { markdownParser.parse(text) as Document }
-  val inlineStyles = InlineStyles(inlineCodeBg = mobileCodeBg, inlineCodeColor = mobileCodeText)
+  val inlineStyles = InlineStyles(inlineCodeBg = mobileCodeBg, inlineCodeColor = mobileCodeText, linkColor = mobileAccent, baseCallout = mobileCallout)
 
   Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
     RenderMarkdownBlocks(
@@ -124,7 +124,7 @@ private fun RenderMarkdownBlocks(
         val headingText = remember(current) { buildInlineMarkdown(current.firstChild, inlineStyles) }
         Text(
           text = headingText,
-          style = headingStyle(current.level),
+          style = headingStyle(current.level, inlineStyles.baseCallout),
           color = textColor,
         )
       }
@@ -231,7 +231,7 @@ private fun RenderParagraph(
 
   Text(
     text = annotated,
-    style = mobileCallout,
+    style = inlineStyles.baseCallout,
     color = textColor,
   )
 }
@@ -315,7 +315,7 @@ private fun RenderListItem(
   ) {
     Text(
       text = marker,
-      style = mobileCallout.copy(fontWeight = FontWeight.SemiBold),
+      style = inlineStyles.baseCallout.copy(fontWeight = FontWeight.SemiBold),
       color = textColor,
       modifier = Modifier.width(24.dp),
     )
@@ -360,7 +360,7 @@ private fun RenderTableBlock(
           val cell = row.cells.getOrNull(index) ?: AnnotatedString("")
           Text(
             text = cell,
-            style = if (row.isHeader) mobileCaption1.copy(fontWeight = FontWeight.SemiBold) else mobileCallout,
+            style = if (row.isHeader) mobileCaption1.copy(fontWeight = FontWeight.SemiBold) else inlineStyles.baseCallout,
             color = textColor,
             modifier = Modifier
               .border(1.dp, mobileTextSecondary.copy(alpha = 0.22f))
@@ -417,6 +417,7 @@ private fun buildInlineMarkdown(start: Node?, inlineStyles: InlineStyles): Annot
       node = start,
       inlineCodeBg = inlineStyles.inlineCodeBg,
       inlineCodeColor = inlineStyles.inlineCodeColor,
+      linkColor = inlineStyles.linkColor,
     )
   }
 }
@@ -425,6 +426,7 @@ private fun AnnotatedString.Builder.appendInlineNode(
   node: Node?,
   inlineCodeBg: Color,
   inlineCodeColor: Color,
+  linkColor: Color,
 ) {
   var current = node
   while (current != null) {
@@ -445,27 +447,27 @@ private fun AnnotatedString.Builder.appendInlineNode(
       }
       is Emphasis -> {
         withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
-          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
+          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor, linkColor = linkColor)
         }
       }
       is StrongEmphasis -> {
         withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
-          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
+          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor, linkColor = linkColor)
         }
       }
       is Strikethrough -> {
         withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) {
-          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
+          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor, linkColor = linkColor)
         }
       }
       is Link -> {
         withStyle(
           SpanStyle(
-            color = mobileAccent,
+            color = linkColor,
             textDecoration = TextDecoration.Underline,
           ),
         ) {
-          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
+          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor, linkColor = linkColor)
         }
       }
       is MarkdownImage -> {
@@ -482,7 +484,7 @@ private fun AnnotatedString.Builder.appendInlineNode(
         }
       }
       else -> {
-        appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
+        appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor, linkColor = linkColor)
       }
     }
     current = current.next
@@ -519,19 +521,21 @@ private fun parseDataImageDestination(destination: String?): ParsedDataImage? {
   return ParsedDataImage(mimeType = "image/$subtype", base64 = base64)
 }
 
-private fun headingStyle(level: Int): TextStyle {
+private fun headingStyle(level: Int, baseCallout: TextStyle): TextStyle {
   return when (level.coerceIn(1, 6)) {
-    1 -> mobileCallout.copy(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold)
-    2 -> mobileCallout.copy(fontSize = 20.sp, lineHeight = 26.sp, fontWeight = FontWeight.Bold)
-    3 -> mobileCallout.copy(fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold)
-    4 -> mobileCallout.copy(fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold)
-    else -> mobileCallout.copy(fontWeight = FontWeight.SemiBold)
+    1 -> baseCallout.copy(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold)
+    2 -> baseCallout.copy(fontSize = 20.sp, lineHeight = 26.sp, fontWeight = FontWeight.Bold)
+    3 -> baseCallout.copy(fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold)
+    4 -> baseCallout.copy(fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold)
+    else -> baseCallout.copy(fontWeight = FontWeight.SemiBold)
   }
 }
 
 private data class InlineStyles(
   val inlineCodeBg: Color,
   val inlineCodeColor: Color,
+  val linkColor: Color,
+  val baseCallout: TextStyle,
 )
 
 private data class TableRenderRow(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
@@ -19,6 +19,7 @@ import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.ui.mobileBorder
 import ai.openclaw.app.ui.mobileCallout
+import ai.openclaw.app.ui.mobileCardSurface
 import ai.openclaw.app.ui.mobileHeadline
 import ai.openclaw.app.ui.mobileText
 import ai.openclaw.app.ui.mobileTextSecondary
@@ -85,7 +86,7 @@ private fun EmptyChatHint(modifier: Modifier = Modifier, healthOk: Boolean) {
   Surface(
     modifier = modifier.fillMaxWidth(),
     shape = RoundedCornerShape(14.dp),
-    color = androidx.compose.ui.graphics.Color.White.copy(alpha = 0.9f),
+    color = mobileCardSurface.copy(alpha = 0.9f),
     border = androidx.compose.foundation.BorderStroke(1.dp, mobileBorder),
   ) {
     androidx.compose.foundation.layout.Column(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -36,7 +36,9 @@ import ai.openclaw.app.ui.mobileBorderStrong
 import ai.openclaw.app.ui.mobileCallout
 import ai.openclaw.app.ui.mobileCaption1
 import ai.openclaw.app.ui.mobileCaption2
+import ai.openclaw.app.ui.mobileCardSurface
 import ai.openclaw.app.ui.mobileCodeBg
+import ai.openclaw.app.ui.mobileCodeBorder
 import ai.openclaw.app.ui.mobileCodeText
 import ai.openclaw.app.ui.mobileHeadline
 import ai.openclaw.app.ui.mobileText
@@ -194,6 +196,7 @@ fun ChatStreamingAssistantBubble(text: String) {
   }
 }
 
+@Composable
 private fun bubbleStyle(role: String): ChatBubbleStyle {
   return when (role) {
     "user" ->
@@ -215,7 +218,7 @@ private fun bubbleStyle(role: String): ChatBubbleStyle {
     else ->
       ChatBubbleStyle(
         alignEnd = false,
-        containerColor = Color.White,
+        containerColor = mobileCardSurface,
         borderColor = mobileBorderStrong,
         roleColor = mobileTextSecondary,
       )
@@ -239,7 +242,7 @@ private fun ChatBase64Image(base64: String, mimeType: String?) {
     Surface(
       shape = RoundedCornerShape(10.dp),
       border = BorderStroke(1.dp, mobileBorder),
-      color = Color.White,
+      color = mobileCardSurface,
       modifier = Modifier.fillMaxWidth(),
     ) {
       Image(
@@ -277,7 +280,7 @@ fun ChatCodeBlock(code: String, language: String?) {
   Surface(
     shape = RoundedCornerShape(8.dp),
     color = mobileCodeBg,
-    border = BorderStroke(1.dp, Color(0xFF2B2E35)),
+    border = BorderStroke(1.dp, mobileCodeBorder),
     modifier = Modifier.fillMaxWidth(),
   ) {
     Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
@@ -36,12 +36,15 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.ui.mobileAccent
+import ai.openclaw.app.ui.mobileAccentBorderStrong
 import ai.openclaw.app.ui.mobileBorder
 import ai.openclaw.app.ui.mobileBorderStrong
 import ai.openclaw.app.ui.mobileCallout
+import ai.openclaw.app.ui.mobileCardSurface
 import ai.openclaw.app.ui.mobileCaption1
 import ai.openclaw.app.ui.mobileCaption2
 import ai.openclaw.app.ui.mobileDanger
+import ai.openclaw.app.ui.mobileDangerSoft
 import ai.openclaw.app.ui.mobileText
 import ai.openclaw.app.ui.mobileTextSecondary
 import java.io.ByteArrayOutputStream
@@ -168,8 +171,8 @@ private fun ChatThreadSelector(
       Surface(
         onClick = { onSelectSession(entry.key) },
         shape = RoundedCornerShape(14.dp),
-        color = if (active) mobileAccent else Color.White,
-        border = BorderStroke(1.dp, if (active) Color(0xFF154CAD) else mobileBorderStrong),
+        color = if (active) mobileAccent else mobileCardSurface,
+        border = BorderStroke(1.dp, if (active) mobileAccentBorderStrong else mobileBorderStrong),
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
       ) {
@@ -190,7 +193,7 @@ private fun ChatThreadSelector(
 private fun ChatErrorRail(errorText: String) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
-    color = androidx.compose.ui.graphics.Color.White,
+    color = mobileDangerSoft,
     shape = RoundedCornerShape(12.dp),
     border = androidx.compose.foundation.BorderStroke(1.dp, mobileDanger),
   ) {

--- a/apps/android/app/src/main/res/values-night/themes.xml
+++ b/apps/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.OpenClawNode" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- **Problem**: `stripThoughtSignatures` in `bootstrap.ts` modifies Anthropic `thinking` and `redacted_thinking` blocks by spreading them into new objects and deleting `thought_signature`. Anthropic's API requires these blocks to be identical to the original response in multi-turn sessions, causing rejection: `thinking or redacted_thinking blocks in the latest assistant message cannot be modified`.
- **Why it matters**: Any multi-turn session with Anthropic extended thinking (e.g. `claude-opus-4-5`) fails after the first turn when thinking blocks are stored and replayed.
- **What changed**: Added an early return in `stripThoughtSignatures` (`bootstrap.ts`) that skips `type: "thinking"` and `type: "redacted_thinking"` blocks entirely, returning the original block reference. Updated test expectations to verify thinking blocks are preserved verbatim.
- **What did NOT change (scope boundary)**: Signature stripping for text and other block types is unchanged. No changes to other sanitization functions.

## Change Type
- [x] Bug fix

## Scope
- [x] Agent/Model

## Linked Issue/PR
- Closes #29618

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
1. Use Anthropic provider with extended thinking enabled (e.g. `claude-opus-4-5`)
2. Multi-turn conversation stores thinking blocks in session
3. On subsequent turn, `stripThoughtSignatures` no longer modifies thinking blocks
4. API accepts the request without error

## Evidence
- [x] Failing test/log before + passing after
- Manual `tsx` test confirms thinking blocks preserved as original references, text block signatures still stripped

## Human Verification
- Verified scenarios: thinking block preservation, redacted_thinking preservation, text block signature stripping still works
- Edge cases checked: mixed blocks (thinking + redacted_thinking + text), empty arrays, null/undefined blocks
- What you did NOT verify: runtime end-to-end testing with actual Anthropic API

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: `src/agents/pi-embedded-helpers/bootstrap.ts`, `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`

## Risks and Mitigations
None — thinking blocks never need signature stripping (only used for Gemini cross-provider compat).

---
*This PR was AI-assisted (verified with manual tsx test).*