### PR TITLE
fix(gateway): verify LaunchAgent is running after restart on macOS

### DIFF
--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -102,6 +102,16 @@ if ! launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null; then
   launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null
   launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
 fi
+# Verify the service is actually running after restart attempts.
+# This ensures the service is loaded and running, especially important after
+# npm global updates where the LaunchAgent may be in an inconsistent state.
+sleep 1
+if ! launchctl print 'gui/${uid}/${escaped}' >/dev/null 2>&1; then
+  # Service not loaded - force a final bootstrap and kickstart
+  launchctl enable 'gui/${uid}/${escaped}' 2>/dev/null
+  launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null
+  launchctl kickstart -kp 'gui/${uid}/${escaped}' 2>/dev/null || true
+fi
 # Self-cleanup
 rm -f "$0"
 `;

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -81,6 +81,12 @@ if ! launchctl kickstart -k "$service_target" >/dev/null 2>&1; then
     launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
   fi
 fi
+# Verify the service is actually running after restart attempts.
+if ! launchctl print "$service_target" >/dev/null 2>&1; then
+  launchctl enable "$service_target" >/dev/null 2>&1
+  launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1
+  launchctl kickstart -kp "$service_target" >/dev/null 2>&1 || true
+fi
 `;
   }
 
@@ -95,6 +101,12 @@ if ! launchctl start "$service_target" >/dev/null 2>&1; then
   else
     launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
   fi
+fi
+# Verify the service is actually running after restart attempts.
+if ! launchctl print "$service_target" >/dev/null 2>&1; then
+  launchctl enable "$service_target" >/dev/null 2>&1
+  launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1
+  launchctl kickstart -kp "$service_target" >/dev/null 2>&1 || true
 fi
 `;
 }


### PR DESCRIPTION
## Description

After `openclaw update` on macOS, the gateway LaunchAgent was not being reloaded, so the service did not come back automatically.

## Root Cause

The restart script used during `openclaw update` was not verifying whether the service was actually running after restart attempts. After npm global updates, the LaunchAgent could end up in an inconsistent state where:
1. The old gateway process was terminated (via SIGTERM during `bootout`)
2. The plist was reloaded via `bootstrap`
3. But the service didn't actually start properly

The script would attempt to restart but didn't verify success, leaving the service unloaded.

## Changes

Added verification logic to both restart scripts:

1. **`src/cli/update-cli/restart-helper.ts`** - Used during `openclaw update`:
   - After the initial restart attempt, added a verification step using `launchctl print`
   - If the service is not running, it performs a final bootstrap and kickstart with the `-kp` flag

2. **`src/daemon/launchd-restart-handoff.ts`** - Used for in-process restarts:
   - Added the same verification logic for consistency

## Related Issue

Fixes: #46012