### PR TITLE
fix(sandbox): tighten base64 heuristic to require credential-named keys

### DIFF
--- a/src/agents/sandbox/sanitize-env-vars.test.ts
+++ b/src/agents/sandbox/sanitize-env-vars.test.ts
@@ -28,7 +28,7 @@ describe("sanitizeEnvVars", () => {
     expect(result.blocked).toEqual(expect.arrayContaining(["MY_TOKEN", "MY_SECRET"]));
   });
 
-  it("adds warnings for suspicious values", () => {
+  it("adds warnings for suspicious values only on credential-named keys", () => {
     const base64Like =
       "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==";
     const result = sanitizeEnvVars({
@@ -39,7 +39,22 @@ describe("sanitizeEnvVars", () => {
 
     expect(result.allowed).toEqual({ USER: "alice", SAFE_TEXT: base64Like });
     expect(result.blocked).toContain("NULL");
-    expect(result.warnings).toContain("SAFE_TEXT: Value looks like base64-encoded credential data");
+    // SAFE_TEXT does not match any credential-hint pattern → no warning
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("flags base64-like values when key name hints at credentials", () => {
+    const base64Like =
+      "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==";
+    const result = sanitizeEnvVars({
+      MY_SIGNING_CERT: base64Like,
+      DEPLOY_AUTH_DATA: base64Like,
+    });
+
+    expect(result.warnings).toEqual([
+      "MY_SIGNING_CERT: Value looks like base64-encoded credential data",
+      "DEPLOY_AUTH_DATA: Value looks like base64-encoded credential data",
+    ]);
   });
 
   it("supports strict mode with explicit allowlist", () => {

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -42,14 +42,25 @@ export type EnvSanitizationOptions = {
   customAllowedPatterns?: ReadonlyArray<RegExp>;
 };
 
-export function validateEnvVarValue(value: string): string | undefined {
+/**
+ * Broader credential-suggestive key patterns for the base64 value heuristic.
+ * Intentionally broader than BLOCKED_ENV_VAR_PATTERNS — triggers a warning
+ * (not a block) when combined with a base64-like value.
+ */
+const CREDENTIAL_HINT_PATTERN =
+  /(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|PRIVATE|AUTH|CERT|SIGNING)/i;
+
+export function validateEnvVarValue(value: string, key?: string): string | undefined {
   if (value.includes("\0")) {
     return "Contains null bytes";
   }
   if (value.length > 32768) {
     return "Value exceeds maximum length";
   }
-  if (/^[A-Za-z0-9+/=]{80,}$/.test(value)) {
+  // Only flag base64-like values when the key name suggests credential data.
+  // Without a key-name hint, skip the heuristic to avoid false positives on
+  // legitimate long alphanumeric values (config blobs, hex strings, JWTs, etc.).
+  if ((!key || CREDENTIAL_HINT_PATTERN.test(key)) && /^[A-Za-z0-9+/=]{80,}$/.test(value)) {
     return "Value looks like base64-encoded credential data";
   }
   return undefined;
@@ -86,7 +97,7 @@ export function sanitizeEnvVars(
       continue;
     }
 
-    const warning = validateEnvVarValue(value);
+    const warning = validateEnvVarValue(value, key);
     if (warning) {
       if (warning === "Contains null bytes") {
         blocked.push(key);


### PR DESCRIPTION
## Summary

The env var value validation regex `/^[A-Za-z0-9+/=]{80,}$/` flags any 80+ character alphanumeric string as "credential data", producing false positives on legitimate values like config blobs, hex strings, and JWT segments.

This PR combines the base64 value check with a key-name credential hint pattern (`KEY`, `SECRET`, `TOKEN`, `PASSWORD`, `CREDENTIAL`, `PRIVATE`, `AUTH`, `CERT`, `SIGNING`). Only env vars whose **key name** contains a credential-suggestive substring AND whose **value** matches the base64 pattern will trigger a warning.

## Change Type
Bug fix — false-positive reduction

## Scope
- `src/agents/sandbox/sanitize-env-vars.ts` — `validateEnvVarValue` now accepts optional `key` parameter
- `src/agents/sandbox/sanitize-env-vars.test.ts` — updated test expectations, added credential-key test

## Linked Issue
Fixes #39680

## Security Impact
The base64 heuristic still fires for credential-named keys. The explicit blocklist (`BLOCKED_ENV_VAR_PATTERNS`) is unchanged. The function remains backward compatible — callers without a `key` parameter get the original behavior.

## Evidence
- All 5 sanitize-env-vars tests pass (including updated and new tests)
- Full build succeeds

## Human Verification
Set a non-credential env var (e.g. `MY_CONFIG`) with a long base64 value in sandbox mode → should no longer produce a warning.

## Compatibility
Backward compatible. Existing callers without key parameter retain old behavior (`!key` guard).

## Failure Recovery
N/A — this is advisory-only (warning, not blocking).

## Risks
Low. Credential-named keys are still caught by both the blocklist and the heuristic.

---
> 🤖 This PR was authored with AI assistance.