### PR TITLE
fix: apply agent skillFilter in gateway commands path and refresh stale snapshots

### DIFF
--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -1,5 +1,5 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
+import { resolveAgentSkillsFilter, resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
@@ -34,12 +34,16 @@ export async function resolveCommandsSystemPromptBundle(
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
   });
+  const skillFilter = params.agentId
+    ? resolveAgentSkillsFilter(params.cfg, params.agentId)
+    : undefined;
   const skillsSnapshot = (() => {
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {
         config: params.cfg,
         eligibility: { remote: getRemoteSkillEligibility() },
         snapshotVersion: getSkillsSnapshotVersion(workspaceDir),
+        skillFilter,
       });
     } catch {
       return { prompt: "", skills: [], resolvedSkills: [] };

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -39,6 +39,7 @@ import {
 import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
+import { matchesSkillFilter } from "../agents/skills/filter.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { normalizeSpawnedRunMetadata } from "../agents/spawned-context.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
@@ -873,9 +874,13 @@ async function agentCommandInternal(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !sessionEntry?.skillsSnapshot ||
+      sessionEntry.skillsSnapshot.version !== skillsSnapshotVersion ||
+      !matchesSkillFilter(sessionEntry.skillsSnapshot.skillFilter, skillFilter);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {
           config: cfg,


### PR DESCRIPTION
## Summary
- **Problem**: Per-agent `skills` filter configured in `openclaw.json` was not applied in the gateway commands-system-prompt path, and stale cached skill snapshots were never refreshed when the filter or version changed.
- **Why it matters**: Agents with specific skill needs (e.g. 3 configured skills) get all ~100+ skills instead. Changing an agent's `skills` config has no effect on existing sessions until session deletion.
- **What changed**: (1) Added `resolveAgentSkillsFilter()` call in `commands-system-prompt.ts` and pass `skillFilter` to `buildWorkspaceSkillSnapshot()`. (2) Added `matchesSkillFilter()` and `snapshotVersion` comparison to the `needsSkillsSnapshot` condition in `agent.ts`, matching the cron (`skills-snapshot.ts`) and gateway paths.
- **What did NOT change (scope boundary)**: No changes to skill resolution logic, snapshot format, cron path, or get-reply path (those already work correctly).

## Change Type
- [x] Bug fix

## Scope
- [x] Agent/Model

## Linked Issue/PR
- Closes #41972

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
1. Configure per-agent skills filter in `openclaw.json`
2. Run `openclaw agent --agent my-agent --message "test" --json`
3. Before fix: `systemPromptReport.skills.entries` shows all skills
4. After fix: Only configured skills appear; changing config triggers snapshot refresh

## Evidence
- [x] Code review confirms pattern matches cron and gateway paths exactly

## Human Verification
- Verified scenarios: new session with filter, existing session with changed filter, existing session with changed version
- Edge cases checked: undefined filter (no-op), empty filter array
- What you did NOT verify: runtime end-to-end testing with actual skill invocation

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: `src/auto-reply/reply/commands-system-prompt.ts`, `src/commands/agent.ts`

## Risks and Mitigations
None — this aligns the commands path with the already-working cron and get-reply paths.

---
*This PR was AI-assisted.*