### PR TITLE
fix(gateway): pass TLS fingerprint to GatewayClient in operator-approvals

### DIFF
--- a/src/gateway/operator-approvals-client.ts
+++ b/src/gateway/operator-approvals-client.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { buildGatewayConnectionDetails } from "./call.js";
 import { GatewayClient, type GatewayClientOptions } from "./client.js";
@@ -30,10 +31,26 @@ export async function createOperatorApprovalsGatewayClient(
     urlOverrideSource: gatewayUrlOverrideSource,
   });
 
+  const isRemoteMode = params.config.gateway?.mode === "remote";
+  const remoteUrl =
+    isRemoteMode && typeof params.config.gateway?.remote?.url === "string"
+      ? params.config.gateway.remote.url.trim() || undefined
+      : undefined;
+  const useLocalTls =
+    params.config.gateway?.tls?.enabled === true &&
+    !gatewayUrlOverrideSource &&
+    !remoteUrl &&
+    gatewayUrl.startsWith("wss://");
+  const tlsRuntime = useLocalTls
+    ? await loadGatewayTlsRuntime(params.config.gateway?.tls)
+    : undefined;
+  const tlsFingerprint = tlsRuntime?.enabled ? tlsRuntime.fingerprintSha256 : undefined;
+
   return new GatewayClient({
     url: gatewayUrl,
     token: auth.token,
     password: auth.password,
+    tlsFingerprint,
     clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
     clientDisplayName: params.clientDisplayName,
     mode: GATEWAY_CLIENT_MODES.BACKEND,


### PR DESCRIPTION
## Summary
Resolve the local TLS runtime fingerprint and pass it to GatewayClient in operator-approvals-client.ts when `gateway.tls.enabled` is true and target URL is `wss://`, mirroring the logic from call.ts.

## Change Type
- [x] Bug fix

## Scope
- [x] Core (`src/`)

## Linked Issue/PR
Closes #41740

## Security Impact
- [x] No security implications — uses existing TLS fingerprint resolution

## Repro + Verification
- Build passes

## Human Verification
Configure Discord exec approvals against a local self-signed TLS gateway — should connect without 'self-signed certificate' error.

## Compatibility / Migration
Backward compatible — fingerprint is only resolved when TLS is enabled.

## Risks and Mitigations
Low risk — mirrors existing TLS fingerprint pattern from call.ts.