### PR TITLE
fix(bluebubbles): preserve underscores inside words in stripMarkdown

### DIFF
--- a/src/line/markdown-to-line.test.ts
+++ b/src/line/markdown-to-line.test.ts
@@ -142,6 +142,14 @@ describe("stripMarkdown", () => {
       ["removes hr ---", "Above\n---\nBelow", "Above\n\nBelow"],
       ["removes hr ***", "Above\n***\nBelow", "Above\n\nBelow"],
       ["strips inline code markers", "Use `const` keyword", "Use const keyword"],
+      // Regression: underscores inside compound words must NOT be stripped (#46185)
+      ["preserves underscores in compound words", "here_is_a_message", "here_is_a_message"],
+      ["still strips real italic _text_", "_italic text_", "italic text"],
+      [
+        "mixed: preserves var underscores and strips italic",
+        "some_var_name and _italic_",
+        "some_var_name and italic",
+      ],
     ] as const;
     for (const [name, input, expected] of cases) {
       expect(stripMarkdown(input), name).toBe(expected);

--- a/src/line/markdown-to-line.ts
+++ b/src/line/markdown-to-line.ts
@@ -350,7 +350,9 @@ export function stripMarkdown(text: string): string {
 
   // Remove italic: *text* or _text_ (but not already processed)
   result = result.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1");
-  result = result.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "$1");
+  // Only strip _text_ when underscores are at word boundaries (whitespace or start/end of string)
+  // This preserves underscores inside compound_words like variable_names
+  result = result.replace(/(?<=\s|^)_(?!_)(.+?)(?<!_)_(?=\s|$|[.,;:!?)])/g, "$1");
 
   // Remove strikethrough: ~~text~~
   result = result.replace(/~~(.+?)~~/g, "$1");


### PR DESCRIPTION
## What

Fix the italic underscore regex in `stripMarkdown` so that underscores inside compound words (e.g. `here_is_a_word`) are preserved, while actual markdown italic formatting (`_italic text_`) is still stripped.

Fixes #46185

## Root Cause

The regex in `src/line/markdown-to-line.ts` matched single underscores anywhere:

```js
// Before — matches underscores inside words
result.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "$1");
```

This caused `here_is_a_message_with_underscores` to become `hereisamessagewithunderscores`.

## Fix

Anchored the regex to word boundaries (whitespace, start/end of string):

```js
// After — only matches _text_ at whitespace/string boundaries
result.replace(/(?<=\s|^)_(?!_)(.+?)(?<!_)_(?=\s|$|[.,;:!?)])/g, "$1");
```

## Tests

3 regression tests added to `src/line/markdown-to-line.test.ts`:
- `here_is_a_message` → `here_is_a_message` (preserved)
- `_italic text_` → `italic text` (still stripped)
- `some_var_name and _italic_` → `some_var_name and italic` (mixed case)

All 319 tests pass.