### PR TITLE
fix(model-auth): add bailian provider to PROVIDER_ENV_API_KEY_CANDIDATES

### DIFF
--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -38,6 +38,7 @@ export const PROVIDER_ENV_API_KEY_CANDIDATES: Record<string, string[]> = {
   sglang: ["SGLANG_API_KEY"],
   vllm: ["VLLM_API_KEY"],
   kilocode: ["KILOCODE_API_KEY"],
+  bailian: ["BAILIAN_API_KEY"],
 };
 
 export function listKnownProviderEnvApiKeyNames(): string[] {


### PR DESCRIPTION
## Problem
`resolveEnvApiKey('bailian')` returned null because the bailian provider was missing from the envMap.

## Changes
- Added `bailian: ["BAILIAN_API_KEY"]` to `PROVIDER_ENV_API_KEY_CANDIDATES`

## Testing
- `pnpm build` passes

## Related
Closes #42858