### PR TITLE
fix(agents): register ACP runs in subagent registry for lifecycle tracking

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -39,11 +39,13 @@ const hoisted = vi.hoisted(() => {
   const resolveStorePathMock = vi.fn();
   const resolveSessionTranscriptFileMock = vi.fn();
   const areHeartbeatsEnabledMock = vi.fn();
+  const registerSubagentRunMock = vi.fn();
   const state = {
     cfg: createDefaultSpawnConfig(),
   };
   return {
     callGatewayMock,
+    registerSubagentRunMock,
     sessionBindingCapabilitiesMock,
     sessionBindingBindMock,
     sessionBindingUnbindMock,
@@ -138,6 +140,10 @@ vi.mock("../infra/heartbeat-wake.js", async (importOriginal) => {
   };
 });
 
+vi.mock("./subagent-registry.js", () => ({
+  registerSubagentRun: (...args: unknown[]) => hoisted.registerSubagentRunMock(...args),
+}));
+
 vi.mock("./acp-spawn-parent-stream.js", () => ({
   startAcpSpawnParentStreamRelay: (...args: unknown[]) =>
     hoisted.startAcpSpawnParentStreamRelayMock(...args),
@@ -201,6 +207,7 @@ function expectResolvedIntroTextInBindMetadata(): void {
 
 describe("spawnAcpDirect", () => {
   beforeEach(() => {
+    hoisted.registerSubagentRunMock.mockReset();
     hoisted.state.cfg = createDefaultSpawnConfig();
     hoisted.areHeartbeatsEnabledMock.mockReset().mockReturnValue(true);
 
@@ -1040,5 +1047,56 @@ describe("spawnAcpDirect", () => {
     expect(result.error).toContain('streamTo="parent"');
     expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
     expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
+  });
+
+  it("registers the ACP run in the subagent registry after successful dispatch", async () => {
+    await spawnAcpDirect(
+      {
+        task: "Run analysis",
+        agentId: "codex",
+        mode: "run",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        childSessionKey: expect.stringMatching(/^agent:codex:acp:/),
+        requesterSessionKey: "main",
+        task: "Run analysis",
+        cleanup: "keep",
+      }),
+    );
+  });
+
+  it("still returns success when registerSubagentRun throws", async () => {
+    hoisted.registerSubagentRunMock.mockImplementation(() => {
+      throw new Error("registry unavailable");
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Run analysis",
+        agentId: "codex",
+        mode: "run",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.childSessionKey).toMatch(/^agent:codex:acp:/);
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -274,16 +274,17 @@ function summarizeError(err: unknown): string {
 function resolveRequesterInternalSessionKey(params: {
   cfg: OpenClawConfig;
   requesterSessionKey?: string;
-}): string {
+}): { key: string; mainKey: string; alias: string } {
   const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
   const requesterSessionKey = params.requesterSessionKey?.trim();
-  return requesterSessionKey
+  const key = requesterSessionKey
     ? resolveInternalSessionKey({
         key: requesterSessionKey,
         alias,
         mainKey,
       })
     : alias;
+  return { key, mainKey, alias };
 }
 
 async function persistAcpSpawnSessionFileBestEffort(params: {
@@ -410,7 +411,11 @@ export async function spawnAcpDirect(
   ctx: SpawnAcpContext,
 ): Promise<SpawnAcpResult> {
   const cfg = loadConfig();
-  const requesterInternalKey = resolveRequesterInternalSessionKey({
+  const {
+    key: requesterInternalKey,
+    mainKey,
+    alias,
+  } = resolveRequesterInternalSessionKey({
     cfg,
     requesterSessionKey: ctx.agentSessionKey,
   });
@@ -737,24 +742,33 @@ export async function spawnAcpDirect(
   // subagent_ended) are emitted when the ACP session completes or exits.
   // Without this, ACP sessions are invisible to the registry and their
   // completion is never propagated back to the requester.
-  const { mainKey, alias } = resolveMainSessionAlias(cfg);
-  const requesterDisplayKey = resolveDisplaySessionKey({
-    key: requesterInternalKey,
-    alias,
-    mainKey,
-  });
-  registerSubagentRun({
-    runId: childRunId,
-    childSessionKey: sessionKey,
-    controllerSessionKey: requesterInternalKey,
-    requesterSessionKey: requesterInternalKey,
-    requesterOrigin,
-    requesterDisplayKey,
-    task: params.task,
-    cleanup: "keep",
-    label: params.label || undefined,
-    spawnMode,
-  });
+  // Wrapped in try/catch: registration failure after a successful dispatch must
+  // not surface as an error to the caller, since the ACP session is already live.
+  try {
+    const requesterDisplayKey = resolveDisplaySessionKey({
+      key: requesterInternalKey,
+      alias,
+      mainKey,
+    });
+    registerSubagentRun({
+      runId: childRunId,
+      childSessionKey: sessionKey,
+      controllerSessionKey: requesterInternalKey,
+      requesterSessionKey: requesterInternalKey,
+      requesterOrigin,
+      requesterDisplayKey,
+      task: params.task,
+      cleanup: "keep",
+      label: params.label || undefined,
+      spawnMode,
+    });
+  } catch (err) {
+    log.warn("Failed to register ACP run in subagent registry (session is still live)", {
+      runId: childRunId,
+      childSessionKey: sessionKey,
+      error: summarizeError(err),
+    });
+  }
 
   if (effectiveStreamToParent && parentSessionKey) {
     if (parentRelay && childRunId !== childIdem) {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -49,7 +49,12 @@ import {
 } from "./acp-spawn-parent-stream.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
-import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
+import { registerSubagentRun } from "./subagent-registry.js";
+import {
+  resolveDisplaySessionKey,
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
 
@@ -727,6 +732,29 @@ export async function spawnAcpDirect(
       childSessionKey: sessionKey,
     };
   }
+
+  // Register ACP run in the subagent registry so lifecycle events (including
+  // subagent_ended) are emitted when the ACP session completes or exits.
+  // Without this, ACP sessions are invisible to the registry and their
+  // completion is never propagated back to the requester.
+  const { mainKey, alias } = resolveMainSessionAlias(cfg);
+  const requesterDisplayKey = resolveDisplaySessionKey({
+    key: requesterInternalKey,
+    alias,
+    mainKey,
+  });
+  registerSubagentRun({
+    runId: childRunId,
+    childSessionKey: sessionKey,
+    controllerSessionKey: requesterInternalKey,
+    requesterSessionKey: requesterInternalKey,
+    requesterOrigin,
+    requesterDisplayKey,
+    task: params.task,
+    cleanup: "keep",
+    label: params.label || undefined,
+    spawnMode,
+  });
 
   if (effectiveStreamToParent && parentSessionKey) {
     if (parentRelay && childRunId !== childIdem) {


### PR DESCRIPTION
## Summary

ACP sessions spawned via sessions_spawn(runtime=acp) are never registered in the subagent registry (subagent-registry.ts), making them invisible to the lifecycle event system. This is the root cause of several issues:

- subagent_ended hooks never fire for ACP sessions
- Completion notifications never reach the requester
- Stale session records accumulate in ~/.acpx/sessions/index.json (zombie sessions)
- maxConcurrentSessions can be exhausted by dead sessions

## Changes

Add a registerSubagentRun() call in acp-spawn.ts after successful ACP dispatch, mirroring the existing pattern in subagent-spawn.ts. This enables:

1. subagent_ended hook fires when ACP sessions complete or exit
2. Proper cleanup via the existing archive/reaper pipeline
3. Plugin support -- plugins (e.g. spawn-interceptor) can detect ACP completion through the standard event stream rather than relying on index.json polling

The registration uses cleanup: keep (ACP sessions manage their own workspace) and passes all available context (requesterOrigin, requesterDisplayKey, task, label, spawnMode) for full observability.

## Test plan

- [ ] Spawn an ACP session with sessions_spawn(runtime=acp) and verify subagent_ended hook fires upon completion
- [ ] Verify ACP session appears in subagentRuns registry during execution
- [ ] Verify existing subagent (non-ACP) spawn behavior is unchanged
- [ ] Verify spawn-interceptor plugin receives ACP completion events via L1 native event stream

Fixes #40272