### PR TITLE
fix: guard against malformed content entries in openai-ws response parsing (closes #35045)

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -687,6 +687,20 @@ describe("buildAssistantMessageFromResponse", () => {
     expect(msg.stopReason).toBe("stop");
   });
 
+  it("skips malformed (null/non-object) content entries without crashing", () => {
+    const response = makeResponseObject("resp_mal", "Valid text");
+    // Inject malformed entries into the content array
+    const msgItem = response.output.find((o) => o.type === "message") as {
+      content: unknown[];
+    };
+    msgItem.content.unshift(null, undefined, 42, "bad");
+    const msg = buildAssistantMessageFromResponse(response, modelInfo);
+    expect(msg.content).toHaveLength(1);
+    const textBlock = msg.content[0] as { type: string; text: string };
+    expect(textBlock.type).toBe("text");
+    expect(textBlock.text).toBe("Valid text");
+  });
+
   it("preserves phase from assistant message output items", () => {
     const response = makeResponseObject("resp_8", "Final answer", undefined, "final_answer");
     const msg = buildAssistantMessageFromResponse(response, modelInfo) as {

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -451,6 +451,9 @@ export function buildAssistantMessageFromResponse(
         assistantPhase = itemPhase;
       }
       for (const part of item.content ?? []) {
+        if (!part || typeof part !== "object") {
+          continue;
+        }
         if (part.type === "output_text" && part.text) {
           content.push({
             type: "text",


### PR DESCRIPTION
## Summary
- Problem: openai-ws response parser crashes on null/malformed content entries
- Why it matters: Process crash aborts request handling
- What changed: Added object guard in buildAssistantMessageFromResponse content loop
- What did NOT change: Behavior for well-formed content entries

## Change Type
- [x] Bug fix

## Scope
- [x] Agent/Model behavior

## Linked Issue/PR
- Closes #35045

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
1. Response with null entries in content array no longer crashes

## Evidence
- [x] pnpm build + pnpm check + pnpm test all passing

## Human Verification
- Verified: build/check/test passing
- Edge cases: null, undefined, non-object entries all skipped
- NOT verified: runtime with actual OpenAI WS connection

## Compatibility / Migration
- Backward compatible? Yes

## Failure Recovery
- How to revert: revert this commit

## Risks and Mitigations
None — strictly defensive guard.

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*