### PR TITLE
fix: normalize reasoning_effort for Groq provider to accepted values (closes #32638)

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -412,6 +412,80 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]).not.toHaveProperty("reasoning_effort");
   });
 
+  it("normalizes reasoning_effort to 'default' for Groq (#32638)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { reasoning_effort: "high" };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "groq", "qwen/qwen3-32b", undefined, "high");
+
+    const model = {
+      api: "openai-completions",
+      provider: "groq",
+      id: "qwen/qwen3-32b",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning_effort).toBe("default");
+    expect(payloads[0]).not.toHaveProperty("reasoning");
+  });
+
+  it("preserves reasoning_effort 'none' for Groq (#32638)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { reasoning_effort: "none" };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "groq", "qwen/qwen3-32b", undefined, "high");
+
+    const model = {
+      api: "openai-completions",
+      provider: "groq",
+      id: "qwen/qwen3-32b",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning_effort).toBe("none");
+  });
+
+  it("sets reasoning_effort to 'none' when thinkingLevel is off for Groq (#32638)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { reasoning_effort: "medium" };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "groq", "qwen/qwen3-32b", undefined, "off");
+
+    const model = {
+      api: "openai-completions",
+      provider: "groq",
+      id: "qwen/qwen3-32b",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning_effort).toBe("none");
+    expect(payloads[0]).not.toHaveProperty("reasoning");
+  });
+
   it("injects parallel_tool_calls for openai-completions payloads when configured", () => {
     const payload = runParallelToolCallsPayloadMutationCase({
       applyProvider: "nvidia-nim",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -31,6 +31,7 @@ import {
   resolveOpenAIServiceTier,
 } from "./openai-stream-wrappers.js";
 import {
+  createGroqWrapper,
   createKilocodeWrapper,
   createOpenRouterSystemCacheWrapper,
   createOpenRouterWrapper,
@@ -420,6 +421,14 @@ export function applyExtraParamsToAgent(
     const kilocodeThinkingLevel =
       modelId === "kilo/auto" || isProxyReasoningUnsupported(modelId) ? undefined : thinkingLevel;
     agent.streamFn = createKilocodeWrapper(agent.streamFn, kilocodeThinkingLevel);
+  }
+
+  if (provider === "groq") {
+    log.debug(`applying Groq reasoning_effort normalization for ${provider}/${modelId}`);
+    // Groq only accepts "none" or "default" for reasoning_effort.
+    // Other values like "low", "medium", "high" cause HTTP 400 errors.
+    // See: openclaw/openclaw#32638
+    agent.streamFn = createGroqWrapper(agent.streamFn, thinkingLevel);
   }
 
   if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -123,6 +123,55 @@ export function isProxyReasoningUnsupported(modelId: string): boolean {
   return modelId.toLowerCase().startsWith("x-ai/");
 }
 
+/**
+ * Normalize `reasoning_effort` for Groq's API.
+ *
+ * Groq only accepts `"none"` or `"default"` for the top-level
+ * `reasoning_effort` field.  Any other value (e.g. "low", "medium", "high")
+ * causes an HTTP 400.  This helper clamps the value accordingly and also
+ * strips the nested `reasoning.effort` object that the generic proxy
+ * normalizer would inject.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/32638
+ */
+function normalizeGroqReasoningPayload(payload: unknown, thinkingLevel?: ThinkLevel): void {
+  if (!payload || typeof payload !== "object") {
+    return;
+  }
+
+  const payloadObj = payload as Record<string, unknown>;
+
+  // Remove nested reasoning.effort — Groq uses top-level reasoning_effort only.
+  delete payloadObj.reasoning;
+
+  if (!thinkingLevel || thinkingLevel === "off") {
+    // When thinking is off, send "none" so reasoning is explicitly disabled.
+    payloadObj.reasoning_effort = "none";
+    return;
+  }
+
+  // Any non-"none" value must be sent as "default" for Groq.
+  const current = payloadObj.reasoning_effort;
+  payloadObj.reasoning_effort = current === "none" ? "none" : "default";
+}
+
+export function createGroqWrapper(
+  baseStreamFn: StreamFn | undefined,
+  thinkingLevel?: ThinkLevel,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const onPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        normalizeGroqReasoningPayload(payload, thinkingLevel);
+        return onPayload?.(payload, model);
+      },
+    });
+  };
+}
+
 export function createKilocodeWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel?: ThinkLevel,


### PR DESCRIPTION
## Summary
- Problem: Groq API rejects reasoning_effort values like "low"/"medium"/"high"
- Why it matters: Groq + reasoning models fail with 400 errors
- What changed: Normalize reasoning_effort to "default" for Groq (unless "none")
- What did NOT change: Other providers still get full range of values

## Change Type
- [x] Bug fix

## Scope
- [x] Agent/Model behavior

## Linked Issue/PR
- Closes #32638

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
1. Configure Groq provider with reasoning model
2. No more 400 errors from invalid reasoning_effort

## Evidence
- [x] pnpm build + pnpm check + pnpm test all passing

## Human Verification
- Verified: build/check/test passing
- NOT verified: runtime with actual Groq API

## Compatibility / Migration
- Backward compatible? Yes

## Failure Recovery
- How to revert: revert this commit

## Risks and Mitigations
Groq users lose granular reasoning_effort control, but Groq only supports none/default anyway.

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*
