### PR TITLE
fix: preserve supportsUsageInStreaming for Azure OpenAI endpoints (closes #38784)

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -212,6 +212,31 @@ describe("normalizeModelCompat", () => {
       baseUrl: "https://my-deployment.openai.azure.com/openai",
     });
   });
+
+  it("does not force supportsUsageInStreaming off for Azure OpenAI", () => {
+    const model = {
+      ...baseModel(),
+      provider: "azure-openai",
+      baseUrl: "https://my-deployment.openai.azure.com/openai",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model as Model<Api>);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBeUndefined();
+  });
+
+  it("preserves explicit supportsUsageInStreaming on Azure OpenAI", () => {
+    const model = {
+      ...baseModel(),
+      provider: "azure-openai",
+      baseUrl: "https://my-deployment.openai.azure.com/openai",
+      compat: { supportsUsageInStreaming: true },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
+  });
+
   it("forces supportsDeveloperRole off for generic custom openai-completions provider", () => {
     expectSupportsDeveloperRoleForcedOff({
       provider: "custom-cpa",

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -20,6 +20,20 @@ function isOpenAINativeEndpoint(baseUrl: string): boolean {
   }
 }
 
+/**
+ * Returns true for Azure OpenAI endpoints (`*.openai.azure.com`).
+ * Azure supports `stream_options: { include_usage: true }` but does NOT
+ * accept the `developer` message role.
+ */
+function isAzureOpenAIEndpoint(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host.endsWith(".openai.azure.com");
+  } catch {
+    return false;
+  }
+}
+
 function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-messages"> {
   return model.api === "anthropic-messages";
 }
@@ -60,9 +74,24 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const compat = model.compat ?? undefined;
   // When baseUrl is empty the pi-ai library defaults to api.openai.com, so
   // leave compat unchanged and let default native behavior apply.
-  const needsForce = baseUrl ? !isOpenAINativeEndpoint(baseUrl) : false;
-  if (!needsForce) {
+  if (!baseUrl || isOpenAINativeEndpoint(baseUrl)) {
     return model;
+  }
+
+  // Azure OpenAI rejects the `developer` role but fully supports
+  // stream_options.include_usage, so only force supportsDeveloperRole off
+  // and leave supportsUsageInStreaming at its default (true).
+  if (isAzureOpenAIEndpoint(baseUrl)) {
+    const forcedDeveloperRole = compat?.supportsDeveloperRole === true;
+    if (forcedDeveloperRole) {
+      return model;
+    }
+    return {
+      ...model,
+      compat: compat
+        ? { ...compat, supportsDeveloperRole: false }
+        : { supportsDeveloperRole: false },
+    } as typeof model;
   }
 
   // Respect explicit user overrides: if the user has set a compat flag to


### PR DESCRIPTION
## Summary
- **Problem:** `normalizeModelCompat()` forces `supportsUsageInStreaming: false` for all non-`api.openai.com` endpoints, including Azure OpenAI (`*.openai.azure.com`). This prevents `stream_options: { include_usage: true }` from being sent, so Azure never returns usage data in streaming chunks. Result: `/status` shows `Context: 0/128k (0%)`, `totalTokens` is always `undefined`, and `memoryFlush` never triggers.
- **Why it matters:** All Azure OpenAI users with `api: "openai-completions"` are affected. Context tracking and memory flush are silently broken (100% repro).
- **What changed:** Added `isAzureOpenAIEndpoint()` check matching `*.openai.azure.com`. For Azure endpoints, only `supportsDeveloperRole` is forced to `false` (Azure rejects `developer` role); `supportsUsageInStreaming` is left at its default (`true`) since Azure fully supports it. Added 2 test cases.
- **What did NOT change (scope boundary):** Generic non-native endpoint behavior unchanged. OpenAI native endpoint behavior unchanged. User explicit compat overrides still respected.

## Change Type
- [x] Bug fix

## Scope
- [x] Agent / model orchestration

## Linked Issue/PR
- Closes #38784

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure Azure OpenAI provider with `api: "openai-completions"` and `baseUrl` pointing to `*.openai.azure.com`
2. Send a message, run `/status`
### Expected
`/status` shows non-zero Context (e.g., `Context: 17k/128k (13%)`)
### Actual (before fix)
`/status` shows `Context: 0/128k (0%)`

## Evidence
- [x] Failing test/log before + passing after
- `pnpm build` passes
- `pnpm exec vitest run src/agents/model-compat` — 36/36 pass

## Human Verification
- Verified scenarios: pnpm build + tests; Azure endpoint detection; non-Azure generic endpoints unchanged
- Edge cases checked: explicit user compat overrides preserved; empty baseUrl unchanged; malformed URLs handled gracefully
- What you did NOT verify: runtime end-to-end with actual Azure OpenAI deployment

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: src/agents/model-compat.ts, src/agents/model-compat.test.ts

## Risks and Mitigations
None — Azure branch is additive; generic non-native behavior unchanged.

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*