### PR TITLE
fix(status): use resolveThinkingDefault for per-model thinking in status display

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -6,6 +6,7 @@ import {
   buildModelAliasIndex,
   resolveConfiguredModelRef,
   resolveModelRefFromString,
+  resolveThinkingDefault,
 } from "../agents/model-selection.js";
 import { resolveSandboxRuntimeStatus } from "../agents/sandbox.js";
 import type { SkillCommandSpec } from "../agents/skills.js";
@@ -508,7 +509,13 @@ export function buildStatusMessage(args: StatusArgs): string {
   }
 
   const thinkLevel =
-    args.resolvedThink ?? args.sessionEntry?.thinkingLevel ?? args.agent?.thinkingDefault ?? "off";
+    args.resolvedThink ??
+    (args.sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
+    resolveThinkingDefault({
+      cfg: contextConfig,
+      provider: activeProvider,
+      model: activeModel,
+    });
   const verboseLevel =
     args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
   const fastMode = args.resolvedFast ?? args.sessionEntry?.fastMode ?? false;


### PR DESCRIPTION
## Problem
Per-model `params.thinking` in config was silently ignored in the status display. `buildStatusMessage()` went directly to the global `thinkingDefault`, bypassing per-model settings.

## Changes
- Replaced direct `args.agent?.thinkingDefault` fallback with `resolveThinkingDefault()` which properly checks per-model `params.thinking` first

## Testing
- `pnpm build` passes

## Related
Closes #30398