### PR TITLE
fix(feishu): send video files with msg_type "file" instead of invalid "media"

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -132,7 +132,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     messageResourceGetMock.mockResolvedValue(Buffer.from("resource-bytes"));
   });
 
-  it("uses msg_type=media for mp4 video", async () => {
+  it("uses msg_type=file for mp4 video", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -148,7 +148,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "file" }),
       }),
     );
   });
@@ -211,7 +211,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media when replying with mp4", async () => {
+  it("uses msg_type=file when replying with mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -223,7 +223,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { message_id: "om_parent" },
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "file" }),
       }),
     );
 
@@ -244,7 +244,7 @@ describe("sendMediaFeishu msg_type routing", () => {
       expect.objectContaining({
         path: { message_id: "om_parent" },
         data: expect.objectContaining({
-          msg_type: "media",
+          msg_type: "file",
           reply_in_thread: true,
         }),
       }),

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -330,8 +330,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "audio" for audio, "media" for video (mp4), "file" for documents */
-  msgType?: "file" | "audio" | "media";
+  /** Use "audio" for opus audio, "file" for all other types (including video) */
+  msgType?: "file" | "audio";
   replyToMessageId?: string;
   replyInThread?: boolean;
   accountId?: string;
@@ -469,8 +469,10 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu API: opus -> "audio", mp4/video -> "media" (playable), others -> "file"
-    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
+    // Feishu API only supports msg_type: "file", "image", "audio".
+    // "media" and "video" are NOT valid msg_type values (error 230001).
+    // Videos (mp4/mov/avi) must be sent as "file".
+    const msgType = fileType === "opus" ? "audio" : "file";
     return sendFileFeishu({
       cfg,
       to,


### PR DESCRIPTION
## Summary
- **Problem**: Feishu plugin sends MP4 video files with `msg_type: "media"`, but the Feishu API rejects it with HTTP 400 error 230001 (`invalid msg_type: video`). According to [Feishu API docs](https://open.feishu.cn/document/server-docs/im-v1/message-content-description/create_json), supported `msg_type` values are: `file`, `image`, `audio` — `"media"` and `"video"` are NOT supported.
- **Why it matters**: All Feishu channel users cannot send video files; 100% reproducible.
- **What changed**: In `extensions/feishu/src/media.ts`, changed the `msgType` for mp4/video files from `"media"` to `"file"`. Also narrowed the `sendFileFeishu` type signature from `"file" | "audio" | "media"` to `"file" | "audio"` to prevent future misuse.
- **What did NOT change (scope boundary)**: Image sending, audio sending, file upload logic, and all other Feishu outbound paths are unchanged.

## Change Type
- [x] Bug fix

## Scope
- [x] Channel: Feishu/Lark

## Linked Issue/PR
- Closes #29560

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Enable Feishu channel with valid appId and appSecret
2. Use message tool to send an MP4 file
### Expected
- Video file sent successfully as a file attachment
### Actual (before fix)
- HTTP 400 error: `{code: 230001, msg: "invalid msg_type: video"}`

## Evidence
- [x] Failing test/log before + passing after
- Root cause confirmed via Feishu API docs: `msg_type: "media"` is not in the supported values list

## Human Verification
- Verified scenarios: mp4/mov/avi files now map to `msg_type: "file"`; opus audio still maps to `"audio"`; other files still map to `"file"`
- Edge cases checked: All `detectFileType` return values produce valid `msgType`
- What you did NOT verify: Runtime end-to-end testing with actual Feishu API

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes — videos now work instead of erroring
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: `extensions/feishu/src/media.ts`

## Risks and Mitigations
None — changes invalid msg_type to valid one per Feishu API spec.

---
*This PR was AI-assisted (fully tested with unit tests, pre-existing build tooling issues prevent full pnpm build/check locally).*