### PR TITLE
fix(agents): remove unconditional "Tools are disabled" prompt injection in CLI runner

### DIFF
--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -82,8 +82,8 @@ describe("runCliAgent with process supervisor", () => {
       sessionFile: "/tmp/session.jsonl",
       workspaceDir: "/tmp",
       prompt: "Run: node script.mjs",
-      provider: "codex-cli",
-      model: "gpt-5.2-codex",
+      provider: "claude-cli",
+      model: "sonnet",
       timeoutMs: 1_000,
       runId: "run-no-tools-disabled",
       extraSystemPrompt: "You are a helpful assistant.",
@@ -94,12 +94,14 @@ describe("runCliAgent with process supervisor", () => {
       argv?: string[];
       input?: string;
     };
-    // The CLI runner must not inject "Tools are disabled" into the system
-    // prompt passed to CLI backends. CLI backends (e.g., Claude Code CLI)
-    // manage their own native tools; the injected text caused them to
-    // refuse using their own tools. See: openclaw/openclaw#44135
+    // Use claude-cli because it defines systemPromptArg ("--append-system-prompt"),
+    // so the system prompt is serialized into argv. The codex-cli backend lacks
+    // systemPromptArg, meaning the prompt is dropped before reaching argv —
+    // making the assertion vacuous. See: openclaw/openclaw#44135
     const allArgs = (input.argv ?? []).join("\n");
     expect(allArgs).not.toContain("Tools are disabled in this session");
+    // Verify the user-supplied system prompt IS present (proves the arg path works)
+    expect(allArgs).toContain("You are a helpful assistant.");
   });
 
   it("runs CLI through supervisor and returns payload", async () => {

--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -63,6 +63,45 @@ describe("runCliAgent with process supervisor", () => {
     requestHeartbeatNowMock.mockClear();
   });
 
+  it("does not inject hardcoded 'Tools are disabled' text into CLI arguments", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "Run: node script.mjs",
+      provider: "codex-cli",
+      model: "gpt-5.2-codex",
+      timeoutMs: 1_000,
+      runId: "run-no-tools-disabled",
+      extraSystemPrompt: "You are a helpful assistant.",
+    });
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as {
+      argv?: string[];
+      input?: string;
+    };
+    // The CLI runner must not inject "Tools are disabled" into the system
+    // prompt passed to CLI backends. CLI backends (e.g., Claude Code CLI)
+    // manage their own native tools; the injected text caused them to
+    // refuse using their own tools. See: openclaw/openclaw#44135
+    const allArgs = (input.argv ?? []).join("\n");
+    expect(allArgs).not.toContain("Tools are disabled in this session");
+  });
+
   it("runs CLI through supervisor and returns payload", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -97,12 +97,7 @@ export async function runCliAgent(params: {
   const normalizedModel = normalizeCliModel(modelId, backend);
   const modelDisplay = `${params.provider}/${modelId}`;
 
-  const extraSystemPrompt = [
-    params.extraSystemPrompt?.trim(),
-    "Tools are disabled in this session. Do not call tools.",
-  ]
-    .filter(Boolean)
-    .join("\n");
+  const extraSystemPrompt = params.extraSystemPrompt?.trim() ?? "";
 
   const sessionLabel = params.sessionKey ?? params.sessionId;
   const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({


### PR DESCRIPTION
## Summary

- Remove hardcoded `"Tools are disabled in this session. Do not call tools."` text that `runCliAgent()` unconditionally appended to every CLI backend session's `extraSystemPrompt`
- Add regression test verifying the injected text is absent from CLI arguments

## Problem

`runCliAgent()` in `src/agents/cli-runner.ts` builds `extraSystemPrompt` as:

```ts
const extraSystemPrompt = [
  params.extraSystemPrompt?.trim(),
  "Tools are disabled in this session. Do not call tools.",
].filter(Boolean).join("\n");
```

This text was intended to prevent the LLM from calling OpenClaw's embedded API tools (since CLI backends manage their own tools natively, and `tools: []` is already passed). However, CLI agents like Claude Code interpret the injected text as a blanket prohibition on **all** tools, including their own native Bash, Read, Write, etc.

**Impact**: Silent failures across cron jobs, group chats, and DM sessions when using any CLI backend. The agent sees "Tools are disabled" in the system prompt and refuses to execute tools, returning text-only responses. Cron jobs report `lastStatus: "ok"` despite failing to run scripts.

## Root cause analysis

Traced via reverse engineering the minified dist bundles (v2026.3.8 and v2026.3.13):

- `disableTools` param is **not** set to `true` for group/cron sessions anywhere in the codebase
- The only `disableTools: true` is in `llm-task-tool.ts` (LLM-only sub-agents)
- Group chat tool restriction uses a separate `GroupToolPolicy` mechanism
- The problem is purely this prompt text injection in `runCliAgent()`
- The injected text is redundant: CLI backends already receive `tools: []` in `buildSystemPrompt()`, so the LLM has no OpenClaw tools to call regardless

## Fix

```ts
// Before:
const extraSystemPrompt = [
  params.extraSystemPrompt?.trim(),
  "Tools are disabled in this session. Do not call tools.",
].filter(Boolean).join("\n");

// After:
const extraSystemPrompt = params.extraSystemPrompt?.trim() ?? "";
```

## Test plan

- [x] Added regression test: `"does not inject hardcoded 'Tools are disabled' text into CLI arguments"`
- [ ] Existing `cli-runner.test.ts` tests pass (CI)
- [ ] `pnpm check` passes (CI)

## AI disclosure

This PR was authored with AI assistance (Claude Code). The root cause was identified by reverse engineering the minified dist bundles, confirmed against the TypeScript source, and validated against real-world cron session transcripts showing the failure. The fix and test follow existing patterns in `cli-runner.test.ts`.

Closes #44135

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)