### PR TITLE
skip DNS pinning when routing through env proxy in trusted mode

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -291,4 +291,27 @@ describe("fetchWithSsrFGuard hardening", () => {
       expectEnvProxy: true,
     });
   });
+
+  it("skips DNS pinning when env proxy is configured in trusted mode", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const lookupFn = vi.fn(async () => {
+      throw new Error("getaddrinfo EAI_AGAIN api.search.brave.com");
+    }) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const requestInit = init as RequestInit & { dispatcher?: unknown };
+      expect(requestInit.dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.search.brave.com/res/v1/web/search?q=test",
+      fetchImpl,
+      lookupFn,
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+    });
+
+    expect(lookupFn).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    await result.release();
+  });
 });

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -189,16 +189,22 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
 
     let dispatcher: Dispatcher | null = null;
     try {
-      const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
-        lookupFn: params.lookupFn,
-        policy: params.policy,
-      });
       const canUseTrustedEnvProxy =
         mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
+
       if (canUseTrustedEnvProxy) {
+        // Skip DNS pinning when routing through an env proxy — the proxy
+        // handles name resolution, so a local lookup would fail in
+        // proxy-only environments (e.g. getaddrinfo EAI_AGAIN).
         dispatcher = new EnvHttpProxyAgent();
-      } else if (params.pinDns !== false) {
-        dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy);
+      } else {
+        const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+          lookupFn: params.lookupFn,
+          policy: params.policy,
+        });
+        if (params.pinDns !== false) {
+          dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy);
+        }
       }
 
       const init: RequestInit & { dispatcher?: Dispatcher } = {


### PR DESCRIPTION
web_search and web_fetch fail with \`getaddrinfo EAI_AGAIN\` behind HTTP proxies even when the proxy env vars are correctly configured. The issue is that \`fetchWithSsrFGuard\` unconditionally runs \`resolvePinnedHostnameWithPolicy\` (a local DNS lookup) before checking whether it should delegate to \`EnvHttpProxyAgent\`. In proxy-only networks where the container has no direct DNS access, this lookup fails before the proxy gets involved.

Moved the trusted-env-proxy check ahead of the DNS pinning step so the proxy handles name resolution directly when \`TRUSTED_ENV_PROXY\` mode is active.

Added a test that verifies the DNS lookup function is never called when env proxy mode is active.

Fixes #46306