### PR TITLE
fix(cli): suppress doctor stdout for ACP commands to prevent ndjson pollution

### DIFF
--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -87,11 +87,19 @@ function getCliLogLevel(actionCommand: Command): LogLevel | undefined {
   return typeof logLevel === "string" ? (logLevel as LogLevel) : undefined;
 }
 
-function isJsonOutputMode(commandPath: string[], argv: string[]): boolean {
+/** Commands whose stdout carries structured protocol data (ndjson, JSON)
+ *  and must not be polluted by doctor warnings or other diagnostics. */
+const STDOUT_RESERVED_COMMANDS = new Set(["acp"]);
+
+function shouldSuppressDoctorStdout(commandPath: string[], argv: string[]): boolean {
+  const primary = commandPath[0] ?? "";
+  if (STDOUT_RESERVED_COMMANDS.has(primary)) {
+    return true;
+  }
   if (!hasFlag(argv, "--json")) {
     return false;
   }
-  const key = `${commandPath[0] ?? ""} ${commandPath[1] ?? ""}`.trim();
+  const key = `${primary} ${commandPath[1] ?? ""}`.trim();
   if (JSON_PARSE_ONLY_COMMANDS.has(key)) {
     return false;
   }
@@ -126,7 +134,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (shouldBypassConfigGuard(commandPath)) {
       return;
     }
-    const suppressDoctorStdout = isJsonOutputMode(commandPath, argv);
+    const suppressDoctorStdout = shouldSuppressDoctorStdout(commandPath, argv);
     const { ensureConfigReady } = await loadConfigGuardModule();
     await ensureConfigReady({
       runtime: defaultRuntime,

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -12,7 +12,7 @@ async function prepareRoutedCommand(params: {
   commandPath: string[];
   loadPlugins?: boolean | ((argv: string[]) => boolean);
 }) {
-  const suppressDoctorStdout = hasFlag(params.argv, "--json");
+  const suppressDoctorStdout = hasFlag(params.argv, "--json") || params.commandPath[0] === "acp";
   emitCliBanner(VERSION, { argv: params.argv });
   await ensureConfigReady({
     runtime: defaultRuntime,


### PR DESCRIPTION
## Summary

`openclaw acp client` fails with JSON parse errors because doctor warnings from `loadAndMaybeMigrateDoctorConfig()` are printed to stdout, breaking the ACP SDK's ndjson stream parser.

## Change Type
Bug fix (non-breaking)

## Scope
`src/cli/program/preaction.ts` — added `acp` to stdout-reserved commands
`src/cli/route.ts` — same suppression for the fast-path routing

## Linked Issue
Fixes #39789

## Root Cause
`ensureConfigReady()` only suppressed doctor stdout when `--json` flag was present. The `acp` command uses stdout for ndjson protocol messages but doesn't pass `--json`, so doctor warnings (ASCII art boxes from `note()`) polluted the stream.

## Fix
Added a `STDOUT_RESERVED_COMMANDS` set containing `"acp"`. When the command path starts with a reserved command, `suppressDoctorStdout` is set to `true` — reusing the existing suppression mechanism that redirects stdout to a no-op and sets `OPENCLAW_SUPPRESS_NOTES=1`.

## Security Impact
None.

## Reproduction & Verification
```bash
# Before: JSON parse error from ASCII art
openclaw acp client

# After: clean ndjson stream
openclaw acp client
```

## Evidence
- `pnpm build` passes
- 8 config-guard tests pass

## Human Verification
The suppression mechanism is already battle-tested for `--json` mode; this change only extends the trigger to include `acp` commands.

## Compatibility
Backward compatible — doctor warnings still appear on stderr via `runtime.error()` for config issues after the guard.

## Failure Recovery
If suppression is incorrect, doctor warnings simply don't appear on stdout (still visible via `openclaw doctor`).

## Risks
None — purely additive to the existing suppression mechanism.

---
> **AI-assisted**: This PR was authored with AI assistance.