### PR TITLE
CLI: shorten node daemon status paths

### DIFF
--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -1,0 +1,52 @@
+import os from "node:os";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeLog = vi.fn();
+const nodeService = {
+  label: "Node",
+  loadedText: "installed",
+  notLoadedText: "not installed",
+  isLoaded: vi.fn(async () => true),
+  readCommand: vi.fn(async () => ({
+    programArguments: ["bun", "node-host"],
+    sourcePath: `${os.homedir()}/Library/LaunchAgents/ai.openclaw.node.plist`,
+    workingDirectory: `${os.homedir()}/.openclaw/node`,
+    environment: {},
+  })),
+  readRuntime: vi.fn(async () => ({ status: "running", pid: 42 })),
+};
+
+vi.mock("../../daemon/node-service.js", () => ({
+  resolveNodeService: () => nodeService,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: runtimeLog,
+  },
+}));
+
+const { runNodeDaemonStatus } = await import("./daemon.js");
+
+describe("runNodeDaemonStatus", () => {
+  beforeEach(() => {
+    runtimeLog.mockReset();
+    nodeService.isLoaded.mockClear();
+    nodeService.readCommand.mockClear();
+    nodeService.readRuntime.mockClear();
+  });
+
+  it("shortens service file and working directory paths in human output", async () => {
+    const home = os.homedir();
+
+    await runNodeDaemonStatus();
+
+    const lines = runtimeLog.mock.calls.map((call) => String(call[0]));
+    expect(lines.join("\n")).toContain("Service file:");
+    expect(lines.join("\n")).toContain("~/Library/LaunchAgents/ai.openclaw.node.plist");
+    expect(lines.join("\n")).not.toContain(`${home}/Library/LaunchAgents/ai.openclaw.node.plist`);
+    expect(lines.join("\n")).toContain("Working dir:");
+    expect(lines.join("\n")).toContain("~/.openclaw/node");
+    expect(lines.join("\n")).not.toContain(`${home}/.openclaw/node`);
+  });
+});

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -18,6 +18,7 @@ import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import { loadNodeHostConfig } from "../../node-host/config.js";
 import { defaultRuntime } from "../../runtime.js";
 import { colorize } from "../../terminal/theme.js";
+import { shortenHomePath } from "../../utils.js";
 import { formatCliCommand } from "../command-format.js";
 import {
   runServiceRestart,
@@ -243,10 +244,14 @@ export async function runNodeDaemonStatus(opts: NodeDaemonStatusOptions = {}) {
     defaultRuntime.log(`${label("Command:")} ${infoText(command.programArguments.join(" "))}`);
   }
   if (command?.sourcePath) {
-    defaultRuntime.log(`${label("Service file:")} ${infoText(command.sourcePath)}`);
+    defaultRuntime.log(
+      `${label("Service file:")} ${infoText(shortenHomePath(command.sourcePath))}`,
+    );
   }
   if (command?.workingDirectory) {
-    defaultRuntime.log(`${label("Working dir:")} ${infoText(command.workingDirectory)}`);
+    defaultRuntime.log(
+      `${label("Working dir:")} ${infoText(shortenHomePath(command.workingDirectory))}`,
+    );
   }
 
   const runtimeLine = formatRuntimeStatus(runtime);


### PR DESCRIPTION
## Summary
- shorten `openclaw node status` service-file and working-directory paths in human-readable output
- keep JSON output unchanged while aligning node daemon status with the rest of the CLI's path formatting
- add a focused status test for home-directory paths

## Testing
- pnpm test src/cli/node-cli/daemon.test.ts
- pnpm exec oxfmt --check src/cli/node-cli/daemon.ts src/cli/node-cli/daemon.test.ts
- pnpm build
