### PR TITLE
fix(cron-ui): accept timeoutSeconds: 0 as no-timeout mode (closes #41272)

### DIFF
--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -845,8 +845,42 @@ describe("cron controller", () => {
     expect(errors.name).toBe("cron.errors.nameRequired");
     expect(errors.cronExpr).toBe("cron.errors.cronExprRequired");
     expect(errors.payloadText).toBe("cron.errors.agentMessageRequired");
-    expect(errors.timeoutSeconds).toBe("cron.errors.timeoutInvalid");
+    expect(errors.timeoutSeconds).toBeUndefined();
     expect(errors.deliveryTo).toBe("cron.errors.webhookUrlInvalid");
+  });
+
+  it("rejects negative timeoutSeconds but allows zero (no-timeout mode)", () => {
+    const errorsNeg = validateCronForm({
+      ...DEFAULT_CRON_FORM,
+      payloadKind: "agentTurn",
+      payloadText: "run",
+      timeoutSeconds: "-5",
+    });
+    expect(errorsNeg.timeoutSeconds).toBe("cron.errors.timeoutInvalid");
+
+    const errorsZero = validateCronForm({
+      ...DEFAULT_CRON_FORM,
+      payloadKind: "agentTurn",
+      payloadText: "run",
+      timeoutSeconds: "0",
+    });
+    expect(errorsZero.timeoutSeconds).toBeUndefined();
+
+    const errorsNonNumeric = validateCronForm({
+      ...DEFAULT_CRON_FORM,
+      payloadKind: "agentTurn",
+      payloadText: "run",
+      timeoutSeconds: "abc",
+    });
+    expect(errorsNonNumeric.timeoutSeconds).toBe("cron.errors.timeoutInvalid");
+
+    const errorsInfinity = validateCronForm({
+      ...DEFAULT_CRON_FORM,
+      payloadKind: "agentTurn",
+      payloadText: "run",
+      timeoutSeconds: "Infinity",
+    });
+    expect(errorsInfinity.timeoutSeconds).toBe("cron.errors.timeoutInvalid");
   });
 
   it("blocks add/update submit when validation errors exist", async () => {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -139,7 +139,7 @@ export function validateCronForm(form: CronFormState): CronFieldErrors {
     const timeoutRaw = form.timeoutSeconds.trim();
     if (timeoutRaw) {
       const timeout = toNumber(timeoutRaw, 0);
-      if (timeout <= 0) {
+      if (!Number.isFinite(Number(timeoutRaw)) || timeout < 0) {
         errors.timeoutSeconds = "cron.errors.timeoutInvalid";
       }
     }
@@ -575,9 +575,14 @@ export function buildCronPayload(form: CronFormState) {
   if (thinking) {
     payload.thinking = thinking;
   }
-  const timeoutSeconds = toNumber(form.timeoutSeconds, 0);
-  if (timeoutSeconds > 0) {
-    payload.timeoutSeconds = timeoutSeconds;
+  const timeoutRaw = form.timeoutSeconds.trim();
+  const timeoutSeconds = toNumber(timeoutRaw, 0);
+  if (Number.isFinite(Number(timeoutRaw)) && timeoutRaw !== "") {
+    if (timeoutSeconds > 0) {
+      payload.timeoutSeconds = timeoutSeconds;
+    } else if (timeoutSeconds === 0) {
+      payload.timeoutSeconds = 0;
+    }
   }
   if (form.payloadLightContext) {
     payload.lightContext = true;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -88,6 +88,7 @@ export default defineConfig({
       "ui/src/ui/views/usage-render-details.test.ts",
       "ui/src/ui/controllers/agents.test.ts",
       "ui/src/ui/controllers/chat.test.ts",
+      "ui/src/ui/controllers/cron.test.ts",
     ],
     setupFiles: ["test/setup.ts"],
     exclude: [


### PR DESCRIPTION
## Summary
- **Problem**: Cron job UI validation rejects `timeoutSeconds: 0`, which should represent "no timeout" mode for long-running jobs.
- **Why it matters**: Users cannot disable timeout for long-running cron jobs via the UI.
- **What changed**:
  - `ui/src/ui/controllers/cron.ts`: Changed validation from `timeout <= 0` to `timeout < 0` so zero is accepted. Updated `buildCronPayload()` to include `timeoutSeconds: 0` in payload when explicitly set.
  - `ui/src/ui/controllers/cron.test.ts`: Updated existing test expectation and added new test verifying negative values are rejected while zero is allowed.
- **What did NOT change**: Backend cron handling, positive timeout values, empty timeout field behavior.

## Change Type
- [x] Bug fix

## Scope
- [x] Control UI

## Linked Issue/PR
- Closes #41272

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
1. Create a cron job, set timeoutSeconds to 0
2. Before fix: validation error `cron.errors.timeoutInvalid`
3. After fix: form submits successfully with `timeoutSeconds: 0` in payload

## Evidence
- [x] Test updated: existing validation test now expects zero to pass
- [x] New test added: verifies negative → rejected, zero → accepted
- AI-assisted: generated by Copilot, lightly tested (unit test logic verified by code review)

## Human Verification
- Verified scenarios: validation logic for 0, negative, positive, and empty values
- Edge cases checked: empty string (no timeout field) still omits from payload
- What you did NOT verify: browser-level UI rendering

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No