### PR TITLE
fix(whatsapp): drain reconnect queue after WhatsApp reconnects (#30806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - fix(exec): replace TOCTOU check-then-read with atomic pinned-fd open in script preflight [AI]. (#62333) Thanks @pgondhi987.
 - WhatsApp/auto-reply: keep inbound reply, media, and composing sends on the current socket across reconnects, wait through reconnect gaps, and retry timeout-only send failures without dropping the active socket ref. (#62892) Thanks @mcaxtr.
 - Config/plugins: let config writes keep disabled plugin entries without forcing required plugin config schemas or crashing raw plugin validation, so slot switches and similar plugin-state updates persist cleanly. (#63296) Thanks @fuller-stack-dev.
+- WhatsApp/outbound queue: drain queued WhatsApp deliveries when the listener reconnects without dropping reconnect-delayed sends after a special TTL or rewriting retry history, so disconnect-window outbound messages can recover once the channel is ready again. (#46299) Thanks @manuel-claw.
 
 ## 2026.4.9
 

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -3,6 +3,7 @@ import { resolveInboundDebounceMs } from "openclaw/plugin-sdk/channel-inbound";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import { waitForever } from "openclaw/plugin-sdk/cli-runtime";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
+import { drainReconnectQueue } from "openclaw/plugin-sdk/infra-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -259,6 +260,19 @@ export async function monitorWebChannel(
     });
 
     setActiveWebListener(account.accountId, listener);
+
+    // Drain any messages that failed with "no listener" during the disconnect window.
+    void drainReconnectQueue({
+      accountId: account.accountId,
+      cfg,
+      log: reconnectLogger,
+    }).catch((err) => {
+      reconnectLogger.warn(
+        { connectionId: active.connectionId, error: String(err) },
+        "reconnect drain failed",
+      );
+    });
+
     active.unregisterUnhandled = registerUnhandledRejectionHandler((reason) => {
       if (!isLikelyWhatsAppCryptoError(reason)) {
         return false;

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -59,7 +59,6 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
 
 const NO_LISTENER_ERROR_RE = /No active WhatsApp Web listener/i;
 const RECONNECT_QUEUE_TTL_MS = 5 * 60 * 1000;
-const RECONNECT_RECOVERY_BUDGET_MS = 30_000;
 
 const drainInProgress = new Map<string, boolean>();
 
@@ -232,13 +231,21 @@ export async function drainReconnectQueue(opts: {
     await Promise.all(eligible.map((entry) => resetReconnectEntry(entry, opts.stateDir)));
 
     const deliver = opts.deliver ?? (await loadDeliverRuntime()).deliverOutboundPayloads;
-    await recoverPendingDeliveries({
-      deliver,
-      cfg: opts.cfg,
-      log: opts.log,
-      stateDir: opts.stateDir,
-      maxRecoveryMs: RECONNECT_RECOVERY_BUDGET_MS,
-    });
+
+    // Deliver only the reset entries for this account instead of replaying the full queue.
+    for (const entry of eligible) {
+      try {
+        await deliver(buildRecoveryDeliverParams(entry, opts.cfg));
+        await ackDelivery(entry.id, opts.stateDir);
+      } catch (err) {
+        const errMsg = formatErrorMessage(err);
+        if (isPermanentDeliveryError(errMsg)) {
+          await moveToFailed(entry.id, opts.stateDir).catch(() => {});
+        } else {
+          await failDelivery(entry.id, errMsg, opts.stateDir).catch(() => {});
+        }
+      }
+    }
   } finally {
     drainInProgress.delete(opts.accountId);
   }

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
 import type { OpenClawConfig } from "../../config/config.js";
 import { formatErrorMessage } from "../errors.js";
 import {
@@ -9,7 +7,6 @@ import {
   moveToFailed,
   type QueuedDelivery,
   type QueuedDeliveryPayload,
-  resolveQueueDir,
 } from "./delivery-queue-storage.js";
 
 export type RecoverySummary = {
@@ -58,9 +55,9 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
 ];
 
 const NO_LISTENER_ERROR_RE = /No active WhatsApp Web listener/i;
-const RECONNECT_QUEUE_TTL_MS = 5 * 60 * 1000;
 
 const drainInProgress = new Map<string, boolean>();
+const entriesInProgress = new Set<string>();
 
 type DeliverRuntimeModule = typeof import("./deliver-runtime.js");
 
@@ -81,31 +78,6 @@ function getErrnoCode(err: unknown): string | null {
     : null;
 }
 
-async function resetReconnectEntry(entry: QueuedDelivery, stateDir?: string): Promise<boolean> {
-  const filePath = path.join(resolveQueueDir(stateDir), `${entry.id}.json`);
-  const tmp = `${filePath}.${process.pid}.tmp`;
-  const reset: QueuedDelivery = {
-    ...entry,
-    retryCount: 0,
-    lastAttemptAt: undefined,
-    lastError: undefined,
-  };
-  await fs.promises.writeFile(tmp, JSON.stringify(reset, null, 2), {
-    encoding: "utf-8",
-    mode: 0o600,
-  });
-  try {
-    await fs.promises.rename(tmp, filePath);
-  } catch (err) {
-    await fs.promises.unlink(tmp).catch(() => {});
-    if (getErrnoCode(err) === "ENOENT") {
-      return false;
-    }
-    throw err;
-  }
-  return true;
-}
-
 function createEmptyRecoverySummary(): RecoverySummary {
   return {
     recovered: 0,
@@ -113,6 +85,18 @@ function createEmptyRecoverySummary(): RecoverySummary {
     skippedMaxRetries: 0,
     deferredBackoff: 0,
   };
+}
+
+function claimRecoveryEntry(entryId: string): boolean {
+  if (entriesInProgress.has(entryId)) {
+    return false;
+  }
+  entriesInProgress.add(entryId);
+  return true;
+}
+
+function releaseRecoveryEntry(entryId: string): void {
+  entriesInProgress.delete(entryId);
 }
 
 function buildRecoveryDeliverParams(entry: QueuedDelivery, cfg: OpenClawConfig) {
@@ -211,62 +195,50 @@ export async function drainReconnectQueue(opts: {
 
   drainInProgress.set(opts.accountId, true);
   try {
-    const pending = await loadPendingDeliveries(opts.stateDir);
-    const now = Date.now();
-    const matchingEntries = pending.filter(
-      (entry) =>
-        entry.channel === "whatsapp" &&
-        normalizeQueueAccountId(entry.accountId) === opts.accountId &&
-        typeof entry.lastError === "string" &&
-        NO_LISTENER_ERROR_RE.test(entry.lastError),
-    );
-    const eligible = matchingEntries.filter(
-      (entry) => entry.retryCount < MAX_RETRIES && now - entry.enqueuedAt < RECONNECT_QUEUE_TTL_MS,
-    );
-    const expired = matchingEntries.filter(
-      (entry) =>
-        entry.retryCount >= MAX_RETRIES || now - entry.enqueuedAt >= RECONNECT_QUEUE_TTL_MS,
-    );
+    const matchingEntries = (await loadPendingDeliveries(opts.stateDir))
+      .filter(
+        (entry) =>
+          entry.channel === "whatsapp" &&
+          normalizeQueueAccountId(entry.accountId) === opts.accountId &&
+          typeof entry.lastError === "string" &&
+          NO_LISTENER_ERROR_RE.test(entry.lastError),
+      )
+      .toSorted((a, b) => a.enqueuedAt - b.enqueuedAt);
 
-    for (const entry of expired) {
-      try {
-        await moveToFailed(entry.id, opts.stateDir);
-      } catch (err) {
-        if (getErrnoCode(err) === "ENOENT") {
-          opts.log.info(`reconnect drain: expired entry ${entry.id} already gone, skipping`);
-          continue;
-        }
-        throw err;
-      }
-      opts.log.warn(
-        `WhatsApp reconnect drain: expired entry ${entry.id} (TTL exceeded or max retries)`,
-      );
-    }
-
-    if (eligible.length === 0) {
+    if (matchingEntries.length === 0) {
       return;
     }
 
     opts.log.info(
-      `WhatsApp reconnect drain: ${eligible.length} pending message(s) for account ${opts.accountId}`,
+      `WhatsApp reconnect drain: ${matchingEntries.length} pending message(s) for account ${opts.accountId}`,
     );
-
-    const resetEntries: QueuedDelivery[] = [];
-    for (const entry of eligible) {
-      const reset = await resetReconnectEntry(entry, opts.stateDir);
-      if (!reset) {
-        opts.log.info(
-          `reconnect drain: entry ${entry.id} already acked by concurrent recovery, skipping`,
-        );
-        continue;
-      }
-      resetEntries.push(entry);
-    }
 
     const deliver = opts.deliver ?? (await loadDeliverRuntime()).deliverOutboundPayloads;
 
-    // Deliver only the reset entries for this account instead of replaying the full queue.
-    for (const entry of resetEntries) {
+    for (const entry of matchingEntries) {
+      if (!claimRecoveryEntry(entry.id)) {
+        opts.log.info(`WhatsApp reconnect drain: entry ${entry.id} is already being recovered`);
+        continue;
+      }
+
+      if (entry.retryCount >= MAX_RETRIES) {
+        try {
+          await moveToFailed(entry.id, opts.stateDir);
+        } catch (err) {
+          if (getErrnoCode(err) === "ENOENT") {
+            opts.log.info(`reconnect drain: entry ${entry.id} already gone, skipping`);
+            continue;
+          }
+          throw err;
+        } finally {
+          releaseRecoveryEntry(entry.id);
+        }
+        opts.log.warn(
+          `WhatsApp reconnect drain: entry ${entry.id} exceeded max retries and was moved to failed/`,
+        );
+        continue;
+      }
+
       try {
         await deliver(buildRecoveryDeliverParams(entry, opts.cfg));
         await ackDelivery(entry.id, opts.stateDir);
@@ -277,6 +249,8 @@ export async function drainReconnectQueue(opts: {
         } else {
           await failDelivery(entry.id, errMsg, opts.stateDir).catch(() => {});
         }
+      } finally {
+        releaseRecoveryEntry(entry.id);
       }
     }
   } finally {
@@ -316,11 +290,19 @@ export async function recoverPendingDeliveries(opts: {
       break;
     }
     if (entry.retryCount >= MAX_RETRIES) {
-      opts.log.warn(
-        `Delivery ${entry.id} exceeded max retries (${entry.retryCount}/${MAX_RETRIES}) — moving to failed/`,
-      );
-      await moveEntryToFailedWithLogging(entry.id, opts.log, opts.stateDir);
-      summary.skippedMaxRetries += 1;
+      if (!claimRecoveryEntry(entry.id)) {
+        opts.log.info(`Recovery skipped for delivery ${entry.id}: already being processed`);
+        continue;
+      }
+      try {
+        opts.log.warn(
+          `Delivery ${entry.id} exceeded max retries (${entry.retryCount}/${MAX_RETRIES}) — moving to failed/`,
+        );
+        await moveEntryToFailedWithLogging(entry.id, opts.log, opts.stateDir);
+        summary.skippedMaxRetries += 1;
+      } finally {
+        releaseRecoveryEntry(entry.id);
+      }
       continue;
     }
 
@@ -330,6 +312,11 @@ export async function recoverPendingDeliveries(opts: {
       opts.log.info(
         `Delivery ${entry.id} not ready for retry yet — backoff ${retryEligibility.remainingBackoffMs}ms remaining`,
       );
+      continue;
+    }
+
+    if (!claimRecoveryEntry(entry.id)) {
+      opts.log.info(`Recovery skipped for delivery ${entry.id}: already being processed`);
       continue;
     }
 
@@ -353,6 +340,8 @@ export async function recoverPendingDeliveries(opts: {
       }
       summary.failed += 1;
       opts.log.warn(`Retry failed for delivery ${entry.id}: ${errMsg}`);
+    } finally {
+      releaseRecoveryEntry(entry.id);
     }
   }
 

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -75,7 +75,13 @@ function normalizeQueueAccountId(accountId?: string): string {
   return (accountId ?? "").trim() || "default";
 }
 
-async function resetReconnectEntry(entry: QueuedDelivery, stateDir?: string): Promise<void> {
+function getErrnoCode(err: unknown): string | null {
+  return err && typeof err === "object" && "code" in err
+    ? String((err as { code?: unknown }).code)
+    : null;
+}
+
+async function resetReconnectEntry(entry: QueuedDelivery, stateDir?: string): Promise<boolean> {
   const filePath = path.join(resolveQueueDir(stateDir), `${entry.id}.json`);
   const tmp = `${filePath}.${process.pid}.tmp`;
   const reset: QueuedDelivery = {
@@ -88,7 +94,16 @@ async function resetReconnectEntry(entry: QueuedDelivery, stateDir?: string): Pr
     encoding: "utf-8",
     mode: 0o600,
   });
-  await fs.promises.rename(tmp, filePath);
+  try {
+    await fs.promises.rename(tmp, filePath);
+  } catch (err) {
+    await fs.promises.unlink(tmp).catch(() => {});
+    if (getErrnoCode(err) === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+  return true;
 }
 
 function createEmptyRecoverySummary(): RecoverySummary {
@@ -214,7 +229,15 @@ export async function drainReconnectQueue(opts: {
     );
 
     for (const entry of expired) {
-      await moveToFailed(entry.id, opts.stateDir);
+      try {
+        await moveToFailed(entry.id, opts.stateDir);
+      } catch (err) {
+        if (getErrnoCode(err) === "ENOENT") {
+          opts.log.info(`reconnect drain: expired entry ${entry.id} already gone, skipping`);
+          continue;
+        }
+        throw err;
+      }
       opts.log.warn(
         `WhatsApp reconnect drain: expired entry ${entry.id} (TTL exceeded or max retries)`,
       );
@@ -228,12 +251,22 @@ export async function drainReconnectQueue(opts: {
       `WhatsApp reconnect drain: ${eligible.length} pending message(s) for account ${opts.accountId}`,
     );
 
-    await Promise.all(eligible.map((entry) => resetReconnectEntry(entry, opts.stateDir)));
+    const resetEntries: QueuedDelivery[] = [];
+    for (const entry of eligible) {
+      const reset = await resetReconnectEntry(entry, opts.stateDir);
+      if (!reset) {
+        opts.log.info(
+          `reconnect drain: entry ${entry.id} already acked by concurrent recovery, skipping`,
+        );
+        continue;
+      }
+      resetEntries.push(entry);
+    }
 
     const deliver = opts.deliver ?? (await loadDeliverRuntime()).deliverOutboundPayloads;
 
     // Deliver only the reset entries for this account instead of replaying the full queue.
-    for (const entry of eligible) {
+    for (const entry of resetEntries) {
       try {
         await deliver(buildRecoveryDeliverParams(entry, opts.cfg));
         await ackDelivery(entry.id, opts.stateDir);

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "../../config/config.js";
 import { formatErrorMessage } from "../errors.js";
 import {
@@ -7,6 +9,7 @@ import {
   moveToFailed,
   type QueuedDelivery,
   type QueuedDeliveryPayload,
+  resolveQueueDir,
 } from "./delivery-queue-storage.js";
 
 export type RecoverySummary = {
@@ -53,6 +56,41 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /ambiguous .* recipient/i,
   /User .* not in room/i,
 ];
+
+const NO_LISTENER_ERROR_RE = /No active WhatsApp Web listener/i;
+const RECONNECT_QUEUE_TTL_MS = 5 * 60 * 1000;
+const RECONNECT_RECOVERY_BUDGET_MS = 30_000;
+
+const drainInProgress = new Map<string, boolean>();
+
+type DeliverRuntimeModule = typeof import("./deliver-runtime.js");
+
+let deliverRuntimePromise: Promise<DeliverRuntimeModule> | null = null;
+
+function loadDeliverRuntime() {
+  deliverRuntimePromise ??= import("./deliver-runtime.js");
+  return deliverRuntimePromise;
+}
+
+function normalizeQueueAccountId(accountId?: string): string {
+  return (accountId ?? "").trim() || "default";
+}
+
+async function resetReconnectEntry(entry: QueuedDelivery, stateDir?: string): Promise<void> {
+  const filePath = path.join(resolveQueueDir(stateDir), `${entry.id}.json`);
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  const reset: QueuedDelivery = {
+    ...entry,
+    retryCount: 0,
+    lastAttemptAt: undefined,
+    lastError: undefined,
+  };
+  await fs.promises.writeFile(tmp, JSON.stringify(reset, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  await fs.promises.rename(tmp, filePath);
+}
 
 function createEmptyRecoverySummary(): RecoverySummary {
   return {
@@ -141,6 +179,69 @@ export function isEntryEligibleForRecoveryRetry(
 
 export function isPermanentDeliveryError(error: string): boolean {
   return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
+}
+
+export async function drainReconnectQueue(opts: {
+  accountId: string;
+  cfg: OpenClawConfig;
+  log: RecoveryLogger;
+  stateDir?: string;
+  deliver?: DeliverFn;
+}): Promise<void> {
+  if (drainInProgress.get(opts.accountId)) {
+    opts.log.info(
+      `WhatsApp reconnect drain: already in progress for account ${opts.accountId}, skipping`,
+    );
+    return;
+  }
+
+  drainInProgress.set(opts.accountId, true);
+  try {
+    const pending = await loadPendingDeliveries(opts.stateDir);
+    const now = Date.now();
+    const matchingEntries = pending.filter(
+      (entry) =>
+        entry.channel === "whatsapp" &&
+        normalizeQueueAccountId(entry.accountId) === opts.accountId &&
+        typeof entry.lastError === "string" &&
+        NO_LISTENER_ERROR_RE.test(entry.lastError),
+    );
+    const eligible = matchingEntries.filter(
+      (entry) => entry.retryCount < MAX_RETRIES && now - entry.enqueuedAt < RECONNECT_QUEUE_TTL_MS,
+    );
+    const expired = matchingEntries.filter(
+      (entry) =>
+        entry.retryCount >= MAX_RETRIES || now - entry.enqueuedAt >= RECONNECT_QUEUE_TTL_MS,
+    );
+
+    for (const entry of expired) {
+      await moveToFailed(entry.id, opts.stateDir);
+      opts.log.warn(
+        `WhatsApp reconnect drain: expired entry ${entry.id} (TTL exceeded or max retries)`,
+      );
+    }
+
+    if (eligible.length === 0) {
+      return;
+    }
+
+    opts.log.info(
+      `WhatsApp reconnect drain: ${eligible.length} pending message(s) for account ${opts.accountId}`,
+    );
+
+    await Promise.all(eligible.map((entry) => resetReconnectEntry(entry, opts.stateDir)));
+
+    const deliver = opts.deliver ?? (await loadDeliverRuntime()).deliverOutboundPayloads;
+    await recoverPendingDeliveries({
+      deliver,
+      cfg: opts.cfg,
+      log: opts.log,
+      stateDir: opts.stateDir,
+      maxRecoveryMs: RECONNECT_RECOVERY_BUDGET_MS,
+    });
+  } finally {
+    drainInProgress.delete(opts.accountId);
+  }
 }
 
 /**

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -38,7 +38,7 @@ export interface QueuedDelivery extends QueuedDeliveryPayload {
   lastError?: string;
 }
 
-function resolveQueueDir(stateDir?: string): string {
+export function resolveQueueDir(stateDir?: string): string {
   const base = stateDir ?? resolveStateDir();
   return path.join(base, QUEUE_DIRNAME);
 }

--- a/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
+++ b/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
@@ -10,6 +10,7 @@ import {
   failDelivery,
   MAX_RETRIES,
   type RecoveryLogger,
+  recoverPendingDeliveries,
 } from "./delivery-queue.js";
 
 function createMockLogger(): RecoveryLogger {
@@ -90,22 +91,24 @@ describe("drainReconnectQueue", () => {
     expect(deliver).not.toHaveBeenCalled();
   });
 
-  it("expires and moves to failed entries older than TTL", async () => {
+  it("retries immediately without resetting retry history", async () => {
     const log = createMockLogger();
-    const deliver = vi.fn<DeliverFn>(async () => {});
+    const deliver = vi.fn<DeliverFn>(async () => {
+      throw new Error("transient failure");
+    });
 
     const id = await enqueueDelivery(
       { channel: "whatsapp", to: "+1555", payloads: [{ text: "hi" }], accountId: "acct1" },
       tmpDir,
     );
     await failDelivery(id, "No active WhatsApp Web listener", tmpDir);
-
-    // Backdate enqueuedAt to exceed 5-minute TTL
     const queueDir = path.join(tmpDir, "delivery-queue");
     const filePath = path.join(queueDir, `${id}.json`);
-    const entry = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    entry.enqueuedAt = Date.now() - 6 * 60 * 1000; // 6 minutes ago
-    fs.writeFileSync(filePath, JSON.stringify(entry, null, 2));
+    const before = JSON.parse(fs.readFileSync(filePath, "utf-8")) as {
+      retryCount: number;
+      lastAttemptAt?: number;
+      lastError?: string;
+    };
 
     await drainReconnectQueue({
       accountId: "acct1",
@@ -115,11 +118,17 @@ describe("drainReconnectQueue", () => {
       deliver,
     });
 
-    // Should have been moved to failed/
-    const failedDir = path.join(queueDir, "failed");
-    const failedFiles = fs.readdirSync(failedDir).filter((f) => f.endsWith(".json"));
-    expect(failedFiles).toHaveLength(1);
-    expect(deliver).not.toHaveBeenCalled();
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    const after = JSON.parse(fs.readFileSync(filePath, "utf-8")) as {
+      retryCount: number;
+      lastAttemptAt?: number;
+      lastError?: string;
+    };
+    expect(after.retryCount).toBe(before.retryCount + 1);
+    expect(after.lastAttemptAt).toBeTypeOf("number");
+    expect(after.lastAttemptAt).toBeGreaterThanOrEqual(before.lastAttemptAt ?? 0);
+    expect(after.lastError).toBe("transient failure");
   });
 
   it("does not throw if delivery fails during drain", async () => {
@@ -212,5 +221,62 @@ describe("drainReconnectQueue", () => {
     // Unblock first drain
     resolveDeliver!();
     await first;
+  });
+
+  it("does not re-deliver an entry already being recovered at startup", async () => {
+    const log = createMockLogger();
+    const startupLog = createMockLogger();
+    let resolveDeliver: () => void;
+    const deliverPromise = new Promise<void>((resolve) => {
+      resolveDeliver = resolve;
+    });
+    const deliver = vi.fn<DeliverFn>(async () => {
+      await deliverPromise;
+    });
+
+    const id = await enqueueDelivery(
+      { channel: "whatsapp", to: "+1555", payloads: [{ text: "hi" }], accountId: "acct1" },
+      tmpDir,
+    );
+    const queuePath = path.join(tmpDir, "delivery-queue", `${id}.json`);
+    const entry = JSON.parse(fs.readFileSync(queuePath, "utf-8")) as {
+      id: string;
+      enqueuedAt: number;
+      channel: string;
+      to: string;
+      accountId?: string;
+      payloads: Array<{ text: string }>;
+      retryCount: number;
+      lastError?: string;
+    };
+    entry.lastError = "No active WhatsApp Web listener";
+    fs.writeFileSync(queuePath, JSON.stringify(entry, null, 2));
+
+    const startupRecovery = recoverPendingDeliveries({
+      cfg: stubCfg,
+      deliver,
+      log: startupLog,
+      stateDir: tmpDir,
+    });
+
+    await vi.waitFor(() => {
+      expect(deliver).toHaveBeenCalledTimes(1);
+    });
+
+    await drainReconnectQueue({
+      accountId: "acct1",
+      cfg: stubCfg,
+      log,
+      stateDir: tmpDir,
+      deliver,
+    });
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining(`entry ${id} is already being recovered`),
+    );
+
+    resolveDeliver!();
+    await startupRecovery;
   });
 });

--- a/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
+++ b/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
@@ -1,0 +1,216 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  type DeliverFn,
+  drainReconnectQueue,
+  enqueueDelivery,
+  failDelivery,
+  MAX_RETRIES,
+  type RecoveryLogger,
+} from "./delivery-queue.js";
+
+function createMockLogger(): RecoveryLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+const stubCfg = {} as OpenClawConfig;
+
+describe("drainReconnectQueue", () => {
+  let fixtureRoot = "";
+  let tmpDir: string;
+  let fixtureCount = 0;
+
+  beforeAll(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-drain-"));
+  });
+
+  beforeEach(() => {
+    tmpDir = path.join(fixtureRoot, `case-${fixtureCount++}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    if (!fixtureRoot) {
+      return;
+    }
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    fixtureRoot = "";
+  });
+
+  it("drains entries that failed with 'no listener' error", async () => {
+    const log = createMockLogger();
+    const deliver = vi.fn<DeliverFn>(async () => {});
+
+    const id = await enqueueDelivery(
+      { channel: "whatsapp", to: "+1555", payloads: [{ text: "hi" }], accountId: "acct1" },
+      tmpDir,
+    );
+    await failDelivery(id, "No active WhatsApp Web listener", tmpDir);
+
+    await drainReconnectQueue({
+      accountId: "acct1",
+      cfg: stubCfg,
+      log,
+      stateDir: tmpDir,
+      deliver,
+    });
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "whatsapp", to: "+1555", skipQueue: true }),
+    );
+  });
+
+  it("skips entries from other accounts", async () => {
+    const log = createMockLogger();
+    const deliver = vi.fn<DeliverFn>(async () => {});
+
+    const id = await enqueueDelivery(
+      { channel: "whatsapp", to: "+1555", payloads: [{ text: "hi" }], accountId: "other" },
+      tmpDir,
+    );
+    await failDelivery(id, "No active WhatsApp Web listener", tmpDir);
+
+    await drainReconnectQueue({
+      accountId: "acct1",
+      cfg: stubCfg,
+      log,
+      stateDir: tmpDir,
+      deliver,
+    });
+
+    // deliver should not be called since no eligible entries for acct1
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("expires and moves to failed entries older than TTL", async () => {
+    const log = createMockLogger();
+    const deliver = vi.fn<DeliverFn>(async () => {});
+
+    const id = await enqueueDelivery(
+      { channel: "whatsapp", to: "+1555", payloads: [{ text: "hi" }], accountId: "acct1" },
+      tmpDir,
+    );
+    await failDelivery(id, "No active WhatsApp Web listener", tmpDir);
+
+    // Backdate enqueuedAt to exceed 5-minute TTL
+    const queueDir = path.join(tmpDir, "delivery-queue");
+    const filePath = path.join(queueDir, `${id}.json`);
+    const entry = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    entry.enqueuedAt = Date.now() - 6 * 60 * 1000; // 6 minutes ago
+    fs.writeFileSync(filePath, JSON.stringify(entry, null, 2));
+
+    await drainReconnectQueue({
+      accountId: "acct1",
+      cfg: stubCfg,
+      log,
+      stateDir: tmpDir,
+      deliver,
+    });
+
+    // Should have been moved to failed/
+    const failedDir = path.join(queueDir, "failed");
+    const failedFiles = fs.readdirSync(failedDir).filter((f) => f.endsWith(".json"));
+    expect(failedFiles).toHaveLength(1);
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("does not throw if delivery fails during drain", async () => {
+    const log = createMockLogger();
+    const deliver = vi.fn<DeliverFn>(async () => {
+      throw new Error("transient failure");
+    });
+
+    const id = await enqueueDelivery(
+      { channel: "whatsapp", to: "+1555", payloads: [{ text: "hi" }], accountId: "acct1" },
+      tmpDir,
+    );
+    await failDelivery(id, "No active WhatsApp Web listener", tmpDir);
+
+    // Should not throw
+    await expect(
+      drainReconnectQueue({
+        accountId: "acct1",
+        cfg: stubCfg,
+        log,
+        stateDir: tmpDir,
+        deliver,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips entries where retryCount >= MAX_RETRIES", async () => {
+    const log = createMockLogger();
+    const deliver = vi.fn<DeliverFn>(async () => {});
+
+    const id = await enqueueDelivery(
+      { channel: "whatsapp", to: "+1555", payloads: [{ text: "hi" }], accountId: "acct1" },
+      tmpDir,
+    );
+
+    // Bump retryCount to MAX_RETRIES
+    for (let i = 0; i < MAX_RETRIES; i++) {
+      await failDelivery(id, "No active WhatsApp Web listener", tmpDir);
+    }
+
+    await drainReconnectQueue({
+      accountId: "acct1",
+      cfg: stubCfg,
+      log,
+      stateDir: tmpDir,
+      deliver,
+    });
+
+    // Should have moved to failed, not delivered
+    expect(deliver).not.toHaveBeenCalled();
+    const failedDir = path.join(tmpDir, "delivery-queue", "failed");
+    const failedFiles = fs.readdirSync(failedDir).filter((f) => f.endsWith(".json"));
+    expect(failedFiles).toHaveLength(1);
+  });
+
+  it("second concurrent call is skipped (concurrency guard)", async () => {
+    const log = createMockLogger();
+    let resolveDeliver: () => void;
+    const deliverPromise = new Promise<void>((resolve) => {
+      resolveDeliver = resolve;
+    });
+    const deliver = vi.fn<DeliverFn>(async () => {
+      await deliverPromise;
+    });
+
+    await enqueueDelivery(
+      { channel: "whatsapp", to: "+1555", payloads: [{ text: "hi" }], accountId: "acct1" },
+      tmpDir,
+    );
+    // Fail it so it matches the "no listener" filter
+    const pending = fs
+      .readdirSync(path.join(tmpDir, "delivery-queue"))
+      .filter((f) => f.endsWith(".json"));
+    const entryPath = path.join(tmpDir, "delivery-queue", pending[0]);
+    const entry = JSON.parse(fs.readFileSync(entryPath, "utf-8"));
+    entry.lastError = "No active WhatsApp Web listener";
+    entry.retryCount = 1;
+    fs.writeFileSync(entryPath, JSON.stringify(entry, null, 2));
+
+    const opts = { accountId: "acct1", cfg: stubCfg, log, stateDir: tmpDir, deliver };
+
+    // Start first drain (will block on deliver)
+    const first = drainReconnectQueue(opts);
+    // Start second drain immediately — should be skipped
+    const second = drainReconnectQueue(opts);
+    await second;
+
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("already in progress"));
+
+    // Unblock first drain
+    resolveDeliver!();
+    await first;
+  });
+});

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -9,6 +9,7 @@ export {
 export type { QueuedDelivery, QueuedDeliveryPayload } from "./delivery-queue-storage.js";
 export {
   computeBackoffMs,
+  drainReconnectQueue,
   isEntryEligibleForRecoveryRetry,
   isPermanentDeliveryError,
   MAX_RETRIES,

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -32,7 +32,7 @@ export * from "../infra/net/proxy-env.js";
 export * from "../infra/net/proxy-fetch.js";
 export * from "../infra/net/undici-global-dispatcher.js";
 export * from "../infra/net/ssrf.js";
-export * from "../infra/outbound/delivery-queue.js";
+export { drainReconnectQueue } from "../infra/outbound/delivery-queue.js";
 export * from "../infra/outbound/identity.js";
 export * from "../infra/outbound/sanitize-text.js";
 export * from "../infra/parse-finite-number.js";

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -32,6 +32,7 @@ export * from "../infra/net/proxy-env.js";
 export * from "../infra/net/proxy-fetch.js";
 export * from "../infra/net/undici-global-dispatcher.js";
 export * from "../infra/net/ssrf.js";
+export * from "../infra/outbound/delivery-queue.js";
 export * from "../infra/outbound/identity.js";
 export * from "../infra/outbound/sanitize-text.js";
 export * from "../infra/parse-finite-number.js";


### PR DESCRIPTION
## Problem

When WhatsApp briefly disconnects (5–11 seconds, status 499/428/408), outbound messages fail with `"No active WhatsApp Web listener"` and are persisted to the delivery queue on disk. However, `recoverPendingDeliveries()` only runs at **gateway startup** — so those messages sit in the queue until the next restart, often hours later.

Fixes #30806. Also mitigates the race condition in #30177 (delivery recovery fires before WhatsApp listener is ready on startup).

## Root Cause

```
sendMessageWhatsApp() → requireActiveWebListener()
  → throws "No active WhatsApp Web listener (account: X)"
→ failDelivery(retryCount=1) → 25s backoff
→ recoverPendingDeliveries() runs only at startup
   ↳ messages wait until next gateway restart
```

## Solution

Add `drainReconnectQueue()` to `delivery-queue.ts` and call it from `monitor.ts` directly after `setActiveWebListener()` succeeds (i.e., after the Baileys socket reaches `connection: "open"`).

The drain resets the backoff on queued "no listener" entries and immediately re-runs delivery — so messages are recovered within milliseconds of reconnect, not hours.

### Changes

- **`src/infra/outbound/delivery-queue.ts`** — adds `drainReconnectQueue()`:
  - Filters entries that failed with `"No active WhatsApp Web listener"` for the reconnected account
  - Expires entries older than 5 minutes (moves to `failed/`) to avoid delivering stale messages
  - Resets `retryCount` and `lastAttemptAt` to bypass exponential backoff
  - Calls `recoverPendingDeliveries()` with a 30s timeout
  - In-memory mutex per account prevents concurrent drains during rapid reconnect flapping
  - Injectable `deliver` parameter for unit testing
- **`extensions/whatsapp/src/auto-reply/monitor.ts`** — calls `drainReconnectQueue()` as fire-and-forget after `setActiveWebListener()`
- **`src/infra/outbound/delivery-queue.reconnect-drain.test.ts`** — 6 unit tests covering: happy path, other-account filtering, TTL expiry, delivery failure resilience, max-retries skip, concurrency guard

### What does NOT change

- No new dependencies
- No breaking API changes
- Fully backward-compatible with existing crash-recovery flow
- The drain is `void` + `.catch()` — a failure never disrupts the reconnect flow

## Test Results

```
✓ src/infra/outbound/delivery-queue.reconnect-drain.test.ts (6 tests) 17ms
Test Files: 955 passed (956 total — 1 pre-existing unrelated failure in store.redirect.test.ts)
Tests: 7982 passed | 1 failed (pre-existing) | 3 skipped
```

The one failing test (`media/store.redirect.test.ts`) is a pre-existing JPEG size assertion unrelated to this change.

## Notes for Reviewers

- `NO_LISTENER_ERROR_RE` lives in the generic `delivery-queue.ts`. This is a minor abstraction tradeoff — the function is exclusively called from WhatsApp code, but an alternative design would pass a `matchError` predicate from `monitor.ts`. Happy to refactor if preferred.
- The dynamic `import('../outbound/deliver.js')` avoids a circular dependency at module load time.
- The `drainInProgress` map is process-local (not persisted). A rapid flap that produces multiple reconnects will skip the second drain — the entries remain in the queue and will be picked up by the next successful drain.

## AI-Assisted

- [x] Built with Claude Code (Opus 4.6) + reviewed by Gemini 3.1 Pro
- [x] Fully tested locally (`pnpm build && pnpm check && pnpm test`)
- [x] Author understands all changes
- [x] No unresolved bot conversations

---

## AI-Assisted Disclosure

- [x] AI-assisted (Claude Sonnet 4.6 via OpenClaw)
- [x] Fully tested — all 6 reconnect-drain unit tests pass
- [x] Bot review comments addressed (Codex P1 + Greptile suggestions implemented)
- [x] Author (manuel-claw / Manuel) understands the code and can explain every change