### PR TITLE
fix(ui): use selected attribute for agents model select initial value (closes #34857)

### DIFF
--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -135,7 +135,7 @@ export function renderAgentOverview(params: {
                       </option>
                     `
               }
-              ${buildModelOptions(configForm, effectivePrimary ?? undefined)}
+              ${buildModelOptions(configForm, isDefault ? (effectivePrimary ?? undefined) : (entryPrimary ?? undefined))}
             </select>
           </label>
           <div class="field">

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -585,7 +585,10 @@ export function buildModelOptions(
       <option value="" disabled>No configured models</option>
     `;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) =>
+      html`<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>`,
+  );
 }
 
 type CompiledPattern =


### PR DESCRIPTION
## Summary
Fixes #34857 — Agents model selection shows wrong primary model on initial load due to Lit render timing.

## Change Type
Bug fix (non-breaking)

## Change Scope
`ui/src/ui/views/agents-utils.ts` — `buildModelOptions`

## Security Impact
None

## How to Reproduce
1. Open Control UI → Agents tab
2. Select any agent with configured primary model
3. Model select shows first option instead of configured value

## Evidence
- Added `?selected` attribute to `<option>` elements
- Selection established during ChildPart render phase

## Human Verification
- [ ] Model select shows correct primary on initial load

## Backward Compatibility
Fully backward compatible — display fix only

## Risks
Minimal — standard HTML selected attribute usage