### PR TITLE
fix(agents): resolve runtime secrets in message tool proactive send path

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -7,6 +7,8 @@ import { createMessageTool } from "./message-tool.js";
 
 const mocks = vi.hoisted(() => ({
   runMessageAction: vi.fn(),
+  getRuntimeConfigSnapshot: vi.fn(),
+  loadConfig: vi.fn(),
 }));
 
 vi.mock("../../infra/outbound/message-action-runner.js", async () => {
@@ -16,6 +18,23 @@ vi.mock("../../infra/outbound/message-action-runner.js", async () => {
   return {
     ...actual,
     runMessageAction: mocks.runMessageAction,
+  };
+});
+
+vi.mock("../../config/io.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config/io.js")>("../../config/io.js");
+  return {
+    ...actual,
+    getRuntimeConfigSnapshot: mocks.getRuntimeConfigSnapshot,
+  };
+});
+
+vi.mock("../../config/config.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../config/config.js")>("../../config/config.js");
+  return {
+    ...actual,
+    loadConfig: mocks.loadConfig,
   };
 });
 
@@ -466,5 +485,49 @@ describe("message tool sandbox passthrough", () => {
     });
 
     expect(call?.requesterSenderId).toBe("1234567890");
+  });
+});
+
+describe("message tool config resolution (SecretRef fallback)", () => {
+  afterEach(() => {
+    mocks.getRuntimeConfigSnapshot.mockReset();
+    mocks.loadConfig.mockReset();
+  });
+
+  it("prefers getRuntimeConfigSnapshot over loadConfig when options.config is absent", async () => {
+    const resolvedConfig = { channels: { telegram: { token: "resolved-token" } } } as never;
+    mocks.getRuntimeConfigSnapshot.mockReturnValue(resolvedConfig);
+    mocks.loadConfig.mockReturnValue({ channels: { telegram: { token: { $ref: "secret" } } } });
+    mockSendResult();
+
+    const call = await executeSend({
+      toolOptions: { config: undefined },
+      action: {
+        target: "telegram:123",
+        message: "hello",
+      },
+    });
+
+    expect(mocks.getRuntimeConfigSnapshot).toHaveBeenCalled();
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(call).toBeDefined();
+  });
+
+  it("falls back to loadConfig when getRuntimeConfigSnapshot returns null", async () => {
+    mocks.getRuntimeConfigSnapshot.mockReturnValue(null);
+    mocks.loadConfig.mockReturnValue({} as never);
+    mockSendResult();
+
+    const call = await executeSend({
+      toolOptions: { config: undefined },
+      action: {
+        target: "telegram:123",
+        message: "hello",
+      },
+    });
+
+    expect(mocks.getRuntimeConfigSnapshot).toHaveBeenCalled();
+    expect(mocks.loadConfig).toHaveBeenCalled();
+    expect(call).toBeDefined();
   });
 });

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -494,13 +494,31 @@ describe("message tool config resolution (SecretRef fallback)", () => {
     mocks.loadConfig.mockReset();
   });
 
-  it("prefers getRuntimeConfigSnapshot over loadConfig when options.config is absent", async () => {
+  it("uses options.config when provided, skipping runtime snapshot and loadConfig", async () => {
+    const explicitConfig = { channels: { telegram: { token: "explicit" } } } as never;
+    mocks.getRuntimeConfigSnapshot.mockReturnValue({ channels: {} } as never);
+    mocks.loadConfig.mockReturnValue({ channels: {} } as never);
+    mockSendResult();
+
+    await executeSend({
+      toolOptions: { config: explicitConfig },
+      action: {
+        target: "telegram:123",
+        message: "hello",
+      },
+    });
+
+    expect(mocks.getRuntimeConfigSnapshot).not.toHaveBeenCalled();
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("prefers runtime snapshot over loadConfig when options.config is absent", async () => {
     const resolvedConfig = { channels: { telegram: { token: "resolved-token" } } } as never;
     mocks.getRuntimeConfigSnapshot.mockReturnValue(resolvedConfig);
     mocks.loadConfig.mockReturnValue({ channels: { telegram: { token: { $ref: "secret" } } } });
     mockSendResult();
 
-    const call = await executeSend({
+    await executeSend({
       toolOptions: { config: undefined },
       action: {
         target: "telegram:123",
@@ -510,15 +528,15 @@ describe("message tool config resolution (SecretRef fallback)", () => {
 
     expect(mocks.getRuntimeConfigSnapshot).toHaveBeenCalled();
     expect(mocks.loadConfig).not.toHaveBeenCalled();
-    expect(call).toBeDefined();
   });
 
-  it("falls back to loadConfig when getRuntimeConfigSnapshot returns null", async () => {
+  it("falls back to loadConfig only when runtime snapshot is null", async () => {
     mocks.getRuntimeConfigSnapshot.mockReturnValue(null);
-    mocks.loadConfig.mockReturnValue({} as never);
+    const fallbackConfig = { channels: {} } as never;
+    mocks.loadConfig.mockReturnValue(fallbackConfig);
     mockSendResult();
 
-    const call = await executeSend({
+    await executeSend({
       toolOptions: { config: undefined },
       action: {
         target: "telegram:123",
@@ -528,6 +546,5 @@ describe("message tool config resolution (SecretRef fallback)", () => {
 
     expect(mocks.getRuntimeConfigSnapshot).toHaveBeenCalled();
     expect(mocks.loadConfig).toHaveBeenCalled();
-    expect(call).toBeDefined();
   });
 });

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -14,6 +14,7 @@ import {
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
+import { getRuntimeConfigSnapshot } from "../../config/io.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../gateway/protocol/client-info.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
@@ -704,7 +705,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         }
       }
 
-      const cfg = options?.config ?? loadConfig();
+      const cfg = options?.config ?? getRuntimeConfigSnapshot() ?? loadConfig();
       const action = readStringParam(params, "action", {
         required: true,
       }) as ChannelMessageActionName;


### PR DESCRIPTION
## Summary

The `message` tool's proactive send path (cron jobs, cross-channel sends, file attachments) falls back to `loadConfig()` when `options.config` is not provided. `loadConfig()` returns raw config containing unresolved `SecretRef` objects, causing sends to fail with:

```
channels.telegram.botToken: unresolved SecretRef "file:filemain:/telegram/botToken"
```

Normal conversation flow works because the gateway resolves SecretRefs at boot time and passes the resolved config through the inbound path. The proactive send path bypasses this.

## Fix

Prefer `getRuntimeConfigSnapshot()` (which returns the boot-time resolved config with secrets already materialized) over raw `loadConfig()`:

```ts
// Before
const cfg = options?.config ?? loadConfig();

// After  
const cfg = options?.config ?? getRuntimeConfigSnapshot() ?? loadConfig();
```

`loadConfig()` is kept as a final fallback for CLI or non-gateway contexts where no runtime snapshot exists.

## Tests

Added 2 tests verifying the fallback chain:
1. Prefers `getRuntimeConfigSnapshot()` when `options.config` is absent
2. Falls back to `loadConfig()` when runtime snapshot is `null`

Fixes #42848