### PR TITLE
fix(feishu): do not treat @all/@_all as bot mention in group chats (closes #37706)

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -453,9 +453,6 @@ function formatSubMessageContent(content: string, contentType: string): string {
 
 function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boolean {
   if (!botOpenId) return false;
-  // Check for @all (@_all in Feishu) — treat as mentioning every bot
-  const rawContent = event.message.content ?? "";
-  if (rawContent.includes("@_all")) return true;
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
     // Rely on Feishu mention IDs; display names can vary by alias/context.


### PR DESCRIPTION
## Summary
- Problem: In Feishu/Lark group chats, `@all`/`@_all` broadcast mentions incorrectly trigger `mentionedBot=true`, causing noisy false-positive replies.
- Why it matters: Bots in busy groups reply to every broadcast notification even when no one intended to talk to the bot.
- What changed: Removed the `@_all` shortcut from `checkBotMentioned()` in `extensions/feishu/src/bot.ts`. The function now relies solely on actual bot mention IDs in the mentions array.
- What did NOT change (scope boundary): No changes to mention-by-name matching, DM handling, or any other mention detection logic.

## Change Type
- [x] Bug fix

## Scope
- [x] Feishu/Lark channel

## Linked Issue/PR
- Closes #37706

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Enable Feishu/Lark channel plugin, add bot to a group chat
2. Send a group-wide `@all` notification without mentioning the bot
### Expected
- Bot does not reply
### Actual (before fix)
- Bot treats `@all` as a bot mention and replies

## Evidence
- [x] Failing test/log before + passing after
- pnpm build passes

## Human Verification
- Verified scenarios: pnpm build passes; `@_all` content no longer triggers `checkBotMentioned()`
- Edge cases checked: real `@bot` mentions still work (relies on `mentions` array matching `botOpenId`)
- What you did NOT verify: runtime end-to-end testing with actual Feishu service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit
- Files/config to restore: `extensions/feishu/src/bot.ts`

## Risks and Mitigations
None — this only removes a false-positive code path.

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*