### PR TITLE
fix(cron): make lane enqueue abort-aware to prevent stale queued runs (closes #43141)

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -265,9 +265,13 @@ export async function runEmbeddedPiAgent(
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
   const globalLane = resolveGlobalLane(params.lane);
   const enqueueGlobal =
-    params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
+    params.enqueue ??
+    ((task, opts) =>
+      enqueueCommandInLane(globalLane, task, { ...opts, abortSignal: params.abortSignal }));
   const enqueueSession =
-    params.enqueue ?? ((task, opts) => enqueueCommandInLane(sessionLane, task, opts));
+    params.enqueue ??
+    ((task, opts) =>
+      enqueueCommandInLane(sessionLane, task, { ...opts, abortSignal: params.abortSignal }));
   const channelHint = params.messageChannel ?? params.messageProvider;
   const resolvedToolResultFormat =
     params.toolResultFormat ??

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -19,6 +19,7 @@ vi.mock("../logging/diagnostic.js", () => ({
 
 import {
   clearCommandLane,
+  CommandLaneAbortError,
   CommandLaneClearedError,
   enqueueCommand,
   enqueueCommandInLane,
@@ -372,5 +373,90 @@ describe("command queue", () => {
       release();
       commandQueueA.resetAllLanes();
     }
+  });
+
+  it("rejects immediately when abortSignal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort("already cancelled");
+    await expect(
+      enqueueCommand(async () => "nope", { abortSignal: controller.signal }),
+    ).rejects.toBeInstanceOf(CommandLaneAbortError);
+  });
+
+  it("rejects queued task when abortSignal fires while waiting", async () => {
+    const { task: blocker, release } = enqueueBlockedMainTask(async () => "first");
+    const controller = new AbortController();
+
+    const second = enqueueCommand(async () => "second", {
+      abortSignal: controller.signal,
+    });
+
+    // second is queued behind blocker
+    expect(getQueueSize()).toBeGreaterThanOrEqual(2);
+
+    controller.abort("timed out");
+
+    await expect(second).rejects.toBeInstanceOf(CommandLaneAbortError);
+
+    // queue entry is removed; only the active blocker remains
+    expect(getQueueSize()).toBe(1);
+
+    release();
+    await expect(blocker).resolves.toBe("first");
+    expect(getQueueSize()).toBe(0);
+  });
+
+  it("does not reject a task that already started when abortSignal fires", async () => {
+    const controller = new AbortController();
+    let resolveTask!: () => void;
+    const taskBlocker = new Promise<void>((r) => {
+      resolveTask = r;
+    });
+
+    // This task starts immediately (nothing ahead of it in the queue)
+    const task = enqueueCommand(
+      async () => {
+        await taskBlocker;
+        return "completed";
+      },
+      { abortSignal: controller.signal },
+    );
+
+    expect(getActiveTaskCount()).toBe(1);
+
+    // Abort fires after task is already active — should have no effect
+    controller.abort("too late");
+
+    resolveTask();
+    await expect(task).resolves.toBe("completed");
+  });
+
+  it("abort removes only the targeted entry from the queue", async () => {
+    const lane = `abort-targeted-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 1);
+
+    const deferred = createDeferred();
+    const first = enqueueCommandInLane(lane, async () => {
+      await deferred.promise;
+      return "first";
+    });
+
+    const controller = new AbortController();
+    const second = enqueueCommandInLane(lane, async () => "second", {
+      abortSignal: controller.signal,
+    });
+    const third = enqueueCommandInLane(lane, async () => "third");
+
+    expect(getQueueSize(lane)).toBeGreaterThanOrEqual(3);
+
+    controller.abort("cancel second");
+    await expect(second).rejects.toBeInstanceOf(CommandLaneAbortError);
+
+    // third should still be queued
+    expect(getQueueSize(lane)).toBeGreaterThanOrEqual(2);
+
+    deferred.resolve();
+    await expect(first).resolves.toBe("first");
+    await expect(third).resolves.toBe("third");
   });
 });

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -24,6 +24,17 @@ export class GatewayDrainingError extends Error {
   }
 }
 
+/**
+ * Dedicated error type thrown when a queued command is rejected because
+ * its abort signal fired while it was waiting in the lane queue.
+ */
+export class CommandLaneAbortError extends Error {
+  constructor(lane?: string) {
+    super(lane ? `Command in lane "${lane}" aborted while queued` : "Command aborted while queued");
+    this.name = "CommandLaneAbortError";
+  }
+}
+
 // Minimal in-process queue to serialize command executions.
 // Default lane ("main") preserves the existing behavior. Additional lanes allow
 // low-risk parallelism (e.g. cron jobs) without interleaving stdin / logs for
@@ -36,6 +47,7 @@ type QueueEntry = {
   enqueuedAt: number;
   warnAfterMs: number;
   onWait?: (waitMs: number, queuedAhead: number) => void;
+  abortCleanup?: () => void;
 };
 
 type LaneState = {
@@ -100,6 +112,7 @@ function drainLane(lane: string) {
     try {
       while (state.activeTaskIds.size < state.maxConcurrent && state.queue.length > 0) {
         const entry = state.queue.shift() as QueueEntry;
+        entry.abortCleanup?.();
         const waitedMs = Date.now() - entry.enqueuedAt;
         if (waitedMs >= entry.warnAfterMs) {
           try {
@@ -171,23 +184,43 @@ export function enqueueCommandInLane<T>(
   opts?: {
     warnAfterMs?: number;
     onWait?: (waitMs: number, queuedAhead: number) => void;
+    abortSignal?: AbortSignal;
   },
 ): Promise<T> {
   if (queueState.gatewayDraining) {
     return Promise.reject(new GatewayDrainingError());
   }
   const cleaned = lane.trim() || CommandLane.Main;
+  if (opts?.abortSignal?.aborted) {
+    return Promise.reject(new CommandLaneAbortError(cleaned));
+  }
   const warnAfterMs = opts?.warnAfterMs ?? 2_000;
   const state = getLaneState(cleaned);
   return new Promise<T>((resolve, reject) => {
-    state.queue.push({
+    const entry: QueueEntry = {
       task: () => task(),
       resolve: (value) => resolve(value as T),
       reject,
       enqueuedAt: Date.now(),
       warnAfterMs,
       onWait: opts?.onWait,
-    });
+    };
+
+    if (opts?.abortSignal) {
+      const signal = opts.abortSignal;
+      const onAbort = () => {
+        const idx = state.queue.indexOf(entry);
+        if (idx !== -1) {
+          state.queue.splice(idx, 1);
+          entry.abortCleanup = undefined;
+          reject(new CommandLaneAbortError(cleaned));
+        }
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      entry.abortCleanup = () => signal.removeEventListener("abort", onAbort);
+    }
+
+    state.queue.push(entry);
     logLaneEnqueue(cleaned, state.queue.length + state.activeTaskIds.size);
     drainLane(cleaned);
   });
@@ -198,6 +231,7 @@ export function enqueueCommand<T>(
   opts?: {
     warnAfterMs?: number;
     onWait?: (waitMs: number, queuedAhead: number) => void;
+    abortSignal?: AbortSignal;
   },
 ): Promise<T> {
   return enqueueCommandInLane(CommandLane.Main, task, opts);
@@ -229,6 +263,7 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
   const removed = state.queue.length;
   const pending = state.queue.splice(0);
   for (const entry of pending) {
+    entry.abortCleanup?.();
     entry.reject(new CommandLaneClearedError(cleaned));
   }
   return removed;


### PR DESCRIPTION
## Summary
- Problem: Queued cron-lane runs spend their full timeout waiting without abort awareness. The caller times out but the queued entry isn't cleaned up.
- Why it matters: Cron jobs time out before reaching model invocation, recording misleading timeout errors.
- What changed: Made lane enqueue abort-aware — checks abort signal while waiting and rejects immediately when fired.
- What did NOT change (scope boundary): Lane execution logic, non-cron queue behavior.

## Change Type
- [x] Bug fix

## Scope
- [x] Cron / scheduling
- [x] Agent core

## Linked Issue/PR
- Closes #43141

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Have one cron-lane task already active
2. Trigger a second isolated cron run
3. Observe the second run waiting in queue
### Expected
- When timeout fires, queued run is immediately cancelled
### Actual (before fix)
- Queued run remains until lane drain

## Evidence
- [x] Failing test/log before + passing after

## Human Verification
- Verified scenarios: pnpm build + pnpm check + pnpm test all passing
- Edge cases checked: normal queue completion unaffected
- What you did NOT verify: runtime end-to-end testing

## Compatibility / Migration
- Backward compatible? Yes
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*