### PR TITLE
fix(usage): include reset archive transcripts in usage calculations (closes #40870)

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -442,4 +442,87 @@ example
     expect(lastPoint?.cumulativeTokens).toBe(165);
     expect(lastPoint?.cumulativeCost).toBeCloseTo(0.055, 8);
   });
+
+  it("includes reset archive transcripts in usage summary", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reset-usage-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const now = new Date();
+    const activeEntry = {
+      type: "message",
+      timestamp: now.toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.2",
+        usage: { input: 10, output: 20, totalTokens: 30, cost: { total: 0.03 } },
+      },
+    };
+    const resetEntry = {
+      type: "message",
+      timestamp: now.toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.2",
+        usage: { input: 100, output: 200, totalTokens: 300, cost: { total: 0.3 } },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-1.jsonl"),
+      JSON.stringify(activeEntry),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-1.jsonl.reset.2026-03-01T00-00-00.000Z"),
+      JSON.stringify(resetEntry),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30 });
+      // Both active (30) and reset archive (300) tokens should be counted
+      expect(summary.totals.totalTokens).toBe(330);
+      expect(summary.totals.totalCost).toBeCloseTo(0.33, 5);
+    });
+  });
+
+  it("discovers reset archive sessions and deduplicates by session ID", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reset-discover-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const userMsg = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "hello from active" },
+    };
+    const resetMsg = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "hello from archive" },
+    };
+
+    // Active file + one reset archive for the same session
+    await fs.writeFile(path.join(sessionsDir, "sess-dup.jsonl"), JSON.stringify(userMsg), "utf-8");
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-dup.jsonl.reset.2026-01-01T00-00-00.000Z"),
+      JSON.stringify(resetMsg),
+      "utf-8",
+    );
+    // Reset-only session (no active file)
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-archived.jsonl.reset.2026-02-01T00-00-00.000Z"),
+      JSON.stringify(resetMsg),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const sessions = await discoverAllSessions({});
+      const ids = sessions.map((s) => s.sessionId).toSorted();
+      expect(ids).toEqual(["sess-archived", "sess-dup"]);
+    });
+  });
 });

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -287,6 +287,21 @@ async function scanUsageFile(params: {
   });
 }
 
+const JSONL_RESET_RE = /\.jsonl(?:\.reset\..+)?$/;
+
+/** Returns true for `.jsonl` and `.jsonl.reset.<timestamp>` filenames. */
+function isTranscriptFile(name: string): boolean {
+  return JSONL_RESET_RE.test(name);
+}
+
+/** Extracts the session ID from a transcript filename. */
+function extractSessionId(name: string): string {
+  // Greedy match captures the longest possible ID, handling edge cases
+  // where the session ID itself might contain ".jsonl".
+  const match = name.match(/^(.+)\.jsonl(?:\.reset\..+)?$/);
+  return match ? match[1] : name;
+}
+
 export async function loadCostUsageSummary(params?: {
   startMs?: number;
   endMs?: number;
@@ -318,7 +333,7 @@ export async function loadCostUsageSummary(params?: {
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter((entry) => entry.isFile() && isTranscriptFile(entry.name))
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);
@@ -390,10 +405,10 @@ export async function discoverAllSessions(params?: {
   const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
 
-  const discovered: DiscoveredSession[] = [];
+  const discoveredMap = new Map<string, DiscoveredSession>();
 
   for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+    if (!entry.isFile() || !isTranscriptFile(entry.name)) {
       continue;
     }
 
@@ -409,51 +424,77 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    // Extract session ID from filename (remove .jsonl)
-    const sessionId = entry.name.slice(0, -6);
+    // Extract session ID from filename (remove .jsonl or .jsonl.reset.<timestamp>)
+    const sessionId = extractSessionId(entry.name);
 
-    // Try to read first user message for label extraction
-    let firstUserMessage: string | undefined;
-    try {
-      for await (const parsed of readJsonlRecords(filePath)) {
-        try {
-          const message = parsed.message as Record<string, unknown> | undefined;
-          if (message?.role === "user") {
-            const content = message.content;
-            if (typeof content === "string") {
-              firstUserMessage = content.slice(0, 100);
-            } else if (Array.isArray(content)) {
-              for (const block of content) {
-                if (
-                  typeof block === "object" &&
-                  block &&
-                  (block as Record<string, unknown>).type === "text"
-                ) {
-                  const text = (block as Record<string, unknown>).text;
-                  if (typeof text === "string") {
-                    firstUserMessage = text.slice(0, 100);
-                  }
-                  break;
-                }
-              }
-            }
-            break; // Found first user message
-          }
-        } catch {
-          // Skip malformed lines
-        }
+    const existing = discoveredMap.get(sessionId);
+    // Prefer the active .jsonl file over reset archives; among reset archives, prefer the most recent
+    const isActive = entry.name.endsWith(".jsonl");
+    const existingIsActive = existing?.sessionFile.endsWith(".jsonl") ?? false;
+    if (existing && existingIsActive && !isActive) {
+      // Keep the active file, but update mtime if this archive is newer
+      if (stats.mtimeMs > existing.mtime) {
+        discoveredMap.set(sessionId, { ...existing, mtime: stats.mtimeMs });
       }
-    } catch {
-      // Ignore read errors
+      continue;
     }
 
-    discovered.push({
+    if (existing && !existingIsActive && !isActive && stats.mtimeMs <= existing.mtime) {
+      // Both are archives; keep the one with the later mtime
+      continue;
+    }
+
+    // Try to read first user message for label extraction
+    // Only read if this is a new session or we're replacing the file reference
+    let firstUserMessage: string | undefined;
+    if (!existing || isActive || !existingIsActive) {
+      try {
+        for await (const parsed of readJsonlRecords(filePath)) {
+          try {
+            const message = parsed.message as Record<string, unknown> | undefined;
+            if (message?.role === "user") {
+              const content = message.content;
+              if (typeof content === "string") {
+                firstUserMessage = content.slice(0, 100);
+              } else if (Array.isArray(content)) {
+                for (const block of content) {
+                  if (
+                    typeof block === "object" &&
+                    block &&
+                    (block as Record<string, unknown>).type === "text"
+                  ) {
+                    const text = (block as Record<string, unknown>).text;
+                    if (typeof text === "string") {
+                      firstUserMessage = text.slice(0, 100);
+                    }
+                    break;
+                  }
+                }
+              }
+              break; // Found first user message
+            }
+          } catch {
+            // Skip malformed lines
+          }
+        }
+      } catch {
+        // Ignore read errors
+      }
+    }
+
+    const mtime = existing ? Math.max(existing.mtime, stats.mtimeMs) : stats.mtimeMs;
+    discoveredMap.set(sessionId, {
       sessionId,
       sessionFile: filePath,
-      mtime: stats.mtimeMs,
-      firstUserMessage,
+      mtime,
+      // Note: firstUserMessage is sourced from the representative file (active or
+      // most-recent archive). For sessions with multiple archives it may not be the
+      // chronological first message.
+      firstUserMessage: firstUserMessage ?? existing?.firstUserMessage,
     });
   }
+
+  const discovered = [...discoveredMap.values()];
 
   // Sort by mtime descending (most recent first)
   return discovered.toSorted((a, b) => b.mtime - a.mtime);


### PR DESCRIPTION
## Summary
- **Problem**: Usage dashboard only counts `.jsonl` transcript files, ignoring `.jsonl.reset.<timestamp>` archives. When sessions are reset, their usage data becomes invisible to the dashboard.
- **Why it matters**: Users see dramatically undercounted token usage and cost — up to 85% of actual usage can be missing from the dashboard.
- **What changed**: Updated `loadCostUsageSummary` and `discoverAllSessions` in `src/infra/session-cost-usage.ts` to scan both `.jsonl` and `.jsonl.reset.*` files. Updated session ID extraction to handle both filename patterns. `discoverAllSessions` now deduplicates entries sharing the same session ID.
- **What did NOT change**: No changes to how usage data is calculated from individual transcript entries, session reset logic, or UI rendering.

## Change Type
- [x] Bug fix

## Scope
- [x] Infrastructure/Usage

## Linked Issue/PR
- Closes #40870

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No (reads same directories, just more files)

## Repro + Verification
### Steps
1. Use OpenClaw with sessions that get reset periodically
2. Check `find ~/.openclaw/agents/*/sessions -name '*.reset.*' | wc -l`
3. Compare dashboard totals with actual API provider usage
### Expected
Dashboard includes usage from both active and reset archive transcripts
### Actual (before fix)
Dashboard only counts active .jsonl files, missing all reset archives

## Evidence
- [x] Lint passes (0 warnings, 0 errors)
- [x] All tests pass (11/11 including 2 new tests for reset archive handling)
- AI-assisted: yes

## Human Verification
- Verified scenarios: all existing tests pass, new tests cover reset archive inclusion and deduplication
- Edge cases checked: no reset files (existing behavior), multiple resets for same session (all aggregated), mixed active + reset files, reset-only sessions
- What you did NOT verify: runtime end-to-end with actual reset archive files

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: src/infra/session-cost-usage.ts

## Risks and Mitigations
Low risk — only changes which files are scanned. Usage calculation logic is unchanged. Dashboard will show higher (correct) numbers after this fix.