### PR TITLE
fix(msteams): use proactive messaging for FileInfoCard after upload

### DIFF
--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -38,9 +38,12 @@ const runtimeStub: PluginRuntime = {
   },
 } as unknown as PluginRuntime;
 
-function createDeps(): MSTeamsMessageHandlerDeps {
+function createDeps() {
+  const proactiveSendActivity = vi.fn(async () => ({ id: "proactive-activity-id" }));
   const adapter: MSTeamsAdapter = {
-    continueConversation: async () => {},
+    continueConversation: async (_appId, _ref, logic) => {
+      await logic({ sendActivity: proactiveSendActivity });
+    },
     process: async () => {},
   };
   const conversationStore: MSTeamsConversationStore = {
@@ -55,7 +58,7 @@ function createDeps(): MSTeamsMessageHandlerDeps {
     getPoll: async () => null,
     recordVote: async () => null,
   };
-  return {
+  const deps: MSTeamsMessageHandlerDeps = {
     cfg: {} as OpenClawConfig,
     runtime: {
       error: vi.fn(),
@@ -75,6 +78,7 @@ function createDeps(): MSTeamsMessageHandlerDeps {
       debug: vi.fn(),
     },
   };
+  return { deps, proactiveSendActivity };
 }
 
 function createActivityHandler(): MSTeamsActivityHandler {
@@ -134,13 +138,14 @@ function createConsentInvokeHarness(params: {
     contentType: "text/plain",
     conversationId: params.pendingConversationId ?? "19:victim@thread.v2",
   });
-  const handler = registerMSTeamsHandlers(createActivityHandler(), createDeps());
+  const { deps, proactiveSendActivity } = createDeps();
+  const handler = registerMSTeamsHandlers(createActivityHandler(), deps);
   const { context, sendActivity } = createInvokeContext({
     conversationId: params.invokeConversationId,
     uploadId,
     action: params.action,
   });
-  return { uploadId, handler, context, sendActivity };
+  return { uploadId, handler, context, sendActivity, proactiveSendActivity };
 }
 
 describe("msteams file consent invoke authz", () => {
@@ -177,21 +182,23 @@ describe("msteams file consent invoke authz", () => {
   });
 
   it("rejects cross-conversation accept invoke and keeps pending upload", async () => {
-    const { uploadId, handler, context, sendActivity } = createConsentInvokeHarness({
-      invokeConversationId: "19:attacker@thread.v2",
-      action: "accept",
-    });
+    const { uploadId, handler, context, sendActivity, proactiveSendActivity } =
+      createConsentInvokeHarness({
+        invokeConversationId: "19:attacker@thread.v2",
+        action: "accept",
+      });
 
     await handler.run?.(context);
 
-    // invokeResponse should be sent immediately
+    // invokeResponse should be sent immediately via the turn context
     expect(sendActivity).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "invokeResponse",
       }),
     );
 
-    expect(sendActivity).toHaveBeenCalledWith(
+    // Expired message sent via proactive messaging (turn context is revoked)
+    expect(proactiveSendActivity).toHaveBeenCalledWith(
       "The file upload request has expired. Please try sending the file again.",
     );
 
@@ -200,14 +207,15 @@ describe("msteams file consent invoke authz", () => {
   });
 
   it("ignores cross-conversation decline invoke and keeps pending upload", async () => {
-    const { uploadId, handler, context, sendActivity } = createConsentInvokeHarness({
-      invokeConversationId: "19:attacker@thread.v2",
-      action: "decline",
-    });
+    const { uploadId, handler, context, sendActivity, proactiveSendActivity } =
+      createConsentInvokeHarness({
+        invokeConversationId: "19:attacker@thread.v2",
+        action: "decline",
+      });
 
     await handler.run?.(context);
 
-    // invokeResponse should be sent immediately
+    // invokeResponse should be sent immediately via the turn context
     expect(sendActivity).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "invokeResponse",
@@ -216,6 +224,9 @@ describe("msteams file consent invoke authz", () => {
 
     expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
     expect(getPendingUpload(uploadId)).toBeDefined();
+    // Only the invoke response should be sent via the turn context
     expect(sendActivity).toHaveBeenCalledTimes(1);
+    // No proactive messages for decline
+    expect(proactiveSendActivity).not.toHaveBeenCalled();
   });
 });

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -7,7 +7,6 @@ import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.j
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
 import { getPendingUpload, removePendingUpload } from "./pending-uploads.js";
 import type { MSTeamsPollStore } from "./polls.js";
-import { withRevokedProxyFallback } from "./revoked-context.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 export type MSTeamsAccessTokenProvider = {
@@ -42,6 +41,7 @@ export type MSTeamsMessageHandlerDeps = {
  */
 async function handleFileConsentInvoke(
   context: MSTeamsTurnContext,
+  sendActivity: (activity: string | object) => Promise<unknown>,
   log: MSTeamsMonitorLogger,
 ): Promise<boolean> {
   const expiredUploadMessage =
@@ -72,7 +72,7 @@ async function handleFileConsentInvoke(
         receivedConversationId: invokeConversationId || undefined,
       });
       if (consentResponse.action === "accept") {
-        await context.sendActivity(expiredUploadMessage);
+        await sendActivity(expiredUploadMessage);
       }
       return true;
     }
@@ -102,7 +102,7 @@ async function handleFileConsentInvoke(
           fileType: consentResponse.uploadInfo.fileType,
         });
 
-        await context.sendActivity({
+        await sendActivity({
           type: "message",
           attachments: [fileInfoCard],
         });
@@ -114,13 +114,13 @@ async function handleFileConsentInvoke(
         });
       } catch (err) {
         log.debug?.("file upload failed", { uploadId, error: String(err) });
-        await context.sendActivity(`File upload failed: ${String(err)}`);
+        await sendActivity(`File upload failed: ${String(err)}`);
       } finally {
         removePendingUpload(uploadId);
       }
     } else {
       log.debug?.("pending file not found for consent", { uploadId });
-      await context.sendActivity(expiredUploadMessage);
+      await sendActivity(expiredUploadMessage);
     }
   } else {
     // User declined
@@ -147,16 +147,44 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
         // Send invoke response IMMEDIATELY to prevent Teams timeout
         await ctx.sendActivity({ type: "invokeResponse", value: { status: 200 } });
 
-        try {
-          await withRevokedProxyFallback({
-            run: async () => await handleFileConsentInvoke(ctx, deps.log),
-            onRevoked: async () => true,
-            onRevokedLog: () => {
-              deps.log.debug?.(
-                "turn context revoked during file consent invoke; skipping delayed response",
-              );
+        // After the invoke response, the Bot Framework SDK revokes the
+        // TurnContext proxy. Use proactive messaging for subsequent sends
+        // so the FileInfoCard (or error message) reaches the user.
+        const activity = ctx.activity;
+        const proactiveRef = {
+          user: activity.from
+            ? {
+                id: activity.from.id,
+                name: activity.from.name,
+                aadObjectId: activity.from.aadObjectId,
+              }
+            : undefined,
+          agent: activity.recipient
+            ? { id: activity.recipient.id, name: activity.recipient.name }
+            : undefined,
+          conversation: {
+            id: normalizeMSTeamsConversationId(activity.conversation?.id ?? ""),
+            conversationType: activity.conversation?.conversationType,
+            tenantId: activity.conversation?.tenantId,
+          },
+          channelId: activity.channelId ?? "msteams",
+          serviceUrl: activity.serviceUrl,
+          locale: activity.locale,
+        };
+        const sendProactive = async (activityToSend: string | object): Promise<unknown> => {
+          let result: unknown;
+          await deps.adapter.continueConversation(
+            deps.appId,
+            proactiveRef,
+            async (proactiveCtx) => {
+              result = await proactiveCtx.sendActivity(activityToSend);
             },
-          });
+          );
+          return result;
+        };
+
+        try {
+          await handleFileConsentInvoke(ctx, sendProactive, deps.log);
         } catch (err) {
           deps.log.debug?.("file consent handler error", { error: String(err) });
         }


### PR DESCRIPTION
## Summary
FileInfoCard failed because TurnContext proxy was revoked after handler returned. Use `adapter.continueConversation()` with stored conversation reference for all post-upload activities, matching the proactive messaging pattern used elsewhere.

## Change Type
- [x] Bug fix

## Scope
- [x] Extensions (`extensions/`)

## Linked Issue/PR
Closes #29847

## Security Impact
- [x] No security implications

## Repro + Verification
- Build passes

## Human Verification
Send file via FileConsentCard in Teams DM — FileInfoCard should now appear after upload.

## Compatibility / Migration
Backward compatible — same proactive messaging pattern used by send.ts.

## Risks and Mitigations
Low risk — replaces broken TurnContext calls with working proactive pattern.