### PR TITLE
fix(bluebubbles): unify debounce key prefix for balloon and text events

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -133,7 +133,7 @@ export function createBlueBubblesDebounceRegistry(params: {
           const balloonBundleId = msg.balloonBundleId?.trim();
           const associatedMessageGuid = msg.associatedMessageGuid?.trim();
           if (balloonBundleId && associatedMessageGuid) {
-            return `bluebubbles:${account.accountId}:balloon:${associatedMessageGuid}`;
+            return `bluebubbles:${account.accountId}:msg:${associatedMessageGuid}`;
           }
 
           const messageId = msg.messageId?.trim();


### PR DESCRIPTION
## Summary
Text and balloon webhook events used different debounce key prefixes (`msg:` vs `balloon:`), so URL-containing messages triggered duplicate replies. Use `msg:` prefix for both so they coalesce correctly.

## Change Type
- [x] Bug fix

## Scope
- [x] Extensions (`extensions/`)

## Linked Issue/PR
Closes #31823

## Security Impact
- [x] No security implications

## Repro + Verification
- Build passes

## Compatibility / Migration
Backward compatible — balloon events now correctly merge with their text counterpart.

## Risks and Mitigations
Low risk — one-line prefix change.