### PR TITLE
fix(acp): emit lifecycle:end after ACP turn completion for auto-announce

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1345,6 +1345,17 @@ export function resolveRequesterForChildSession(childSessionKey: string): {
   };
 }
 
+export function resolveActiveRunIdForChildSession(childSessionKey: string): string | undefined {
+  const runIds = findRunIdsByChildSessionKey(childSessionKey);
+  for (const runId of runIds) {
+    const entry = subagentRuns.get(runId);
+    if (entry && typeof entry.endedAt !== "number") {
+      return runId;
+    }
+  }
+  return undefined;
+}
+
 export function isSubagentSessionRunActive(childSessionKey: string): boolean {
   const runIds = findRunIdsByChildSessionKey(childSessionKey);
   for (const runId of runIds) {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -13,6 +13,7 @@ import { readAcpSessionEntry } from "../../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
@@ -189,6 +190,7 @@ export async function tryDispatchAcpReply(params: {
   cfg: OpenClawConfig;
   dispatcher: ReplyDispatcher;
   sessionKey?: string;
+  runId?: string;
   inboundAudio: boolean;
   sessionTtsAuto?: TtsAutoMode;
   ttsChannel?: string;
@@ -365,6 +367,17 @@ export async function tryDispatchAcpReply(params: {
       `acp-dispatch: session=${sessionKey} outcome=ok latencyMs=${Date.now() - acpDispatchStartedAt} queueDepth=${acpStats.turns.queueDepth} activeRuntimes=${acpStats.runtimeCache.activeSessions}`,
     );
     params.recordProcessed("completed", { reason: "acp_dispatch" });
+    if (params.runId) {
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: acpDispatchStartedAt,
+          endedAt: Date.now(),
+        },
+      });
+    }
     params.markIdle("message_completed");
     return { queuedFinal, counts };
   } catch (err) {
@@ -388,6 +401,18 @@ export async function tryDispatchAcpReply(params: {
     params.recordProcessed("completed", {
       reason: `acp_error:${acpError.code.toLowerCase()}`,
     });
+    if (params.runId) {
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          startedAt: acpDispatchStartedAt,
+          endedAt: Date.now(),
+          error: acpError.code,
+        },
+      });
+    }
     params.markIdle("message_completed");
     return { queuedFinal, counts };
   }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,5 +1,6 @@
 import { shouldSuppressLocalDiscordExecApprovalPrompt } from "../../../extensions/discord/src/exec-approvals.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveActiveRunIdForChildSession } from "../../agents/subagent-registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   loadSessionStore,
@@ -345,11 +346,16 @@ export async function dispatchReplyFromConfig(params: {
     }
 
     const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
+    const acpRunId =
+      (acpDispatchSessionKey
+        ? resolveActiveRunIdForChildSession(acpDispatchSessionKey)
+        : undefined) ?? params.replyOptions?.runId;
     const acpDispatch = await tryDispatchAcpReply({
       ctx,
       cfg,
       dispatcher,
       sessionKey: acpDispatchSessionKey,
+      runId: acpRunId,
       inboundAudio,
       sessionTtsAuto,
       ttsChannel,
@@ -478,11 +484,16 @@ export async function dispatchReplyFromConfig(params: {
       // Command handling prepared a trailing prompt after ACP in-place reset.
       // Route that tail through ACP now (same turn) instead of embedded dispatch.
       ctx.AcpDispatchTailAfterReset = false;
+      const acpTailRunId =
+        (acpDispatchSessionKey
+          ? resolveActiveRunIdForChildSession(acpDispatchSessionKey)
+          : undefined) ?? params.replyOptions?.runId;
       const acpTailDispatch = await tryDispatchAcpReply({
         ctx,
         cfg,
         dispatcher,
         sessionKey: acpDispatchSessionKey,
+        runId: acpTailRunId,
         inboundAudio,
         sessionTtsAuto,
         ttsChannel,


### PR DESCRIPTION
## Summary

ACP sessions spawned via `sessions_spawn({ runtime: "acp", mode: "run" })` never trigger auto-announce to the parent session because `tryDispatchAcpReply` did not emit the `lifecycle:end` event that the subagent registry listens for.

## Change Type
Bug fix (non-breaking)

## Scope
`src/auto-reply/reply/dispatch-acp.ts` — emit lifecycle events after ACP turn
`src/auto-reply/reply/dispatch-from-config.ts` — thread `runId` to ACP dispatch

## Linked Issue
Fixes #40693

## Root Cause
Standard subagent runs go through `runEmbeddedPiAgent` which emits `{ stream: "lifecycle", phase: "end" }` when done. The subagent registry listener picks up that event → calls `completeSubagentRun` → triggers `runSubagentAnnounceFlow`.

ACP turns dispatch via `tryDispatchAcpReply` → `acpManager.runTurn()`, which calls `recordProcessed("completed")` and `markIdle("message_completed")` but never emits the lifecycle event. The subagent registry listener never fires → no announce.

## Fix
1. Thread `runId` from `replyOptions` through `dispatchReplyFromConfig` into `tryDispatchAcpReply`
2. After successful ACP turn: emit `lifecycle:end` with the `runId`
3. After failed ACP turn: emit `lifecycle:error` with the `runId` and error message

## Security Impact
None.

## Evidence
- 9 dispatch-acp tests pass
- `pnpm build` passes

## Compatibility
Backward compatible — the `runId` parameter is optional. When absent (e.g. non-spawned ACP sessions), no lifecycle event is emitted.

## Failure Recovery
If lifecycle emission fails, the ACP turn still completes normally. The only effect is that auto-announce doesn't fire (same as current behavior).

## Risks
Low — additive change that only emits events when `runId` is present.

---
> **AI-assisted**: This PR was authored with AI assistance.