### PR TITLE
fix: guard against malformed entries in Grok response parser (closes #35063)

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -295,6 +295,66 @@ describe("web_search grok response parsing", () => {
     expect(result.annotationCitations).toEqual([]);
   });
 
+  it("handles null entries in output array", () => {
+    const result = extractGrokContent({
+      output: [
+        null as never,
+        {
+          type: "message",
+          content: [{ type: "output_text", text: "after null" }],
+        },
+      ],
+    });
+    expect(result.text).toBe("after null");
+    expect(result.annotationCitations).toEqual([]);
+  });
+
+  it("handles null entries in content array", () => {
+    const result = extractGrokContent({
+      output: [
+        {
+          type: "message",
+          content: [null as never, { type: "output_text", text: "after null content" }],
+        },
+      ],
+    });
+    expect(result.text).toBe("after null content");
+    expect(result.annotationCitations).toEqual([]);
+  });
+
+  it("handles entries missing type in output array", () => {
+    const result = extractGrokContent({
+      output: [
+        {} as never,
+        {
+          type: "message",
+          content: [{ type: "output_text", text: "after empty" }],
+        },
+      ],
+    });
+    expect(result.text).toBe("after empty");
+  });
+
+  it("handles entries missing type in content array", () => {
+    const result = extractGrokContent({
+      output: [
+        {
+          type: "message",
+          content: [{} as never, { type: "output_text", text: "after typeless" }],
+        },
+      ],
+    });
+    expect(result.text).toBe("after typeless");
+  });
+
+  it("returns undefined text when all output entries are malformed", () => {
+    const result = extractGrokContent({
+      output: [null as never, undefined as never, {} as never],
+    });
+    expect(result.text).toBeUndefined();
+    expect(result.annotationCitations).toEqual([]);
+  });
+
   it("extracts output_text blocks directly in output array (no message wrapper)", () => {
     const result = extractGrokContent({
       output: [

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -462,8 +462,14 @@ function extractGrokContent(data: GrokSearchResponse): {
 } {
   // xAI Responses API format: find the message output with text content
   for (const output of data.output ?? []) {
+    if (!output || typeof output !== "object" || !output.type) {
+      continue;
+    }
     if (output.type === "message") {
       for (const block of output.content ?? []) {
+        if (!block || typeof block !== "object" || !block.type) {
+          continue;
+        }
         if (block.type === "output_text" && typeof block.text === "string" && block.text) {
           const urls = (block.annotations ?? [])
             .filter((a) => a.type === "url_citation" && typeof a.url === "string")


### PR DESCRIPTION
## Summary
- Problem: Grok response parser crashes on null/malformed output entries
- What changed: Added object guards in extractGrokContent iteration loops
- What did NOT change: Behavior for well-formed entries

## Change Type
- [x] Bug fix
## Linked Issue/PR
- Closes #35063
## Security Impact
All No
## Evidence
- [x] pnpm build + pnpm check + pnpm test all passing
## Compatibility / Migration
- Backward compatible? Yes
## Failure Recovery
- How to revert: revert this commit
---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*