### PR TITLE
ci: move Docker release to GitHub-hosted runners

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,6 +27,7 @@ jobs:
   # DO NOT MOVE IT BACK TO BLACKSMITH WITHOUT RE-VALIDATING TAG BUILDS AND BACKFILLS.
   # Build amd64 images (default + slim share the build stage cache)
   build-amd64:
+    # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04
     permissions:
       packages: write
@@ -104,6 +105,7 @@ jobs:
 
       - name: Build and push amd64 image
         id: build
+        # WARNING: KEEP THE OFFICIAL DOCKER ACTION HERE; DO NOT SWITCH THIS BACK TO BLACKSMITH BLINDLY.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -115,6 +117,7 @@ jobs:
 
       - name: Build and push amd64 slim image
         id: build-slim
+        # WARNING: KEEP THE OFFICIAL DOCKER ACTION HERE; DO NOT SWITCH THIS BACK TO BLACKSMITH BLINDLY.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -128,6 +131,7 @@ jobs:
 
   # Build arm64 images (default + slim share the build stage cache)
   build-arm64:
+    # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04-arm
     permissions:
       packages: write
@@ -205,6 +209,7 @@ jobs:
 
       - name: Build and push arm64 image
         id: build
+        # WARNING: KEEP THE OFFICIAL DOCKER ACTION HERE; DO NOT SWITCH THIS BACK TO BLACKSMITH BLINDLY.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -216,6 +221,7 @@ jobs:
 
       - name: Build and push arm64 slim image
         id: build-slim
+        # WARNING: KEEP THE OFFICIAL DOCKER ACTION HERE; DO NOT SWITCH THIS BACK TO BLACKSMITH BLINDLY.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -229,6 +235,7 @@ jobs:
 
   # Create multi-platform manifests
   create-manifest:
+    # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04
     permissions:
       packages: write

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -23,9 +23,11 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # KEEP THIS WORKFLOW ON GITHUB-HOSTED RUNNERS.
+  # DO NOT MOVE IT BACK TO BLACKSMITH WITHOUT RE-VALIDATING TAG BUILDS AND BACKFILLS.
   # Build amd64 images (default + slim share the build stage cache)
   build-amd64:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
       contents: read
@@ -102,7 +104,7 @@ jobs:
 
       - name: Build and push amd64 image
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
@@ -113,7 +115,7 @@ jobs:
 
       - name: Build and push amd64 slim image
         id: build-slim
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
@@ -126,7 +128,7 @@ jobs:
 
   # Build arm64 images (default + slim share the build stage cache)
   build-arm64:
-    runs-on: blacksmith-16vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     permissions:
       packages: write
       contents: read
@@ -203,7 +205,7 @@ jobs:
 
       - name: Build and push arm64 image
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64
@@ -214,7 +216,7 @@ jobs:
 
       - name: Build and push arm64 slim image
         id: build-slim
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64
@@ -227,7 +229,7 @@ jobs:
 
   # Create multi-platform manifests
   create-manifest:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
## TL;DR
This moves the Docker release workflow off Blacksmith and onto GitHub-hosted runners. It also swaps the build step to the official Docker action and adds an all-caps note in the workflow to keep this release path on GitHub-hosted runners.

## Summary
- switch `docker-release.yml` runner labels from Blacksmith to GitHub-hosted Ubuntu runners
- replace `useblacksmith/build-push-action@v2` with `docker/build-push-action@v6`
- add an explicit warning comment to keep the workflow on GitHub-hosted runners
- address the repeated `v2026.3.13` backfill failures tracked in #46076

## Review focus
- confirm `ubuntu-24.04-arm` is the desired arm64 runner label for this repo
- confirm we want the official Docker build action here rather than the Blacksmith wrapper
- confirm the all-caps workflow note is strong enough to prevent this from drifting back

## Test plan
- [x] inspect the final workflow diff
- [x] `git diff --check`
- [ ] let GitHub Actions validate the updated workflow on the PR
