### PR TITLE
fix(msteams): use conversation.id thread root as implicit mention fallback

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -676,10 +676,14 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       ? (activity.attachments as unknown as MSTeamsAttachmentLike[])
       : [];
     const wasMentioned = wasMSTeamsBotMentioned(activity);
-    const conversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
+    const rawConversationId = activity.conversation?.id ?? "";
+    const conversationId = normalizeMSTeamsConversationId(rawConversationId);
     const replyToId = activity.replyToId ?? undefined;
+    const threadRootId = extractMSTeamsConversationMessageId(rawConversationId);
     const implicitMention = Boolean(
-      conversationId && replyToId && wasMSTeamsMessageSent(conversationId, replyToId),
+      conversationId &&
+      ((replyToId && wasMSTeamsMessageSent(conversationId, replyToId)) ||
+        (threadRootId && wasMSTeamsMessageSent(conversationId, threadRootId))),
     );
 
     await inboundDebouncer.enqueue({


### PR DESCRIPTION
## Summary

**Problem:** Implicit mention detection in MS Teams relies solely on `activity.replyToId`, which Teams does not reliably provide (Desktop: null, Mobile: "0").

**Why it matters:** Thread replies to bot messages are silently ignored in Teams channels with `requireMention: true` (the default).

**What changed:** Added `extractMSTeamsConversationMessageId(rawConversationId)` as a fallback — Teams encodes the thread root message ID as `;messageid=XXX` in `conversation.id` for thread replies.

**What did NOT change:** Primary `replyToId` check remains. Fallback only fires when `replyToId` is absent/invalid.

## Change Type
Bug fix

## Linked Issue
Closes #38629

## Security Impact
None.

## Evidence
TypeScript compilation passes.

---
*This PR was authored with help from GitHub Copilot.*