### PR TITLE
fix(doctor): allow --repair to work in non-interactive mode

### DIFF
--- a/src/commands/doctor-prompter.ts
+++ b/src/commands/doctor-prompter.ts
@@ -36,11 +36,11 @@ export function createDoctorPrompter(params: {
 
   const canPrompt = isTty && !yes && !nonInteractive;
   const confirmDefault = async (p: Parameters<typeof confirm>[0]) => {
-    if (nonInteractive) {
-      return false;
-    }
     if (shouldRepair) {
       return true;
+    }
+    if (nonInteractive) {
+      return false;
     }
     if (!canPrompt) {
       return Boolean(p.initialValue ?? false);


### PR DESCRIPTION
## Summary

`confirmDefault` in `doctor-prompter.ts` checked `nonInteractive` before `shouldRepair`, causing `--repair` (or `--fix`) to be completely ineffective when running without a TTY (cron jobs, CI, `--non-interactive` flag). Functions like `maybeRepairLegacyCronStore` use `confirmDefault`, so cron store normalization was silently skipped.

## Change Type
Bug fix (non-breaking)

## Scope
`src/commands/doctor-prompter.ts` — swap two guard clauses

## Linked Issue
Fixes #44185

## Root Cause
```ts
// Before (buggy):
if (nonInteractive) return false;  // ← always hit first
if (shouldRepair) return true;     // ← never reached
```

## Fix
```ts
// After:
if (shouldRepair) return true;     // ← repair takes priority
if (nonInteractive) return false;
```

## Security Impact
None.

## Reproduction & Verification
```bash
# Before: silently skips repairs
openclaw doctor --repair --non-interactive

# After: repairs execute as expected
openclaw doctor --repair --non-interactive
```

## Evidence
- `pnpm build` passes
- 28 doctor tests pass (doctor-cron + doctor-config-flow)

## Human Verification
Logic is a two-line swap; the intent is unambiguous from the issue description.

## Compatibility
Backward compatible — only changes behavior when both `--repair` and non-interactive mode are active (previously broken).

## Failure Recovery
N/A — repair actions are idempotent.

## Risks
None.

---
> **AI-assisted**: This PR was authored with AI assistance.