### PR TITLE
fix(context): defer eager context window cache warmup to avoid TDZ

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -194,9 +194,10 @@ export function lookupContextTokens(modelId?: string): number | undefined {
 }
 
 if (!shouldSkipEagerContextWindowWarmup()) {
-  // Keep prior behavior where model limits begin loading during startup.
-  // This avoids a cold-start miss on the first context token lookup.
-  void ensureContextWindowCacheLoaded();
+  // Defer warmup past module initialization to avoid TDZ errors when
+  // ensureContextWindowCacheLoaded() transitively references consts
+  // (e.g. ANTHROPIC_MODEL_ALIASES) that haven't been initialized yet.
+  setImmediate(() => void ensureContextWindowCacheLoaded());
 }
 
 function resolveConfiguredModelParams(


### PR DESCRIPTION
## Problem
`ensureContextWindowCacheLoaded()` was called at module level before `ANTHROPIC_MODEL_ALIASES` was initialized, causing a `ReferenceError` due to temporal dead zone.

## Changes
- Wrapped the eager call in `setImmediate()` to run after all module-level consts are initialized

## Testing
- `pnpm build` passes

## Related
Closes #45085