### PR TITLE
fix(bootstrap-cache): invalidate cache when file mtime changes

### DIFF
--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, statSync: vi.fn() };
+});
+
+import { type Stats, statSync } from "node:fs";
 import {
   clearAllBootstrapSnapshots,
   clearBootstrapSnapshot,
@@ -13,6 +20,9 @@ vi.mock("./workspace.js", () => ({
 import { loadWorkspaceBootstrapFiles } from "./workspace.js";
 
 const mockLoad = vi.mocked(loadWorkspaceBootstrapFiles);
+const mockStatSync = vi.mocked(statSync);
+
+let mtimeCounter = 1;
 
 function makeFile(name: string, content: string): WorkspaceBootstrapFile {
   return {
@@ -23,12 +33,30 @@ function makeFile(name: string, content: string): WorkspaceBootstrapFile {
   };
 }
 
+/** Make statSync return a stable mtimeMs for every known file path. */
+function setupStatSync(files: WorkspaceBootstrapFile[]): Map<string, number> {
+  const mtimes = new Map<string, number>();
+  for (const f of files) {
+    mtimes.set(f.path, mtimeCounter++);
+  }
+  mockStatSync.mockImplementation((p: unknown) => {
+    const ms = mtimes.get(String(p));
+    if (ms === undefined) {
+      throw new Error(`ENOENT: ${String(p)}`);
+    }
+    return { mtimeMs: ms } as Stats;
+  });
+  return mtimes;
+}
+
 describe("getOrLoadBootstrapFiles", () => {
   const files = [makeFile("AGENTS.md", "# Agent"), makeFile("SOUL.md", "# Soul")];
+  let originalMtimes: Map<string, number>;
 
   beforeEach(() => {
     clearAllBootstrapSnapshots();
     mockLoad.mockResolvedValue(files);
+    originalMtimes = setupStatSync(files);
   });
 
   afterEach(() => {
@@ -65,12 +93,76 @@ describe("getOrLoadBootstrapFiles", () => {
     expect(r2).toBe(files2);
     expect(mockLoad).toHaveBeenCalledTimes(2);
   });
+
+  it("reloads when a file mtime changes (staleness check)", async () => {
+    await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+
+    // Simulate mtime change on AGENTS.md only
+    mockStatSync.mockImplementation((p: unknown) => {
+      if (String(p) === "/ws/AGENTS.md") {
+        return { mtimeMs: Date.now() + 99999 } as Stats;
+      }
+      if (String(p) === "/ws/SOUL.md") {
+        return { mtimeMs: originalMtimes.get("/ws/SOUL.md") } as Stats;
+      }
+      throw new Error(`ENOENT: ${String(p)}`);
+    });
+
+    const updatedFiles = [makeFile("AGENTS.md", "# Agent v2"), makeFile("SOUL.md", "# Soul")];
+    mockLoad.mockResolvedValueOnce(updatedFiles);
+
+    const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    expect(result).toBe(updatedFiles);
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
+
+  it("reloads when a previously-missing file appears on disk", async () => {
+    // Start with BOOTSTRAP.md missing from disk
+    const bootstrapFile = makeFile("BOOTSTRAP.md", "");
+    const filesWithMissing = [...files, bootstrapFile];
+    mockLoad.mockResolvedValueOnce(filesWithMissing);
+
+    // statSync throws for BOOTSTRAP.md (missing), succeeds for others
+    mockStatSync.mockImplementation((p: unknown) => {
+      const ms = originalMtimes.get(String(p));
+      if (ms !== undefined) {
+        return { mtimeMs: ms } as Stats;
+      }
+      throw new Error(`ENOENT: ${String(p)}`);
+    });
+
+    await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+
+    // Now BOOTSTRAP.md appears on disk
+    mockStatSync.mockImplementation((p: unknown) => {
+      if (String(p) === "/ws/BOOTSTRAP.md") {
+        return { mtimeMs: 999 } as Stats;
+      }
+      const ms = originalMtimes.get(String(p));
+      if (ms !== undefined) {
+        return { mtimeMs: ms } as Stats;
+      }
+      throw new Error(`ENOENT: ${String(p)}`);
+    });
+
+    const updatedFiles = [...files, { ...bootstrapFile, content: "# Bootstrap", missing: false }];
+    mockLoad.mockResolvedValueOnce(updatedFiles);
+
+    const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    expect(result).toBe(updatedFiles);
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("clearBootstrapSnapshot", () => {
+  const clearFiles = [makeFile("AGENTS.md", "content")];
+
   beforeEach(() => {
     clearAllBootstrapSnapshots();
-    mockLoad.mockResolvedValue([makeFile("AGENTS.md", "content")]);
+    mockLoad.mockResolvedValue(clearFiles);
+    setupStatSync(clearFiles);
   });
 
   afterEach(() => {

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,18 +1,54 @@
+import { statSync } from "node:fs";
 import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
 
-const cache = new Map<string, WorkspaceBootstrapFile[]>();
+interface CachedSnapshot {
+  files: WorkspaceBootstrapFile[];
+  mtimes: Map<string, number | null>; // path → mtimeMs, null = missing at cache time
+}
+
+function isStale(snap: CachedSnapshot): boolean {
+  for (const [filePath, cachedMtime] of snap.mtimes) {
+    try {
+      const currentMtime = statSync(filePath).mtimeMs;
+      // File was missing before but now exists, or mtime changed
+      if (cachedMtime === null || currentMtime !== cachedMtime) {
+        return true;
+      }
+    } catch {
+      // File is currently missing; stale only if it previously existed
+      if (cachedMtime !== null) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function collectMtimes(files: WorkspaceBootstrapFile[]): Map<string, number | null> {
+  const mtimes = new Map<string, number | null>();
+  for (const file of files) {
+    try {
+      mtimes.set(file.path, statSync(file.path).mtimeMs);
+    } catch {
+      mtimes.set(file.path, null);
+    }
+  }
+  return mtimes;
+}
+
+const cache = new Map<string, CachedSnapshot>();
 
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
 }): Promise<WorkspaceBootstrapFile[]> {
   const existing = cache.get(params.sessionKey);
-  if (existing) {
-    return existing;
+  if (existing && !isStale(existing)) {
+    return existing.files;
   }
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  cache.set(params.sessionKey, files);
+  cache.set(params.sessionKey, { files, mtimes: collectMtimes(files) });
   return files;
 }
 


### PR DESCRIPTION
## Problem
The bootstrap cache served stale files indefinitely — once loaded, it never checked if files had changed on disk.

## Changes
- Track file mtimes at cache load time
- Check mtimes on cache hit and reload if stale
- Added test for staleness invalidation

## Testing
- New test passes
- `pnpm build` passes

## Related
Closes #28594