### PR TITLE
fix(gateway): add operator.write scope hierarchy for admin grant (closes #22574)

### DIFF
--- a/src/shared/operator-scope-compat.test.ts
+++ b/src/shared/operator-scope-compat.test.ts
@@ -114,6 +114,49 @@ describe("roleScopesAllow", () => {
     ).toBe(true);
   });
 
+  it("enforces full operator scope hierarchy: read < write < admin", () => {
+    // admin satisfies all lower scopes
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.read", "operator.write"],
+        allowedScopes: ["operator.admin"],
+      }),
+    ).toBe(true);
+
+    // write satisfies read but not admin
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.read"],
+        allowedScopes: ["operator.write"],
+      }),
+    ).toBe(true);
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.admin"],
+        allowedScopes: ["operator.write"],
+      }),
+    ).toBe(false);
+
+    // read does not satisfy write or admin
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.write"],
+        allowedScopes: ["operator.read"],
+      }),
+    ).toBe(false);
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.admin"],
+        allowedScopes: ["operator.read"],
+      }),
+    ).toBe(false);
+  });
+
   it("rejects unsatisfied operator write scopes and empty allowed scopes", () => {
     expect(
       roleScopesAllow({

--- a/src/shared/operator-scope-compat.ts
+++ b/src/shared/operator-scope-compat.ts
@@ -20,10 +20,14 @@ function operatorScopeSatisfied(requestedScope: string, granted: Set<string>): b
     return true;
   }
   if (requestedScope === OPERATOR_READ_SCOPE) {
-    return granted.has(OPERATOR_READ_SCOPE) || granted.has(OPERATOR_WRITE_SCOPE);
+    return (
+      granted.has(OPERATOR_READ_SCOPE) ||
+      granted.has(OPERATOR_WRITE_SCOPE) ||
+      granted.has(OPERATOR_ADMIN_SCOPE)
+    );
   }
   if (requestedScope === OPERATOR_WRITE_SCOPE) {
-    return granted.has(OPERATOR_WRITE_SCOPE);
+    return granted.has(OPERATOR_WRITE_SCOPE) || granted.has(OPERATOR_ADMIN_SCOPE);
   }
   return granted.has(requestedScope);
 }


### PR DESCRIPTION
## Summary
Fixes #22574 — `operatorScopeSatisfied()` lacks hierarchy logic for `operator.write`, causing gateway-client to enter a "pairing required" loop when device has `operator.admin` but requests `operator.write`.

## Change Type
Bug fix (non-breaking)

## Change Scope
`src/shared/operator-scope-compat.ts`

## Security Impact
Correct scope hierarchy: operator.admin properly satisfies operator.write requests (principle of least surprise)

## How to Reproduce
1. Fresh OpenClaw install
2. Gateway starts → gateway-client connects with operator.write
3. Device has operator.admin granted
4. Connection rejected → infinite pairing loop

## Evidence
- Added operator.write hierarchy check
- Tests verify read ⊂ write ⊂ admin

## Human Verification
- [ ] Fresh install no longer enters pairing loop

## Backward Compatibility
Fully backward compatible — relaxes a check that was too strict

## Risks
Minimal — standard scope hierarchy pattern