### PR TITLE
fix: use globalThis singleton for Discord componentEntries to survive chunk splitting (closes #40923)

### DIFF
--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -2,8 +2,25 @@ import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 
 const DEFAULT_COMPONENT_TTL_MS = 30 * 60 * 1000;
 
-const componentEntries = new Map<string, DiscordComponentEntry>();
-const modalEntries = new Map<string, DiscordModalEntry>();
+// Use globalThis singletons to survive Rolldown chunk splitting.
+// Without this, registering in one chunk and looking up in another fails. Refs #40923.
+const COMPONENT_ENTRIES_KEY = Symbol.for("openclaw.discordComponentEntries");
+const MODAL_ENTRIES_KEY = Symbol.for("openclaw.discordModalEntries");
+
+type GlobalWithEntries = typeof globalThis & {
+  [COMPONENT_ENTRIES_KEY]?: Map<string, DiscordComponentEntry>;
+  [MODAL_ENTRIES_KEY]?: Map<string, DiscordModalEntry>;
+};
+
+const g = globalThis as GlobalWithEntries;
+if (!g[COMPONENT_ENTRIES_KEY]) {
+  g[COMPONENT_ENTRIES_KEY] = new Map<string, DiscordComponentEntry>();
+}
+if (!g[MODAL_ENTRIES_KEY]) {
+  g[MODAL_ENTRIES_KEY] = new Map<string, DiscordModalEntry>();
+}
+const componentEntries = g[COMPONENT_ENTRIES_KEY];
+const modalEntries = g[MODAL_ENTRIES_KEY];
 
 function isExpired(entry: { expiresAt?: number }, now: number) {
   return typeof entry.expiresAt === "number" && entry.expiresAt <= now;


### PR DESCRIPTION
## Summary
Replace module-scoped `Map` instances for `componentEntries` and `modalEntries` with `globalThis` + `Symbol.for` singletons. Rolldown's chunk splitting duplicates module-level state across output chunks, causing component registration and lookup to happen on different Maps — making all interactive buttons appear expired.

## Change Type
Bug fix

## Scope
- `extensions/discord/src/components-registry.ts` – singleton pattern for both Maps

## Linked Issue
Closes #40923

## Security Impact
None – same data, same scope, just shared across chunks.

## Repro
1. Send message with `reusable: true` components on Discord
2. Click button → Previously: "This component has expired"
3. After fix: button interaction routes correctly

## Evidence
- `pnpm build` ✅
- `vitest run extensions/discord/src/components.test.ts` – 4 tests pass

## Human Verification
Pattern matches `src/plugins/runtime.ts` (`Symbol.for("openclaw.pluginRegistryState")` on `globalThis`).

## Compatibility
Backward-compatible – same API surface, just different storage backing.

## Risks
None – proven pattern already used in the codebase.

*This PR was AI-assisted (fully tested with pnpm build/check/test).*