### PR TITLE
fix(web-search): handle Brave LLM snippet objects alongside strings

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -301,7 +301,11 @@ type BraveSearchResponse = {
   };
 };
 
-type BraveLlmContextResult = { url: string; title: string; snippets: string[] };
+type BraveLlmContextResult = {
+  url: string;
+  title: string;
+  snippets: (string | { text?: string })[];
+};
 type BraveLlmContextResponse = {
   grounding: { generic?: BraveLlmContextResult[] };
   sources?: { url?: string; hostname?: string; date?: string }[];
@@ -1517,7 +1521,9 @@ function mapBraveLlmContextResults(
   return genericResults.map((entry) => ({
     url: entry.url ?? "",
     title: entry.title ?? "",
-    snippets: (entry.snippets ?? []).filter((s) => typeof s === "string" && s.length > 0),
+    snippets: (entry.snippets ?? [])
+      .map((s) => (typeof s === "string" ? s : (s.text ?? "")))
+      .filter(Boolean),
     siteName: resolveSiteName(entry.url) || undefined,
   }));
 }


### PR DESCRIPTION
## Problem
Brave API returns LLM snippets as either plain strings or `{text}` objects. The existing `filter` discarded non-string entries silently.

## Changes
- Updated `BraveLlmContextResult.snippets` type to `(string | { text?: string })[]`
- Changed filter to map that handles both formats

## Testing
- `pnpm build` passes

## Related
Closes #43701