### PR TITLE
fix(ui): i18n locale before render + fix: tool_use mismatch suggest /new (#46366, #46365)

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -62,6 +62,22 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("Session history looks corrupted");
     expect(result).toContain("/new");
   });
+  it("returns a recovery hint for tool_use_id mismatch errors", () => {
+    const msg = makeAssistantError(
+      'tool_result block with tool_use_id "toolu_abc" not found in the immediately preceding assistant message',
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Conversation history corruption detected");
+    expect(result).toContain("/new");
+  });
+  it("returns a recovery hint for unexpected tool_result block errors", () => {
+    const msg = makeAssistantError(
+      "unexpected tool_result block: no corresponding tool_use in the previous assistant turn",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Conversation history corruption detected");
+    expect(result).toContain("/new");
+  });
   it("handles JSON-wrapped role errors", () => {
     const msg = makeAssistantError('{"error":{"message":"400 Incorrect role information"}}');
     const result = formatAssistantErrorText(msg);

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -27,6 +27,15 @@ describe("sanitizeUserFacingText", () => {
     expect(result).toContain("Message ordering conflict");
   });
 
+  it("sanitizes tool_use/tool_result mismatch errors", () => {
+    const result = sanitizeUserFacingText(
+      'tool_result block with tool_use_id "toolu_xyz" has no corresponding tool_use',
+      { errorContext: true },
+    );
+    expect(result).toContain("Conversation history corruption detected");
+    expect(result).toContain("/new");
+  });
+
   it("sanitizes HTTP status errors with error hints", () => {
     expect(sanitizeUserFacingText("500 Internal Server Error", { errorContext: true })).toBe(
       "HTTP 500: Internal Server Error",

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -39,6 +39,7 @@ export {
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
+  isToolUseResultMismatchError,
   isTransientHttpError,
   isTimeoutErrorMessage,
   parseImageDimensionError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -732,6 +732,10 @@ export function formatAssistantErrorText(
     );
   }
 
+  if (isToolUseResultMismatchError(raw)) {
+    return "Conversation history corruption detected. Please use /new to start a fresh session.";
+  }
+
   const invalidRequest = raw.match(/"type":"invalid_request_error".*?"message":"([^"]+)"/);
   if (invalidRequest?.[1]) {
     return `LLM request rejected: ${invalidRequest[1]}`;
@@ -782,6 +786,10 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
       );
     }
 
+    if (isToolUseResultMismatchError(trimmed)) {
+      return "Conversation history corruption detected. Please use /new to start a fresh session.";
+    }
+
     if (shouldRewriteContextOverflowText(trimmed)) {
       return (
         "Context overflow: prompt too large for the model. " +
@@ -827,6 +835,9 @@ const TOOL_CALL_INPUT_MISSING_RE =
 const TOOL_CALL_INPUT_PATH_RE =
   /messages\.\d+\.content\.\d+\.tool_(?:use|call)\.(?:input|arguments)/i;
 
+const TOOL_USE_RESULT_MISMATCH_RE =
+  /tool_use_id|tool_result.*corresponding.*tool_use|unexpected.*tool.*block/i;
+
 const IMAGE_DIMENSION_ERROR_RE =
   /image dimensions exceed max allowed size for many-image requests:\s*(\d+)\s*pixels/i;
 const IMAGE_DIMENSION_PATH_RE = /messages\.(\d+)\.content\.(\d+)\.image/i;
@@ -837,6 +848,13 @@ export function isMissingToolCallInputError(raw: string): boolean {
     return false;
   }
   return TOOL_CALL_INPUT_MISSING_RE.test(raw) || TOOL_CALL_INPUT_PATH_RE.test(raw);
+}
+
+export function isToolUseResultMismatchError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return TOOL_USE_RESULT_MISMATCH_RE.test(raw);
 }
 
 export function isBillingAssistantError(msg: AssistantMessage | undefined): boolean {

--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -17,8 +17,11 @@ class I18nManager {
   private translations: Partial<Record<Locale, TranslationMap>> = { [DEFAULT_LOCALE]: en };
   private subscribers: Set<Subscriber> = new Set();
 
+  /** Resolves once the initial (persisted / navigator-derived) locale is loaded. */
+  public readonly ready: Promise<void>;
+
   constructor() {
-    this.loadLocale();
+    this.ready = this.loadLocale();
   }
 
   private readStoredLocale(): string | null {
@@ -55,7 +58,7 @@ class I18nManager {
     return resolveNavigatorLocale(language ?? "");
   }
 
-  private loadLocale() {
+  private async loadLocale(): Promise<void> {
     const initialLocale = this.resolveInitialLocale();
     if (initialLocale === DEFAULT_LOCALE) {
       this.locale = DEFAULT_LOCALE;
@@ -63,7 +66,7 @@ class I18nManager {
     }
     // Use the normal locale setter so startup locale loading follows the same
     // translation-loading + notify path as manual locale changes.
-    void this.setLocale(initialLocale);
+    await this.setLocale(initialLocale);
   }
 
   public getLocale(): Locale {

--- a/ui/src/i18n/test/translate.test.ts
+++ b/ui/src/i18n/test/translate.test.ts
@@ -85,9 +85,7 @@ describe("i18n", () => {
     vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
     localStorage.setItem("openclaw.i18n.locale", "zh-CN");
     const fresh = await import("../lib/translate.ts");
-    await vi.waitFor(() => {
-      expect(fresh.i18n.getLocale()).toBe("zh-CN");
-    });
+    await fresh.i18n.ready;
     expect(fresh.i18n.getLocale()).toBe("zh-CN");
     expect(fresh.t("common.health")).toBe("健康状况");
   });

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1,4 +1,4 @@
-import { LitElement } from "lit";
+import { LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { i18n, I18nController, isSupportedLocale } from "../i18n/index.ts";
 import {
@@ -115,11 +115,21 @@ export class OpenClawApp extends LitElement {
   clientInstanceId = generateUUID();
   connectGeneration = 0;
   @state() settings: UiSettings = loadSettings();
+  @state() private localeReady = false;
   constructor() {
     super();
-    if (isSupportedLocale(this.settings.locale)) {
-      void i18n.setLocale(this.settings.locale);
-    }
+    const settingsLocale = isSupportedLocale(this.settings.locale)
+      ? i18n.setLocale(this.settings.locale)
+      : Promise.resolve();
+    Promise.all([i18n.ready, settingsLocale]).then(
+      () => {
+        this.localeReady = true;
+      },
+      () => {
+        // Locale load failed; render with the default locale.
+        this.localeReady = true;
+      },
+    );
   }
   @state() password = "";
   @state() loginShowGatewayToken = false;
@@ -716,6 +726,9 @@ export class OpenClawApp extends LitElement {
   }
 
   render() {
+    if (!this.localeReady) {
+      return nothing;
+    }
     return renderApp(this as unknown as AppViewState);
   }
 }


### PR DESCRIPTION
Combines fixes from upstream PRs:
- #46366: fix(ui): ensure i18n locale is loaded before initial render (closes #24803)
- #46365: fix: detect tool_use/tool_result mismatch and suggest /new instead of looping (closes #44473)

Merged from openclaw/openclaw PRs.