### PR TITLE
fix: add Matrix to VOICE_BUBBLE_CHANNELS for native TTS voice bubbles (closes #37061)

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -501,7 +501,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 /** Channels that require opus audio and support voice-bubble playback */
-const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp"]);
+const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix"]);
 
 function resolveOutputFormat(channelId?: string | null) {
   if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {


### PR DESCRIPTION
## Summary
Add `"matrix"` to the `VOICE_BUBBLE_CHANNELS` set in `src/tts/tts.ts` so TTS auto-replies on Matrix use Opus format and native MSC3245 voice message bubbles instead of generic MP3 file attachments.

## Change Type
Bug fix

## Scope
- `src/tts/tts.ts` – add `"matrix"` to `VOICE_BUBBLE_CHANNELS`

## Linked Issue
Closes #37061

## Security Impact
None

## Repro
1. Configure `messages.tts.auto: "inbound"` with an OpenAI-compatible TTS provider
2. Send a voice message on Matrix → TTS reply appears as downloadable file (MP3)
3. After fix → TTS reply appears as inline voice bubble (Opus + MSC3245)

## Evidence
- `pnpm build` ✅
- `vitest run src/tts/` – 37 tests pass (2 files)

## Human Verification
`resolveOutputFormat("matrix")` now returns `TELEGRAM_OUTPUT` (Opus, voiceCompatible: true) and the downstream `audioAsVoice` flag is set correctly.

## Compatibility
Backward-compatible – only affects Matrix TTS replies (improves them).

## Failure Recovery
N/A – additive change with no new failure modes.

## Risks
None – Matrix send pipeline already supports `audioAsVoice` and MSC3245 metadata.

*This PR was AI-assisted (fully tested with pnpm build/check/test).*