### PR TITLE
fix(memory): watch for external file changes and auto-reindex

### DIFF
--- a/extensions/memory-core/src/memory/manager.external-file-watch.test.ts
+++ b/extensions/memory-core/src/memory/manager.external-file-watch.test.ts
@@ -1,0 +1,178 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../engine-host-api.js";
+import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
+import type { MemoryIndexManager } from "./index.js";
+import { getRequiredMemoryIndexManager } from "./test-manager-helpers.js";
+
+describe("memory manager external file watch", () => {
+  let workspaceDir: string;
+  let indexPath: string;
+  let manager: MemoryIndexManager | null = null;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    resetEmbeddingMocks();
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-watch-"));
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"));
+    await fs.writeFile(path.join(workspaceDir, "memory", "notes.md"), "initial content");
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("triggers sync when external file changes are detected", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath, vector: { enabled: false } },
+            sync: { watch: true, watchDebounceMs: 50, onSessionStart: false, onSearch: false },
+            query: { minScore: 0, hybrid: { enabled: false } },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    manager = await getRequiredMemoryIndexManager({ cfg, agentId: "main" });
+    const syncSpy = vi.spyOn(manager, "sync");
+
+    // Initial sync to index the file
+    await manager.sync({ reason: "initial" });
+    syncSpy.mockClear();
+
+    const initialStatus = manager.status();
+    expect(initialStatus.files).toBe(1);
+    expect(initialStatus.chunks).toBeGreaterThan(0);
+
+    // Simulate external file change by calling internal watcher trigger
+    // This mimics what chokidar does when it detects a file change
+    const internalManager = manager as unknown as {
+      dirty: boolean;
+      scheduleWatchSync: () => void;
+    };
+    internalManager.dirty = true;
+    internalManager.scheduleWatchSync();
+
+    // Run the debounce timer
+    await vi.runOnlyPendingTimersAsync();
+
+    // Verify sync was called
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+    expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
+  });
+
+  it("debounces multiple rapid file changes", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath, vector: { enabled: false } },
+            sync: { watch: true, watchDebounceMs: 100, onSessionStart: false, onSearch: false },
+            query: { minScore: 0, hybrid: { enabled: false } },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    manager = await getRequiredMemoryIndexManager({ cfg, agentId: "main" });
+    const syncSpy = vi.spyOn(manager, "sync");
+
+    // Initial sync
+    await manager.sync({ reason: "initial" });
+    syncSpy.mockClear();
+
+    const internalManager = manager as unknown as {
+      dirty: boolean;
+      scheduleWatchSync: () => void;
+    };
+
+    // Simulate multiple rapid file changes (like a bulk save or editor autosave)
+    internalManager.dirty = true;
+    internalManager.scheduleWatchSync();
+
+    // Advance time partially (less than debounce)
+    await vi.advanceTimersByTimeAsync(30);
+
+    // Another file change comes in
+    internalManager.scheduleWatchSync();
+
+    // Advance time partially again
+    await vi.advanceTimersByTimeAsync(30);
+
+    // Yet another file change
+    internalManager.scheduleWatchSync();
+
+    // Should not have synced yet
+    expect(syncSpy).not.toHaveBeenCalled();
+
+    // Now advance past the debounce time
+    await vi.advanceTimersByTimeAsync(100);
+
+    // Should have synced exactly once
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+    expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
+  });
+
+  it("reindexes modified file content after external change", async () => {
+    vi.useRealTimers(); // Need real timers for actual file operations
+
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath, vector: { enabled: false } },
+            sync: { watch: true, watchDebounceMs: 50, onSessionStart: false, onSearch: false },
+            query: { minScore: 0, hybrid: { enabled: false } },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    manager = await getRequiredMemoryIndexManager({ cfg, agentId: "main" });
+
+    // Initial sync
+    await manager.sync({ reason: "initial" });
+    const initialStatus = manager.status();
+    expect(initialStatus.files).toBe(1);
+
+    // Modify file content externally (adding more content)
+    const filePath = path.join(workspaceDir, "memory", "notes.md");
+    await fs.writeFile(
+      filePath,
+      "initial content\n\nAdditional paragraph with more information that will create more chunks.",
+    );
+
+    // Mark dirty and force sync (simulating what the watcher would do)
+    const internalManager = manager as unknown as { dirty: boolean };
+    internalManager.dirty = true;
+    await manager.sync({ reason: "watch", force: true });
+
+    // Verify the content was reindexed
+    const newStatus = manager.status();
+    expect(newStatus.files).toBe(1);
+    // Content should have been reprocessed (chunks may vary based on content length)
+    expect(newStatus.dirty).toBe(false);
+  });
+});

--- a/extensions/memory-core/src/memory/manager.external-file-watch.test.ts
+++ b/extensions/memory-core/src/memory/manager.external-file-watch.test.ts
@@ -132,7 +132,10 @@ describe("memory manager external file watch", () => {
   });
 
   it("reindexes modified file content after external change", async () => {
-    vi.useRealTimers(); // Need real timers for actual file operations
+    // Need real timers for actual file operations. Note: chokidar may fire a
+    // concurrent sync between writeFile and manual sync, but this is benign
+    // since we only assert dirty=false. afterEach handles cleanup properly.
+    vi.useRealTimers();
 
     const cfg = {
       agents: {

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -56,11 +56,9 @@ export const doctorHandlers: GatewayRequestHandlers = {
       };
       respond(true, payload, undefined);
     } finally {
-      try {
-        await manager.close();
-      } catch {
-        // Ignore close errors - response already sent
-      }
+      // Do NOT close the manager here — it may be the long-lived cached
+      // instance from startup whose file watcher must stay active.
+      // Manager lifecycle is handled by closeAllMemorySearchManagers at shutdown.
     }
   },
 };

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -56,9 +56,9 @@ export const doctorHandlers: GatewayRequestHandlers = {
       };
       respond(true, payload, undefined);
     } finally {
-      // Do NOT close the manager here — it may be the long-lived cached
-      // instance from startup whose file watcher must stay active.
-      // Manager lifecycle is handled by closeAllMemorySearchManagers at shutdown.
+      // Status-only managers are not cached and should be cleaned up.
+      // The long-lived startup instances use purpose:'default' and are handled by closeAllMemorySearchManagers.
+      await manager.close?.().catch(() => {});
     }
   },
 };

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -55,8 +55,6 @@ export const doctorHandlers: GatewayRequestHandlers = {
         },
       };
       respond(true, payload, undefined);
-    } finally {
-      await manager.close?.().catch(() => {});
     }
   },
 };

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -55,6 +55,8 @@ export const doctorHandlers: GatewayRequestHandlers = {
         },
       };
       respond(true, payload, undefined);
+    } finally {
+      await manager.close();
     }
   },
 };

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -56,7 +56,11 @@ export const doctorHandlers: GatewayRequestHandlers = {
       };
       respond(true, payload, undefined);
     } finally {
-      await manager.close();
+      try {
+        await manager.close();
+      } catch {
+        // Ignore close errors - response already sent
+      }
     }
   },
 };

--- a/src/gateway/server-startup-memory.test.ts
+++ b/src/gateway/server-startup-memory.test.ts
@@ -23,6 +23,13 @@ function createQmdConfig(agents: OpenClawConfig["agents"]): OpenClawConfig {
   } as OpenClawConfig;
 }
 
+function createBuiltinConfig(agents: OpenClawConfig["agents"]): OpenClawConfig {
+  return {
+    agents,
+    memory: { backend: "builtin" },
+  } as OpenClawConfig;
+}
+
 function createGatewayLogMock() {
   return { info: vi.fn(), warn: vi.fn() };
 }
@@ -37,17 +44,18 @@ describe("startGatewayMemoryBackend", () => {
     }));
   });
 
-  it("skips initialization when memory backend is not qmd", async () => {
-    const cfg = {
-      agents: { list: [{ id: "main", default: true }] },
-      memory: { backend: "builtin" },
-    } as OpenClawConfig;
-    const log = { info: vi.fn(), warn: vi.fn() };
+  it("initializes builtin backend for each configured agent", async () => {
+    const cfg = createBuiltinConfig({ list: [{ id: "main", default: true }] });
+    const log = createGatewayLogMock();
+    getMemorySearchManagerMock.mockResolvedValue({ manager: { search: vi.fn() } });
 
     await startGatewayMemoryBackend({ cfg, log });
 
-    expect(getMemorySearchManagerMock).not.toHaveBeenCalled();
-    expect(log.info).not.toHaveBeenCalled();
+    expect(getMemorySearchManagerMock).toHaveBeenCalledTimes(1);
+    expect(getMemorySearchManagerMock).toHaveBeenCalledWith({ cfg, agentId: "main" });
+    expect(log.info).toHaveBeenCalledWith(
+      'builtin memory startup initialization armed for agent "main"',
+    );
     expect(log.warn).not.toHaveBeenCalled();
   });
 
@@ -72,7 +80,7 @@ describe("startGatewayMemoryBackend", () => {
     expect(log.warn).not.toHaveBeenCalled();
   });
 
-  it("logs a warning when qmd manager init fails and continues with other agents", async () => {
+  it("logs a warning when manager init fails and continues with other agents", async () => {
     const cfg = createQmdConfig({ list: [{ id: "main", default: true }, { id: "ops" }] });
     const log = createGatewayLogMock();
     getMemorySearchManagerMock
@@ -87,6 +95,19 @@ describe("startGatewayMemoryBackend", () => {
     expect(log.info).toHaveBeenCalledWith(
       'qmd memory startup initialization armed for agent "ops"',
     );
+  });
+
+  it("logs a warning when builtin manager init fails", async () => {
+    const cfg = createBuiltinConfig({ list: [{ id: "main", default: true }] });
+    const log = createGatewayLogMock();
+    getMemorySearchManagerMock.mockResolvedValue({ manager: null, error: "sqlite error" });
+
+    await startGatewayMemoryBackend({ cfg, log });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'builtin memory startup initialization failed for agent "main": sqlite error',
+    );
+    expect(log.info).not.toHaveBeenCalled();
   });
 
   it("skips agents with memory search disabled", async () => {

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -19,7 +19,7 @@ export async function startGatewayMemoryBackend(params: {
     if (!resolved) {
       continue;
     }
-    const backendLabel = resolved.backend === "qmd" ? "qmd" : "builtin";
+    const backendLabel = resolved.backend;
 
     const { manager, error } = await getActiveMemorySearchManager({ cfg: params.cfg, agentId });
     if (!manager) {

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -19,17 +19,15 @@ export async function startGatewayMemoryBackend(params: {
     if (!resolved) {
       continue;
     }
-    if (resolved.backend !== "qmd" || !resolved.qmd) {
-      continue;
-    }
+    const backendLabel = resolved.backend === "qmd" ? "qmd" : "builtin";
 
     const { manager, error } = await getActiveMemorySearchManager({ cfg: params.cfg, agentId });
     if (!manager) {
       params.log.warn(
-        `qmd memory startup initialization failed for agent "${agentId}": ${error ?? "unknown error"}`,
+        `${backendLabel} memory startup initialization failed for agent "${agentId}": ${error ?? "unknown error"}`,
       );
       continue;
     }
-    params.log.info?.(`qmd memory startup initialization armed for agent "${agentId}"`);
+    params.log.info?.(`${backendLabel} memory startup initialization armed for agent "${agentId}"`);
   }
 }


### PR DESCRIPTION
## Summary

- Initialize memory managers for both builtin SQLite and qmd backends at gateway startup
- This ensures the filesystem watcher (chokidar) is set up for the default builtin provider
- When files are modified externally, the watcher detects changes and triggers auto-reindex with debouncing

Previously, the gateway startup only initialized memory managers for the qmd backend, skipping the default builtin SQLite provider. This meant the filesystem watcher was never set up, and external file changes were not detected.

## Test plan

- [x] Added test for external file watcher triggering sync
- [x] Added test for debouncing multiple rapid file changes
- [x] Added tests for builtin backend initialization at gateway startup
- [x] oxlint passes on changed files

Fixes #45818