### PR TITLE
fix(cron): respect delivery.bestEffort when subagents are active (closes #44428)

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -431,7 +431,7 @@ export async function dispatchCronDelivery(
           })
         : undefined;
     const hadDescendants = activeSubagentRuns > 0 || Boolean(completedDescendantReply);
-    if (activeSubagentRuns > 0 || expectedSubagentFollowup) {
+    if (!params.deliveryBestEffort && (activeSubagentRuns > 0 || expectedSubagentFollowup)) {
       let finalReply = await waitForDescendantSubagentSummary({
         sessionKey: params.agentSessionKey,
         initialReply: initialSynthesizedText,
@@ -459,7 +459,7 @@ export async function dispatchCronDelivery(
       synthesizedText = completedDescendantReply;
       deliveryPayloads = [{ text: completedDescendantReply }];
     }
-    if (activeSubagentRuns > 0) {
+    if (!params.deliveryBestEffort && activeSubagentRuns > 0) {
       // Parent orchestration is still in progress; avoid announcing a partial
       // update to the main requester. Mark deliveryAttempted so the timer does
       // not fire a redundant enqueueSystemEvent fallback (double-announce bug).
@@ -473,6 +473,7 @@ export async function dispatchCronDelivery(
       });
     }
     if (
+      !params.deliveryBestEffort &&
       hadDescendants &&
       synthesizedText.trim() === initialSynthesizedText &&
       isLikelyInterimCronMessage(initialSynthesizedText) &&


### PR DESCRIPTION
## Summary
- Problem: Isolated cron with `delivery.bestEffort: true` blocks for full timeout when fire-and-forget subagents are active, recording timeout errors despite job completing successfully.
- Why it matters: `consecutiveErrors` increments continuously and failure alerts fire even though job work completed.
- What changed: Added `deliveryBestEffort` checks to skip descendant wait and delivery suppression in `delivery-dispatch.ts`.
- What did NOT change (scope boundary): Non-bestEffort delivery behavior, subagent execution logic.

## Change Type
- [x] Bug fix

## Scope
- [x] Cron / scheduling

## Linked Issue/PR
- Closes #44428

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Create isolated cron with delivery.bestEffort: true
2. Job spawns fire-and-forget subagents
3. Observe delivery timing
### Expected
- Job delivers immediately after own work completes
### Actual (before fix)
- Blocks for full timeoutMs, records timeout error

## Evidence
- [x] Failing test/log before + passing after

## Human Verification
- Verified scenarios: pnpm build + pnpm check + pnpm test all passing
- Edge cases checked: non-bestEffort still waits for descendants
- What you did NOT verify: runtime end-to-end testing

## Compatibility / Migration
- Backward compatible? Yes
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
- Risk: bestEffort jobs may deliver before subagent summaries are ready. Mitigation: that's the intended behavior of bestEffort.

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*