### PR TITLE
fix: handle object-typed payload.model in cron list table (closes #44084)

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -222,13 +222,12 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
     const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
-    const modelLabel = pad(
-      truncate(
-        (job.payload.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
-        CRON_MODEL_PAD,
-      ),
-      CRON_MODEL_PAD,
-    );
+    const rawModel = job.payload.kind === "agentTurn" ? job.payload.model : undefined;
+    const modelStr =
+      typeof rawModel === "string"
+        ? rawModel
+        : (rawModel as { primary?: string } | undefined)?.primary;
+    const modelLabel = pad(truncate(modelStr ?? "-", CRON_MODEL_PAD), CRON_MODEL_PAD);
 
     const coloredStatus = (() => {
       if (statusRaw === "ok") {


### PR DESCRIPTION
## Summary
`openclaw cron list` crashed with `TypeError: value.slice is not a function` when any cron job had `payload.model` stored as an object `{ primary, fallbacks }` instead of a plain string.

## Root Cause
`truncate()` calls `value.slice()` but `payload.model` can be a `{primary, fallbacks}` object (the normalized format after `openclaw doctor --fix`). The `?? "-"` guard only catches `undefined`/`null`, not objects.

## Changes
**`src/cli/cron-cli/shared.ts`** — extract `model` to a string before passing to `truncate()`:
- If string: use directly
- If object: extract `.primary`
- If undefined: fall back to "-"

## Change Type
Bug fix

## Scope
CLI cron list (1 file, net -1 line)

## Linked Issue
Closes #44084

## Security Impact
None

## Evidence
- `pnpm build` ✅
- `pnpm check` ✅

## Compatibility
Backward-compatible — handles both string and object model formats.

*This PR was AI-assisted (fully tested with pnpm build/check/test).*