### PR TITLE
fix(line): include file type in media download condition (closes #26330)

### DIFF
--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -82,6 +82,19 @@ describe("downloadLineMedia", () => {
     expect(writtenPath).toBe(result.path);
   });
 
+  it("downloads file attachments (PDF) as application/octet-stream", async () => {
+    // PDF magic bytes: %PDF
+    const pdf = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([pdf]));
+    vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
+
+    const result = await downloadLineMedia("mid-pdf", "token");
+
+    expect(result.contentType).toBe("application/octet-stream");
+    expect(result.path).toMatch(/\.bin$/);
+    expect(result.size).toBe(pdf.length);
+  });
+
   it("detects MP4 video from ftyp major brand (isom)", async () => {
     const mp4 = Buffer.from([
       0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,


### PR DESCRIPTION
## Summary
- Problem: LINE file attachments (PDF, Word, etc.) not downloaded — only image/video/audio handled
- Why it matters: Agents cannot process document attachments sent via LINE
- What changed: Added test for file type download (fix already present in source via 9a5bfb1)
- What did NOT change: Image/video/audio handling

## Change Type
- [x] Bug fix

## Scope
- [x] LINE extension

## Linked Issue/PR
- Closes #26330

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — file content now downloaded via LINE Content API (same as other media)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence
- [x] pnpm build passing
- [x] pnpm test (LINE download tests) passing

## Compatibility / Migration
- Backward compatible? Yes

## Failure Recovery
- How to revert: revert this commit

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*