### PR TITLE
fix(config): print copy-paste-ready label stubs on parity test failure

### DIFF
--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -586,15 +586,53 @@ describe("config help copy quality", () => {
   }
 
   it("keeps root section labels and help complete", () => {
+    const missingLabels: string[] = [];
+    const missingHelp: string[] = [];
     for (const key of ROOT_SECTIONS) {
-      expect(FIELD_LABELS[key], `missing root label for ${key}`).toBeDefined();
-      expect(FIELD_HELP[key], `missing root help for ${key}`).toBeDefined();
+      if (FIELD_LABELS[key] === undefined) {
+        missingLabels.push(key);
+      }
+      if (FIELD_HELP[key] === undefined) {
+        missingHelp.push(key);
+      }
+    }
+    if (missingLabels.length > 0 || missingHelp.length > 0) {
+      const parts: string[] = [];
+      if (missingLabels.length > 0) {
+        const stubs = missingLabels
+          .map((k) => `  "${k}": "${k.charAt(0).toUpperCase()}${k.slice(1)}",`)
+          .join("\n");
+        parts.push(`Missing root labels (add to schema.labels.ts):\n${stubs}`);
+      }
+      if (missingHelp.length > 0) {
+        parts.push(`Missing root help keys: ${missingHelp.join(", ")}`);
+      }
+      expect.fail(parts.join("\n\n"));
     }
   });
 
   it("keeps labels in parity for all help keys", () => {
+    const missing: string[] = [];
     for (const key of Object.keys(FIELD_HELP)) {
-      expect(FIELD_LABELS[key], `missing label for help key ${key}`).toBeDefined();
+      if (FIELD_LABELS[key] === undefined) {
+        missing.push(key);
+      }
+    }
+    if (missing.length > 0) {
+      const stubs = missing
+        .map((key) => {
+          const label = key
+            .split(".")
+            .pop()!
+            .replace(/([a-z])([A-Z])/g, "$1 $2")
+            .replace(/^./, (c) => c.toUpperCase());
+          return `  "${key}": "${label}",`;
+        })
+        .join("\n");
+      expect.fail(
+        `${missing.length} help key(s) missing from FIELD_LABELS.\n` +
+          `Add the following to src/config/schema.labels.ts:\n\n${stubs}\n`,
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

When new help keys are added without corresponding FIELD_LABELS entries, the test fails one-by-one with opaque `missing label for help key X` messages. Contributors must manually hunt for the pattern and write label entries.

Now the test collects **all** missing keys and prints ready-to-paste label stubs with auto-generated Title Case labels, making fixes quick and mechanical.

## Change Type
Developer experience improvement

## Scope
`src/config/schema.help.quality.test.ts`

## Linked Issue
Fixes #44292

## What Changed
- `keeps labels in parity for all help keys`: collects all missing keys, generates `"key": "Label"` stubs, prints them in a single `expect.fail()`
- `keeps root section labels and help complete`: same approach for root section labels and help keys

## Security Impact
None — test-only change.

## Evidence
- All 20 schema help quality tests pass
- `pnpm build` passes

## Example Output (when labels are missing)
```
3 help key(s) missing from FIELD_LABELS.
Add the following to src/config/schema.labels.ts:

  "gateway.push": "Push",
  "gateway.push.enabled": "Enabled",
  "gateway.push.interval": "Interval",
```

## Compatibility
Backward compatible — only changes test failure messages.

## Risks
None.

---
> **AI-assisted**: This PR was authored with AI assistance.