### PR TITLE
fix: guard against malformed content entries in openai-ws input conversion (closes #35051)

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -613,6 +613,60 @@ describe("convertMessagesToInputItems", () => {
   it("returns empty array for empty messages", () => {
     expect(convertMessagesToInputItems([])).toEqual([]);
   });
+
+  it("skips null entries in user content arrays", () => {
+    const msg = {
+      role: "user",
+      content: [null, { type: "text", text: "hello" }, null, undefined],
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ type: "message", role: "user", content: "hello" });
+  });
+
+  it("skips null entries in assistant content arrays", () => {
+    const msg = {
+      role: "assistant",
+      content: [null, { type: "text", text: "hi" }, undefined],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([msg] as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ type: "message", role: "assistant", content: "hi" });
+  });
+
+  it("handles content array of only null entries without crashing", () => {
+    const userOnlyNulls = {
+      role: "user",
+      content: [null, null],
+      timestamp: 0,
+    };
+    const assistantOnlyNulls = {
+      role: "assistant",
+      content: [null, undefined],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([
+      userOnlyNulls,
+      assistantOnlyNulls,
+    ] as unknown as Parameters<typeof convertMessagesToInputItems>[0]);
+    expect(items).toEqual([]);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -195,6 +195,9 @@ function contentToOpenAIParts(content: unknown, modelOverride?: ReplayModelInfo)
     mimeType?: string;
     source?: unknown;
   }>) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
     if (
       (part.type === "text" || part.type === "input_text" || part.type === "output_text") &&
       typeof part.text === "string"
@@ -343,6 +346,9 @@ export function convertMessagesToInputItems(
           arguments?: unknown;
           thinkingSignature?: unknown;
         }>) {
+          if (!block || typeof block !== "object") {
+            continue;
+          }
           if (block.type === "text" && typeof block.text === "string") {
             const parsedSignature = parseAssistantTextSignature(block.textSignature);
             if (!assistantPhase) {


### PR DESCRIPTION
## Summary
- Problem: openai-ws input conversion crashes on null/malformed content array entries
- Why it matters: Process crash aborts the entire request
- What changed: Added object guards in contentToOpenAIParts and assistant content iteration
- What did NOT change: Behavior for well-formed content entries

## Change Type
- [x] Bug fix

## Scope
- [x] Agent/Model behavior

## Linked Issue/PR
- Closes #35051

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
1. Messages with null entries in content array no longer crash

## Evidence
- [x] pnpm build + pnpm check + pnpm test all passing

## Human Verification
- Verified: build/check/test passing
- Edge cases: null, undefined, non-object entries all skipped
- NOT verified: runtime with actual OpenAI WS connection

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No

## Failure Recovery
- How to revert: revert this commit

## Risks and Mitigations
None — strictly defensive guard, no behavior change for valid inputs.

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*