### PR TITLE
fix(hooks): prevent hook runner reinitialization from skipping in-flight hooks (closes #42644)

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -32,7 +32,7 @@ import {
 } from "../../hooks/message-hook-mappers.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
-import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { getGlobalHookRunner, withGlobalHookExecution } from "../../plugins/hook-runner-global.js";
 import { throwIfAborted } from "./abort.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
 import type { OutboundIdentity } from "./identity.js";
@@ -424,20 +424,23 @@ async function applyMessageSendingHook(params: {
     };
   }
   try {
-    const sendingResult = await params.hookRunner!.runMessageSending(
-      {
-        to: params.to,
-        content: params.payloadSummary.text,
-        metadata: {
-          channel: params.channel,
-          accountId: params.accountId,
-          mediaUrls: params.payloadSummary.mediaUrls,
+    // Guard: prevent hook runner reinitialization while the hook executes (#42644)
+    const sendingResult = await withGlobalHookExecution(() =>
+      params.hookRunner!.runMessageSending(
+        {
+          to: params.to,
+          content: params.payloadSummary.text,
+          metadata: {
+            channel: params.channel,
+            accountId: params.accountId,
+            mediaUrls: params.payloadSummary.mediaUrls,
+          },
         },
-      },
-      {
-        channelId: params.channel,
-        accountId: params.accountId ?? undefined,
-      },
+        {
+          channelId: params.channel,
+          accountId: params.accountId ?? undefined,
+        },
+      ),
     );
     if (sendingResult?.cancel) {
       return {

--- a/src/plugins/hook-runner-global.test.ts
+++ b/src/plugins/hook-runner-global.test.ts
@@ -46,4 +46,134 @@ describe("hook-runner-global", () => {
     expect(modC.getGlobalHookRunner()).toBeNull();
     expect(modC.getGlobalPluginRegistry()).toBeNull();
   });
+
+  describe("reinitialization race condition (#42644)", () => {
+    it("defers reinitialization while a hook execution is in-flight", async () => {
+      const mod = await importHookRunnerGlobalModule();
+
+      let resolveHook!: () => void;
+      const hookPromise = new Promise<void>((resolve) => {
+        resolveHook = resolve;
+      });
+      const handler = vi.fn(() => hookPromise);
+
+      const registryA = createMockPluginRegistry([{ hookName: "message_sending", handler }]);
+      mod.initializeGlobalHookRunner(registryA);
+
+      const runnerA = mod.getGlobalHookRunner();
+      expect(runnerA?.hasHooks("message_sending")).toBe(true);
+
+      // Start an in-flight hook execution
+      const executionPromise = mod.withGlobalHookExecution(() =>
+        runnerA!.runMessageSending(
+          { to: "user", content: "hello", metadata: { channel: "test" } } as never,
+          { channelId: "test" } as never,
+        ),
+      );
+
+      // While the hook is in-flight, reinitialize with a new registry
+      const registryB = createMockPluginRegistry([
+        { hookName: "message_received", handler: vi.fn() },
+      ]);
+      mod.initializeGlobalHookRunner(registryB);
+
+      // The old runner should still be active (reinitialization deferred)
+      expect(mod.getGlobalHookRunner()).toBe(runnerA);
+      expect(mod.getGlobalPluginRegistry()).toBe(registryA);
+
+      // Complete the in-flight hook
+      resolveHook();
+      await executionPromise;
+
+      // Now the deferred reinitialization should have been applied
+      expect(mod.getGlobalPluginRegistry()).toBe(registryB);
+      expect(mod.getGlobalHookRunner()?.hasHooks("message_received")).toBe(true);
+      expect(mod.getGlobalHookRunner()?.hasHooks("message_sending")).toBe(false);
+    });
+
+    it("applies the latest pending registry when multiple reinits are deferred", async () => {
+      const mod = await importHookRunnerGlobalModule();
+
+      let resolveHook!: () => void;
+      const hookPromise = new Promise<void>((resolve) => {
+        resolveHook = resolve;
+      });
+      const handler = vi.fn(() => hookPromise);
+
+      const registryA = createMockPluginRegistry([{ hookName: "message_sending", handler }]);
+      mod.initializeGlobalHookRunner(registryA);
+
+      const runnerA = mod.getGlobalHookRunner();
+
+      // Start in-flight execution
+      const executionPromise = mod.withGlobalHookExecution(() =>
+        runnerA!.runMessageSending(
+          { to: "user", content: "hello", metadata: { channel: "test" } } as never,
+          { channelId: "test" } as never,
+        ),
+      );
+
+      // Queue two reinitializations — only the last should take effect
+      const registryB = createMockPluginRegistry([
+        { hookName: "message_received", handler: vi.fn() },
+      ]);
+      const registryC = createMockPluginRegistry([{ hookName: "session_start", handler: vi.fn() }]);
+      mod.initializeGlobalHookRunner(registryB);
+      mod.initializeGlobalHookRunner(registryC);
+
+      // Still the old runner
+      expect(mod.getGlobalPluginRegistry()).toBe(registryA);
+
+      resolveHook();
+      await executionPromise;
+
+      // Only registryC (the latest) should be active
+      expect(mod.getGlobalPluginRegistry()).toBe(registryC);
+      expect(mod.getGlobalHookRunner()?.hasHooks("session_start")).toBe(true);
+      expect(mod.getGlobalHookRunner()?.hasHooks("message_received")).toBe(false);
+    });
+
+    it("swaps immediately when no hooks are in-flight", async () => {
+      const mod = await importHookRunnerGlobalModule();
+
+      const registryA = createMockPluginRegistry([
+        { hookName: "message_sending", handler: vi.fn() },
+      ]);
+      mod.initializeGlobalHookRunner(registryA);
+
+      const registryB = createMockPluginRegistry([
+        { hookName: "message_received", handler: vi.fn() },
+      ]);
+      mod.initializeGlobalHookRunner(registryB);
+
+      // Immediate swap — no in-flight hooks
+      expect(mod.getGlobalPluginRegistry()).toBe(registryB);
+      expect(mod.getGlobalHookRunner()?.hasHooks("message_received")).toBe(true);
+    });
+
+    it("keeps old runner active if hook errors during guarded execution", async () => {
+      const mod = await importHookRunnerGlobalModule();
+
+      const handler = vi.fn(() => Promise.reject(new Error("hook failed")));
+      const registryA = createMockPluginRegistry([{ hookName: "message_sending", handler }]);
+      mod.initializeGlobalHookRunner(registryA);
+
+      const registryB = createMockPluginRegistry([
+        { hookName: "message_received", handler: vi.fn() },
+      ]);
+
+      // Even if the hook throws, the deferred init should still fire
+      await expect(
+        mod.withGlobalHookExecution(async () => {
+          mod.initializeGlobalHookRunner(registryB);
+          // Old runner is still active during execution
+          expect(mod.getGlobalPluginRegistry()).toBe(registryA);
+          throw new Error("hook failed");
+        }),
+      ).rejects.toThrow("hook failed");
+
+      // Pending init should have been flushed in the finally block
+      expect(mod.getGlobalPluginRegistry()).toBe(registryB);
+    });
+  });
 });

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -3,6 +3,10 @@
  *
  * Singleton hook runner that's initialized when plugins are loaded
  * and can be called from anywhere in the codebase.
+ *
+ * Reinitialization is deferred while hook executions are in-flight so that
+ * hooks (e.g. message_sending) are never skipped due to a mid-execution
+ * registry swap.  See #42644.
  */
 
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -12,9 +16,22 @@ import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./typ
 
 const log = createSubsystemLogger("plugins");
 
+/**
+ * Maximum time (ms) to wait for in-flight hooks to drain before force-flushing
+ * a deferred registry swap.  Prevents permanent starvation when a guarded hook
+ * never resolves.
+ */
+export const DEFER_TIMEOUT_MS = 30_000;
+
 type HookRunnerGlobalState = {
   hookRunner: HookRunner | null;
   registry: PluginRegistry | null;
+  /** Number of hook executions currently in progress. */
+  inFlightCount: number;
+  /** Registry waiting to be applied once in-flight hooks drain. */
+  pendingInit: PluginRegistry | null;
+  /** Handle for the starvation-prevention timeout, if one is scheduled. */
+  pendingInitTimeout: ReturnType<typeof setTimeout> | null;
 };
 
 const hookRunnerGlobalStateKey = Symbol.for("openclaw.plugins.hook-runner-global-state");
@@ -26,17 +43,14 @@ function getHookRunnerGlobalState(): HookRunnerGlobalState {
   return (globalStore[hookRunnerGlobalStateKey] ??= {
     hookRunner: null,
     registry: null,
+    inFlightCount: 0,
+    pendingInit: null,
+    pendingInitTimeout: null,
   });
 }
 
-/**
- * Initialize the global hook runner with a plugin registry.
- * Called once when plugins are loaded during gateway startup.
- */
-export function initializeGlobalHookRunner(registry: PluginRegistry): void {
-  const state = getHookRunnerGlobalState();
-  state.registry = registry;
-  state.hookRunner = createHookRunner(registry, {
+function applyHookRunnerInit(state: HookRunnerGlobalState, registry: PluginRegistry): void {
+  const newRunner = createHookRunner(registry, {
     logger: {
       debug: (msg) => log.debug(msg),
       warn: (msg) => log.warn(msg),
@@ -45,9 +59,90 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
     catchErrors: true,
   });
 
+  // Atomic swap: both fields are updated together so consumers never
+  // observe a partially-initialized state.
+  state.hookRunner = newRunner;
+  state.registry = registry;
+
   const hookCount = registry.hooks.length;
   if (hookCount > 0) {
     log.info(`hook runner initialized with ${hookCount} registered hooks`);
+  }
+}
+
+/**
+ * Initialize the global hook runner with a plugin registry.
+ *
+ * If hook executions are currently in-flight the swap is deferred until all
+ * of them complete — the old runner stays active so no hooks are skipped.
+ */
+export function initializeGlobalHookRunner(registry: PluginRegistry): void {
+  const state = getHookRunnerGlobalState();
+
+  if (state.inFlightCount > 0) {
+    // Keep only the latest pending registry (newer reload wins).
+    state.pendingInit = registry;
+
+    // Reset the starvation-prevention timer so it always counts from the
+    // most recent defer request.
+    if (state.pendingInitTimeout) {
+      clearTimeout(state.pendingInitTimeout);
+    }
+    state.pendingInitTimeout = setTimeout(() => {
+      if (state.pendingInit) {
+        log.warn(
+          `hook runner reinitialization forced after timeout — ${state.inFlightCount} hook(s) still in-flight`,
+        );
+        const pendingRegistry = state.pendingInit;
+        state.pendingInit = null;
+        state.pendingInitTimeout = null;
+        try {
+          applyHookRunnerInit(state, pendingRegistry);
+        } catch (err) {
+          log.error(`failed to force-apply deferred hook runner init: ${String(err)}`);
+        }
+      }
+    }, DEFER_TIMEOUT_MS);
+
+    log.debug(
+      `hook runner reinitialization deferred — ${state.inFlightCount} hook(s) still in-flight`,
+    );
+    return;
+  }
+
+  applyHookRunnerInit(state, registry);
+}
+
+/**
+ * Execute an async callback while guarding the hook runner against
+ * reinitialization.  Any call to {@link initializeGlobalHookRunner} that
+ * occurs while `fn` is executing will be deferred until all guarded
+ * executions have finished.
+ *
+ * Returns the result of `fn`.
+ */
+export async function withGlobalHookExecution<T>(fn: () => Promise<T>): Promise<T> {
+  const state = getHookRunnerGlobalState();
+  state.inFlightCount++;
+  try {
+    return await fn();
+  } finally {
+    state.inFlightCount--;
+    if (state.inFlightCount === 0 && state.pendingInit) {
+      const registry = state.pendingInit;
+      state.pendingInit = null;
+      if (state.pendingInitTimeout) {
+        clearTimeout(state.pendingInitTimeout);
+        state.pendingInitTimeout = null;
+      }
+      try {
+        applyHookRunnerInit(state, registry);
+      } catch (err) {
+        log.error(`failed to apply deferred hook runner init: ${String(err)}`);
+        // Restore so the next execution drain can retry.
+        state.pendingInit = registry;
+      }
+    }
   }
 }
 
@@ -99,6 +194,12 @@ export async function runGlobalGatewayStopSafely(params: {
  */
 export function resetGlobalHookRunner(): void {
   const state = getHookRunnerGlobalState();
+  if (state.pendingInitTimeout) {
+    clearTimeout(state.pendingInitTimeout);
+  }
   state.hookRunner = null;
   state.registry = null;
+  state.inFlightCount = 0;
+  state.pendingInit = null;
+  state.pendingInitTimeout = null;
 }


### PR DESCRIPTION
## Summary
Fixes #42644 — Hook runner reinitialization race condition causes `message_sending` hooks to be skipped intermittently.

## Change Type
Bug fix (non-breaking)

## Change Scope
Hook runner system

## Security Impact
Fixes a security-relevant bug — hooks used for content filtering/security rules were being skipped.

## How to Reproduce
1. Set up a plugin with message_sending hook
2. Send messages rapidly while plugins are being reloaded
3. Some messages bypass the hook entirely

## Evidence
- Hook registry swap is now atomic
- In-flight hook executions complete before reinitialization

## Human Verification
- [ ] Rapid message sending during plugin reload no longer skips hooks

## Backward Compatibility
Fully backward compatible

## Failure Recovery
If new registry fails to initialize, old registry remains active

## Risks
Minimal — adds synchronization to hook runner lifecycle