### PR TITLE
fix(status): treat scope-limited probe as reachable

### DIFF
--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -34,6 +34,7 @@ import { buildChannelsTable } from "./status-all/channels.js";
 import { formatDurationPrecise, formatGatewayAuthUsed } from "./status-all/format.js";
 import { pickGatewaySelfPresence } from "./status-all/gateway.js";
 import { buildStatusAllReportLines } from "./status-all/report-lines.js";
+import { isGatewayProbeReachable } from "./status.gateway-probe.js";
 import { readServiceStatusSummary } from "./status.service-summary.js";
 import { formatUpdateOneLiner } from "./status.update.js";
 
@@ -133,7 +134,7 @@ export async function statusAllCommand(
       auth: probeAuth,
       timeoutMs: Math.min(5000, opts?.timeoutMs ?? 10_000),
     }).catch(() => null);
-    const gatewayReachable = gatewayProbe?.ok === true;
+    const gatewayReachable = isGatewayProbeReachable(gatewayProbe);
     const gatewaySelf = pickGatewaySelfPresence(gatewayProbe?.presence ?? null);
     progress.tick();
 
@@ -252,7 +253,9 @@ export async function statusAllCommand(
 
     const gatewayTarget = remoteUrlMissing ? `fallback ${connection.url}` : connection.url;
     const gatewayStatus = gatewayReachable
-      ? `reachable ${formatDurationPrecise(gatewayProbe?.connectLatencyMs ?? 0)}`
+      ? `reachable ${formatDurationPrecise(gatewayProbe?.connectLatencyMs ?? 0)}${
+          gatewayProbe?.error ? ` · diagnostics limited (${gatewayProbe.error})` : ""
+        }`
       : gatewayProbe?.error
         ? `unreachable (${gatewayProbe.error})`
         : "unreachable";

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -260,7 +260,9 @@ export async function statusCommand(
     const reach = remoteUrlMissing
       ? warn("misconfigured (remote.url missing)")
       : gatewayReachable
-        ? ok(`reachable ${formatDuration(gatewayProbe?.connectLatencyMs)}`)
+        ? `${ok(`reachable ${formatDuration(gatewayProbe?.connectLatencyMs)}`)}${
+            gatewayProbe?.error ? ` · ${warn(`diagnostics limited (${gatewayProbe.error})`)}` : ""
+          }`
         : warn(gatewayProbe?.error ? `unreachable (${gatewayProbe.error})` : "unreachable");
     const auth =
       gatewayReachable && !remoteUrlMissing

--- a/src/commands/status.gateway-probe.ts
+++ b/src/commands/status.gateway-probe.ts
@@ -1,6 +1,9 @@
 import type { loadConfig } from "../config/config.js";
 import { resolveGatewayProbeAuthSafe } from "../gateway/probe-auth.js";
+import type { GatewayProbeResult } from "../gateway/probe.js";
 export { pickGatewaySelfPresence } from "./gateway-presence.js";
+
+const MISSING_SCOPE_PATTERN = /\bmissing scope\b/i;
 
 export function resolveGatewayProbeAuthResolution(cfg: ReturnType<typeof loadConfig>): {
   auth: {
@@ -21,4 +24,15 @@ export function resolveGatewayProbeAuth(cfg: ReturnType<typeof loadConfig>): {
   password?: string;
 } {
   return resolveGatewayProbeAuthResolution(cfg).auth;
+}
+
+export function isScopeLimitedProbeFailure(probe: GatewayProbeResult | null): boolean {
+  if (!probe || probe.ok || probe.connectLatencyMs == null) {
+    return false;
+  }
+  return MISSING_SCOPE_PATTERN.test(probe.error ?? "");
+}
+
+export function isGatewayProbeReachable(probe: GatewayProbeResult | null): boolean {
+  return probe?.ok === true || isScopeLimitedProbeFailure(probe);
 }

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -16,6 +16,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { buildChannelsTable } from "./status-all/channels.js";
 import { getAgentLocalStatuses } from "./status.agent-local.js";
 import {
+  isGatewayProbeReachable,
   pickGatewaySelfPresence,
   resolveGatewayProbeAuthResolution,
 } from "./status.gateway-probe.js";
@@ -231,7 +232,7 @@ async function scanStatusJsonFast(opts: {
     gatewayProbeAuthWarning,
     gatewayProbe,
   } = gatewaySnapshot;
-  const gatewayReachable = gatewayProbe?.ok === true;
+  const gatewayReachable = isGatewayProbeReachable(gatewayProbe);
   const gatewaySelf = gatewayProbe?.presence
     ? pickGatewaySelfPresence(gatewayProbe.presence)
     : null;
@@ -341,7 +342,7 @@ export async function scanStatus(
         gatewayProbeAuthWarning,
         gatewayProbe,
       } = await resolveGatewayProbeSnapshot({ cfg, opts });
-      const gatewayReachable = gatewayProbe?.ok === true;
+      const gatewayReachable = isGatewayProbeReachable(gatewayProbe);
       const gatewaySelf = gatewayProbe?.presence
         ? pickGatewaySelfPresence(gatewayProbe.presence)
         : null;

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -509,6 +509,24 @@ describe("statusCommand", () => {
     expect(payload.gateway.error).toContain("SecretRef");
   });
 
+  it("reports reachable when probe connect succeeds but diagnostics are scope-limited", async () => {
+    mockProbeGatewayResult({
+      ok: false,
+      connectLatencyMs: 12,
+      error: "missing scope: operator.read",
+      close: { code: 1008, reason: "missing scope: operator.read" },
+      health: null,
+      status: null,
+      presence: [],
+    });
+
+    const joined = await runStatusAndGetJoinedLogs();
+    expect(joined).toContain("reachable");
+    expect(joined).toContain("diagnostics limited");
+    expect(joined).toContain("scope: operator.read");
+    expect(joined).not.toContain("unreachable (missing scope: operator.read)");
+  });
+
   it("surfaces channel runtime errors from the gateway", async () => {
     mockProbeGatewayResult({
       ok: true,


### PR DESCRIPTION
## Summary
- add `isGatewayProbeReachable` helper that treats a scope-limited probe (`missing scope ...` after connect latency is recorded) as reachable
- use that helper in both `status` scan paths and in `status --all`
- keep degraded diagnostics explicit in output: `reachable ... · diagnostics limited (...)`
- add a regression test in `status.test.ts` for connect-ok + scope-limited probes

## Why
When probe RPCs fail with errors like `missing scope: operator.read`, the gateway is still reachable and operational. Reporting `unreachable` is misleading and triggers unnecessary troubleshooting.

## Validation
- ✅ `pnpm vitest src/commands/status-all/report-lines.test.ts src/commands/gateway-status.test.ts`
- ⚠️ `pnpm vitest src/commands/status.test.ts` (local env missing optional package `@mariozechner/pi-ai/oauth`; test suite fails before running assertions)
