### PR TITLE
feat(exec): add global pty config option for tools.exec (closes #44603)

### DIFF
--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -26,6 +26,7 @@ export type ExecToolDefaults = {
   accountId?: string;
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
+  pty?: boolean;
   cwd?: string;
 };
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -429,7 +429,7 @@ export function createExecTool(
           command: params.command,
           workdir,
           env,
-          pty: params.pty === true && !sandbox,
+          pty: (params.pty === true || (params.pty == null && defaults?.pty === true)) && !sandbox,
           timeoutSec: params.timeout,
           defaultTimeoutSec,
           security,
@@ -463,7 +463,8 @@ export function createExecTool(
         ? null
         : (explicitTimeoutSec ?? defaultTimeoutSec);
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
-      const usePty = params.pty === true && !sandbox;
+      const usePty =
+        (params.pty === true || (params.pty == null && defaults?.pty === true)) && !sandbox;
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -156,6 +156,7 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
     notifyOnExitEmptySuccess:
       agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
     applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
+    pty: agentExec?.pty ?? globalExec?.pty,
   };
 }
 
@@ -433,6 +434,7 @@ export function createOpenClawCodingTools(options?: {
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     notifyOnExitEmptySuccess:
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
+    pty: options?.exec?.pty ?? execConfig.pty,
     sandbox: sandbox
       ? {
           containerName: sandbox.containerName,

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -257,6 +257,8 @@ export type ExecToolConfig = {
    * Default false to reduce context noise.
    */
   notifyOnExitEmptySuccess?: boolean;
+  /** Use PTY mode by default for exec commands (default: false). */
+  pty?: boolean;
   /** apply_patch subtool configuration (experimental). */
   applyPatch?: {
     /** Enable apply_patch for OpenAI models (default: false). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -427,6 +427,7 @@ const ToolExecBaseShape = {
   cleanupMs: z.number().int().positive().optional(),
   notifyOnExit: z.boolean().optional(),
   notifyOnExitEmptySuccess: z.boolean().optional(),
+  pty: z.boolean().optional(),
   applyPatch: ToolExecApplyPatchSchema,
 } as const;
 


### PR DESCRIPTION
## Summary
- **Problem**: `pty` mode for exec commands can only be set per-call by the LLM. There is no global config default, so users running long-running commands see buffered output (displayed all at once after completion) unless the LLM explicitly passes `pty: true`.
- **Why it matters**: Users running 5-15 minute tasks see no output and may think the system is frozen.
- **What changed**: Added `pty` as an optional boolean to the exec tool config schema (`ToolExecBaseShape`) and `ExecToolDefaults` type, and updated `bash-tools.exec.ts` to fall back to the config default when the per-call parameter is not set.
- **What did NOT change**: Per-call `pty` parameter still takes precedence. No changes to PTY implementation itself. Sandbox mode still forces pipes.

## Change Type
- [x] New feature (non-breaking)

## Scope
- [x] Tools/Exec

## Linked Issue/PR
- Closes #44603

## Security Impact
- New permissions/capabilities? No (PTY mode already existed as per-call option)
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No (same PTY capability, just configurable default)
- Data access scope changed? No

## Repro + Verification
### Steps
1. Add \`"tools": { "exec": { "pty": true } }\` to openclaw.json
2. Run a long-running command that produces streaming output
3. Observe real-time output instead of buffered output

## Compatibility / Migration
- Backward compatible? Yes (new optional config, default behavior unchanged)
- Config/env changes? New optional config: tools.exec.pty
- Migration needed? No

## Risks and Mitigations
Low risk — PTY mode already exists and works. This only adds a config default. Per-call parameter still overrides. Sandbox correctly ignores PTY regardless.