### PR TITLE
fix(compaction): check turnPrefixMessages in manual compact safeguard

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1528,6 +1528,36 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(getApiKeyMock).not.toHaveBeenCalled();
   });
 
+  it("does not cancel compaction when turnPrefixMessages has real conversation messages", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [
+          { role: "user" as const, content: [{ type: "text" as const, text: "hello" }] },
+          { role: "assistant" as const, content: [{ type: "text" as const, text: "hi" }] },
+        ] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        isSplitTurn: true,
+        tokensBefore: 1500,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 500, keepRecentTokens: 500 },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result, getApiKeyMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: "sk-test", // pragma: allowlist secret
+    });
+    expect(result?.cancel).not.toBe(true);
+    expect(getApiKeyMock).toHaveBeenCalled();
+  });
+
   it("continues when messages include real conversation content", async () => {
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -702,7 +702,10 @@ async function readWorkspaceContextForSummary(): Promise<string> {
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
     const { preparation, customInstructions: eventInstructions, signal } = event;
-    if (!preparation.messagesToSummarize.some(isRealConversationMessage)) {
+    const hasRealMessages =
+      preparation.messagesToSummarize.some(isRealConversationMessage) ||
+      (preparation.turnPrefixMessages ?? []).some(isRealConversationMessage);
+    if (!hasRealMessages) {
       log.warn(
         "Compaction safeguard: cancelling compaction with no real conversation messages to summarize.",
       );


### PR DESCRIPTION
## Summary
Extended the compaction safeguard to check both `messagesToSummarize` and `turnPrefixMessages` for real conversation messages. In split-turn scenarios (common in Discord threads), real messages can be exclusively in `turnPrefixMessages`, causing manual `/compact` to be incorrectly cancelled.

## Change Type
- [x] Bug fix

## Scope
- [x] Core (`src/`)

## Linked Issue/PR
Closes #44138

## Security Impact
- [x] No security implications

## Repro + Verification
- `compaction-safeguard.test.ts` (67 tests) all pass, including new split-turn test
- Build passes

## Compatibility / Migration
Backward compatible — only relaxes the safeguard to accept more valid compaction scenarios.

## Risks and Mitigations
Low risk — aligns safeguard with existing logic at line 935-936.