### PR TITLE
feat(telegram): add topic-edit action for editForumTopic API

### DIFF
--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -115,6 +115,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (isEnabled("createForumTopic")) {
       actions.add("topic-create");
     }
+    if (isEnabled("editForumTopic")) {
+      actions.add("topic-edit");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -282,6 +285,31 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           chatId,
           name,
           iconColor: iconColor ?? undefined,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "topic-edit") {
+      const chatId = readTelegramChatIdParam(params);
+      const messageThreadId = readNumberParam(params, "messageThreadId", {
+        required: true,
+        integer: true,
+      });
+      if (typeof messageThreadId !== "number") {
+        throw new Error("messageThreadId is required.");
+      }
+      const name = readStringParam(params, "name");
+      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+      return await handleTelegramAction(
+        {
+          action: "editForumTopic",
+          chatId,
+          messageThreadId,
+          name: name ?? undefined,
           iconCustomEmojiId: iconCustomEmojiId ?? undefined,
           accountId: accountId ?? undefined,
         },

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -295,12 +295,11 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
 
     if (action === "topic-edit") {
       const chatId = readTelegramChatIdParam(params);
-      const messageThreadId = readNumberParam(params, "messageThreadId", {
-        required: true,
-        integer: true,
-      });
+      const messageThreadId =
+        readNumberParam(params, "messageThreadId", { integer: true }) ??
+        readNumberParam(params, "threadId", { integer: true });
       if (typeof messageThreadId !== "number") {
-        throw new Error("messageThreadId is required.");
+        throw new Error("messageThreadId or threadId is required.");
       }
       const name = readStringParam(params, "name");
       const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2086,4 +2086,22 @@ describe("editForumTopicTelegram", () => {
       }),
     ).rejects.toThrow("Forum topic name must be 128 characters or fewer");
   });
+
+  it("throws when name is whitespace-only", async () => {
+    const api = {} as unknown as Bot["api"];
+    await expect(
+      editForumTopicTelegram("-1001234567890", 42, { token: "tok", api, name: "   " }),
+    ).rejects.toThrow("Forum topic name cannot be empty");
+  });
+
+  it("throws when iconCustomEmojiId is whitespace-only", async () => {
+    const api = {} as unknown as Bot["api"];
+    await expect(
+      editForumTopicTelegram("-1001234567890", 42, {
+        token: "tok",
+        api,
+        iconCustomEmojiId: "   ",
+      }),
+    ).rejects.toThrow("Forum topic icon custom emoji ID cannot be empty");
+  });
 });

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -15,6 +15,7 @@ const { botApi, botCtorSpy, loadConfig, loadWebMedia, maybePersistResolvedTelegr
 const {
   buildInlineKeyboard,
   createForumTopicTelegram,
+  editForumTopicTelegram,
   editMessageTelegram,
   reactMessageTelegram,
   sendMessageTelegram,
@@ -2004,4 +2005,85 @@ describe("createForumTopicTelegram", () => {
       expect(result).toEqual(testCase.expectedResult);
     });
   }
+});
+
+describe("editForumTopicTelegram", () => {
+  it("calls editForumTopic with name only", async () => {
+    const editForumTopic = vi.fn().mockResolvedValue(true);
+    const api = { editForumTopic } as unknown as Bot["api"];
+
+    const result = await editForumTopicTelegram("-1001234567890", 42, {
+      token: "tok",
+      api,
+      name: "New Name",
+    });
+
+    expect(editForumTopic).toHaveBeenCalledWith("-1001234567890", 42, { name: "New Name" });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("calls editForumTopic with iconCustomEmojiId only", async () => {
+    const editForumTopic = vi.fn().mockResolvedValue(true);
+    const api = { editForumTopic } as unknown as Bot["api"];
+
+    const result = await editForumTopicTelegram("-1001234567890", 42, {
+      token: "tok",
+      api,
+      iconCustomEmojiId: "  emoji123  ",
+    });
+
+    expect(editForumTopic).toHaveBeenCalledWith("-1001234567890", 42, {
+      icon_custom_emoji_id: "emoji123",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("calls editForumTopic with both name and icon", async () => {
+    const editForumTopic = vi.fn().mockResolvedValue(true);
+    const api = { editForumTopic } as unknown as Bot["api"];
+
+    const result = await editForumTopicTelegram("-1001234567890", 42, {
+      token: "tok",
+      api,
+      name: "Renamed",
+      iconCustomEmojiId: "emoji456",
+    });
+
+    expect(editForumTopic).toHaveBeenCalledWith("-1001234567890", 42, {
+      name: "Renamed",
+      icon_custom_emoji_id: "emoji456",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("strips topic suffix from target", async () => {
+    const editForumTopic = vi.fn().mockResolvedValue(true);
+    const api = { editForumTopic } as unknown as Bot["api"];
+
+    await editForumTopicTelegram("telegram:group:-1001234567890:topic:271", 42, {
+      token: "tok",
+      api,
+      name: "Stripped",
+    });
+
+    expect(editForumTopic).toHaveBeenCalledWith("-1001234567890", 42, { name: "Stripped" });
+  });
+
+  it("throws when neither name nor iconCustomEmojiId is provided", async () => {
+    const api = {} as unknown as Bot["api"];
+    await expect(
+      editForumTopicTelegram("-1001234567890", 42, { token: "tok", api }),
+    ).rejects.toThrow("At least one of name or iconCustomEmojiId must be provided");
+  });
+
+  it("throws when name exceeds 128 characters", async () => {
+    const api = {} as unknown as Bot["api"];
+    await expect(
+      editForumTopicTelegram("-1001234567890", 42, {
+        token: "tok",
+        api,
+        name: "x".repeat(129),
+      }),
+    ).rejects.toThrow("Forum topic name must be 128 characters or fewer");
+  });
 });

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1529,3 +1529,85 @@ export async function createForumTopicTelegram(
     chatId: normalizedChatId,
   };
 }
+
+// ---------------------------------------------------------------------------
+// editForumTopic
+// ---------------------------------------------------------------------------
+
+type TelegramEditForumTopicOpts = {
+  cfg?: ReturnType<typeof loadConfig>;
+  token?: string;
+  accountId?: string;
+  api?: TelegramApiOverride;
+  verbose?: boolean;
+  retry?: RetryConfig;
+  /** New topic name (1-128 characters). */
+  name?: string;
+  /** New custom emoji ID for the topic icon. */
+  iconCustomEmojiId?: string;
+};
+
+/**
+ * Edit a forum topic in a Telegram supergroup (rename / change icon).
+ * Requires the bot to have `can_manage_topics` permission.
+ *
+ * @param chatId - Supergroup chat ID
+ * @param messageThreadId - Topic thread ID
+ * @param opts - At least one of `name` or `iconCustomEmojiId` must be provided
+ */
+export async function editForumTopicTelegram(
+  chatId: string,
+  messageThreadId: number,
+  opts: TelegramEditForumTopicOpts = {},
+): Promise<{ ok: true }> {
+  const name = opts.name?.trim();
+  const iconCustomEmojiId = opts.iconCustomEmojiId?.trim();
+
+  if (!name && !iconCustomEmojiId) {
+    throw new Error("At least one of name or iconCustomEmojiId must be provided");
+  }
+  if (name != null && name.length === 0) {
+    throw new Error("Forum topic name cannot be empty");
+  }
+  if (name != null && name.length > 128) {
+    throw new Error("Forum topic name must be 128 characters or fewer");
+  }
+
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
+  const target = parseTelegramTarget(chatId);
+  const normalizedChatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: target.chatId,
+    persistTarget: chatId,
+    verbose: opts.verbose,
+  });
+
+  const requestWithDiag = createTelegramNonIdempotentRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+  });
+
+  const extra: Record<string, unknown> = {};
+  if (name) {
+    extra.name = name;
+  }
+  if (iconCustomEmojiId) {
+    extra.icon_custom_emoji_id = iconCustomEmojiId;
+  }
+
+  await requestWithDiag(
+    () => api.editForumTopic(normalizedChatId, messageThreadId, extra),
+    "editForumTopic",
+  );
+
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+
+  return { ok: true };
+}

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1563,11 +1563,14 @@ export async function editForumTopicTelegram(
   const name = opts.name?.trim();
   const iconCustomEmojiId = opts.iconCustomEmojiId?.trim();
 
-  if (!name && !iconCustomEmojiId) {
-    throw new Error("At least one of name or iconCustomEmojiId must be provided");
-  }
   if (name != null && name.length === 0) {
     throw new Error("Forum topic name cannot be empty");
+  }
+  if (iconCustomEmojiId != null && iconCustomEmojiId.length === 0) {
+    throw new Error("Forum topic icon custom emoji ID cannot be empty");
+  }
+  if (!name && !iconCustomEmojiId) {
+    throw new Error("At least one of name or iconCustomEmojiId must be provided");
   }
   if (name != null && name.length > 128) {
     throw new Error("Forum topic name must be 128 characters or fewer");

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -28,6 +28,7 @@ const createForumTopicTelegram = vi.fn(async () => ({
   name: "Topic",
   chatId: "123",
 }));
+const editForumTopicTelegram = vi.fn(async () => ({ ok: true }));
 let envSnapshot: ReturnType<typeof captureEnv>;
 
 vi.mock("../../../extensions/telegram/src/send.js", () => ({
@@ -44,6 +45,8 @@ vi.mock("../../../extensions/telegram/src/send.js", () => ({
     editMessageTelegram(...args),
   createForumTopicTelegram: (...args: Parameters<typeof createForumTopicTelegram>) =>
     createForumTopicTelegram(...args),
+  editForumTopicTelegram: (...args: Parameters<typeof editForumTopicTelegram>) =>
+    editForumTopicTelegram(...args),
 }));
 
 describe("handleTelegramAction", () => {
@@ -106,6 +109,7 @@ describe("handleTelegramAction", () => {
     deleteMessageTelegram.mockClear();
     editMessageTelegram.mockClear();
     createForumTopicTelegram.mockClear();
+    editForumTopicTelegram.mockClear();
     process.env.TELEGRAM_BOT_TOKEN = "tok";
   });
 
@@ -456,6 +460,14 @@ describe("handleTelegramAction", () => {
       assertCall: (
         readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
       ) => readCallOpts(createForumTopicTelegram.mock.calls as unknown[][], 2),
+    },
+    {
+      name: "editForumTopic",
+      params: { action: "editForumTopic", chatId: "123", messageThreadId: 42, name: "New" },
+      cfg: telegramConfig({ actions: { editForumTopic: true } }),
+      assertCall: (
+        readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
+      ) => readCallOpts(editForumTopicTelegram.mock.calls as unknown[][], 2),
     },
   ])("forwards resolved cfg for $name action", async ({ params, cfg, assertCall }) => {
     const readCallOpts = (calls: unknown[][], argIndex: number): Record<string, unknown> => {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -14,8 +14,8 @@ import {
 import { resolveTelegramReactionLevel } from "../../../extensions/telegram/src/reaction-level.js";
 import {
   createForumTopicTelegram,
-  editForumTopicTelegram,
   deleteMessageTelegram,
+  editForumTopicTelegram,
   editMessageTelegram,
   reactMessageTelegram,
   sendMessageTelegram,
@@ -486,12 +486,11 @@ export async function handleTelegramAction(
     const chatId = readStringOrNumberParam(params, "chatId", {
       required: true,
     });
-    const messageThreadId = readNumberParam(params, "messageThreadId", {
-      required: true,
-      integer: true,
-    });
+    const messageThreadId =
+      readNumberParam(params, "messageThreadId", { integer: true }) ??
+      readNumberParam(params, "threadId", { integer: true });
     if (typeof messageThreadId !== "number") {
-      throw new Error("messageThreadId is required.");
+      throw new Error("messageThreadId or threadId is required.");
     }
     const name = readStringParam(params, "name");
     const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -14,6 +14,7 @@ import {
 import { resolveTelegramReactionLevel } from "../../../extensions/telegram/src/reaction-level.js";
 import {
   createForumTopicTelegram,
+  editForumTopicTelegram,
   deleteMessageTelegram,
   editMessageTelegram,
   reactMessageTelegram,
@@ -476,6 +477,38 @@ export async function handleTelegramAction(
       name: result.name,
       chatId: result.chatId,
     });
+  }
+
+  if (action === "editForumTopic") {
+    if (!isActionEnabled("editForumTopic")) {
+      throw new Error("Telegram editForumTopic is disabled.");
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageThreadId = readNumberParam(params, "messageThreadId", {
+      required: true,
+      integer: true,
+    });
+    if (typeof messageThreadId !== "number") {
+      throw new Error("messageThreadId is required.");
+    }
+    const name = readStringParam(params, "name");
+    const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const result = await editForumTopicTelegram(chatId ?? "", messageThreadId, {
+      cfg,
+      token,
+      accountId: accountId ?? undefined,
+      name: name ?? undefined,
+      iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+    });
+    return jsonResult(result);
   }
 
   throw new Error(`Unsupported Telegram action: ${action}`);

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -44,6 +44,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "category-edit",
   "category-delete",
   "topic-create",
+  "topic-edit",
   "voice-status",
   "event-list",
   "event-create",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -23,6 +23,8 @@ export type TelegramActionConfig = {
   sticker?: boolean;
   /** Enable forum topic creation. */
   createForumTopic?: boolean;
+  /** Enable forum topic editing (rename / change icon). */
+  editForumTopic?: boolean;
 };
 
 export type TelegramNetworkConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -255,6 +255,7 @@ export const TelegramAccountSchemaBase = z
         editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
         createForumTopic: z.boolean().optional(),
+        editForumTopic: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -49,6 +49,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     "category-edit": "none",
     "category-delete": "none",
     "topic-create": "to",
+    "topic-edit": "to",
     "voice-status": "none",
     "event-list": "none",
     "event-create": "none",


### PR DESCRIPTION
## Summary
Add `topic-edit` action to the Telegram message plugin, enabling agents to rename forum topics and change their icons using the Telegram Bot API's `editForumTopic` method.

<img width="587" height="451" alt="CleanShot 2026-03-14 at 18 12 01" src="https://github.com/user-attachments/assets/6cbcbb3b-7329-4064-82b7-7d6fd59fb822" />


## Changes
- Add `editForumTopicTelegram` function in `extensions/telegram/src/send.ts`
- Add `topic-edit` action name to message action names
- Add `editForumTopic` gate to Telegram action config
- Wire up action handling in channel-actions and telegram-actions
- Add tests

## Motivation
Closes #7746

Currently OpenClaw supports creating forum topics (`topic-create`) but not editing them. The Telegram Bot API's `editForumTopic` method allows changing a topic's name and icon, which is useful for agents managing conversations in forum-enabled chats (including 1:1 DM topics with bots).

## Testing
- Unit tests for the new function and action handler
- Manual testing with Telegram bot in forum-enabled chat

lobster-biscuit

## Sign-Off
Built with Claude (claude-opus-4-6). AI-assisted development.