### PR TITLE
fix(session-lock): reclaim stale lock when holding process is dead

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -151,6 +151,25 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
+  it("immediately reclaims a recent lock held by a dead process", async () => {
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      // Write a lock with a dead PID and a very recent timestamp.
+      // Use a high staleMs so age-based reclaim does NOT trigger — only
+      // the dead-PID check should cause reclamation.
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({ pid: 99999999, createdAt: new Date().toISOString() }),
+        "utf8",
+      );
+
+      await expectCurrentPidOwnsLock({
+        sessionFile,
+        timeoutMs: 2000,
+        staleMs: 30 * 60 * 1000,
+      });
+    });
+  });
+
   it("does not reclaim fresh malformed lock files during contention", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     try {

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -522,6 +522,15 @@ export async function acquireSessionWriteLock(params: {
         throw err;
       }
       const payload = await readLockPayload(lockPath);
+
+      // Fast path: if the stored PID is confirmed dead, immediately reclaim
+      // the stale lock without further inspection. This handles the common
+      // case where the previous lock holder crashed or was killed (SIGKILL).
+      if (payload?.pid != null && payload.pid > 0 && !isPidAlive(payload.pid)) {
+        await fs.rm(lockPath, { force: true });
+        continue;
+      }
+
       const nowMs = Date.now();
       const inspected = inspectLockPayload(payload, staleMs, nowMs);
       const orphanSelfLock = shouldTreatAsOrphanSelfLock({


### PR DESCRIPTION
## Problem
When a process holding a session lock dies unexpectedly, the lock file persists and blocks all subsequent sessions until manual cleanup.

## Changes
- Added dead-PID fast-path in acquireSessionWriteLock: if stored PID is not alive, remove stale lock and retry
- Added test for dead-process lock reclamation

## Testing
- All 19 tests pass (18 existing + 1 new)
- pnpm build passes

## Related
Closes #32799