### PR TITLE
fix(media): resolve symlinks in agent-scoped media local roots

### DIFF
--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -51,6 +52,17 @@ export function getAgentScopedMediaLocalRoots(
   const normalizedWorkspaceDir = path.resolve(workspaceDir);
   if (!roots.includes(normalizedWorkspaceDir)) {
     roots.push(normalizedWorkspaceDir);
+  }
+  // When the workspace is a symlink (e.g. virtiofs mount), also add the
+  // realpath-resolved directory so assertLocalMediaAllowed matches files
+  // whose paths were resolved through the symlink.
+  try {
+    const realWorkspaceDir = fs.realpathSync(normalizedWorkspaceDir);
+    if (realWorkspaceDir !== normalizedWorkspaceDir && !roots.includes(realWorkspaceDir)) {
+      roots.push(realWorkspaceDir);
+    }
+  } catch {
+    // Workspace directory may not exist yet — ignore.
   }
   return roots;
 }


### PR DESCRIPTION
## Summary

**Problem:** When an agent workspace is a symlink (e.g., pointing to a virtiofs mount), `assertLocalMediaAllowed()` rejects media files because `fs.realpath()` resolves the file path through the symlink but the allowed root uses the original symlink path.

**Why it matters:** Users with symlinked workspaces (common in VM/container setups with virtiofs) cannot send media files from agent workspaces.

**What changed:** `getAgentScopedMediaLocalRoots` now also adds the `fs.realpathSync`-resolved workspace directory to the allowed roots, so both the symlink path and the real path are accepted.

**What did NOT change:** No changes to `assertLocalMediaAllowed` itself or `buildMediaLocalRoots`. Only the agent-scoped root list is extended.

## Change Type
Bug fix

## Linked Issue
Closes #40181

## Security Impact
None — the realpath resolves to the same physical directory the symlink points to. No new directories are added.

## Evidence
TypeScript compilation passes.

---
*This PR was authored with help from GitHub Copilot.*