### PR TITLE
fix(media): classify audio-only MP4/M4A containers as audio in sniffMime

### DIFF
--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -65,12 +65,23 @@ export function normalizeMimeType(mime?: string | null): string | undefined {
   return cleaned || undefined;
 }
 
+/** Audio-only MPEG-4 ftyp major brands (ISO BMFF bytes 8-11). */
+const AUDIO_FTYP_BRANDS = new Set(["m4a", "m4b"]);
+
 async function sniffMime(buffer?: Buffer): Promise<string | undefined> {
   if (!buffer) {
     return undefined;
   }
   try {
     const type = await fileTypeFromBuffer(buffer);
+    // file-type returns "video/mp4" for all MPEG-4 containers — correct
+    // audio-only ones (M4A/M4B) by inspecting the ftyp major brand.
+    if (type?.mime === "video/mp4" && buffer.length >= 12) {
+      const brand = buffer.toString("ascii", 8, 12).trimEnd().toLowerCase();
+      if (AUDIO_FTYP_BRANDS.has(brand)) {
+        return "audio/mp4";
+      }
+    }
     return type?.mime ?? undefined;
   } catch {
     return undefined;


### PR DESCRIPTION
## Summary

**Problem:** The `file-type` library returns `video/mp4` for all MPEG-4 containers, including audio-only M4A/M4B files. `kindFromMime("video/mp4")` returns `"video"`, so `selectAttachments({ capability: "audio" })` skips them — audio transcription never triggers.

**Why it matters:** Audio-only `.m4a` files (common voice memo format) are silently skipped by the transcription pipeline.

**What changed:** Added ftyp major-brand detection (ISO BMFF bytes 8–11) in `sniffMime()` to correct `video/mp4` → `audio/mp4` for M4A/M4B containers. Generalizes the LINE-specific fix from commit `1da7906` to benefit all channels.

**What did NOT change:** `detectMime()` priority logic, extension-based MIME mapping, LINE-specific code.

## Change Type
Bug fix

## Linked Issue
Closes #43313

## Security Impact
None.

## Evidence
All 44 mime tests pass.

---
*This PR was authored with help from GitHub Copilot.*