### PR TITLE
fix: clamp heartbeat intervalMs to Node.js 32-bit timer limit (closes #41240)

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -164,6 +164,27 @@ describe("resolveHeartbeatIntervalMs", () => {
       ),
     ).toBe(5 * 60_000);
   });
+
+  it("clamps values exceeding the Node.js 32-bit timer limit", () => {
+    // "30d" = 2,592,000,000ms which exceeds 2^31-1 (2,147,483,647)
+    expect(
+      resolveHeartbeatIntervalMs({
+        agents: { defaults: { heartbeat: { every: "30d" } } },
+      }),
+    ).toBe(2_147_483_647);
+    // "25d" = 2,160,000,000ms which also exceeds the limit
+    expect(
+      resolveHeartbeatIntervalMs({
+        agents: { defaults: { heartbeat: { every: "25d" } } },
+      }),
+    ).toBe(2_147_483_647);
+    // "24d" = 2,073,600,000ms which is within the limit
+    expect(
+      resolveHeartbeatIntervalMs({
+        agents: { defaults: { heartbeat: { every: "24d" } } },
+      }),
+    ).toBe(24 * 24 * 60 * 60_000);
+  });
 });
 
 describe("resolveHeartbeatPrompt", () => {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -237,6 +237,16 @@ export function resolveHeartbeatIntervalMs(
   if (ms <= 0) {
     return null;
   }
+  // Node.js setTimeout uses a 32-bit signed integer for the delay.
+  // Values above 2^31-1 overflow, causing the timer to fire immediately.
+  const MAX_TIMEOUT_MS = 2_147_483_647;
+  if (ms > MAX_TIMEOUT_MS) {
+    log.warn("heartbeat: intervalMs exceeds Node.js 32-bit timer limit, clamping", {
+      originalMs: ms,
+      clampedMs: MAX_TIMEOUT_MS,
+    });
+    ms = MAX_TIMEOUT_MS;
+  }
   return ms;
 }
 
@@ -1060,7 +1070,7 @@ export function startHeartbeatRunner(opts: {
     if (!Number.isFinite(nextDue)) {
       return;
     }
-    const delay = Math.max(0, nextDue - now);
+    const delay = Math.min(Math.max(0, nextDue - now), 2_147_483_647);
     state.timer = setTimeout(() => {
       state.timer = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });


### PR DESCRIPTION
## Summary
- Problem: heartbeat intervalMs overflows 32-bit setTimeout causing 500MB log spam
- What changed: intervalMs clamped to 2^31-1 before setTimeout, warning logged
- What did NOT change: Normal heartbeat intervals, config resolution

## Change Type
- [x] Bug fix
## Linked Issue/PR
- Closes #41240
## Security Impact
All No
## Evidence
- [x] pnpm build + pnpm check + pnpm test all passing
## Compatibility / Migration
- Backward compatible? Yes
## Failure Recovery
- How to revert: revert this commit
---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*