### PR TITLE
fix: strip trailing orphaned user messages on retry to prevent duplicates

### DIFF
--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import { writeFileSync } from "node:fs";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string }; id?: string };
@@ -58,19 +57,20 @@ export async function prepareSessionManagerForRun(params: {
   // appendFileSync a duplicate user message. Strip trailing orphaned user
   // messages (user messages after the last assistant) to prevent duplicates.
   if (params.hadSessionFile && header && hasAssistant) {
-    stripTrailingOrphanedUserMessages(sm, params.sessionFile);
+    await stripTrailingOrphanedUserMessages(sm, params.sessionFile);
   }
 }
 
-function stripTrailingOrphanedUserMessages(
+async function stripTrailingOrphanedUserMessages(
   sm: {
     flushed: boolean;
     fileEntries: Array<SessionHeaderEntry | SessionMessageEntry | { type: string }>;
     byId?: Map<string, unknown>;
+    labelsById?: Map<string, unknown>;
     leafId?: string | null;
   },
   sessionFile: string,
-): void {
+): Promise<void> {
   // Find the last assistant message index
   let lastAssistantIdx = -1;
   for (let i = sm.fileEntries.length - 1; i >= 0; i--) {
@@ -97,6 +97,7 @@ function stripTrailingOrphanedUserMessages(
     const removed = sm.fileEntries.splice(idx, 1)[0];
     if (removed && "id" in removed && typeof (removed as SessionMessageEntry).id === "string") {
       sm.byId?.delete((removed as SessionMessageEntry).id!);
+      sm.labelsById?.delete((removed as SessionMessageEntry).id!);
     }
   }
 
@@ -106,5 +107,5 @@ function stripTrailingOrphanedUserMessages(
 
   // Rewrite the file without the orphaned user messages
   const lines = sm.fileEntries.map((e) => JSON.stringify(e)).join("\n") + "\n";
-  writeFileSync(sessionFile, lines, "utf-8");
+  await fs.writeFile(sessionFile, lines, "utf-8");
 }

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
+import { writeFileSync } from "node:fs";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
-type SessionMessageEntry = { type: "message"; message?: { role?: string } };
+type SessionMessageEntry = { type: "message"; message?: { role?: string }; id?: string };
 
 /**
  * pi-coding-agent SessionManager persistence quirk:
@@ -50,4 +51,60 @@ export async function prepareSessionManagerForRun(params: {
     sm.leafId = null;
     sm.flushed = false;
   }
+
+  // On retry attempts, the JSONL file already contains the user message from
+  // the previous attempt. When SessionManager is reconstructed from the file
+  // with hasAssistant=true, flushed=true, so prompt() will immediately
+  // appendFileSync a duplicate user message. Strip trailing orphaned user
+  // messages (user messages after the last assistant) to prevent duplicates.
+  if (params.hadSessionFile && header && hasAssistant) {
+    stripTrailingOrphanedUserMessages(sm, params.sessionFile);
+  }
+}
+
+function stripTrailingOrphanedUserMessages(
+  sm: {
+    flushed: boolean;
+    fileEntries: Array<SessionHeaderEntry | SessionMessageEntry | { type: string }>;
+    byId?: Map<string, unknown>;
+    leafId?: string | null;
+  },
+  sessionFile: string,
+): void {
+  // Find the last assistant message index
+  let lastAssistantIdx = -1;
+  for (let i = sm.fileEntries.length - 1; i >= 0; i--) {
+    const e = sm.fileEntries[i];
+    if (e.type === "message" && (e as SessionMessageEntry).message?.role === "assistant") {
+      lastAssistantIdx = i;
+      break;
+    }
+  }
+  if (lastAssistantIdx < 0) return;
+
+  // Check if there are user messages after the last assistant
+  const trailingUserIndices: number[] = [];
+  for (let i = lastAssistantIdx + 1; i < sm.fileEntries.length; i++) {
+    const e = sm.fileEntries[i];
+    if (e.type === "message" && (e as SessionMessageEntry).message?.role === "user") {
+      trailingUserIndices.push(i);
+    }
+  }
+  if (trailingUserIndices.length === 0) return;
+
+  // Remove trailing user messages from in-memory entries
+  for (const idx of trailingUserIndices.reverse()) {
+    const removed = sm.fileEntries.splice(idx, 1)[0];
+    if (removed && "id" in removed && typeof (removed as SessionMessageEntry).id === "string") {
+      sm.byId?.delete((removed as SessionMessageEntry).id!);
+    }
+  }
+
+  // Update leafId to the last remaining entry
+  const lastEntry = sm.fileEntries[sm.fileEntries.length - 1];
+  sm.leafId = lastEntry && "id" in lastEntry ? (lastEntry as SessionMessageEntry).id ?? null : null;
+
+  // Rewrite the file without the orphaned user messages
+  const lines = sm.fileEntries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  writeFileSync(sessionFile, lines, "utf-8");
 }


### PR DESCRIPTION
## Problem

When a `chat.send` RPC triggers an embedded agent run that fails (429 rate limit, model exhaustion, etc.) and the retry loop in `run.ts` calls `runEmbeddedAttempt` again, a **new SessionManager** is constructed from the existing JSONL file.

Since `hasAssistant=true` (the error entry has `role: "assistant"`), `flushed=true` immediately. When `prompt()` calls `appendMessage(userMessage)`, the Pi agent's `_persist()` method calls `appendFileSync` immediately — writing a **duplicate user message**.

Each retry creates another duplicate. Result: N retries = N+1 copies of the same user message in the session JSONL.

## Evidence

Single `chat.send` RPC produces 4 user message entries with unique IDs and timestamps 10-40s apart:

```
{"id":"8cfa68f8","timestamp":"2026-03-14T10:44:10.682Z"}
{"id":"a1b28ab6","timestamp":"2026-03-14T10:44:22.368Z"}
{"id":"a62bfc33","timestamp":"2026-03-14T10:44:47.593Z"}
{"id":"89ad76ee","timestamp":"2026-03-14T10:44:53.092Z"}
```

## Root Cause

In `prepareSessionManagerForRun()`, the `hadSessionFile && header && !hasAssistant` branch resets the file. But on retry, `hasAssistant=true` (error entries have `role: "assistant"`), so no reset happens, `flushed` stays `true`, and the next `prompt()` call writes the user message again.

## Fix

Added `stripTrailingOrphanedUserMessages()` to `prepareSessionManagerForRun()`. When the file exists and has assistant entries, it detects user messages after the last assistant entry (orphaned from a previous failed attempt) and removes them from both the in-memory entries and the JSONL file before the retry prompt.

This is a minimal, surgical fix that doesn't change the retry logic or the Pi agent runtime.

Fixes #46005