### PR TITLE
fix(cron): respect sandbox.mode config in isolated cron sessions (closes #38663)

### DIFF
--- a/src/agents/sandbox/runtime-status.test.ts
+++ b/src/agents/sandbox/runtime-status.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
+
+describe("resolveSandboxRuntimeStatus", () => {
+  it("returns sandboxed=false for mode='all' when sessionKey is empty", () => {
+    const result = resolveSandboxRuntimeStatus({
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all",
+            },
+          },
+        },
+      } as never,
+      sessionKey: "",
+    });
+    expect(result.mode).toBe("all");
+    expect(result.sandboxed).toBe(false);
+  });
+
+  it("returns sandboxed=true for mode='all' with a non-empty sessionKey", () => {
+    const result = resolveSandboxRuntimeStatus({
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all",
+            },
+          },
+        },
+      } as never,
+      sessionKey: "cron:test-session",
+    });
+    expect(result.mode).toBe("all");
+    expect(result.sandboxed).toBe(true);
+  });
+
+  it("returns sandboxed=false for mode='off' with non-empty sessionKey", () => {
+    const result = resolveSandboxRuntimeStatus({
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "off",
+            },
+          },
+        },
+      } as never,
+      sessionKey: "cron:test-session",
+    });
+    expect(result.mode).toBe("off");
+    expect(result.sandboxed).toBe(false);
+  });
+
+  it("returns sandboxed=false for mode='off' with empty sessionKey", () => {
+    const result = resolveSandboxRuntimeStatus({
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "off",
+            },
+          },
+        },
+      } as never,
+      sessionKey: "",
+    });
+    expect(result.mode).toBe("off");
+    expect(result.sandboxed).toBe(false);
+  });
+
+  it("returns sandboxed=false for missing sandbox config with empty sessionKey", () => {
+    const result = resolveSandboxRuntimeStatus({
+      cfg: {} as never,
+      sessionKey: "",
+    });
+    expect(result.mode).toBe("off");
+    expect(result.sandboxed).toBe(false);
+  });
+
+  it("returns sandboxed=false for mode='all' with undefined sessionKey", () => {
+    const result = resolveSandboxRuntimeStatus({
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all",
+            },
+          },
+        },
+      } as never,
+    });
+    expect(result.mode).toBe("all");
+    expect(result.sandboxed).toBe(false);
+  });
+});

--- a/src/cron/isolated-agent/run.sandbox-activation.test.ts
+++ b/src/cron/isolated-agent/run.sandbox-activation.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runEmbeddedPiAgentMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function makeJob(overrides?: Record<string, unknown>) {
+  return {
+    id: "sandbox-activation-job",
+    name: "Sandbox Activation",
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    payload: { kind: "agentTurn", message: "test" },
+    ...overrides,
+  } as never;
+}
+
+function makeParams(overrides?: Record<string, unknown>) {
+  return {
+    cfg: {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all" as const,
+            workspaceAccess: "rw" as const,
+          },
+        },
+      },
+    },
+    deps: {} as never,
+    job: makeJob(),
+    message: "run sandbox test",
+    sessionKey: "cron:sandbox-activation",
+    ...overrides,
+  };
+}
+
+describe("runCronIsolatedAgentTurn sandbox activation", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+    mockRunCronFallbackPassthrough();
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("passes non-empty sessionKey to runEmbeddedPiAgent so sandbox resolves", async () => {
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+    expect(callArgs.sessionKey).toBeTruthy();
+    expect(callArgs.config?.agents?.defaults?.sandbox?.mode).toBe("all");
+  });
+
+  it("sandbox.mode='off' still passes config through without forcing sandbox", async () => {
+    await runCronIsolatedAgentTurn(
+      makeParams({
+        cfg: {
+          agents: {
+            defaults: {
+              sandbox: {
+                mode: "off" as const,
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+    expect(callArgs.config?.agents?.defaults?.sandbox?.mode).toBe("off");
+  });
+
+  it("passes original sessionKey when sessionKey is undefined", async () => {
+    await runCronIsolatedAgentTurn(makeParams({ sessionKey: undefined }));
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+    // Falls back to cron:<job.id> so the key is always non-empty.
+    expect(callArgs.sessionKey).toBeTruthy();
+    expect(callArgs.config?.agents?.defaults?.sandbox?.mode).toBe("all");
+  });
+});


### PR DESCRIPTION
## Summary
- Problem: Isolated cron jobs execute in Gateway process despite `sandbox.mode="all"` configuration.
- Why it matters: Jobs requiring sandbox dependencies fail when triggered by cron but work when triggered manually.
- What changed: Added sandbox config resolution to the cron isolated agent turn path, passing it to `runEmbeddedPiAgent()`.
- What did NOT change (scope boundary): Normal message path sandbox handling, sandbox runtime logic.

## Change Type
- [x] Bug fix

## Scope
- [x] Cron / scheduling
- [x] Exec / sandbox

## Linked Issue/PR
- Closes #38663

## Security Impact
- New permissions/capabilities? No (existing sandbox config now correctly applied to cron)
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure sandbox.mode: 'all'
2. Create isolated cron job
3. Run job
### Expected
- Job executes in sandbox container
### Actual (before fix)
- Job executes in Gateway process

## Evidence
- [x] Failing test/log before + passing after

## Human Verification
- Verified scenarios: pnpm build + pnpm check + pnpm test all passing
- Edge cases checked: sandbox.mode='off' still skips sandbox
- What you did NOT verify: runtime end-to-end with actual Docker sandbox

## Compatibility / Migration
- Backward compatible? Yes
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*