### PR TITLE
fix: honour hook transform model override even when not in allowlist (closes #36326)

### DIFF
--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -251,3 +251,89 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });
 });
+
+describe("runCronIsolatedAgentTurn — hook transform model override (#36326)", () => {
+  let previousFastTestEnv: string | undefined;
+  let cronSession: ReturnType<typeof makeCronSession>;
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+
+    // Agent default model is Opus
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    resolveAgentConfigMock.mockReturnValue(undefined);
+    updateSessionStoreMock.mockResolvedValue(undefined);
+
+    cronSession = makeCronSession({
+      sessionEntry: makeFreshSessionEntry(),
+    });
+    resolveCronSessionMock.mockReturnValue(cronSession);
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("honours payload model even when model allowlist rejects it", async () => {
+    // The transform returns a model that is not in agents.defaults.models.
+    // resolveAllowedModelRef returns the lowercase "model not allowed:" error.
+    resolveAllowedModelRefMock.mockReturnValueOnce({
+      error: "model not allowed: anthropic-proxy/claude-sonnet-4-6",
+    });
+
+    runWithModelFallbackMock.mockResolvedValueOnce(
+      makeSuccessfulRunResult({
+        provider: "anthropic-proxy",
+        model: "claude-sonnet-4-6",
+      }),
+    );
+
+    const job = makeJob({
+      payload: {
+        kind: "agentTurn",
+        message: "hook message",
+        model: "anthropic-proxy/claude-sonnet-4-6",
+      },
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job }));
+
+    expect(result.status).toBe("ok");
+    // The session entry should record the hook transform model, not the
+    // agent default (Opus).  Before #36326, the "model not allowed" case
+    // silently fell back to the default.
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic-proxy");
+    expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("falls back when model not allowed AND cannot be parsed", async () => {
+    // Edge case: model is "not allowed" and also fails parsing (should not
+    // happen in practice since resolveAllowedModelRef already parsed it,
+    // but guard against corruption).
+    resolveAllowedModelRefMock.mockReturnValueOnce({
+      error: "model not allowed: /",
+    });
+
+    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
+
+    const job = makeJob({
+      payload: {
+        kind: "agentTurn",
+        message: "hook message",
+        model: "/",
+      },
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job }));
+
+    // Should still succeed but with the default model (fallback)
+    expect(result.status).toBe("ok");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+    expect(cronSession.sessionEntry.model).toBe("claude-opus-4-6");
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -23,6 +23,7 @@ import {
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveModelRefFromString,
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -325,9 +326,24 @@ export async function runCronIsolatedAgentTurn(params: {
     });
     if ("error" in resolvedOverride) {
       if (resolvedOverride.error.startsWith("model not allowed:")) {
-        logWarn(
-          `cron: payload.model '${modelOverride}' not allowed, falling back to agent defaults`,
-        );
+        // #36326: Payload model overrides come from trusted admin-controlled
+        // sources (cron config, hook transforms, API).  Honour them even when
+        // they are not in agents.defaults.models so that hook transform model
+        // overrides work as expected.  The interactive /model allowlist still
+        // gates session-level overrides separately.
+        const parsed = resolveModelRefFromString({
+          raw: modelOverride,
+          defaultProvider: resolvedDefault.provider,
+        });
+        if (parsed) {
+          provider = parsed.ref.provider;
+          model = parsed.ref.model;
+          logWarn(`cron: payload.model '${modelOverride}' not in model allowlist, using as-is`);
+        } else {
+          logWarn(
+            `cron: payload.model '${modelOverride}' could not be parsed, falling back to agent defaults`,
+          );
+        }
       } else {
         return { status: "error", error: resolvedOverride.error };
       }

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -182,6 +182,41 @@ describe("hooks mapping", () => {
     }
   });
 
+  it("passes model override from transform (#36326)", async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-model-"));
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    const modPath = path.join(transformsRoot, "model-transform.mjs");
+    fs.writeFileSync(
+      modPath,
+      `export default () => ({ message: "transformed", model: "anthropic-proxy/claude-sonnet-4-6" });`,
+    );
+
+    const mappings = resolveHookMappings(
+      {
+        mappings: [
+          {
+            match: { path: "custom" },
+            action: "agent",
+            transform: { module: "model-transform.mjs" },
+          },
+        ],
+      },
+      { configDir },
+    );
+
+    const result = await applyHookMappings(mappings, {
+      payload: {},
+      headers: {},
+      url: new URL("http://127.0.0.1:18789/hooks/custom"),
+      path: "custom",
+    });
+
+    expect(result?.ok).toBe(true);
+    expect(result).toHaveProperty(["action", "kind"], "agent");
+    expect(result).toHaveProperty(["action", "model"], "anthropic-proxy/claude-sonnet-4-6");
+  });
+
   it("rejects transform module traversal outside transformsDir", () => {
     const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-traversal-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");


### PR DESCRIPTION
## Summary

When a hook transform returns a `model` field, the model was correctly merged into the cron job payload but silently dropped at runtime if it was not listed in `agents.defaults.models`.

Commit 15cfba707 (PR #26717) introduced a "model not allowed" fallback path that discarded the payload model and used the agent default instead. This caused hook transform model overrides to be silently ignored.

## Fix

Payload model overrides come from admin-controlled sources (cron config, hook transforms, API). When the model is rejected by the interactive allowlist, the code now parses and uses the model directly (with a warning log) instead of falling back to agent defaults. The interactive `/model` allowlist still gates session-level overrides separately.

## Changes

- `src/cron/isolated-agent/run.ts`: When `resolveAllowedModelRef` returns "model not allowed", parse the model with `parseModelRef` and use it instead of falling back to defaults
- `src/cron/isolated-agent/run.cron-model-override.test.ts`: Added 2 tests for the new behaviour
- `src/gateway/hooks-mapping.test.ts`: Added test verifying transform-returned model flows through `mergeAction`

## Test Results

- `run.cron-model-override.test.ts`: 8/8 passed
- `hooks-mapping.test.ts`: 22/22 passed

Closes #36326