### PR TITLE
fix(plugins): suppress duplicate warning when origins differ (fixes #46079)

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -137,7 +137,7 @@ afterAll(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id and same origin rank", () => {
+  it("emits duplicate warning for distinct plugins with same id when neither is config origin", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
@@ -148,7 +148,7 @@ describe("loadPluginManifestRegistry", () => {
       createPluginCandidate({
         idHint: "test-plugin",
         rootDir: dirA,
-        origin: "global",
+        origin: "bundled",
       }),
       createPluginCandidate({
         idHint: "test-plugin",
@@ -160,7 +160,7 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
   });
 
-  it("suppresses duplicate warning when candidates have different origin precedence (config vs global)", () => {
+  it("suppresses duplicate warning when config-origin candidate is discovered first", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "feishu", configSchema: { type: "object" } };
@@ -177,6 +177,32 @@ describe("loadPluginManifestRegistry", () => {
         idHint: "feishu",
         rootDir: dirB,
         origin: "global",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    expect(registry.plugins.length).toBe(1);
+    expect(registry.plugins[0]?.origin).toBe("config");
+  });
+
+  it("suppresses duplicate warning and prefers config when lower-precedence candidate is discovered first", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirA,
+        origin: "global",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirB,
+        origin: "config",
       }),
     ];
 

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -210,6 +210,30 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins.length).toBe(2);
   });
 
+  it("warns on config/config duplicates because both paths are user-explicit", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirA,
+        origin: "config",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirB,
+        origin: "config",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(1);
+  });
+
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {
     const realDir = makeTempDir();
     const manifest = { id: "feishu", configSchema: { type: "object" } };

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -182,11 +182,10 @@ describe("loadPluginManifestRegistry", () => {
 
     const registry = loadRegistry(candidates);
     expect(countDuplicateWarnings(registry)).toBe(0);
-    expect(registry.plugins.length).toBe(1);
-    expect(registry.plugins[0]?.origin).toBe("config");
+    expect(registry.plugins.length).toBe(2);
   });
 
-  it("suppresses duplicate warning and prefers config when lower-precedence candidate is discovered first", () => {
+  it("suppresses duplicate warning and emits both records when lower-precedence candidate is discovered first", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "feishu", configSchema: { type: "object" } };
@@ -208,8 +207,7 @@ describe("loadPluginManifestRegistry", () => {
 
     const registry = loadRegistry(candidates);
     expect(countDuplicateWarnings(registry)).toBe(0);
-    expect(registry.plugins.length).toBe(1);
-    expect(registry.plugins[0]?.origin).toBe("config");
+    expect(registry.plugins.length).toBe(2);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -137,7 +137,7 @@ afterAll(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id", () => {
+  it("emits duplicate warning for truly distinct plugins with same id and same origin rank", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
@@ -148,7 +148,7 @@ describe("loadPluginManifestRegistry", () => {
       createPluginCandidate({
         idHint: "test-plugin",
         rootDir: dirA,
-        origin: "bundled",
+        origin: "global",
       }),
       createPluginCandidate({
         idHint: "test-plugin",
@@ -158,6 +158,32 @@ describe("loadPluginManifestRegistry", () => {
     ];
 
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+  });
+
+  it("suppresses duplicate warning when candidates have different origin precedence (config vs global)", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirA,
+        origin: "config",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirB,
+        origin: "global",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    expect(registry.plugins.length).toBe(1);
+    expect(registry.plugins[0]?.origin).toBe("config");
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -221,9 +221,12 @@ export function loadPluginManifestRegistry(params: {
 
       const existingRank = PLUGIN_ORIGIN_RANK[existing.candidate.origin];
       const candidateRank = PLUGIN_ORIGIN_RANK[candidate.origin];
+      const hasConfigOrigin =
+        candidate.origin === "config" || existing.candidate.origin === "config";
 
-      if (samePlugin || existingRank !== candidateRank) {
-        // Either the same physical directory or different origin precedence.
+      if (samePlugin || hasConfigOrigin) {
+        // Either the same physical directory, or one candidate was explicitly
+        // loaded via plugins.load.paths / plugins.installs (origin "config").
         // Silently keep the higher-precedence candidate without warning.
         // This covers the common case where plugins.installs places a plugin
         // into the extensions dir and auto-discovery finds it again with a

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -221,16 +221,10 @@ export function loadPluginManifestRegistry(params: {
 
       const existingRank = PLUGIN_ORIGIN_RANK[existing.candidate.origin];
       const candidateRank = PLUGIN_ORIGIN_RANK[candidate.origin];
-      const hasConfigOrigin =
-        candidate.origin === "config" || existing.candidate.origin === "config";
 
-      if (samePlugin || hasConfigOrigin) {
-        // Either the same physical directory, or one candidate was explicitly
-        // loaded via plugins.load.paths / plugins.installs (origin "config").
-        // Silently keep the higher-precedence candidate without warning.
-        // This covers the common case where plugins.installs places a plugin
-        // into the extensions dir and auto-discovery finds it again with a
-        // different origin (e.g. config vs global).
+      if (samePlugin) {
+        // Same physical directory (possibly via symlink). Silently keep the
+        // higher-precedence candidate and skip the duplicate entirely.
         if (candidateRank < existingRank) {
           records[existing.recordIndex] = buildRecord({
             manifest,
@@ -243,12 +237,23 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
-      });
+
+      const hasConfigOrigin =
+        candidate.origin === "config" || existing.candidate.origin === "config";
+
+      if (!hasConfigOrigin) {
+        // Neither candidate was explicitly loaded via plugins.load.paths or
+        // plugins.installs; this is a genuine duplicate worth warning about.
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        });
+      }
+      // When one candidate has config origin (user-explicit intent), suppress
+      // the warning but still emit both records so the loader can resolve
+      // precedence and mark the lower-priority candidate as overridden.
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -239,7 +239,7 @@ export function loadPluginManifestRegistry(params: {
       }
 
       const hasConfigOrigin =
-        candidate.origin === "config" || existing.candidate.origin === "config";
+        (candidate.origin === "config") !== (existing.candidate.origin === "config");
 
       if (!hasConfigOrigin) {
         // Neither candidate was explicitly loaded via plugins.load.paths or

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -218,10 +218,17 @@ export function loadPluginManifestRegistry(params: {
         const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
         return Boolean(existingReal && candidateReal && existingReal === candidateReal);
       })();
-      if (samePlugin) {
-        // Prefer higher-precedence origins even if candidates are passed in
-        // an unexpected order (config > workspace > global > bundled).
-        if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
+
+      const existingRank = PLUGIN_ORIGIN_RANK[existing.candidate.origin];
+      const candidateRank = PLUGIN_ORIGIN_RANK[candidate.origin];
+
+      if (samePlugin || existingRank !== candidateRank) {
+        // Either the same physical directory or different origin precedence.
+        // Silently keep the higher-precedence candidate without warning.
+        // This covers the common case where plugins.installs places a plugin
+        // into the extensions dir and auto-discovery finds it again with a
+        // different origin (e.g. config vs global).
+        if (candidateRank < existingRank) {
           records[existing.recordIndex] = buildRecord({
             manifest,
             candidate,


### PR DESCRIPTION
When a plugin is discovered from two different paths with different origin
precedence (e.g. config vs global from plugins.installs + auto-scan),
silently prefer the higher-precedence candidate instead of emitting a
misleading 'duplicate plugin id detected' warning.

Only emit the warning when both candidates share the same origin rank,
indicating a genuine conflict.

## Summary

- Problem: When `plugins.entries` configures a plugin and the same plugin exists in `extensions/` via `plugins.installs`, a false "duplicate plugin id detected" warning fires at startup.
- Why it matters: Users cannot suppress this warning through any supported config (`plugins.allow`, `plugins.autoDiscover`), causing confusion and noisy logs.
- What changed: Duplicate detection in `manifest-registry.ts` now silently resolves by origin precedence (config > workspace > global > bundled) when two candidates have different origin ranks. Warning only fires for same-rank collisions.
- What did NOT change (scope boundary): Same-rank duplicate warnings, same-path dedup logic, plugin loading order, and enable/disable resolution are all untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46079

## User-visible / Behavior Changes

- Startup no longer emits "duplicate plugin id detected" warning when the same plugin is discovered from different origins (e.g. `plugins.installs` + auto-scan from `extensions/`).
- Duplicate warnings still fire when two genuinely different plugins share the same id at the same origin rank.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.7.2
- Runtime/container: Node v22+
- Model/provider: N/A
- Integration/channel (if any): Feishu plugin
- Relevant config (redacted):

```json
{
  "plugins": {
    "allow": ["feishu"],
    "entries": { "feishu": { "enabled": true } },
    "installs": { "feishu": {} }
  }
}
```

### Steps

1. Configure `plugins.entries.feishu` with `enabled: true`
2. Have feishu plugin installed in `extensions/` directory via `plugins.installs`
3. Start gateway

### Expected

- No "duplicate plugin id detected" warning

### Actual

- Warning: `plugins.entries.feishu: plugin feishu: duplicate plugin id detected; later plugin may be overridden`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 10 tests in `manifest-registry.test.ts` pass, including new test covering config vs global origin dedup.

## Human Verification (required)

- Verified scenarios: Ran `vitest run src/plugins/manifest-registry.test.ts` — 10/10 pass
- Edge cases checked: Same-rank duplicates still warn; different-rank duplicates silently resolve; same-path dedup unchanged
- What you did **not** verify: Full gateway startup with actual feishu plugin installed

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit
- Files/config to restore: `src/plugins/manifest-registry.ts`
- Known bad symptoms reviewers should watch for: If a genuinely conflicting plugin (same rank, different code) is silently swallowed instead of warned

## Risks and Mitigations

- Risk: Two truly different plugins with the same id at different origin ranks get silently resolved instead of warned.
  - Mitigation: This is the intended behavior — the origin precedence system (config > workspace > global > bundled) exists precisely for this purpose. Same-rank collisions still warn.
