### PR TITLE
fix(tui): honor active Gateway runtime port in TUI connection (closes #42461)

### DIFF
--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -2,15 +2,17 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayServiceCommandConfig } from "../daemon/service-types.js";
 import {
   loadConfigMock as loadConfig,
   resolveGatewayPortMock as resolveGatewayPort,
 } from "../gateway/gateway-connection.test-mocks.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 
-const readCommandMock = vi.fn(async () => null);
+const readCommandMock = vi.fn<() => Promise<GatewayServiceCommandConfig | null>>(async () => null);
+const readRuntimeMock = vi.fn(async () => ({ status: "running" as const }));
 vi.mock("../daemon/service.js", () => ({
-  resolveGatewayService: () => ({ readCommand: readCommandMock }),
+  resolveGatewayService: () => ({ readCommand: readCommandMock, readRuntime: readRuntimeMock }),
 }));
 
 const { resolveGatewayConnection } = await import("./gateway-chat.js");

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -1,12 +1,17 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   loadConfigMock as loadConfig,
   resolveGatewayPortMock as resolveGatewayPort,
 } from "../gateway/gateway-connection.test-mocks.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
+
+const readCommandMock = vi.fn(async () => null);
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => ({ readCommand: readCommandMock }),
+}));
 
 const { resolveGatewayConnection } = await import("./gateway-chat.js");
 
@@ -88,14 +93,17 @@ describe("resolveGatewayConnection", () => {
       "OPENCLAW_GATEWAY_URL",
       "OPENCLAW_GATEWAY_TOKEN",
       "OPENCLAW_GATEWAY_PASSWORD",
+      "OPENCLAW_GATEWAY_PORT",
       "CLAWDBOT_GATEWAY_URL",
     ]);
     loadConfig.mockClear();
     resolveGatewayPort.mockClear();
     resolveGatewayPort.mockReturnValue(18789);
+    readCommandMock.mockReset().mockResolvedValue(null);
     delete process.env.OPENCLAW_GATEWAY_URL;
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
     delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+    delete process.env.OPENCLAW_GATEWAY_PORT;
     delete process.env.CLAWDBOT_GATEWAY_URL;
   });
 
@@ -350,5 +358,50 @@ describe("resolveGatewayConnection", () => {
         expect(await fileExists(passwordMarker)).toBe(true);
       },
     );
+  });
+
+  it("applies daemon service runtime port when OPENCLAW_GATEWAY_PORT is unset", async () => {
+    readCommandMock.mockResolvedValue({
+      programArguments: [],
+      environment: { OPENCLAW_GATEWAY_PORT: "48789" },
+    });
+    resolveGatewayPort.mockImplementation(() => {
+      const raw = process.env.OPENCLAW_GATEWAY_PORT;
+      if (raw) {
+        const parsed = Number.parseInt(raw, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          return parsed;
+        }
+      }
+      return 18789;
+    });
+    loadConfig.mockReturnValue({ gateway: { auth: { mode: "none" } } });
+
+    const result = await resolveGatewayConnection({});
+    expect(result.url).toContain("48789");
+    expect(process.env.OPENCLAW_GATEWAY_PORT).toBe("48789");
+  });
+
+  it("does not override OPENCLAW_GATEWAY_PORT when already set", async () => {
+    process.env.OPENCLAW_GATEWAY_PORT = "29000";
+    readCommandMock.mockResolvedValue({
+      programArguments: [],
+      environment: { OPENCLAW_GATEWAY_PORT: "48789" },
+    });
+    resolveGatewayPort.mockImplementation(() => {
+      const raw = process.env.OPENCLAW_GATEWAY_PORT;
+      if (raw) {
+        const parsed = Number.parseInt(raw, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          return parsed;
+        }
+      }
+      return 18789;
+    });
+    loadConfig.mockReturnValue({ gateway: { auth: { mode: "none" } } });
+
+    const result = await resolveGatewayConnection({});
+    expect(result.url).toContain("29000");
+    expect(process.env.OPENCLAW_GATEWAY_PORT).toBe("29000");
   });
 });

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -271,6 +271,10 @@ export class GatewayChatClient {
  * Best-effort: read the daemon service definition and apply
  * OPENCLAW_GATEWAY_PORT to the current process so that
  * resolveGatewayPort() picks up the actual runtime port.
+ *
+ * Only applies the override when the daemon is confirmed running,
+ * since readCommand() reads persisted service definitions which may
+ * be stale or belong to a stopped daemon.
  */
 async function applyGatewayRuntimePortEnvOverride(): Promise<void> {
   if (process.env.OPENCLAW_GATEWAY_PORT) {
@@ -279,6 +283,10 @@ async function applyGatewayRuntimePortEnvOverride(): Promise<void> {
   try {
     const { resolveGatewayService } = await import("../daemon/service.js");
     const service = resolveGatewayService();
+    const runtime = await service.readRuntime(process.env);
+    if (runtime?.status !== "running") {
+      return;
+    }
     const command = await service.readCommand(process.env);
     const port = command?.environment?.OPENCLAW_GATEWAY_PORT;
     if (port) {

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -267,9 +267,32 @@ export class GatewayChatClient {
   }
 }
 
+/**
+ * Best-effort: read the daemon service definition and apply
+ * OPENCLAW_GATEWAY_PORT to the current process so that
+ * resolveGatewayPort() picks up the actual runtime port.
+ */
+async function applyGatewayRuntimePortEnvOverride(): Promise<void> {
+  if (process.env.OPENCLAW_GATEWAY_PORT) {
+    return;
+  }
+  try {
+    const { resolveGatewayService } = await import("../daemon/service.js");
+    const service = resolveGatewayService();
+    const command = await service.readCommand(process.env);
+    const port = command?.environment?.OPENCLAW_GATEWAY_PORT;
+    if (port) {
+      process.env.OPENCLAW_GATEWAY_PORT = port;
+    }
+  } catch {
+    // Daemon may not be installed or platform unsupported — fall through.
+  }
+}
+
 export async function resolveGatewayConnection(
   opts: GatewayConnectionOptions,
 ): Promise<ResolvedGatewayConnection> {
+  await applyGatewayRuntimePortEnvOverride();
   const config = loadConfig();
   const env = process.env;
   const gatewayAuthMode = config.gateway?.auth?.mode;


### PR DESCRIPTION
## Summary
- Problem: `openclaw tui` ignores the active Gateway runtime port and always connects to the default port 18789, even when the Gateway is running on a custom port (e.g., 48789).
- Why it matters: Users must manually pass `--url ws://127.0.0.1:48789` every time, which is inconsistent with other Gateway-aware CLI flows.
- What changed: Added `applyGatewayRuntimePortEnvOverride()` at the start of `resolveGatewayConnection()` in `src/tui/gateway-chat.ts`. This reads the daemon service definition (launchd plist / systemd unit / schtask) and applies `OPENCLAW_GATEWAY_PORT` to `process.env` so that `resolveGatewayPort()` picks up the actual runtime port. Also added regression tests.
- What did NOT change (scope boundary): No changes to the Gateway server, daemon install, or any other CLI command.

## Change Type
- [x] Bug fix

## Scope
- [x] CLI / TUI

## Linked Issue/PR
- Closes #42461

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Start Gateway on custom port: `openclaw gateway --port 48789`
2. Run `openclaw tui`
### Expected
- TUI connects to `ws://127.0.0.1:48789`
### Actual (before fix)
- TUI targets `ws://127.0.0.1:18789`

## Evidence
- [x] Failing test/log before + passing after
- pnpm build passes
- Regression tests added for runtime port override and no-clobber behavior

## Human Verification
- Verified scenarios: pnpm build passes, new tests cover both port override and no-clobber cases
- Edge cases checked: env already set (no-clobber), daemon not installed (silent fallthrough), unsupported platform (catch block)
- What you did NOT verify: runtime end-to-end testing with actual service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: `src/tui/gateway-chat.ts`, `src/tui/gateway-chat.test.ts`

## Risks and Mitigations
The daemon service read is best-effort (wrapped in try/catch). If it fails for any reason, the TUI falls back to the previous behavior (config port or default 18789).

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*