### PR TITLE
feat: add Chinese rate-limit error patterns for MiniMax and other CN providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Pi: wait for embedded abort cleanup to settle before releasing the session write lock, preventing follow-up turns from racing previous prompt teardown. (#80239) Thanks @samzong.
 - WhatsApp: downgrade OpenClaw watchdog-triggered Web reconnects from runtime errors to recovery warnings and clear the recovered reconnect status after the next healthy connection. (#77026) Thanks @rubencu.
 - ACPX/Windows: hide the MCP proxy target child process window on Windows so ACP-backed agents do not flash or fail because of terminal window handling. Fixes #60672. (#60678) Thanks @KChow-ctrl.
+- Agents/failover: classify precise MiniMax Chinese rate-limit payloads without treating generic retry copy as rate limits. (#45937) Thanks @yingriyanlong.
 
 ## 2026.5.9
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1369,6 +1369,16 @@ describe("classifyFailoverReason provider messages", () => {
     expect(classifyFailoverReason("系统异常")).toBe("timeout");
 
     // Rate limit errors
+    expect(
+      classifyFailoverReason(
+        "当前请求量较高，标准套餐的速率限制可能会临时收紧。请稍后重试，或升级至 High-Speed 套餐以获得优先容量支持。 (2062)",
+      ),
+    ).toBe("rate_limit");
+    expect(classifyFailoverReason('{"code":2062,"message":"请求量较高，触发速率限制"}')).toBe(
+      "rate_limit",
+    );
+    expect(classifyFailoverReason("当前请求量较高")).toBe("rate_limit");
+    expect(classifyFailoverReason("速率限制")).toBe("rate_limit");
     expect(classifyFailoverReason("请求过于频繁，请稍后重试")).toBe("rate_limit");
     expect(classifyFailoverReason("调用频率超限")).toBe("rate_limit");
     expect(classifyFailoverReason("频率限制")).toBe("rate_limit");
@@ -1388,10 +1398,14 @@ describe("classifyFailoverReason provider messages", () => {
     expect(classifyFailoverReason("认证失败")).toBe("auth");
     expect(classifyFailoverReason("鉴权失败，请检查API Key")).toBe("auth");
     expect(classifyFailoverReason("密钥无效")).toBe("auth");
+    expect(classifyFailoverReason("鉴权失败，请稍后重试")).toBe("auth");
 
     // Overloaded errors
     expect(classifyFailoverReason("服务过载，请稍后重试")).toBe("overloaded");
     expect(classifyFailoverReason("当前负载过高")).toBe("overloaded");
+
+    // Generic retry copy is not a rate-limit signal by itself.
+    expect(classifyFailoverReason("请稍后重试")).toBeNull();
   });
 });
 

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -11,6 +11,7 @@ export {
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
   BILLING_ERROR_USER_MESSAGE,
+  classifyFailoverAssistantReason,
   classifyProviderRuntimeFailureKind,
   formatBillingErrorMessage,
   formatRateLimitOrOverloadedErrorCopy,

--- a/src/agents/pi-embedded-helpers/errors.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.test.ts
@@ -2,7 +2,11 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assistant-error-format.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
-import { formatAssistantErrorText } from "./errors.js";
+import {
+  classifyFailoverAssistantReason,
+  formatAssistantErrorText,
+  isFailoverAssistantError,
+} from "./errors.js";
 
 describe("formatAssistantErrorText streaming JSON parse classification", () => {
   const makeAssistantError = (errorMessage: string): AssistantMessage =>
@@ -34,5 +38,67 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
     expect(formatAssistantErrorText(msg)).toBe(
       "LLM request rejected: Expected value in JSON at position 12 for messages.0.content",
     );
+  });
+});
+
+describe("assistant failover classification", () => {
+  it("preserves the reason for MiniMax text-body rate-limit payloads", () => {
+    const msg = makeAssistantMessageFixture({
+      provider: "minimax",
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [
+        {
+          type: "text",
+          text:
+            "当前请求量较高，标准套餐的速率限制可能会临时收紧。" +
+            "请稍后重试，或升级至 High-Speed 套餐以获得优先容量支持。 (2062)",
+        },
+      ],
+    });
+
+    expect(classifyFailoverAssistantReason(msg)).toBe("rate_limit");
+    expect(isFailoverAssistantError(msg)).toBe(true);
+  });
+
+  it("does not scan generic successful assistant prose for failover terms", () => {
+    const msg = makeAssistantMessageFixture({
+      provider: "openai",
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [
+        {
+          type: "text",
+          text: "A rate limit is a quota that protects a high demand service.",
+        },
+      ],
+    });
+
+    expect(classifyFailoverAssistantReason(msg)).toBeNull();
+    expect(isFailoverAssistantError(msg)).toBe(false);
+  });
+
+  it("preserves errorMessage failover classification on non-error assistant messages", () => {
+    const msg = makeAssistantMessageFixture({
+      provider: "openai",
+      stopReason: "length",
+      errorMessage: "rate limit exceeded",
+      content: [],
+    });
+
+    expect(classifyFailoverAssistantReason(msg)).toBe("rate_limit");
+    expect(isFailoverAssistantError(msg)).toBe(true);
+  });
+
+  it("does not treat generic MiniMax retry copy as a text-body rate limit", () => {
+    const msg = makeAssistantMessageFixture({
+      provider: "minimax",
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [{ type: "text", text: "请稍后重试" }],
+    });
+
+    expect(classifyFailoverAssistantReason(msg)).toBeNull();
+    expect(isFailoverAssistantError(msg)).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -1339,9 +1339,54 @@ export function isFailoverErrorMessage(raw: string, opts?: { provider?: string }
   return classifyFailoverReason(raw, opts) !== null;
 }
 
-export function isFailoverAssistantError(msg: AssistantMessage | undefined): boolean {
-  if (!msg || msg.stopReason !== "error") {
-    return false;
+function isMiniMaxProvider(provider: string | undefined): boolean {
+  return normalizeLowercaseStringOrEmpty(provider).includes("minimax");
+}
+
+function extractAssistantTextContent(msg: AssistantMessage): string {
+  if (!Array.isArray(msg.content)) {
+    return "";
   }
-  return isFailoverErrorMessage(msg.errorMessage ?? "", { provider: msg.provider });
+  return msg.content
+    .map((block) =>
+      block && typeof block === "object" && "text" in block && typeof block.text === "string"
+        ? block.text
+        : "",
+    )
+    .join("")
+    .trim();
+}
+
+function classifyMiniMaxNonErrorText(raw: string): FailoverReason | null {
+  if (!raw || raw.length > 500) {
+    return null;
+  }
+  const hasMiniMaxRateLimitText = raw.includes("速率限制") && raw.includes("请求量较高");
+  const hasMiniMaxRateLimitCode = /(?:^|[^\d])2062(?:[^\d]|$)/.test(raw);
+  if (hasMiniMaxRateLimitText && hasMiniMaxRateLimitCode) {
+    return "rate_limit";
+  }
+  return null;
+}
+
+export function classifyFailoverAssistantReason(
+  msg: AssistantMessage | undefined,
+): FailoverReason | null {
+  if (!msg) {
+    return null;
+  }
+  const errorMessageReason = classifyFailoverReason(msg.errorMessage ?? "", {
+    provider: msg.provider,
+  });
+  if (errorMessageReason !== null) {
+    return errorMessageReason;
+  }
+  if (msg.stopReason === "error" || !isMiniMaxProvider(msg.provider)) {
+    return null;
+  }
+  return classifyMiniMaxNonErrorText(extractAssistantTextContent(msg));
+}
+
+export function isFailoverAssistantError(msg: AssistantMessage | undefined): boolean {
+  return classifyFailoverAssistantReason(msg) !== null;
 }

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -79,6 +79,10 @@ const ERROR_PATTERNS = {
     "tokens per minute",
     "tokens per day",
     // Chinese provider rate-limit messages
+    "速率限制",
+    "请求量较高",
+    /\bcode["']?\s*[:=]\s*["']?2062\b/i,
+    /\(2062\)/,
     "请求过于频繁",
     "调用频率",
     "频率限制",

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -4,6 +4,7 @@ import { hasCommittedMessagingToolDeliveryEvidence } from "./delivery-evidence.j
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedClassifyFailoverAssistantReason,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
   mockedLog,
@@ -112,7 +113,8 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    expect(mockedClassifyFailoverReason).toHaveBeenCalledTimes(1);
+    expect(mockedClassifyFailoverAssistantReason).toHaveBeenCalledTimes(1);
+    expect(mockedClassifyFailoverReason).not.toHaveBeenCalled();
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("verify before retrying");
   });

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -172,10 +172,10 @@ export const mockedExtractObservedOverflowTokenCount = vi.fn((msg?: string) => {
   return match?.[1] ? Number(match[1].replaceAll(",", "")) : undefined;
 });
 export const mockedFormatAssistantErrorText = vi.fn(() => "");
-export const mockedIsAuthAssistantError = vi.fn(() => false);
-export const mockedIsBillingAssistantError = vi.fn(() => false);
+export const mockedIsAuthAssistantError = vi.fn<(msg?: unknown) => boolean>(() => false);
+export const mockedIsBillingAssistantError = vi.fn<(msg?: unknown) => boolean>(() => false);
 export const mockedIsCompactionFailureError = vi.fn(() => false);
-export const mockedIsFailoverAssistantError = vi.fn(() => false);
+export const mockedIsFailoverAssistantError = vi.fn<(msg?: unknown) => boolean>(() => false);
 export const mockedIsFailoverErrorMessage = vi.fn(() => false);
 export const mockedIsLikelyContextOverflowError = vi.fn((msg?: string) => {
   const lower = normalizeLowercaseStringOrEmpty(msg ?? "");
@@ -187,8 +187,25 @@ export const mockedIsLikelyContextOverflowError = vi.fn((msg?: string) => {
 });
 export const mockedParseImageSizeError = vi.fn(() => null);
 export const mockedParseImageDimensionError = vi.fn(() => null);
-export const mockedIsRateLimitAssistantError = vi.fn(() => false);
+export const mockedIsRateLimitAssistantError = vi.fn<(msg?: unknown) => boolean>(() => false);
 export const mockedIsTimeoutErrorMessage = vi.fn(() => false);
+export const mockedClassifyFailoverAssistantReason = vi.fn(
+  (msg?: { errorMessage?: string }): FailoverReason | null => {
+    if (!mockedIsFailoverAssistantError(msg)) {
+      return null;
+    }
+    if (mockedIsRateLimitAssistantError(msg)) {
+      return "rate_limit";
+    }
+    if (mockedIsBillingAssistantError(msg)) {
+      return "billing";
+    }
+    if (mockedIsAuthAssistantError(msg)) {
+      return "auth";
+    }
+    return mockedClassifyFailoverReason(msg?.errorMessage ?? "") ?? "unknown";
+  },
+);
 export const mockedPickFallbackThinkingLevel = vi.fn<(params?: unknown) => ThinkLevel | null>(
   () => null,
 );
@@ -347,6 +364,24 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedIsCompactionFailureError.mockReturnValue(false);
   mockedIsFailoverAssistantError.mockReset();
   mockedIsFailoverAssistantError.mockReturnValue(false);
+  mockedClassifyFailoverAssistantReason.mockReset();
+  mockedClassifyFailoverAssistantReason.mockImplementation(
+    (msg?: { errorMessage?: string }): FailoverReason | null => {
+      if (!mockedIsFailoverAssistantError(msg)) {
+        return null;
+      }
+      if (mockedIsRateLimitAssistantError(msg)) {
+        return "rate_limit";
+      }
+      if (mockedIsBillingAssistantError(msg)) {
+        return "billing";
+      }
+      if (mockedIsAuthAssistantError(msg)) {
+        return "auth";
+      }
+      return mockedClassifyFailoverReason(msg?.errorMessage ?? "") ?? "unknown";
+    },
+  );
   mockedIsFailoverErrorMessage.mockReset();
   mockedIsFailoverErrorMessage.mockReturnValue(false);
   mockedIsLikelyContextOverflowError.mockReset();
@@ -486,6 +521,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("../pi-embedded-helpers.js", () => ({
     formatBillingErrorMessage: mockedFormatBillingErrorMessage,
+    classifyFailoverAssistantReason: mockedClassifyFailoverAssistantReason,
     classifyFailoverReason: mockedClassifyFailoverReason,
     extractObservedOverflowTokenCount: mockedExtractObservedOverflowTokenCount,
     formatAssistantErrorText: mockedFormatAssistantErrorText,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -66,6 +66,7 @@ import {
   retireSessionMcpRuntimeForSessionKey,
 } from "../pi-bundle-mcp-tools.js";
 import {
+  classifyFailoverAssistantReason,
   classifyFailoverReason,
   extractObservedOverflowTokenCount,
   type FailoverReason,
@@ -73,7 +74,6 @@ import {
   isAuthAssistantError,
   isBillingAssistantError,
   isCompactionFailureError,
-  isFailoverAssistantError,
   isFailoverErrorMessage,
   isLikelyContextOverflowError,
   isRateLimitAssistantError,
@@ -2207,16 +2207,15 @@ export async function runEmbeddedPiAgent(
             continue;
           }
 
-          const authFailure = isAuthAssistantError(assistantForFailover);
-          const rateLimitFailure = isRateLimitAssistantError(assistantForFailover);
-          const billingFailure = isBillingAssistantError(assistantForFailover);
-          const failoverFailure = isFailoverAssistantError(assistantForFailover);
-          const assistantFailoverReason = classifyFailoverReason(
-            assistantForFailover?.errorMessage ?? "",
-            {
-              provider: assistantForFailover?.provider,
-            },
-          );
+          const assistantFailoverReason = classifyFailoverAssistantReason(assistantForFailover);
+          const authFailure =
+            isAuthAssistantError(assistantForFailover) || assistantFailoverReason === "auth";
+          const rateLimitFailure =
+            isRateLimitAssistantError(assistantForFailover) ||
+            assistantFailoverReason === "rate_limit";
+          const billingFailure =
+            isBillingAssistantError(assistantForFailover) || assistantFailoverReason === "billing";
+          const failoverFailure = assistantFailoverReason !== null;
           const assistantProfileFailureReason =
             resolveRunAuthProfileFailureReason(assistantFailoverReason);
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;


### PR DESCRIPTION
## Problem

Some Chinese API providers (e.g. **MiniMax**) return rate-limit error messages in Chinese rather than English. The existing `rateLimit` patterns in `ERROR_PATTERNS` only match English strings (`"rate limit"`, `"too many requests"`, etc.), so these errors are **not recognized as rate-limit failures** and model fallback is never triggered.

### Example error from MiniMax (error code 2062):

```
当前请求量较高，标准套餐的速率限制可能会临时收紧。
请稍后重试，或升级至 High-Speed 套餐以获得优先容量支持。 (2062)
```

## Solution

Add four new patterns to `ERROR_PATTERNS.rateLimit` in `failover-matches.ts`:

| Pattern | Meaning |
|---------|---------|
| `"速率限制"` | rate limit |
| `"请求量较高"` | high request volume |
| `"请稍后重试"` | please retry later |
| `/\(2062\)/` | MiniMax-specific rate-limit error code |

## Impact

- Enables automatic model fallback when Chinese providers return rate-limit errors
- No impact on existing English pattern matching
- Minimal change: 5 lines added (4 patterns + 1 comment)