### PR TITLE
fix: skip implicit provider auto-detection when explicit providers are configured (closes #33327)

### DIFF
--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -33,12 +33,24 @@ async function resolveProvidersForModelsJson(params: {
 }): Promise<Record<string, ProviderConfig>> {
   const { cfg, agentDir, env } = params;
   const explicitProviders = cfg.models?.providers ?? {};
+  const hasExplicitProviders = Object.keys(explicitProviders).length > 0;
+
+  // When explicit providers are configured, skip implicit discovery entirely
+  // to avoid unrelated outbound API calls / latency (#33327).
+  if (hasExplicitProviders) {
+    return mergeProviders({
+      implicit: undefined,
+      explicit: explicitProviders,
+    });
+  }
+
   const implicitProviders = await resolveImplicitProviders({
     agentDir,
     config: cfg,
     env,
     explicitProviders,
   });
+
   return mergeProviders({
     implicit: implicitProviders,
     explicit: explicitProviders,
@@ -65,6 +77,7 @@ async function resolveProvidersForMode(params: {
   providers: Record<string, ProviderConfig>;
   secretRefManagedProviders: ReadonlySet<string>;
   explicitBaseUrlProviders: ReadonlySet<string>;
+  hasExplicitProviders?: boolean;
 }): Promise<Record<string, ProviderConfig>> {
   if (params.mode !== "merge") {
     return params.providers;
@@ -73,10 +86,21 @@ async function resolveProvidersForMode(params: {
   if (!isRecord(existing) || !isRecord(existing.providers)) {
     return params.providers;
   }
-  const existingProviders = existing.providers as Record<
+  let existingProviders = existing.providers as Record<
     string,
     NonNullable<ModelsConfig["providers"]>[string]
   >;
+
+  // When explicit providers are configured, prune previously-written implicit
+  // providers from the existing models.json that are no longer in the resolved
+  // set, so stale auto-detected entries do not remain routable (#33327).
+  if (params.hasExplicitProviders) {
+    const nextKeys = new Set(Object.keys(params.providers));
+    existingProviders = Object.fromEntries(
+      Object.entries(existingProviders).filter(([key]) => nextKeys.has(key)),
+    );
+  }
+
   return mergeWithExistingProviderSecrets({
     nextProviders: params.providers,
     existingProviders: existingProviders as Record<string, ExistingProviderConfig>,
@@ -112,12 +136,14 @@ export async function planOpenClawModelsJson(params: {
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? providers;
+  const hasExplicitProviders = Object.keys(cfg.models?.providers ?? {}).length > 0;
   const mergedProviders = await resolveProvidersForMode({
     mode,
     existingParsed: params.existingParsed,
     providers: normalizedProviders,
     secretRefManagedProviders,
     explicitBaseUrlProviders: resolveExplicitBaseUrlProviders(cfg.models),
+    hasExplicitProviders,
   });
   const secretEnforcedProviders =
     enforceSourceManagedProviderSecrets({

--- a/src/agents/models-config.skips-implicit-when-explicit-providers.test.ts
+++ b/src/agents/models-config.skips-implicit-when-explicit-providers.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import {
+  CUSTOM_PROXY_MODELS_CONFIG,
+  installModelsConfigTestHooks,
+  MODELS_CONFIG_IMPLICIT_ENV_VARS,
+  unsetEnv,
+  withTempEnv,
+  withModelsTempHome as withTempHome,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+
+installModelsConfigTestHooks();
+
+type ProviderConfig = {
+  baseUrl?: string;
+  apiKey?: string;
+  models?: Array<{ id: string }>;
+};
+
+type ModelsJson = {
+  providers: Record<string, ProviderConfig>;
+};
+
+describe("models-config – skip implicit providers when explicit providers are configured", () => {
+  it("does not include implicit env-var providers when explicit providers are set", async () => {
+    await withTempHome(async () => {
+      // Set env vars that would normally trigger implicit provider discovery.
+      await withTempEnv(["MINIMAX_API_KEY", ...MODELS_CONFIG_IMPLICIT_ENV_VARS], async () => {
+        process.env.MINIMAX_API_KEY = "sk-minimax-test";
+
+        // Configure an explicit provider – implicit detection should be skipped.
+        await ensureOpenClawModelsJson(CUSTOM_PROXY_MODELS_CONFIG);
+
+        const modelPath = path.join(resolveOpenClawAgentDir(), "models.json");
+        const raw = await fs.readFile(modelPath, "utf8");
+        const parsed = JSON.parse(raw) as ModelsJson;
+
+        // Explicit provider must be present.
+        expect(parsed.providers["custom-proxy"]).toBeDefined();
+        expect(parsed.providers["custom-proxy"]?.baseUrl).toBe("http://localhost:4000/v1");
+
+        // Implicit minimax provider must NOT be present.
+        expect(parsed.providers["minimax"]).toBeUndefined();
+      });
+    });
+  });
+
+  it("still uses implicit providers when no explicit providers are configured", async () => {
+    await withTempHome(async () => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+        process.env.MINIMAX_API_KEY = "sk-minimax-test";
+
+        // Empty explicit providers – implicit detection should kick in.
+        await ensureOpenClawModelsJson({});
+
+        const modelPath = path.join(resolveOpenClawAgentDir(), "models.json");
+        const raw = await fs.readFile(modelPath, "utf8");
+        const parsed = JSON.parse(raw) as ModelsJson;
+
+        // Minimax should be discovered implicitly.
+        expect(parsed.providers["minimax"]).toBeDefined();
+        expect(parsed.providers["minimax"]?.apiKey).toBe("MINIMAX_API_KEY");
+      });
+    });
+  });
+
+  it("skips models.json when explicit providers are empty and no env tokens exist", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv([...MODELS_CONFIG_IMPLICIT_ENV_VARS, "KIMI_API_KEY"], async () => {
+        unsetEnv([...MODELS_CONFIG_IMPLICIT_ENV_VARS, "KIMI_API_KEY"]);
+
+        const agentDir = path.join(home, "agent-no-providers");
+        process.env.OPENCLAW_AGENT_DIR = agentDir;
+        process.env.PI_CODING_AGENT_DIR = agentDir;
+
+        const result = await ensureOpenClawModelsJson({ models: { providers: {} } }, agentDir);
+
+        expect(result.wrote).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Problem: Implicit provider auto-discovery merges with explicit config, causing unintended routing
- Why it matters: Traffic can leak to wrong providers, confusing errors on startup, compliance issues
- What changed: When models.providers has entries, implicit detection is skipped
- What did NOT change: Zero-config onboarding (empty providers) still auto-detects

## Change Type
- [x] Bug fix

## Scope
- [x] Agent/Model behavior
- [x] Config/CLI

## Linked Issue/PR
- Closes #33327

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (fewer, actually)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
1. Configure explicit providers in models.providers
2. Set AWS_PROFILE or other env vars for unrelated tools
3. No more spurious provider detection

## Evidence
- [x] pnpm build + pnpm check + pnpm test all passing

## Human Verification
- Verified: build/check/test passing
- Edge cases: empty providers still auto-detects
- NOT verified: runtime with actual provider configs

## Compatibility / Migration
- Backward compatible? Yes — only changes behavior when explicit providers exist
- Config/env changes? No

## Failure Recovery
- How to revert: revert this commit

## Risks and Mitigations
Users relying on implicit+explicit merge will need to add providers explicitly. This is the intended behavior per the issue.

---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*