### PR TITLE
refactor(tts): extract provider implementations into TtsEngine interface

### DIFF
--- a/src/tts/engine.ts
+++ b/src/tts/engine.ts
@@ -1,0 +1,37 @@
+import type { TtsDirectiveOverrides } from "./tts.js";
+
+export type TtsSynthesizeRequest = {
+  text: string;
+  outputFormat: string;
+  timeoutMs: number;
+  overrides?: TtsDirectiveOverrides;
+};
+
+export type TtsSynthesizeResult = {
+  audio: Buffer;
+  format: string;
+};
+
+export type TtsSynthesizeToFileResult = {
+  audioPath: string;
+  format: string;
+  voiceCompatible: boolean;
+};
+
+export interface TtsEngine {
+  readonly id: string;
+
+  isConfigured(): boolean;
+
+  synthesize(request: TtsSynthesizeRequest): Promise<TtsSynthesizeResult>;
+
+  /**
+   * Edge TTS writes directly to a file; other engines buffer in memory then
+   * write to a temp file. This optional method lets engines that need special
+   * file-output handling (like Edge with its fallback logic) override the
+   * default buffer-to-file path.
+   */
+  synthesizeToFile?(request: TtsSynthesizeRequest): Promise<TtsSynthesizeToFileResult>;
+
+  supportsTelephony(): boolean;
+}

--- a/src/tts/engines/edge.ts
+++ b/src/tts/engines/edge.ts
@@ -72,13 +72,13 @@ export class EdgeTtsEngine implements TtsEngine {
         edgeOutputFormat = fallbackEdgeOutputFormat;
         try {
           edgeResult = await attemptEdgeTts(edgeOutputFormat);
-        } catch {
+        } catch (fallbackErr) {
           try {
             rmSync(tempDir, { recursive: true, force: true });
           } catch {
             // ignore cleanup errors
           }
-          throw err;
+          throw fallbackErr;
         }
       } else {
         try {

--- a/src/tts/engines/edge.ts
+++ b/src/tts/engines/edge.ts
@@ -1,0 +1,102 @@
+import { readFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { EdgeTTS } from "node-edge-tts";
+import { logVerbose } from "../../globals.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
+import { isVoiceCompatibleAudio } from "../../media/audio.js";
+import type {
+  TtsEngine,
+  TtsSynthesizeRequest,
+  TtsSynthesizeResult,
+  TtsSynthesizeToFileResult,
+} from "../engine.js";
+import { inferEdgeExtension, scheduleCleanup } from "../tts-core.js";
+import type { ResolvedTtsConfig } from "../tts.js";
+
+const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+
+export class EdgeTtsEngine implements TtsEngine {
+  readonly id = "edge";
+
+  constructor(private readonly config: ResolvedTtsConfig["edge"]) {}
+
+  isConfigured(): boolean {
+    return this.config.enabled;
+  }
+
+  supportsTelephony(): boolean {
+    return false;
+  }
+
+  async synthesize(request: TtsSynthesizeRequest): Promise<TtsSynthesizeResult> {
+    const result = await this.synthesizeToFile(request);
+    const audio = readFileSync(result.audioPath);
+    return { audio, format: result.format };
+  }
+
+  async synthesizeToFile(request: TtsSynthesizeRequest): Promise<TtsSynthesizeToFileResult> {
+    const tempRoot = resolvePreferredOpenClawTmpDir();
+    mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+    const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
+
+    let edgeOutputFormat = this.config.outputFormat;
+    const fallbackEdgeOutputFormat =
+      edgeOutputFormat !== DEFAULT_EDGE_OUTPUT_FORMAT ? DEFAULT_EDGE_OUTPUT_FORMAT : undefined;
+
+    const attemptEdgeTts = async (outputFormat: string) => {
+      const extension = inferEdgeExtension(outputFormat);
+      const audioPath = path.join(tempDir, `voice-${Date.now()}${extension}`);
+      const tts = new EdgeTTS({
+        voice: this.config.voice,
+        lang: this.config.lang,
+        outputFormat,
+        saveSubtitles: this.config.saveSubtitles,
+        proxy: this.config.proxy,
+        rate: this.config.rate,
+        pitch: this.config.pitch,
+        volume: this.config.volume,
+        timeout: this.config.timeoutMs ?? request.timeoutMs,
+      });
+      await tts.ttsPromise(request.text, audioPath);
+      return { audioPath, outputFormat };
+    };
+
+    let edgeResult: { audioPath: string; outputFormat: string };
+    try {
+      edgeResult = await attemptEdgeTts(edgeOutputFormat);
+    } catch (err) {
+      if (fallbackEdgeOutputFormat && fallbackEdgeOutputFormat !== edgeOutputFormat) {
+        logVerbose(
+          `TTS: Edge output ${edgeOutputFormat} failed; retrying with ${fallbackEdgeOutputFormat}.`,
+        );
+        edgeOutputFormat = fallbackEdgeOutputFormat;
+        try {
+          edgeResult = await attemptEdgeTts(edgeOutputFormat);
+        } catch {
+          try {
+            rmSync(tempDir, { recursive: true, force: true });
+          } catch {
+            // ignore cleanup errors
+          }
+          throw err;
+        }
+      } else {
+        try {
+          rmSync(tempDir, { recursive: true, force: true });
+        } catch {
+          // ignore cleanup errors
+        }
+        throw err;
+      }
+    }
+
+    scheduleCleanup(tempDir);
+    const voiceCompatible = isVoiceCompatibleAudio({ fileName: edgeResult.audioPath });
+
+    return {
+      audioPath: edgeResult.audioPath,
+      format: edgeResult.outputFormat,
+      voiceCompatible,
+    };
+  }
+}

--- a/src/tts/engines/elevenlabs.ts
+++ b/src/tts/engines/elevenlabs.ts
@@ -18,12 +18,6 @@ function normalizeElevenLabsBaseUrl(baseUrl: string): string {
   return trimmed.replace(/\/+$/, "");
 }
 
-function requireInRange(value: number, min: number, max: number, label: string): void {
-  if (!Number.isFinite(value) || value < min || value > max) {
-    throw new Error(`${label} must be between ${min} and ${max}`);
-  }
-}
-
 function assertVoiceSettings(settings: ResolvedTtsConfig["elevenlabs"]["voiceSettings"]) {
   requireInRange(settings.stability, 0, 1, "stability");
   requireInRange(settings.similarityBoost, 0, 1, "similarityBoost");

--- a/src/tts/engines/elevenlabs.ts
+++ b/src/tts/engines/elevenlabs.ts
@@ -1,5 +1,11 @@
 import type { TtsEngine, TtsSynthesizeRequest, TtsSynthesizeResult } from "../engine.js";
-import { isValidVoiceId } from "../tts-core.js";
+import {
+  isValidVoiceId,
+  normalizeApplyTextNormalization,
+  normalizeLanguageCode,
+  normalizeSeed,
+  requireInRange,
+} from "../tts-core.js";
 import type { ResolvedTtsConfig } from "../tts.js";
 
 const DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io";
@@ -23,41 +29,6 @@ function assertVoiceSettings(settings: ResolvedTtsConfig["elevenlabs"]["voiceSet
   requireInRange(settings.similarityBoost, 0, 1, "similarityBoost");
   requireInRange(settings.style, 0, 1, "style");
   requireInRange(settings.speed, 0.5, 2, "speed");
-}
-
-function normalizeLanguageCode(code?: string): string | undefined {
-  const trimmed = code?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const normalized = trimmed.toLowerCase();
-  if (!/^[a-z]{2}$/.test(normalized)) {
-    throw new Error("languageCode must be a 2-letter ISO 639-1 code (e.g. en, de, fr)");
-  }
-  return normalized;
-}
-
-function normalizeApplyTextNormalization(mode?: string): "auto" | "on" | "off" | undefined {
-  const trimmed = mode?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const normalized = trimmed.toLowerCase();
-  if (normalized === "auto" || normalized === "on" || normalized === "off") {
-    return normalized;
-  }
-  throw new Error("applyTextNormalization must be one of: auto, on, off");
-}
-
-function normalizeSeed(seed?: number): number | undefined {
-  if (seed == null) {
-    return undefined;
-  }
-  const next = Math.floor(seed);
-  if (!Number.isFinite(next) || next < 0 || next > 4_294_967_295) {
-    throw new Error("seed must be between 0 and 4294967295");
-  }
-  return next;
 }
 
 export class ElevenLabsTtsEngine implements TtsEngine {

--- a/src/tts/engines/elevenlabs.ts
+++ b/src/tts/engines/elevenlabs.ts
@@ -1,0 +1,152 @@
+import type { TtsEngine, TtsSynthesizeRequest, TtsSynthesizeResult } from "../engine.js";
+import { isValidVoiceId } from "../tts-core.js";
+import type { ResolvedTtsConfig } from "../tts.js";
+
+const DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io";
+
+function normalizeElevenLabsBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim();
+  if (!trimmed) {
+    return DEFAULT_ELEVENLABS_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+function requireInRange(value: number, min: number, max: number, label: string): void {
+  if (!Number.isFinite(value) || value < min || value > max) {
+    throw new Error(`${label} must be between ${min} and ${max}`);
+  }
+}
+
+function assertVoiceSettings(settings: ResolvedTtsConfig["elevenlabs"]["voiceSettings"]) {
+  requireInRange(settings.stability, 0, 1, "stability");
+  requireInRange(settings.similarityBoost, 0, 1, "similarityBoost");
+  requireInRange(settings.style, 0, 1, "style");
+  requireInRange(settings.speed, 0.5, 2, "speed");
+}
+
+function normalizeLanguageCode(code?: string): string | undefined {
+  const trimmed = code?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = trimmed.toLowerCase();
+  if (!/^[a-z]{2}$/.test(normalized)) {
+    throw new Error("languageCode must be a 2-letter ISO 639-1 code (e.g. en, de, fr)");
+  }
+  return normalized;
+}
+
+function normalizeApplyTextNormalization(mode?: string): "auto" | "on" | "off" | undefined {
+  const trimmed = mode?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = trimmed.toLowerCase();
+  if (normalized === "auto" || normalized === "on" || normalized === "off") {
+    return normalized;
+  }
+  throw new Error("applyTextNormalization must be one of: auto, on, off");
+}
+
+function normalizeSeed(seed?: number): number | undefined {
+  if (seed == null) {
+    return undefined;
+  }
+  const next = Math.floor(seed);
+  if (!Number.isFinite(next) || next < 0 || next > 4_294_967_295) {
+    throw new Error("seed must be between 0 and 4294967295");
+  }
+  return next;
+}
+
+export class ElevenLabsTtsEngine implements TtsEngine {
+  readonly id = "elevenlabs";
+
+  constructor(
+    private readonly config: ResolvedTtsConfig["elevenlabs"],
+    private readonly apiKey: string | undefined,
+  ) {}
+
+  isConfigured(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  supportsTelephony(): boolean {
+    return true;
+  }
+
+  async synthesize(request: TtsSynthesizeRequest): Promise<TtsSynthesizeResult> {
+    const apiKey = this.apiKey;
+    if (!apiKey) {
+      throw new Error("ElevenLabs TTS: no API key");
+    }
+
+    const overrides = request.overrides?.elevenlabs;
+    const voiceId = overrides?.voiceId ?? this.config.voiceId;
+    const modelId = overrides?.modelId ?? this.config.modelId;
+    const voiceSettings = {
+      ...this.config.voiceSettings,
+      ...overrides?.voiceSettings,
+    };
+    const seed = overrides?.seed ?? this.config.seed;
+    const applyTextNormalization =
+      overrides?.applyTextNormalization ?? this.config.applyTextNormalization;
+    const languageCode = overrides?.languageCode ?? this.config.languageCode;
+
+    if (!isValidVoiceId(voiceId)) {
+      throw new Error("Invalid voiceId format");
+    }
+    assertVoiceSettings(voiceSettings);
+    const normalizedLanguage = normalizeLanguageCode(languageCode);
+    const normalizedNormalization = normalizeApplyTextNormalization(applyTextNormalization);
+    const normalizedSeed = normalizeSeed(seed);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), request.timeoutMs);
+
+    try {
+      const url = new URL(
+        `${normalizeElevenLabsBaseUrl(this.config.baseUrl)}/v1/text-to-speech/${voiceId}`,
+      );
+      if (request.outputFormat) {
+        url.searchParams.set("output_format", request.outputFormat);
+      }
+
+      const response = await fetch(url.toString(), {
+        method: "POST",
+        headers: {
+          "xi-api-key": apiKey,
+          "Content-Type": "application/json",
+          Accept: "audio/mpeg",
+        },
+        body: JSON.stringify({
+          text: request.text,
+          model_id: modelId,
+          seed: normalizedSeed,
+          apply_text_normalization: normalizedNormalization,
+          language_code: normalizedLanguage,
+          voice_settings: {
+            stability: voiceSettings.stability,
+            similarity_boost: voiceSettings.similarityBoost,
+            style: voiceSettings.style,
+            use_speaker_boost: voiceSettings.useSpeakerBoost,
+            speed: voiceSettings.speed,
+          },
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`ElevenLabs API error (${response.status})`);
+      }
+
+      return {
+        audio: Buffer.from(await response.arrayBuffer()),
+        format: request.outputFormat,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/src/tts/engines/openai.ts
+++ b/src/tts/engines/openai.ts
@@ -1,0 +1,76 @@
+import type { TtsEngine, TtsSynthesizeRequest, TtsSynthesizeResult } from "../engine.js";
+import {
+  isValidOpenAIModel,
+  isValidOpenAIVoice,
+  resolveOpenAITtsInstructions,
+} from "../tts-core.js";
+import type { ResolvedTtsConfig } from "../tts.js";
+
+export class OpenAiTtsEngine implements TtsEngine {
+  readonly id = "openai";
+
+  constructor(
+    private readonly config: ResolvedTtsConfig["openai"],
+    private readonly apiKey: string | undefined,
+  ) {}
+
+  isConfigured(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  supportsTelephony(): boolean {
+    return true;
+  }
+
+  async synthesize(request: TtsSynthesizeRequest): Promise<TtsSynthesizeResult> {
+    const apiKey = this.apiKey;
+    if (!apiKey) {
+      throw new Error("OpenAI TTS: no API key");
+    }
+
+    const model = request.overrides?.openai?.model ?? this.config.model;
+    const voice = request.overrides?.openai?.voice ?? this.config.voice;
+    const { baseUrl, speed, instructions } = this.config;
+    const effectiveInstructions = resolveOpenAITtsInstructions(model, instructions);
+
+    if (!isValidOpenAIModel(model, baseUrl)) {
+      throw new Error(`Invalid model: ${model}`);
+    }
+    if (!isValidOpenAIVoice(voice, baseUrl)) {
+      throw new Error(`Invalid voice: ${voice}`);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), request.timeoutMs);
+
+    try {
+      const response = await fetch(`${baseUrl}/audio/speech`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          input: request.text,
+          voice,
+          response_format: request.outputFormat,
+          ...(speed != null && { speed }),
+          ...(effectiveInstructions != null && { instructions: effectiveInstructions }),
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`OpenAI TTS API error (${response.status})`);
+      }
+
+      return {
+        audio: Buffer.from(await response.arrayBuffer()),
+        format: request.outputFormat,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/src/tts/registry.ts
+++ b/src/tts/registry.ts
@@ -1,0 +1,32 @@
+import type { TtsEngine } from "./engine.js";
+import { EdgeTtsEngine } from "./engines/edge.js";
+import { ElevenLabsTtsEngine } from "./engines/elevenlabs.js";
+import { OpenAiTtsEngine } from "./engines/openai.js";
+import type { ResolvedTtsConfig } from "./tts.js";
+
+/**
+ * Resolve the API key for a given provider from config + env.
+ * Mirrors the original `resolveTtsApiKey` logic but scoped to engine creation.
+ */
+function resolveApiKey(
+  config: ResolvedTtsConfig,
+  provider: "openai" | "elevenlabs",
+): string | undefined {
+  if (provider === "elevenlabs") {
+    return config.elevenlabs.apiKey || process.env.ELEVENLABS_API_KEY || process.env.XI_API_KEY;
+  }
+  return config.openai.apiKey || process.env.OPENAI_API_KEY;
+}
+
+export function createTtsEngines(config: ResolvedTtsConfig): Map<string, TtsEngine> {
+  const engines = new Map<string, TtsEngine>();
+
+  engines.set("openai", new OpenAiTtsEngine(config.openai, resolveApiKey(config, "openai")));
+  engines.set(
+    "elevenlabs",
+    new ElevenLabsTtsEngine(config.elevenlabs, resolveApiKey(config, "elevenlabs")),
+  );
+  engines.set("edge", new EdgeTtsEngine(config.edge));
+
+  return engines;
+}

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -38,13 +38,13 @@ function trimToUndefined(value?: string): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
-function requireInRange(value: number, min: number, max: number, label: string): void {
+export function requireInRange(value: number, min: number, max: number, label: string): void {
   if (!Number.isFinite(value) || value < min || value > max) {
     throw new Error(`${label} must be between ${min} and ${max}`);
   }
 }
 
-function normalizeLanguageCode(code?: string): string | undefined {
+export function normalizeLanguageCode(code?: string): string | undefined {
   const trimmed = code?.trim();
   if (!trimmed) {
     return undefined;
@@ -56,7 +56,7 @@ function normalizeLanguageCode(code?: string): string | undefined {
   return normalized;
 }
 
-function normalizeApplyTextNormalization(mode?: string): "auto" | "on" | "off" | undefined {
+export function normalizeApplyTextNormalization(mode?: string): "auto" | "on" | "off" | undefined {
   const trimmed = mode?.trim();
   if (!trimmed) {
     return undefined;
@@ -68,7 +68,7 @@ function normalizeApplyTextNormalization(mode?: string): "auto" | "on" | "off" |
   throw new Error("applyTextNormalization must be one of: auto, on, off");
 }
 
-function normalizeSeed(seed?: number): number | undefined {
+export function normalizeSeed(seed?: number): number | undefined {
   if (seed == null) {
     return undefined;
   }

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,6 +1,5 @@
 import { rmSync } from "node:fs";
 import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
-import { EdgeTTS } from "node-edge-tts";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
 import { getApiKeyForModel, requireApiKey } from "../agents/model-auth.js";
 import {
@@ -19,20 +18,11 @@ import type {
   TtsDirectiveParseResult,
 } from "./tts.js";
 
-const DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io";
 export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const TEMP_FILE_CLEANUP_DELAY_MS = 5 * 60 * 1000; // 5 minutes
 
 export function isValidVoiceId(voiceId: string): boolean {
   return /^[a-zA-Z0-9]{10,40}$/.test(voiceId);
-}
-
-function normalizeElevenLabsBaseUrl(baseUrl: string): string {
-  const trimmed = baseUrl.trim();
-  if (!trimmed) {
-    return DEFAULT_ELEVENLABS_BASE_URL;
-  }
-  return trimmed.replace(/\/+$/, "");
 }
 
 function normalizeOpenAITtsBaseUrl(baseUrl?: string): string {
@@ -52,13 +42,6 @@ function requireInRange(value: number, min: number, max: number, label: string):
   if (!Number.isFinite(value) || value < min || value > max) {
     throw new Error(`${label} must be between ${min} and ${max}`);
   }
-}
-
-function assertElevenLabsVoiceSettings(settings: ResolvedTtsConfig["elevenlabs"]["voiceSettings"]) {
-  requireInRange(settings.stability, 0, 1, "stability");
-  requireInRange(settings.similarityBoost, 0, 1, "similarityBoost");
-  requireInRange(settings.style, 0, 1, "style");
-  requireInRange(settings.speed, 0.5, 2, "speed");
 }
 
 function normalizeLanguageCode(code?: string): string | undefined {
@@ -549,136 +532,6 @@ export function scheduleCleanup(
   timer.unref();
 }
 
-export async function elevenLabsTTS(params: {
-  text: string;
-  apiKey: string;
-  baseUrl: string;
-  voiceId: string;
-  modelId: string;
-  outputFormat: string;
-  seed?: number;
-  applyTextNormalization?: "auto" | "on" | "off";
-  languageCode?: string;
-  voiceSettings: ResolvedTtsConfig["elevenlabs"]["voiceSettings"];
-  timeoutMs: number;
-}): Promise<Buffer> {
-  const {
-    text,
-    apiKey,
-    baseUrl,
-    voiceId,
-    modelId,
-    outputFormat,
-    seed,
-    applyTextNormalization,
-    languageCode,
-    voiceSettings,
-    timeoutMs,
-  } = params;
-  if (!isValidVoiceId(voiceId)) {
-    throw new Error("Invalid voiceId format");
-  }
-  assertElevenLabsVoiceSettings(voiceSettings);
-  const normalizedLanguage = normalizeLanguageCode(languageCode);
-  const normalizedNormalization = normalizeApplyTextNormalization(applyTextNormalization);
-  const normalizedSeed = normalizeSeed(seed);
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const url = new URL(`${normalizeElevenLabsBaseUrl(baseUrl)}/v1/text-to-speech/${voiceId}`);
-    if (outputFormat) {
-      url.searchParams.set("output_format", outputFormat);
-    }
-
-    const response = await fetch(url.toString(), {
-      method: "POST",
-      headers: {
-        "xi-api-key": apiKey,
-        "Content-Type": "application/json",
-        Accept: "audio/mpeg",
-      },
-      body: JSON.stringify({
-        text,
-        model_id: modelId,
-        seed: normalizedSeed,
-        apply_text_normalization: normalizedNormalization,
-        language_code: normalizedLanguage,
-        voice_settings: {
-          stability: voiceSettings.stability,
-          similarity_boost: voiceSettings.similarityBoost,
-          style: voiceSettings.style,
-          use_speaker_boost: voiceSettings.useSpeakerBoost,
-          speed: voiceSettings.speed,
-        },
-      }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      throw new Error(`ElevenLabs API error (${response.status})`);
-    }
-
-    return Buffer.from(await response.arrayBuffer());
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-export async function openaiTTS(params: {
-  text: string;
-  apiKey: string;
-  baseUrl: string;
-  model: string;
-  voice: string;
-  speed?: number;
-  instructions?: string;
-  responseFormat: "mp3" | "opus" | "pcm";
-  timeoutMs: number;
-}): Promise<Buffer> {
-  const { text, apiKey, baseUrl, model, voice, speed, instructions, responseFormat, timeoutMs } =
-    params;
-  const effectiveInstructions = resolveOpenAITtsInstructions(model, instructions);
-
-  if (!isValidOpenAIModel(model, baseUrl)) {
-    throw new Error(`Invalid model: ${model}`);
-  }
-  if (!isValidOpenAIVoice(voice, baseUrl)) {
-    throw new Error(`Invalid voice: ${voice}`);
-  }
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const response = await fetch(`${baseUrl}/audio/speech`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model,
-        input: text,
-        voice,
-        response_format: responseFormat,
-        ...(speed != null && { speed }),
-        ...(effectiveInstructions != null && { instructions: effectiveInstructions }),
-      }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      throw new Error(`OpenAI TTS API error (${response.status})`);
-    }
-
-    return Buffer.from(await response.arrayBuffer());
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
 export function inferEdgeExtension(outputFormat: string): string {
   const normalized = outputFormat.toLowerCase();
   if (normalized.includes("webm")) {
@@ -694,25 +547,4 @@ export function inferEdgeExtension(outputFormat: string): string {
     return ".wav";
   }
   return ".mp3";
-}
-
-export async function edgeTTS(params: {
-  text: string;
-  outputPath: string;
-  config: ResolvedTtsConfig["edge"];
-  timeoutMs: number;
-}): Promise<void> {
-  const { text, outputPath, config, timeoutMs } = params;
-  const tts = new EdgeTTS({
-    voice: config.voice,
-    lang: config.lang,
-    outputFormat: config.outputFormat,
-    saveSubtitles: config.saveSubtitles,
-    proxy: config.proxy,
-    rate: config.rate,
-    pitch: config.pitch,
-    volume: config.volume,
-    timeout: config.timeoutMs ?? timeoutMs,
-  });
-  await tts.ttsPromise(text, outputPath);
 }

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -621,11 +621,7 @@ export async function textToSpeech(params: {
       }
 
       const outputFormat =
-        provider === "openai"
-          ? output.openai
-          : provider === "elevenlabs"
-            ? output.elevenlabs
-            : output.openai;
+        provider === "openai" ? output.openai : provider === "elevenlabs" ? output.elevenlabs : "";
 
       if (engine.synthesizeToFile) {
         const fileResult = await engine.synthesizeToFile({

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -5,7 +5,6 @@ import {
   readFileSync,
   writeFileSync,
   mkdtempSync,
-  rmSync,
   renameSync,
   unlinkSync,
 } from "node:fs";
@@ -25,20 +24,16 @@ import type {
 import { logVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { stripMarkdown } from "../line/markdown-to-line.js";
-import { isVoiceCompatibleAudio } from "../media/audio.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
+import { createTtsEngines } from "./registry.js";
 import {
   DEFAULT_OPENAI_BASE_URL,
-  edgeTTS,
-  elevenLabsTTS,
-  inferEdgeExtension,
   isValidOpenAIModel,
   isValidOpenAIVoice,
   isValidVoiceId,
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
   resolveOpenAITtsInstructions,
-  openaiTTS,
   parseTtsDirectives,
   scheduleCleanup,
   summarizeText,
@@ -608,127 +603,53 @@ export async function textToSpeech(params: {
   const { config, providers } = setup;
   const channelId = resolveChannelId(params.channel);
   const output = resolveOutputFormat(channelId);
+  const engines = createTtsEngines(config);
 
   const errors: string[] = [];
 
   for (const provider of providers) {
     const providerStart = Date.now();
     try {
-      if (provider === "edge") {
-        if (!config.edge.enabled) {
-          errors.push("edge: disabled");
-          continue;
-        }
-
-        const tempRoot = resolvePreferredOpenClawTmpDir();
-        mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
-        const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
-        let edgeOutputFormat = resolveEdgeOutputFormat(config);
-        const fallbackEdgeOutputFormat =
-          edgeOutputFormat !== DEFAULT_EDGE_OUTPUT_FORMAT ? DEFAULT_EDGE_OUTPUT_FORMAT : undefined;
-
-        const attemptEdgeTts = async (outputFormat: string) => {
-          const extension = inferEdgeExtension(outputFormat);
-          const audioPath = path.join(tempDir, `voice-${Date.now()}${extension}`);
-          await edgeTTS({
-            text: params.text,
-            outputPath: audioPath,
-            config: {
-              ...config.edge,
-              outputFormat,
-            },
-            timeoutMs: config.timeoutMs,
-          });
-          return { audioPath, outputFormat };
-        };
-
-        let edgeResult: { audioPath: string; outputFormat: string };
-        try {
-          edgeResult = await attemptEdgeTts(edgeOutputFormat);
-        } catch (err) {
-          if (fallbackEdgeOutputFormat && fallbackEdgeOutputFormat !== edgeOutputFormat) {
-            logVerbose(
-              `TTS: Edge output ${edgeOutputFormat} failed; retrying with ${fallbackEdgeOutputFormat}.`,
-            );
-            edgeOutputFormat = fallbackEdgeOutputFormat;
-            try {
-              edgeResult = await attemptEdgeTts(edgeOutputFormat);
-            } catch (fallbackErr) {
-              try {
-                rmSync(tempDir, { recursive: true, force: true });
-              } catch {
-                // ignore cleanup errors
-              }
-              throw fallbackErr;
-            }
-          } else {
-            try {
-              rmSync(tempDir, { recursive: true, force: true });
-            } catch {
-              // ignore cleanup errors
-            }
-            throw err;
-          }
-        }
-
-        scheduleCleanup(tempDir);
-        const voiceCompatible = isVoiceCompatibleAudio({ fileName: edgeResult.audioPath });
-
-        return {
-          success: true,
-          audioPath: edgeResult.audioPath,
-          latencyMs: Date.now() - providerStart,
-          provider,
-          outputFormat: edgeResult.outputFormat,
-          voiceCompatible,
-        };
+      const engine = engines.get(provider);
+      if (!engine) {
+        errors.push(`${provider}: unknown provider`);
+        continue;
       }
-
-      const apiKey = resolveTtsApiKey(config, provider);
-      if (!apiKey) {
-        errors.push(`${provider}: no API key`);
+      if (!engine.isConfigured()) {
+        errors.push(`${provider}: ${provider === "edge" ? "disabled" : "no API key"}`);
         continue;
       }
 
-      let audioBuffer: Buffer;
-      if (provider === "elevenlabs") {
-        const voiceIdOverride = params.overrides?.elevenlabs?.voiceId;
-        const modelIdOverride = params.overrides?.elevenlabs?.modelId;
-        const voiceSettings = {
-          ...config.elevenlabs.voiceSettings,
-          ...params.overrides?.elevenlabs?.voiceSettings,
+      const outputFormat =
+        provider === "openai"
+          ? output.openai
+          : provider === "elevenlabs"
+            ? output.elevenlabs
+            : output.openai;
+
+      if (engine.synthesizeToFile) {
+        const fileResult = await engine.synthesizeToFile({
+          text: params.text,
+          outputFormat,
+          timeoutMs: config.timeoutMs,
+          overrides: params.overrides,
+        });
+        return {
+          success: true,
+          audioPath: fileResult.audioPath,
+          latencyMs: Date.now() - providerStart,
+          provider,
+          outputFormat: fileResult.format,
+          voiceCompatible: fileResult.voiceCompatible,
         };
-        const seedOverride = params.overrides?.elevenlabs?.seed;
-        const normalizationOverride = params.overrides?.elevenlabs?.applyTextNormalization;
-        const languageOverride = params.overrides?.elevenlabs?.languageCode;
-        audioBuffer = await elevenLabsTTS({
-          text: params.text,
-          apiKey,
-          baseUrl: config.elevenlabs.baseUrl,
-          voiceId: voiceIdOverride ?? config.elevenlabs.voiceId,
-          modelId: modelIdOverride ?? config.elevenlabs.modelId,
-          outputFormat: output.elevenlabs,
-          seed: seedOverride ?? config.elevenlabs.seed,
-          applyTextNormalization: normalizationOverride ?? config.elevenlabs.applyTextNormalization,
-          languageCode: languageOverride ?? config.elevenlabs.languageCode,
-          voiceSettings,
-          timeoutMs: config.timeoutMs,
-        });
-      } else {
-        const openaiModelOverride = params.overrides?.openai?.model;
-        const openaiVoiceOverride = params.overrides?.openai?.voice;
-        audioBuffer = await openaiTTS({
-          text: params.text,
-          apiKey,
-          baseUrl: config.openai.baseUrl,
-          model: openaiModelOverride ?? config.openai.model,
-          voice: openaiVoiceOverride ?? config.openai.voice,
-          speed: config.openai.speed,
-          instructions: config.openai.instructions,
-          responseFormat: output.openai,
-          timeoutMs: config.timeoutMs,
-        });
       }
+
+      const result = await engine.synthesize({
+        text: params.text,
+        outputFormat,
+        timeoutMs: config.timeoutMs,
+        overrides: params.overrides,
+      });
 
       const latencyMs = Date.now() - providerStart;
 
@@ -736,7 +657,7 @@ export async function textToSpeech(params: {
       mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
       const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
       const audioPath = path.join(tempDir, `voice-${Date.now()}${output.extension}`);
-      writeFileSync(audioPath, audioBuffer);
+      writeFileSync(audioPath, result.audio);
       scheduleCleanup(tempDir);
 
       return {
@@ -744,7 +665,7 @@ export async function textToSpeech(params: {
         audioPath,
         latencyMs,
         provider,
-        outputFormat: provider === "openai" ? output.openai : output.elevenlabs,
+        outputFormat: result.format,
         voiceCompatible: output.voiceCompatible,
       };
     } catch (err) {
@@ -770,69 +691,43 @@ export async function textToSpeechTelephony(params: {
   }
 
   const { config, providers } = setup;
+  const engines = createTtsEngines(config);
 
   const errors: string[] = [];
 
   for (const provider of providers) {
     const providerStart = Date.now();
     try {
-      if (provider === "edge") {
-        errors.push("edge: unsupported for telephony");
+      const engine = engines.get(provider);
+      if (!engine) {
+        errors.push(`${provider}: unknown provider`);
         continue;
       }
-
-      const apiKey = resolveTtsApiKey(config, provider);
-      if (!apiKey) {
+      if (!engine.supportsTelephony()) {
+        errors.push(`${provider}: unsupported for telephony`);
+        continue;
+      }
+      if (!engine.isConfigured()) {
         errors.push(`${provider}: no API key`);
         continue;
       }
 
-      if (provider === "elevenlabs") {
-        const output = TELEPHONY_OUTPUT.elevenlabs;
-        const audioBuffer = await elevenLabsTTS({
-          text: params.text,
-          apiKey,
-          baseUrl: config.elevenlabs.baseUrl,
-          voiceId: config.elevenlabs.voiceId,
-          modelId: config.elevenlabs.modelId,
-          outputFormat: output.format,
-          seed: config.elevenlabs.seed,
-          applyTextNormalization: config.elevenlabs.applyTextNormalization,
-          languageCode: config.elevenlabs.languageCode,
-          voiceSettings: config.elevenlabs.voiceSettings,
-          timeoutMs: config.timeoutMs,
-        });
+      const telephonyOutput =
+        provider === "elevenlabs" ? TELEPHONY_OUTPUT.elevenlabs : TELEPHONY_OUTPUT.openai;
 
-        return {
-          success: true,
-          audioBuffer,
-          latencyMs: Date.now() - providerStart,
-          provider,
-          outputFormat: output.format,
-          sampleRate: output.sampleRate,
-        };
-      }
-
-      const output = TELEPHONY_OUTPUT.openai;
-      const audioBuffer = await openaiTTS({
+      const result = await engine.synthesize({
         text: params.text,
-        apiKey,
-        baseUrl: config.openai.baseUrl,
-        model: config.openai.model,
-        voice: config.openai.voice,
-        speed: config.openai.speed,
-        instructions: config.openai.instructions,
-        responseFormat: output.format,
+        outputFormat: telephonyOutput.format,
         timeoutMs: config.timeoutMs,
       });
 
       return {
         success: true,
-        audioBuffer,
+        audioBuffer: result.audio,
         latencyMs: Date.now() - providerStart,
         provider,
-        outputFormat: output.format,
-        sampleRate: output.sampleRate,
+        outputFormat: telephonyOutput.format,
+        sampleRate: telephonyOutput.sampleRate,
       };
     } catch (err) {
       errors.push(formatTtsProviderError(provider, err));


### PR DESCRIPTION
## Summary

- Introduce a `TtsEngine` interface abstraction (`engine.ts`) with `synthesize()`, optional `synthesizeToFile()`, `isConfigured()`, and `supportsTelephony()` methods
- Extract existing OpenAI, ElevenLabs, and Edge TTS implementations into dedicated engine classes under `engines/` directory
- Add a `createTtsEngines()` registry factory (`registry.ts`) that replaces hard-coded if/else provider dispatch in `textToSpeech()` and `textToSpeechTelephony()`
- Clean up `tts-core.ts` by removing migrated provider functions while retaining shared helpers (directives parsing, summarization, voice validation)

## Motivation

The current TTS module uses a monolithic if/else chain to dispatch across providers, making it difficult to add new providers or modify existing ones in isolation. This refactoring:

1. **Decouples** provider-specific logic from orchestration logic
2. **Standardizes** the provider contract via `TtsEngine` interface
3. **Simplifies** adding new providers — just implement `TtsEngine` and register in the registry
4. **Preserves** the public API surface — zero changes required by external consumers

## Changed files

| File | Change |
|------|--------|
| `src/tts/engine.ts` | New — `TtsEngine` interface + request/result types |
| `src/tts/engines/openai.ts` | New — `OpenAiTtsEngine` class |
| `src/tts/engines/elevenlabs.ts` | New — `ElevenLabsTtsEngine` class |
| `src/tts/engines/edge.ts` | New — `EdgeTtsEngine` class with `synthesizeToFile` |
| `src/tts/registry.ts` | New — `createTtsEngines()` factory |
| `src/tts/tts.ts` | Refactored — engine-based dispatch loop |
| `src/tts/tts-core.ts` | Cleaned — removed migrated provider functions |

## Test plan

- [x] All existing TTS unit tests pass (`vitest run --testPathPattern tts`)
- [x] No changes to the public API — external callers (`textToSpeech`, `textToSpeechTelephony`, type exports) remain unchanged
- [x] Linter (oxlint) passes with zero warnings/errors on all changed files

Made with [Cursor](https://cursor.com)