### PR TITLE
fix(ui): make lifecycle node tests runnable under vitest.node.config (closes #36620)

### DIFF
--- a/ui/src/ui/app-lifecycle-connect.node.test.ts
+++ b/ui/src/ui/app-lifecycle-connect.node.test.ts
@@ -1,4 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).window = {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+});
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).window;
+});
 
 const { applySettingsFromUrlMock, connectGatewayMock, loadBootstrapMock } = vi.hoisted(() => ({
   applySettingsFromUrlMock: vi.fn(),

--- a/ui/src/ui/app-lifecycle.node.test.ts
+++ b/ui/src/ui/app-lifecycle.node.test.ts
@@ -1,4 +1,45 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("./app-gateway.ts", () => ({
+  connectGateway: vi.fn(),
+}));
+vi.mock("./controllers/control-ui-bootstrap.ts", () => ({
+  loadControlUiBootstrapConfig: vi.fn(),
+}));
+vi.mock("./app-settings.ts", () => ({
+  applySettingsFromUrl: vi.fn(),
+  attachThemeListener: vi.fn(),
+  detachThemeListener: vi.fn(),
+  inferBasePath: vi.fn(() => "/"),
+  syncTabWithLocation: vi.fn(),
+  syncThemeWithSettings: vi.fn(),
+}));
+vi.mock("./app-polling.ts", () => ({
+  startLogsPolling: vi.fn(),
+  startNodesPolling: vi.fn(),
+  stopLogsPolling: vi.fn(),
+  stopNodesPolling: vi.fn(),
+  startDebugPolling: vi.fn(),
+  stopDebugPolling: vi.fn(),
+}));
+vi.mock("./app-scroll.ts", () => ({
+  observeTopbar: vi.fn(),
+  scheduleChatScroll: vi.fn(),
+  scheduleLogsScroll: vi.fn(),
+}));
+
+const windowStub = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+};
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).window = windowStub;
+});
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).window;
+});
+
 import { handleDisconnected } from "./app-lifecycle.ts";
 
 function createHost() {


### PR DESCRIPTION
## Summary
- Problem: The two UI lifecycle node test files (`app-lifecycle-connect.node.test.ts` and `app-lifecycle.node.test.ts`) fail immediately under `ui/vitest.node.config.ts` and provide zero regression coverage.
- Why it matters: Lifecycle regressions can slip through because these intended node tests are not actually runnable.
- What changed:
  - `app-lifecycle-connect.node.test.ts`: Added `globalThis.window` stub (`addEventListener`/`removeEventListener`) in `beforeAll`/`afterAll` so `handleConnected()` can call `window.addEventListener` in a node environment.
  - `app-lifecycle.node.test.ts`: Added `vi.mock()` calls for all sibling modules that `app-lifecycle.ts` imports (matching the connect test) to prevent transitive import errors (`@noble/ed25519`). Added the same `globalThis.window` stub.
- What did NOT change (scope boundary): No changes to production code. Only test files were modified.

## Change Type
- [x] Bug fix

## Scope
- [x] UI / frontend

## Linked Issue/PR
- Closes #36620

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. `cd ui && pnpm exec vitest run --config vitest.node.config.ts src/ui/app-lifecycle.node.test.ts src/ui/app-lifecycle-connect.node.test.ts`
### Expected
- All 4 tests pass
### Actual (before fix)
- `ReferenceError: window is not defined` (connect test)
- `Error: Cannot find package @noble/ed25519` (lifecycle test)

## Evidence
- [x] Failing test/log before + passing after
- Before: 2 test files failed, 0 tests passed
- After: 2 test files passed, 4 tests passed

## Human Verification
- Verified scenarios: `pnpm build` passes, both node test files pass under `vitest.node.config.ts`
- Edge cases checked: `afterAll` cleans up the `globalThis.window` stub so it does not leak into other test files
- What you did NOT verify: runtime end-to-end testing with actual service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: `ui/src/ui/app-lifecycle-connect.node.test.ts`, `ui/src/ui/app-lifecycle.node.test.ts`

## Risks and Mitigations
None

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*