### PR TITLE
fix: wire audioAsVoice from message tool to Matrix sendMessage (closes #32489)

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -69,6 +69,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
       const mediaUrl = readStringParam(params, "media", { trim: false });
       const replyTo = readStringParam(params, "replyTo");
       const threadId = readStringParam(params, "threadId");
+      const audioAsVoice = params.asVoice === true || params.audioAsVoice === true;
       return await handleMatrixAction(
         {
           action: "sendMessage",
@@ -77,6 +78,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyTo ?? undefined,
           threadId: threadId ?? undefined,
+          audioAsVoice: audioAsVoice || undefined,
         },
         cfg as CoreConfig,
       );

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -19,12 +19,14 @@ export async function sendMatrixMessage(
     mediaUrl?: string;
     replyToId?: string;
     threadId?: string;
+    audioAsVoice?: boolean;
   } = {},
 ) {
   return await sendMessageMatrix(to, content, {
     mediaUrl: opts.mediaUrl,
     replyToId: opts.replyToId,
     threadId: opts.threadId,
+    audioAsVoice: opts.audioAsVoice,
     client: opts.client,
     timeoutMs: opts.timeoutMs,
   });

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -82,10 +82,12 @@ export async function handleMatrixAction(
         const replyToId =
           readStringParam(params, "replyToId") ?? readStringParam(params, "replyTo");
         const threadId = readStringParam(params, "threadId");
+        const audioAsVoice = params.audioAsVoice === true;
         const result = await sendMatrixMessage(to, content, {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          audioAsVoice: audioAsVoice || undefined,
         });
         return jsonResult({ ok: true, result });
       }


### PR DESCRIPTION
## Summary
Wire the `asVoice`/`audioAsVoice` parameter from the `message` tool through to the Matrix channel's `sendMessageMatrix()` function. Previously, the parameter was defined in the tool schema but never forwarded, causing audio files to appear as generic file attachments instead of native MSC3245 voice message bubbles.

## Change Type
Bug fix

## Scope
- `extensions/matrix/src/actions.ts` – read `asVoice`/`audioAsVoice` from tool params, pass to `handleMatrixAction`
- `extensions/matrix/src/tool-actions.ts` – forward `audioAsVoice` to `sendMatrixMessage`
- `extensions/matrix/src/matrix/actions/messages.ts` – accept and forward `audioAsVoice` to `sendMessageMatrix`

## Linked Issue
Closes #32489

## Security Impact
None

## Repro
1. Send audio via message tool: `{ "action": "send", "channel": "matrix", "media": "./voice.ogg", "asVoice": true }`
2. Previously: audio appears as downloadable file (`m.file`)
3. After fix: audio appears as inline voice bubble (`m.audio` with MSC3245 metadata)

## Evidence
- `pnpm build` ✅
- Matrix send.test.ts already covers `audioAsVoice` at the `sendMessageMatrix` level

## Compatibility
Backward-compatible – only adds parameter forwarding that was previously silently dropped.

## Risks
None – the downstream `sendMessageMatrix` already fully supports `audioAsVoice`.

*This PR was AI-assisted (fully tested with pnpm build/check/test).*