### PR TITLE
fix(discord): avoid destructured renames that jiti mangles

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -370,10 +370,12 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
         includeApplication: true,
       }),
     auditAccount: async ({ account, timeoutMs, cfg }) => {
-      const { channelIds, unresolvedChannels } = collectDiscordAuditChannelIds({
+      const _auditIds = collectDiscordAuditChannelIds({
         cfg,
         accountId: account.accountId,
       });
+      const channelIds = _auditIds.channelIds;
+      const unresolvedChannels = _auditIds.unresolvedChannels;
       if (!channelIds.length && unresolvedChannels === 0) {
         return undefined;
       }

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -1,6 +1,8 @@
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/discord";
 
-const { setRuntime: setDiscordRuntime, getRuntime: getDiscordRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Discord runtime not initialized");
+// Avoid destructured rename so jiti transpilation cannot mangle the bindings.
+const _runtimeStore = createPluginRuntimeStore<PluginRuntime>("Discord runtime not initialized");
+const setDiscordRuntime = _runtimeStore.setRuntime;
+const getDiscordRuntime = _runtimeStore.getRuntime;
 export { getDiscordRuntime, setDiscordRuntime };

--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -70,6 +70,9 @@ function getJiti() {
   jitiLoader = createJiti(__filename, {
     interopDefault: true,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+    transformOptions: {
+      babel: { compact: false, minified: false },
+    },
   });
   return jitiLoader;
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -632,6 +632,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     jitiLoader = createJiti(import.meta.url, {
       interopDefault: true,
       extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+      transformOptions: {
+        babel: { compact: false, minified: false },
+      },
       ...(Object.keys(aliasMap).length > 0
         ? {
             alias: aliasMap,


### PR DESCRIPTION
## Summary
Replace destructured rename patterns with explicit property access in Discord extension to prevent jiti transpilation from mangling variable names at runtime. Also disable babel compact/minified in plugin loader as defense-in-depth.

## Change Type
- [x] Bug fix

## Scope
- [x] Extensions (`extensions/`) and Core (`src/`)

## Linked Issue/PR
Closes #34540

## Security Impact
- [x] No security implications

## Repro + Verification
- Build passes

## Compatibility / Migration
Backward compatible — semantically identical code, just avoids a pattern jiti mishandles.

## Risks and Mitigations
Low risk — equivalent code that avoids a known transpiler issue.