### PR TITLE
fix(voice-call): skip initial message on answered when streaming is active

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -281,6 +281,14 @@ export class CallManager {
       return;
     }
 
+    // When streaming is enabled for non-notify modes, the media stream's
+    // onConnect handler speaks the initial message after the stream is
+    // established. Speaking here would overwrite the <Stream> TwiML.
+    const mode = call.metadata?.mode as string | undefined;
+    if (this.config.streaming?.enabled && mode !== "notify") {
+      return;
+    }
+
     void this.speakInitialMessage(call.providerCallId);
   }
 


### PR DESCRIPTION
## Summary

**Problem:** On outbound calls with streaming enabled, `maybeSpeakInitialMessageOnAnswered()` fires before the WebSocket media stream connects. The TTS fallback overwrites the `<Stream>` TwiML with `<Say>`, causing Twilio to tear down the stream within ~11ms.

**Why it matters:** Callers hear nothing (or a brief click) and the call auto-ends.

**What changed:** Added a guard in `maybeSpeakInitialMessageOnAnswered` to skip when streaming is active in non-notify mode. The stream's `onConnect` handler already speaks the initial message after the stream is established.

**What did NOT change:** Non-streaming calls and notify-mode calls still use the on-answered path.

## Change Type
Bug fix

## Linked Issue
Closes #42113

## Security Impact
None.

## Evidence
TypeScript compilation passes.

---
*This PR was authored with help from GitHub Copilot.*