### PR TITLE
fix(exec): resolve login shell PATH when exec host defaults to sandbox

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -381,7 +381,7 @@ export function createExecTool(
           })
         : mergedEnv;
 
-      if (!sandbox && host === "gateway" && !params.env?.PATH) {
+      if (!sandbox && (host === "gateway" || host === "sandbox") && !params.env?.PATH) {
         const shellPath = getShellPathFromLoginShell({
           env: process.env,
           timeoutMs: resolveShellEnvFallbackTimeoutMs(process.env),


### PR DESCRIPTION
## Problem
When `tools.exec.host` defaults to `"sandbox"` but no sandbox runtime exists (mode=off), login shell PATH resolution was skipped because it only ran for `host === "gateway"`. This caused version-manager-installed tools (nvm/fnm/volta) to be missing from PATH.

## Changes
- Extended the condition in `bash-tools.exec.ts` to also cover `host === "sandbox"`

## Testing
- `pnpm build` passes

## Related
Closes #41549