### PR TITLE
fix: fall back to built-in compaction when model/apiKey unavailable

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1655,7 +1655,7 @@ describe("compaction-safeguard extension model fallback", () => {
       apiKey: null,
     });
 
-    expect(result).toEqual({ cancel: true });
+    expect(result).toBeUndefined();
 
     // KEY ASSERTION: Prove the fallback path was exercised
     // The handler should have resolved request auth with runtime.model
@@ -1682,10 +1682,37 @@ describe("compaction-safeguard extension model fallback", () => {
       apiKey: null,
     });
 
-    expect(result).toEqual({ cancel: true });
+    expect(result).toBeUndefined();
 
     // Verify early return: request auth should NOT have been resolved when both models are missing.
     expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to built-in compaction when model is undefined (returns undefined, not cancel)", async () => {
+    const sessionManager = stubSessionManager();
+    // Do NOT set runtime model
+    const mockEvent = createCompactionEvent({ messageText: "test", tokensBefore: 500 });
+    const { result, getApiKeyMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: null,
+    });
+    expect(result).toBeUndefined();
+    expect(getApiKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to built-in compaction when API key is missing (returns undefined, not cancel)", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+    const mockEvent = createCompactionEvent({ messageText: "test", tokensBefore: 500 });
+    const { result, getApiKeyMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: null,
+    });
+    expect(result).toBeUndefined();
+    expect(getApiKeyMock).toHaveBeenCalledWith(model);
   });
 });
 
@@ -1836,7 +1863,7 @@ describe("compaction-safeguard double-compaction guard", () => {
       event: mockEvent,
       apiKey: null,
     });
-    expect(result).toEqual({ cancel: true });
+    expect(result).toBeUndefined();
     expect(getApiKeyAndHeadersMock).toHaveBeenCalled();
   });
 

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1667,7 +1667,7 @@ describe("compaction-safeguard extension model fallback", () => {
     expect(retrieved?.model).toEqual(model);
   });
 
-  it("cancels compaction when both ctx.model and runtime.model are undefined", async () => {
+  it("falls back to built-in compaction when both ctx.model and runtime.model are undefined", async () => {
     const sessionManager = stubSessionManager();
 
     // Do NOT set runtime.model (both ctx.model and runtime.model will be undefined)
@@ -1688,31 +1688,18 @@ describe("compaction-safeguard extension model fallback", () => {
     expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to built-in compaction when model is undefined (returns undefined, not cancel)", async () => {
-    const sessionManager = stubSessionManager();
-    // Do NOT set runtime model
-    const mockEvent = createCompactionEvent({ messageText: "test", tokensBefore: 500 });
-    const { result, getApiKeyMock } = await runCompactionScenario({
-      sessionManager,
-      event: mockEvent,
-      apiKey: null,
-    });
-    expect(result).toBeUndefined();
-    expect(getApiKeyMock).not.toHaveBeenCalled();
-  });
-
   it("falls back to built-in compaction when API key is missing (returns undefined, not cancel)", async () => {
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();
     setCompactionSafeguardRuntime(sessionManager, { model });
     const mockEvent = createCompactionEvent({ messageText: "test", tokensBefore: 500 });
-    const { result, getApiKeyMock } = await runCompactionScenario({
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
       apiKey: null,
     });
     expect(result).toBeUndefined();
-    expect(getApiKeyMock).toHaveBeenCalledWith(model);
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(model);
   });
 });
 
@@ -1845,8 +1832,8 @@ describe("compaction-safeguard double-compaction guard", () => {
       apiKey: null,
     });
     // Should NOT take the boundary fast-path — falls through to normal compaction
-    // (which cancels due to no API key, but that's the expected normal path)
-    expect(result).toEqual({ cancel: true });
+    // (which falls back to built-in compaction due to no API key)
+    expect(result).toBeUndefined();
   });
 
   it("continues when messages include real conversation content", async () => {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -624,11 +624,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             "was not called and model was not passed through runtime registry.",
         );
       }
-      setCompactionSafeguardCancelReason(
-        ctx.sessionManager,
-        "Compaction safeguard could not resolve a summarization model.",
-      );
-      return { cancel: true };
+      return undefined;
     }
 
     let requestAuth: ResolvedRequestAuth;
@@ -641,35 +637,23 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       log.warn(
-        `Compaction safeguard: request credentials unavailable; cancelling compaction. ${error}`,
+        `Compaction safeguard: request credentials unavailable; falling back to built-in compaction. ${error}`,
       );
-      setCompactionSafeguardCancelReason(
-        ctx.sessionManager,
-        `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}: ${error}`,
-      );
-      return { cancel: true };
+      return undefined;
     }
     if (!requestAuth.ok) {
       log.warn(
-        `Compaction safeguard: request credential resolution failed for ${model.provider}/${model.id}: ${requestAuth.error}`,
+        `Compaction safeguard: request credential resolution failed for ${model.provider}/${model.id}; falling back to built-in compaction. ${requestAuth.error}`,
       );
-      setCompactionSafeguardCancelReason(
-        ctx.sessionManager,
-        `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}: ${requestAuth.error}`,
-      );
-      return { cancel: true };
+      return undefined;
     }
     const apiKey = requestAuth.apiKey;
     const headers = requestAuth.headers;
     if (!apiKey && !headers) {
       log.warn(
-        "Compaction safeguard: no request credentials available; cancelling compaction to preserve history.",
+        "Compaction safeguard: no request credentials available; falling back to built-in compaction.",
       );
-      setCompactionSafeguardCancelReason(
-        ctx.sessionManager,
-        `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
-      );
-      return { cancel: true };
+      return undefined;
     }
 
     try {


### PR DESCRIPTION
When `agents.defaults.compaction.model` is undefined or the API key is unavailable, the `compactionSafeguardExtension` hook was returning `{ cancel: true }`, which cancels compaction entirely and blocks the session lane.

## Problem

The `session_before_compact` hook in `compaction-safeguard.ts` has two early-exit paths that return `{ cancel: true }`:

1. When both `ctx.model` and `runtime.model` are undefined (no compaction model configured)
2. When `modelRegistry.getApiKey(model)` returns falsy (API key not available)

Returning `{ cancel: true }` from the hook cancels compaction entirely, which means the session context grows unbounded until it hits the context window limit and the lane blocks.

## Fix

Changed both paths to `return undefined` instead of `return { cancel: true }`.

Returning `undefined` from a `session_before_compact` hook means "I have no opinion, let the default behavior run" — which triggers the built-in truncation-based compaction from pi-coding-agent. This is a graceful degradation: summarization-based compaction requires a model and API key, but truncation-based compaction does not.

The warning logs are preserved so operators can still see when the model/key is missing.

## What is NOT changed

- The `return { cancel: true }` for empty/non-real messages (correct behavior — nothing to compact)
- The catch block `return { cancel: true }` (correct behavior — preserve history on unexpected errors)

## Tests

Updated existing tests and added explicit tests verifying the fallback returns `undefined` for both the model-undefined and apiKey-missing scenarios.