### PR TITLE
fix(telegram): support dots in provider IDs for model list buttons (closes #38745)

### DIFF
--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -18,6 +18,7 @@ describe("parseModelCallbackData", () => {
       ["mdl_back", { type: "back" }],
       ["mdl_list_anthropic_2", { type: "list", provider: "anthropic", page: 2 }],
       ["mdl_list_open-ai_1", { type: "list", provider: "open-ai", page: 1 }],
+      ["mdl_list_hf.co_1", { type: "list", provider: "hf.co", page: 1 }],
       [
         "mdl_sel_anthropic/claude-sonnet-4-5",
         { type: "select", provider: "anthropic", model: "claude-sonnet-4-5" },

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -60,7 +60,7 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
   }
 
   // mdl_list_{provider}_{page}
-  const listMatch = trimmed.match(/^mdl_list_([a-z0-9_-]+)_(\d+)$/i);
+  const listMatch = trimmed.match(/^mdl_list_([a-z0-9_.-]+)_(\d+)$/i);
   if (listMatch) {
     const [, provider, pageStr] = listMatch;
     const page = Number.parseInt(pageStr ?? "1", 10);


### PR DESCRIPTION
## Summary
- **Problem:** Telegram `/models` inline buttons break for providers with dots in their ID (e.g. `hf.co`). The provider button renders but tapping it shows plain text instead of a model list keyboard.
- **Why it matters:** Users with dotted provider IDs (common with HuggingFace, custom endpoints) cannot use the inline model picker.
- **What changed:** Added `.` to the regex character class in `parseModelCallbackData()` (`extensions/telegram/src/model-buttons.ts`) so `mdl_list_hf.co_1` parses correctly.
- **What did NOT change (scope boundary):** No changes to callback data generation, model selection, or any other parsing paths.

## Change Type
- [x] Bug fix

## Scope
- [x] Telegram

## Linked Issue/PR
- Closes #38745

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure a provider with dots in its ID (e.g. `hf.co`)
2. In Telegram, send `/model` → tap `Browse providers` → tap `hf.co (2)`
### Expected
- Inline keyboard with models from `hf.co` provider
### Actual (before fix)
- Plain text list instead of buttons — `parseModelCallbackData` returns null for `mdl_list_hf.co_1`

## Evidence
- [x] Failing test/log before + passing after
- Added test case `["mdl_list_hf.co_1", { type: "list", provider: "hf.co", page: 1 }]`
- `vitest run extensions/telegram/src/model-buttons.test.ts` — 20 tests passed

## Human Verification
- Verified scenarios: dotted provider IDs (hf.co), existing providers (anthropic, open-ai) still parse correctly
- Edge cases checked: dots at start/end of provider ID, multiple dots
- What you did NOT verify: runtime end-to-end testing with actual Telegram bot

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: `extensions/telegram/src/model-buttons.ts`

## Risks and Mitigations
None — additive regex change, all existing tests still pass.

---
*This PR was AI-assisted (fully tested with vitest).*