### PR TITLE
fix(feishu): pass form_value, input_value and other interactive fields in card actions

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -39,6 +39,32 @@ describe("Feishu Card Action Handler", () => {
     );
   });
 
+  it("handles card action with form_value / input_value (structured payload)", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok-form",
+      action: {
+        value: { record_id: "recXXX" },
+        tag: "form_submit",
+        form_value: { expense_reason: "Purchased iPad for testing" },
+        name: "expense_form",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)?.[0];
+    const content = JSON.parse(call?.event?.message?.content ?? "{}");
+    const payload = JSON.parse(content.text);
+    expect(payload).toEqual({
+      action: "form_submit",
+      value: { record_id: "recXXX" },
+      form_value: { expense_reason: "Purchased iPad for testing" },
+      name: "expense_form",
+    });
+  });
+
   it("handles card action with JSON object payload", async () => {
     const event: FeishuCardActionEvent = {
       operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -12,6 +12,11 @@ export type FeishuCardActionEvent = {
   action: {
     value: Record<string, unknown>;
     tag: string;
+    name?: string;
+    option?: string;
+    options?: string[];
+    input_value?: string;
+    form_value?: Record<string, unknown>;
   };
   context: {
     open_id: string;
@@ -19,20 +24,6 @@ export type FeishuCardActionEvent = {
     chat_id: string;
   };
 };
-
-function buildCardActionTextFallback(event: FeishuCardActionEvent): string {
-  const actionValue = event.action.value;
-  if (typeof actionValue === "object" && actionValue !== null) {
-    if ("text" in actionValue && typeof actionValue.text === "string") {
-      return actionValue.text;
-    }
-    if ("command" in actionValue && typeof actionValue.command === "string") {
-      return actionValue.command;
-    }
-    return JSON.stringify(actionValue);
-  }
-  return String(actionValue);
-}
 
 export async function handleFeishuCardAction(params: {
   cfg: ClawdbotConfig;
@@ -44,7 +35,50 @@ export async function handleFeishuCardAction(params: {
   const { cfg, event, runtime, accountId } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   const log = runtime?.log ?? console.log;
-  const content = buildCardActionTextFallback(event);
+
+  // Extract action value — include interactive component fields when present
+  const actionValue = event.action.value;
+  const hasExtraFields =
+    event.action.name !== undefined ||
+    event.action.form_value !== undefined ||
+    event.action.input_value !== undefined ||
+    event.action.option !== undefined ||
+    event.action.options !== undefined;
+
+  let content = "";
+  // Preserve command/text extraction so slash-commands stay parseable by handleFeishuMessage,
+  // even when extra fields like `name` are present.
+  if (
+    typeof actionValue === "object" &&
+    actionValue !== null &&
+    "text" in actionValue &&
+    typeof actionValue.text === "string"
+  ) {
+    content = actionValue.text;
+  } else if (
+    typeof actionValue === "object" &&
+    actionValue !== null &&
+    "command" in actionValue &&
+    typeof actionValue.command === "string"
+  ) {
+    content = actionValue.command;
+  } else if (hasExtraFields) {
+    // Build a structured payload so the agent receives all form/input data
+    const payload: Record<string, unknown> = {
+      action: event.action.tag,
+      value: actionValue,
+    };
+    if (event.action.form_value !== undefined) payload.form_value = event.action.form_value;
+    if (event.action.input_value !== undefined) payload.input_value = event.action.input_value;
+    if (event.action.name !== undefined) payload.name = event.action.name;
+    if (event.action.option !== undefined) payload.option = event.action.option;
+    if (event.action.options !== undefined) payload.options = event.action.options;
+    content = JSON.stringify(payload);
+  } else if (typeof actionValue === "object" && actionValue !== null) {
+    content = JSON.stringify(actionValue);
+  } else {
+    content = String(actionValue);
+  }
 
   // Construct a synthetic message event
   const messageEvent: FeishuMessageEvent = {


### PR DESCRIPTION
## Summary

The Feishu card action handler only extracted `action.value` from card callbacks, silently dropping `form_value`, `input_value`, `option`, `options`, and `name` fields. This made it impossible for agents to receive structured form data from interactive cards (input boxes, dropdowns, form submissions).

## Change Type
Bug fix (non-breaking)

## Scope
`extensions/feishu/src/card-action.ts` — type extension + conditional payload building
`extensions/feishu/src/bot.card-action.test.ts` — new test for form_value scenario

## Linked Issue
Fixes #43202

## Root Cause
`handleFeishuCardAction` only extracted `event.action.value` and passed it as text to the agent. Fields like `form_value` (form submissions), `input_value` (text inputs), `option`/`options` (selectors), and `name` (component identifier) were discarded.

## Fix
1. Extended `FeishuCardActionEvent` type with the missing optional fields
2. Added conditional logic: when any interactive component field is present, build a structured JSON payload containing all relevant fields
3. Simple button clicks with only `value` remain unchanged (backward compatible)

Example structured payload:
```json
{"action":"form_submit","value":{"record_id":"recXXX"},"form_value":{"expense_reason":"Purchased iPad"}}
```

## Security Impact
None — only passes through existing Feishu event fields that were previously discarded.

## Reproduction & Verification
1. Create an interactive card with input fields and form submission
2. Before fix: agent only receives button `value`, form data is dropped
3. After fix: agent receives structured JSON with all form/input data

## Evidence
- All 3 card action tests pass (including new form_value test)
- `pnpm build` passes
- All 363 feishu extension tests pass

## Human Verification
Verified backward compatibility: existing button-only card actions produce identical output.

## Compatibility
Fully backward compatible — the new structured payload only activates when interactive fields are present. Existing button-only flows are unchanged.

## Failure Recovery
If the structured payload format is unexpected, agents can still parse the JSON text. No data loss compared to current behavior (which drops the fields entirely).

## Risks
Low — additive change that only exposes previously-discarded data.

---
> **AI-assisted**: This PR was authored with AI assistance.