### PR TITLE
fix(onboard): raise verification max_tokens from 1 to 16

### DIFF
--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -346,7 +346,7 @@ async function requestOpenAiVerification(params: {
       body: {
         model: params.modelId,
         messages: [{ role: "user", content: "Hi" }],
-        max_tokens: 1,
+        max_tokens: 16,
         stream: false,
       },
     });
@@ -374,7 +374,7 @@ async function requestAnthropicVerification(params: {
     headers: buildAnthropicHeaders(params.apiKey),
     body: {
       model: params.modelId,
-      max_tokens: 1,
+      max_tokens: 16,
       messages: [{ role: "user", content: "Hi" }],
       stream: false,
     },


### PR DESCRIPTION
## Problem
Model verification in the onboard wizard used `max_tokens: 1`, but some models (e.g. GPT-5.4) require a minimum of 16.

## Changes
- Changed `max_tokens: 1` to `max_tokens: 16` in both verification request bodies in `onboard-custom.ts`

## Testing
- `pnpm build` passes

## Related
Closes #40857