### PR TITLE
Fix Control UI /model provider refs

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -114,8 +114,8 @@ describe("handleSendChat", () => {
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "openai/gpt-5-mini",
     });
-    expect(host.chatModelOverrides.main).toBe("gpt-5-mini");
+    expect(host.chatModelOverrides.main).toBe("openai/gpt-5-mini");
   });
 });

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -238,6 +238,7 @@ describe("executeSlashCommand directives", () => {
           defaults: { model: "default-model" },
           sessions: [
             row("agent:main:main", {
+              modelProvider: "openai",
               model: "gpt-4.1-mini",
             }),
           ],
@@ -262,10 +263,41 @@ describe("executeSlashCommand directives", () => {
     );
 
     expect(result.content).toBe(
-      "**Current model:** `gpt-4.1-mini`\n**Available:** `openai/gpt-4.1-mini`, `openai/gpt-4.1`",
+      "**Current model:** `openai/gpt-4.1-mini`\n**Available:** `openai/gpt-4.1-mini`, `openai/gpt-4.1`",
     );
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
     expect(request).toHaveBeenNthCalledWith(2, "models.list", {});
+  });
+
+  it("filters malformed available entries that are missing a model id", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          defaults: { model: "openai/gpt-4.1-mini" },
+          sessions: [],
+        };
+      }
+      if (method === "models.list") {
+        return {
+          models: [
+            { id: "", provider: "openai" },
+            { id: "gpt-4.1-mini", provider: "openai" },
+          ],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "",
+    );
+
+    expect(result.content).toBe(
+      "**Current model:** `openai/gpt-4.1-mini`\n**Available:** `openai/gpt-4.1-mini`",
+    );
   });
 
   it("expands a unique bare /model id to provider/model before patching", async () => {

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -245,7 +245,10 @@ describe("executeSlashCommand directives", () => {
       }
       if (method === "models.list") {
         return {
-          models: [{ id: "gpt-4.1-mini" }, { id: "gpt-4.1" }],
+          models: [
+            { id: "gpt-4.1-mini", provider: "openai" },
+            { id: "gpt-4.1", provider: "openai" },
+          ],
         };
       }
       throw new Error(`unexpected method: ${method}`);
@@ -259,10 +262,39 @@ describe("executeSlashCommand directives", () => {
     );
 
     expect(result.content).toBe(
-      "**Current model:** `gpt-4.1-mini`\n**Available:** `gpt-4.1-mini`, `gpt-4.1`",
+      "**Current model:** `gpt-4.1-mini`\n**Available:** `openai/gpt-4.1-mini`, `openai/gpt-4.1`",
     );
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
     expect(request).toHaveBeenNthCalledWith(2, "models.list", {});
+  });
+
+  it("expands a unique bare /model id to provider/model before patching", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "models.list") {
+        return {
+          models: [{ id: "gpt-4.1-mini", provider: "openai" }],
+        };
+      }
+      if (method === "sessions.patch") {
+        return { ok: true };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "gpt-4.1-mini",
+    );
+
+    expect(result.content).toBe("Model set to `openai/gpt-4.1-mini`.");
+    expect(result.sessionPatch).toEqual({ model: "openai/gpt-4.1-mini" });
+    expect(request).toHaveBeenNthCalledWith(1, "models.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.patch", {
+      key: "main",
+      model: "openai/gpt-4.1-mini",
+    });
   });
 
   it("resolves the legacy main alias for /usage", async () => {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -42,11 +42,11 @@ export type SlashCommandResult = {
 function formatModelRef(entry: Pick<ModelCatalogEntry, "id" | "provider">): string {
   const id = String(entry.id ?? "").trim();
   const provider = String(entry.provider ?? "").trim();
-  if (!provider) {
+  if (!provider || id.includes("/")) {
     return id;
   }
   if (!id) {
-    return provider;
+    return "";
   }
   return `${provider}/${id}`;
 }
@@ -160,7 +160,10 @@ async function executeModel(
         client.request<{ models: ModelCatalogEntry[] }>("models.list", {}),
       ]);
       const session = resolveCurrentSession(sessions, sessionKey);
-      const model = session?.model || sessions?.defaults?.model || "default";
+      const rawModel = session?.model || sessions?.defaults?.model;
+      const model = rawModel
+        ? formatModelRef({ provider: session?.modelProvider ?? "", id: rawModel })
+        : "default";
       const available =
         models?.models?.map((entry: ModelCatalogEntry) => formatModelRef(entry)).filter(Boolean) ??
         [];

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -39,6 +39,40 @@ export type SlashCommandResult = {
   };
 };
 
+function formatModelRef(entry: Pick<ModelCatalogEntry, "id" | "provider">): string {
+  const id = String(entry.id ?? "").trim();
+  const provider = String(entry.provider ?? "").trim();
+  if (!provider) {
+    return id;
+  }
+  if (!id) {
+    return provider;
+  }
+  return `${provider}/${id}`;
+}
+
+function maybeResolveModelArg(raw: string, catalog: ModelCatalogEntry[]): string {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.includes("/")) {
+    return trimmed;
+  }
+
+  const matches = catalog
+    .filter(
+      (entry) =>
+        String(entry.id ?? "")
+          .trim()
+          .toLowerCase() === trimmed.toLowerCase(),
+    )
+    .map((entry) => formatModelRef(entry))
+    .filter(Boolean);
+  const uniqueMatches = Array.from(new Set(matches.map((match) => match.toLowerCase())));
+  if (uniqueMatches.length !== 1) {
+    return trimmed;
+  }
+  return matches.find((match) => match.toLowerCase() === uniqueMatches[0]) ?? trimmed;
+}
+
 export async function executeSlashCommand(
   client: GatewayBrowserClient,
   sessionKey: string,
@@ -127,7 +161,9 @@ async function executeModel(
       ]);
       const session = resolveCurrentSession(sessions, sessionKey);
       const model = session?.model || sessions?.defaults?.model || "default";
-      const available = models?.models?.map((m: ModelCatalogEntry) => m.id) ?? [];
+      const available =
+        models?.models?.map((entry: ModelCatalogEntry) => formatModelRef(entry)).filter(Boolean) ??
+        [];
       const lines = [`**Current model:** \`${model}\``];
       if (available.length > 0) {
         lines.push(
@@ -144,11 +180,16 @@ async function executeModel(
   }
 
   try {
-    await client.request("sessions.patch", { key: sessionKey, model: args.trim() });
+    let nextModel = args.trim();
+    if (nextModel && !nextModel.includes("/")) {
+      const models = await client.request<{ models: ModelCatalogEntry[] }>("models.list", {});
+      nextModel = maybeResolveModelArg(nextModel, models?.models ?? []);
+    }
+    await client.request("sessions.patch", { key: sessionKey, model: nextModel });
     return {
-      content: `Model set to \`${args.trim()}\`.`,
+      content: `Model set to \`${nextModel}\`.`,
       action: "refresh",
-      sessionPatch: { model: args.trim() },
+      sessionPatch: { model: nextModel },
     };
   } catch (err) {
     return { content: `Failed to set model: ${String(err)}` };

--- a/ui/src/ui/chat/slash-commands.ts
+++ b/ui/src/ui/chat/slash-commands.ts
@@ -65,7 +65,7 @@ export const SLASH_COMMANDS: SlashCommandDef[] = [
   {
     name: "model",
     description: "Show or set model",
-    args: "<name>",
+    args: "<provider/model|id>",
     icon: "brain",
     category: "model",
     executeLocal: true,


### PR DESCRIPTION
## Summary
- show fully qualified `provider/model` refs in the Control UI's bare `/model` response
- expand a unique bare model id to `provider/model` before `sessions.patch`
- align the local slash command hint text with the accepted formats

Closes #46091

## Testing
- `npm exec --yes pnpm@10.23.0 -- --dir ui exec vitest run src/ui/chat/slash-command-executor.node.test.ts --project unit-node`
- `npm exec --yes pnpm@10.23.0 -- vitest run ui/src/ui/app-chat.test.ts`
- `/Users/jamesavery/.openclaw/openclaw-pr-check.sh`