### PR TITLE
feat(plugins): expose gateway.dispatchMethod on plugin runtime

### DIFF
--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -73,7 +73,7 @@ export async function dispatchGatewayMethod<T>(
   const isWebchatConnect = scope?.isWebchatConnect ?? (() => false);
   if (!context) {
     throw new Error(
-      `Plugin subagent dispatch requires a gateway request scope (method: ${method}). No scope set and no fallback context available.`,
+      `Plugin gateway dispatch requires a gateway request scope (method: ${method}). No scope set and no fallback context available.`,
     );
   }
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -64,7 +64,7 @@ function createSyntheticOperatorClient(): GatewayRequestOptions["client"] {
   };
 }
 
-async function dispatchGatewayMethod<T>(
+export async function dispatchGatewayMethod<T>(
   method: string,
   params: Record<string, unknown>,
 ): Promise<T> {
@@ -110,7 +110,9 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       key: params.sessionKey,
       ...(params.limit != null && { limit: params.limit }),
     });
-    return { messages: Array.isArray(payload?.messages) ? payload.messages : [] };
+    return {
+      messages: Array.isArray(payload?.messages) ? payload.messages : [],
+    };
   };
 
   return {
@@ -119,7 +121,9 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         sessionKey: params.sessionKey,
         message: params.message,
         deliver: params.deliver ?? false,
-        ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
+        ...(params.extraSystemPrompt && {
+          extraSystemPrompt: params.extraSystemPrompt,
+        }),
         ...(params.lane && { lane: params.lane }),
         ...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
       });
@@ -130,13 +134,13 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       return { runId };
     },
     async waitForRun(params) {
-      const payload = await dispatchGatewayMethod<{ status?: string; error?: string }>(
-        "agent.wait",
-        {
-          runId: params.runId,
-          ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
-        },
-      );
+      const payload = await dispatchGatewayMethod<{
+        status?: string;
+        error?: string;
+      }>("agent.wait", {
+        runId: params.runId,
+        ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
+      });
       const status = payload?.status;
       if (status !== "ok" && status !== "error" && status !== "timeout") {
         throw new Error(`Gateway agent.wait returned unexpected status: ${status}`);
@@ -185,6 +189,9 @@ export function loadGatewayPlugins(params: {
     coreGatewayHandlers: params.coreGatewayHandlers,
     runtimeOptions: {
       subagent: createGatewaySubagentRuntime(),
+      gateway: {
+        dispatchMethod: dispatchGatewayMethod,
+      },
     },
   });
   const pluginMethods = Object.keys(pluginRegistry.gatewayHandlers);

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -45,8 +45,19 @@ function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
   };
 }
 
+function createUnavailableGatewayRuntime(): PluginRuntime["gateway"] {
+  return {
+    dispatchMethod: () => {
+      throw new Error(
+        "Plugin runtime gateway.dispatchMethod is only available when running inside a gateway.",
+      );
+    },
+  };
+}
+
 export type CreatePluginRuntimeOptions = {
   subagent?: PluginRuntime["subagent"];
+  gateway?: PluginRuntime["gateway"];
 };
 
 export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): PluginRuntime {
@@ -54,6 +65,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     version: resolveVersion(),
     config: createRuntimeConfig(),
     subagent: _options.subagent ?? createUnavailableSubagentRuntime(),
+    gateway: _options.gateway ?? createUnavailableGatewayRuntime(),
     system: createRuntimeSystem(),
     media: createRuntimeMedia(),
     tts: { textToSpeechTelephony },

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -59,5 +59,9 @@ export type PluginRuntime = PluginRuntimeCore & {
     getSession: (params: SubagentGetSessionParams) => Promise<SubagentGetSessionResult>;
     deleteSession: (params: SubagentDeleteSessionParams) => Promise<void>;
   };
+  gateway: {
+    /** Dispatch an internal gateway RPC (same as calling via WebSocket, but in-process). */
+    dispatchMethod: <T = unknown>(method: string, params: Record<string, unknown>) => Promise<T>;
+  };
   channel: PluginRuntimeChannel;
 };


### PR DESCRIPTION
## Summary

- Expose `runtime.gateway.dispatchMethod()` on the plugin runtime, allowing plugins to dispatch internal gateway RPCs (e.g. `chat.history`, `sessions.list`) from anywhere — not just inside `registerGatewayMethod` handler callbacks.
- Export the existing `dispatchGatewayMethod` from `server-plugins.ts` and wire it into the plugin runtime options.

## Motivation

Plugins building custom channels or UI adapters need to call gateway methods like `chat.history` from service handlers (`registerService.start()`) and event listeners (`runtime.events.onAgentEvent()`). Currently, the only way to read session history from a plugin is via `runtime.subagent.getSessionMessages()`, which dispatches `sessions.get` — returning raw, unstripped transcript data (with timestamps, envelope data, oversized payloads). `chat.history` applies stripping and sanitization, but is only callable via WebSocket RPC.

With `runtime.gateway.dispatchMethod`, a plugin can call any registered gateway method internally:

```ts
const history = await api.runtime.gateway.dispatchMethod<{ messages: unknown[] }>(
  'chat.history',
  { sessionKey, limit: 200 }
)
```

This uses the same `dispatchGatewayMethod` infrastructure that `runtime.subagent.*` already relies on — it's just exposed to plugin code.

## Changes

| File | Change |
|------|--------|
| `src/gateway/server-plugins.ts` | Export `dispatchGatewayMethod`, pass it as `gateway: { dispatchMethod }` in runtime options |
| `src/plugins/runtime/types.ts` | Add `gateway.dispatchMethod` to `PluginRuntime` interface |
| `src/plugins/runtime/index.ts` | Add `createUnavailableGatewayRuntime()` fallback, wire `_options.gateway` into runtime |

## Test plan

- [ ] `pnpm typecheck` passes (verified locally)
- [ ] Existing plugin tests pass (no behavioral change to existing APIs)
- [ ] Manual: plugin calling `runtime.gateway.dispatchMethod('chat.history', { sessionKey })` returns stripped messages

Generated with [Claude Code](https://claude.com/claude-code)