### PR TITLE
fix(signal): pass replyTo through to signal-cli quote parameters (closes #36628)

### DIFF
--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -18,6 +18,7 @@ export type SignalSendOpts = {
   timeoutMs?: number;
   textMode?: "markdown" | "plain";
   textStyles?: SignalTextStyleRange[];
+  replyTo?: string;
 };
 
 export type SignalSendResult = {
@@ -180,6 +181,22 @@ export async function sendMessageSignal(
     throw new Error("Signal recipient is required");
   }
   Object.assign(params, targetParams);
+
+  if (opts.replyTo) {
+    const quoteTimestamp = Number(opts.replyTo);
+    if (!Number.isNaN(quoteTimestamp) && quoteTimestamp > 0) {
+      const quoteAuthor =
+        target.type === "recipient"
+          ? target.recipient
+          : target.type === "username"
+            ? target.username
+            : undefined;
+      if (quoteAuthor) {
+        params["quote-timestamp"] = quoteTimestamp;
+        params["quote-author"] = quoteAuthor;
+      }
+    }
+  }
 
   const result = await signalRpcRequest<{ timestamp?: number }>("send", params, {
     baseUrl,

--- a/src/channels/plugins/outbound/signal.ts
+++ b/src/channels/plugins/outbound/signal.ts
@@ -13,16 +13,18 @@ export const signalOutbound = createDirectTextMediaOutbound({
   channel: "signal",
   resolveSender: resolveSignalSender,
   resolveMaxBytes: createScopedChannelMediaMaxBytesResolver("signal"),
-  buildTextOptions: ({ cfg, maxBytes, accountId }) => ({
+  buildTextOptions: ({ cfg, maxBytes, accountId, replyToId }) => ({
     cfg,
     maxBytes,
     accountId: accountId ?? undefined,
+    replyTo: replyToId ?? undefined,
   }),
-  buildMediaOptions: ({ cfg, mediaUrl, maxBytes, accountId, mediaLocalRoots }) => ({
+  buildMediaOptions: ({ cfg, mediaUrl, maxBytes, accountId, mediaLocalRoots, replyToId }) => ({
     cfg,
     mediaUrl,
     maxBytes,
     accountId: accountId ?? undefined,
     mediaLocalRoots,
+    replyTo: replyToId ?? undefined,
   }),
 });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -627,7 +627,7 @@ async function deliverOutboundPayloadsCore(
     }
   };
 
-  const sendSignalText = async (text: string, styles: SignalTextStyleRange[]) => {
+  const sendSignalText = async (text: string, styles: SignalTextStyleRange[], replyTo?: string) => {
     throwIfAborted(abortSignal);
     return {
       channel: "signal" as const,
@@ -637,11 +637,12 @@ async function deliverOutboundPayloadsCore(
         accountId: accountId ?? undefined,
         textMode: "plain",
         textStyles: styles,
+        replyTo,
       })),
     };
   };
 
-  const sendSignalTextChunks = async (text: string) => {
+  const sendSignalTextChunks = async (text: string, overrides?: { replyToId?: string }) => {
     throwIfAborted(abortSignal);
     let signalChunks =
       textLimit === undefined
@@ -654,11 +655,11 @@ async function deliverOutboundPayloadsCore(
     }
     for (const chunk of signalChunks) {
       throwIfAborted(abortSignal);
-      results.push(await sendSignalText(chunk.text, chunk.styles));
+      results.push(await sendSignalText(chunk.text, chunk.styles, overrides?.replyToId));
     }
   };
 
-  const sendSignalMedia = async (caption: string, mediaUrl: string) => {
+  const sendSignalMedia = async (caption: string, mediaUrl: string, replyTo?: string) => {
     throwIfAborted(abortSignal);
     const formatted = markdownToSignalTextChunks(caption, Number.POSITIVE_INFINITY, {
       tableMode: signalTableMode,
@@ -676,6 +677,7 @@ async function deliverOutboundPayloadsCore(
         textMode: "plain",
         textStyles: formatted.styles,
         mediaLocalRoots,
+        replyTo,
       })),
     };
   };
@@ -749,7 +751,7 @@ async function deliverOutboundPayloadsCore(
       if (payloadSummary.mediaUrls.length === 0) {
         const beforeCount = results.length;
         if (isSignalChannel) {
-          await sendSignalTextChunks(payloadSummary.text);
+          await sendSignalTextChunks(payloadSummary.text, sendOverrides);
         } else {
           await sendTextChunks(payloadSummary.text, sendOverrides);
         }
@@ -795,7 +797,7 @@ async function deliverOutboundPayloadsCore(
         const caption = first ? payloadSummary.text : "";
         first = false;
         if (isSignalChannel) {
-          const delivery = await sendSignalMedia(caption, url);
+          const delivery = await sendSignalMedia(caption, url, sendOverrides.replyToId);
           results.push(delivery);
           lastMessageId = delivery.messageId;
         } else {


### PR DESCRIPTION
## Summary
- Problem: Signal quote-replies not working — replyTo tag stripped but never passed to signal-cli
- What changed: sendOverrides passed to Signal delivery; sendMessageSignal translates replyTo to quote params
- What did NOT change: Other channels, non-reply messages

## Change Type
- [x] Bug fix
## Linked Issue/PR
- Closes #36628
## Security Impact
All No
## Evidence
- [x] pnpm build + pnpm check + pnpm test all passing
## Compatibility / Migration
- Backward compatible? Yes
## Failure Recovery
- How to revert: revert this commit
---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*