### PR TITLE
fix(synology-chat): load config from runtime when cfg not provided in sendText/sendMedia

### DIFF
--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -196,7 +196,8 @@ export function createSynologyChatPlugin() {
       textChunkLimit: 2000,
 
       sendText: async ({ to, text, accountId, cfg }: any) => {
-        const account: ResolvedSynologyChatAccount = resolveAccount(cfg ?? {}, accountId);
+        const effectiveCfg = cfg ?? (await getSynologyRuntime().config.loadConfig());
+        const account: ResolvedSynologyChatAccount = resolveAccount(effectiveCfg, accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");
@@ -210,7 +211,8 @@ export function createSynologyChatPlugin() {
       },
 
       sendMedia: async ({ to, mediaUrl, accountId, cfg }: any) => {
-        const account: ResolvedSynologyChatAccount = resolveAccount(cfg ?? {}, accountId);
+        const effectiveCfg = cfg ?? (await getSynologyRuntime().config.loadConfig());
+        const account: ResolvedSynologyChatAccount = resolveAccount(effectiveCfg, accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");


### PR DESCRIPTION
## Summary

**Problem:** `sendText` and `sendMedia` in Synology Chat fall back to `resolveAccount({}, accountId)` when `cfg` is not provided (e.g., delivery recovery), causing `incomingUrl` to be empty and the send to fail.

**Why it matters:** AI agent replies are generated successfully but never reach users in Synology Chat during delivery recovery.

**What changed:** Load config from the Synology Chat runtime as a fallback when `cfg` is not passed to `sendText`/`sendMedia`.

**What did NOT change:** Normal delivery path (where cfg IS provided) is unaffected.

## Change Type
Bug fix

## Linked Issue
Closes #37852

## Security Impact
None.

## Evidence
TypeScript compilation passes.

---
*This PR was authored with help from GitHub Copilot.*