### PR TITLE
Memory: normalize session path basenames

### DIFF
--- a/src/memory/session-files.test.ts
+++ b/src/memory/session-files.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildSessionEntry } from "./session-files.js";
+import { buildSessionEntry, sessionPathForFile } from "./session-files.js";
 
 describe("buildSessionEntry", () => {
   let tmpDir: string;
@@ -83,5 +83,11 @@ describe("buildSessionEntry", () => {
     const entry = await buildSessionEntry(filePath);
     expect(entry).not.toBeNull();
     expect(entry!.lineMap).toEqual([3, 5]);
+  });
+
+  it("normalizes Windows-style separators when deriving session paths", () => {
+    expect(sessionPathForFile("C:\\Users\\kai\\sessions\\thread.jsonl")).toBe(
+      "sessions/thread.jsonl",
+    );
   });
 });

--- a/src/memory/session-files.ts
+++ b/src/memory/session-files.ts
@@ -7,6 +7,10 @@ import { hashText } from "./internal.js";
 
 const log = createSubsystemLogger("memory");
 
+function basenameAcrossSeparators(filePath: string): string {
+  return path.win32.basename(path.posix.basename(filePath));
+}
+
 export type SessionFileEntry = {
   path: string;
   absPath: string;
@@ -33,7 +37,7 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
 }
 
 export function sessionPathForFile(absPath: string): string {
-  return path.join("sessions", path.basename(absPath)).replace(/\\/g, "/");
+  return path.join("sessions", basenameAcrossSeparators(absPath)).replace(/\\/g, "/");
 }
 
 function normalizeSessionText(value: string): string {


### PR DESCRIPTION
## Summary
- normalize session file basenames across `/` and `\\` when deriving memory-session paths
- avoid leaking Windows-style path segments into `sessions/<name>.jsonl` keys on non-Windows hosts
- add a focused regression test for Windows-style absolute session paths

## Testing
- pnpm test src/memory/session-files.test.ts
- pnpm exec oxfmt --check src/memory/session-files.ts src/memory/session-files.test.ts
- pnpm build
