### PR TITLE
Daemon: harden launchd plist writes and abortable service restarts

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -21,9 +22,19 @@ const state = vi.hoisted(() => ({
   kickstartError: "",
   kickstartFailuresRemaining: 0,
   dirs: new Set<string>(),
+  symlinks: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
   fileModes: new Map<string, number>(),
+}));
+
+vi.mock("node:os", () => ({
+  default: {
+    homedir: vi.fn(() => "/Users/test"),
+    userInfo: vi.fn(() => ({ homedir: "/Users/test" })),
+  },
+  homedir: vi.fn(() => "/Users/test"),
+  userInfo: vi.fn(() => ({ homedir: "/Users/test" })),
 }));
 const launchdRestartHandoffState = vi.hoisted(() => ({
   isCurrentProcessLaunchdServiceLabel: vi.fn<(label: string) => boolean>(() => false),
@@ -102,8 +113,40 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     }),
     mkdir: vi.fn(async (p: string, opts?: { mode?: number }) => {
       const key = String(p);
+      if (state.symlinks.has(key)) {
+        return;
+      }
       state.dirs.add(key);
       state.dirModes.set(key, opts?.mode ?? 0o777);
+    }),
+    lstat: vi.fn(async (p: string) => {
+      const key = String(p);
+      if (state.symlinks.has(key)) {
+        return {
+          mode: 0o777,
+          isDirectory: () => false,
+          isSymbolicLink: () => true,
+        };
+      }
+      if (state.dirs.has(key)) {
+        return {
+          mode: state.dirModes.get(key) ?? 0o777,
+          isDirectory: () => true,
+          isSymbolicLink: () => false,
+        };
+      }
+      if (state.files.has(key)) {
+        return {
+          mode: state.fileModes.get(key) ?? 0o666,
+          isDirectory: () => false,
+          isSymbolicLink: () => false,
+        };
+      }
+      const error = new Error(
+        `ENOENT: no such file or directory, lstat '${key}'`,
+      ) as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      throw error;
     }),
     stat: vi.fn(async (p: string) => {
       const key = String(p);
@@ -127,8 +170,41 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       }
       throw new Error(`ENOENT: no such file or directory, chmod '${key}'`);
     }),
+    open: vi.fn(async (p: string, _flags?: number, mode?: number) => {
+      const key = String(p);
+      if (state.symlinks.has(key)) {
+        const error = new Error(
+          `ELOOP: too many symbolic links encountered, open '${key}'`,
+        ) as NodeJS.ErrnoException;
+        error.code = "ELOOP";
+        throw error;
+      }
+      state.fileModes.set(key, typeof mode === "number" ? mode : 0o666);
+      return {
+        writeFile: async (data: string) => {
+          state.files.set(key, data);
+          state.fileModes.set(key, typeof mode === "number" ? mode : 0o666);
+        },
+        close: async () => {},
+      };
+    }),
+    rename: vi.fn(async (from: string, to: string) => {
+      const fromKey = String(from);
+      const toKey = String(to);
+      const content = state.files.get(fromKey);
+      if (content === undefined) {
+        throw new Error(`ENOENT: no such file or directory, rename '${fromKey}'`);
+      }
+      state.files.set(toKey, content);
+      state.fileModes.set(toKey, state.fileModes.get(fromKey) ?? 0o666);
+      state.files.delete(fromKey);
+      state.fileModes.delete(fromKey);
+      state.symlinks.delete(toKey);
+    }),
     unlink: vi.fn(async (p: string) => {
-      state.files.delete(String(p));
+      const key = String(p);
+      state.files.delete(key);
+      state.symlinks.delete(key);
     }),
     writeFile: vi.fn(async (p: string, data: string, opts?: { mode?: number }) => {
       const key = String(p);
@@ -148,6 +224,7 @@ beforeEach(() => {
   state.kickstartError = "";
   state.kickstartFailuresRemaining = 0;
   state.dirs.clear();
+  state.symlinks.clear();
   state.dirModes.clear();
   state.files.clear();
   state.fileModes.clear();
@@ -242,7 +319,6 @@ describe("launchd bootstrap repair", () => {
     const kickstartIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
-
     expect(kickstartIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeLessThan(kickstartIndex);
   });
@@ -288,6 +364,54 @@ describe("launchd install", () => {
     expect(plist).toContain(`<string>${tmpDir}</string>`);
   });
 
+  it("uses the process homedir instead of a conflicting HOME override for plist paths", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      HOME: "/tmp/attacker-home",
+    };
+
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+    });
+
+    expect(resolveLaunchAgentPlistPath(env)).toBe(
+      "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist",
+    );
+    expect(
+      state.files.has("/tmp/attacker-home/Library/LaunchAgents/ai.openclaw.gateway.plist"),
+    ).toBe(false);
+  });
+
+  it("falls back to os.homedir when userInfo lookup is unavailable", () => {
+    vi.mocked(os.userInfo).mockImplementationOnce(() => {
+      throw new Error("user lookup failed");
+    });
+    vi.mocked(os.homedir).mockReturnValueOnce("/Users/fallback-home");
+
+    expect(
+      resolveLaunchAgentPlistPath({
+        ...createDefaultLaunchdEnv(),
+        HOME: "/tmp/attacker-home",
+      }),
+    ).toBe("/Users/fallback-home/Library/LaunchAgents/ai.openclaw.gateway.plist");
+  });
+
+  it("fails closed when trusted homedir cannot be resolved", () => {
+    vi.mocked(os.userInfo).mockImplementationOnce(() => {
+      throw new Error("user lookup failed");
+    });
+    vi.mocked(os.homedir).mockReturnValueOnce("   ");
+
+    expect(() =>
+      resolveLaunchAgentPlistPath({
+        ...createDefaultLaunchdEnv(),
+        HOME: "/tmp/attacker-home",
+      }),
+    ).toThrow("Unable to resolve trusted user home for launchd operations.");
+  });
+
   it("writes KeepAlive=true policy with restrictive umask", async () => {
     const env = createDefaultLaunchdEnv();
     await installLaunchAgent({
@@ -309,8 +433,6 @@ describe("launchd install", () => {
 
   it("tightens writable bits on launch agent dirs and plist", async () => {
     const env = createDefaultLaunchdEnv();
-    state.dirs.add(env.HOME!);
-    state.dirModes.set(env.HOME!, 0o777);
     state.dirs.add("/Users/test/Library");
     state.dirModes.set("/Users/test/Library", 0o777);
 
@@ -321,10 +443,44 @@ describe("launchd install", () => {
     });
 
     const plistPath = resolveLaunchAgentPlistPath(env);
-    expect(state.dirModes.get(env.HOME!)).toBe(0o755);
-    expect(state.dirModes.get("/Users/test/Library")).toBe(0o755);
+    expect(state.dirModes.get("/Users/test/Library")).toBe(0o777);
     expect(state.dirModes.get("/Users/test/Library/LaunchAgents")).toBe(0o755);
-    expect(state.fileModes.get(plistPath)).toBe(0o644);
+    expect(state.fileModes.get(plistPath)).toBe(0o600);
+  });
+
+  it("rejects symlinked launch agent directories", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.dirs.add("/Users/test/Library");
+    state.dirModes.set("/Users/test/Library", 0o755);
+    state.symlinks.add("/Users/test/Library/LaunchAgents");
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow(
+      "Refusing to use symlinked LaunchAgent path: /Users/test/Library/LaunchAgents",
+    );
+  });
+
+  it("rejects symlinked launch agent plist targets", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.dirs.add("/Users/test/Library");
+    state.dirModes.set("/Users/test/Library", 0o755);
+    state.dirs.add("/Users/test/Library/LaunchAgents");
+    state.dirModes.set("/Users/test/Library/LaunchAgents", 0o755);
+    state.symlinks.add(plistPath);
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow(`Refusing to use symlinked LaunchAgent path: ${plistPath}`);
   });
 
   it("restarts LaunchAgent with kickstart and no bootout", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,4 +1,6 @@
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import {
@@ -17,7 +19,7 @@ import {
   scheduleDetachedLaunchdRestartHandoff,
 } from "./launchd-restart-handoff.js";
 import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
-import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
+import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type {
@@ -31,7 +33,23 @@ import type {
 } from "./service-types.js";
 
 const LAUNCH_AGENT_DIR_MODE = 0o755;
-const LAUNCH_AGENT_PLIST_MODE = 0o644;
+const LAUNCH_AGENT_PLIST_MODE = 0o600;
+
+function resolveTrustedLaunchAgentHome(): string {
+  const home = (() => {
+    try {
+      const fromUserInfo = os.userInfo().homedir.trim();
+      if (fromUserInfo) {
+        return fromUserInfo;
+      }
+    } catch {}
+    return os.homedir().trim();
+  })();
+  if (!home) {
+    throw new Error("Unable to resolve trusted user home for launchd operations.");
+  }
+  return toPosixPath(home);
+}
 
 function resolveLaunchAgentLabel(args?: { env?: Record<string, string | undefined> }): string {
   const envLabel = args?.env?.OPENCLAW_LAUNCHD_LABEL?.trim();
@@ -45,7 +63,7 @@ function resolveLaunchAgentPlistPathForLabel(
   env: Record<string, string | undefined>,
   label: string,
 ): string {
-  const home = toPosixPath(resolveHomeDir(env));
+  const home = resolveTrustedLaunchAgentHome();
   return path.posix.join(home, "Library", "LaunchAgents", `${label}.plist`);
 }
 
@@ -106,11 +124,16 @@ export function buildLaunchAgentPlist({
 
 async function execLaunchctl(
   args: string[],
+  options?: { signal?: AbortSignal },
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const isWindows = process.platform === "win32";
   const file = isWindows ? (process.env.ComSpec ?? "cmd.exe") : "launchctl";
   const fileArgs = isWindows ? ["/d", "/s", "/c", "launchctl", ...args] : args;
-  return await execFileUtf8(file, fileArgs, isWindows ? { windowsHide: true } : {});
+  const opts: Record<string, unknown> = isWindows ? { windowsHide: true } : {};
+  if (options?.signal) {
+    opts.signal = options.signal;
+  }
+  return await execFileUtf8(file, fileArgs, opts);
 }
 
 function resolveGuiDomain(): string {
@@ -155,9 +178,11 @@ async function bootstrapLaunchAgentOrThrow(params: {
   serviceTarget: string;
   plistPath: string;
   actionHint: string;
+  signal?: AbortSignal;
 }) {
-  await execLaunchctl(["enable", params.serviceTarget]);
-  const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath]);
+  const options = params.signal ? { signal: params.signal } : undefined;
+  await execLaunchctl(["enable", params.serviceTarget], options);
+  const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath], options);
   if (boot.code === 0) {
     return;
   }
@@ -174,16 +199,54 @@ async function bootstrapLaunchAgentOrThrow(params: {
 
 async function ensureSecureDirectory(targetPath: string): Promise<void> {
   await fs.mkdir(targetPath, { recursive: true, mode: LAUNCH_AGENT_DIR_MODE });
-  try {
-    const stat = await fs.stat(targetPath);
-    const mode = stat.mode & 0o777;
-    const tightenedMode = mode & ~0o022;
-    if (tightenedMode !== mode) {
-      await fs.chmod(targetPath, tightenedMode);
-    }
-  } catch {
-    // Best effort: keep install working even if chmod/stat is unavailable.
+  const stat = await fs.lstat(targetPath);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Refusing to use symlinked LaunchAgent path: ${targetPath}`);
   }
+  if (!stat.isDirectory()) {
+    throw new Error(`Expected LaunchAgent directory at ${targetPath}`);
+  }
+  const mode = stat.mode & 0o777;
+  const tightenedMode = mode & ~0o022;
+  if (tightenedMode !== mode) {
+    await fs.chmod(targetPath, tightenedMode).catch(() => undefined);
+  }
+}
+
+async function assertNotSymlink(targetPath: string): Promise<void> {
+  try {
+    const stat = await fs.lstat(targetPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to use symlinked LaunchAgent path: ${targetPath}`);
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function writeLaunchAgentPlistSecure(plistPath: string, plist: string): Promise<void> {
+  await assertNotSymlink(plistPath);
+  const dir = path.dirname(plistPath);
+  const tempPath = path.join(dir, `.${path.basename(plistPath)}.${process.pid}.tmp`);
+  await assertNotSymlink(tempPath);
+  const handle = await fs.open(
+    tempPath,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW,
+    LAUNCH_AGENT_PLIST_MODE,
+  );
+  try {
+    await handle.writeFile(plist, { encoding: "utf8" });
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    await fs.unlink(tempPath).catch(() => undefined);
+    throw error;
+  }
+  await handle.close();
+  await fs.rename(tempPath, plistPath);
 }
 
 export type LaunchctlPrintInfo = {
@@ -333,8 +396,8 @@ export async function uninstallLegacyLaunchAgents({
     return agents;
   }
 
-  const home = toPosixPath(resolveHomeDir(env));
-  const trashDir = path.posix.join(home, ".Trash");
+  const trustedHome = resolveTrustedLaunchAgentHome();
+  const trashDir = path.posix.join(trustedHome, ".Trash");
   try {
     await fs.mkdir(trashDir, { recursive: true });
   } catch {
@@ -380,8 +443,7 @@ export async function uninstallLaunchAgent({
     return;
   }
 
-  const home = toPosixPath(resolveHomeDir(env));
-  const trashDir = path.posix.join(home, ".Trash");
+  const trashDir = path.posix.join(resolveTrustedLaunchAgentHome(), ".Trash");
   const dest = path.join(trashDir, `${label}.plist`);
   try {
     await fs.mkdir(trashDir, { recursive: true });
@@ -444,10 +506,6 @@ export async function installLaunchAgent({
   }
 
   const plistPath = resolveLaunchAgentPlistPathForLabel(env, label);
-  const home = toPosixPath(resolveHomeDir(env));
-  const libraryDir = path.posix.join(home, "Library");
-  await ensureSecureDirectory(home);
-  await ensureSecureDirectory(libraryDir);
   await ensureSecureDirectory(path.dirname(plistPath));
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
@@ -460,8 +518,7 @@ export async function installLaunchAgent({
     stderrPath,
     environment,
   });
-  await fs.writeFile(plistPath, plist, { encoding: "utf8", mode: LAUNCH_AGENT_PLIST_MODE });
-  await fs.chmod(plistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
+  await writeLaunchAgentPlistSecure(plistPath, plist);
 
   await execLaunchctl(["bootout", domain, plistPath]);
   await execLaunchctl(["unload", plistPath]);
@@ -491,11 +548,13 @@ export async function installLaunchAgent({
 export async function restartLaunchAgent({
   stdout,
   env,
+  signal,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  const sig = { signal };
   const serviceTarget = `${domain}/${label}`;
 
   // Restart requests issued from inside the managed gateway process tree need a
@@ -514,7 +573,7 @@ export async function restartLaunchAgent({
     return { outcome: "scheduled" };
   }
 
-  const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
+  const start = await execLaunchctl(["kickstart", "-k", serviceTarget], sig);
   if (start.code === 0) {
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
     return { outcome: "completed" };
@@ -530,9 +589,10 @@ export async function restartLaunchAgent({
     serviceTarget,
     plistPath,
     actionHint: "openclaw gateway restart",
+    signal,
   });
 
-  const retry = await execLaunchctl(["kickstart", "-k", serviceTarget]);
+  const retry = await execLaunchctl(["kickstart", "-k", serviceTarget], sig);
   if (retry.code !== 0) {
     throw new Error(`launchctl kickstart failed: ${retry.stderr || retry.stdout}`.trim());
   }

--- a/src/daemon/schtasks-exec.ts
+++ b/src/daemon/schtasks-exec.ts
@@ -5,10 +5,12 @@ const SCHTASKS_NO_OUTPUT_TIMEOUT_MS = 5_000;
 
 export async function execSchtasks(
   args: string[],
+  options?: { signal?: AbortSignal },
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const result = await runCommandWithTimeout(["schtasks", ...args], {
     timeoutMs: SCHTASKS_TIMEOUT_MS,
     noOutputTimeoutMs: SCHTASKS_NO_OUTPUT_TIMEOUT_MS,
+    signal: options?.signal,
   });
   const timeoutDetail =
     result.termination === "timeout"

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -694,6 +694,7 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
 export async function restartScheduledTask({
   stdout,
   env,
+  signal,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   const effectiveEnv = env ?? (process.env as GatewayServiceEnv);
   try {
@@ -710,7 +711,8 @@ export async function restartScheduledTask({
     }
   }
   const taskName = resolveTaskName(effectiveEnv);
-  await execSchtasks(["/End", "/TN", taskName]);
+  const sig = signal ? { signal } : undefined;
+  await execSchtasks(["/End", "/TN", taskName], sig);
   const restartPort = await resolveScheduledTaskPort(effectiveEnv);
   await terminateScheduledTaskGatewayListeners(effectiveEnv);
   await terminateInstalledStartupRuntime(effectiveEnv);
@@ -724,7 +726,7 @@ export async function restartScheduledTask({
       }
     }
   }
-  const res = await execSchtasks(["/Run", "/TN", taskName]);
+  const res = await execSchtasks(["/Run", "/TN", taskName], sig);
   if (res.code !== 0) {
     throw new Error(`schtasks run failed: ${res.stderr || res.stdout}`.trim());
   }

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -17,6 +17,8 @@ export type GatewayServiceManageArgs = {
 export type GatewayServiceControlArgs = {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
+  /** When aborted, child processes spawned by the operation should be killed. */
+  signal?: AbortSignal;
 };
 
 export type GatewayServiceRestartResult = { outcome: "completed" } | { outcome: "scheduled" };

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -254,8 +254,9 @@ export function parseSystemdShow(output: string): SystemdServiceInfo {
 
 async function execSystemctl(
   args: string[],
+  options?: { signal?: AbortSignal },
 ): Promise<{ stdout: string; stderr: string; code: number }> {
-  return await execFileUtf8("systemctl", args);
+  return await execFileUtf8("systemctl", args, options?.signal ? { signal: options.signal } : {});
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
@@ -388,6 +389,7 @@ function shouldFallbackToMachineUserScope(detail: string): boolean {
 async function execSystemctlUser(
   env: GatewayServiceEnv,
   args: string[],
+  options?: { signal?: AbortSignal },
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const machineUser = resolveSystemctlMachineScopeUser(env);
   const sudoUser = env.SUDO_USER?.trim();
@@ -396,11 +398,14 @@ async function execSystemctlUser(
   if (sudoUser && sudoUser !== "root" && machineUser) {
     const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
     if (machineScopeArgs.length > 0) {
-      return await execSystemctl([...machineScopeArgs, ...args]);
+      return await execSystemctl([...machineScopeArgs, ...args], options);
     }
   }
 
-  const directResult = await execSystemctl([...resolveSystemctlDirectUserScopeArgs(), ...args]);
+  const directResult = await execSystemctl(
+    [...resolveSystemctlDirectUserScopeArgs(), ...args],
+    options,
+  );
   if (directResult.code === 0) {
     return directResult;
   }
@@ -414,7 +419,7 @@ async function execSystemctlUser(
   if (machineScopeArgs.length === 0) {
     return directResult;
   }
-  return await execSystemctl([...machineScopeArgs, ...args]);
+  return await execSystemctl([...machineScopeArgs, ...args], options);
 }
 
 export async function isSystemdUserServiceAvailable(
@@ -542,6 +547,7 @@ export async function uninstallSystemdService({
 async function runSystemdServiceAction(params: {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
+  signal?: AbortSignal;
   action: "stop" | "restart";
   label: string;
 }) {
@@ -549,7 +555,7 @@ async function runSystemdServiceAction(params: {
   await assertSystemdAvailable(env);
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, [params.action, unitName]);
+  const res = await execSystemctlUser(env, [params.action, unitName], { signal: params.signal });
   if (res.code !== 0) {
     throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
   }
@@ -559,10 +565,12 @@ async function runSystemdServiceAction(params: {
 export async function stopSystemdService({
   stdout,
   env,
+  signal,
 }: GatewayServiceControlArgs): Promise<void> {
   await runSystemdServiceAction({
     stdout,
     env,
+    signal,
     action: "stop",
     label: "Stopped systemd service",
   });
@@ -571,10 +579,12 @@ export async function stopSystemdService({
 export async function restartSystemdService({
   stdout,
   env,
+  signal,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   await runSystemdServiceAction({
     stdout,
     env,
+    signal,
     action: "restart",
     label: "Restarted systemd service",
   });

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -171,6 +171,7 @@ export type CommandOptions = {
   env?: NodeJS.ProcessEnv;
   windowsVerbatimArguments?: boolean;
   noOutputTimeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 export function resolveCommandEnv(params: {
@@ -215,7 +216,7 @@ export async function runCommandWithTimeout(
 ): Promise<SpawnResult> {
   const options: CommandOptions =
     typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
-  const { timeoutMs, cwd, input, env, noOutputTimeoutMs } = options;
+  const { timeoutMs, cwd, input, env, noOutputTimeoutMs, signal } = options;
   const { windowsVerbatimArguments } = options;
   const hasInput = input !== undefined;
   const resolvedEnv = resolveCommandEnv({ argv, env });
@@ -247,6 +248,7 @@ export async function runCommandWithTimeout(
     let timedOut = false;
     let noOutputTimedOut = false;
     let noOutputTimer: NodeJS.Timeout | null = null;
+    let onAbort: (() => void) | undefined;
     const shouldTrackOutputTimeout =
       typeof noOutputTimeoutMs === "number" &&
       Number.isFinite(noOutputTimeoutMs) &&
@@ -284,6 +286,22 @@ export async function runCommandWithTimeout(
     }, timeoutMs);
     armNoOutputTimer();
 
+    if (signal) {
+      onAbort = () => {
+        if (settled) {
+          return;
+        }
+        if (typeof child.kill === "function") {
+          child.kill("SIGKILL");
+        }
+      };
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
     if (hasInput && child.stdin) {
       child.stdin.write(input ?? "");
       child.stdin.end();
@@ -304,6 +322,9 @@ export async function runCommandWithTimeout(
       settled = true;
       clearTimeout(timer);
       clearNoOutputTimer();
+      if (signal && onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
       reject(err);
     });
     child.on("close", (code, signal) => {
@@ -313,6 +334,9 @@ export async function runCommandWithTimeout(
       settled = true;
       clearTimeout(timer);
       clearNoOutputTimer();
+      if (options.signal && onAbort) {
+        options.signal.removeEventListener("abort", onAbort);
+      }
       const termination = noOutputTimedOut
         ? "no-output-timeout"
         : timedOut


### PR DESCRIPTION
## Summary

- Problem: launchd plist handling and managed-service restart paths were too trusting about filesystem targets and could not propagate abort signals down to child service-control commands.
- Why it matters: LaunchAgent install/restart touches user-owned plist paths and supervisor commands; symlink-safe writes and abortable restarts reduce both security risk and stuck watchdog behavior.
- What changed: hardens launchd home/plist resolution and atomic writes, rejects symlinked LaunchAgent paths, tightens plist permissions to `0600`, and threads `AbortSignal` through launchd/systemd/schtasks restart helpers via `runCommandWithTimeout`.
- What did NOT change (scope boundary): no rescue watchdog engine, no onboarding flow, no cron payload/schema changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #31480
- Related #44113

## User-visible / Behavior Changes

- LaunchAgent install now refuses symlinked target paths and writes plist files with `0600` via a temp-file + rename flow.
- Managed service restart helpers now accept abort signals so higher-level watchdog code can cancel in-flight restart attempts cleanly.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  This change only narrows existing service-control behavior. Child restart commands now honor `AbortSignal`, and launchd plist writes reject symlink targets and use trusted homedir resolution plus atomic writes to reduce path-hijack risk.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): local managed gateway service only

### Steps

1. Run the daemon/service unit tests covering launchd, systemd, schtasks, and process exec timeout behavior.
2. Build the repo to confirm the daemon and exec changes compile cleanly.
3. Inspect the launchd code path to confirm plist writes now resolve a trusted home, reject symlink targets, and use atomic temp-file writes.

### Expected

- Launchd plist writes fail closed on symlinked paths and persist with restrictive permissions.
- Abort signals reach child service-control commands on launchd/systemd/schtasks restart paths.

### Actual

- Verified by targeted tests and local build; behavior matches the expected outcomes above.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - launchd plist path resolution ignores a conflicting `HOME` override and uses trusted user home lookup.
  - launchd install rejects symlinked LaunchAgents directories and plist targets.
  - launchd plist writes use restrictive `0600` mode.
  - `AbortSignal` now propagates through launchd/systemd/schtasks restart helpers into the process exec layer.
- Edge cases checked:
  - `os.userInfo()` failure falls back to `os.homedir()`.
  - unresolved trusted home throws instead of silently writing to an unsafe path.
  - Windows scheduled-task wrapper keeps existing timeout behavior while adding abort support.
- What you did **not** verify:
  - manual end-to-end launchd/systemd restart behavior on a real long-running host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/daemon/launchd.ts`, `src/daemon/systemd.ts`, `src/daemon/schtasks.ts`, `src/process/exec.ts`
- Known bad symptoms reviewers should watch for: LaunchAgent install unexpectedly failing on valid paths, or service restart paths no longer responding to cancellation.

## Risks and Mitigations

- Risk: launchd path hardening could reject previously tolerated but unsafe filesystem layouts.
  - Mitigation: the checks are limited to symlinked/non-directory targets in the LaunchAgents path and have focused test coverage.
- Risk: abort propagation could alter restart timing on platforms that previously ignored cancellation.
  - Mitigation: the change is additive, targeted tests pass, and the underlying timeout behavior is preserved.
