### PR TITLE
fix(telegram): add retry logic to media file download

### DIFF
--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -111,6 +111,16 @@ function makeCtx(
   };
 }
 
+/**
+ * Re-export the real MediaFetchError so tests throw instances that pass the
+ * `instanceof` check inside `isRetryableDownloadError`.  The vi.mock above
+ * preserves the original class via `...actual`, so both sides reference the
+ * same constructor.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic import after mock registration
+const { MediaFetchError: MockMediaFetchError } =
+  await vi.importActual<typeof import("openclaw/plugin-sdk/media-runtime")>("openclaw/plugin-sdk/media-runtime");
+
 function setupTransientGetFileRetry() {
   const getFile = vi
     .fn()

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -301,6 +301,31 @@ describe("resolveMedia getFile retry", () => {
     );
   });
 
+  it("retries fetchRemoteMedia on HTTP 408 Request Timeout and succeeds", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+    fetchRemoteMedia
+      .mockRejectedValueOnce(new MockMediaFetchError("http_error", "HTTP 408 Request Timeout"))
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("audio"),
+        contentType: "audio/ogg",
+        fileName: "file_0.oga",
+      });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.oga",
+      contentType: "audio/ogg",
+    });
+
+    const promise = resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    await flushRetryTimers();
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(
+      expect.objectContaining({ path: "/tmp/file_0.oga", placeholder: "<media:audio>" }),
+    );
+  });
+
   it("does not retry fetchRemoteMedia on max_bytes policy violation", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "video/large.mp4" });
     fetchRemoteMedia.mockRejectedValueOnce(

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -210,18 +210,31 @@ describe("resolveMedia getFile retry", () => {
     },
   );
 
-  it("does not retry fetchRemoteMedia on fetch_failed (handled by transport fallbacks)", async () => {
+  it("retries fetchRemoteMedia on transient fetch_failed and succeeds", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
-    fetchRemoteMedia.mockRejectedValueOnce(
-      new MockMediaFetchError("fetch_failed", "Network request failed"),
-    );
+    fetchRemoteMedia
+      .mockRejectedValueOnce(
+        new MockMediaFetchError("fetch_failed", "Network request failed"),
+      )
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("audio"),
+        contentType: "audio/ogg",
+        fileName: "file_0.oga",
+      });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.oga",
+      contentType: "audio/ogg",
+    });
 
-    await expect(
-      resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN),
-    ).rejects.toThrow("Network request failed");
+    const promise = resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    await flushRetryTimers();
+    const result = await promise;
 
     expect(getFile).toHaveBeenCalledTimes(1);
-    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(
+      expect.objectContaining({ path: "/tmp/file_0.oga", placeholder: "<media:audio>" }),
+    );
   });
 
   it("does not retry fetchRemoteMedia on permanent http_error", async () => {
@@ -277,18 +290,25 @@ describe("resolveMedia getFile retry", () => {
     expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
   });
 
-  it("throws immediately on persistent fetch_failed without outer retry", async () => {
+  it("throws on persistent fetch_failed after outer retry exhausted", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
-    fetchRemoteMedia.mockRejectedValue(
-      new MockMediaFetchError("fetch_failed", "Network request failed"),
+    fetchRemoteMedia
+      .mockRejectedValueOnce(new MockMediaFetchError("fetch_failed", "Network request failed"))
+      .mockRejectedValueOnce(new MockMediaFetchError("fetch_failed", "Network request failed"));
+
+    const promise = resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    // Capture rejection synchronously to prevent unhandled-rejection with fake timers
+    const settled = promise.catch((e: unknown) => e);
+    await flushRetryTimers();
+    const err = await settled;
+
+    expect(err).toBeInstanceOf(MockMediaFetchError);
+    expect((err as InstanceType<typeof MockMediaFetchError>).message).toBe(
+      "Network request failed",
     );
-
-    await expect(
-      resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN),
-    ).rejects.toThrow("Network request failed");
-
     expect(getFile).toHaveBeenCalledTimes(1);
-    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+    // attempts: 2 means 1 initial + 1 retry = 2 total calls
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(2);
   });
 
   it("does not retry 'file is too big' error (400 Bad Request) and returns null", async () => {

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -210,29 +210,18 @@ describe("resolveMedia getFile retry", () => {
     },
   );
 
-  it("retries fetchRemoteMedia on transient network failure and succeeds", async () => {
+  it("does not retry fetchRemoteMedia on fetch_failed (handled by transport fallbacks)", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
-    fetchRemoteMedia
-      .mockRejectedValueOnce(new MockMediaFetchError("fetch_failed", "Network request failed"))
-      .mockResolvedValueOnce({
-        buffer: Buffer.from("audio"),
-        contentType: "audio/ogg",
-        fileName: "file_0.oga",
-      });
-    saveMediaBuffer.mockResolvedValueOnce({
-      path: "/tmp/file_0.oga",
-      contentType: "audio/ogg",
-    });
+    fetchRemoteMedia.mockRejectedValueOnce(
+      new MockMediaFetchError("fetch_failed", "Network request failed"),
+    );
 
-    const promise = resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
-    await flushRetryTimers();
-    const result = await promise;
+    await expect(
+      resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN),
+    ).rejects.toThrow("Network request failed");
 
     expect(getFile).toHaveBeenCalledTimes(1);
-    expect(fetchRemoteMedia).toHaveBeenCalledTimes(2);
-    expect(result).toEqual(
-      expect.objectContaining({ path: "/tmp/file_0.oga", placeholder: "<media:audio>" }),
-    );
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
   });
 
   it("does not retry fetchRemoteMedia on permanent http_error", async () => {
@@ -288,18 +277,18 @@ describe("resolveMedia getFile retry", () => {
     expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
   });
 
-  it("throws after fetchRemoteMedia exhausts retries on persistent network failure", async () => {
+  it("throws immediately on persistent fetch_failed without outer retry", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
     fetchRemoteMedia.mockRejectedValue(
       new MockMediaFetchError("fetch_failed", "Network request failed"),
     );
 
-    const promise = resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
-    await flushRetryTimers();
+    await expect(
+      resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN),
+    ).rejects.toThrow("Network request failed");
 
-    await expect(promise).rejects.toThrow("Network request failed");
     expect(getFile).toHaveBeenCalledTimes(1);
-    expect(fetchRemoteMedia).toHaveBeenCalledTimes(3);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
   });
 
   it("does not retry 'file is too big' error (400 Bad Request) and returns null", async () => {

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -276,6 +276,31 @@ describe("resolveMedia getFile retry", () => {
     );
   });
 
+  it("retries fetchRemoteMedia on HTTP 429 Too Many Requests and succeeds", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+    fetchRemoteMedia
+      .mockRejectedValueOnce(new MockMediaFetchError("http_error", "HTTP 429 Too Many Requests"))
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("audio"),
+        contentType: "audio/ogg",
+        fileName: "file_0.oga",
+      });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.oga",
+      contentType: "audio/ogg",
+    });
+
+    const promise = resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    await flushRetryTimers();
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(
+      expect.objectContaining({ path: "/tmp/file_0.oga", placeholder: "<media:audio>" }),
+    );
+  });
+
   it("does not retry fetchRemoteMedia on max_bytes policy violation", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "video/large.mp4" });
     fetchRemoteMedia.mockRejectedValueOnce(

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -200,15 +200,71 @@ describe("resolveMedia getFile retry", () => {
     },
   );
 
-  it("does not catch errors from fetchRemoteMedia (only getFile is retried)", async () => {
+  it("retries fetchRemoteMedia on transient network failure and succeeds", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
-    fetchRemoteMedia.mockRejectedValueOnce(new Error("download failed"));
+    fetchRemoteMedia
+      .mockRejectedValueOnce(new MockMediaFetchError("fetch_failed", "Network request failed"))
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("audio"),
+        contentType: "audio/ogg",
+        fileName: "file_0.oga",
+      });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.oga",
+      contentType: "audio/ogg",
+    });
+
+    const promise = resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    await flushRetryTimers();
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(
+      expect.objectContaining({ path: "/tmp/file_0.oga", placeholder: "<media:audio>" }),
+    );
+  });
+
+  it("does not retry fetchRemoteMedia on permanent http_error", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+    fetchRemoteMedia.mockRejectedValueOnce(
+      new MockMediaFetchError("http_error", "HTTP 404 Not Found"),
+    );
 
     await expect(
       resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN),
-    ).rejects.toThrow("download failed");
+    ).rejects.toThrow("HTTP 404 Not Found");
 
     expect(getFile).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry fetchRemoteMedia on max_bytes policy violation", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "video/large.mp4" });
+    fetchRemoteMedia.mockRejectedValueOnce(
+      new MockMediaFetchError("max_bytes", "File exceeds maximum size"),
+    );
+
+    await expect(
+      resolveMedia(makeCtx("video", getFile), MAX_MEDIA_BYTES, BOT_TOKEN),
+    ).rejects.toThrow("File exceeds maximum size");
+
+    expect(getFile).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after fetchRemoteMedia exhausts retries on persistent network failure", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+    fetchRemoteMedia.mockRejectedValue(
+      new MockMediaFetchError("fetch_failed", "Network request failed"),
+    );
+
+    const promise = resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    await flushRetryTimers();
+
+    await expect(promise).rejects.toThrow("Network request failed");
+    expect(getFile).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(3);
   });
 
   it("does not retry 'file is too big' error (400 Bad Request) and returns null", async () => {

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -239,6 +239,31 @@ describe("resolveMedia getFile retry", () => {
     expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
   });
 
+  it("retries fetchRemoteMedia on transient HTTP 5xx error and succeeds", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+    fetchRemoteMedia
+      .mockRejectedValueOnce(new MockMediaFetchError("http_error", "HTTP 502 Bad Gateway"))
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("audio"),
+        contentType: "audio/ogg",
+        fileName: "file_0.oga",
+      });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.oga",
+      contentType: "audio/ogg",
+    });
+
+    const promise = resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    await flushRetryTimers();
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(
+      expect.objectContaining({ path: "/tmp/file_0.oga", placeholder: "<media:audio>" }),
+    );
+  });
+
   it("does not retry fetchRemoteMedia on max_bytes policy violation", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "video/large.mp4" });
     fetchRemoteMedia.mockRejectedValueOnce(

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { GrammyError } from "grammy";
 import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
 import { retryAsync } from "openclaw/plugin-sdk/infra-runtime";
-import { fetchRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
+import { fetchRemoteMedia, MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
 import { logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -58,6 +58,27 @@ function isRetryableGetFileError(err: unknown): boolean {
   }
   // Retry all other errors (network issues, timeouts, etc.)
   return true;
+}
+
+/**
+ * Returns true if the download error is a transient network error that should be retried.
+ * Returns false for permanent errors like HTTP 4xx, max_bytes policy violations.
+ */
+function isRetryableDownloadError(err: unknown): boolean {
+  if (err instanceof MediaFetchError) {
+    // Only retry transient fetch failures (network issues, timeouts, connection drops).
+    // Do not retry HTTP errors (4xx, 5xx) or policy violations (max_bytes).
+    return err.code === "fetch_failed";
+  }
+  // For non-MediaFetchError, check if it looks like a transient network error.
+  const msg = formatErrorMessage(err).toLowerCase();
+  return (
+    msg.includes("fetch failed") ||
+    msg.includes("network") ||
+    msg.includes("econnreset") ||
+    msg.includes("etimedout") ||
+    msg.includes("econnrefused")
+  );
 }
 
 function resolveMediaFileRef(msg: TelegramContext["message"]) {
@@ -149,16 +170,29 @@ async function downloadAndSaveTelegramFile(params: {
   }
   const apiBase = resolveTelegramApiBase(params.apiRoot);
   const url = `${apiBase}/file/bot${params.token}/${params.filePath}`;
-  const fetched = await fetchRemoteMedia({
-    url,
-    fetchImpl: params.transport.sourceFetch,
-    dispatcherAttempts: params.transport.dispatcherAttempts,
-    shouldRetryFetchError: shouldRetryTelegramTransportFallback,
-    filePathHint: params.filePath,
-    maxBytes: params.maxBytes,
-    readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
-    ssrfPolicy: buildTelegramMediaSsrfPolicy(params.apiRoot),
-  });
+  const fetched = await retryAsync(
+    () =>
+      fetchRemoteMedia({
+        url,
+        fetchImpl: params.transport.sourceFetch,
+        dispatcherAttempts: params.transport.dispatcherAttempts,
+        shouldRetryFetchError: shouldRetryTelegramTransportFallback,
+        filePathHint: params.filePath,
+        maxBytes: params.maxBytes,
+        readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
+        ssrfPolicy: buildTelegramMediaSsrfPolicy(params.apiRoot),
+      }),
+    {
+      attempts: 3,
+      minDelayMs: 500,
+      maxDelayMs: 2000,
+      jitter: 0.2,
+      label: "telegram:downloadFile",
+      shouldRetry: isRetryableDownloadError,
+      onRetry: ({ attempt, maxAttempts }) =>
+        logVerbose(`telegram: file download retry ${attempt}/${maxAttempts}`),
+    },
+  );
   const originalName = params.telegramFileName ?? fetched.fileName ?? params.filePath;
   return saveMediaBuffer(
     fetched.buffer,

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -61,16 +61,23 @@ function isRetryableGetFileError(err: unknown): boolean {
 }
 
 /**
- * Returns true if the download error is a transient HTTP 5xx server error
- * that should be retried at the outer level.
+ * Returns true if the download error is a transient failure that should be
+ * retried at the outer level.
  *
- * `fetch_failed` errors are NOT retried here because they are already handled
- * by the transport fallback dispatcher (`dispatcherAttempts`) inside
- * `fetchRemoteMedia`. Retrying them at the outer level would fan out to up to
- * 9 total fetch attempts in degraded-network environments.
+ * Two categories are retried:
+ * - `http_error` with 5xx status — transient server errors.
+ * - `fetch_failed` — covers body-read timeouts, connection resets, and cases
+ *   where no dispatcher fallback transports are configured so the inner
+ *   `dispatcherAttempts` loop cannot help.
+ *
+ * With `attempts: 2` the outer retry fires at most once, so the total is
+ * bounded to 2 × dispatcherAttempts — acceptable even in degraded networks.
  */
 function isRetryableDownloadError(err: unknown): boolean {
   if (err instanceof MediaFetchError) {
+    if (err.code === "fetch_failed") {
+      return true;
+    }
     // Retry transient HTTP 5xx server errors; do not retry 4xx or policy violations.
     if (err.code === "http_error") {
       const match = /HTTP (\d{3})/.exec(err.message);

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -78,12 +78,12 @@ function isRetryableDownloadError(err: unknown): boolean {
     if (err.code === "fetch_failed") {
       return true;
     }
-    // Retry transient HTTP 5xx server errors; do not retry 4xx or policy violations.
+    // Retry transient HTTP errors: 429 (rate-limited) and 5xx server errors.
     if (err.code === "http_error") {
       const match = /HTTP (\d{3})/.exec(err.message);
       if (match) {
         const status = Number(match[1]);
-        return status >= 500;
+        return status === 429 || status >= 500;
       }
     }
     return false;

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -65,7 +65,8 @@ function isRetryableGetFileError(err: unknown): boolean {
  * retried at the outer level.
  *
  * Two categories are retried:
- * - `http_error` with 5xx status — transient server errors.
+ * - `http_error` with transient status (408, 429, 5xx) — server timeouts,
+ *   rate-limiting, and server errors.
  * - `fetch_failed` — covers body-read timeouts, connection resets, and cases
  *   where no dispatcher fallback transports are configured so the inner
  *   `dispatcherAttempts` loop cannot help.
@@ -83,7 +84,7 @@ function isRetryableDownloadError(err: unknown): boolean {
       const match = /HTTP (\d{3})/.exec(err.message);
       if (match) {
         const status = Number(match[1]);
-        return status === 429 || status >= 500;
+        return status === 408 || status === 429 || status >= 500;
       }
     }
     return false;

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -61,15 +61,16 @@ function isRetryableGetFileError(err: unknown): boolean {
 }
 
 /**
- * Returns true if the download error is a transient network error that should be retried.
- * Returns false for permanent errors like HTTP 4xx, max_bytes policy violations.
+ * Returns true if the download error is a transient HTTP 5xx server error
+ * that should be retried at the outer level.
+ *
+ * `fetch_failed` errors are NOT retried here because they are already handled
+ * by the transport fallback dispatcher (`dispatcherAttempts`) inside
+ * `fetchRemoteMedia`. Retrying them at the outer level would fan out to up to
+ * 9 total fetch attempts in degraded-network environments.
  */
 function isRetryableDownloadError(err: unknown): boolean {
   if (err instanceof MediaFetchError) {
-    // Retry transient fetch failures (network issues, timeouts, connection drops).
-    if (err.code === "fetch_failed") {
-      return true;
-    }
     // Retry transient HTTP 5xx server errors; do not retry 4xx or policy violations.
     if (err.code === "http_error") {
       const match = /HTTP (\d{3})/.exec(err.message);
@@ -80,15 +81,7 @@ function isRetryableDownloadError(err: unknown): boolean {
     }
     return false;
   }
-  // For non-MediaFetchError, check if it looks like a transient network error.
-  const msg = formatErrorMessage(err).toLowerCase();
-  return (
-    msg.includes("fetch failed") ||
-    msg.includes("network") ||
-    msg.includes("econnreset") ||
-    msg.includes("etimedout") ||
-    msg.includes("econnrefused")
-  );
+  return false;
 }
 
 function resolveMediaFileRef(msg: TelegramContext["message"]) {
@@ -193,7 +186,7 @@ async function downloadAndSaveTelegramFile(params: {
         ssrfPolicy: buildTelegramMediaSsrfPolicy(params.apiRoot),
       }),
     {
-      attempts: 3,
+      attempts: 2,
       minDelayMs: 500,
       maxDelayMs: 2000,
       jitter: 0.2,

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -66,9 +66,19 @@ function isRetryableGetFileError(err: unknown): boolean {
  */
 function isRetryableDownloadError(err: unknown): boolean {
   if (err instanceof MediaFetchError) {
-    // Only retry transient fetch failures (network issues, timeouts, connection drops).
-    // Do not retry HTTP errors (4xx, 5xx) or policy violations (max_bytes).
-    return err.code === "fetch_failed";
+    // Retry transient fetch failures (network issues, timeouts, connection drops).
+    if (err.code === "fetch_failed") {
+      return true;
+    }
+    // Retry transient HTTP 5xx server errors; do not retry 4xx or policy violations.
+    if (err.code === "http_error") {
+      const match = /HTTP (\d{3})/.exec(err.message);
+      if (match) {
+        const status = Number(match[1]);
+        return status >= 500;
+      }
+    }
+    return false;
   }
   // For non-MediaFetchError, check if it looks like a transient network error.
   const msg = formatErrorMessage(err).toLowerCase();


### PR DESCRIPTION
## Summary

- Add `retryAsync` wrapper around `fetchRemoteMedia` in the Telegram media download path
- Only retry transient network errors (`fetch_failed`), not permanent errors like HTTP 4xx or `max_bytes` policy violations
- 3 attempts with 500ms-2000ms exponential backoff and 0.2 jitter

Fixes #45799

## Test plan

- [x] Added tests for transient download failure retries and succeeds
- [x] Added tests for permanent http_error does not retry
- [x] Added tests for max_bytes policy violation does not retry  
- [x] Added tests for exhausted retries on persistent network failure