### PR TITLE
fix(exec): warn when pty:true is silently disabled in sandbox mode

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -464,6 +464,11 @@ export function createExecTool(
         : (explicitTimeoutSec ?? defaultTimeoutSec);
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
+      if (params.pty === true && sandbox) {
+        warnings.push(
+          "Warning: pty is not supported in sandbox mode; the pty:true parameter will be ignored.",
+        );
+      }
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.


### PR DESCRIPTION
## Summary

When a user sets `pty: true` on the exec tool but the session runs in sandbox mode, PTY is silently disabled without any feedback. This breaks interactive terminal tools (coding agents, terminal UIs) with no indication of why.

This PR adds a warning message when `pty: true` is requested but PTY cannot be provided due to sandbox mode restrictions.

## Change Type
Bug fix — missing user feedback

## Scope
`src/agents/bash-tools.exec.ts` — PTY sandbox warning

## Linked Issue
Fixes #38601

## Security Impact
None. This only adds a warning message; the existing PTY-disable behavior is unchanged.

## Evidence
- PTY fallback test passes (1 test)
- Full build succeeds

## Human Verification
Set `pty: true` in sandbox mode → should see warning "pty is not supported in sandbox mode; the pty:true parameter will be ignored."

## Compatibility
Fully backward compatible. No behavioral change, only adds informational output.

## Failure Recovery
N/A — advisory warning only.

## Risks
None. This is a 4-line addition that emits a warning string.

---
> 🤖 This PR was authored with AI assistance.