### PR TITLE
fix: drain system events from main key for per-channel-peer DM sessions

### DIFF
--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -1,5 +1,6 @@
 import { resolveUserTimezone } from "../../agents/date-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveMainSessionKey } from "../../config/sessions.js";
 import { buildChannelSummary } from "../../infra/channel-summary.js";
 import {
   formatUtcTimestamp,
@@ -80,6 +81,14 @@ export async function drainFormattedSystemEvents(params: {
 
   const systemLines: string[] = [];
   const queued = drainSystemEventEntries(params.sessionKey);
+  const mainSessionKey = resolveMainSessionKey(params.cfg);
+  if (mainSessionKey !== params.sessionKey) {
+    // System-triggered events still enqueue against the canonical main session key.
+    // In isolated DM scopes, merge that queue into the active session drain so the
+    // currently active DM session can consume those events on its next turn.
+    queued.push(...drainSystemEventEntries(mainSessionKey));
+  }
+  queued.sort((left, right) => left.ts - right.ts);
   systemLines.push(
     ...queued.flatMap((event) => {
       const compacted = compactSystemEvent(event.text);

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { drainFormattedSystemEvents } from "../auto-reply/reply/session-updates.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { buildAgentSessionKey } from "../routing/resolve-route.js";
 import { isCronSystemEvent } from "./heartbeat-runner.js";
 import {
   drainSystemEventEntries,
@@ -62,6 +63,56 @@ describe("system events (session routing)", () => {
     const discord = await drainFormattedEvents("discord:group:123");
     expect(discord).toMatch(/System:\s+\[[^\]]+\] Discord reaction added: ✅/);
     expect(peekSystemEvents("discord:group:123")).toEqual([]);
+  });
+
+  it("drains canonical main-session events into per-channel-peer DM sessions", async () => {
+    vi.useFakeTimers();
+    try {
+      const scopedCfg = { session: { dmScope: "per-channel-peer" } } as OpenClawConfig;
+      const scopedMainKey = resolveMainSessionKey(scopedCfg);
+      const activeSessionKey = buildAgentSessionKey({
+        agentId: "main",
+        channel: "telegram",
+        peer: { kind: "direct", id: "6534796624" },
+        dmScope: "per-channel-peer",
+      });
+
+      vi.setSystemTime(new Date("2026-03-14T10:00:00Z"));
+      enqueueSystemEvent("Cron wake queued on main session", {
+        sessionKey: scopedMainKey,
+      });
+
+      vi.setSystemTime(new Date("2026-03-14T10:00:05Z"));
+      enqueueSystemEvent("Telegram DM event queued on active session", {
+        sessionKey: activeSessionKey,
+      });
+
+      const result = await drainFormattedSystemEvents({
+        cfg: scopedCfg,
+        sessionKey: activeSessionKey,
+        isMainSession: false,
+        isNewSession: false,
+      });
+
+      expect(result).toBeDefined();
+      expect(result).toContain("Cron wake queued on main session");
+      expect(result).toContain("Telegram DM event queued on active session");
+      expect(result!.indexOf("Cron wake queued on main session")).toBeLessThan(
+        result!.indexOf("Telegram DM event queued on active session"),
+      );
+      expect(peekSystemEvents(scopedMainKey)).toEqual([]);
+      expect(peekSystemEvents(activeSessionKey)).toEqual([]);
+      expect(
+        await drainFormattedSystemEvents({
+          cfg: scopedCfg,
+          sessionKey: activeSessionKey,
+          isMainSession: false,
+          isNewSession: false,
+        }),
+      ).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("requires an explicit session key", () => {


### PR DESCRIPTION
## Problem

When `session.dmScope` is `per-channel-peer`, system events from `openclaw system event --mode now`, cron wake, and `/hooks/wake` are enqueued under the agent's canonical main session key (`agent:<id>:main`). However, the active Telegram/Discord DM session uses a per-channel-peer key like `agent:<id>:telegram:direct:<peer-id>`.

`drainSystemEventEntries()` only drains from the active session's key, so events queued under the main key **are never consumed**. They sit in the queue permanently.

Fixes #42919

## Solution

In `drainFormattedSystemEvents()`, also drain from the agent's main session key when it differs from the active session key. Events from both queues are merged and sorted by timestamp.

This is a receiver-side fix — no changes needed to the enqueue paths (`system-event` handler, cron wake, hooks).

## Changes

- `src/auto-reply/reply/session-updates.ts`: Import `resolveMainSessionKey`, drain from main key when it differs from active session key, sort merged events by timestamp
- `src/infra/system-events.test.ts`: Added test verifying events queued under `agent:main:main` are consumed by a `per-channel-peer` DM session (`agent:main:telegram:direct:<peer-id>`)

## Testing

- All 15 system-events tests pass (including the new per-channel-peer drain test)
- `npx vitest run src/infra/system-events.test.ts` ✅