### PR TITLE
fix(directives): preserve code block indentation in whitespace normalization (closes #41699)

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  parseInlineDirectives,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
@@ -55,5 +56,98 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
     };
     const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
     expect(result).toEqual(input);
+  });
+});
+
+describe("parseInlineDirectives – code block indentation", () => {
+  test("preserves indentation inside backtick-fenced code blocks", () => {
+    const input = [
+      "Here is some JSON:",
+      "```json",
+      "{",
+      '  "name": "test",',
+      '  "nested": {',
+      '    "key": "value"',
+      "  }",
+      "}",
+      "```",
+    ].join("\n");
+    const result = parseInlineDirectives(input);
+    expect(result.text).toContain('  "name": "test"');
+    expect(result.text).toContain('    "key": "value"');
+  });
+
+  test("preserves indentation inside tilde-fenced code blocks", () => {
+    const input = ["Some text:", "~~~", "  indented line", "    deeper", "~~~"].join("\n");
+    const result = parseInlineDirectives(input);
+    expect(result.text).toContain("  indented line");
+    expect(result.text).toContain("    deeper");
+  });
+
+  test("normalizes whitespace outside code blocks while preserving inside", () => {
+    const input = [
+      "  Hello   world  ",
+      "```",
+      "  keep  this  spacing",
+      "```",
+      "  After   code  ",
+    ].join("\n");
+    const result = parseInlineDirectives(input);
+    // Outside code blocks: collapsed
+    expect(result.text).toMatch(/^Hello world/);
+    expect(result.text).toMatch(/After code$/);
+    // Inside code block: preserved
+    expect(result.text).toContain("  keep  this  spacing");
+  });
+
+  test("handles multiple code blocks", () => {
+    const input = [
+      "First block:",
+      "```",
+      "  alpha",
+      "```",
+      "Middle text",
+      "```",
+      "    beta",
+      "```",
+    ].join("\n");
+    const result = parseInlineDirectives(input);
+    expect(result.text).toContain("  alpha");
+    expect(result.text).toContain("    beta");
+  });
+
+  test("handles empty code blocks", () => {
+    const input = ["Before", "```", "```", "After"].join("\n");
+    const result = parseInlineDirectives(input);
+    expect(result.text).toContain("```\n```");
+  });
+
+  test("handles code blocks at the very start and end of text", () => {
+    const input = ["```", "  indented", "```"].join("\n");
+    const result = parseInlineDirectives(input);
+    expect(result.text).toContain("  indented");
+  });
+
+  test("strips directives outside code blocks while preserving code block content", () => {
+    const input = [
+      "[[audio_as_voice]] Here is code:",
+      "```python",
+      "def hello():",
+      '    print("hi")',
+      "```",
+      "[[reply_to_current]]",
+    ].join("\n");
+    const result = parseInlineDirectives(input);
+    expect(result.audioAsVoice).toBe(true);
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.text).toContain('    print("hi")');
+    expect(result.text).not.toContain("[[audio_as_voice]]");
+    expect(result.text).not.toContain("[[reply_to_current]]");
+  });
+
+  test("text with no code blocks normalizes as before", () => {
+    const input = "  Hello   world  \n  foo   bar  ";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("Hello world\nfoo bar");
   });
 });

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -18,10 +18,23 @@ const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 
 function normalizeDirectiveWhitespace(text: string): string {
-  return text
-    .replace(/[ \t]+/g, " ")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .trim();
+  // Split on fenced code blocks (must start at beginning of a line).
+  // Matched code blocks land at odd indices in the resulting array.
+  const parts = text.split(/((?:^|\n)```[\s\S]*?\n```(?:\n|$)|(?:^|\n)~~~[\s\S]*?\n~~~(?:\n|$))/g);
+
+  return parts
+    .map((part, i) => {
+      if (i % 2 === 1) {
+        // Code block — preserve as-is
+        return part;
+      }
+      return part
+        .replace(/[ \t]+/g, " ")
+        .replace(/[ \t]*\n[ \t]*/g, "\n")
+        .trim();
+    })
+    .filter(Boolean)
+    .join("\n");
 }
 
 type StripInlineDirectiveTagsResult = {


### PR DESCRIPTION
## Summary
- Problem: `normalizeDirectiveWhitespace()` in `src/utils/directive-tags.ts` strips leading indentation from fenced code blocks in outbound replies, making JSON/Python/YAML unreadable.
- Why it matters: Code blocks lose their formatting when delivered to chat channels, significantly degrading readability of structured content.
- What changed: Modified whitespace normalization to split text at code fence boundaries and only normalize non-code-block segments. Code block content is preserved as-is.
- What did NOT change (scope boundary): Directive tag parsing logic, non-code-block whitespace normalization behavior.

## Change Type
- [x] Bug fix

## Scope
- [x] Agent core

## Linked Issue/PR
- Closes #41699

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Send a message that generates a reply containing a fenced code block with indentation
2. Check the delivered message in the chat channel

### Expected
- Code block indentation preserved

### Actual (before fix)
- All leading whitespace stripped from code block lines

## Evidence
- [x] Failing test/log before + passing after

## Human Verification
- Verified scenarios: pnpm build + pnpm check + pnpm test all passing
- Edge cases checked: nested code blocks, empty code blocks, code blocks at start/end of text, mixed prose and code
- What you did NOT verify: runtime end-to-end testing with actual chat channels

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: src/utils/directive-tags.ts

## Risks and Mitigations
None

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*