### PR TITLE
fix(gateway): preserve device identity for loopback probe

### DIFF
--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -40,7 +40,6 @@ export async function probeGateway(opts: {
   let connectError: string | null = null;
   let close: GatewayProbeClose | null = null;
 
-
   return await new Promise<GatewayProbeResult>((resolve) => {
     let settled = false;
     const settle = (result: Omit<GatewayProbeResult, "url">) => {

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -4,7 +4,6 @@ import type { SystemPresence } from "../infra/system-presence.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
 import { READ_SCOPE } from "./method-scopes.js";
-import { isLoopbackHost } from "./net.js";
 
 export type GatewayProbeAuth = {
   token?: string;
@@ -41,13 +40,7 @@ export async function probeGateway(opts: {
   let connectError: string | null = null;
   let close: GatewayProbeClose | null = null;
 
-  const disableDeviceIdentity = (() => {
-    try {
-      return isLoopbackHost(new URL(opts.url).hostname);
-    } catch {
-      return false;
-    }
-  })();
+  const disableDeviceIdentity = false;
 
   return await new Promise<GatewayProbeResult>((resolve) => {
     let settled = false;

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -40,7 +40,6 @@ export async function probeGateway(opts: {
   let connectError: string | null = null;
   let close: GatewayProbeClose | null = null;
 
-  const disableDeviceIdentity = false;
 
   return await new Promise<GatewayProbeResult>((resolve) => {
     let settled = false;
@@ -63,7 +62,7 @@ export async function probeGateway(opts: {
       clientVersion: "dev",
       mode: GATEWAY_CLIENT_MODES.PROBE,
       instanceId,
-      deviceIdentity: disableDeviceIdentity ? null : undefined,
+      deviceIdentity: undefined,
       onConnectError: (err) => {
         connectError = formatErrorMessage(err);
       },


### PR DESCRIPTION
## Summary

Loopback probes forced `deviceIdentity: null`, causing the gateway to strip requested scopes (including `operator.read`) from the probe connection. This made `openclaw status`, `openclaw gateway probe`, and `openclaw gateway health` falsely report `missing scope: operator.read` even when the CLI device was properly paired.

## Root Cause

In `src/gateway/probe.ts`, the probe explicitly disabled device identity for loopback connections:

```ts
const disableDeviceIdentity = (() => {
  try {
    return isLoopbackHost(new URL(opts.url).hostname);
  } catch {
    return false;
  }
})();
// ...
deviceIdentity: disableDeviceIdentity ? null : undefined,
```

On the server side, unbound connections have their requested scopes cleared during the WS handshake. The probe connects but its `operator.read` scope is stripped before detail RPC runs.

## Fix

Remove the loopback device identity override — loopback probes should use normal device identity just like remote probes.

Fixes #46014