### PR TITLE
fix: rotate auth profile on /new by consulting last-used from store (closes #32444)

### DIFF
--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -6,16 +6,24 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import { resolveSessionAuthProfileOverride } from "./session-override.js";
 
-async function writeAuthStore(agentDir: string) {
+async function writeAuthStore(
+  agentDir: string,
+  extra?: {
+    usageStats?: Record<string, unknown>;
+    profiles?: Record<string, unknown>;
+    order?: Record<string, string[]>;
+  },
+) {
   const authPath = path.join(agentDir, "auth-profiles.json");
   const payload = {
     version: 1,
-    profiles: {
+    profiles: extra?.profiles ?? {
       "zai:work": { type: "api_key", provider: "zai", key: "sk-test" },
     },
-    order: {
+    order: extra?.order ?? {
       zai: ["zai:work"],
     },
+    ...(extra?.usageStats ? { usageStats: extra.usageStats } : {}),
   };
   await fs.writeFile(authPath, JSON.stringify(payload), "utf-8");
 }
@@ -48,6 +56,84 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       expect(resolved).toBe("zai:work");
       expect(sessionEntry.authProfileOverride).toBe("zai:work");
+    });
+  });
+
+  it("rotates past last-used profile on new session with no current override", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        profiles: {
+          "zai:a": { type: "api_key", provider: "zai", key: "sk-a" },
+          "zai:b": { type: "api_key", provider: "zai", key: "sk-b" },
+          "zai:c": { type: "api_key", provider: "zai", key: "sk-c" },
+        },
+        order: { zai: ["zai:a", "zai:b", "zai:c"] },
+        usageStats: {
+          "zai:a": { lastUsed: 1000 },
+          "zai:b": { lastUsed: 3000 },
+          "zai:c": { lastUsed: 2000 },
+        },
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s-new",
+        updatedAt: Date.now(),
+        // no authProfileOverride — simulates /new or /reset
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "zai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      // "zai:b" was last used (t=3000), so rotation should pick "zai:c" (next in order)
+      expect(resolved).toBe("zai:c");
+      expect(sessionEntry.authProfileOverride).toBe("zai:c");
+    });
+  });
+
+  it("falls back to first available when no usageStats exist on new session", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        profiles: {
+          "zai:a": { type: "api_key", provider: "zai", key: "sk-a" },
+          "zai:b": { type: "api_key", provider: "zai", key: "sk-b" },
+        },
+        order: { zai: ["zai:a", "zai:b"] },
+        // no usageStats
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s-fresh",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "zai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      // No usage history → falls back to first available
+      expect(resolved).toBe("zai:a");
+      expect(sessionEntry.authProfileOverride).toBe("zai:a");
     });
   });
 });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -120,7 +120,30 @@ export async function resolveSessionAuthProfileOverride(params: {
 
   let next = current;
   if (isNewSession) {
-    next = current ? pickNextAvailable(current) : pickFirstAvailable();
+    if (current) {
+      next = pickNextAvailable(current);
+    } else {
+      // When current is undefined (new session has no authProfileOverride),
+      // consult the store's usageStats to find the most recently used profile
+      // so we can rotate past it instead of always picking the first.
+      let lastUsedInOrder: string | undefined;
+      let lastUsedTime = 0;
+      for (const id of order) {
+        const ts = store.usageStats?.[id]?.lastUsed;
+        if (typeof ts === "number" && ts > lastUsedTime) {
+          lastUsedTime = ts;
+          lastUsedInOrder = id;
+        }
+      }
+      if (lastUsedInOrder) {
+        const candidate = pickNextAvailable(lastUsedInOrder);
+        // If all profiles are in cooldown, prefer order[0] (sorted by earliest
+        // cooldown expiry) over the most-recently-used anchor.
+        next = isProfileInCooldown(store, candidate) ? pickFirstAvailable() : candidate;
+      } else {
+        next = pickFirstAvailable();
+      }
+    }
   } else if (current && compactionCount > storedCompaction) {
     next = pickNextAvailable(current);
   } else if (!current || isProfileInCooldown(store, current)) {


### PR DESCRIPTION
## Summary
- Problem: /new always picks first auth profile, breaking round-robin rotation
- What changed: New sessions now consult last-used profile for rotation
- What did NOT change: Existing session profile selection, non-/new paths

## Change Type
- [x] Bug fix
## Linked Issue/PR
- Closes #32444
## Security Impact
All No
## Evidence
- [x] pnpm build + pnpm check + pnpm test all passing
## Compatibility / Migration
- Backward compatible? Yes
## Failure Recovery
- How to revert: revert this commit
---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*