### PR TITLE
fix(telegram): propagate mediaMaxMb limit to outbound media reply delivery

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -111,6 +111,8 @@ type DispatchTelegramMessageParams = {
   textLimit: number;
   telegramCfg: TelegramAccountConfig;
   opts: Pick<TelegramBotOptions, "token">;
+  /** Maximum outbound media size in bytes (from configured mediaMaxMb). */
+  mediaMaxBytes?: number;
 };
 
 type TelegramReasoningLevel = "off" | "on" | "stream";
@@ -148,6 +150,7 @@ export const dispatchTelegramMessage = async ({
   textLimit,
   telegramCfg,
   opts,
+  mediaMaxBytes,
 }: DispatchTelegramMessageParams) => {
   const {
     ctxPayload,
@@ -457,6 +460,7 @@ export const dispatchTelegramMessage = async ({
     runtime,
     bot,
     mediaLocalRoots,
+    mediaMaxBytes,
     replyToMode,
     textLimit,
     thread: threadSpec,

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -22,6 +22,8 @@ type TelegramMessageProcessorDeps = Omit<
   streamMode: TelegramStreamMode;
   textLimit: number;
   opts: Pick<TelegramBotOptions, "token">;
+  /** Maximum outbound media size in bytes (from configured mediaMaxMb). */
+  mediaMaxBytes?: number;
 };
 
 export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDeps) => {
@@ -46,6 +48,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     streamMode,
     textLimit,
     opts,
+    mediaMaxBytes,
   } = deps;
 
   return async (
@@ -90,6 +93,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         textLimit,
         telegramCfg,
         opts,
+        mediaMaxBytes,
       });
     } catch (err) {
       runtime.error?.(danger(`telegram message processing failed: ${String(err)}`));

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -140,6 +140,8 @@ type RegisterTelegramNativeCommandsParams = {
   ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   opts: { token: string };
+  /** Maximum outbound media size in bytes (from configured mediaMaxMb). */
+  mediaMaxBytes?: number;
 };
 
 async function resolveTelegramCommandAuth(params: {
@@ -362,6 +364,7 @@ export const registerTelegramNativeCommands = ({
   resolveTelegramGroupConfig,
   shouldSkipUpdate,
   opts,
+  mediaMaxBytes,
 }: RegisterTelegramNativeCommandsParams) => {
   const boundRoute =
     nativeEnabled && nativeSkillsEnabled
@@ -542,6 +545,7 @@ export const registerTelegramNativeCommands = ({
     tableMode: params.tableMode,
     chunkMode: params.chunkMode,
     linkPreview: telegramCfg.linkPreview,
+    mediaMaxBytes,
   });
 
   if (commandsToRegister.length > 0 || pluginCatalog.commands.length > 0) {

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -471,6 +471,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     streamMode,
     textLimit,
     opts,
+    mediaMaxBytes,
   });
 
   registerTelegramNativeCommands({
@@ -491,6 +492,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     resolveTelegramGroupConfig,
     shouldSkipUpdate,
     opts,
+    mediaMaxBytes,
   });
 
   registerTelegramHandlers({

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -234,6 +234,8 @@ async function deliverMediaReply(params: {
   thread?: TelegramThreadSpec | null;
   tableMode?: MarkdownTableMode;
   mediaLocalRoots?: readonly string[];
+  /** Maximum outbound media size in bytes (from configured mediaMaxMb). */
+  mediaMaxBytes?: number;
   chunkText: ChunkTextFn;
   onVoiceRecording?: () => Promise<void> | void;
   linkPreview?: boolean;
@@ -250,7 +252,10 @@ async function deliverMediaReply(params: {
     const isFirstMedia = first;
     const media = await loadWebMedia(
       mediaUrl,
-      buildOutboundMediaLoadOptions({ mediaLocalRoots: params.mediaLocalRoots }),
+      buildOutboundMediaLoadOptions({
+        mediaLocalRoots: params.mediaLocalRoots,
+        maxBytes: params.mediaMaxBytes,
+      }),
     );
     const kind = kindFromMime(media.contentType ?? undefined);
     const isGif = isGifMedia({
@@ -548,6 +553,8 @@ export async function deliverReplies(params: {
   runtime: RuntimeEnv;
   bot: Bot;
   mediaLocalRoots?: readonly string[];
+  /** Maximum outbound media size in bytes (from configured mediaMaxMb). */
+  mediaMaxBytes?: number;
   replyToMode: ReplyToMode;
   textLimit: number;
   thread?: TelegramThreadSpec | null;
@@ -651,6 +658,7 @@ export async function deliverReplies(params: {
           thread: params.thread,
           tableMode: params.tableMode,
           mediaLocalRoots: params.mediaLocalRoots,
+          mediaMaxBytes: params.mediaMaxBytes,
           chunkText,
           onVoiceRecording: params.onVoiceRecording,
           linkPreview: params.linkPreview,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -855,4 +855,41 @@ describe("deliverReplies", () => {
     expect(sendVoice).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
   });
+
+  it("passes mediaMaxBytes to loadWebMedia for outbound media replies", async () => {
+    const { runtime, bot } = createSendMessageHarness();
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 5, chat: { id: "123" } });
+    (bot.api as Record<string, unknown>).sendPhoto = sendPhoto;
+    mockMediaLoad("photo.jpg", "image/jpeg", "img-data");
+
+    await deliverReplies({
+      ...baseDeliveryParams,
+      replies: [{ text: "caption", mediaUrl: "https://example.com/photo.jpg" }],
+      runtime,
+      bot,
+      mediaMaxBytes: 50 * 1024 * 1024,
+    });
+
+    expect(loadWebMedia).toHaveBeenCalledTimes(1);
+    const loadOpts = loadWebMedia.mock.calls[0]?.[1] as { maxBytes?: number } | undefined;
+    expect(loadOpts?.maxBytes).toBe(50 * 1024 * 1024);
+  });
+
+  it("omits maxBytes from loadWebMedia when mediaMaxBytes is not set", async () => {
+    const { runtime, bot } = createSendMessageHarness();
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 5, chat: { id: "123" } });
+    (bot.api as Record<string, unknown>).sendPhoto = sendPhoto;
+    mockMediaLoad("photo.jpg", "image/jpeg", "img-data");
+
+    await deliverReplies({
+      ...baseDeliveryParams,
+      replies: [{ text: "caption", mediaUrl: "https://example.com/photo.jpg" }],
+      runtime,
+      bot,
+    });
+
+    expect(loadWebMedia).toHaveBeenCalledTimes(1);
+    const loadOpts = loadWebMedia.mock.calls[0]?.[1] as { maxBytes?: number } | undefined;
+    expect(loadOpts?.maxBytes).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- **Problem:** The configured `mediaMaxMb` limit is ignored when Telegram delivers final replies containing media. `loadWebMedia()` in the reply delivery path always falls back to the default 100 MB cap.
- **Why it matters:** Operators who set a lower `mediaMaxMb` (e.g., 10 MB) to save bandwidth or comply with Telegram file-size limits see no effect on outbound reply media, only on the direct-send path.
- **What changed:** Thread `mediaMaxBytes` through five files in the Telegram outbound delivery chain: `bot.ts` → `bot-message.ts` → `bot-message-dispatch.ts` → `delivery.replies.ts`, plus the parallel native-commands path via `bot-native-commands.ts`.
- **What did NOT change:** The direct-send path in `send.ts` (already correct), media loading internals, or any default values.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46023

## User-visible / Behavior Changes

When \`mediaMaxMb\` is configured in Telegram account settings, outbound media in reply messages now respects that limit. Previously only direct sends honored it.

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: Linux (tested), platform-independent change
- Runtime/container: Node.js 22+
- Model/provider: N/A (channel-level bug)
- Integration/channel: Telegram
- Relevant config: \`telegramAccounts[].mediaMaxMb\` or \`opts.mediaMaxMb\`

### Steps

1. Configure a Telegram account with \`mediaMaxMb: 10\`
2. Send a message that triggers a reply containing a media URL larger than 10 MB
3. Observe the media is fetched and sent without size enforcement

### Expected

\`loadWebMedia()\` receives \`maxBytes: 10485760\` and enforces the configured limit.

### Actual (before fix)

\`loadWebMedia()\` receives no \`maxBytes\` parameter, falling back to the default 100 MB limit.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two new unit tests in \`delivery.test.ts\`:
- \`passes mediaMaxBytes to loadWebMedia for outbound media replies\` — verifies the parameter reaches \`loadWebMedia\`
- \`omits maxBytes from loadWebMedia when mediaMaxBytes is not set\` — verifies \`undefined\` when not configured

All related test suites pass: delivery (31), dispatch (67), native-commands (6), bot-message (4) — 108 total.

## Human Verification (required)

- Verified scenarios: \`pnpm build\` succeeds, \`pnpm check\` clean for changed files, all 108 tests in 4 related test suites pass
- Edge cases checked: \`mediaMaxBytes\` is \`undefined\` when not configured (preserves default behavior), threading is correct in both message-processor and native-commands paths
- What I did **not** verify: End-to-end with a live Telegram bot (no test instance available); relied on unit tests and code review of the existing \`send.ts\` reference pattern

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? \`Yes\` — \`mediaMaxBytes\` is optional at every level; when absent, behavior is unchanged
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Media in Telegram replies being rejected or truncated unexpectedly when \`mediaMaxMb\` is set very low

## Risks and Mitigations

None.

---

> [!NOTE]
> This pull request was authored with assistance from Claude Code (claude-opus-4-6). Fully tested. I understand what the code does — it is a straightforward parameter-threading fix following the existing pattern in \`send.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)