### PR TITLE
fix(whatsapp): share active-listener Map across bundled chunks

### DIFF
--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -1,6 +1,7 @@
 import { formatCliCommand } from "../../../src/cli/command-format.js";
 import type { PollInput } from "../../../src/polls.js";
 import { DEFAULT_ACCOUNT_ID } from "../../../src/routing/session-key.js";
+import { resolveGlobalMap } from "../../../src/shared/global-singleton.js";
 
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
@@ -30,7 +31,9 @@ export type ActiveWebListener = {
 
 let _currentListener: ActiveWebListener | null = null;
 
-const listeners = new Map<string, ActiveWebListener>();
+const listeners = resolveGlobalMap<string, ActiveWebListener>(
+  Symbol.for("openclaw.whatsapp.active-listeners"),
+);
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;


### PR DESCRIPTION
## Summary

- Migrate WhatsApp `active-listener.ts` `listeners` Map to a `globalThis`-backed singleton via `resolveGlobalMap`, following the same pattern established in PR #43683 for other channels

## Problem

The bundler (tsdown) emits `extensions/whatsapp/src/active-listener.ts` into multiple chunks (`model-selection-*.js` and `reply-*.js`), each with its own independent `listeners = new Map()`. This causes:

- `setActiveWebListener()` (called by `channel-web` during WhatsApp connection setup) registers the listener in one chunk's Map
- `requireActiveWebListener()` (called by the gateway WebSocket handler / agent outbound path for proactive sends) checks a **different** chunk's Map — always empty
- Result: all proactive WhatsApp sends fail with *"No active WhatsApp Web listener (account: default)"* even though WhatsApp is fully connected and inbound auto-replies work fine

This is the exact same class of bug fixed by #43683 for Telegram, Slack, Signal, iMessage, and core pipeline singletons. **WhatsApp's `active-listener.ts` was not included in that fix.**

## Fix

One-line change: replace `new Map()` with `resolveGlobalMap(Symbol.for("openclaw.whatsapp.active-listeners"))` so all chunks share the same Map instance.

## Test plan

- [ ] Start gateway with WhatsApp linked
- [ ] Verify `openclaw channels status --probe` shows `connected`
- [ ] Run `openclaw message send --channel whatsapp --target <number> --message "test"` — should succeed
- [ ] Run a cron job with WhatsApp announce delivery — should deliver
- [ ] Verify inbound auto-replies still work

Fixes #45994
Related: #30177, #43683

🤖 Generated with [Claude Code](https://claude.com/claude-code)