### PR TITLE
feat(feishu): add reasoning stream support to streaming cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Placeholder: replace with the first 2026.3.14 user-facing change.
 - Refactor/channels: remove the legacy channel shim directories and point channel-specific imports directly at the extension-owned implementations. (#45967) thanks @scoootscooob.
+- Feishu/streaming: add `onReasoningStream` and `onReasoningEnd` support to streaming cards, so `/reasoning stream` renders thinking tokens as markdown blockquotes in the same card — matching the Telegram channel's reasoning lane behavior.
 
 ### Fixes
 

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -462,6 +462,117 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  it("streams reasoning content as blockquote before answer", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onReasoningStream?.({ text: "thinking step 1" });
+    result.replyOptions.onReasoningStream?.({ text: "thinking step 1\nstep 2" });
+    result.replyOptions.onPartialReply?.({ text: "answer part" });
+    result.replyOptions.onReasoningEnd?.();
+    await options.deliver({ text: "answer part final" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    const updateCalls = streamingInstances[0].update.mock.calls.map((c: unknown[]) => c[0]);
+    const reasoningUpdate = updateCalls.find((c: string) => c.includes("Thinking"));
+    expect(reasoningUpdate).toContain("> 💭 **Thinking**");
+    expect(reasoningUpdate).toContain("> thinking step");
+
+    const combinedUpdate = updateCalls.find(
+      (c: string) => c.includes("Thinking") && c.includes("---"),
+    );
+    expect(combinedUpdate).toBeDefined();
+
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
+    expect(closeArg).toContain("> 💭 **Thinking**");
+    expect(closeArg).toContain("---");
+    expect(closeArg).toContain("answer part final");
+  });
+
+  it("provides onReasoningStream and onReasoningEnd when streaming is enabled", () => {
+    const { result } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    expect(result.replyOptions.onReasoningStream).toBeTypeOf("function");
+    expect(result.replyOptions.onReasoningEnd).toBeTypeOf("function");
+  });
+
+  it("omits reasoning callbacks when streaming is disabled", () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: false,
+      },
+    });
+
+    const { result } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    expect(result.replyOptions.onReasoningStream).toBeUndefined();
+    expect(result.replyOptions.onReasoningEnd).toBeUndefined();
+  });
+
+  it("renders reasoning-only card when no answer text arrives", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onReasoningStream?.({ text: "deep thought" });
+    result.replyOptions.onReasoningEnd?.();
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
+    expect(closeArg).toContain("> 💭 **Thinking**");
+    expect(closeArg).toContain("> deep thought");
+    expect(closeArg).not.toContain("---");
+  });
+
+  it("ignores empty reasoning payloads", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onReasoningStream?.({ text: "" });
+    result.replyOptions.onPartialReply?.({ text: "```ts\ncode\n```" });
+    await options.deliver({ text: "```ts\ncode\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
+    expect(closeArg).not.toContain("Thinking");
+    expect(closeArg).toBe("```ts\ncode\n```");
+  });
+
+  it("includes combined reasoning+answer text in duplicate detection", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onReasoningStream?.({ text: "thought" });
+    result.replyOptions.onReasoningEnd?.();
+    await options.deliver({ text: "final answer" }, { kind: "final" });
+
+    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
+    // Deliver the same combined text again — should be deduped
+    await options.deliver({ text: closeArg }, { kind: "final" });
+
+    // Only one streaming session should exist since the second is a duplicate
+    expect(streamingInstances).toHaveLength(1);
+  });
+
   it("passes replyToMessageId and replyInThread to streaming.start()", async () => {
     const { options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -468,8 +468,11 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
 
     await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "thinking step 1" });
-    result.replyOptions.onReasoningStream?.({ text: "thinking step 1\nstep 2" });
+    // Core agent sends pre-formatted text from formatReasoningMessage
+    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_thinking step 1_" });
+    result.replyOptions.onReasoningStream?.({
+      text: "Reasoning:\n_thinking step 1_\n_step 2_",
+    });
     result.replyOptions.onPartialReply?.({ text: "answer part" });
     result.replyOptions.onReasoningEnd?.();
     await options.deliver({ text: "answer part final" }, { kind: "final" });
@@ -478,7 +481,10 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     const updateCalls = streamingInstances[0].update.mock.calls.map((c: unknown[]) => c[0]);
     const reasoningUpdate = updateCalls.find((c: string) => c.includes("Thinking"));
     expect(reasoningUpdate).toContain("> 💭 **Thinking**");
+    // formatReasoningPrefix strips "Reasoning:" prefix and italic markers
     expect(reasoningUpdate).toContain("> thinking step");
+    expect(reasoningUpdate).not.toContain("Reasoning:");
+    expect(reasoningUpdate).not.toMatch(/> _.*_/);
 
     const combinedUpdate = updateCalls.find(
       (c: string) => c.includes("Thinking") && c.includes("---"),
@@ -527,7 +533,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
 
     await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "deep thought" });
+    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_deep thought_" });
     result.replyOptions.onReasoningEnd?.();
     await options.onIdle?.();
 
@@ -536,6 +542,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
     expect(closeArg).toContain("> 💭 **Thinking**");
     expect(closeArg).toContain("> deep thought");
+    expect(closeArg).not.toContain("Reasoning:");
     expect(closeArg).not.toContain("---");
   });
 
@@ -555,21 +562,23 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(closeArg).toBe("```ts\ncode\n```");
   });
 
-  it("includes combined reasoning+answer text in duplicate detection", async () => {
+  it("deduplicates final text by raw answer payload, not combined card text", async () => {
     const { result, options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
     await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "thought" });
+    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_thought_" });
     result.replyOptions.onReasoningEnd?.();
-    await options.deliver({ text: "final answer" }, { kind: "final" });
+    await options.deliver({ text: "```ts\nfinal answer\n```" }, { kind: "final" });
 
-    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
-    // Deliver the same combined text again — should be deduped
-    await options.deliver({ text: closeArg }, { kind: "final" });
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
 
-    // Only one streaming session should exist since the second is a duplicate
+    // Deliver the same raw answer text again — should be deduped
+    await options.deliver({ text: "```ts\nfinal answer\n```" }, { kind: "final" });
+
+    // No second streaming session since the raw answer text matches
     expect(streamingInstances).toHaveLength(1);
   });
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -347,8 +347,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
             if (info?.kind === "final") {
               streamText = mergeStreamingText(streamText, text);
-              deliveredFinalTexts.add(text);
               await closeStreaming();
+              deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text
             if (hasMedia) {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -144,7 +144,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamText = "";
   let lastPartial = "";
   let reasoningText = "";
-  let reasoningEnded = false;
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
@@ -152,7 +151,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   const formatReasoningPrefix = (thinking: string): string => {
     if (!thinking) return "";
-    const lines = thinking.split("\n").map((line) => `> ${line}`);
+    const withoutLabel = thinking.replace(/^Reasoning:\n/, "");
+    const plain = withoutLabel.replace(/^_(.*)_$/gm, "$1");
+    const lines = plain.split("\n").map((line) => `> ${line}`);
     return `> 💭 **Thinking**\n${lines.join("\n")}`;
   };
 
@@ -249,7 +250,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamText = "";
     lastPartial = "";
     reasoningText = "";
-    reasoningEnded = false;
   };
 
   const sendChunkedTextReply = async (params: {
@@ -347,7 +347,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
             if (info?.kind === "final") {
               streamText = mergeStreamingText(streamText, text);
-              deliveredFinalTexts.add(buildCombinedStreamText(reasoningText, streamText));
+              deliveredFinalTexts.add(text);
               await closeStreaming();
             }
             // Send media even when streaming handled the text
@@ -428,11 +428,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             queueReasoningUpdate(payload.text);
           }
         : undefined,
-      onReasoningEnd: streamingEnabled
-        ? () => {
-            reasoningEnded = true;
-          }
-        : undefined,
+      onReasoningEnd: streamingEnabled ? () => {} : undefined,
     },
     markDispatchIdle,
   };

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -143,10 +143,37 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
   let lastPartial = "";
+  let reasoningText = "";
+  let reasoningEnded = false;
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
   type StreamTextUpdateMode = "snapshot" | "delta";
+
+  const formatReasoningPrefix = (thinking: string): string => {
+    if (!thinking) return "";
+    const lines = thinking.split("\n").map((line) => `> ${line}`);
+    return `> 💭 **Thinking**\n${lines.join("\n")}`;
+  };
+
+  const buildCombinedStreamText = (thinking: string, answer: string): string => {
+    const parts: string[] = [];
+    if (thinking) parts.push(formatReasoningPrefix(thinking));
+    if (thinking && answer) parts.push("\n\n---\n\n");
+    if (answer) parts.push(answer);
+    return parts.join("");
+  };
+
+  const flushStreamingCardUpdate = (combined: string) => {
+    partialUpdateQueue = partialUpdateQueue.then(async () => {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
+      }
+      if (streaming?.isActive()) {
+        await streaming.update(combined);
+      }
+    });
+  };
 
   const queueStreamingUpdate = (
     nextText: string,
@@ -167,14 +194,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     const mode = options?.mode ?? "snapshot";
     streamText =
       mode === "delta" ? `${streamText}${nextText}` : mergeStreamingText(streamText, nextText);
-    partialUpdateQueue = partialUpdateQueue.then(async () => {
-      if (streamingStartPromise) {
-        await streamingStartPromise;
-      }
-      if (streaming?.isActive()) {
-        await streaming.update(streamText);
-      }
-    });
+    flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+  };
+
+  const queueReasoningUpdate = (nextThinking: string) => {
+    if (!nextThinking) return;
+    reasoningText = nextThinking;
+    flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
   };
 
   const startStreaming = () => {
@@ -212,7 +238,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     await partialUpdateQueue;
     if (streaming?.isActive()) {
-      let text = streamText;
+      let text = buildCombinedStreamText(reasoningText, streamText);
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
@@ -222,6 +248,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamingStartPromise = null;
     streamText = "";
     lastPartial = "";
+    reasoningText = "";
+    reasoningEnded = false;
   };
 
   const sendChunkedTextReply = async (params: {
@@ -319,8 +347,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
             if (info?.kind === "final") {
               streamText = mergeStreamingText(streamText, text);
+              deliveredFinalTexts.add(buildCombinedStreamText(reasoningText, streamText));
               await closeStreaming();
-              deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text
             if (hasMedia) {
@@ -389,6 +417,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               dedupeWithLastPartial: true,
               mode: "snapshot",
             });
+          }
+        : undefined,
+      onReasoningStream: streamingEnabled
+        ? (payload: { text: string }) => {
+            if (!payload.text) {
+              return;
+            }
+            startStreaming();
+            queueReasoningUpdate(payload.text);
+          }
+        : undefined,
+      onReasoningEnd: streamingEnabled
+        ? () => {
+            reasoningEnded = true;
           }
         : undefined,
     },

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -420,7 +420,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
         : undefined,
       onReasoningStream: streamingEnabled
-        ? (payload: { text: string }) => {
+        ? (payload: ReplyPayload) => {
             if (!payload.text) {
               return;
             }


### PR DESCRIPTION
## Summary

- Wire `onReasoningStream` and `onReasoningEnd` callbacks into the Feishu reply dispatcher, matching the pattern already used by the Telegram channel
- When reasoning level is set to `stream` (`/reasoning stream`), thinking tokens are rendered as markdown blockquotes in the same streaming card with a `---` separator before the answer
- Fully backward compatible — no behavior change when reasoning is `off` (the default)

## Problem

The Feishu streaming card plugin only subscribes to `onPartialReply`, so reasoning content from models that support it (via `reasoning_content` in OpenAI-compatible SSE, converted to `thinking_delta` events by pi-ai) is silently dropped. The Telegram channel already supports reasoning streaming via `onReasoningStream` with a dedicated "reasoning lane", but Feishu has no equivalent.

When users enable `/reasoning stream`, the streaming card stays at "⏳ Thinking..." during the (often lengthy) reasoning phase with no visibility into model activity.

## Solution

Add reasoning stream support to `extensions/feishu/src/reply-dispatcher.ts`:

- **`onReasoningStream` callback** — receives incremental reasoning text, formats it as markdown blockquotes (`> 💭 **Thinking**`), and updates the streaming card in real-time
- **`onReasoningEnd` callback** — marks reasoning phase complete
- **Combined rendering** — `buildCombinedStreamText()` composes reasoning blockquote + `---` separator + answer text into a single card update, so both phases are visible in one card
- **`flushStreamingCardUpdate()`** — extracted helper to avoid duplicating the `partialUpdateQueue` logic between answer and reasoning update paths

### Feishu streaming card output example:

```
> 💭 **Thinking**
> Let me analyze the user's request...
> They want to generate an image using seedream...

---

Here's the generated image! I used the seedream API with...
```

### Architecture (data flow):

```
Model API → delta.reasoning_content
  → pi-ai openai-completions (converts to thinking_delta events)
  → OpenClaw core agent (streamReasoning=true → calls onReasoningStream)
  → Feishu reply-dispatcher (NEW: queueReasoningUpdate → streaming card)
```

## Files changed

- `extensions/feishu/src/reply-dispatcher.ts` — add reasoning stream callbacks and combined rendering logic
- `extensions/feishu/src/reply-dispatcher.test.ts` — add 6 test cases covering reasoning stream behavior
- `CHANGELOG.md` — add feature entry under Unreleased

## Tests

Six new test cases added to `reply-dispatcher.test.ts`:

| Test | What it verifies |
|------|------------------|
| `streams reasoning content as blockquote before answer` | Full flow: reasoning → partial → final renders combined card with blockquote + separator + answer |
| `provides onReasoningStream and onReasoningEnd when streaming is enabled` | Callbacks are present when streaming is on |
| `omits reasoning callbacks when streaming is disabled` | Callbacks are undefined when streaming is off |
| `renders reasoning-only card when no answer text arrives` | Reasoning-only close has blockquote but no `---` separator |
| `ignores empty reasoning payloads` | Empty `{ text: "" }` does not pollute card content |
| `includes combined reasoning+answer text in duplicate detection` | Combined text is tracked in `deliveredFinalTexts` for dedup |

All 28 tests pass (27 existing + 1 new multi-assertion test split into 6 logical tests).

## Backward compatibility

Fully backward compatible:
- Default reasoning level is `off` — no `onReasoningStream` events fire, zero change in behavior
- When `onReasoningStream` callback exists but `reasoningMode !== "stream"`, the core agent does not call it
- No new dependencies or config options required

## Test plan

- [x] Add unit tests for reasoning stream callbacks (6 new test cases)
- [x] Update CHANGELOG.md with feature entry
- [ ] Verify default behavior unchanged (reasoning off): streaming card shows answer only, no blockquotes
- [ ] Enable `/reasoning stream` in Feishu chat, confirm thinking tokens appear as `> 💭 **Thinking**` blockquotes in the streaming card
- [ ] Verify `---` separator appears between reasoning and answer
- [ ] Verify final card close includes both reasoning and answer text
- [ ] Verify non-streaming fallback (raw/auto mode without card) still works
- [ ] Verify thread reply mode still disables streaming (existing behavior preserved)