### PR TITLE
Sandbox: allow writes with workspaceAccess none

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -84,7 +84,7 @@ Details:
 - **Two prompts**: a user prompt plus a system prompt append the reminder.
 - **One flush per compaction cycle** (tracked in `sessions.json`).
 - **Workspace must be writable**: if the session runs sandboxed with
-  `workspaceAccess: "ro"` or `"none"`, the flush is skipped.
+  `workspaceAccess: "ro"`, the flush is skipped.
 
 For the full compaction lifecycle, see
 [Session management + compaction](/reference/session-management-compaction).

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -172,7 +172,7 @@ describe("ensureSandboxBrowser create args", () => {
     expect(result?.noVncUrl).toBeUndefined();
   });
 
-  it("mounts the main workspace read-only when workspaceAccess is none", async () => {
+  it("keeps the main workspace writable when workspaceAccess is none", async () => {
     const cfg = buildConfig(false);
     cfg.workspaceAccess = "none";
 
@@ -186,7 +186,8 @@ describe("ensureSandboxBrowser create args", () => {
     const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
 
     expect(createArgs).toBeDefined();
-    expect(createArgs).toContain("/tmp/workspace:/workspace:ro");
+    expect(createArgs).toContain("/tmp/workspace:/workspace");
+    expect(createArgs).not.toContain("/tmp/workspace:/workspace:ro");
   });
 
   it("keeps the main workspace writable when workspaceAccess is rw", async () => {

--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -41,12 +41,22 @@ function normalizeForHash(value: unknown): unknown {
   return value;
 }
 
+function resolveWorkspaceMountMode(access: SandboxWorkspaceAccess): "ro" | "rw" {
+  return access === "ro" ? "ro" : "rw";
+}
+
 export function computeSandboxConfigHash(input: SandboxHashInput): string {
-  return computeHash(input);
+  return computeHash({
+    ...input,
+    workspaceMountMode: resolveWorkspaceMountMode(input.workspaceAccess),
+  });
 }
 
 export function computeSandboxBrowserConfigHash(input: SandboxBrowserHashInput): string {
-  return computeHash(input);
+  return computeHash({
+    ...input,
+    workspaceMountMode: resolveWorkspaceMountMode(input.workspaceAccess),
+  });
 }
 
 function computeHash(input: unknown): string {

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -248,7 +248,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
   it.each([
     { workspaceAccess: "rw" as const, expectedMainMount: "/tmp/workspace:/workspace" },
     { workspaceAccess: "ro" as const, expectedMainMount: "/tmp/workspace:/workspace:ro" },
-    { workspaceAccess: "none" as const, expectedMainMount: "/tmp/workspace:/workspace:ro" },
+    { workspaceAccess: "none" as const, expectedMainMount: "/tmp/workspace:/workspace" },
   ])(
     "uses expected main mount permissions when workspaceAccess=$workspaceAccess",
     async ({ workspaceAccess, expectedMainMount }) => {

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -317,7 +317,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
 }
 
 function allowsWrites(access: SandboxWorkspaceAccess): boolean {
-  return access === "rw";
+  return access !== "ro";
 }
 
 function coerceStatType(typeRaw?: string): "file" | "directory" | "other" {

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -62,7 +62,7 @@ export function buildSandboxFsMounts(sandbox: SandboxContext): SandboxFsMount[] 
     {
       hostRoot: path.resolve(sandbox.workspaceDir),
       containerRoot: normalizeContainerPath(sandbox.containerWorkdir),
-      writable: sandbox.workspaceAccess === "rw",
+      writable: sandbox.workspaceAccess !== "ro",
       source: "workspace",
     },
   ];
@@ -74,7 +74,7 @@ export function buildSandboxFsMounts(sandbox: SandboxContext): SandboxFsMount[] 
     mounts.push({
       hostRoot: path.resolve(sandbox.agentWorkspaceDir),
       containerRoot: SANDBOX_AGENT_WORKSPACE_MOUNT,
-      writable: sandbox.workspaceAccess === "rw",
+      writable: sandbox.workspaceAccess !== "ro",
       source: "agent",
     });
   }

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -5,7 +5,7 @@ describe("appendWorkspaceMountArgs", () => {
   it.each([
     { access: "rw" as const, expected: "/tmp/workspace:/workspace" },
     { access: "ro" as const, expected: "/tmp/workspace:/workspace:ro" },
-    { access: "none" as const, expected: "/tmp/workspace:/workspace:ro" },
+    { access: "none" as const, expected: "/tmp/workspace:/workspace" },
   ])("sets main mount permissions for workspaceAccess=$access", ({ access, expected }) => {
     const args: string[] = [];
     appendWorkspaceMountArgs({
@@ -30,7 +30,7 @@ describe("appendWorkspaceMountArgs", () => {
     });
 
     const mounts = args.filter((arg) => arg.startsWith("/tmp/"));
-    expect(mounts).toEqual(["/tmp/workspace:/workspace:ro"]);
+    expect(mounts).toEqual(["/tmp/workspace:/workspace"]);
   });
 
   it("omits agent workspace mount when paths are identical", () => {

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -2,7 +2,7 @@ import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
 function mainWorkspaceMountSuffix(access: SandboxWorkspaceAccess): "" | ":ro" {
-  return access === "rw" ? "" : ":ro";
+  return access === "ro" ? ":ro" : "";
 }
 
 function agentWorkspaceMountSuffix(access: SandboxWorkspaceAccess): "" | ":ro" {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -279,7 +279,7 @@ export async function runMemoryFlushIfNeeded(params: {
       return true;
     }
     const sandboxCfg = resolveSandboxConfigForAgent(params.cfg, runtime.agentId);
-    return sandboxCfg.workspaceAccess === "rw";
+    return sandboxCfg.workspaceAccess !== "ro";
   })();
 
   const isCli = isCliProvider(params.followupRun.run.provider, params.cfg);


### PR DESCRIPTION
  ## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: `workspaceAccess: "none"` mounts the sandbox workspace read-only, even though tools are allowed to write in
  that mode.
  - Why it matters: Sandbox writes (including tool output and memory-flush writes) can fail despite the config implying
  a writable sandbox workspace.
  - What changed: Treat `workspaceAccess: "none"` as writable for the sandbox workspace mounts and FS bridge; updated
  tests.
  - What did NOT change (scope boundary): No changes to tool policy, sandbox scope, or Docker config semantics beyond
  mount permissions.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [x] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #

  ## User-visible / Behavior Changes

  Sandbox workspace stays writable when `workspaceAccess: "none"` (previously mounted read-only).

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No): Yes
  - Secrets/tokens handling changed? (Yes/No): No
  - New/changed network calls? (Yes/No): No
  - Command/tool execution surface changed? (Yes/No): No
  - Data access scope changed? (Yes/No): No
  - If any `Yes`, explain risk + mitigation:
    - Risk: tools can write to the sandbox workspace when `workspaceAccess: "none"`.
    - Mitigation: writes stay inside the sandbox workspace (not the host workspace); host access remains blocked.

  ## Repro + Verification

  ### Environment

  - OS: Windows
  - Runtime/container: Docker sandbox (not run)
  - Model/provider: N/A
  - Integration/channel (if any): N/A
  - Relevant config (redacted): `agents.defaults.sandbox.workspaceAccess: "none"`

  ### Steps

  1. Configure sandbox with `workspaceAccess: "none"`.
  2. Attempt tool write to sandbox workspace.

  ### Expected

  - Writes succeed inside sandbox workspace.

  ### Actual

  - Previously failed due to read-only mount; fixed now.

  ## Evidence

  Attach at least one:

  - [ ] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: Not run.
  - Edge cases checked: None.
  - What you did **not** verify: Docker sandbox runtime behavior and tests.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review
  conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No): Yes
  - Config/env changes? (Yes/No): No
  - Migration needed? (Yes/No): No
  - If yes, exact upgrade steps:

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: Revert this PR.
  - Files/config to restore: `src/agents/sandbox/workspace-mounts.ts`, `src/agents/sandbox/fs-paths.ts`, `src/agents/
  sandbox/fs-bridge.ts`
  - Known bad symptoms reviewers should watch for: Sandbox workspace unexpectedly writable when configured
  `workspaceAccess: "none"`.

  ## Risks and Mitigations

  List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk: Additional writes to sandbox workspace for `workspaceAccess: "none"`.
    - Mitigation: Writes are still confined to the sandbox workspace (not host workspace).