### PR TITLE
fix(msteams): save conversation reference in pairing branch

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -221,6 +221,29 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
             label: senderName,
           });
         }
+        // Persist conversation reference so --notify can reach this user
+        // even though the message itself is dropped.
+        const agent = activity.recipient;
+        const pairingConvRef: StoredConversationReference = {
+          activityId: activity.id,
+          user: { id: from.id, name: from.name, aadObjectId: from.aadObjectId },
+          agent,
+          bot: agent ? { id: agent.id, name: agent.name } : undefined,
+          conversation: {
+            id: conversationId,
+            conversationType,
+            tenantId: conversation?.tenantId,
+          },
+          teamId,
+          channelId: activity.channelId,
+          serviceUrl: activity.serviceUrl,
+          locale: activity.locale,
+        };
+        conversationStore.upsert(conversationId, pairingConvRef).catch((err) => {
+          log.debug?.("failed to save conversation reference", {
+            error: formatUnknownError(err),
+          });
+        });
       }
       log.debug?.("dropping dm (not allowlisted)", {
         sender: senderId,


### PR DESCRIPTION
## Summary
First DM created pairing request but returned before saving conversation reference, so `--notify` could never send proactive messages. Add targeted `conversationStore.upsert()` in the pairing branch after request creation.

## Change Type
- [x] Bug fix

## Scope
- [x] Extensions (`extensions/`)

## Linked Issue/PR
Closes #43323

## Security Impact
- [x] No security implications

## Repro + Verification
- `extensions/msteams/` (229 tests) all pass
- Build passes

## Human Verification
Deploy with MS Teams, send first DM, approve pairing with --notify — notification should now be delivered.

## Compatibility / Migration
Backward compatible — adds a conversation reference save that was missing.

## Risks and Mitigations
Low risk — only adds a save in a path that previously skipped it.