### PR TITLE
fix: sanitize prototype pollution keys from JSON5 config parsing

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -660,12 +660,34 @@ function maybeLoadDotEnvForConfig(env: NodeJS.ProcessEnv): void {
   loadDotEnv({ quiet: true });
 }
 
+/**
+ * Recursively strip dangerous prototype-pollution keys (`__proto__`,
+ * `constructor`, `prototype`) from a parsed JSON5 value.
+ */
+function stripPrototypePollutionKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripPrototypePollutionKeys);
+  }
+  if (value !== null && typeof value === "object") {
+    const clean: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      if (isBlockedObjectKey(key)) {
+        continue;
+      }
+      clean[key] = stripPrototypePollutionKeys((value as Record<string, unknown>)[key]);
+    }
+    return clean;
+  }
+  return value;
+}
+
 export function parseConfigJson5(
   raw: string,
   json5: { parse: (value: string) => unknown } = JSON5,
 ): ParseConfigJson5Result {
   try {
-    return { ok: true, parsed: json5.parse(raw) };
+    const parsed = json5.parse(raw);
+    return { ok: true, parsed: stripPrototypePollutionKeys(parsed) };
   } catch (err) {
     return { ok: false, error: String(err) };
   }


### PR DESCRIPTION
## Summary

- `parseConfigJson5()` in `src/config/io.ts` passed `JSON5.parse()` output directly without stripping dangerous keys. Unlike standard `JSON.parse()`, `JSON5.parse()` treats `__proto__` as a live prototype property rather than a plain string key, enabling Object.prototype pollution.
- An attacker with access to the `config.patch` endpoint could send `{"__proto__": {"admin": true}}` to pollute all JavaScript objects in the process, potentially bypassing authentication or escalating privileges.

## Changes

- Add `stripPrototypePollutionKeys()` that recursively removes `__proto__`, `constructor`, and `prototype` keys (using the existing `isBlockedObjectKey` helper) from the parsed JSON5 output before returning it.
- Applied inside `parseConfigJson5()` so all config parsing paths are protected.

## Test plan

- [ ] Verify normal JSON5 config parsing still works (comments, trailing commas, etc.)
- [ ] Confirm `parseConfigJson5('{"__proto__": {"admin": true}}')` returns an object without `__proto__` key
- [ ] Confirm `parseConfigJson5('{"constructor": {"prototype": {"x": 1}}}')` strips nested dangerous keys
- [ ] Verify `Object.prototype` is not polluted after parsing malicious input