### PR TITLE
fix(exec): route to gateway approval flow when sandbox unavailable via default fallback

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -334,17 +334,18 @@ export function createExecTool(
       }
 
       const sandbox = host === "sandbox" ? defaults?.sandbox : undefined;
-      if (
-        host === "sandbox" &&
-        !sandbox &&
-        (sandboxHostConfigured || requestedHost === "sandbox")
-      ) {
-        throw new Error(
-          [
-            "exec host=sandbox is configured, but sandbox runtime is unavailable for this session.",
-            'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or set tools.exec.host to "gateway"/"node".',
-          ].join("\n"),
-        );
+      if (host === "sandbox" && !sandbox) {
+        if (sandboxHostConfigured || requestedHost === "sandbox") {
+          throw new Error(
+            [
+              "exec host=sandbox is configured, but sandbox runtime is unavailable for this session.",
+              'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or set tools.exec.host to "gateway"/"node".',
+            ].join("\n"),
+          );
+        }
+        // Sandbox unavailable via default fallback (tools.exec.host unset):
+        // route to gateway so the approval flow (allowlist + ask) applies.
+        host = "gateway";
       }
       const rawWorkdir = params.workdir?.trim() || defaults?.cwd || process.cwd();
       let workdir = rawWorkdir;


### PR DESCRIPTION
## Summary

When `tools.exec.host` is unset and sandbox runtime is unavailable, exec commands bypass all approval checks (allowlist, ask, security policy) and run directly on the host. This PR routes to the gateway approval flow instead.

## The bug

`sandboxHostConfigured` is `defaults?.host === "sandbox"`, which is `false` when `defaults?.host` is `undefined` (the default fallback case). The guard only throws for explicitly configured sandbox, silently allowing unrestricted exec in the common case where users never set `tools.exec.host`.

## The fix

When sandbox is unavailable via default fallback, set `host = "gateway"` so the code falls through to `processGatewayAllowlist()` at line 427. This applies the full approval flow (allowlist + ask + security) without requiring users to explicitly configure `tools.exec.host`.

The existing error for "sandbox explicitly configured but unavailable" is preserved.

Fixes #45963

## Test plan

- [ ] `tools.exec.host` unset + no sandbox → exec routes to gateway, approval flow applies
- [ ] `tools.exec.host = "sandbox"` + no sandbox → still throws error (existing behavior)
- [ ] `tools.exec.host = "gateway"` → approval flow applies (existing behavior)
- [ ] `tools.exec.host = "sandbox"` + sandbox available → sandbox runs (existing behavior)