### PR TITLE
fix: add Windows npm global path resolution for Gemini CLI OAuth (closes #30403)

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -189,6 +189,53 @@ describe("extractGeminiCliCredentials", () => {
     expectFakeCliCredentials(result);
   });
 
+  it("falls back to APPDATA npm global path on Windows when gemini is not in PATH", async () => {
+    const originalPlatform = process.platform;
+    const originalAppdata = process.env.APPDATA;
+    try {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      process.env.APPDATA = join(rootDir, "fake", "AppData", "Roaming");
+      process.env.PATH = "/nonexistent";
+
+      const appdataOauth2Path = join(
+        process.env.APPDATA,
+        "npm",
+        "node_modules",
+        "@google",
+        "gemini-cli",
+        "node_modules",
+        "@google",
+        "gemini-cli-core",
+        "dist",
+        "src",
+        "code_assist",
+        "oauth2.js",
+      );
+
+      mockExistsSync.mockImplementation((p: string) => {
+        const normalized = normalizePath(p);
+        if (normalized === normalizePath(appdataOauth2Path)) {
+          return true;
+        }
+        return false;
+      });
+      mockReadFileSync.mockReturnValue(FAKE_OAUTH2_CONTENT);
+
+      const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+      clearCredentialsCache();
+      const result = extractGeminiCliCredentials();
+
+      expectFakeCliCredentials(result);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+      if (originalAppdata !== undefined) {
+        process.env.APPDATA = originalAppdata;
+      } else {
+        delete process.env.APPDATA;
+      }
+    }
+  });
+
   it("returns null when oauth2.js cannot be found", async () => {
     installGeminiLayout({ oauth2Exists: false, readdir: [] });
 

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -74,12 +74,17 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
 
   try {
     const geminiPath = findInPath("gemini");
-    if (!geminiPath) {
+    let geminiCliDirs: string[];
+    if (geminiPath) {
+      const resolvedPath = realpathSync(geminiPath);
+      geminiCliDirs = resolveGeminiCliDirs(geminiPath, resolvedPath);
+    } else if (process.platform === "win32" && process.env.APPDATA) {
+      // Fallback: on Windows the npm global bin may not be in PATH, but
+      // globally-installed packages are still under %APPDATA%\npm\node_modules.
+      geminiCliDirs = [join(process.env.APPDATA, "npm", "node_modules", "@google", "gemini-cli")];
+    } else {
       return null;
     }
-
-    const resolvedPath = realpathSync(geminiPath);
-    const geminiCliDirs = resolveGeminiCliDirs(geminiPath, resolvedPath);
 
     let content: string | null = null;
     for (const geminiCliDir of geminiCliDirs) {
@@ -145,6 +150,12 @@ function resolveGeminiCliDirs(geminiPath: string, resolvedPath: string): string[
     join(dirname(binDir), "node_modules", "@google", "gemini-cli"),
     join(dirname(binDir), "lib", "node_modules", "@google", "gemini-cli"),
   ];
+
+  // On Windows, npm global packages live under %APPDATA%\npm\node_modules
+  // regardless of where the bin shim is located.
+  if (process.platform === "win32" && process.env.APPDATA) {
+    candidates.push(join(process.env.APPDATA, "npm", "node_modules", "@google", "gemini-cli"));
+  }
 
   const deduped: string[] = [];
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary
- Problem: Gemini CLI OAuth fails on Windows — can't find oauth2.js in npm global path
- What changed: Added Windows-specific npm global path pattern to extractGeminiCliCredentials
- What did NOT change: Mac/Linux path resolution

## Change Type
- [x] Bug fix
## Linked Issue/PR
- Closes #30403
## Security Impact
All No
## Evidence
- [x] pnpm build + pnpm check + pnpm test all passing
## Compatibility / Migration
- Backward compatible? Yes
## Failure Recovery
- How to revert: revert this commit
---
*This PR was AI-assisted (fully tested with pnpm build/check/test).*