### PR TITLE
fix(cron): suppress NO_REPLY on thread-based and structured delivery

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -399,6 +399,22 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
+  it("delivers media payloads even when synthesizedText is NO_REPLY (#45909)", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: "NO_REPLY" });
+    (params.resolvedDelivery as { threadId?: string }).threadId = "42";
+    (params as Record<string, unknown>).deliveryPayloads = [
+      { text: "", mediaUrl: "https://example.com/image.png", mediaUrls: [] },
+    ];
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.delivered).toBe(true);
+    // Media payloads must NOT be suppressed even when text is NO_REPLY
+    expect(deliverOutboundPayloads).toHaveBeenCalled();
+  });
+
   it("structured/thread delivery also bypasses the write-ahead queue", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -371,6 +371,34 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     );
   });
 
+  it("suppresses NO_REPLY on direct (thread-based) delivery path (#45909)", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: "NO_REPLY" });
+    // Simulate thread-based delivery so useDirectDelivery = true
+    (params.resolvedDelivery as { threadId?: string }).threadId = "42";
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryAttempted).toBe(true);
+    // Must NOT call deliverOutboundPayloads — NO_REPLY should be suppressed
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("suppresses NO_REPLY on structured content delivery path (#45909)", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: "NO_REPLY" });
+    (params as Record<string, unknown>).deliveryPayloadHasStructuredContent = true;
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryAttempted).toBe(true);
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
   it("structured/thread delivery also bypasses the write-ahead queue", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -546,6 +546,32 @@ export async function dispatchCronDelivery(
       };
     }
 
+    // Suppress SILENT_REPLY_TOKEN before delivery path selection (#45909).
+    // This check previously only lived inside finalizeTextDelivery, so the
+    // direct delivery path (thread-based / structured content) leaked NO_REPLY.
+    if (
+      synthesizedText?.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase() &&
+      deliveryPayloads.every(
+        (p) => !p.text || p.text.trim().toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase(),
+      )
+    ) {
+      return {
+        result: params.withRunSession({
+          status: "ok",
+          summary,
+          outputText,
+          delivered: true,
+          ...params.telemetry,
+        }),
+        delivered: true,
+        deliveryAttempted: true,
+        summary,
+        outputText,
+        synthesizedText,
+        deliveryPayloads,
+      };
+    }
+
     // Finalize descendant/subagent output first for text-only cron runs, then
     // send through the real outbound adapter so delivered=true always reflects
     // an actual channel send instead of internal announce routing.

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -546,14 +546,26 @@ export async function dispatchCronDelivery(
       };
     }
 
-    // Suppress SILENT_REPLY_TOKEN before delivery path selection (#45909).
-    // This check previously only lived inside finalizeTextDelivery, so the
-    // direct delivery path (thread-based / structured content) leaked NO_REPLY.
+    // Finalize descendant/subagent output first for text-only cron runs, then
+    // send through the real outbound adapter so delivered=true always reflects
+    // an actual channel send instead of internal announce routing.
+    const useDirectDelivery =
+      params.deliveryPayloadHasStructuredContent || params.resolvedDelivery.threadId != null;
+
+    // Suppress SILENT_REPLY_TOKEN on the direct delivery path only (#45909).
+    // The text path already suppresses inside finalizeTextDelivery, which also
+    // waits for active descendants — short-circuiting before that would skip
+    // descendant fallback summaries. Only suppress when payloads carry no real
+    // media/structured content.
     if (
+      useDirectDelivery &&
       synthesizedText?.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase() &&
-      deliveryPayloads.every(
-        (p) => !p.text || p.text.trim().toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase(),
-      )
+      deliveryPayloads.every((p) => {
+        const hasMedia = Boolean(p.mediaUrl || (p.mediaUrls && p.mediaUrls.length > 0));
+        const hasChannelData = Boolean(p.channelData && Object.keys(p.channelData).length > 0);
+        if (hasMedia || hasChannelData) return false;
+        return !p.text || p.text.trim().toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase();
+      })
     ) {
       return {
         result: params.withRunSession({
@@ -572,11 +584,6 @@ export async function dispatchCronDelivery(
       };
     }
 
-    // Finalize descendant/subagent output first for text-only cron runs, then
-    // send through the real outbound adapter so delivered=true always reflects
-    // an actual channel send instead of internal announce routing.
-    const useDirectDelivery =
-      params.deliveryPayloadHasStructuredContent || params.resolvedDelivery.threadId != null;
     if (useDirectDelivery) {
       const directResult = await deliverViaDirect(params.resolvedDelivery);
       if (directResult) {


### PR DESCRIPTION
## Summary

The `SILENT_REPLY_TOKEN` (`NO_REPLY`) check only lives inside `finalizeTextDelivery`, so the direct delivery path — used when `threadId != null` (forum topics) or when the payload has structured content — leaks the literal `NO_REPLY` string to the channel.

This moves the suppression check before the `useDirectDelivery` branch so both delivery paths are covered. Also handles the edge case where `deliveryPayloads` items contain only NO_REPLY text.

- `src/cron/isolated-agent/delivery-dispatch.ts` — add early return before `useDirectDelivery` branch when text is NO_REPLY
- `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` — 2 new tests (thread-based + structured content paths)

Fixes #45909

## Test plan

- [x] New tests pass (thread-based + structured NO_REPLY suppression)
- [x] All 523 cron tests pass (`pnpm test -- --run src/cron/`)
- [ ] CI green