### PR TITLE
fix(whatsapp): pass accountId through applyGroupGating to group policy

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
@@ -9,23 +9,37 @@ import {
   resolveGroupSessionKey,
   resolveStorePath,
 } from "../../../../../src/config/sessions.js";
+import { resolveAccountEntry } from "../../../../../src/routing/account-lookup.js";
 
-export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conversationId: string) {
+export function resolveGroupPolicyFor(
+  cfg: ReturnType<typeof loadConfig>,
+  conversationId: string,
+  accountId?: string | null,
+) {
   const groupId = resolveGroupSessionKey({
     From: conversationId,
     ChatType: "group",
     Provider: "whatsapp",
   })?.id;
   const whatsappCfg = cfg.channels?.whatsapp as
-    | { groupAllowFrom?: string[]; allowFrom?: string[] }
+    | {
+        groupAllowFrom?: string[];
+        allowFrom?: string[];
+        accounts?: Record<string, { groupAllowFrom?: string[]; allowFrom?: string[] }>;
+      }
     | undefined;
+  const accountCfg = accountId ? resolveAccountEntry(whatsappCfg?.accounts, accountId) : undefined;
   const hasGroupAllowFrom = Boolean(
-    whatsappCfg?.groupAllowFrom?.length || whatsappCfg?.allowFrom?.length,
+    accountCfg?.groupAllowFrom?.length ||
+    accountCfg?.allowFrom?.length ||
+    whatsappCfg?.groupAllowFrom?.length ||
+    whatsappCfg?.allowFrom?.length,
   );
   return resolveChannelGroupPolicy({
     cfg,
     channel: "whatsapp",
     groupId: groupId ?? conversationId,
+    accountId,
     hasGroupAllowFrom,
   });
 }

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -80,7 +80,11 @@ function skipGroupMessageAndStoreHistory(params: ApplyGroupGatingParams, verbose
 }
 
 export function applyGroupGating(params: ApplyGroupGatingParams) {
-  const groupPolicy = resolveGroupPolicyFor(params.cfg, params.conversationId);
+  const groupPolicy = resolveGroupPolicyFor(
+    params.cfg,
+    params.conversationId,
+    params.msg.accountId,
+  );
   if (groupPolicy.allowlistEnabled && !groupPolicy.allowed) {
     params.logVerbose(`Skipping group message ${params.conversationId} (not in allowlist)`);
     return { shouldProcess: false };


### PR DESCRIPTION
## Summary

**Problem:** `applyGroupGating` calls `resolveGroupPolicyFor` without `accountId`. `resolveChannelGroupPolicy` falls back to `"default"` account, reading the wrong group allowlist in multi-account setups. The group-level allowlist is completely bypassed.

**Why it matters:** Any multi-account WhatsApp setup using `groupPolicy: "allowlist"` with `groupAllowFrom` is affected — the bot responds in unauthorized groups.

**What changed:**
- `resolveGroupPolicyFor` now accepts an optional `accountId` parameter and forwards it to `resolveChannelGroupPolicy`
- `applyGroupGating` passes `params.msg.accountId` through

**What did NOT change:** `resolveChannelGroupPolicy` already accepted `accountId` — only the WhatsApp caller was missing it.

## Change Type
Bug fix

## Linked Issue
Closes #40019

## Security Impact
Fixes a security bypass where group allowlists were not enforced in multi-account WhatsApp setups.

## Evidence
All 13 web-auto-reply-monitor tests pass.

---
*This PR was authored with help from GitHub Copilot.*