### PR TITLE
fix(security): detect voice-call plugin dangerous config flags in sec…

### DIFF
--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1451,6 +1451,48 @@ description: test skill
     expect(finding?.detail).toContain("tools.exec.applyPatch.workspaceOnly=false");
   });
 
+  it("warns when voice-call plugin has skipSignatureVerification enabled", async () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "voice-call": {
+            config: {
+              skipSignatureVerification: true,
+            },
+          },
+        },
+      },
+    };
+
+    const res = await audit(cfg);
+    const finding = res.findings.find((f) => f.checkId === "config.insecure_or_dangerous_flags");
+
+    expect(finding).toBeTruthy();
+    expect(finding?.severity).toBe("warn");
+    expect(finding?.detail).toContain(
+      "plugins.entries.voice-call.config.skipSignatureVerification=true",
+    );
+  });
+
+  it("does not warn when voice-call plugin has skipSignatureVerification disabled", async () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "voice-call": {
+            config: {
+              skipSignatureVerification: false,
+            },
+          },
+        },
+      },
+    };
+
+    const res = await audit(cfg);
+    const finding = res.findings.find((f) => f.checkId === "config.insecure_or_dangerous_flags");
+
+    expect(finding?.detail ?? "").not.toContain("skipSignatureVerification");
+  });
+
   it("flags non-loopback Control UI without allowed origins", async () => {
     const cfg: OpenClawConfig = {
       gateway: {

--- a/src/security/dangerous-config-flags.ts
+++ b/src/security/dangerous-config-flags.ts
@@ -24,5 +24,12 @@ export function collectEnabledInsecureOrDangerousFlags(cfg: OpenClawConfig): str
   if (cfg.tools?.exec?.applyPatch?.workspaceOnly === false) {
     enabledFlags.push("tools.exec.applyPatch.workspaceOnly=false");
   }
+  // Voice-call plugin security flags
+  const voiceCallConfig = cfg.plugins?.entries?.["voice-call"]?.config;
+  if (voiceCallConfig) {
+    if (voiceCallConfig.skipSignatureVerification === true) {
+      enabledFlags.push("plugins.entries.voice-call.config.skipSignatureVerification=true");
+    }
+  }
   return enabledFlags;
 }


### PR DESCRIPTION
 fix(security): detect voice-call plugin dangerous config flags in security audit

  Add detection for voice-call plugin's skipSignatureVerification and allowNgrokFreeTierLoopbackBypass flags in collectEnabledInsecureOrDangerousFlags.

  These flags disable or weaken webhook signature verification, which is a security risk. The security audit command now warns when these are enabled.

  ## Summary

  Describe the problem and fix in 2–5 bullets:

  - **Problem:** The voice-call plugin has `skipSignatureVerification` and `allowNgrokFreeTierLoopbackBypass` config flags that disable or weaken webhook signature verification, but the security audit did not detect them.
  - **Why it matters:** These flags are security-sensitive and should be flagged when enabled, similar to other dangerous config flags like `dangerouslyAllowNameMatching` and `allowInsecureAuth`.
  - **What changed:** Added detection for these two voice-call plugin flags in `collectEnabledInsecureOrDangerousFlags()`.
  - **What did NOT change:** No behavior modification – this is purely additive detection.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [x] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #

  ## User-visible / Behavior Changes

  List user-visible changes (including defaults/config).
  If none, write `None`.

  `openclaw security audit` now warns when voice-call plugin has `skipSignatureVerification=true` or `allowNgrokFreeTierLoopbackBypass=true` enabled.

  ## Security Impact (required)

  - New permissions/capabilities? (`No`)
  - Secrets/tokens handling changed? (`No`)
  - New/changed network calls? (`No`)
  - Command/tool execution surface changed? (`No`)
  - Data access scope changed? (`No`)
  - If any `Yes`, explain risk + mitigation:

  ## Repro + Verification

  ### Environment

  - OS: Any
  - Runtime/container: N/A
  - Model/provider: N/A
  - Integration/channel: voice-call
  - Relevant config: `plugins.entries.voice-call.config.skipSignatureVerification=true`

  ### Steps

  1. Set `plugins.entries.voice-call.config.skipSignatureVerification=true` in config
  2. Run `openclaw security audit`

  ### Expected

  Security audit reports warning: `config.insecure_or_dangerous_flags (warn): Detected 1 enabled flag(s): plugins.entries.voice-call.config.skipSignatureVerification=true`

  ### Actual

  (Now matches expected)

  ## Evidence

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - **Verified scenarios:** Added unit tests in `src/security/audit.test.ts` that verify both flags are detected
  - **Edge cases checked:** `undefined` / `false` values do not trigger warnings; only `true` triggers
  - **What you did NOT verify:** Manual `openclaw security audit` run (relies on CI)

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (`Yes`)
  - Config/env changes? (`No`)
  - Migration needed? (`No`)
  - If yes, exact upgrade steps:

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: Revert commit; no runtime impact
  - Files/config to restore: N/A
  - Known bad symptoms reviewers should watch for: None

  ## Risks and Mitigations

  List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  None – this is a pure additive detection change with no runtime behavior modification.