### PR TITLE
feat: add WORKING.md as opt-in bootstrap file for working memory

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_MEMORY_FILENAME,
   DEFAULT_TOOLS_FILENAME,
   DEFAULT_USER_FILENAME,
+  DEFAULT_WORKING_FILENAME,
   ensureAgentWorkspace,
   filterBootstrapFilesForSession,
   loadWorkspaceBootstrapFiles,
@@ -189,6 +190,29 @@ describe("loadWorkspaceBootstrapFiles", () => {
 
     const files = await loadWorkspaceBootstrapFiles(tempDir);
     expect(getMemoryEntries(files)).toHaveLength(0);
+  });
+
+  it("includes WORKING.md when present", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: "WORKING.md",
+      content: "# Active task\nDoing stuff",
+    });
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const working = files.find((f) => f.name === DEFAULT_WORKING_FILENAME);
+    expect(working).toBeDefined();
+    expect(working?.missing).toBe(false);
+    expect(working?.content).toBe("# Active task\nDoing stuff");
+  });
+
+  it("omits WORKING.md when not present", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const working = files.find((f) => f.name === DEFAULT_WORKING_FILENAME);
+    expect(working).toBeUndefined();
   });
 
   it("treats hardlinked bootstrap aliases as missing", async () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -31,6 +31,7 @@ export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 export const DEFAULT_MEMORY_FILENAME = "MEMORY.md";
 export const DEFAULT_MEMORY_ALT_FILENAME = "memory.md";
+export const DEFAULT_WORKING_FILENAME = "WORKING.md";
 const WORKSPACE_STATE_DIRNAME = ".openclaw";
 const WORKSPACE_STATE_FILENAME = "workspace-state.json";
 const WORKSPACE_STATE_VERSION = 1;
@@ -138,7 +139,8 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_HEARTBEAT_FILENAME
   | typeof DEFAULT_BOOTSTRAP_FILENAME
   | typeof DEFAULT_MEMORY_FILENAME
-  | typeof DEFAULT_MEMORY_ALT_FILENAME;
+  | typeof DEFAULT_MEMORY_ALT_FILENAME
+  | typeof DEFAULT_WORKING_FILENAME;
 
 export type WorkspaceBootstrapFile = {
   name: WorkspaceBootstrapFileName;
@@ -176,6 +178,7 @@ const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_MEMORY_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
+  DEFAULT_WORKING_FILENAME,
 ]);
 
 async function writeFileIfMissing(filePath: string, content: string): Promise<boolean> {
@@ -518,6 +521,15 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   const memoryEntry = await resolveMemoryBootstrapEntry(resolvedDir);
   if (memoryEntry) {
     entries.push(memoryEntry);
+  }
+
+  // WORKING.md is opt-in: only loaded when present in the workspace.
+  const workingPath = path.join(resolvedDir, DEFAULT_WORKING_FILENAME);
+  try {
+    await fs.access(workingPath);
+    entries.push({ name: DEFAULT_WORKING_FILENAME, filePath: workingPath });
+  } catch {
+    // WORKING.md not present — skip
   }
 
   const result: WorkspaceBootstrapFile[] = [];


### PR DESCRIPTION
## Summary

Add `WORKING.md` to the workspace bootstrap file system, enabling persistent working memory that survives context compaction.

## Problem

After session compaction, agents lose all active task state, decisions in progress, and working context. The only memory files (`MEMORY.md`) are designed for long-term facts, not session-scoped working state. Agents have no reliable way to maintain context across compaction boundaries for long-horizon tasks.

## Solution

Add `DEFAULT_WORKING_FILENAME` (`WORKING.md`) as an opt-in bootstrap file:

- Added constant and type to `WorkspaceBootstrapFileName` union
- Added to `VALID_BOOTSTRAP_NAMES` for runtime validation
- `loadWorkspaceBootstrapFiles()` includes it when present (opt-in, like `MEMORY.md`)
- Excluded from `MINIMAL_BOOTSTRAP_ALLOWLIST` (subagent/cron sessions don't receive it)

When users create `WORKING.md` in their workspace, it is automatically injected into every session — including post-compaction sessions — giving agents persistent working memory.

## Non-breaking

- Workspaces without `WORKING.md` are completely unaffected
- No template is seeded automatically; users create it when they want working memory
- No changes to the workspace setup wizard

## Validation

```
pnpm exec vitest run src/agents/workspace.test.ts  # 17/17 passed (+2 new)
```

Fixes #9386