### PR TITLE
fix(slack): thread agent identity through draft stream for streaming messages

### DIFF
--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -19,6 +19,7 @@ export function createSlackDraftStream(params: {
   target: string;
   token: string;
   accountId?: string;
+  identity?: import("./send.js").SlackSendIdentity;
   maxChars?: number;
   throttleMs?: number;
   resolveThreadTs?: () => string | undefined;
@@ -69,6 +70,7 @@ export function createSlackDraftStream(params: {
         token: params.token,
         accountId: params.accountId,
         threadTs: params.resolveThreadTs?.(),
+        identity: params.identity,
       });
       streamChannelId = sent.channelId || streamChannelId;
       streamMessageId = sent.messageId || streamMessageId;

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -378,6 +378,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     target: prepared.replyTarget,
     token: ctx.botToken,
     accountId: account.accountId,
+    identity: slackIdentity,
     maxChars: Math.min(ctx.textLimit, 4000),
     resolveThreadTs: () => {
       const ts = replyPlan.nextThreadTs();


### PR DESCRIPTION
## Summary

**Problem:** When `streaming` is enabled, Slack messages show the default app name instead of the custom agent identity (name/emoji/icon). Non-streaming messages display correctly.

**Why it matters:** Multi-agent setups lose their visual identity in streaming mode, making it impossible to distinguish agents.

**What changed:**
- Added optional `identity` parameter to `createSlackDraftStream` in `extensions/slack/src/draft-stream.ts`
- Forward `identity` to the initial `send()` call so `chat.postMessage` receives `username`/`icon_url`/`icon_emoji`
- Threaded `slackIdentity` from dispatch.ts into the draft stream constructor

**What did NOT change:** Non-streaming path, edit calls (which preserve original message author display), native streaming path.

## Change Type
Bug fix

## Linked Issue
Closes #38235

## Security Impact
No

## Evidence
- 7 draft-stream tests pass
- Build succeeds

*This PR was AI-assisted (fully tested with pnpm build/check/test).*