### PR TITLE
Docs: fix quickstart and redirect drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Full beginner guide (auth, pairing, channels): [Getting started](https://docs.op
 ```bash
 openclaw onboard --install-daemon
 
-openclaw gateway --port 18789 --verbose
+openclaw gateway status
 
 # Send a message
-openclaw message send --to +1234567890 --message "Hello from OpenClaw"
+openclaw message send --target +1234567890 --message "Hello from OpenClaw"
 
 # Talk to the assistant (optionally deliver back to any connected channel: WhatsApp/Telegram/Slack/Discord/Google Chat/Signal/iMessage/BlueBubbles/IRC/Microsoft Teams/Matrix/Feishu/LINE/Mattermost/Nextcloud Talk/Nostr/Synology Chat/Tlon/Twitch/Zalo/Zalo Personal/WebChat)
 openclaw agent --message "Ship checklist" --thinking high

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,7 +61,7 @@
     },
     {
       "source": "/cron",
-      "destination": "/cron-jobs"
+      "destination": "/automation/cron-jobs"
     },
     {
       "source": "/minimax",
@@ -509,11 +509,11 @@
     },
     {
       "source": "/model",
-      "destination": "/models"
+      "destination": "/concepts/models"
     },
     {
       "source": "/model/",
-      "destination": "/models"
+      "destination": "/concepts/models"
     },
     {
       "source": "/models",

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,10 +106,10 @@ The Gateway is the single source of truth for sessions, routing, and channel con
     openclaw onboard --install-daemon
     ```
   </Step>
-  <Step title="Pair WhatsApp and start the Gateway">
+  <Step title="Check the Gateway and open the Control UI">
     ```bash
-    openclaw channels login
-    openclaw gateway --port 18789
+    openclaw gateway status
+    openclaw dashboard
     ```
   </Step>
 </Steps>


### PR DESCRIPTION
## Summary

- Problem: the README quick start used `message send --to`, which does not match the current CLI surface.
- Why it matters: the first command path users copy from the README could fail immediately, and the docs landing page suggested manually starting the gateway right after `--install-daemon` onboarding.
- What changed: fixed the README command example, updated the docs landing page quick start to verify the managed gateway and open the dashboard, and flattened two stale redirect chains in `docs/docs.json`.
- What did NOT change (scope boundary): no CLI behavior, product behavior, or generated translation files changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- README quick start now uses `openclaw message send --target ...`.
- Docs landing page quick start now points users to `openclaw gateway status` and `openclaw dashboard` after onboarding instead of telling them to start the gateway again manually.
- Legacy `/cron` and `/model` redirects now point directly to their current docs destinations.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Compare README and docs landing page command examples against the current CLI registrations.
2. Verify `message send` expects `--target` and that onboarding docs elsewhere already treat `--install-daemon` as the managed-service path.
3. Validate the edited redirect destinations against the current docs tree.

### Expected

- First-run docs copy/paste paths match the current CLI.
- Redirects point directly to existing docs pages.

### Actual

- Updated docs now match the current command surface and direct users through the managed-service flow.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: checked the edited command examples against `src/cli/program/register.message.ts`, `src/cli/program/message/helpers.ts`, `src/cli/program/register.agent.ts`, and the gateway/dashboard docs flow.
- Edge cases checked: validated the edited redirect targets against the current `docs/` file tree.
- What you did **not** verify: full Mintlify render/build; generated translated docs.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the three docs commits on this branch.
- Files/config to restore: `README.md`, `docs/index.md`, `docs/docs.json`
- Known bad symptoms reviewers should watch for: broken landing-page quick start copy or redirect regressions.

## Risks and Mitigations

- Risk: redirect edits could miss an expected legacy destination.
  - Mitigation: only flattened chains to destinations that already exist in the current docs tree.
