### PR TITLE
docs: Fix bootstrap files list - add missing HEARTBEAT.md and MEMORY.md

### DIFF
--- a/docs/start/bootstrapping.md
+++ b/docs/start/bootstrapping.md
@@ -19,7 +19,7 @@ for the first time.
 On the first agent run, OpenClaw bootstraps the workspace (default
 `~/.openclaw/workspace`):
 
-- Seeds bootstrap files in order: `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, and `MEMORY.md`.
+- Seeds bootstrap files in order: `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, and (when present) `MEMORY.md`.
 - Runs a short Q&A ritual (one question at a time).
 - Writes identity + preferences to `IDENTITY.md`, `USER.md`, `SOUL.md`.
 - Removes `BOOTSTRAP.md` when finished so it only runs once.

--- a/docs/start/bootstrapping.md
+++ b/docs/start/bootstrapping.md
@@ -19,7 +19,7 @@ for the first time.
 On the first agent run, OpenClaw bootstraps the workspace (default
 `~/.openclaw/workspace`):
 
-- Seeds `AGENTS.md`, `BOOTSTRAP.md`, `IDENTITY.md`, `USER.md`.
+- Seeds bootstrap files in order: `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, and `MEMORY.md`.
 - Runs a short Q&A ritual (one question at a time).
 - Writes identity + preferences to `IDENTITY.md`, `USER.md`, `SOUL.md`.
 - Removes `BOOTSTRAP.md` when finished so it only runs once.


### PR DESCRIPTION
Fixes #7928

**This PR is AI-assisted.** 🤖

- **Degree of testing:** Documentation-only change, verified against source code (workspace.js → loadWorkspaceBootstrapFiles())
- **Understanding:** Confirmed the 8 bootstrap files and their injection order by examining the source

**Change:**
Documentation listed only 4 bootstrap files, but source code loads 8 files in injection order.

**Updated list:**
- AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md
- USER.md, HEARTBEAT.md, BOOTSTRAP.md, MEMORY.md

This matches the actual injection order and includes the 2 previously undocumented files (HEARTBEAT.md and MEMORY.md).