### PR TITLE
feat(slack): add global/DM systemPrompt and built-in mrkdwn platform prompt

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -331,7 +331,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     expect(prepared).toBeTruthy();
-    expect(prepared!.ctxPayload.GroupSystemPrompt).toBe("Config prompt");
+    expect(prepared!.ctxPayload.GroupSystemPrompt).toContain("*Slack Formatting Rules*");
+    expect(prepared!.ctxPayload.GroupSystemPrompt).toContain("Config prompt");
     expect(prepared!.ctxPayload.UntrustedContext?.length).toBe(1);
     const untrusted = prepared!.ctxPayload.UntrustedContext?.[0] ?? "";
     expect(untrusted).toContain("UNTRUSTED channel metadata (slack)");

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -645,6 +645,9 @@ export async function prepareSlackMessage(params: {
     isRoomish,
     channelInfo,
     channelConfig,
+    globalSystemPrompt: account.config?.systemPrompt ?? cfg.channels?.slack?.systemPrompt,
+    dmSystemPrompt: cfg.channels?.slack?.dm?.systemPrompt,
+    isDirectMessage,
   });
 
   const {
@@ -695,7 +698,7 @@ export async function prepareSlackMessage(params: {
     ChatType: isDirectMessage ? "direct" : "channel",
     ConversationLabel: envelopeFrom,
     GroupSubject: isRoomish ? roomLabel : undefined,
-    GroupSystemPrompt: isRoomish ? groupSystemPrompt : undefined,
+    GroupSystemPrompt: groupSystemPrompt,
     UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
     SenderName: senderName,
     SenderId: senderId,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -646,7 +646,7 @@ export async function prepareSlackMessage(params: {
     channelInfo,
     channelConfig,
     globalSystemPrompt: account.config?.systemPrompt ?? cfg.channels?.slack?.systemPrompt,
-    dmSystemPrompt: cfg.channels?.slack?.dm?.systemPrompt,
+    dmSystemPrompt: account.config?.dm?.systemPrompt ?? cfg.channels?.slack?.dm?.systemPrompt,
     isDirectMessage,
   });
 

--- a/extensions/slack/src/monitor/room-context.test.ts
+++ b/extensions/slack/src/monitor/room-context.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { resolveSlackRoomContextHints } from "./room-context.js";
+
+describe("resolveSlackRoomContextHints", () => {
+  it("always includes platform prompt for channel messages", () => {
+    const result = resolveSlackRoomContextHints({
+      isRoomish: true,
+      isDirectMessage: false,
+    });
+    expect(result.groupSystemPrompt).toContain("*Slack Formatting Rules*");
+  });
+
+  it("always includes platform prompt for DMs", () => {
+    const result = resolveSlackRoomContextHints({
+      isRoomish: false,
+      isDirectMessage: true,
+    });
+    expect(result.groupSystemPrompt).toContain("*Slack Formatting Rules*");
+  });
+
+  it("stacks global + channel systemPrompt for channels", () => {
+    const result = resolveSlackRoomContextHints({
+      isRoomish: true,
+      isDirectMessage: false,
+      globalSystemPrompt: "You are a bot.",
+      channelConfig: { systemPrompt: "Focus on engineering." },
+    });
+    expect(result.groupSystemPrompt).toContain("*Slack Formatting Rules*");
+    expect(result.groupSystemPrompt).toContain("You are a bot.");
+    expect(result.groupSystemPrompt).toContain("Focus on engineering.");
+  });
+
+  it("stacks global + DM systemPrompt for DMs", () => {
+    const result = resolveSlackRoomContextHints({
+      isRoomish: false,
+      isDirectMessage: true,
+      globalSystemPrompt: "You are a bot.",
+      dmSystemPrompt: "Be concise.",
+    });
+    expect(result.groupSystemPrompt).toContain("You are a bot.");
+    expect(result.groupSystemPrompt).toContain("Be concise.");
+  });
+
+  it("does not include DM prompt in channels", () => {
+    const result = resolveSlackRoomContextHints({
+      isRoomish: true,
+      isDirectMessage: false,
+      dmSystemPrompt: "DM only prompt",
+      channelConfig: { systemPrompt: "Channel prompt" },
+    });
+    expect(result.groupSystemPrompt).toContain("Channel prompt");
+    expect(result.groupSystemPrompt).not.toContain("DM only prompt");
+  });
+
+  it("does not include channel prompt in DMs", () => {
+    const result = resolveSlackRoomContextHints({
+      isRoomish: false,
+      isDirectMessage: true,
+      channelConfig: { systemPrompt: "Channel prompt" },
+      dmSystemPrompt: "DM prompt",
+    });
+    expect(result.groupSystemPrompt).toContain("DM prompt");
+    expect(result.groupSystemPrompt).not.toContain("Channel prompt");
+  });
+
+  it("returns untrustedChannelMetadata only for roomish", () => {
+    const roomResult = resolveSlackRoomContextHints({
+      isRoomish: true,
+      isDirectMessage: false,
+      channelInfo: { topic: "test topic", purpose: "test purpose" },
+    });
+    expect(roomResult.untrustedChannelMetadata).toBeDefined();
+
+    const dmResult = resolveSlackRoomContextHints({
+      isRoomish: false,
+      isDirectMessage: true,
+      channelInfo: { topic: "test topic", purpose: "test purpose" },
+    });
+    expect(dmResult.untrustedChannelMetadata).toBeUndefined();
+  });
+
+  it("trims whitespace from system prompts", () => {
+    const result = resolveSlackRoomContextHints({
+      isRoomish: false,
+      isDirectMessage: true,
+      globalSystemPrompt: "  padded  ",
+    });
+    expect(result.groupSystemPrompt).toContain("padded");
+    expect(result.groupSystemPrompt).not.toContain("  padded  ");
+  });
+
+  it("skips empty/null system prompts", () => {
+    const result = resolveSlackRoomContextHints({
+      isRoomish: true,
+      isDirectMessage: false,
+      globalSystemPrompt: "  ",
+      channelConfig: { systemPrompt: null },
+    });
+    // Should only contain platform prompt, no extra newlines from empty parts
+    const parts = result.groupSystemPrompt!.split("\n\n");
+    // Platform prompt is multi-paragraph itself, but no trailing empty sections
+    expect(result.groupSystemPrompt).not.toMatch(/\n\n$/);
+  });
+});

--- a/extensions/slack/src/monitor/room-context.test.ts
+++ b/extensions/slack/src/monitor/room-context.test.ts
@@ -97,8 +97,6 @@ describe("resolveSlackRoomContextHints", () => {
       channelConfig: { systemPrompt: null },
     });
     // Should only contain platform prompt, no extra newlines from empty parts
-    const parts = result.groupSystemPrompt!.split("\n\n");
-    // Platform prompt is multi-paragraph itself, but no trailing empty sections
     expect(result.groupSystemPrompt).not.toMatch(/\n\n$/);
   });
 });

--- a/extensions/slack/src/monitor/room-context.ts
+++ b/extensions/slack/src/monitor/room-context.ts
@@ -53,8 +53,7 @@ export function resolveSlackRoomContextHints(params: {
     params.isDirectMessage ? params.dmSystemPrompt?.trim() || null : null,
   ].filter((entry): entry is string => Boolean(entry));
 
-  const groupSystemPrompt =
-    systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
+  const groupSystemPrompt = systemPromptParts.join("\n\n");
 
   return {
     untrustedChannelMetadata,

--- a/extensions/slack/src/monitor/room-context.ts
+++ b/extensions/slack/src/monitor/room-context.ts
@@ -1,26 +1,58 @@
 import { buildUntrustedChannelMetadata } from "openclaw/plugin-sdk/security-runtime";
 
+// LLMs default to standard Markdown (e.g. **bold**, # headers, [links](url)),
+// which Slack does not render correctly. This prompt overrides that behavior
+// so responses use Slack's native mrkdwn syntax instead.
+const SLACK_PLATFORM_PROMPT = `\
+*Slack Formatting Rules*
+
+You are responding in a Slack workspace. Use Slack mrkdwn syntax, NOT standard Markdown.
+
+Key differences from standard Markdown:
+- Bold: *bold* (single asterisks, NOT double)
+- Italic: _italic_ (underscores)
+- Strikethrough: ~strikethrough~ (single tildes)
+- Code inline: \`code\`
+- Code block: \`\`\`code block\`\`\` (no language identifier)
+- Bulleted list: use a single space before the dash (e.g. " - item")
+- Numbered list: use a single space before the number (e.g. " 1. item")
+- Links: <URL|display text>
+- Block quote: > text
+
+Do NOT use:
+- **double asterisks** for bold
+- # headers (use *bold* on its own line instead)
+- [text](url) markdown links
+- Language identifiers in code blocks (e.g. \`\`\`js)
+- Tables in pipe-delimited format`;
+
 export function resolveSlackRoomContextHints(params: {
   isRoomish: boolean;
   channelInfo?: { topic?: string; purpose?: string };
   channelConfig?: { systemPrompt?: string | null } | null;
+  globalSystemPrompt?: string | null;
+  dmSystemPrompt?: string | null;
+  isDirectMessage: boolean;
 }): {
   untrustedChannelMetadata?: ReturnType<typeof buildUntrustedChannelMetadata>;
   groupSystemPrompt?: string;
 } {
-  if (!params.isRoomish) {
-    return {};
-  }
+  const untrustedChannelMetadata = params.isRoomish
+    ? buildUntrustedChannelMetadata({
+        source: "slack",
+        label: "Slack channel description",
+        entries: [params.channelInfo?.topic, params.channelInfo?.purpose],
+      })
+    : undefined;
 
-  const untrustedChannelMetadata = buildUntrustedChannelMetadata({
-    source: "slack",
-    label: "Slack channel description",
-    entries: [params.channelInfo?.topic, params.channelInfo?.purpose],
-  });
+  // Build system prompt: platform > global > channel/DM-specific
+  const systemPromptParts = [
+    SLACK_PLATFORM_PROMPT,
+    params.globalSystemPrompt?.trim() || null,
+    params.isRoomish ? params.channelConfig?.systemPrompt?.trim() || null : null,
+    params.isDirectMessage ? params.dmSystemPrompt?.trim() || null : null,
+  ].filter((entry): entry is string => Boolean(entry));
 
-  const systemPromptParts = [params.channelConfig?.systemPrompt?.trim() || null].filter(
-    (entry): entry is string => Boolean(entry),
-  );
   const groupSystemPrompt =
     systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
 

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -538,6 +538,9 @@ export async function registerSlackMonitorSlashCommands(params: {
         isRoomish,
         channelInfo,
         channelConfig,
+        globalSystemPrompt: account.config?.systemPrompt ?? cfg.channels?.slack?.systemPrompt,
+        dmSystemPrompt: cfg.channels?.slack?.dm?.systemPrompt,
+        isDirectMessage,
       });
 
       const { sessionKey, commandTargetSessionKey } = resolveNativeCommandSessionTargets({
@@ -572,7 +575,7 @@ export async function registerSlackMonitorSlashCommands(params: {
                 : `slack:group:${command.channel_id}`,
           }) ?? (isDirectMessage ? senderName : roomLabel),
         GroupSubject: isRoomish ? roomLabel : undefined,
-        GroupSystemPrompt: isRoomish ? groupSystemPrompt : undefined,
+        GroupSystemPrompt: groupSystemPrompt,
         UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
         SenderName: senderName,
         SenderId: command.user_id,

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -539,7 +539,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         channelInfo,
         channelConfig,
         globalSystemPrompt: account.config?.systemPrompt ?? cfg.channels?.slack?.systemPrompt,
-        dmSystemPrompt: cfg.channels?.slack?.dm?.systemPrompt,
+        dmSystemPrompt: account.config?.dm?.systemPrompt ?? cfg.channels?.slack?.dm?.systemPrompt,
         isDirectMessage,
       });
 

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -25,6 +25,8 @@ export type SlackDmConfig = {
   groupChannels?: Array<string | number>;
   /** @deprecated Prefer channels.slack.replyToModeByChatType.direct. */
   replyToMode?: ReplyToMode;
+  /** Optional system prompt applied to all direct messages. */
+  systemPrompt?: string;
 };
 
 export type SlackChannelConfig = {
@@ -90,6 +92,8 @@ export type SlackThreadConfig = {
 export type SlackAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
+  /** Optional system prompt applied to all Slack conversations (channels and DMs). */
+  systemPrompt?: string;
   /** Slack connection mode (socket|http). Default: socket. */
   mode?: "socket" | "http";
   /** Slack signing secret (required for HTTP mode). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -826,6 +826,7 @@ export const SlackDmSchema = z
     groupEnabled: z.boolean().optional(),
     groupChannels: z.array(z.union([z.string(), z.number()])).optional(),
     replyToMode: ReplyToModeSchema.optional(),
+    systemPrompt: z.string().optional(),
   })
   .strict();
 
@@ -862,6 +863,7 @@ const SlackReplyToModeByChatTypeSchema = z
 export const SlackAccountSchema = z
   .object({
     name: z.string().optional(),
+    systemPrompt: z.string().optional(),
     mode: z.enum(["socket", "http"]).optional(),
     signingSecret: SecretInputSchema.optional().register(sensitive),
     webhookPath: z.string().optional(),


### PR DESCRIPTION
## Summary

- Add `systemPrompt` to `SlackAccountConfig` (applies to all Slack conversations) and `SlackDmConfig` (DM-specific override)
- Add built-in `SLACK_PLATFORM_PROMPT` constant with Slack mrkdwn formatting rules, automatically prepended to all Slack conversations (LLMs default to standard Markdown which Slack doesn't render correctly)
- Prompt stacking order: platform → global → channel/DM-specific
- Enable `GroupSystemPrompt` for DMs (previously channel-only)
- Add Zod schema validation for new fields
- Add unit tests for `resolveSlackRoomContextHints` (9 cases)
- Fix existing test broken by platform prompt prepend

## Config example

```json
{
  "channels": {
    "slack": {
      "systemPrompt": "You are a helpful team assistant.",
      "dm": {
        "systemPrompt": "Be concise in DM replies."
      },
      "channels": {
        "C0ABC12345": {
          "systemPrompt": "Focus on engineering topics."
        }
      }
    }
  }
}
```

## Test plan

- [x] `prepare.test.ts` — 21 tests pass (including updated assertion)
- [x] `room-context.test.ts` — 9 new tests pass (platform prompt, global+channel, global+DM, isolation, untrustedChannelMetadata, trim, null handling)
- [x] TypeScript type check passes (no errors in modified files)

## Follow-up

- `GroupSystemPrompt` field name is misleading now that it applies to DMs too — consider renaming in a separate PR

