### PR TITLE
docs(nav): move btw to end of built-in tools

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1009,7 +1009,8 @@
                   "tools/loop-detection",
                   "tools/reactions",
                   "tools/thinking",
-                  "tools/web"
+                  "tools/web",
+                  "tools/btw"
                 ]
               },
               {
@@ -1033,7 +1034,6 @@
               {
                 "group": "Skills",
                 "pages": [
-                  "tools/btw",
                   "tools/creating-skills",
                   "tools/slash-commands",
                   "tools/skills",


### PR DESCRIPTION
## Summary
- move `/tools/btw` under `Built-in tools`
- place it last in that section instead of first
- keep the Mintlify nav ordering consistent with the requested docs layout

## Testing
- node -e "JSON.parse(require('node:fs').readFileSync('docs/docs.json','utf8')); console.log('docs.json ok')"
