### PR TITLE
fix(agents): parse MiniMax M2.5 XML tool calls instead of silently stripping

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -15,6 +15,7 @@ import {
   extractThinkingFromTaggedStream,
   extractThinkingFromTaggedText,
   formatReasoningMessage,
+  promoteMinimaxToolCallsToBlocks,
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
@@ -268,6 +269,7 @@ export function handleMessageEnd(
     return;
   }
   promoteThinkingTagsToBlocks(assistantMessage);
+  promoteMinimaxToolCallsToBlocks(assistantMessage);
 
   const rawText = extractAssistantText(assistantMessage);
   appendRawStream({

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   extractAssistantText,
   formatReasoningMessage,
+  parseMinimaxToolCallXml,
+  promoteMinimaxToolCallsToBlocks,
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
 } from "./pi-embedded-utils.js";
@@ -603,5 +605,277 @@ describe("empty input handling", () => {
     for (const helper of helpers) {
       expect(helper("")).toBe("");
     }
+  });
+});
+
+describe("parseMinimaxToolCallXml", () => {
+  it("returns empty array for text without minimax markers", () => {
+    expect(parseMinimaxToolCallXml("Hello world")).toEqual([]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(parseMinimaxToolCallXml("")).toEqual([]);
+  });
+
+  it("parses a single tool invocation", () => {
+    const text = `<minimax:tool_call><invoke name="Bash">
+<parameter name="command">ls -la</parameter>
+</invoke></minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Bash");
+    expect(result[0].input).toEqual({ command: "ls -la" });
+    expect(result[0].id).toMatch(/^toolu_minimax_\d+$/);
+  });
+
+  it("parses multiple tool invocations", () => {
+    const text = `<invoke name="Read">
+<parameter name="path">file1.txt</parameter>
+</invoke>
+</minimax:tool_call><invoke name="Bash">
+<parameter name="command">pwd</parameter>
+</invoke>
+</minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Read");
+    expect(result[0].input).toEqual({ path: "file1.txt" });
+    expect(result[1].name).toBe("Bash");
+    expect(result[1].input).toEqual({ command: "pwd" });
+    expect(result[0].id).not.toBe(result[1].id);
+  });
+
+  it("parses multiple parameters", () => {
+    const text = `<minimax:tool_call><invoke name="Write">
+<parameter name="path">/tmp/test.txt</parameter>
+<parameter name="content">hello world</parameter>
+</invoke></minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].input).toEqual({ path: "/tmp/test.txt", content: "hello world" });
+  });
+
+  it("handles invoke with extra attributes", () => {
+    const text = `<invoke name='Bash' data-foo="bar">
+<parameter name="command">ls</parameter>
+</invoke></minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Bash");
+    expect(result[0].input).toEqual({ command: "ls" });
+  });
+
+  it("skips invoke blocks without name attribute", () => {
+    const text = `<invoke>Drop</invoke><minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toEqual([]);
+  });
+
+  it("generates unique IDs across calls", () => {
+    const text = `<minimax:tool_call><invoke name="Bash">
+<parameter name="command">echo hi</parameter>
+</invoke></minimax:tool_call>`;
+    const r1 = parseMinimaxToolCallXml(text);
+    const r2 = parseMinimaxToolCallXml(text);
+    expect(r1[0].id).not.toBe(r2[0].id);
+  });
+
+  it("handles parameter values with special characters", () => {
+    const text = `<minimax:tool_call><invoke name="Bash">
+<parameter name="command">echo "hello &amp; world" | grep test</parameter>
+</invoke></minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].input.command).toBe('echo "hello & world" | grep test');
+  });
+});
+
+describe("promoteMinimaxToolCallsToBlocks", () => {
+  it("converts XML tool call to structured toolUse block", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `Let me check.<invoke name="Bash">
+<parameter name="command">ls -la</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const types = msg.content.map((b: { type?: string }) => b?.type);
+    expect(types).toContain("text");
+    expect(types).toContain("toolUse");
+
+    const textBlock = msg.content.find((b: { type?: string }) => b?.type === "text") as unknown as {
+      type: string;
+      text: string;
+    };
+    expect(textBlock.text).toBe("Let me check.");
+
+    const toolBlock = msg.content.find(
+      (b: { type?: string }) => b?.type === "toolUse",
+    ) as unknown as {
+      type: string;
+      id: string;
+      name: string;
+      input: Record<string, string>;
+    };
+    expect(toolBlock.name).toBe("Bash");
+    expect(toolBlock.input).toEqual({ command: "ls -la" });
+    expect(toolBlock.id).toMatch(/^toolu_minimax_\d+$/);
+  });
+
+  it("handles tool-only text (no surrounding prose)", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">pwd</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const types = msg.content.map((b: { type?: string }) => b?.type);
+    expect(types).not.toContain("text");
+    expect(types).toContain("toolUse");
+  });
+
+  it("handles multiple invoke blocks in one text block", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `First.<invoke name="Read">
+<parameter name="path">a.txt</parameter>
+</invoke>
+</minimax:tool_call>Second.<invoke name="Bash">
+<parameter name="command">pwd</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const toolBlocks = msg.content.filter(
+      (b: { type?: string }) => b?.type === "toolUse",
+    ) as Array<{ name: string }>;
+    expect(toolBlocks).toHaveLength(2);
+    expect(toolBlocks[0].name).toBe("Read");
+    expect(toolBlocks[1].name).toBe("Bash");
+
+    // Verify interleaving is preserved: text → tool → text → tool
+    const types = msg.content.map((b: { type?: string }) => b?.type);
+    expect(types).toEqual(["text", "toolUse", "text", "toolUse"]);
+  });
+
+  it("leaves non-minimax text blocks unchanged", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "text", text: "Normal text." },
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">ls</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const textBlocks = msg.content.filter((b: { type?: string }) => b?.type === "text") as Array<{
+      text: string;
+    }>;
+    expect(textBlocks).toHaveLength(1);
+    expect(textBlocks[0].text).toBe("Normal text.");
+  });
+
+  it("does not modify message without minimax markers", () => {
+    const original = [{ type: "text" as const, text: "Hello world" }];
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [...original],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+    expect(msg.content).toEqual(original);
+  });
+
+  it("preserves existing toolUse blocks", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "toolUse", id: "existing_1", name: "Read", input: { path: "x" } } as never,
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">ls</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const toolBlocks = msg.content.filter(
+      (b: { type?: string }) => b?.type === "toolUse",
+    ) as Array<{ id: string; name: string }>;
+    expect(toolBlocks).toHaveLength(2);
+    expect(toolBlocks[0].id).toBe("existing_1");
+    expect(toolBlocks[1].name).toBe("Bash");
+  });
+
+  it("falls back gracefully when invoke has no name", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Before<invoke>Drop</invoke><minimax:tool_call>After",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    // No parseable invocations → block left as-is for stripMinimaxToolCallXml to handle.
+    promoteMinimaxToolCallsToBlocks(msg);
+    const types = msg.content.map((b: { type?: string }) => b?.type);
+    expect(types).not.toContain("toolUse");
+  });
+
+  it("does not crash on null or undefined content entries", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        null as never,
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">ls</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    expect(() => promoteMinimaxToolCallsToBlocks(msg)).not.toThrow();
+    const types = msg.content.map((b: { type?: string }) => b?.type);
+    expect(types).toContain("toolUse");
   });
 });

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -9,6 +9,211 @@ export function isAssistantMessage(msg: AgentMessage | undefined): msg is Assist
   return msg?.role === "assistant";
 }
 
+export interface ParsedMinimaxToolCall {
+  name: string;
+  input: Record<string, string>;
+  id: string;
+}
+
+let minimaxToolCallCounter = 0;
+
+/** Reset the tool-call counter (for test isolation). */
+export function resetMinimaxToolCallCounter(): void {
+  minimaxToolCallCounter = 0;
+}
+
+const XML_ENTITY_MAP: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&apos;": "'",
+};
+
+function decodeXmlEntities(text: string): string {
+  return text.replace(/&(?:amp|lt|gt|quot|apos);/g, (entity) => XML_ENTITY_MAP[entity] ?? entity);
+}
+
+/**
+ * Parse MiniMax XML tool invocations from text content.
+ *
+ * MiniMax M2.5 embeds tool calls as XML instead of structured `toolUse` blocks:
+ * ```xml
+ * <minimax:tool_call>
+ * <invoke name="some_tool">
+ * <parameter name="param1">value1</parameter>
+ * </invoke>
+ * </minimax:tool_call>
+ * ```
+ *
+ * Returns an array of parsed tool calls. Returns empty array when the text
+ * contains no minimax tool call markers or no parseable invocations.
+ */
+export function parseMinimaxToolCallXml(text: string): ParsedMinimaxToolCall[] {
+  if (!text || (!/minimax:tool_call/i.test(text) && !/<invoke\s/i.test(text))) {
+    return [];
+  }
+
+  const toolCalls: ParsedMinimaxToolCall[] = [];
+
+  // Track character ranges covered by <minimax:tool_call> segments so bare
+  // <invoke> blocks inside them are not double-counted.
+  const coveredRanges: [number, number][] = [];
+
+  // First: parse <invoke> blocks within <minimax:tool_call>...</minimax:tool_call> segments.
+  const segmentRe = /<minimax:tool_call>([\s\S]*?)<\/minimax:tool_call>/gi;
+
+  for (const segment of text.matchAll(segmentRe)) {
+    coveredRanges.push([segment.index, segment.index + segment[0].length]);
+    const segmentText = segment[1];
+    const invokeRe = /<invoke\s+name=["']([^"']+)["'][^>]*>([\s\S]*?)<\/invoke>/gi;
+
+    for (const match of segmentText.matchAll(invokeRe)) {
+      const name = match[1];
+      const body = match[2];
+      const input: Record<string, string> = {};
+
+      const paramRe = /<parameter\s+name=["']([^"']+)["'][^>]*>([\s\S]*?)<\/parameter>/gi;
+      for (const paramMatch of body.matchAll(paramRe)) {
+        input[paramMatch[1]] = decodeXmlEntities(paramMatch[2]);
+      }
+
+      minimaxToolCallCounter += 1;
+      toolCalls.push({
+        name,
+        input,
+        id: `toolu_minimax_${minimaxToolCallCounter}`,
+      });
+    }
+  }
+
+  // Second: parse bare <invoke> blocks not inside any <minimax:tool_call> segment.
+  // MiniMax can send <invoke> without the wrapping <minimax:tool_call> tag.
+  const bareInvokeRe = /<invoke\s+name=["']([^"']+)["'][^>]*>([\s\S]*?)<\/invoke>/gi;
+  for (const match of text.matchAll(bareInvokeRe)) {
+    const matchStart = match.index;
+    const matchEnd = matchStart + match[0].length;
+    if (coveredRanges.some(([s, e]) => matchStart >= s && matchEnd <= e)) {
+      continue;
+    }
+
+    const name = match[1];
+    const body = match[2];
+    const input: Record<string, string> = {};
+
+    const paramRe = /<parameter\s+name=["']([^"']+)["'][^>]*>([\s\S]*?)<\/parameter>/gi;
+    for (const paramMatch of body.matchAll(paramRe)) {
+      input[paramMatch[1]] = decodeXmlEntities(paramMatch[2]);
+    }
+
+    minimaxToolCallCounter += 1;
+    toolCalls.push({
+      name,
+      input,
+      id: `toolu_minimax_${minimaxToolCallCounter}`,
+    });
+  }
+
+  return toolCalls;
+}
+
+/**
+ * Transform MiniMax XML tool invocations in text content blocks into
+ * structured `toolUse` content blocks on the assistant message.
+ *
+ * Follows the same in-place mutation pattern as {@link promoteThinkingTagsToBlocks}.
+ * Must be called before {@link extractAssistantText} so the tool calls are
+ * available as structured blocks and the XML is removed from displayed text.
+ *
+ * Falls back gracefully: if parsing yields no tool calls the text block is
+ * left untouched and the existing strip-only path in extractAssistantText
+ * will clean it up.
+ */
+export function promoteMinimaxToolCallsToBlocks(message: AssistantMessage): void {
+  if (!Array.isArray(message.content)) {
+    return;
+  }
+
+  const next: AssistantMessage["content"] = [];
+  let changed = false;
+
+  for (const block of message.content) {
+    if (!block || typeof block !== "object" || !("type" in block)) {
+      next.push(block);
+      continue;
+    }
+    if (block.type !== "text") {
+      next.push(block);
+      continue;
+    }
+    const text: string = (block as { text?: string }).text ?? "";
+    if (!text || (!/minimax:tool_call/i.test(text) && !/<invoke\s/i.test(text))) {
+      next.push(block);
+      continue;
+    }
+
+    const toolCalls = parseMinimaxToolCallXml(text);
+    if (toolCalls.length === 0) {
+      // No parseable invocations — keep the block as-is; the strip function
+      // inside extractAssistantText will still clean stray tags.
+      next.push(block);
+      continue;
+    }
+
+    changed = true;
+
+    // Walk through tool-call regions: either <minimax:tool_call>...</minimax:tool_call>
+    // segments or bare <invoke>...</invoke> blocks.
+    const regionRe =
+      /<minimax:tool_call>[\s\S]*?<\/minimax:tool_call>|<invoke\s+name=["'][^"']+["'][^>]*>[\s\S]*?<\/invoke>/gi;
+    let cursor = 0;
+    let tcIdx = 0;
+
+    for (const regionMatch of text.matchAll(regionRe)) {
+      const matchStart = regionMatch.index;
+      // Strip stray minimax wrapper tags from interleaved prose.
+      const prose = text
+        .slice(cursor, matchStart)
+        .replace(/<\/?minimax:tool_call>/gi, "")
+        .trim();
+      if (prose) {
+        next.push({ type: "text", text: prose });
+      }
+
+      // Count invoke blocks within this region to advance tcIdx
+      const invokeReInner = /<invoke\s+name=["'][^"']+["'][^>]*>[\s\S]*?<\/invoke>/gi;
+      for (const _inv of regionMatch[0].matchAll(invokeReInner)) {
+        if (tcIdx < toolCalls.length) {
+          const tc = toolCalls[tcIdx];
+          next.push({
+            type: "toolUse",
+            id: tc.id,
+            name: tc.name,
+            input: tc.input,
+          } as unknown as (typeof next)[number]);
+          tcIdx += 1;
+        }
+      }
+
+      cursor = matchStart + regionMatch[0].length;
+    }
+
+    // Trailing prose after the last region.
+    const trailing = text
+      .slice(cursor)
+      .replace(/<\/?minimax:tool_call>/gi, "")
+      .trim();
+    if (trailing) {
+      next.push({ type: "text", text: trailing });
+    }
+  }
+
+  if (!changed) {
+    return;
+  }
+  message.content = next;
+}
+
 /**
  * Strip malformed Minimax tool invocations that leak into text content.
  * Minimax sometimes embeds tool calls as XML in text blocks instead of


### PR DESCRIPTION
## Summary

Fixes #41839 — MiniMax M2.5 tool calls were silently stripped from assistant messages instead of being dispatched as structured tool calls.

## Problem

MiniMax M2.5 embeds tool invocations as XML in text content blocks instead of emitting standard `toolUse` blocks:

```xml
<minimax:tool_call>
<invoke name="Bash">
<parameter name="command">ls -la</parameter>
</invoke>
</minimax:tool_call>
```

The existing `stripMinimaxToolCallXml()` removed this XML from displayed text but never parsed or dispatched the tool calls — they were silently dropped.

## Solution

### New functions in `pi-embedded-utils.ts`:

- **`parseMinimaxToolCallXml(text)`** — Extracts `<invoke name="..."><parameter name="...">value</parameter></invoke>` blocks from text containing `minimax:tool_call` markers. Returns an array of `{ name, input, id }` objects with `toolu_minimax_` prefixed IDs.

- **`promoteMinimaxToolCallsToBlocks(message)`** — Transforms assistant message content in-place (same pattern as `promoteThinkingTagsToBlocks`): iterates text blocks, parses XML tool calls, strips the XML from remaining text, and inserts structured `{ type: "toolUse", id, name, input }` content blocks.

### Integration:

Called in `pi-embedded-subscribe.handlers.messages.ts` right after `promoteThinkingTagsToBlocks()` and before `extractAssistantText()`, ensuring tool calls are available as structured blocks before text sanitization runs.

### Backward compatibility:

Falls back gracefully — if parsing yields no tool calls (e.g. `<invoke>` without `name` attribute), the text block is left untouched and the existing `stripMinimaxToolCallXml()` inside `extractAssistantText()` still cleans stray tags.

## Test plan

- 9 tests for `parseMinimaxToolCallXml` (empty input, single/multiple invocations, multiple params, extra attributes, missing name, unique IDs, special characters)
- 8 tests for `promoteMinimaxToolCallsToBlocks` (basic conversion, tool-only text, multiple blocks, non-minimax blocks preserved, existing toolUse preserved, fallback on missing name, null content entries)
- All 23 existing `extractAssistantText` tests continue to pass

> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.