### PR TITLE
fix(browser): skip shared_worker/service_worker CDP targets gracefully

### DIFF
--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -157,5 +157,20 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         expect.stringContaining("This operation was aborted"),
       );
     });
+
+    it("does not exit on Playwright worker target assertion (#45791)", () => {
+      const err = new Error(
+        'targetInfo: {"type":"shared_worker","url":"https://www.facebook.com/sw.js"}',
+      );
+      err.stack = `Error: targetInfo: {"type":"shared_worker"}
+    at assert (playwright-core/lib/utils/isomorphic/assert.js:1:1)
+    at CRBrowser._onAttachedToTarget (playwright-core/lib/server/chromium/crBrowser.js:147:5)`;
+
+      expectExitCodeFromUnhandled(err, []);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[openclaw] Suppressed Playwright worker target assertion (continuing):",
+        expect.stringContaining("_onAttachedToTarget"),
+      );
+    });
   });
 });

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isAbortError, isTransientNetworkError } from "./unhandled-rejections.js";
+import {
+  isAbortError,
+  isPlaywrightWorkerTargetAssertion,
+  isTransientNetworkError,
+} from "./unhandled-rejections.js";
 
 describe("isAbortError", () => {
   it("returns true for error with name AbortError", () => {
@@ -186,4 +190,67 @@ describe("isTransientNetworkError", () => {
     const error = new AggregateError([new Error("regular error")], "Multiple errors");
     expect(isTransientNetworkError(error)).toBe(false);
   });
+});
+
+describe("isPlaywrightWorkerTargetAssertion", () => {
+  it("returns true for shared_worker assertion with targetInfo in message", () => {
+    const error = new Error(
+      'targetInfo: {"type":"shared_worker","url":"https://www.facebook.com/sw.js"}',
+    );
+    error.stack = `Error: targetInfo: ...
+    at assert (playwright-core/lib/utils/isomorphic/assert.js:1:1)
+    at CRBrowser._onAttachedToTarget (playwright-core/lib/server/chromium/crBrowser.js:147:5)`;
+    expect(isPlaywrightWorkerTargetAssertion(error)).toBe(true);
+  });
+
+  it("returns true for service_worker assertion with targetInfo in message", () => {
+    const error = new Error('targetInfo: {"type":"service_worker","url":"https://x.com/sw.js"}');
+    error.stack = `Error: targetInfo: ...
+    at assert (playwright-core/lib/utils/isomorphic/assert.js:1:1)
+    at CRBrowser._onAttachedToTarget (playwright-core/lib/server/chromium/crBrowser.js:147:5)`;
+    expect(isPlaywrightWorkerTargetAssertion(error)).toBe(true);
+  });
+
+  it("returns true when message has worker type and Playwright stack (no targetInfo keyword)", () => {
+    const error = new Error('unexpected target type: "shared_worker"');
+    error.stack = `Error: unexpected target type
+    at CRBrowser._onAttachedToTarget (crBrowser.js:147:5)`;
+    expect(isPlaywrightWorkerTargetAssertion(error)).toBe(true);
+  });
+
+  it("returns true when message has worker type and crBrowser in stack", () => {
+    const error = new Error("unexpected type shared_worker");
+    error.stack = `Error: unexpected
+    at Object.crBrowser (lib/server/chromium/crBrowser.js:150:3)`;
+    expect(isPlaywrightWorkerTargetAssertion(error)).toBe(true);
+  });
+
+  it("returns false for regular errors", () => {
+    expect(isPlaywrightWorkerTargetAssertion(new Error("Something went wrong"))).toBe(false);
+  });
+
+  it("returns false for errors with worker type but no Playwright context", () => {
+    const error = new Error("shared_worker failed to load");
+    expect(isPlaywrightWorkerTargetAssertion(error)).toBe(false);
+  });
+
+  it("returns false when targetInfo is in message but no Playwright stack frames are present", () => {
+    const error = new Error('targetInfo: {"type":"shared_worker"} failed in custom CDP handler');
+    error.stack = "Error: targetInfo ...\n    at customCDP.handleTarget (custom-cdp.js:10:1)";
+    expect(isPlaywrightWorkerTargetAssertion(error)).toBe(false);
+  });
+
+  it("returns false for Playwright errors without worker types", () => {
+    const error = new Error('targetInfo: {"type":"page","url":"https://example.com"}');
+    error.stack = `Error: targetInfo: ...
+    at CRBrowser._onAttachedToTarget (crBrowser.js:147:5)`;
+    expect(isPlaywrightWorkerTargetAssertion(error)).toBe(false);
+  });
+
+  it.each([null, undefined, "string error", 42, { message: "plain object" }])(
+    "returns false for non-error input %#",
+    (value) => {
+      expect(isPlaywrightWorkerTargetAssertion(value)).toBe(false);
+    },
+  );
 });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -195,6 +195,26 @@ export function isTransientNetworkError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * Detects Playwright assertion errors triggered by CDP worker targets (shared_worker,
+ * service_worker). Browsers like Brave emit Target.attachedToTarget events for these
+ * target types, but Playwright's CRBrowser._onAttachedToTarget only expects page targets
+ * and throws an assertion. Suppressing this avoids crashing the gateway (#45791).
+ */
+export function isPlaywrightWorkerTargetAssertion(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const message = "message" in err && typeof err.message === "string" ? err.message : "";
+  const stack = "stack" in err && typeof err.stack === "string" ? err.stack : "";
+
+  // The assertion message includes the stringified targetInfo object with the "type" field.
+  const hasWorkerType = /\b(shared_worker|service_worker)\b/.test(message);
+  const hasPlaywrightStack = stack.includes("_onAttachedToTarget") || stack.includes("crBrowser");
+
+  return hasWorkerType && hasPlaywrightStack;
+}
+
 export function registerUnhandledRejectionHandler(handler: UnhandledRejectionHandler): () => void {
   handlers.add(handler);
   return () => {
@@ -246,6 +266,14 @@ export function installUnhandledRejectionHandler(): void {
     if (isTransientNetworkError(reason)) {
       console.warn(
         "[openclaw] Non-fatal unhandled rejection (continuing):",
+        formatUncaughtError(reason),
+      );
+      return;
+    }
+
+    if (isPlaywrightWorkerTargetAssertion(reason)) {
+      console.warn(
+        "[openclaw] Suppressed Playwright worker target assertion (continuing):",
         formatUncaughtError(reason),
       );
       return;


### PR DESCRIPTION
## Summary

Fixes #45791.

When Brave (or other Chromium browsers) attaches to tabs that spawn `shared_worker` or `service_worker` targets (e.g. Facebook, X/Twitter), Playwright's internal `CRBrowser._onAttachedToTarget` handler hits an assertion because it only expects page-type targets. This causes an unhandled promise rejection that crashes the gateway process.

This PR adds a targeted detection function `isPlaywrightWorkerTargetAssertion()` to the unhandled rejection handler that identifies these specific Playwright assertion errors by checking for worker target type keywords in the error message combined with Playwright stack frame markers. When matched, the error is logged as a warning and suppressed instead of crashing the process.

## Changes

- `src/infra/unhandled-rejections.ts`: Added `isPlaywrightWorkerTargetAssertion()` detection function and wired it into `installUnhandledRejectionHandler` to suppress worker target assertions gracefully
- `src/infra/unhandled-rejections.test.ts`: Unit tests for the new detection function (7 cases covering shared_worker, service_worker, edge cases, and negative cases)
- `src/infra/unhandled-rejections.fatal-detection.test.ts`: Integration test verifying the handler suppresses the error without calling `process.exit`

## Target types now skipped

- `shared_worker` (e.g. Facebook shared workers)
- `service_worker` (e.g. PWA service workers)

## Test plan

- [x] All existing unhandled-rejections tests pass (45 unit + 7 integration)
- [x] New tests cover detection of both worker target types
- [x] New tests verify no false positives on regular errors or non-worker Playwright errors
- [x] Integration test confirms no `process.exit` on worker target assertion
- [x] `pnpm check` passes (lint + format)