### PR TITLE
fix(macos): recognize openclaw-gateway process title in PortGuardian

### DIFF
--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -369,7 +369,7 @@ actor PortGuardian {
             return false
         case .local:
             // The gateway daemon may listen as `openclaw` or as its runtime (`node`, `bun`, etc).
-            if full.contains("gateway-daemon") { return true }
+            if full.contains("gateway-daemon") || full.contains("openclaw-gateway") { return true }
             // If args are unavailable, treat a CLI listener as expected.
             if cmd.contains("openclaw"), full == cmd { return true }
             return false


### PR DESCRIPTION
## Summary
`PortGuardian.isExpected()` only matched `gateway-daemon` but the actual process title is `openclaw-gateway` (set by preaction.ts). Added `openclaw-gateway` to the match.

## Change Type
- [x] Bug fix

## Scope
- [x] macOS app (`apps/macos/`)

## Linked Issue/PR
Closes #28363

## Security Impact
- [x] No security implications

## Repro + Verification
- One-line Swift change, verified by inspection

## Compatibility / Migration
Backward compatible — also accepts legacy `gateway-daemon` title.

## Risks and Mitigations
Low risk — widens the accepted process title set.