### PR TITLE
fix: bootstrap zsh completion when compinit is missing (AI-assisted)

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -1,0 +1,53 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getCoreCliCommandNames = vi.hoisted(() => vi.fn(() => []));
+const registerCoreCliByName = vi.hoisted(() => vi.fn(async () => {}));
+const getProgramContext = vi.hoisted(() => vi.fn(() => null));
+const getSubCliEntries = vi.hoisted(() => vi.fn(() => []));
+const registerSubCliByName = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("./program/command-registry.js", () => ({
+  getCoreCliCommandNames,
+  registerCoreCliByName,
+}));
+
+vi.mock("./program/program-context.js", () => ({
+  getProgramContext,
+}));
+
+vi.mock("./program/register.subclis.js", () => ({
+  getSubCliEntries,
+  registerSubCliByName,
+}));
+
+import { registerCompletionCli } from "./completion-cli.js";
+
+describe("registerCompletionCli", () => {
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutWriteSpy.mockRestore();
+  });
+
+  it("bootstraps zsh compinit before binding compdef", async () => {
+    const program = new Command();
+    program.name("openclaw");
+    registerCompletionCli(program);
+
+    await program.parseAsync(["completion", "--shell", "zsh"], { from: "user" });
+
+    const output = stdoutWriteSpy.mock.calls
+      .map((call: [unknown, ...unknown[]]) => String(call[0]))
+      .join("");
+    expect(output).toContain("autoload -Uz compinit");
+    expect(output).toContain("compinit -i -C >/dev/null 2>&1");
+    expect(output).toContain(
+      "(( $+functions[compdef] )) && compdef _openclaw_root_completion openclaw",
+    );
+  });
+});

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -401,7 +401,12 @@ _${rootCmd}_root_completion() {
 
 ${generateZshSubcommands(program, rootCmd)}
 
-compdef _${rootCmd}_root_completion ${rootCmd}
+if ! (( $+functions[compdef] )); then
+  autoload -Uz compinit
+  compinit -i -C >/dev/null 2>&1
+fi
+
+(( $+functions[compdef] )) && compdef _${rootCmd}_root_completion ${rootCmd}
 `;
   return script;
 }


### PR DESCRIPTION
## Summary
- bootstrap `compinit` in generated zsh completion scripts when `compdef` is not available yet
- guard the final `compdef` binding so sourcing the script no longer prints `command not found: compdef` on plain zsh setups
- add a focused test that verifies the generated zsh script includes the bootstrap and guarded binding

Closes #28149.

## Testing
- `npm exec --yes pnpm@10.23.0 -- build`
- `npm exec --yes pnpm@10.23.0 -- check`
- `npm exec --yes pnpm@10.23.0 -- test`

## AI Assistance
- AI-assisted
- Fully tested with the repo-standard build/check/test flow above
- I understand the code change: it only affects the generated zsh completion script and leaves other shells unchanged
