### PR TITLE
ci: add dry-run gate to npm release workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Protect the ownership rules themselves.
+/.github/CODEOWNERS @steipete
+
+# Release workflow and its supporting release-path checks.
+/.github/workflows/openclaw-npm-release.yml @openclaw/openclaw-release-managers
+/docs/reference/RELEASING.md @openclaw/openclaw-release-managers
+/scripts/openclaw-npm-publish.sh @openclaw/openclaw-release-managers
+/scripts/openclaw-npm-release-check.ts @openclaw/openclaw-release-managers
+/scripts/release-check.ts @openclaw/openclaw-release-managers

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -129,6 +129,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           RELEASE_MAIN_REF: origin/main
+          RELEASE_SKIP_CALVER_WINDOW: "1"
         run: |
           set -euo pipefail
           RELEASE_SHA=$(git rev-parse HEAD)

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -4,9 +4,15 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish (for example v2026.3.14 or v2026.3.14-beta.1)
+        required: true
+        type: string
 
 concurrency:
-  group: openclaw-npm-release-${{ github.ref }}
+  group: openclaw-npm-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
   cancel-in-progress: false
 
 env:
@@ -15,8 +21,8 @@ env:
   PNPM_VERSION: "10.23.0"
 
 jobs:
-  publish_openclaw_npm:
-    # npm trusted publishing + provenance requires a GitHub-hosted runner.
+  preview_openclaw_npm:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,13 +41,87 @@ jobs:
           install-bun: "false"
           use-sticky-disk: "false"
 
+      - name: Print release plan
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "Release plan for ${RELEASE_TAG}:"
+          echo "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main"
+          echo "pnpm release:openclaw:npm:check"
+          echo "pnpm check"
+          echo "pnpm build"
+          echo "pnpm release:check"
+          bash scripts/openclaw-npm-publish.sh --dry-run
+
       - name: Validate release tag and package metadata
         env:
-          RELEASE_SHA: ${{ github.sha }}
           RELEASE_TAG: ${{ github.ref_name }}
           RELEASE_MAIN_REF: origin/main
         run: |
           set -euo pipefail
+          RELEASE_SHA=$(git rev-parse HEAD)
+          export RELEASE_SHA RELEASE_TAG RELEASE_MAIN_REF
+          # Fetch the full main ref so merge-base ancestry checks keep working
+          # for older tagged commits that are still contained in main.
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          pnpm release:openclaw:npm:check
+
+      - name: Ensure version is not already published
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          if npm view "openclaw@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "openclaw@${PACKAGE_VERSION} is already published on npm."
+            exit 1
+          fi
+
+          echo "Previewing openclaw@${PACKAGE_VERSION}"
+
+      - name: Check
+        run: pnpm check
+
+      - name: Build
+        run: pnpm build
+
+      - name: Verify release contents
+        run: pnpm release:check
+
+      - name: Preview publish command
+        run: bash scripts/openclaw-npm-publish.sh --dry-run
+
+  publish_openclaw_npm:
+    if: github.event_name == 'workflow_dispatch'
+    # npm trusted publishing + provenance requires a GitHub-hosted runner.
+    runs-on: ubuntu-latest
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Validate release tag and package metadata
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_MAIN_REF: origin/main
+        run: |
+          set -euo pipefail
+          RELEASE_SHA=$(git rev-parse HEAD)
+          export RELEASE_SHA RELEASE_TAG RELEASE_MAIN_REF
           # Fetch the full main ref so merge-base ancestry checks keep working
           # for older tagged commits that are still contained in main.
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
@@ -71,15 +151,4 @@ jobs:
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
-            printf '//registry.npmjs.org/:_authToken=%s\n' "$NODE_AUTH_TOKEN" > "$HOME/.npmrc"
-          fi
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-
-          if [[ "$PACKAGE_VERSION" == *-beta.* ]]; then
-            npm publish --access public --tag beta --provenance
-          else
-            npm publish --access public --provenance
-          fi
+        run: bash scripts/openclaw-npm-publish.sh --publish

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -57,7 +56,6 @@ jobs:
           echo "Would run: pnpm check"
           echo "Would run: pnpm build"
           echo "Would run: pnpm release:check"
-          bash scripts/openclaw-npm-publish.sh --dry-run
 
       - name: Validate release tag and package metadata
         env:
@@ -111,6 +109,16 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Validate tag input format
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-beta\.[1-9][0-9]*)?$ ]]; then
+            echo "Invalid release tag format: ${RELEASE_TAG}"
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -161,6 +169,4 @@ jobs:
         run: pnpm release:check
 
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bash scripts/openclaw-npm-publish.sh --publish

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -46,12 +46,17 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          RELEASE_SHA=$(git rev-parse HEAD)
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
           echo "Release plan for ${RELEASE_TAG}:"
-          echo "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main"
-          echo "pnpm release:openclaw:npm:check"
-          echo "pnpm check"
-          echo "pnpm build"
-          echo "pnpm release:check"
+          echo "Resolved release SHA: ${RELEASE_SHA}"
+          echo "Resolved package version: ${PACKAGE_VERSION}"
+          echo "Would run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main"
+          echo "Would run with env: RELEASE_SHA=${RELEASE_SHA} RELEASE_TAG=${RELEASE_TAG} RELEASE_MAIN_REF=origin/main pnpm release:openclaw:npm:check"
+          echo "Would run: npm view openclaw@${PACKAGE_VERSION} version"
+          echo "Would run: pnpm check"
+          echo "Would run: pnpm build"
+          echo "Would run: pnpm release:check"
           bash scripts/openclaw-npm-publish.sh --dry-run
 
       - name: Validate release tag and package metadata
@@ -59,7 +64,7 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
           RELEASE_MAIN_REF: origin/main
         run: |
-          set -euo pipefail
+          set -euxo pipefail
           RELEASE_SHA=$(git rev-parse HEAD)
           export RELEASE_SHA RELEASE_TAG RELEASE_MAIN_REF
           # Fetch the full main ref so merge-base ancestry checks keep working
@@ -69,7 +74,7 @@ jobs:
 
       - name: Ensure version is not already published
         run: |
-          set -euo pipefail
+          set -euxo pipefail
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
 
           if npm view "openclaw@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
@@ -80,13 +85,19 @@ jobs:
           echo "Previewing openclaw@${PACKAGE_VERSION}"
 
       - name: Check
-        run: pnpm check
+        run: |
+          set -euxo pipefail
+          pnpm check
 
       - name: Build
-        run: pnpm build
+        run: |
+          set -euxo pipefail
+          pnpm build
 
       - name: Verify release contents
-        run: pnpm release:check
+        run: |
+          set -euxo pipefail
+          pnpm release:check
 
       - name: Preview publish command
         run: bash scripts/openclaw-npm-publish.sh --dry-run

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -137,7 +137,6 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           RELEASE_MAIN_REF: origin/main
-          RELEASE_SKIP_CALVER_WINDOW: "1"
         run: |
           set -euo pipefail
           RELEASE_SHA=$(git rev-parse HEAD)

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -38,7 +38,7 @@ Current OpenClaw releases use date-based versioning.
   - `latest` = stable
   - `beta` = prerelease/testing
 - Dev is the moving head of `main`, not a normal git-tagged release.
-- The release workflow enforces the current stable/beta tag formats and rejects versions whose CalVer date is more than 2 UTC calendar days away from the release date.
+- The tag-triggered preview run enforces the current stable/beta tag formats and rejects versions whose CalVer date is more than 2 UTC calendar days away from the release date.
 
 Historical note:
 
@@ -98,7 +98,8 @@ Historical note:
 - [ ] Run `OpenClaw NPM Release` manually with the same tag to publish after `npm-release` environment approval.
   - Stable tags publish to npm `latest`.
   - Beta tags publish to npm `beta`.
-  - The workflow rejects tags that do not match `package.json`, are not on `main`, or whose CalVer date is more than 2 UTC calendar days away from the release date.
+  - The preview run rejects tags that do not match `package.json`, are not on `main`, or whose CalVer date is more than 2 UTC calendar days away from the release date.
+  - The manual publish run rechecks tag/package/main alignment, but it does not expire a tag just because approval happens later.
 - [ ] Verify the registry: `npm view openclaw version`, `npm view openclaw dist-tags`, and `npx -y openclaw@X.Y.Z --version` (or `--help`).
 
 ### Troubleshooting (notes from 2.0.0-beta2 release)

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -99,8 +99,7 @@ Historical note:
 - [ ] Run `OpenClaw NPM Release` manually with the same tag to publish after `npm-release` environment approval.
   - Stable tags publish to npm `latest`.
   - Beta tags publish to npm `beta`.
-  - The preview run rejects tags that do not match `package.json`, are not on `main`, or whose CalVer date is more than 2 UTC calendar days away from the release date.
-  - The manual publish run rechecks tag/package/main alignment, but it does not expire a tag just because approval happens later.
+  - Both the preview run and the manual publish run reject tags that do not match `package.json`, are not on `main`, or whose CalVer date is more than 2 UTC calendar days away from the release date.
 - [ ] Verify the registry: `npm view openclaw version`, `npm view openclaw dist-tags`, and `npx -y openclaw@X.Y.Z --version` (or `--help`).
 
 ### Troubleshooting (notes from 2.0.0-beta2 release)

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -94,6 +94,7 @@ Historical note:
 
 - [ ] Confirm git status is clean; commit and push as needed.
 - [ ] Confirm npm trusted publishing is configured for the `openclaw` package.
+- [ ] Do not rely on an `NPM_TOKEN` secret for this workflow; the publish job uses GitHub OIDC trusted publishing.
 - [ ] Push the matching git tag to trigger the preview run in `.github/workflows/openclaw-npm-release.yml`.
 - [ ] Run `OpenClaw NPM Release` manually with the same tag to publish after `npm-release` environment approval.
   - Stable tags publish to npm `latest`.

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -94,7 +94,8 @@ Historical note:
 
 - [ ] Confirm git status is clean; commit and push as needed.
 - [ ] Confirm npm trusted publishing is configured for the `openclaw` package.
-- [ ] Push the matching git tag to trigger `.github/workflows/openclaw-npm-release.yml`.
+- [ ] Push the matching git tag to trigger the preview run in `.github/workflows/openclaw-npm-release.yml`.
+- [ ] Run `OpenClaw NPM Release` manually with the same tag to publish after `npm-release` environment approval.
   - Stable tags publish to npm `latest`.
   - Beta tags publish to npm `beta`.
   - The workflow rejects tags that do not match `package.json`, are not on `main`, or whose CalVer date is more than 2 UTC calendar days away from the release date.

--- a/scripts/openclaw-npm-publish.sh
+++ b/scripts/openclaw-npm-publish.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mode="${1:-}"
+
+if [[ "${mode}" != "--dry-run" && "${mode}" != "--publish" ]]; then
+  echo "usage: bash scripts/openclaw-npm-publish.sh [--dry-run|--publish]" >&2
+  exit 2
+fi
+
+package_version="$(node -p "require('./package.json').version")"
+publish_cmd=(npm publish --access public --provenance)
+
+if [[ "${package_version}" == *-beta.* ]]; then
+  publish_cmd=(npm publish --access public --tag beta --provenance)
+fi
+
+if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
+  if [[ "${mode}" == "--dry-run" ]]; then
+    echo 'Would write npm auth config to $HOME/.npmrc using NODE_AUTH_TOKEN'
+  else
+    printf '//registry.npmjs.org/:_authToken=%s\n' "${NODE_AUTH_TOKEN}" > "${HOME}/.npmrc"
+  fi
+fi
+
+printf 'Publish command:'
+printf ' %q' "${publish_cmd[@]}"
+printf '\n'
+
+if [[ "${mode}" == "--dry-run" ]]; then
+  exit 0
+fi
+
+"${publish_cmd[@]}"

--- a/scripts/openclaw-npm-publish.sh
+++ b/scripts/openclaw-npm-publish.sh
@@ -20,16 +20,7 @@ fi
 
 echo "Resolved package version: ${package_version}"
 echo "Resolved release channel: ${release_channel}"
-
-if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
-  if [[ "${mode}" == "--dry-run" ]]; then
-    echo 'Would write npm auth config to $HOME/.npmrc using NODE_AUTH_TOKEN'
-  else
-    printf '//registry.npmjs.org/:_authToken=%s\n' "${NODE_AUTH_TOKEN}" > "${HOME}/.npmrc"
-  fi
-else
-  echo 'No NODE_AUTH_TOKEN set in this environment'
-fi
+echo "Publish auth: GitHub OIDC trusted publishing"
 
 printf 'Publish command:'
 printf ' %q' "${publish_cmd[@]}"

--- a/scripts/openclaw-npm-publish.sh
+++ b/scripts/openclaw-npm-publish.sh
@@ -11,10 +11,15 @@ fi
 
 package_version="$(node -p "require('./package.json').version")"
 publish_cmd=(npm publish --access public --provenance)
+release_channel="stable"
 
 if [[ "${package_version}" == *-beta.* ]]; then
   publish_cmd=(npm publish --access public --tag beta --provenance)
+  release_channel="beta"
 fi
+
+echo "Resolved package version: ${package_version}"
+echo "Resolved release channel: ${release_channel}"
 
 if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
   if [[ "${mode}" == "--dry-run" ]]; then
@@ -22,6 +27,8 @@ if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
   else
     printf '//registry.npmjs.org/:_authToken=%s\n' "${NODE_AUTH_TOKEN}" > "${HOME}/.npmrc"
   fi
+else
+  echo 'No NODE_AUTH_TOKEN set in this environment'
 fi
 
 printf 'Publish command:'

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -162,13 +162,11 @@ export function collectReleaseTagErrors(params: {
   releaseSha?: string;
   releaseMainRef?: string;
   now?: Date;
-  enforceCalverWindow?: boolean;
 }): string[] {
   const errors: string[] = [];
   const releaseTag = params.releaseTag.trim();
   const packageVersion = params.packageVersion.trim();
   const now = params.now ?? new Date();
-  const enforceCalverWindow = params.enforceCalverWindow ?? true;
 
   const parsedVersion = parseReleaseVersion(packageVersion);
   if (parsedVersion === null) {
@@ -198,7 +196,7 @@ export function collectReleaseTagErrors(params: {
     );
   }
 
-  if (parsedVersion !== null && enforceCalverWindow) {
+  if (parsedVersion !== null) {
     const dayDistance = utcCalendarDayDistance(parsedVersion.date, now);
     if (dayDistance > MAX_CALVER_DISTANCE_DAYS) {
       const nowLabel = now.toISOString().slice(0, 10);
@@ -232,7 +230,6 @@ function loadPackageJson(): PackageJson {
 
 function main(): number {
   const pkg = loadPackageJson();
-  const skipCalverWindow = process.env.RELEASE_SKIP_CALVER_WINDOW === "1";
   const now = new Date();
   const metadataErrors = collectReleasePackageMetadataErrors(pkg);
   const tagErrors = collectReleaseTagErrors({
@@ -241,7 +238,6 @@ function main(): number {
     releaseSha: process.env.RELEASE_SHA,
     releaseMainRef: process.env.RELEASE_MAIN_REF,
     now,
-    enforceCalverWindow: !skipCalverWindow,
   });
   const errors = [...metadataErrors, ...tagErrors];
 
@@ -255,11 +251,7 @@ function main(): number {
   const parsedVersion = parseReleaseVersion(pkg.version ?? "");
   const channel = parsedVersion?.channel ?? "unknown";
   const dayDistance =
-    parsedVersion === null
-      ? "unknown"
-      : skipCalverWindow
-        ? "skipped"
-        : String(utcCalendarDayDistance(parsedVersion.date, now));
+    parsedVersion === null ? "unknown" : String(utcCalendarDayDistance(parsedVersion.date, now));
   console.log(
     `openclaw-npm-release-check: validated ${channel} release ${pkg.version} (${dayDistance} day UTC delta).`,
   );

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -162,11 +162,13 @@ export function collectReleaseTagErrors(params: {
   releaseSha?: string;
   releaseMainRef?: string;
   now?: Date;
+  enforceCalverWindow?: boolean;
 }): string[] {
   const errors: string[] = [];
   const releaseTag = params.releaseTag.trim();
   const packageVersion = params.packageVersion.trim();
   const now = params.now ?? new Date();
+  const enforceCalverWindow = params.enforceCalverWindow ?? true;
 
   const parsedVersion = parseReleaseVersion(packageVersion);
   if (parsedVersion === null) {
@@ -196,7 +198,7 @@ export function collectReleaseTagErrors(params: {
     );
   }
 
-  if (parsedVersion !== null) {
+  if (parsedVersion !== null && enforceCalverWindow) {
     const dayDistance = utcCalendarDayDistance(parsedVersion.date, now);
     if (dayDistance > MAX_CALVER_DISTANCE_DAYS) {
       const nowLabel = now.toISOString().slice(0, 10);
@@ -230,12 +232,16 @@ function loadPackageJson(): PackageJson {
 
 function main(): number {
   const pkg = loadPackageJson();
+  const skipCalverWindow = process.env.RELEASE_SKIP_CALVER_WINDOW === "1";
+  const now = new Date();
   const metadataErrors = collectReleasePackageMetadataErrors(pkg);
   const tagErrors = collectReleaseTagErrors({
     packageVersion: pkg.version ?? "",
     releaseTag: process.env.RELEASE_TAG ?? "",
     releaseSha: process.env.RELEASE_SHA,
     releaseMainRef: process.env.RELEASE_MAIN_REF,
+    now,
+    enforceCalverWindow: !skipCalverWindow,
   });
   const errors = [...metadataErrors, ...tagErrors];
 
@@ -251,7 +257,9 @@ function main(): number {
   const dayDistance =
     parsedVersion === null
       ? "unknown"
-      : String(utcCalendarDayDistance(parsedVersion.date, new Date()));
+      : skipCalverWindow
+        ? "skipped"
+        : String(utcCalendarDayDistance(parsedVersion.date, now));
   console.log(
     `openclaw-npm-release-check: validated ${channel} release ${pkg.version} (${dayDistance} day UTC delta).`,
   );

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -66,6 +66,17 @@ describe("collectReleaseTagErrors", () => {
     ).toContainEqual(expect.stringContaining("must be within 2 days"));
   });
 
+  it("allows manual publish validation to skip the CalVer freshness window", () => {
+    expect(
+      collectReleaseTagErrors({
+        packageVersion: "2026.3.10",
+        releaseTag: "v2026.3.10",
+        now: new Date("2026-03-20T00:00:00Z"),
+        enforceCalverWindow: false,
+      }),
+    ).toEqual([]);
+  });
+
   it("rejects tags that do not match the current release format", () => {
     expect(
       collectReleaseTagErrors({

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -66,17 +66,6 @@ describe("collectReleaseTagErrors", () => {
     ).toContainEqual(expect.stringContaining("must be within 2 days"));
   });
 
-  it("allows manual publish validation to skip the CalVer freshness window", () => {
-    expect(
-      collectReleaseTagErrors({
-        packageVersion: "2026.3.10",
-        releaseTag: "v2026.3.10",
-        now: new Date("2026-03-20T00:00:00Z"),
-        enforceCalverWindow: false,
-      }),
-    ).toEqual([]);
-  });
-
   it("rejects tags that do not match the current release format", () => {
     expect(
       collectReleaseTagErrors({


### PR DESCRIPTION
## TL;DR
I wanna convert this to a dry run. In the first run, instead of publishing, it should just show the operations it will do, fully with all arguments.

## Summary
- split the npm release workflow into tag-push preview and manual publish paths
- gate the real publish job behind the `npm-release` environment
- add a small helper script so preview and publish use the same computed `npm publish` command

## Review focus
- whether the manual dispatch path is the right approval point for real publishes
- whether the preview output is explicit enough for release operators
- whether checking out `refs/tags/<input>` is the right publish target

## Test plan
- [x] `bash -n scripts/openclaw-npm-publish.sh`
- [x] `bash scripts/openclaw-npm-publish.sh --dry-run`
- [ ] Push a `v*` tag and confirm the workflow previews without publishing
- [ ] Run the workflow manually with a release tag and confirm `npm-release` approval is required before publish
