### PR TITLE
CLI: shorten secrets plan output paths

### DIFF
--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import os from "node:os";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "./test-runtime-capture.js";
@@ -154,6 +156,41 @@ describe("secrets CLI", () => {
       }),
     );
     expect(runtimeLogs.at(-1)).toContain("Secrets applied");
+  });
+
+  it("shortens planOut paths in configure output", async () => {
+    const home = os.homedir();
+    const planOut = `${home}/secrets-plan.json`;
+    runSecretsConfigureInteractive.mockResolvedValue({
+      plan: {
+        version: 1,
+        protocolVersion: 1,
+        generatedAt: "2026-02-26T00:00:00.000Z",
+        generatedBy: "openclaw secrets configure",
+        targets: [],
+      },
+      preflight: {
+        mode: "dry-run",
+        changed: true,
+        changedFiles: [`${home}/.openclaw/openclaw.json`],
+        warningCount: 0,
+        warnings: [],
+      },
+    });
+    confirm.mockResolvedValue(false);
+
+    try {
+      await createProgram().parseAsync(["secrets", "configure", "--plan-out", planOut], {
+        from: "user",
+      });
+
+      expect(runtimeLogs.some((line) => line.includes("Plan written to ~/secrets-plan.json"))).toBe(
+        true,
+      );
+      expect(runtimeLogs.some((line) => line.includes(planOut))).toBe(false);
+    } finally {
+      fs.rmSync(planOut, { force: true });
+    }
   });
 
   it("forwards --agent to secrets configure", async () => {

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -9,6 +9,7 @@ import { runSecretsConfigureInteractive } from "../secrets/configure.js";
 import { isSecretsApplyPlan, type SecretsApplyPlan } from "../secrets/plan.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
+import { shortenHomePath } from "../utils.js";
 import { addGatewayClientOptions, callGatewayFromCli, type GatewayRpcOpts } from "./gateway-rpc.js";
 
 type SecretsReloadOptions = GatewayRpcOpts & { json?: boolean };
@@ -166,7 +167,7 @@ export function registerSecretsCli(program: Command) {
             `Plan: targets=${configured.plan.targets.length}, providerUpserts=${providerUpserts}, providerDeletes=${providerDeletes}.`,
           );
           if (opts.planOut) {
-            defaultRuntime.log(`Plan written to ${opts.planOut}`);
+            defaultRuntime.log(`Plan written to ${shortenHomePath(opts.planOut)}`);
           }
         }
 


### PR DESCRIPTION
## Summary
- shorten the `--plan-out` path shown by `openclaw secrets configure` in human-readable output
- keep JSON output unchanged while aligning the terminal summary with other CLI path formatting
- add a CLI regression test that covers a home-directory plan output file

## Testing
- pnpm test src/cli/secrets-cli.test.ts
- pnpm exec oxfmt --check src/cli/secrets-cli.ts src/cli/secrets-cli.test.ts
- pnpm build
