### PR TITLE
fix(line): use snapshot configured field in collectStatusIssues

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -539,20 +539,12 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       const issues: ChannelStatusIssue[] = [];
       for (const account of accounts) {
         const accountId = account.accountId ?? DEFAULT_ACCOUNT_ID;
-        if (!account.channelAccessToken?.trim()) {
+        if (!account.configured) {
           issues.push({
             channel: "line",
             accountId,
             kind: "config",
-            message: "LINE channel access token not configured",
-          });
-        }
-        if (!account.channelSecret?.trim()) {
-          issues.push({
-            channel: "line",
-            accountId,
-            kind: "config",
-            message: "LINE channel secret not configured",
+            message: "LINE channel access token or channel secret not configured",
           });
         }
       }


### PR DESCRIPTION
## Summary

**Problem:** `collectStatusIssues` checked `account.channelAccessToken` on a `ChannelAccountSnapshot` object, but sensitive fields like `channelAccessToken` are stripped from snapshots. The check was always falsy, producing a permanent "LINE channel access token not configured" warning in `openclaw status` and `openclaw doctor`.

**Why it matters:** Users see a misleading WARN even when LINE is correctly configured and operational.

**What changed:** Replaced direct `channelAccessToken`/`channelSecret` checks with the computed `account.configured` boolean, which `buildAccountSnapshot` already derives correctly from the raw config.

**What did NOT change:** `buildAccountSnapshot` logic, probe behavior, gateway startup checks.

## Change Type
Bug fix

## Linked Issue
Closes #45693
Closes #44546

## Security Impact
None.

## Evidence
TypeScript compiles cleanly.

---
*This PR was authored with help from GitHub Copilot.*