### PR TITLE
macOS: Fix MacOS App Build

### DIFF
--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -254,6 +254,71 @@ struct CronJob: Identifiable, Codable, Equatable {
         case state
     }
 
+    init(
+        id: String,
+        agentId: String?,
+        name: String,
+        description: String?,
+        enabled: Bool,
+        deleteAfterRun: Bool?,
+        createdAtMs: Int,
+        updatedAtMs: Int,
+        schedule: CronSchedule,
+        sessionTargetRaw: String,
+        wakeMode: CronWakeMode,
+        payload: CronPayload,
+        delivery: CronDelivery?,
+        state: CronJobState)
+    {
+        self.id = id
+        self.agentId = agentId
+        self.name = name
+        self.description = description
+        self.enabled = enabled
+        self.deleteAfterRun = deleteAfterRun
+        self.createdAtMs = createdAtMs
+        self.updatedAtMs = updatedAtMs
+        self.schedule = schedule
+        self.sessionTargetRaw = sessionTargetRaw
+        self.wakeMode = wakeMode
+        self.payload = payload
+        self.delivery = delivery
+        self.state = state
+    }
+
+    init(
+        id: String,
+        agentId: String?,
+        name: String,
+        description: String?,
+        enabled: Bool,
+        deleteAfterRun: Bool?,
+        createdAtMs: Int,
+        updatedAtMs: Int,
+        schedule: CronSchedule,
+        sessionTarget: CronSessionTarget,
+        wakeMode: CronWakeMode,
+        payload: CronPayload,
+        delivery: CronDelivery?,
+        state: CronJobState)
+    {
+        self.init(
+            id: id,
+            agentId: agentId,
+            name: name,
+            description: description,
+            enabled: enabled,
+            deleteAfterRun: deleteAfterRun,
+            createdAtMs: createdAtMs,
+            updatedAtMs: updatedAtMs,
+            schedule: schedule,
+            sessionTargetRaw: sessionTarget.rawValue,
+            wakeMode: wakeMode,
+            payload: payload,
+            delivery: delivery,
+            state: state)
+    }
+
     /// Parsed session target (predefined or custom session ID)
     var parsedSessionTarget: CronCustomSessionTarget {
         CronCustomSessionTarget.from(self.sessionTargetRaw)


### PR DESCRIPTION
## Summary

Fixes the MacOS App build.

- Problem:  Fixes the MacOS App Build break introduced by commit e7d9648fb
- Why it matters: MacOS App needs to build successfully :)
- What changed: 
The build break happened because CronJob stopped getting a usable memberwise initializer once sessionTargetRaw became a private stored property, leaving
  only synthesized decoding init visible. CronSettings+Testing.swift still constructed CronJob directly for previews/testing, so Swift treated those calls as
  invalid and the macOS app build failed.

  The fix restores explicit CronJob initializers in apps/macos/Sources/OpenClaw/CronModels.swift:257 (apps/macos/Sources/OpenClaw/CronModels.swift:257): one
  that accepts sessionTargetRaw and one compatibility overload that accepts CronSessionTarget and maps it to the raw value. That keeps the newer model
  representation intact while restoring source compatibility for preview/test construction paths.

- What did NOT change (scope boundary): Everything else

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ x] CI/CD / infra

## Linked Issue/PR

n/a

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

`scripts/restart-mac.sh`

### Environment

- OS: MacOS 26.3
- Runtime/container: n/a
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

`scripts/restart-mac.sh`

### Expected

- Build Succeeds

### Actual

- Build Fails

## Evidence

Attach at least one:

- [ x] Failing test/log before + passing after

Before:

Build error:

source/openclaw/apps/macos/Sources/OpenClaw/CronSettings+Testing.swift:8:20: error: extra arguments at positions #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14 in call
  6 |         let store = CronJobsStore(isPreview: true)
  7 |         store.jobs = [
  8 |             CronJob(
    |                    `- error: extra arguments at positions #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14 in call
  9 |                 id: "job-1",
 10 |                 agentId: "ops",

OpenClaw.CronJob.init:2:10: note: 'init(from:)' declared here
1 | struct CronJob {
2 | internal init(from decoder: any Decoder) throws}
  |          `- note: 'init(from:)' declared here
3 |


After:

Build succeeds.


## Human Verification (required)

What you personally verified (not just CI), and how:

`git checkout fix-swift-build-2026-03-14 && pnpm install && pnpm build && scripts/restart-mac.sh` succeeds

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Just revert the commit
- Files/config to restore: n/a
- Known bad symptoms reviewers should watch for: none

## Risks and Mitigations

None