### PR TITLE
fix(compaction): check turnPrefixMessages in compaction safeguard

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -702,7 +702,11 @@ async function readWorkspaceContextForSummary(): Promise<string> {
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
     const { preparation, customInstructions: eventInstructions, signal } = event;
-    if (!preparation.messagesToSummarize.some(isRealConversationMessage)) {
+    const candidateMessages = [
+      ...preparation.messagesToSummarize,
+      ...(preparation.turnPrefixMessages ?? []),
+    ];
+    if (!candidateMessages.some(isRealConversationMessage)) {
       log.warn(
         "Compaction safeguard: cancelling compaction with no real conversation messages to summarize.",
       );


### PR DESCRIPTION
## Problem
Manual `/compact` failed with "no real conversation messages to summarize" when real messages were only in `turnPrefixMessages`.

## Changes
- Extended compaction safeguard to check both `messagesToSummarize` and `turnPrefixMessages`

## Testing
- `pnpm build` passes

## Related
Closes #41432