### PR TITLE
fix(discord): add content-based fallback for mention detection

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -404,8 +404,12 @@ export async function preflightDiscordMessage(
     return null;
   }
   const mentionRegexes = buildMentionRegexes(params.cfg, effectiveRoute.agentId);
+  const mentionedByEntity = message.mentionedUsers?.some((user: User) => user.id === botId);
   const explicitlyMentioned = Boolean(
-    botId && message.mentionedUsers?.some((user: User) => user.id === botId),
+    botId &&
+    (mentionedByEntity ||
+      (!message.mentionedUsers?.length &&
+        (message.content?.includes(`<@${botId}>`) || message.content?.includes(`<@!${botId}>`)))),
   );
   const hasAnyMention = Boolean(
     !isDirectMessage &&


### PR DESCRIPTION
## Summary

## Change Type
- [x] Bug fix

## Scope
- [x] Extensions (`extensions/`)

## Linked Issue/PR
Closes #44524

## Security Impact
- [x] No security implications

## Repro + Verification
- `message-handler.preflight.test.ts` (20 tests) all pass, including 2 new fallback tests
- Build passes

## Human Verification
Send a message mentioning the bot in a new Discord thread where mentionedUsers is empty — bot should now respond.

## Compatibility / Migration
Backward compatible — mentionedUsers check still runs first, content fallback is additive.

## Risks and Mitigations
Low risk — fallback only triggers when mentionedUsers misses the bot.