### PR TITLE
fix(fallback): throw FailoverError for unknown model errors

### DIFF
--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -17,6 +17,7 @@ import {
 } from "../config/sessions.js";
 import { diagnosticLogger as diag } from "../logging/diagnostic.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
+import { FailoverError } from "./failover-error.js";
 import { getApiKeyForModel, requireApiKey } from "./model-auth.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./pi-embedded-block-chunker.js";
@@ -150,7 +151,11 @@ async function resolveRuntimeModel(params: {
     cfg: params.cfg,
   });
   if (!model) {
-    throw new Error(`Unknown model: ${params.provider}/${params.model}`);
+    throw new FailoverError(`Unknown model: ${params.provider}/${params.model}`, {
+      reason: "model_not_found",
+      provider: params.provider,
+      model: params.model,
+    });
   }
 
   const authProfileId = await resolveSessionAuthProfileOverride({

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -1,6 +1,7 @@
 import { type Api, type Model } from "@mariozechner/pi-ai";
 import { getDefaultLocalRoots } from "../../../extensions/whatsapp/src/media.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { FailoverError } from "../failover-error.js";
 import type { ImageModelConfig } from "./image-tool.helpers.js";
 import { getApiKeyForModel, normalizeWorkspaceDir, requireApiKey } from "./tool-runtime.helpers.js";
 
@@ -89,7 +90,11 @@ export function resolveModelFromRegistry(params: {
 }): Model<Api> {
   const model = params.modelRegistry.find(params.provider, params.modelId) as Model<Api> | null;
   if (!model) {
-    throw new Error(`Unknown model: ${params.provider}/${params.modelId}`);
+    throw new FailoverError(`Unknown model: ${params.provider}/${params.modelId}`, {
+      reason: "model_not_found",
+      provider: params.provider,
+      model: params.modelId,
+    });
   }
   return model;
 }

--- a/src/media-understanding/providers/image.ts
+++ b/src/media-understanding/providers/image.ts
@@ -1,5 +1,6 @@
 import type { Api, Context, Model } from "@mariozechner/pi-ai";
 import { complete } from "@mariozechner/pi-ai";
+import { FailoverError } from "../../agents/failover-error.js";
 import { isMinimaxVlmModel, minimaxUnderstandImage } from "../../agents/minimax-vlm.js";
 import { getApiKeyForModel, requireApiKey } from "../../agents/model-auth.js";
 import { normalizeModelRef } from "../../agents/model-selection.js";
@@ -27,7 +28,11 @@ export async function describeImageWithModel(
   const resolvedRef = normalizeModelRef(params.provider, params.model);
   const model = modelRegistry.find(resolvedRef.provider, resolvedRef.model) as Model<Api> | null;
   if (!model) {
-    throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
+    throw new FailoverError(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`, {
+      reason: "model_not_found",
+      provider: resolvedRef.provider,
+      model: resolvedRef.model,
+    });
   }
   if (!model.input?.includes("image")) {
     throw new Error(`Model does not support images: ${params.provider}/${params.model}`);


### PR DESCRIPTION
## Problem
Unknown model errors were thrown as plain `Error`, bypassing the fallback chain entirely even when valid fallback models were configured.

## Changes
- Changed `throw new Error(...)` to `throw new FailoverError(...)` in 3 files: btw.ts, media-tool-shared.ts, image.ts
- Uses `reason: "model_not_found"` consistent with existing pattern

## Testing
- `pnpm build` passes

## Related
Closes #21107