### PR TITLE
fix(session): canonicalize key in initSessionState before store write

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -30,6 +30,7 @@ import {
 } from "../../config/sessions.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
+import { resolveSessionStoreKey } from "../../gateway/session-utils.js";
 import { resolveConversationIdFromTargets } from "../../infra/outbound/conversation-id.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -294,7 +295,10 @@ export async function initSessionState(params: {
     }
   }
 
-  sessionKey = resolveSessionKey(sessionScope, sessionCtxForState, mainKey);
+  sessionKey = resolveSessionStoreKey({
+    cfg,
+    sessionKey: resolveSessionKey(sessionScope, sessionCtxForState, mainKey),
+  });
   const retiredLegacyMainDelivery = maybeRetireLegacyMainDeliveryRoute({
     sessionCfg,
     sessionKey,


### PR DESCRIPTION
## Summary
Canonicalize the session key in `initSessionState` via `resolveSessionStoreKey()` immediately after `resolveSessionKey()` so that writes and reads use the same canonical form (e.g. `agent:main:settings2` instead of raw `settings2`).

## Change Type
- [x] Bug fix

## Scope
- [x] Core (`src/`)

## Linked Issue/PR
Closes #29683

## Security Impact
- [x] No security implications

## Repro + Verification
- Verified `session.test.ts` (50 tests) all pass
- Build passes

## Evidence
The raw key `settings2` is now canonicalized to `agent:main:settings2` before any store read/write, matching all read paths.

## Human Verification
Send a message, restart gateway, send another — same session is resumed (no orphaned transcript).

## Compatibility / Migration
- Backward compatible — existing canonical keys continue to work
- Sessions created with raw keys before this fix will still be orphaned (one-time)

## Risks and Mitigations
Low risk — single additional function call on session init path.