### PR TITLE
fix(agents): MiniMax M2.5 XML tool calls + fix(gateway): config.patch hot-reload (#46401, #46397)

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -15,6 +15,7 @@ import {
   extractThinkingFromTaggedStream,
   extractThinkingFromTaggedText,
   formatReasoningMessage,
+  promoteMinimaxToolCallsToBlocks,
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
@@ -268,6 +269,7 @@ export function handleMessageEnd(
     return;
   }
   promoteThinkingTagsToBlocks(assistantMessage);
+  promoteMinimaxToolCallsToBlocks(assistantMessage);
 
   const rawText = extractAssistantText(assistantMessage);
   appendRawStream({

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   extractAssistantText,
   formatReasoningMessage,
+  parseMinimaxToolCallXml,
+  promoteMinimaxToolCallsToBlocks,
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
 } from "./pi-embedded-utils.js";
@@ -603,5 +605,271 @@ describe("empty input handling", () => {
     for (const helper of helpers) {
       expect(helper("")).toBe("");
     }
+  });
+});
+
+describe("parseMinimaxToolCallXml", () => {
+  it("returns empty array for text without minimax markers", () => {
+    expect(parseMinimaxToolCallXml("Hello world")).toEqual([]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(parseMinimaxToolCallXml("")).toEqual([]);
+  });
+
+  it("parses a single tool invocation", () => {
+    const text = `<minimax:tool_call><invoke name="Bash">
+<parameter name="command">ls -la</parameter>
+</invoke></minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Bash");
+    expect(result[0].input).toEqual({ command: "ls -la" });
+    expect(result[0].id).toMatch(/^toolu_minimax_\d+$/);
+  });
+
+  it("parses multiple tool invocations", () => {
+    const text = `<invoke name="Read">
+<parameter name="path">file1.txt</parameter>
+</invoke>
+</minimax:tool_call><invoke name="Bash">
+<parameter name="command">pwd</parameter>
+</invoke>
+</minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Read");
+    expect(result[0].input).toEqual({ path: "file1.txt" });
+    expect(result[1].name).toBe("Bash");
+    expect(result[1].input).toEqual({ command: "pwd" });
+    expect(result[0].id).not.toBe(result[1].id);
+  });
+
+  it("parses multiple parameters", () => {
+    const text = `<minimax:tool_call><invoke name="Write">
+<parameter name="path">/tmp/test.txt</parameter>
+<parameter name="content">hello world</parameter>
+</invoke></minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].input).toEqual({ path: "/tmp/test.txt", content: "hello world" });
+  });
+
+  it("handles invoke with extra attributes", () => {
+    const text = `<invoke name='Bash' data-foo="bar">
+<parameter name="command">ls</parameter>
+</invoke></minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Bash");
+    expect(result[0].input).toEqual({ command: "ls" });
+  });
+
+  it("skips invoke blocks without name attribute", () => {
+    const text = `<invoke>Drop</invoke><minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toEqual([]);
+  });
+
+  it("generates unique IDs across calls", () => {
+    const text = `<minimax:tool_call><invoke name="Bash">
+<parameter name="command">echo hi</parameter>
+</invoke></minimax:tool_call>`;
+    const r1 = parseMinimaxToolCallXml(text);
+    const r2 = parseMinimaxToolCallXml(text);
+    expect(r1[0].id).not.toBe(r2[0].id);
+  });
+
+  it("handles parameter values with special characters", () => {
+    const text = `<minimax:tool_call><invoke name="Bash">
+<parameter name="command">echo "hello &amp; world" | grep test</parameter>
+</invoke></minimax:tool_call>`;
+    const result = parseMinimaxToolCallXml(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].input.command).toBe('echo "hello &amp; world" | grep test');
+  });
+});
+
+describe("promoteMinimaxToolCallsToBlocks", () => {
+  it("converts XML tool call to structured toolUse block", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `Let me check.<invoke name="Bash">
+<parameter name="command">ls -la</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const types = msg.content.map((b: { type?: string }) => b?.type);
+    expect(types).toContain("text");
+    expect(types).toContain("toolUse");
+
+    const textBlock = msg.content.find((b: { type?: string }) => b?.type === "text") as {
+      type: string;
+      text: string;
+    };
+    expect(textBlock.text).toBe("Let me check.");
+
+    const toolBlock = msg.content.find((b: { type?: string }) => b?.type === "toolUse") as {
+      type: string;
+      id: string;
+      name: string;
+      input: Record<string, string>;
+    };
+    expect(toolBlock.name).toBe("Bash");
+    expect(toolBlock.input).toEqual({ command: "ls -la" });
+    expect(toolBlock.id).toMatch(/^toolu_minimax_\d+$/);
+  });
+
+  it("handles tool-only text (no surrounding prose)", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">pwd</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const types = msg.content.map((b: { type?: string }) => b?.type);
+    expect(types).not.toContain("text");
+    expect(types).toContain("toolUse");
+  });
+
+  it("handles multiple invoke blocks in one text block", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `First.<invoke name="Read">
+<parameter name="path">a.txt</parameter>
+</invoke>
+</minimax:tool_call>Second.<invoke name="Bash">
+<parameter name="command">pwd</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const toolBlocks = msg.content.filter(
+      (b: { type?: string }) => b?.type === "toolUse",
+    ) as Array<{ name: string }>;
+    expect(toolBlocks).toHaveLength(2);
+    expect(toolBlocks[0].name).toBe("Read");
+    expect(toolBlocks[1].name).toBe("Bash");
+  });
+
+  it("leaves non-minimax text blocks unchanged", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "text", text: "Normal text." },
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">ls</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const textBlocks = msg.content.filter((b: { type?: string }) => b?.type === "text") as Array<{
+      text: string;
+    }>;
+    expect(textBlocks).toHaveLength(1);
+    expect(textBlocks[0].text).toBe("Normal text.");
+  });
+
+  it("does not modify message without minimax markers", () => {
+    const original = [{ type: "text" as const, text: "Hello world" }];
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [...original],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+    expect(msg.content).toEqual(original);
+  });
+
+  it("preserves existing toolUse blocks", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "toolUse", id: "existing_1", name: "Read", input: { path: "x" } } as never,
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">ls</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    promoteMinimaxToolCallsToBlocks(msg);
+
+    const toolBlocks = msg.content.filter(
+      (b: { type?: string }) => b?.type === "toolUse",
+    ) as Array<{ id: string; name: string }>;
+    expect(toolBlocks).toHaveLength(2);
+    expect(toolBlocks[0].id).toBe("existing_1");
+    expect(toolBlocks[1].name).toBe("Bash");
+  });
+
+  it("falls back gracefully when invoke has no name", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Before<invoke>Drop</invoke><minimax:tool_call>After",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    // No parseable invocations → block left as-is for stripMinimaxToolCallXml to handle.
+    promoteMinimaxToolCallsToBlocks(msg);
+    const types = msg.content.map((b: { type?: string }) => b?.type);
+    expect(types).not.toContain("toolUse");
+  });
+
+  it("does not crash on null or undefined content entries", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        null as never,
+        {
+          type: "text",
+          text: `<invoke name="Bash">
+<parameter name="command">ls</parameter>
+</invoke>
+</minimax:tool_call>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    expect(() => promoteMinimaxToolCallsToBlocks(msg)).not.toThrow();
+    const types = msg.content.map((b: { type?: string }) => b?.type);
+    expect(types).toContain("toolUse");
   });
 });

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -9,6 +9,126 @@ export function isAssistantMessage(msg: AgentMessage | undefined): msg is Assist
   return msg?.role === "assistant";
 }
 
+export interface ParsedMinimaxToolCall {
+  name: string;
+  input: Record<string, string>;
+  id: string;
+}
+
+let minimaxToolCallCounter = 0;
+
+/**
+ * Parse MiniMax XML tool invocations from text content.
+ *
+ * MiniMax M2.5 embeds tool calls as XML instead of structured `toolUse` blocks:
+ * ```xml
+ * <minimax:tool_call>
+ * <invoke name="some_tool">
+ * <parameter name="param1">value1</parameter>
+ * </invoke>
+ * </minimax:tool_call>
+ * ```
+ *
+ * Returns an array of parsed tool calls. Returns empty array when the text
+ * contains no minimax tool call markers or no parseable invocations.
+ */
+export function parseMinimaxToolCallXml(text: string): ParsedMinimaxToolCall[] {
+  if (!text || !/minimax:tool_call/i.test(text)) {
+    return [];
+  }
+
+  const toolCalls: ParsedMinimaxToolCall[] = [];
+  const invokeRe = /<invoke\s+name=["']([^"']+)["'][^>]*>([\s\S]*?)<\/invoke>/gi;
+
+  for (const match of text.matchAll(invokeRe)) {
+    const name = match[1];
+    const body = match[2];
+    const input: Record<string, string> = {};
+
+    const paramRe = /<parameter\s+name=["']([^"']+)["'][^>]*>([\s\S]*?)<\/parameter>/gi;
+    for (const paramMatch of body.matchAll(paramRe)) {
+      input[paramMatch[1]] = paramMatch[2]!;
+    }
+
+    minimaxToolCallCounter += 1;
+    toolCalls.push({
+      name,
+      input,
+      id: `toolu_minimax_${minimaxToolCallCounter}`,
+    });
+  }
+
+  return toolCalls;
+}
+
+/**
+ * Transform MiniMax XML tool invocations in text content blocks into
+ * structured `toolUse` content blocks on the assistant message.
+ *
+ * Follows the same in-place mutation pattern as {@link promoteThinkingTagsToBlocks}.
+ * Must be called before {@link extractAssistantText} so the tool calls are
+ * available as structured blocks and the XML is removed from displayed text.
+ *
+ * Falls back gracefully: if parsing yields no tool calls the text block is
+ * left untouched and the existing strip-only path in extractAssistantText
+ * will clean it up.
+ */
+export function promoteMinimaxToolCallsToBlocks(message: AssistantMessage): void {
+  if (!Array.isArray(message.content)) {
+    return;
+  }
+
+  const next: AssistantMessage["content"] = [];
+  let changed = false;
+
+  for (const block of message.content) {
+    if (!block || typeof block !== "object" || !("type" in block)) {
+      next.push(block);
+      continue;
+    }
+    if (block.type !== "text") {
+      next.push(block);
+      continue;
+    }
+    const text: string = (block as { text?: string }).text ?? "";
+    if (!text || !/minimax:tool_call/i.test(text)) {
+      next.push(block);
+      continue;
+    }
+
+    const toolCalls = parseMinimaxToolCallXml(text);
+    if (toolCalls.length === 0) {
+      // No parseable invocations — keep the block as-is; the strip function
+      // inside extractAssistantText will still clean stray tags.
+      next.push(block);
+      continue;
+    }
+
+    changed = true;
+
+    // Strip XML from text and keep any remaining prose.
+    const cleaned = stripMinimaxToolCallXml(text).trim();
+    if (cleaned) {
+      next.push({ type: "text", text: cleaned });
+    }
+
+    // Insert structured toolUse blocks.
+    for (const tc of toolCalls) {
+      next.push({
+        type: "toolUse",
+        id: tc.id,
+        name: tc.name,
+        input: tc.input,
+      } as unknown as (typeof next)[number]);
+    }
+  }
+
+  if (!changed) {
+    return;
+  }
+  message.content = next;
+}
+
 /**
  * Strip malformed Minimax tool invocations that leak into text content.
  * Minimax sometimes embeds tool calls as XML in text blocks instead of

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -487,7 +487,7 @@ export function buildAgentSystemPrompt(params: {
           "Get Updates (self-update) is ONLY allowed when the user explicitly asks for it.",
           "Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.",
           "Use config.schema.lookup with a specific dot path to inspect only the relevant config subtree before making config changes or answering config-field questions; avoid guessing field names/types.",
-          "Actions: config.schema.lookup, config.get, config.apply (validate + write full config, then restart), config.patch (partial update, merges with existing), update.run (update deps or git, then restart).",
+          "Actions: config.schema.lookup, config.get, config.apply (validate + write full config, then restart), config.patch (partial update, merges with existing, hot-reloads when possible), update.run (update deps or git, then restart).",
           "After restart, OpenClaw pings the last active session automatically.",
         ].join("\n")
       : "",

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -76,7 +76,7 @@ export function createGatewayTool(opts?: {
     name: "gateway",
     ownerOnly: true,
     description:
-      "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Both trigger restart after writing. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart.",
+      "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing) and let the gateway hot-reload when possible. Use config.apply only when replacing the entire config. Always pass a human-readable completion message via the `note` parameter so the system can deliver it after any required restart.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -9,6 +9,7 @@ import {
   buildGatewayReloadPlan,
   diffConfigPaths,
   resolveGatewayReloadSettings,
+  shouldConfigPatchTriggerGatewayRestart,
   startGatewayConfigReloader,
 } from "./config-reload.js";
 
@@ -250,6 +251,61 @@ describe("resolveGatewayReloadSettings", () => {
     const settings = resolveGatewayReloadSettings({});
     expect(settings.mode).toBe("hybrid");
     expect(settings.debounceMs).toBe(300);
+  });
+});
+
+describe("shouldConfigPatchTriggerGatewayRestart", () => {
+  it("skips restart when the patch changes nothing", () => {
+    expect(
+      shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode: "restart" } } }, []),
+    ).toBe(false);
+  });
+
+  it.each(["hybrid", "hot"] as const)(
+    "skips restart for hot-reload browser changes in %s mode",
+    (mode) => {
+      expect(
+        shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode } } }, [
+          "browser.profiles.sandbox.cdpUrl",
+        ]),
+      ).toBe(false);
+    },
+  );
+
+  it("skips restart when all changed paths are hot-reloadable or no-op", () => {
+    expect(
+      shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode: "hybrid" } } }, [
+        "browser.profiles.sandbox.cdpUrl",
+        "gateway.reload.mode",
+      ]),
+    ).toBe(false);
+  });
+
+  it.each(["off", "restart"] as const)(
+    "still restarts explicit patches for browser changes in %s mode",
+    (mode) => {
+      expect(
+        shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode } } }, [
+          "browser.profiles.sandbox.cdpUrl",
+        ]),
+      ).toBe(true);
+    },
+  );
+
+  it("still restarts explicit patches for restart-required paths in hot mode", () => {
+    expect(
+      shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode: "hot" } } }, [
+        "gateway.port",
+      ]),
+    ).toBe(true);
+  });
+
+  it("restarts when a changed path needs a full gateway restart", () => {
+    expect(
+      shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode: "hybrid" } } }, [
+        "gateway.port",
+      ]),
+    ).toBe(true);
   });
 });
 

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -65,6 +65,27 @@ export function resolveGatewayReloadSettings(cfg: OpenClawConfig): GatewayReload
   return { mode, debounceMs };
 }
 
+/**
+ * Explicit config.patch writes should only skip SIGUSR1 when the changed paths
+ * can already take effect via hot reload (or the patch is effectively a no-op).
+ */
+export function shouldConfigPatchTriggerGatewayRestart(
+  cfg: OpenClawConfig,
+  changedPaths: string[],
+): boolean {
+  if (changedPaths.length === 0) {
+    return false;
+  }
+
+  const settings = resolveGatewayReloadSettings(cfg);
+  if (settings.mode === "off" || settings.mode === "restart") {
+    return true;
+  }
+
+  const plan = buildGatewayReloadPlan(changedPaths);
+  return plan.restartGateway;
+}
+
 export type GatewayConfigReloader = {
   stop: () => Promise<void>;
 };

--- a/src/gateway/server-methods/config.restart.test.ts
+++ b/src/gateway/server-methods/config.restart.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
+
+const writeConfigFileMock = vi.fn(async () => {});
+const writeRestartSentinelMock = vi.fn(
+  async (_payload: RestartSentinelPayload) => "/tmp/restart-sentinel.json",
+);
+const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
+
+const baseConfig = {
+  gateway: {
+    auth: { mode: "token", token: "test-token" },
+    reload: { mode: "restart" },
+  },
+};
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: () => "/tmp/openclaw",
+  resolveDefaultAgentId: () => "main",
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  listChannelPlugins: () => [],
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    createConfigIO: () => ({ configPath: "/tmp/openclaw.json" }),
+    loadConfig: () => ({}),
+    readConfigFileSnapshotForWrite: async () => ({
+      snapshot: {
+        path: "/tmp/openclaw.json",
+        exists: true,
+        raw: JSON.stringify(baseConfig),
+        parsed: baseConfig,
+        resolved: baseConfig,
+        valid: true,
+        config: baseConfig,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      },
+      writeOptions: {},
+    }),
+    resolveConfigSnapshotHash: () => "snapshot-hash",
+    validateConfigObjectWithPlugins: (config: unknown) => ({
+      ok: true,
+      config,
+      issues: [],
+    }),
+    writeConfigFile: writeConfigFileMock,
+  };
+});
+
+vi.mock("../../config/legacy.js", () => ({
+  applyLegacyMigrations: (config: unknown) => ({ next: config }),
+}));
+
+vi.mock("../../config/redact-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/redact-snapshot.js")>();
+  return {
+    ...actual,
+    redactConfigObject: (config: unknown) => config,
+    restoreRedactedValues: (config: unknown) => ({ ok: true, result: config }),
+  };
+});
+
+vi.mock("../../config/schema.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/schema.js")>();
+  return {
+    ...actual,
+    buildConfigSchema: () => ({ uiHints: {} }),
+  };
+});
+
+vi.mock("../../config/sessions.js", () => ({
+  extractDeliveryInfo: () => ({ deliveryContext: undefined, threadId: undefined }),
+}));
+
+vi.mock("../../infra/restart-sentinel.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/restart-sentinel.js")>();
+  return {
+    ...actual,
+    writeRestartSentinel: writeRestartSentinelMock,
+  };
+});
+
+vi.mock("../../infra/restart.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/restart.js")>();
+  return {
+    ...actual,
+    scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
+  };
+});
+
+vi.mock("../../plugins/loader.js", () => ({
+  loadOpenClawPlugins: () => ({ plugins: [] }),
+}));
+
+vi.mock("./validation.js", () => ({
+  assertValidParams: () => true,
+}));
+
+beforeEach(() => {
+  writeConfigFileMock.mockClear();
+  writeRestartSentinelMock.mockClear();
+  scheduleGatewaySigusr1RestartMock.mockClear();
+  scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+});
+
+async function invokeConfigPatch(raw: Record<string, unknown>) {
+  const { configHandlers } = await import("./config.js");
+  let response:
+    | {
+        ok: boolean;
+        payload?: Record<string, unknown>;
+        error?: unknown;
+      }
+    | undefined;
+
+  await configHandlers["config.patch"]({
+    params: {
+      raw: JSON.stringify(raw),
+      baseHash: "snapshot-hash",
+    },
+    client: undefined,
+    context: {
+      logGateway: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+    respond: ((ok: boolean, payload?: unknown, error?: unknown) => {
+      response = {
+        ok,
+        payload: (payload as Record<string, unknown> | undefined) ?? undefined,
+        error,
+      };
+    }) as never,
+  } as never);
+
+  if (!response) {
+    throw new Error("config.patch did not respond");
+  }
+  return response;
+}
+
+describe("config.patch restart scheduling", () => {
+  it("uses the patched reload mode before deciding whether browser changes need SIGUSR1", async () => {
+    const response = await invokeConfigPatch({
+      gateway: {
+        reload: {
+          mode: "hybrid",
+        },
+      },
+      browser: {
+        profiles: {
+          sandbox: {
+            cdpUrl: "http://127.0.0.1:9222",
+            color: "#0066CC",
+          },
+        },
+      },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(writeRestartSentinelMock).not.toHaveBeenCalled();
+    expect(response.payload?.restart).toBeNull();
+    expect(response.payload?.sentinel).toBeNull();
+    expect(response.payload?.config).toMatchObject({
+      gateway: {
+        auth: { mode: "token", token: "test-token" },
+        reload: { mode: "hybrid" },
+      },
+      browser: {
+        profiles: {
+          sandbox: {
+            cdpUrl: "http://127.0.0.1:9222",
+            color: "#0066CC",
+          },
+        },
+      },
+    });
+  });
+
+  it("still schedules restart and sentinel for restart-required paths", async () => {
+    const response = await invokeConfigPatch({
+      gateway: {
+        port: 18888,
+      },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(writeRestartSentinelMock).toHaveBeenCalledTimes(1);
+    expect(response.payload?.restart).toEqual({ scheduled: true });
+    expect(response.payload?.sentinel).toMatchObject({
+      path: "/tmp/restart-sentinel.json",
+      payload: expect.objectContaining({
+        kind: "config-patch",
+        stats: expect.objectContaining({
+          mode: "config.patch",
+        }),
+      }),
+    });
+  });
+});

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -33,7 +33,7 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { loadOpenClawPlugins } from "../../plugins/loader.js";
-import { diffConfigPaths } from "../config-reload.js";
+import { diffConfigPaths, shouldConfigPatchTriggerGatewayRestart } from "../config-reload.js";
 import {
   formatControlPlaneActor,
   resolveControlPlaneActor,
@@ -425,34 +425,46 @@ export const configHandlers: GatewayRequestHandlers = {
     const changedPaths = diffConfigPaths(snapshot.config, validated.config);
     const actor = resolveControlPlaneActor(client);
     context?.logGateway?.info(
-      `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
+      `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)}`,
     );
     await writeConfigFile(validated.config, writeOptions);
 
-    const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
-      resolveConfigRestartRequest(params);
-    const payload = buildConfigRestartSentinelPayload({
-      kind: "config-patch",
-      mode: "config.patch",
-      sessionKey,
-      deliveryContext,
-      threadId,
-      note,
-    });
-    const sentinelPath = await tryWriteRestartSentinelPayload(payload);
-    const restart = scheduleGatewaySigusr1Restart({
-      delayMs: restartDelayMs,
-      reason: "config.patch",
-      audit: {
-        actor: actor.actor,
-        deviceId: actor.deviceId,
-        clientIp: actor.clientIp,
-        changedPaths,
-      },
-    });
-    if (restart.coalesced) {
-      context?.logGateway?.warn(
-        `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+    let restart: ReturnType<typeof scheduleGatewaySigusr1Restart> | null = null;
+    let sentinel: { path: string | null; payload: RestartSentinelPayload } | null = null;
+    if (shouldConfigPatchTriggerGatewayRestart(validated.config, changedPaths)) {
+      const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
+        resolveConfigRestartRequest(params);
+      const payload = buildConfigRestartSentinelPayload({
+        kind: "config-patch",
+        mode: "config.patch",
+        sessionKey,
+        deliveryContext,
+        threadId,
+        note,
+      });
+      const sentinelPath = await tryWriteRestartSentinelPayload(payload);
+      sentinel = {
+        path: sentinelPath,
+        payload,
+      };
+      restart = scheduleGatewaySigusr1Restart({
+        delayMs: restartDelayMs,
+        reason: "config.patch",
+        audit: {
+          actor: actor.actor,
+          deviceId: actor.deviceId,
+          clientIp: actor.clientIp,
+          changedPaths,
+        },
+      });
+      if (restart.coalesced) {
+        context?.logGateway?.warn(
+          `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+        );
+      }
+    } else {
+      context?.logGateway?.info(
+        `config.patch restart skipped ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)}`,
       );
     }
     respond(
@@ -462,10 +474,7 @@ export const configHandlers: GatewayRequestHandlers = {
         path: createConfigIO().configPath,
         config: redactConfigObject(validated.config, schemaPatch.uiHints),
         restart,
-        sentinel: {
-          path: sentinelPath,
-          payload,
-        },
+        sentinel,
       },
       undefined,
     );


### PR DESCRIPTION
Combines fixes from upstream PRs:
- #46401: fix(agents): parse MiniMax M2.5 XML tool calls instead of silently stripping (Fixes #41839)
- #46397: fix(gateway): skip config.patch restart for hot-reloadable changes (Closes #46310)

Merged from openclaw/openclaw PRs.