### PR TITLE
fix(ui): prioritize session label over displayName in dropdown (closes #45120)

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -685,18 +685,28 @@ function resolveSessionScopedOptionLabel(
   row?: SessionsListResult["sessions"][number],
   rest?: string,
 ) {
-  const base = rest?.trim() || key;
-  if (!row) {
-    return base;
-  }
+  // Priority: label > displayName > scoped suffix > key
+  const label =
+    typeof row?.label === "string" && row.label.trim().length > 0 ? row.label.trim() : null;
+  const displayName =
+    typeof row?.displayName === "string" && row.displayName.trim().length > 0
+      ? row.displayName.trim()
+      : null;
 
-  const label = row.label?.trim() || "";
-  const displayName = row.displayName?.trim() || "";
-  if ((label && label !== key) || (displayName && displayName !== key)) {
-    return resolveSessionDisplayName(key, row);
+  // Use label if available
+  if (label) {
+    return `${key} · ${label}`;
   }
-
-  return base;
+  // Fall back to displayName
+  if (displayName && displayName !== key) {
+    return `${key} · ${displayName}`;
+  }
+  // Fall back to scoped suffix from parsed session key
+  if (rest && rest.trim().length > 0) {
+    return `${key} · ${rest.trim()}`;
+  }
+  // Default to key
+  return key;
 }
 
 type ThemeOption = { id: ThemeName; label: string; icon: string };


### PR DESCRIPTION
## Summary
Fixes #45120 — Session dropdown in Control UI shows raw session keys instead of human-readable labels due to incorrect field priority.

## Change Type
Bug fix (non-breaking)

## Change Scope
`ui/src/ui/app-render.helpers.ts` — `resolveSessionScopedOptionLabel`

## Security Impact
None

## How to Reproduce
1. Open Control UI → Chat tab
2. Click session dropdown
3. Sessions show keys like `agent:main:subagent:...` instead of labels

## Evidence
- Changed field priority: label > displayName > key
- Consistent format: `key · label` when label available

## Human Verification
- [ ] Session dropdown shows human-readable labels

## Backward Compatibility
Fully backward compatible — display-only change

## Risks
Minimal — UI text rendering change only