### PR TITLE
fix(message): strip auto-populated poll and components params on send

### DIFF
--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -422,3 +422,43 @@ export function parseComponentsParam(params: Record<string, unknown>): void {
     throw new Error("--components must be valid JSON");
   }
 }
+
+/**
+ * Strip components that are empty or auto-populated skeletons.
+ *
+ * Models (especially GPT-family) tend to fill the `components` schema with
+ * empty scaffolding like `{ blocks: [], modal: { fields: [], title: "" } }`
+ * even when the user only wants a plain send. These empty containers cause
+ * Discord rendering issues (broken attachment display, red X buttons) and
+ * modal validation errors (`components.modal.fields must be a non-empty array`).
+ *
+ * See: https://github.com/openclaw/openclaw/issues/43015
+ */
+export function stripEmptyComponents(params: Record<string, unknown>): void {
+  const components = params.components;
+  if (components == null || typeof components !== "object") {
+    return;
+  }
+
+  const comp = components as Record<string, unknown>;
+
+  // Strip empty modal (no fields or only empty fields array)
+  if (comp.modal != null && typeof comp.modal === "object") {
+    const modal = comp.modal as Record<string, unknown>;
+    const fields = modal.fields;
+    if (!Array.isArray(fields) || fields.length === 0) {
+      delete comp.modal;
+    }
+  }
+
+  // Check if the remaining components have any meaningful content
+  const blocks = comp.blocks;
+  const hasBlocks = Array.isArray(blocks) && blocks.length > 0;
+  const hasText = typeof comp.text === "string" && comp.text.trim().length > 0;
+  const hasModal = comp.modal != null;
+
+  // If nothing meaningful remains, remove the entire components object
+  if (!hasBlocks && !hasText && !hasModal) {
+    delete params.components;
+  }
+}

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -186,6 +186,11 @@ describe("runMessageAction context isolation", () => {
     ).rejects.toThrow(/message required/i);
   });
 
+  // Poll params on send actions are now silently stripped instead of rejected.
+  // This prevents false positives when models auto-fill poll fields from the
+  // shared tool schema on plain send requests.
+  // See: https://github.com/openclaw/openclaw/issues/42820
+  //      https://github.com/openclaw/openclaw/issues/43015
   it.each([
     {
       name: "structured poll params",
@@ -218,14 +223,15 @@ describe("runMessageAction context isolation", () => {
         poll_public: "true",
       },
     },
-  ])("rejects send actions that include $name", async ({ actionParams }) => {
+  ])("strips poll params from send actions that include $name", async ({ actionParams }) => {
+    // Should NOT reject — poll params are stripped and send proceeds normally
     await expect(
       runDrySend({
         cfg: slackConfig,
         actionParams,
         toolContext: { currentChannelId: "C12345678" },
       }),
-    ).rejects.toThrow(/use action "poll" instead of "send"/i);
+    ).resolves.not.toThrow();
   });
 
   it.each([

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -14,7 +14,11 @@ import type {
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
-import { hasPollCreationParams, resolveTelegramPollVisibility } from "../../poll-params.js";
+import {
+  hasPollCreationParams,
+  resolveTelegramPollVisibility,
+  stripPollCreationParams,
+} from "../../poll-params.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -33,6 +37,7 @@ import {
   parseButtonsParam,
   parseCardParam,
   parseComponentsParam,
+  stripEmptyComponents,
   readBooleanParam,
   resolveAttachmentMediaPolicy,
   resolveSlackAutoThreadId,
@@ -708,6 +713,11 @@ export async function runMessageAction(
   parseButtonsParam(params);
   parseCardParam(params);
   parseComponentsParam(params);
+  // Strip empty/skeleton components that models auto-populate from the schema.
+  // Empty components containers cause Discord rendering issues (e.g. broken
+  // attachment display) and modal validation errors.
+  // See: https://github.com/openclaw/openclaw/issues/43015
+  stripEmptyComponents(params);
 
   const action = input.action;
   if (action === "broadcast") {
@@ -768,6 +778,15 @@ export async function runMessageAction(
     toolContext: input.toolContext,
     cfg,
   });
+
+  // Strip auto-populated poll fields from send requests.
+  // Models often fill optional poll params from the shared tool schema even
+  // when only a plain message/attachment send is intended.
+  // See: https://github.com/openclaw/openclaw/issues/42820
+  //      https://github.com/openclaw/openclaw/issues/43015
+  if (action === "send") {
+    stripPollCreationParams(params);
+  }
 
   if (action === "send" && hasPollCreationParams(params)) {
     throw new Error('Poll fields require action "poll"; use action "poll" instead of "send".');

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -1,53 +1,99 @@
 import { describe, expect, it } from "vitest";
-import { hasPollCreationParams, resolveTelegramPollVisibility } from "./poll-params.js";
+import {
+  hasPollCreationParams,
+  resolveTelegramPollVisibility,
+  stripPollCreationParams,
+} from "./poll-params.js";
 
 describe("poll params", () => {
-  it("does not treat explicit false booleans as poll creation params", () => {
+  // --- hasPollCreationParams: now gates on pollQuestion ---
+
+  it("returns false when no poll params are present", () => {
+    expect(hasPollCreationParams({})).toBe(false);
+  });
+
+  it("returns false when only non-question poll params are present (model auto-fill)", () => {
+    // This is the core bug fix: models auto-fill these defaults on action="send"
+    expect(hasPollCreationParams({ pollMulti: false })).toBe(false);
+    expect(hasPollCreationParams({ pollMulti: true })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: 24 })).toBe(false);
+    expect(hasPollCreationParams({ pollAnonymous: false })).toBe(false);
+    expect(hasPollCreationParams({ pollPublic: true })).toBe(false);
+    expect(hasPollCreationParams({ pollOption: ["Pizza", "Sushi"] })).toBe(false);
+  });
+
+  it("returns true when pollQuestion has a non-empty value", () => {
+    expect(hasPollCreationParams({ pollQuestion: "Lunch?" })).toBe(true);
+  });
+
+  it("returns false when pollQuestion is empty or whitespace", () => {
+    expect(hasPollCreationParams({ pollQuestion: "" })).toBe(false);
+    expect(hasPollCreationParams({ pollQuestion: "   " })).toBe(false);
+  });
+
+  it("detects snake_case poll_question as poll creation intent", () => {
+    expect(hasPollCreationParams({ poll_question: "Lunch?" })).toBe(true);
+    expect(hasPollCreationParams({ poll_question: "" })).toBe(false);
+  });
+
+  it("returns true when pollQuestion is present alongside other poll params", () => {
     expect(
       hasPollCreationParams({
-        pollMulti: false,
-        pollAnonymous: false,
-        pollPublic: false,
+        pollQuestion: "Lunch?",
+        pollOption: ["Pizza", "Sushi"],
+        pollMulti: true,
+        pollDurationHours: 24,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it.each([{ key: "pollMulti" }, { key: "pollAnonymous" }, { key: "pollPublic" }])(
-    "treats $key=true as poll creation intent",
-    ({ key }) => {
-      expect(
-        hasPollCreationParams({
-          [key]: true,
-        }),
-      ).toBe(true);
-    },
-  );
+  // --- stripPollCreationParams ---
 
-  it("treats finite numeric poll params as poll creation intent", () => {
-    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationHours: Number.NaN })).toBe(false);
-    expect(hasPollCreationParams({ pollDurationSeconds: Infinity })).toBe(false);
-    expect(hasPollCreationParams({ pollDurationSeconds: "60abc" })).toBe(false);
+  it("strips all poll creation params from a params object", () => {
+    const params: Record<string, unknown> = {
+      action: "send",
+      channel: "discord",
+      message: "Hello",
+      filePath: "/tmp/image.png",
+      pollQuestion: "Lunch?",
+      pollOption: ["Pizza", "Sushi"],
+      pollDurationHours: 24,
+      pollMulti: true,
+    };
+    stripPollCreationParams(params);
+    expect(params).toEqual({
+      action: "send",
+      channel: "discord",
+      message: "Hello",
+      filePath: "/tmp/image.png",
+    });
   });
 
-  it("treats string-encoded boolean poll params as poll creation intent when true", () => {
-    expect(hasPollCreationParams({ pollPublic: "true" })).toBe(true);
-    expect(hasPollCreationParams({ pollAnonymous: "false" })).toBe(false);
+  it("strips snake_case poll params", () => {
+    const params: Record<string, unknown> = {
+      message: "Hello",
+      poll_question: "Lunch?",
+      poll_option: ["A", "B"],
+      poll_duration_hours: 12,
+      poll_multi: false,
+    };
+    stripPollCreationParams(params);
+    expect(params).toEqual({ message: "Hello" });
   });
 
-  it("treats string poll options as poll creation intent", () => {
-    expect(hasPollCreationParams({ pollOption: "Yes" })).toBe(true);
+  it("is a no-op when no poll params are present", () => {
+    const params: Record<string, unknown> = {
+      action: "send",
+      channel: "discord",
+      message: "Hello",
+    };
+    const original = { ...params };
+    stripPollCreationParams(params);
+    expect(params).toEqual(original);
   });
 
-  it("detects snake_case poll fields as poll creation intent", () => {
-    expect(hasPollCreationParams({ poll_question: "Lunch?" })).toBe(true);
-    expect(hasPollCreationParams({ poll_option: ["Pizza", "Sushi"] })).toBe(true);
-    expect(hasPollCreationParams({ poll_duration_seconds: "60" })).toBe(true);
-    expect(hasPollCreationParams({ poll_public: "true" })).toBe(true);
-  });
+  // --- resolveTelegramPollVisibility (unchanged) ---
 
   it("resolves telegram poll visibility flags", () => {
     expect(resolveTelegramPollVisibility({ pollAnonymous: true })).toBe(true);

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -35,43 +35,43 @@ export function resolveTelegramPollVisibility(params: {
   return params.pollAnonymous ? true : params.pollPublic ? false : undefined;
 }
 
+/**
+ * Check whether params contain meaningful poll creation intent.
+ *
+ * Models frequently auto-fill optional poll fields from the tool schema even
+ * when the user only wants a plain send. To avoid false positives we require
+ * **pollQuestion** (the one field that unambiguously signals poll intent) to
+ * be present and non-empty. Without a question there is no actionable poll,
+ * so stray defaults like `pollDurationHours: 0` or `pollMulti: false` are
+ * harmless noise.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/42820
+ *      https://github.com/openclaw/openclaw/issues/43015
+ */
 export function hasPollCreationParams(params: Record<string, unknown>): boolean {
+  // Gate on pollQuestion — the only required field for a real poll.
+  const question = readPollParamRaw(params, "pollQuestion");
+  if (typeof question !== "string" || question.trim().length === 0) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Strip all poll-creation parameters from a params bag.
+ * Useful for sanitizing `action="send"` requests where models may have
+ * auto-populated poll fields from the shared tool schema.
+ */
+export function stripPollCreationParams(params: Record<string, unknown>): void {
   for (const key of POLL_CREATION_PARAM_NAMES) {
-    const def = POLL_CREATION_PARAM_DEFS[key];
-    const value = readPollParamRaw(params, key);
-    if (def.kind === "string" && typeof value === "string" && value.trim().length > 0) {
-      return true;
-    }
-    if (def.kind === "stringArray") {
-      if (
-        Array.isArray(value) &&
-        value.some((entry) => typeof entry === "string" && entry.trim())
-      ) {
-        return true;
-      }
-      if (typeof value === "string" && value.trim().length > 0) {
-        return true;
-      }
-    }
-    if (def.kind === "number") {
-      if (typeof value === "number" && Number.isFinite(value)) {
-        return true;
-      }
-      if (typeof value === "string") {
-        const trimmed = value.trim();
-        if (trimmed.length > 0 && Number.isFinite(Number(trimmed))) {
-          return true;
-        }
-      }
-    }
-    if (def.kind === "boolean") {
-      if (value === true) {
-        return true;
-      }
-      if (typeof value === "string" && value.trim().toLowerCase() === "true") {
-        return true;
-      }
+    delete params[key];
+    // Also delete snake_case variants (e.g. poll_question)
+    const snakeKey = key
+      .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+      .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+      .toLowerCase();
+    if (snakeKey !== key) {
+      delete params[snakeKey];
     }
   }
-  return false;
 }


### PR DESCRIPTION
## Summary

- Strip auto-populated poll creation parameters from `action="send"` requests before the poll guard check
- Tighten `hasPollCreationParams()` to only gate on `pollQuestion` presence (the only field that unambiguously signals poll intent)
- Strip empty/skeleton `components` objects that models auto-populate from the shared tool schema

## Problem

Models (especially GPT-family) auto-fill optional poll and components fields from the message tool schema even when the user only wants a plain send. This causes:

1. **Poll guard false positive**: `hasPollCreationParams()` returns true on default values like `pollDurationHours: 0` (`Number.isFinite(0)` is true), rejecting valid send+attachment requests with `Poll fields require action "poll"`.

2. **Empty components skeleton**: auto-populated `components.modal` with empty `fields: []` causes Discord rendering issues (broken attachment display, red X buttons) and validation errors.

## Changes

| File | Change |
|------|--------|
| `src/poll-params.ts` | `hasPollCreationParams()` now only checks `pollQuestion`; added `stripPollCreationParams()` |
| `src/infra/outbound/message-action-runner.ts` | Strip poll params on `action="send"` before guard; call `stripEmptyComponents()` after parsing |
| `src/infra/outbound/message-action-params.ts` | Added `stripEmptyComponents()` to remove empty modal/blocks/text |
| `src/poll-params.test.ts` | Updated tests for new gating logic + strip function coverage |
| `src/infra/outbound/message-action-runner.context.test.ts` | Updated 3 tests: send+poll params now resolves instead of rejects |

## Test plan

- [x] `src/poll-params.test.ts` — 10 tests passed
- [x] `src/infra/outbound/message-action-runner.poll.test.ts` — 6 tests passed
- [x] `src/infra/outbound/message-action-runner.context.test.ts` — all passed
- [x] All 6 test files, 64 tests passed with zero failures
- [x] VPS live test: Discord image send via CLI succeeds (text+image, pure text, pure image)
- [x] VPS live test: Bot no longer throws "Poll fields require action poll" on send

Fixes #42820
Fixes #43015