### PR TITLE
fix: honor defaults-only heartbeat scope across agents

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -195,7 +195,17 @@ describe("isHeartbeatEnabledForAgent", () => {
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
   });
 
-  it("falls back to default agent when no explicit heartbeat entries", () => {
+  it("disables all agents when heartbeat is not configured anywhere", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
+  });
+
+  it("enables all scoped agents when only defaults heartbeat is configured", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },
@@ -203,7 +213,7 @@ describe("isHeartbeatEnabledForAgent", () => {
       },
     };
     expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
-    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
   });
 });
 

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -61,6 +61,30 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("schedules all known agents when only defaults heartbeat is configured", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "30m" } },
+          list: [{ id: "main" }, { id: "ops" }],
+        },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+
+    expect(runSpy).toHaveBeenCalledTimes(2);
+    expect(runSpy.mock.calls.map((call) => call[0]?.agentId)).toEqual(["main", "ops"]);
+
+    runner.stop();
+  });
+
   it("continues scheduling after runOnce throws an unhandled error", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -80,7 +80,9 @@ describe("startHeartbeatRunner", () => {
     await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
 
     expect(runSpy).toHaveBeenCalledTimes(2);
-    expect(runSpy.mock.calls.map((call) => call[0]?.agentId)).toEqual(["main", "ops"]);
+    expect(runSpy.mock.calls.map((call) => call[0]?.agentId)).toEqual(
+      expect.arrayContaining(["main", "ops"]),
+    );
 
     runner.stop();
   });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -118,6 +118,25 @@ function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   return list.some((entry) => Boolean(entry?.heartbeat));
 }
 
+function hasDefaultHeartbeatConfig(cfg: OpenClawConfig) {
+  return cfg.agents?.defaults?.heartbeat !== undefined;
+}
+
+function resolveHeartbeatScopedAgentIds(cfg: OpenClawConfig): string[] {
+  const ids = new Set<string>();
+  const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
+  if (defaultAgentId) {
+    ids.add(defaultAgentId);
+  }
+  for (const entry of cfg.agents?.list ?? []) {
+    const agentId = normalizeAgentId(entry?.id);
+    if (agentId) {
+      ids.add(agentId);
+    }
+  }
+  return [...ids];
+}
+
 export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string): boolean {
   const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
   const list = cfg.agents?.list ?? [];
@@ -127,7 +146,10 @@ export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string
       (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
     );
   }
-  return resolvedAgentId === resolveDefaultAgentId(cfg);
+  if (hasDefaultHeartbeatConfig(cfg)) {
+    return resolveHeartbeatScopedAgentIds(cfg).includes(resolvedAgentId);
+  }
+  return false;
 }
 
 function resolveHeartbeatConfig(
@@ -204,8 +226,13 @@ function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
       })
       .filter((entry) => entry.agentId);
   }
-  const fallbackId = resolveDefaultAgentId(cfg);
-  return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
+  if (!hasDefaultHeartbeatConfig(cfg)) {
+    return [];
+  }
+  return resolveHeartbeatScopedAgentIds(cfg).map((agentId) => ({
+    agentId,
+    heartbeat: resolveHeartbeatConfig(cfg, agentId),
+  }));
 }
 
 export function resolveHeartbeatIntervalMs(

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -125,14 +125,14 @@ function hasDefaultHeartbeatConfig(cfg: OpenClawConfig) {
 function resolveHeartbeatScopedAgentIds(cfg: OpenClawConfig): string[] {
   const ids = new Set<string>();
   const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
-  if (defaultAgentId) {
-    ids.add(defaultAgentId);
-  }
+  ids.add(defaultAgentId);
   for (const entry of cfg.agents?.list ?? []) {
-    const agentId = normalizeAgentId(entry?.id);
-    if (agentId) {
-      ids.add(agentId);
+    const rawId = entry?.id?.trim();
+    if (!rawId) {
+      continue;
     }
+    const agentId = normalizeAgentId(rawId);
+    ids.add(agentId);
   }
   return [...ids];
 }


### PR DESCRIPTION
## Summary
- disable heartbeat for all agents when heartbeat is not configured anywhere
- apply `agents.defaults.heartbeat` to the full scoped agent set when no per-agent heartbeat entries exist
- keep scheduler coverage focused on membership instead of call order

## Testing
- `./node_modules/.bin/vitest run src/infra/heartbeat-runner*.test.ts`

Closes #41879.
