### PR TITLE
feat(whatsapp): surface forwarding metadata in inbound agent context [AI]

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -425,4 +425,54 @@ describe("web processMessage inbound contract", () => {
 
     expect(updateLastRouteMock).toHaveBeenCalledTimes(1);
   });
+
+  it("sets ForwardedFrom to 'unknown sender' when message is forwarded", async () => {
+    capturedCtx = undefined;
+
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+1000",
+        groupHistoryKey: "+1000",
+        msg: {
+          id: "msg-fwd-1",
+          from: "+1000",
+          to: "+2000",
+          chatType: "direct",
+          body: "forwarded text",
+          isForwarded: true,
+          forwardingScore: 1,
+        },
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const ctx = capturedCtx as any;
+    expect(ctx.ForwardedFrom).toBe("unknown sender");
+    expect(ctx.ForwardingScore).toBe(1);
+  });
+
+  it("does not set ForwardedFrom when message is not forwarded", async () => {
+    capturedCtx = undefined;
+
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+1000",
+        groupHistoryKey: "+1000",
+        msg: {
+          id: "msg-nofwd-1",
+          from: "+1000",
+          to: "+2000",
+          chatType: "direct",
+          body: "regular text",
+        },
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const ctx = capturedCtx as any;
+    expect(ctx.ForwardedFrom).toBeUndefined();
+    expect(ctx.ForwardingScore).toBeUndefined();
+  });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -448,7 +448,9 @@ describe("web processMessage inbound contract", () => {
     expect(capturedCtx).toBeTruthy();
     // oxlint-disable-next-line typescript/no-explicit-any
     const ctx = capturedCtx as any;
-    expect(ctx.ForwardedFrom).toBe("unknown sender");
+    expect(ctx.ForwardedFrom).toBe(
+      "unknown sender (WhatsApp does not disclose the original sender)",
+    );
     expect(ctx.ForwardingScore).toBe(1);
   });
 

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -333,8 +333,11 @@ export async function processMessage(params: {
     OriginatingTo: params.msg.from,
     ...(params.msg.isForwarded
       ? {
-          // WhatsApp does not expose the original sender for privacy reasons.
-          ForwardedFrom: "unknown sender",
+          // WhatsApp intentionally withholds the original sender's identity for all
+          // forwarded messages — this is a platform-level privacy design, not missing
+          // data. The string below is surfaced verbatim to agents so they understand
+          // they cannot determine who wrote the original content.
+          ForwardedFrom: "unknown sender (WhatsApp does not disclose the original sender)",
           ForwardingScore: params.msg.forwardingScore,
         }
       : {}),

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -331,6 +331,13 @@ export async function processMessage(params: {
     Surface: "whatsapp",
     OriginatingChannel: "whatsapp",
     OriginatingTo: params.msg.from,
+    ...(params.msg.isForwarded
+      ? {
+          // WhatsApp does not expose the original sender for privacy reasons.
+          ForwardedFrom: "unknown sender",
+          ForwardingScore: params.msg.forwardingScore,
+        }
+      : {}),
   });
 
   // Only update main session's lastRoute when DM actually IS the main session.

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -58,6 +58,22 @@ function extractContextInfo(message: proto.IMessage | undefined): proto.IContext
   return undefined;
 }
 
+export function extractForwardingInfo(
+  rawMessage: proto.IMessage | undefined,
+): { isForwarded: boolean; forwardingScore: number } | null {
+  const message = unwrapMessage(rawMessage);
+  if (!message) {
+    return null;
+  }
+  const contextInfo = extractContextInfo(message);
+  if (!contextInfo?.isForwarded) {
+    return null;
+  }
+  const forwardingScore =
+    typeof contextInfo.forwardingScore === "number" ? contextInfo.forwardingScore : 0;
+  return { isForwarded: true, forwardingScore };
+}
+
 export function extractMentionedJids(rawMessage: proto.IMessage | undefined): string[] | undefined {
   const message = unwrapMessage(rawMessage);
   if (!message) {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -13,6 +13,7 @@ import { checkInboundAccessControl } from "./access-control.js";
 import { isRecentInboundMessage } from "./dedupe.js";
 import {
   describeReplyContext,
+  extractForwardingInfo,
   extractLocationData,
   extractMediaPlaceholder,
   extractMentionedJids,
@@ -258,6 +259,7 @@ export async function monitorWebInbox(options: {
     body: string;
     location?: ReturnType<typeof extractLocationData>;
     replyContext?: ReturnType<typeof describeReplyContext>;
+    forwardingInfo?: ReturnType<typeof extractForwardingInfo>;
     mediaPath?: string;
     mediaType?: string;
     mediaFileName?: string;
@@ -277,6 +279,7 @@ export async function monitorWebInbox(options: {
       }
     }
     const replyContext = describeReplyContext(msg.message as proto.IMessage | undefined);
+    const forwardingInfo = extractForwardingInfo(msg.message as proto.IMessage | undefined);
 
     let mediaPath: string | undefined;
     let mediaType: string | undefined;
@@ -308,6 +311,7 @@ export async function monitorWebInbox(options: {
       body,
       location: location ?? undefined,
       replyContext,
+      forwardingInfo: forwardingInfo ?? undefined,
       mediaPath,
       mediaType,
       mediaFileName,
@@ -381,6 +385,8 @@ export async function monitorWebInbox(options: {
       mediaPath: enriched.mediaPath,
       mediaType: enriched.mediaType,
       mediaFileName: enriched.mediaFileName,
+      isForwarded: enriched.forwardingInfo?.isForwarded,
+      forwardingScore: enriched.forwardingInfo?.forwardingScore,
     };
     try {
       const task = Promise.resolve(debouncer.enqueue(inboundMessage));

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -41,4 +41,6 @@ export type WebInboundMessage = {
   mediaFileName?: string;
   mediaUrl?: string;
   wasMentioned?: boolean;
+  isForwarded?: boolean;
+  forwardingScore?: number;
 };

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -201,6 +201,8 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
             signature: safeTrim(ctx.ForwardedFromSignature),
             chat_type: safeTrim(ctx.ForwardedFromChatType),
             date_ms: typeof ctx.ForwardedDate === "number" ? ctx.ForwardedDate : undefined,
+            forwarding_score:
+              typeof ctx.ForwardingScore === "number" ? ctx.ForwardingScore : undefined,
           },
           null,
           2,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -81,6 +81,8 @@ export type MsgContext = {
   ForwardedFromChatType?: string;
   ForwardedFromMessageId?: number;
   ForwardedDate?: number;
+  /** How many times the message has been forwarded (WhatsApp forwarding score). */
+  ForwardingScore?: number;
   ThreadStarterBody?: string;
   /** Full thread history when starting a new thread session. */
   ThreadHistoryBody?: string;

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -72,6 +72,13 @@ export type MsgContext = {
   ReplyToForwardedFromUsername?: string;
   ReplyToForwardedFromTitle?: string;
   ReplyToForwardedDate?: number;
+  /**
+   * Display name / identifier of the original sender of a forwarded message.
+   * For Telegram this is resolved from the forward_origin (user name, channel
+   * title, etc.). For WhatsApp the platform intentionally does not disclose the
+   * original sender, so this field is set to a fixed privacy-placeholder string
+   * — do NOT treat an "unknown sender" value as a data-quality problem.
+   */
   ForwardedFrom?: string;
   ForwardedFromType?: string;
   ForwardedFromId?: string;


### PR DESCRIPTION
This PR improves WhatsApp message handling so that the bot can differentiate between forwarded messages and direct messages. I wrote this with Copilot and reviewed the code before submitting it here. 

## Summary

- **Problem:** WhatsApp inbound pipeline discarded `contextInfo.isForwarded` / `contextInfo.forwardingScore` from Baileys; agents had no signal that a message was forwarded and couldn't distinguish user-authored content from third-party content the user forwarded.
- **Why it matters:** Enables forwarding-aware agent workflows (e.g. "forward me a message and I'll help with it"); parity with Telegram which already surfaces forwarded origin via `normalizeForwardedContext()`. The forwarding score also exposes viral/spam signal (WhatsApp marks ≥5 hops as "Forwarded many times").
- **What changed:** `contextInfo.isForwarded` + `contextInfo.forwardingScore` extracted from Baileys messages, threaded through `WebInboundMessage` → `finalizeInboundContext()` → agent system prompt. `ForwardedFrom` is set to `"unknown sender (WhatsApp does not disclose the original sender)"` — WhatsApp intentionally withholds origin identity at the platform level; the reason is embedded in the string so agents don't misinterpret it as missing data. `ForwardingScore` carries the raw hop count.
- **What did NOT change:** Telegram forwarding logic is untouched. `buildInboundMetaSystemPrompt()` rendering logic is unchanged except for the additive `forwarding_score` key.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #

## User-visible / Behavior Changes

When a WhatsApp user forwards a message to an agent, the system prompt now includes a forwarded context block:

```
Forwarded message context (untrusted metadata):

{
  "from": "unknown sender (WhatsApp does not disclose the original sender)",
  "forwarding_score": 3
}
```

Non-forwarded messages: no change.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- Integration/channel: WhatsApp (Baileys)

### Steps

1. Forward any WhatsApp message to an agent
2. Inspect the agent system prompt / context payload

### Expected

- `ForwardedFrom: "unknown sender (WhatsApp does not disclose the original sender)"` present
- `ForwardingScore: N` reflects Baileys hop count
- Non-forwarded messages have neither field set

### Actual

- Before: no forwarding fields; agent had no signal

## Evidence

- [x] Failing test/log before + passing after

Two new tests in `process-message.inbound-contract.test.ts` covering the forwarded and non-forwarded cases. All 13 tests pass.

## Human Verification (required)

- Verified scenarios: Claw currently can’t tell the difference between forwarded and direct message in WhatsApp conversations. 
- Edge cases checked:
- What you did **not** verify: live end-to-end with a real WhatsApp account

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — purely additive context fields
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert: remove the `...(params.msg.isForwarded ? { ForwardedFrom, ForwardingScore } : {})` spread in `process-message.ts`
- Files: `extensions/whatsapp/src/auto-reply/monitor/process-message.ts`
- Known bad symptoms: none expected; fields are additive and only populated when `contextInfo.isForwarded` is truthy

## Risks and Mitigations

- Risk: `contextInfo.isForwarded` undefined on older Baileys message shapes
  - Mitigation: `extractForwardingInfo()` gates on `contextInfo?.isForwarded` being truthy — undefined and false both return `null`, leaving context unchanged