### PR TITLE
fix: use SSRF-guarded fetch for Firecrawl integration

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -382,17 +382,20 @@ export async function fetchFirecrawlContent(params: {
     storeInCache: params.storeInCache,
   };
 
-  const res = await fetch(endpoint, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${params.apiKey}`,
-      "Content-Type": "application/json",
+  const { response: res, release } = await fetchWithWebToolsNetworkGuard({
+    url: endpoint,
+    init: {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
     },
-    body: JSON.stringify(body),
-    signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+    timeoutSeconds: params.timeoutSeconds,
   });
 
-  const payload = (await res.json()) as {
+  let payload: {
     success?: boolean;
     data?: {
       markdown?: string;
@@ -406,6 +409,11 @@ export async function fetchFirecrawlContent(params: {
     warning?: string;
     error?: string;
   };
+  try {
+    payload = (await res.json()) as typeof payload;
+  } finally {
+    await release();
+  }
 
   if (!res.ok || payload?.success === false) {
     const detail = payload?.error ?? "";


### PR DESCRIPTION
## Vulnerability: SSRF and API Key Exfiltration via Unguarded Firecrawl Integration

**Severity:** High (CVSS 7.7)

## Root Cause

The Firecrawl integration in `fetchFirecrawlContent()` uses raw `fetch()` to POST to the Firecrawl endpoint, while the main web-fetch path uses `fetchWithWebToolsNetworkGuard()` with full SSRF protection (DNS pinning, private IP blocking, redirect validation).

An attacker with `operator.admin` scope can modify `firecrawl.baseUrl` via `config.patch` to point at an arbitrary server. Every subsequent `web_fetch` call then POSTs the Firecrawl API key (in the `Authorization` header) and the user's target URL to the attacker-controlled endpoint. The same vector enables SSRF against cloud metadata services (169.254.169.254), internal Redis/etcd/K8s APIs, etc.

## Fix

Replace raw `fetch()` with `fetchWithWebToolsNetworkGuard()` which enforces DNS pinning, private IP blocking, and redirect validation — matching the protection already applied to the main web-fetch path.

## Affected File

- `src/agents/tools/web-fetch.ts`