### PR TITLE
fix(line): preserve underscores inside words in stripMarkdown

### DIFF
--- a/src/line/markdown-to-line.test.ts
+++ b/src/line/markdown-to-line.test.ts
@@ -148,6 +148,18 @@ describe("stripMarkdown", () => {
     }
   });
 
+  it("preserves underscores inside words", () => {
+    expect(stripMarkdown("here_is_a_message")).toBe("here_is_a_message");
+    expect(stripMarkdown("snake_case_var")).toBe("snake_case_var");
+    expect(stripMarkdown("use foo_bar_baz in code")).toBe("use foo_bar_baz in code");
+  });
+
+  it("still strips proper italic _text_", () => {
+    expect(stripMarkdown("This is _italic_ text")).toBe("This is italic text");
+    expect(stripMarkdown("_italic_ at start")).toBe("italic at start");
+    expect(stripMarkdown("end _italic_")).toBe("end italic");
+  });
+
   it("handles complex markdown", () => {
     const input = `# Title
 

--- a/src/line/markdown-to-line.ts
+++ b/src/line/markdown-to-line.ts
@@ -350,7 +350,7 @@ export function stripMarkdown(text: string): string {
 
   // Remove italic: *text* or _text_ (but not already processed)
   result = result.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1");
-  result = result.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "$1");
+  result = result.replace(/(?<!\w)_(?!_)(.+?)(?<!_)_(?!\w)/g, "$1");
 
   // Remove strikethrough: ~~text~~
   result = result.replace(/~~(.+?)~~/g, "$1");


### PR DESCRIPTION
## Summary
- The italic-underscore regex in `stripMarkdown` incorrectly stripped underscores inside snake_case words (e.g. `here_is_a_message` → `herisamessage`).
- Tighten lookbehind/lookahead from `(?<!_)` / `(?!_)` to `(?<!\w)` / `(?!\w)` so only standalone `_italic_` markers are removed.
- Added 3 test cases covering underscore preservation and proper italic stripping.

Fixes #46185

## Test plan
- [x] `pnpm test src/line/markdown-to-line.test.ts` — 18/18 pass
- [x] New tests verify `snake_case_var`, `here_is_a_message` preserved
- [x] Existing italic stripping tests still pass