### PR TITLE
fix(logging): expand tilde in logging.file config path

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { Logger as TsLogger } from "tslog";
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { readLoggingConfig } from "./config.js";
 import type { ConsoleStyle } from "./console.js";
@@ -100,7 +101,7 @@ function resolveSettings(): ResolvedSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? defaultRollingPathForToday();
+  const file = expandHomePrefix(cfg?.file ?? defaultRollingPathForToday());
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }


### PR DESCRIPTION
## Summary

**Problem:** Setting `logging.file` to a tilde-prefixed path (e.g. `~/.openclaw/logs/gateway.log`) crashes the gateway on startup with `ENOENT: no such file or directory, mkdir '~/.openclaw/logs'`. Node.js `fs` APIs do not expand `~`.

**Why it matters:** Agents or users may set tilde paths via `openclaw config set`, causing a crash → launchd restart loop.

**What changed:** Added `expandHomePrefix()` call on the resolved file path in `resolveSettings()` in `src/logging/logger.ts`.

**What did NOT change:** Default rolling path behavior, log level resolution, max file size handling.

## Change Type
Bug fix

## Linked Issue
Closes #30401

## Security Impact
No

## Evidence
- 5 logger settings tests pass
- Build succeeds

*This PR was AI-assisted (fully tested with pnpm build/check/test).*