### PR TITLE
fix(route-reply): recognize plugin channels in isRoutableChannel

### DIFF
--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -12,6 +12,7 @@ import { isSlackInteractiveRepliesEnabled } from "../../../extensions/slack/src/
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
+import { normalizeAnyChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
@@ -209,5 +210,8 @@ export function isRoutableChannel(
   if (!channel || channel === INTERNAL_MESSAGE_CHANNEL) {
     return false;
   }
-  return normalizeChannelId(channel) !== null;
+  // Also recognize plugin-based channels (e.g. DingTalk) that are not in the
+  // built-in CHAT_CHANNEL_ORDER list. normalizeChannelId only validates
+  // built-in channels; normalizeAnyChannelId checks the plugin registry too.
+  return normalizeChannelId(channel) !== null || normalizeAnyChannelId(channel) !== null;
 }


### PR DESCRIPTION
## Summary
Add `normalizeAnyChannelId` as fallback in `isRoutableChannel` to recognize registered plugin channels. Previously only built-in `CHAT_CHANNEL_ORDER` channels were accepted, causing plugin-based channels like DingTalk to silently drop all queued replies.

## Change Type
- [x] Bug fix

## Scope
- [x] Core (`src/`)

## Linked Issue/PR
Closes #40521

## Security Impact
- [x] No security implications

## Repro + Verification
- `route-reply.test.ts` (20 tests) all pass
- Build passes

## Human Verification
Send a message via a plugin channel (e.g. DingTalk) — followup replies should now be delivered instead of silently dropped.

## Compatibility / Migration
Backward compatible — built-in channels still checked first, plugin fallback is additive.

## Risks and Mitigations
Low risk — only widens the set of recognized channels to include registered plugins.