### PR TITLE
fix: add SSRF guard to MiniMax VLM image understanding endpoint

### DIFF
--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -1,5 +1,9 @@
 import { isRecord } from "../utils.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+import {
+  fetchWithSsrFGuard,
+  withStrictGuardedFetchMode,
+} from "../infra/net/fetch-guard.js";
 
 type MinimaxBaseResp = {
   status_code?: number;
@@ -73,18 +77,24 @@ export async function minimaxUnderstandImage(params: {
   });
   const url = new URL("/v1/coding_plan/vlm", host).toString();
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-      "MM-API-Source": "OpenClaw",
-    },
-    body: JSON.stringify({
-      prompt,
-      image_url: imageDataUrl,
+  const { response: res, release } = await fetchWithSsrFGuard(
+    withStrictGuardedFetchMode({
+      url,
+      init: {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          "MM-API-Source": "OpenClaw",
+        },
+        body: JSON.stringify({
+          prompt,
+          image_url: imageDataUrl,
+        }),
+      },
     }),
-  });
+  );
+  try {
 
   const traceId = res.headers.get("Trace-Id") ?? "";
   if (!res.ok) {
@@ -118,4 +128,7 @@ export async function minimaxUnderstandImage(params: {
   }
 
   return content;
+  } finally {
+    await release();
+  }
 }


### PR DESCRIPTION
## Summary

- `minimaxUnderstandImage()` in `src/agents/minimax-vlm.ts` used raw `fetch()` with a user-controlled `apiHost`/`modelBaseUrl` parameter. An attacker could set these to an internal/private IP or attacker-controlled server, causing the application to send the MiniMax API key (via `Authorization: Bearer` header) and full image data to an unintended destination (SSRF).
- The `coerceApiHost()` function only performed basic URL parsing without any hostname/IP validation against private ranges or cloud metadata endpoints.

## Changes

- Replace raw `fetch()` with `fetchWithSsrFGuard(withStrictGuardedFetchMode(...))` which validates the resolved hostname/IP against the SSRF blocklist (private IPs, cloud metadata, etc.) before connecting.
- Add proper `release()` cleanup in a `finally` block.

## Test plan

- [ ] Verify MiniMax VLM image understanding still works with default `https://api.minimax.io` host
- [ ] Confirm that setting `apiHost` to a private IP (e.g. `http://169.254.169.254`) is blocked by the SSRF guard
- [ ] Confirm that setting `modelBaseUrl` to an internal address is also blocked