### PR TITLE
fix(attempt): re-run OpenAI transcript sanitizers after contextEngine.assemble()

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -59,6 +59,7 @@ import { createOpenAIWebSocketStreamFn, releaseWsSession } from "../../openai-ws
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
+  downgradeOpenAIReasoningBlocks,
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
@@ -2103,7 +2104,18 @@ export async function runEmbeddedAttempt(
               tokenBudget: params.contextTokenBudget,
             });
             if (assembled.messages !== activeSession.messages) {
-              activeSession.agent.replaceMessages(assembled.messages);
+              // Re-run OpenAI transcript sanitizers on assembled messages.
+              // contextEngine.assemble() may re-introduce call_id/fc_id pairs
+              // that were stripped by sanitizeSessionHistory above.
+              const isOpenAIResponses =
+                params.model.api === "openai-responses" ||
+                params.model.api === "openai-codex-responses";
+              const sanitizedAssembled = isOpenAIResponses
+                ? downgradeOpenAIFunctionCallReasoningPairs(
+                    downgradeOpenAIReasoningBlocks(assembled.messages),
+                  )
+                : assembled.messages;
+              activeSession.agent.replaceMessages(sanitizedAssembled);
             }
             if (assembled.systemPromptAddition) {
               systemPromptText = prependSystemPromptAddition({


### PR DESCRIPTION
## Summary
Re-apply `downgradeOpenAIReasoningBlocks` and `downgradeOpenAIFunctionCallReasoningPairs` after `contextEngine.assemble()` when the model API is openai-responses or openai-codex-responses. This prevents assembled messages from re-introducing call_id|fc_id pairs that OpenAI Responses rejects.

## Change Type
- [x] Bug fix

## Scope
- [x] Core (`src/`)

## Linked Issue/PR
Closes #42794

## Security Impact
- [x] No security implications

## Repro + Verification
- `attempt.test.ts` (64 tests) all pass
- Build passes

## Human Verification
Enable a contextEngine plugin, send messages that trigger function calls, verify no transcript sanitizer bypass errors.

## Compatibility / Migration
Backward compatible — only adds post-assemble sanitization for openai-responses/codex models.

## Risks and Mitigations
Low risk — mirrors existing sanitization logic from sanitizeSessionHistory().