### PR TITLE
fix(errors): classify OpenAI server_error as retryable

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -860,4 +860,12 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+
+  it("classifies OpenAI/Codex server_error JSON payloads as timeout", () => {
+    expect(
+      classifyFailoverReason(
+        '{"type":"server_error","code":"server_error","message":"The server had an error processing your request.","param":null}',
+      ),
+    ).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -853,7 +853,15 @@ function isJsonApiInternalServerError(raw: string): boolean {
   const value = raw.toLowerCase();
   // Anthropic often wraps transient 500s in JSON payloads like:
   // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  if (value.includes('"type":"api_error"') && value.includes("internal server error")) {
+    return true;
+  }
+  // OpenAI/Codex returns server_error in both "type" and "code" fields:
+  // {"type":"server_error","code":"server_error","message":"...","param":null}
+  if (value.includes('"type":"server_error"') && value.includes('"code":"server_error"')) {
+    return true;
+  }
+  return false;
 }
 
 export function parseImageDimensionError(raw: string): {


### PR DESCRIPTION
## Problem
`isJsonApiInternalServerError` missed the OpenAI/Codex pattern where both `type` and `code` are `server_error`, preventing model fallback on transient failures.

## Changes
- Extended detection to match `type:server_error + code:server_error` pattern
- Added test for the OpenAI/Codex server_error payload

## Testing
- New test passes
- `pnpm build` passes

## Related
Closes #35160