### PR TITLE
fix(gateway): preserve stored scopes when reconnecting with device token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 - Android/canvas security: require exact normalized A2UI URL matches before forwarding canvas bridge actions, rejecting query mismatches and descendant paths while still allowing fragment-only A2UI navigation.
 - Cron: send failure notifications through the job's primary delivery channel using the same session context as successful delivery when no explicit `failureDestination` is configured. (#60622) Thanks @artwalker.
 - Gateway/auth: serialize async shared-secret auth attempts per client so concurrent Tailscale-capable failures cannot overrun the intended auth rate-limit budget. Thanks @Telecaster2147.- Doctor/config: compare normalized `talk` configs by deep structural equality instead of key-order-sensitive serialization so `openclaw doctor --fix` stops repeatedly reporting/applying no-op `talk.provider/providers` normalization. (#59911) Thanks @ejames-dev.
+- Gateway/device auth: reuse cached device-token scopes only for cached-token reconnects, while keeping explicit `deviceToken` scope requests and empty-cache fallbacks intact so reconnects preserve `operator.read` without breaking explicit auth flows. (#46032) Thanks @caicongyang.
 
 ## 2026.4.2
 

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -430,12 +430,24 @@ describe("GatewayClient connect auth payload", () => {
     return parsed.params?.auth ?? {};
   }
 
+  function connectScopesFrom(ws: MockWebSocket) {
+    const raw = ws.sent.find((frame) => frame.includes('"method":"connect"'));
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw ?? "{}") as {
+      params?: {
+        scopes?: string[];
+      };
+    };
+    return parsed.params?.scopes ?? [];
+  }
+
   function connectRequestFrom(ws: MockWebSocket) {
     const raw = ws.sent.find((frame) => frame.includes('"method":"connect"'));
     expect(raw).toBeTruthy();
     return JSON.parse(raw ?? "{}") as {
       id?: string;
       params?: {
+        scopes?: string[];
         auth?: {
           token?: string;
           deviceToken?: string;
@@ -550,8 +562,11 @@ describe("GatewayClient connect auth payload", () => {
     client.stop();
   });
 
-  it("uses stored device token when shared token is not provided", () => {
-    loadDeviceAuthTokenMock.mockReturnValue({ token: "stored-device-token" });
+  it("uses stored device token scopes when shared token is not provided", () => {
+    loadDeviceAuthTokenMock.mockReturnValue({
+      token: "stored-device-token",
+      scopes: ["operator.read", "operator.write"],
+    });
     const client = new GatewayClient({
       url: "ws://127.0.0.1:18789",
     });
@@ -565,6 +580,7 @@ describe("GatewayClient connect auth payload", () => {
       token: "stored-device-token",
       deviceToken: "stored-device-token",
     });
+    expect(connectScopesFrom(ws)).toEqual(["operator.read", "operator.write"]);
     client.stop();
   });
 
@@ -589,10 +605,14 @@ describe("GatewayClient connect auth payload", () => {
   });
 
   it("prefers explicit deviceToken over stored device token", () => {
-    loadDeviceAuthTokenMock.mockReturnValue({ token: "stored-device-token" });
+    loadDeviceAuthTokenMock.mockReturnValue({
+      token: "stored-device-token",
+      scopes: ["operator.admin", "operator.read"],
+    });
     const client = new GatewayClient({
       url: "ws://127.0.0.1:18789",
       deviceToken: "explicit-device-token",
+      scopes: ["operator.pairing"],
     });
 
     client.start();
@@ -604,11 +624,38 @@ describe("GatewayClient connect auth payload", () => {
       token: "explicit-device-token",
       deviceToken: "explicit-device-token",
     });
+    expect(connectScopesFrom(ws)).toEqual(["operator.pairing"]);
+    client.stop();
+  });
+
+  it("falls back to requested scopes when stored device token has no cached scopes", () => {
+    loadDeviceAuthTokenMock.mockReturnValue({
+      token: "stored-device-token",
+      scopes: [],
+    });
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      scopes: ["operator.approvals"],
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+
+    expect(connectFrameFrom(ws)).toMatchObject({
+      token: "stored-device-token",
+      deviceToken: "stored-device-token",
+    });
+    expect(connectScopesFrom(ws)).toEqual(["operator.approvals"]);
     client.stop();
   });
 
   it("retries with stored device token after shared-token mismatch on trusted endpoints", async () => {
-    loadDeviceAuthTokenMock.mockReturnValue({ token: "stored-device-token" });
+    loadDeviceAuthTokenMock.mockReturnValue({
+      token: "stored-device-token",
+      scopes: ["operator.read"],
+    });
     const client = new GatewayClient({
       url: "ws://127.0.0.1:18789",
       token: "shared-token",
@@ -627,6 +674,8 @@ describe("GatewayClient connect auth payload", () => {
       token: "shared-token",
       deviceToken: "stored-device-token",
     });
+    const ws = getLatestWs();
+    expect(connectScopesFrom(ws)).toEqual(["operator.read"]);
     client.stop();
   });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -63,6 +63,7 @@ type SelectedConnectAuth = {
   resolvedDeviceToken?: string;
   storedToken?: string;
   storedScopes?: string[];
+  usingStoredDeviceToken?: boolean;
 };
 
 class GatewayClientRequestError extends Error {
@@ -419,6 +420,7 @@ export class GatewayClient {
       resolvedDeviceToken,
       storedToken,
       storedScopes,
+      usingStoredDeviceToken,
     } = this.selectConnectAuth(role);
     if (this.pendingDeviceTokenRetry && authDeviceToken) {
       this.pendingDeviceTokenRetry = false;
@@ -433,10 +435,12 @@ export class GatewayClient {
           }
         : undefined;
     const signedAtMs = Date.now();
-    // Use stored scopes when reconnecting with a device token to preserve the authorized scopes.
-    // Otherwise, fall back to explicitly requested scopes or the default admin-only scope.
+    // Reuse cached scopes only when the client is reusing the cached device token.
+    // Explicit device tokens should keep the caller-requested scope set.
     const scopes =
-      storedScopes && resolvedDeviceToken ? storedScopes : (this.opts.scopes ?? ["operator.admin"]);
+      usingStoredDeviceToken && storedScopes && storedScopes.length > 0
+        ? storedScopes
+        : (this.opts.scopes ?? ["operator.admin"]);
     const platform = this.opts.platform ?? process.platform;
     const device = (() => {
       if (!this.opts.deviceIdentity) {
@@ -639,6 +643,11 @@ export class GatewayClient {
       (!(explicitGatewayToken || authPassword) && (!explicitBootstrapToken || Boolean(storedToken)))
         ? (storedToken ?? undefined)
         : undefined);
+    const usingStoredDeviceToken =
+      Boolean(resolvedDeviceToken) &&
+      !explicitDeviceToken &&
+      Boolean(storedToken) &&
+      resolvedDeviceToken === storedToken;
     // Legacy compatibility: keep `auth.token` populated for device-token auth when
     // no explicit shared token is present.
     const authToken = explicitGatewayToken ?? resolvedDeviceToken;
@@ -653,6 +662,7 @@ export class GatewayClient {
       resolvedDeviceToken,
       storedToken: storedToken ?? undefined,
       storedScopes,
+      usingStoredDeviceToken,
     };
   }
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -62,6 +62,7 @@ type SelectedConnectAuth = {
   signatureToken?: string;
   resolvedDeviceToken?: string;
   storedToken?: string;
+  storedScopes?: string[];
 };
 
 class GatewayClientRequestError extends Error {
@@ -417,6 +418,7 @@ export class GatewayClient {
       signatureToken,
       resolvedDeviceToken,
       storedToken,
+      storedScopes,
     } = this.selectConnectAuth(role);
     if (this.pendingDeviceTokenRetry && authDeviceToken) {
       this.pendingDeviceTokenRetry = false;
@@ -431,7 +433,10 @@ export class GatewayClient {
           }
         : undefined;
     const signedAtMs = Date.now();
-    const scopes = this.opts.scopes ?? ["operator.admin"];
+    // Use stored scopes when reconnecting with a device token to preserve the authorized scopes.
+    // Otherwise, fall back to explicitly requested scopes or the default admin-only scope.
+    const scopes =
+      storedScopes && resolvedDeviceToken ? storedScopes : (this.opts.scopes ?? ["operator.admin"]);
     const platform = this.opts.platform ?? process.platform;
     const device = (() => {
       if (!this.opts.deviceIdentity) {
@@ -617,9 +622,11 @@ export class GatewayClient {
     const explicitBootstrapToken = this.opts.bootstrapToken?.trim() || undefined;
     const explicitDeviceToken = this.opts.deviceToken?.trim() || undefined;
     const authPassword = this.opts.password?.trim() || undefined;
-    const storedToken = this.opts.deviceIdentity
-      ? loadDeviceAuthToken({ deviceId: this.opts.deviceIdentity.deviceId, role })?.token
+    const storedAuth = this.opts.deviceIdentity
+      ? loadDeviceAuthToken({ deviceId: this.opts.deviceIdentity.deviceId, role })
       : null;
+    const storedToken = storedAuth?.token ?? null;
+    const storedScopes = storedAuth?.scopes;
     const shouldUseDeviceRetryToken =
       this.pendingDeviceTokenRetry &&
       !explicitDeviceToken &&
@@ -645,6 +652,7 @@ export class GatewayClient {
       signatureToken: authToken ?? authBootstrapToken ?? undefined,
       resolvedDeviceToken,
       storedToken: storedToken ?? undefined,
+      storedScopes,
     };
   }
 


### PR DESCRIPTION
## Description

On Windows, when the local gateway reissues the operator device token (after restart or reconnect), it was losing the `operator.read` scope, breaking `status`, `probe`, and `health` commands.

## Root Cause

When the gateway client reconnects using a stored device token, it was defaulting to `["operator.admin"]` scopes instead of preserving the previously authorized scopes from the stored token in `device-auth.json`. This caused the token to be regenerated with only `operator.admin` scope.

## Changes

Modified `src/gateway/client.ts`:
1. Modified `selectConnectAuth()` to also load the stored scopes along with the stored token
2. Modified the connect logic to use stored scopes when reconnecting with a valid device token
3. Falls back to explicitly requested scopes or default `["operator.admin"]` when no stored scopes exist

This ensures that when the CLI reconnects to the gateway (e.g., after gateway restart), it preserves the previously authorized scopes including `operator.read`, `operator.write`, `operator.approvals`, and `operator.pairing`.

## Related Issue

Fixes: #46000