### PR TITLE
Rescue: add watchdog core service and cron engine

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -146,6 +146,28 @@ describe("normalizeCronJobCreate", () => {
     expect("sessionKey" in cleared).toBe(false);
   });
 
+  it("infers isolated sessionTarget for rescue watchdog payloads", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "rescue",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      wakeMode: "now",
+      payload: {
+        kind: "rescueWatchdog",
+        monitoredProfile: " work ",
+        timeoutSeconds: 120.9,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("isolated");
+    expect(normalized.delivery).toBeUndefined();
+    expect(normalized.payload).toEqual({
+      kind: "rescueWatchdog",
+      monitoredProfile: "work",
+      timeoutSeconds: 120,
+    });
+  });
+
   it("canonicalizes payload.channel casing", () => {
     const normalized = normalizeIsolatedAgentTurnCreateJob({
       name: "legacy provider",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -89,6 +89,8 @@ function coercePayload(payload: UnknownRecord) {
   const kindRaw = typeof next.kind === "string" ? next.kind.trim().toLowerCase() : "";
   if (kindRaw === "agentturn") {
     next.kind = "agentTurn";
+  } else if (kindRaw === "rescuewatchdog") {
+    next.kind = "rescueWatchdog";
   } else if (kindRaw === "systemevent") {
     next.kind = "systemEvent";
   } else if (kindRaw) {
@@ -152,6 +154,18 @@ function coercePayload(payload: UnknownRecord) {
       next.timeoutSeconds = Math.max(0, Math.floor(next.timeoutSeconds));
     } else {
       delete next.timeoutSeconds;
+    }
+  }
+  if ("monitoredProfile" in next) {
+    if (typeof next.monitoredProfile === "string") {
+      const trimmed = next.monitoredProfile.trim();
+      if (trimmed) {
+        next.monitoredProfile = trimmed;
+      } else {
+        delete next.monitoredProfile;
+      }
+    } else {
+      delete next.monitoredProfile;
     }
   }
   if (
@@ -443,11 +457,11 @@ export function normalizeCronJobInput(
       const kind = typeof next.payload.kind === "string" ? next.payload.kind : "";
       // Keep default behavior unchanged for backward compatibility:
       // - systemEvent defaults to "main"
-      // - agentTurn defaults to "isolated" (NOT "current", to avoid token accumulation)
+      // - agentTurn / rescueWatchdog default to "isolated" (NOT "current", to avoid token accumulation)
       // Users must explicitly specify "current" or "session:xxx" for custom session binding
       if (kind === "systemEvent") {
         next.sessionTarget = "main";
-      } else if (kind === "agentTurn") {
+      } else if (kind === "agentTurn" || kind === "rescueWatchdog") {
         next.sessionTarget = "isolated";
       }
     }
@@ -464,14 +478,6 @@ export function normalizeCronJobInput(
       // If "current" wasn't resolved, fall back to "isolated" behavior
       // This handles CLI/headless usage where no session context exists
       if (next.sessionTarget === "current") {
-        next.sessionTarget = "isolated";
-      }
-    }
-    if (next.sessionTarget === "current") {
-      const sessionKey = options.sessionContext?.sessionKey?.trim();
-      if (sessionKey) {
-        next.sessionTarget = `session:${sessionKey}`;
-      } else {
         next.sessionTarget = "isolated";
       }
     }

--- a/src/cron/rescue-watchdog.test.ts
+++ b/src/cron/rescue-watchdog.test.ts
@@ -1,0 +1,509 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadConfig = vi.hoisted(() =>
+  vi.fn<
+    () => {
+      gateway: {
+        port: number;
+        bind: string;
+        customBindHost?: string;
+        tls?: { enabled?: boolean };
+        auth: {
+          mode: string;
+          token: string;
+        };
+      };
+    }
+  >(() => ({
+    gateway: {
+      port: 18_789,
+      bind: "loopback",
+      auth: {
+        mode: "token",
+        token: "main-token",
+      },
+    },
+  })),
+);
+const restartService = vi.hoisted(() => vi.fn(async () => {}));
+const probeGateway = vi.hoisted(() => vi.fn());
+const resolveGatewayProbeAuthSafe = vi.hoisted(() =>
+  vi.fn(() => ({
+    auth: { token: "main-token" },
+  })),
+);
+const runCommandWithTimeout = vi.hoisted(() =>
+  vi.fn(async () => ({
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit" as const,
+    noOutputTimedOut: false,
+  })),
+);
+const resolveGatewayBindHost = vi.hoisted(() =>
+  vi.fn(async (bind: string | undefined, customHost?: string): Promise<string> => {
+    if (bind === "custom") {
+      return customHost?.trim() || "0.0.0.0";
+    }
+    if (bind === "tailnet") {
+      return "100.64.0.10";
+    }
+    return "127.0.0.1";
+  }),
+);
+
+vi.mock("../config/io.js", () => ({
+  createConfigIO: vi.fn(() => ({
+    loadConfig,
+  })),
+}));
+
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: vi.fn(() => ({
+    restart: restartService,
+  })),
+}));
+
+vi.mock("../gateway/probe.js", () => ({
+  probeGateway,
+}));
+
+vi.mock("../gateway/probe-auth.js", () => ({
+  resolveGatewayProbeAuthSafe,
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout,
+}));
+vi.mock("../gateway/net.js", () => ({
+  resolveGatewayBindHost,
+}));
+
+import { runRescueWatchdogJob } from "./rescue-watchdog.js";
+
+describe("runRescueWatchdogJob", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-10T00:00:00.000Z"));
+    loadConfig.mockClear();
+    restartService.mockClear();
+    probeGateway.mockReset();
+    resolveGatewayProbeAuthSafe.mockClear();
+    resolveGatewayBindHost.mockClear();
+    runCommandWithTimeout.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns without repair when the monitored gateway is already healthy", async () => {
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      error: null,
+    });
+
+    const result = await runRescueWatchdogJob({
+      job: {
+        id: "job-1",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "default",
+          timeoutSeconds: 120,
+        },
+      } as never,
+      monitoredProfile: "default",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("found it healthy");
+    expect(restartService).not.toHaveBeenCalled();
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("probes with the configured scheme and custom bind host", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        port: 18_789,
+        bind: "custom",
+        customBindHost: "gateway.internal",
+        tls: { enabled: true },
+        auth: {
+          mode: "token",
+          token: "main-token",
+        },
+      },
+    });
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      error: null,
+    });
+
+    const result = await runRescueWatchdogJob({
+      job: {
+        id: "job-custom-bind",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 120,
+        },
+      } as never,
+      monitoredProfile: "work",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://gateway.internal:18789",
+      }),
+    );
+  });
+
+  it("brackets IPv6 custom bind hosts in the watchdog probe URL", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        port: 18_789,
+        bind: "custom",
+        customBindHost: "::1",
+        auth: {
+          mode: "token",
+          token: "main-token",
+        },
+      },
+    });
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      error: null,
+    });
+
+    const result = await runRescueWatchdogJob({
+      job: {
+        id: "job-custom-ipv6",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 120,
+        },
+      } as never,
+      monitoredProfile: "work",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://[::1]:18789",
+      }),
+    );
+  });
+
+  it("probes loopback when custom bind host falls back to wildcard listen", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        port: 18_789,
+        bind: "custom",
+        customBindHost: "192.168.10.77",
+        auth: {
+          mode: "token",
+          token: "main-token",
+        },
+      },
+    });
+    resolveGatewayBindHost.mockResolvedValueOnce("0.0.0.0");
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      error: null,
+    });
+
+    const result = await runRescueWatchdogJob({
+      job: {
+        id: "job-custom-fallback",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 120,
+        },
+      } as never,
+      monitoredProfile: "work",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(resolveGatewayBindHost).toHaveBeenCalledWith("custom", "192.168.10.77");
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+      }),
+    );
+  });
+
+  it("rejects rescue-shaped monitored profiles before service actions", async () => {
+    const result = await runRescueWatchdogJob({
+      job: {
+        id: "job-rescue-profile",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "rescue",
+          timeoutSeconds: 120,
+        },
+      } as never,
+      monitoredProfile: "rescue",
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("cannot monitor rescue profiles");
+    expect(restartService).not.toHaveBeenCalled();
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("restarts the managed service before escalating to doctor", async () => {
+    probeGateway
+      .mockResolvedValueOnce({
+        ok: false,
+        close: { code: 1006, reason: "down" },
+        error: "down",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        close: null,
+        error: null,
+      });
+
+    const result = await runRescueWatchdogJob({
+      job: {
+        id: "job-2",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 120,
+        },
+      } as never,
+      monitoredProfile: "work",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("restarted managed gateway service");
+    expect(restartService).toHaveBeenCalledTimes(1);
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("falls back to doctor with a fixed argv when restart does not recover the gateway", async () => {
+    let probeCount = 0;
+    probeGateway.mockImplementation(async () => {
+      probeCount += 1;
+      if (probeCount >= 62) {
+        return {
+          ok: true,
+          close: null,
+          error: null,
+        };
+      }
+      return {
+        ok: false,
+        close: { code: 1006, reason: "down" },
+        error: "down",
+      };
+    });
+
+    const runPromise = runRescueWatchdogJob({
+      job: {
+        id: "job-3",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 120,
+        },
+      } as never,
+      monitoredProfile: "work",
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    const result = await runPromise;
+
+    expect(result.status).toBe("ok");
+    expect(runCommandWithTimeout).toHaveBeenCalledWith(
+      expect.arrayContaining(["--profile", "work", "doctor", "--repair", "--non-interactive"]),
+      expect.objectContaining({
+        timeoutMs: expect.any(Number),
+      }),
+    );
+    expect(result.summary).toContain("ran doctor --repair --non-interactive");
+  });
+
+  it("skips doctor when the cron timeout budget is already exhausted", async () => {
+    probeGateway.mockResolvedValue({
+      ok: false,
+      close: { code: 1006, reason: "down" },
+      error: "down",
+    });
+
+    const runPromise = runRescueWatchdogJob({
+      job: {
+        id: "job-4",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 5,
+        },
+      } as never,
+      monitoredProfile: "work",
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    const result = await runPromise;
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("skipped doctor fallback");
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("bounds service restart by timeout budget", async () => {
+    probeGateway.mockResolvedValue({
+      ok: false,
+      close: { code: 1006, reason: "down" },
+      error: "down",
+    });
+    restartService.mockImplementation(() => new Promise<void>(() => {}));
+
+    const runPromise = runRescueWatchdogJob({
+      job: {
+        id: "job-restart-timeout",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 45,
+        },
+      } as never,
+      monitoredProfile: "work",
+    });
+
+    await vi.advanceTimersByTimeAsync(46_000);
+    const result = await runPromise;
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("restart failed: service restart timed out");
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("returns quickly when aborted during service restart", async () => {
+    probeGateway.mockResolvedValue({
+      ok: false,
+      close: { code: 1006, reason: "down" },
+      error: "down",
+    });
+    restartService.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 60_000);
+        }),
+    );
+    const abort = new AbortController();
+
+    const runPromise = runRescueWatchdogJob({
+      job: {
+        id: "job-restart-abort",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 120,
+        },
+      } as never,
+      monitoredProfile: "work",
+      abortSignal: abort.signal,
+    });
+    abort.abort();
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await runPromise;
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("service restart aborted");
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("clips post-repair probe wait to the remaining timeout budget", async () => {
+    probeGateway.mockResolvedValue({
+      ok: false,
+      close: { code: 1006, reason: "down" },
+      error: "down",
+    });
+    restartService.mockImplementation(() => new Promise<void>(() => {}));
+
+    let settled = false;
+    const runPromise = runRescueWatchdogJob({
+      job: {
+        id: "job-post-repair-probe-budget",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 47,
+        },
+      } as never,
+      monitoredProfile: "work",
+    }).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await vi.advanceTimersByTimeAsync(52_000);
+    expect(settled).toBe(true);
+    const result = await runPromise;
+
+    expect(result.status).toBe("error");
+    expect(runCommandWithTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps per-probe timeout to the remaining probe budget", async () => {
+    probeGateway.mockResolvedValue({
+      ok: false,
+      close: { code: 1006, reason: "down" },
+      error: "down",
+    });
+    restartService.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 700);
+        }),
+    );
+
+    const runPromise = runRescueWatchdogJob({
+      job: {
+        id: "job-probe-timeout-budget",
+        name: "rescue",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "work",
+          timeoutSeconds: 1,
+        },
+      } as never,
+      monitoredProfile: "work",
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await runPromise;
+
+    expect(result.status).toBe("error");
+    expect(probeGateway).toHaveBeenCalled();
+    const probeTimeouts = probeGateway.mock.calls
+      .map((call) => (call[0] as { timeoutMs?: number } | undefined)?.timeoutMs)
+      .filter((timeoutMs): timeoutMs is number => typeof timeoutMs === "number");
+    expect(probeTimeouts.length).toBeGreaterThan(0);
+    expect(Math.min(...probeTimeouts)).toBeGreaterThan(0);
+    expect(probeTimeouts.some((timeoutMs) => timeoutMs <= 1_000)).toBe(true);
+  });
+});

--- a/src/cron/rescue-watchdog.ts
+++ b/src/cron/rescue-watchdog.ts
@@ -1,0 +1,467 @@
+import net from "node:net";
+import { isValidProfileName } from "../cli/profile-utils.js";
+import { createConfigIO } from "../config/io.js";
+import { resolveGatewayPort } from "../config/paths.js";
+import { resolveGatewayService } from "../daemon/service.js";
+import { resolveGatewayBindHost } from "../gateway/net.js";
+import { resolveGatewayProbeAuthSafe } from "../gateway/probe-auth.js";
+import { probeGateway } from "../gateway/probe.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+import {
+  buildRescueProfileEnv,
+  canEnableRescueWatchdog,
+  resolveMonitoredProfileName,
+} from "../rescue/watchdog-shared.js";
+import type { CronJob, CronRunOutcome, CronRunTelemetry } from "./types.js";
+
+const PROBE_TIMEOUT_MS = 1_500;
+const PROBE_POLL_MS = 500;
+const RECOVERY_WAIT_DEADLINE_MS = 30_000;
+const DOCTOR_REPAIR_TIMEOUT_MS = 60_000;
+const MIN_DOCTOR_TIMEOUT_MS = 1_000;
+const RESTART_TIMEOUT_MS = 15_000;
+const MIN_RESTART_TIMEOUT_MS = 500;
+
+function looksLikeAuthClose(code: number | undefined, reason: string | undefined): boolean {
+  if (code !== 1008) {
+    return false;
+  }
+  const normalized = (reason ?? "").toLowerCase();
+  return (
+    normalized.includes("auth") ||
+    normalized.includes("token") ||
+    normalized.includes("password") ||
+    normalized.includes("scope") ||
+    normalized.includes("role")
+  );
+}
+
+function summarizeProbeFailure(result: Awaited<ReturnType<typeof probeGateway>>): string {
+  if (result.error?.trim()) {
+    return result.error.trim();
+  }
+  if (result.close) {
+    const reason = result.close.reason?.trim();
+    return reason ? `close ${result.close.code}: ${reason}` : `close ${result.close.code}`;
+  }
+  return "unreachable";
+}
+
+function summarizeCommandFailure(
+  result: Awaited<ReturnType<typeof runCommandWithTimeout>>,
+): string {
+  const output = [result.stderr.trim(), result.stdout.trim()].find(Boolean);
+  if (output) {
+    return output;
+  }
+  if (result.termination === "timeout" || result.termination === "no-output-timeout") {
+    return "command timed out";
+  }
+  if (result.signal) {
+    return `terminated by ${result.signal}`;
+  }
+  return `exit code ${result.code ?? "unknown"}`;
+}
+
+function formatGatewayProbeHost(host: string): string {
+  return net.isIP(host) === 6 && !host.startsWith("[") ? `[${host}]` : host;
+}
+
+function resolveProbeHostForBindAddress(bindHost: string): string {
+  if (bindHost === "0.0.0.0") {
+    return "127.0.0.1";
+  }
+  if (bindHost === "::") {
+    return "::1";
+  }
+  return bindHost;
+}
+
+async function resolveProfileGatewayProbeUrl(
+  cfg: {
+    gateway?: {
+      bind?: import("../config/config.js").GatewayBindMode;
+      customBindHost?: string;
+      tls?: { enabled?: boolean };
+    };
+  },
+  port: number,
+): Promise<string> {
+  const scheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
+  const bindMode = cfg.gateway?.bind;
+  const customBindHost = cfg.gateway?.customBindHost?.trim();
+  const bindHost = await resolveGatewayBindHost(bindMode, customBindHost);
+  const host = resolveProbeHostForBindAddress(bindHost);
+  return `${scheme}://${formatGatewayProbeHost(host)}:${port}`;
+}
+
+async function probeProfileGateway(params: {
+  cfg: {
+    gateway?: {
+      bind?: import("../config/config.js").GatewayBindMode;
+      customBindHost?: string;
+      tls?: { enabled?: boolean };
+    };
+  };
+  port: number;
+  auth: { token?: string; password?: string };
+  timeoutMs?: number;
+}): Promise<{ healthy: boolean; detail?: string }> {
+  const url = await resolveProfileGatewayProbeUrl(params.cfg, params.port);
+  const probe = await probeGateway({
+    url,
+    auth:
+      params.auth.token || params.auth.password
+        ? { token: params.auth.token, password: params.auth.password }
+        : undefined,
+    timeoutMs:
+      typeof params.timeoutMs === "number"
+        ? Math.max(1, Math.min(PROBE_TIMEOUT_MS, params.timeoutMs))
+        : PROBE_TIMEOUT_MS,
+  });
+  if (probe.ok || looksLikeAuthClose(probe.close?.code, probe.close?.reason)) {
+    return { healthy: true };
+  }
+  return { healthy: false, detail: summarizeProbeFailure(probe) };
+}
+
+async function waitForProfileGateway(params: {
+  cfg: {
+    gateway?: {
+      bind?: import("../config/config.js").GatewayBindMode;
+      customBindHost?: string;
+      tls?: { enabled?: boolean };
+    };
+  };
+  port: number;
+  auth: { token?: string; password?: string };
+  abortSignal?: AbortSignal;
+  timeoutMs?: number;
+}): Promise<{ healthy: boolean; detail?: string }> {
+  const timeoutMs =
+    typeof params.timeoutMs === "number"
+      ? Math.max(0, params.timeoutMs)
+      : RECOVERY_WAIT_DEADLINE_MS;
+  if (timeoutMs <= 0) {
+    return { healthy: false, detail: "probe skipped because cron timeout budget was exhausted" };
+  }
+  const deadlineAt = Date.now() + timeoutMs;
+  let lastDetail: string | undefined;
+  while (Date.now() < deadlineAt) {
+    if (params.abortSignal?.aborted) {
+      return { healthy: false, detail: "aborted" };
+    }
+    const remainingProbeBudgetMs = deadlineAt - Date.now();
+    if (remainingProbeBudgetMs <= 0) {
+      break;
+    }
+    const probe = await probeProfileGateway({
+      ...params,
+      timeoutMs: remainingProbeBudgetMs,
+    });
+    if (probe.healthy) {
+      return probe;
+    }
+    lastDetail = probe.detail;
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        params.abortSignal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, PROBE_POLL_MS);
+      const onAbort = () => {
+        clearTimeout(timer);
+        params.abortSignal?.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+  return { healthy: false, detail: lastDetail ?? "unreachable after restart" };
+}
+
+function buildSummary(monitoredProfile: string, actions: string[]): string {
+  if (actions.length === 0) {
+    return `Rescue watchdog checked "${monitoredProfile}" and found it healthy.`;
+  }
+  return `Rescue watchdog repaired "${monitoredProfile}": ${actions.join(", ")}.`;
+}
+
+function resolveRemainingJobBudgetMs(params: {
+  startedAtMs: number;
+  payload: CronJob["payload"];
+}): number | undefined {
+  if (
+    params.payload.kind !== "rescueWatchdog" ||
+    typeof params.payload.timeoutSeconds !== "number" ||
+    params.payload.timeoutSeconds <= 0
+  ) {
+    return undefined;
+  }
+  return Math.max(
+    0,
+    Math.floor(params.payload.timeoutSeconds * 1_000) - (Date.now() - params.startedAtMs),
+  );
+}
+
+type RunBoundedResult = { ok: true } | { ok: false; error: string; aborted: boolean };
+
+async function runBoundedStep(params: {
+  run: (signal: AbortSignal) => Promise<void>;
+  timeoutMs: number;
+  abortSignal?: AbortSignal;
+  label: string;
+}): Promise<RunBoundedResult> {
+  if (params.abortSignal?.aborted) {
+    return { ok: false, error: `${params.label} aborted`, aborted: true };
+  }
+  // Internal controller so we can kill child processes on timeout/abort.
+  const stepController = new AbortController();
+  let timer: NodeJS.Timeout | undefined;
+  let onAbort: (() => void) | undefined;
+  try {
+    const runPromise = params.run(stepController.signal).then(
+      () => ({ kind: "done" as const }),
+      (error: unknown) => ({ kind: "error" as const, error }),
+    );
+    const timeoutPromise = new Promise<{ kind: "timeout" }>((resolve) => {
+      timer = setTimeout(() => resolve({ kind: "timeout" }), params.timeoutMs);
+    });
+    const abortPromise = new Promise<{ kind: "aborted" }>((resolve) => {
+      if (!params.abortSignal) {
+        return;
+      }
+      onAbort = () => resolve({ kind: "aborted" });
+      params.abortSignal.addEventListener("abort", onAbort, { once: true });
+    });
+
+    const outcome = await Promise.race([runPromise, timeoutPromise, abortPromise]);
+    if (outcome.kind === "done") {
+      return { ok: true };
+    }
+    // On timeout or abort, cancel in-flight child processes.
+    stepController.abort();
+    if (outcome.kind === "error") {
+      return {
+        ok: false,
+        error: outcome.error instanceof Error ? outcome.error.message : `${params.label} failed`,
+        aborted: false,
+      };
+    }
+    if (outcome.kind === "aborted") {
+      return { ok: false, error: `${params.label} aborted`, aborted: true };
+    }
+    return {
+      ok: false,
+      error: `${params.label} timed out after ${params.timeoutMs}ms`,
+      aborted: false,
+    };
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    if (params.abortSignal && onAbort) {
+      params.abortSignal.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
+export async function runRescueWatchdogJob(params: {
+  job: CronJob;
+  monitoredProfile: string;
+  abortSignal?: AbortSignal;
+}): Promise<CronRunOutcome & CronRunTelemetry> {
+  const startedAtMs = Date.now();
+  const monitoredProfile = resolveMonitoredProfileName(params.monitoredProfile);
+  if (monitoredProfile !== "default" && !isValidProfileName(monitoredProfile)) {
+    return {
+      status: "error",
+      error: `invalid monitored profile "${monitoredProfile}"`,
+    };
+  }
+  if (!canEnableRescueWatchdog(monitoredProfile)) {
+    return {
+      status: "error",
+      error: `invalid monitored profile "${monitoredProfile}": rescue watchdog cannot monitor rescue profiles`,
+    };
+  }
+
+  const env = buildRescueProfileEnv(monitoredProfile);
+  let cfg;
+  try {
+    cfg = createConfigIO({ env }).loadConfig();
+  } catch (error) {
+    return {
+      status: "error",
+      error: `failed to load monitored profile config: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  const port = resolveGatewayPort(cfg, env);
+  const { auth, warning } = resolveGatewayProbeAuthSafe({
+    cfg,
+    mode: "local",
+    env,
+  });
+  let service;
+  try {
+    service = resolveGatewayService();
+  } catch (error) {
+    return {
+      status: "error",
+      error: `gateway service control unavailable: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  const actions: string[] = [];
+
+  const initialProbe = await probeProfileGateway({ cfg, port, auth });
+  if (initialProbe.healthy) {
+    return {
+      status: "ok",
+      summary: buildSummary(monitoredProfile, actions),
+    };
+  }
+
+  let restartError: string | undefined;
+  const remainingBeforeRestartMs = resolveRemainingJobBudgetMs({
+    startedAtMs,
+    payload: params.job.payload,
+  });
+  if (
+    typeof remainingBeforeRestartMs === "number" &&
+    remainingBeforeRestartMs < MIN_RESTART_TIMEOUT_MS
+  ) {
+    restartError = `skipped restart because only ${remainingBeforeRestartMs}ms remained in the cron job budget`;
+  } else {
+    const restartTimeoutMs =
+      typeof remainingBeforeRestartMs === "number"
+        ? Math.min(RESTART_TIMEOUT_MS, remainingBeforeRestartMs)
+        : RESTART_TIMEOUT_MS;
+    const restartResult = await runBoundedStep({
+      run: async (signal) => {
+        await service.restart({ env, stdout: process.stdout, signal });
+      },
+      timeoutMs: restartTimeoutMs,
+      abortSignal: params.abortSignal,
+      label: "service restart",
+    });
+    if (restartResult.ok) {
+      actions.push("restarted managed gateway service");
+    } else {
+      restartError = restartResult.error;
+      if (restartResult.aborted) {
+        return {
+          status: "error",
+          error: restartResult.error,
+          summary: actions.length > 0 ? buildSummary(monitoredProfile, actions) : undefined,
+        };
+      }
+    }
+  }
+
+  const restartProbe = await waitForProfileGateway({
+    cfg,
+    port,
+    auth,
+    abortSignal: params.abortSignal,
+    timeoutMs: (() => {
+      const remaining = resolveRemainingJobBudgetMs({
+        startedAtMs,
+        payload: params.job.payload,
+      });
+      return typeof remaining === "number"
+        ? Math.min(RECOVERY_WAIT_DEADLINE_MS, remaining)
+        : undefined;
+    })(),
+  });
+  if (restartProbe.healthy) {
+    return {
+      status: "ok",
+      summary: buildSummary(monitoredProfile, actions),
+    };
+  }
+
+  const remainingJobBudgetMs = resolveRemainingJobBudgetMs({
+    startedAtMs,
+    payload: params.job.payload,
+  });
+  if (typeof remainingJobBudgetMs === "number" && remainingJobBudgetMs < MIN_DOCTOR_TIMEOUT_MS) {
+    const errors = [
+      warning,
+      restartError ? `restart failed: ${restartError}` : undefined,
+      `skipped doctor fallback because only ${remainingJobBudgetMs}ms remained in the cron job budget`,
+      `probe failed: ${restartProbe.detail ?? initialProbe.detail ?? "unreachable"}`,
+    ].filter(Boolean);
+    return {
+      status: "error",
+      error: errors.join(" | "),
+      summary: actions.length > 0 ? buildSummary(monitoredProfile, actions) : undefined,
+    };
+  }
+
+  if (params.abortSignal?.aborted) {
+    const errors = [
+      warning,
+      restartError ? `restart failed: ${restartError}` : undefined,
+      "doctor fallback aborted",
+      `probe failed: ${restartProbe.detail ?? initialProbe.detail ?? "unreachable"}`,
+    ].filter(Boolean);
+    return {
+      status: "error",
+      error: errors.join(" | "),
+      summary: actions.length > 0 ? buildSummary(monitoredProfile, actions) : undefined,
+    };
+  }
+
+  // Keep the repair fallback deterministic: exact argv, no shell, no agent prompt.
+  // Use the same runtime + entrypoint as the current process so the binary is
+  // resolved without relying on PATH (managed service environments often run
+  // with a minimized PATH that omits the CLI binary).
+  const doctorArgs = ["--profile", monitoredProfile, "doctor", "--repair", "--non-interactive"];
+  const doctorArgv = process.argv[1]
+    ? [process.execPath, process.argv[1], ...doctorArgs]
+    : [process.execPath, ...doctorArgs];
+  const doctorResult = await runCommandWithTimeout(doctorArgv, {
+    timeoutMs:
+      typeof remainingJobBudgetMs === "number"
+        ? Math.min(DOCTOR_REPAIR_TIMEOUT_MS, remainingJobBudgetMs)
+        : DOCTOR_REPAIR_TIMEOUT_MS,
+    env,
+  });
+  if (doctorResult.code === 0) {
+    actions.push("ran doctor --repair --non-interactive");
+  }
+
+  const doctorProbe = await waitForProfileGateway({
+    cfg,
+    port,
+    auth,
+    abortSignal: params.abortSignal,
+    timeoutMs: (() => {
+      const remaining = resolveRemainingJobBudgetMs({
+        startedAtMs,
+        payload: params.job.payload,
+      });
+      return typeof remaining === "number"
+        ? Math.min(RECOVERY_WAIT_DEADLINE_MS, remaining)
+        : undefined;
+    })(),
+  });
+  if (doctorProbe.healthy) {
+    return {
+      status: "ok",
+      summary: buildSummary(monitoredProfile, actions),
+    };
+  }
+
+  const errors = [
+    warning,
+    restartError ? `restart failed: ${restartError}` : undefined,
+    doctorResult.code === 0 ? undefined : `doctor failed: ${summarizeCommandFailure(doctorResult)}`,
+    `probe failed: ${doctorProbe.detail ?? restartProbe.detail ?? initialProbe.detail ?? "unreachable"}`,
+  ].filter(Boolean);
+
+  return {
+    status: "error",
+    error: errors.join(" | "),
+    summary: actions.length > 0 ? buildSummary(monitoredProfile, actions) : undefined,
+  };
+}

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -214,6 +214,115 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("accepts isolated rescue watchdog jobs without announce delivery defaults", () => {
+    const now = Date.now();
+    const job = createJob(
+      {
+        deps: {
+          defaultAgentId: "main",
+          nowMs: () => now,
+        },
+      } as unknown as CronServiceState,
+      {
+        name: "rescue",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "default",
+          timeoutSeconds: 120,
+        },
+      },
+    );
+
+    expect(job.payload).toEqual({
+      kind: "rescueWatchdog",
+      monitoredProfile: "default",
+      timeoutSeconds: 120,
+    });
+    expect(job.delivery).toBeUndefined();
+  });
+
+  it("updates monitoredProfile on rescue watchdog payload patches", () => {
+    const job = createIsolatedAgentTurnJob("job-rescue", undefined, {
+      payload: {
+        kind: "rescueWatchdog",
+        monitoredProfile: "default",
+        timeoutSeconds: 120,
+      },
+      delivery: undefined,
+    });
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "rescueWatchdog",
+        monitoredProfile: "work",
+      },
+    });
+
+    expect(job.payload).toEqual({
+      kind: "rescueWatchdog",
+      monitoredProfile: "work",
+      timeoutSeconds: 120,
+    });
+  });
+
+  it("rejects delivery on rescue watchdog jobs", () => {
+    const expectedError = 'cron payload.kind="rescueWatchdog" does not support delivery';
+
+    expect(() =>
+      createJob(
+        {
+          deps: {
+            defaultAgentId: "main",
+            nowMs: () => Date.now(),
+          },
+        } as unknown as CronServiceState,
+        {
+          name: "rescue-delivery",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "isolated",
+          wakeMode: "now",
+          payload: {
+            kind: "rescueWatchdog",
+            monitoredProfile: "default",
+          },
+          delivery: { mode: "announce", channel: "telegram", to: "123" },
+        },
+      ),
+    ).toThrow(expectedError);
+  });
+
+  it("rejects failure destinations on rescue watchdog jobs", () => {
+    const expectedError =
+      'cron payload.kind="rescueWatchdog" does not support delivery.failureDestination';
+    const job = createIsolatedAgentTurnJob(
+      "job-rescue-failure-destination",
+      {
+        mode: "none",
+      },
+      {
+        payload: {
+          kind: "rescueWatchdog",
+          monitoredProfile: "default",
+        },
+        delivery: { mode: "none" },
+      },
+    );
+
+    expect(() =>
+      applyJobPatch(job, {
+        delivery: {
+          mode: "none",
+          failureDestination: { mode: "webhook", to: "https://example.invalid/rescue" },
+        },
+      }),
+    ).toThrow(expectedError);
+  });
+
   it("rejects webhook delivery without a valid http(s) target URL", () => {
     const expectedError = "cron webhook delivery requires delivery.to to be a valid http(s) URL";
     const cases = [

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -139,8 +139,10 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
   if (job.sessionTarget === "main" && job.payload.kind !== "systemEvent") {
     throw new Error('main cron jobs require payload.kind="systemEvent"');
   }
-  if (isIsolatedLike && job.payload.kind !== "agentTurn") {
-    throw new Error('isolated/current/session cron jobs require payload.kind="agentTurn"');
+  if (isIsolatedLike && job.payload.kind !== "agentTurn" && job.payload.kind !== "rescueWatchdog") {
+    throw new Error(
+      'isolated/current/session cron jobs require payload.kind="agentTurn" or "rescueWatchdog"',
+    );
   }
 }
 
@@ -180,10 +182,13 @@ function validateTelegramDeliveryTarget(to: string | undefined): string | undefi
   return undefined;
 }
 
-function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">) {
+function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery" | "payload">) {
   // No delivery object or mode is "none" -- nothing to validate.
   if (!job.delivery || job.delivery.mode === "none") {
     return;
+  }
+  if (job.payload.kind === "rescueWatchdog") {
+    throw new Error('cron payload.kind="rescueWatchdog" does not support delivery');
   }
   // Webhook delivery is allowed for any session target
   if (job.delivery.mode === "webhook") {
@@ -209,10 +214,17 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
   }
 }
 
-function assertFailureDestinationSupport(job: Pick<CronJob, "sessionTarget" | "delivery">) {
+function assertFailureDestinationSupport(
+  job: Pick<CronJob, "sessionTarget" | "delivery" | "payload">,
+) {
   const failureDestination = job.delivery?.failureDestination;
   if (!failureDestination) {
     return;
+  }
+  if (job.payload.kind === "rescueWatchdog") {
+    throw new Error(
+      'cron payload.kind="rescueWatchdog" does not support delivery.failureDestination',
+    );
   }
   if (job.sessionTarget === "main" && job.delivery?.mode !== "webhook") {
     throw new Error(
@@ -669,6 +681,20 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
     return { kind: "systemEvent", text };
   }
 
+  if (patch.kind === "rescueWatchdog") {
+    if (existing.kind !== "rescueWatchdog") {
+      return buildPayloadFromPatch(patch);
+    }
+    const monitoredProfile =
+      typeof patch.monitoredProfile === "string" ? patch.monitoredProfile.trim() : "";
+    return {
+      kind: "rescueWatchdog",
+      monitoredProfile: monitoredProfile || existing.monitoredProfile,
+      timeoutSeconds:
+        typeof patch.timeoutSeconds === "number" ? patch.timeoutSeconds : existing.timeoutSeconds,
+    };
+  }
+
   if (existing.kind !== "agentTurn") {
     return buildPayloadFromPatch(patch);
   }
@@ -756,22 +782,35 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     return { kind: "systemEvent", text: patch.text };
   }
 
-  if (typeof patch.message !== "string" || patch.message.length === 0) {
-    throw new Error('cron.update payload.kind="agentTurn" requires message');
+  if (patch.kind === "agentTurn") {
+    if (typeof patch.message !== "string" || patch.message.length === 0) {
+      throw new Error('cron.update payload.kind="agentTurn" requires message');
+    }
+    return {
+      kind: "agentTurn",
+      message: patch.message,
+      model: patch.model,
+      thinking: patch.thinking,
+      timeoutSeconds: patch.timeoutSeconds,
+      lightContext: patch.lightContext,
+      allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
+      deliver: patch.deliver,
+      channel: patch.channel,
+      to: patch.to,
+      bestEffortDeliver: patch.bestEffortDeliver,
+    };
+  }
+
+  const monitoredProfile =
+    typeof patch.monitoredProfile === "string" ? patch.monitoredProfile.trim() : "";
+  if (!monitoredProfile) {
+    throw new Error('cron.update payload.kind="rescueWatchdog" requires monitoredProfile');
   }
 
   return {
-    kind: "agentTurn",
-    message: patch.message,
-    model: patch.model,
-    thinking: patch.thinking,
+    kind: "rescueWatchdog",
+    monitoredProfile,
     timeoutSeconds: patch.timeoutSeconds,
-    lightContext: patch.lightContext,
-    allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
-    deliver: patch.deliver,
-    channel: patch.channel,
-    to: patch.to,
-    bestEffortDeliver: patch.bestEffortDeliver,
   };
 }
 

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -49,14 +49,17 @@ export function normalizeOptionalSessionKey(raw: unknown) {
 
 export function inferLegacyName(job: {
   schedule?: { kind?: unknown; everyMs?: unknown; expr?: unknown };
-  payload?: { kind?: unknown; text?: unknown; message?: unknown };
+  payload?: { kind?: unknown; text?: unknown; message?: unknown; monitoredProfile?: unknown };
 }) {
   const text =
     job?.payload?.kind === "systemEvent" && typeof job.payload.text === "string"
       ? job.payload.text
       : job?.payload?.kind === "agentTurn" && typeof job.payload.message === "string"
         ? job.payload.message
-        : "";
+        : job?.payload?.kind === "rescueWatchdog" &&
+            typeof job.payload.monitoredProfile === "string"
+          ? `Rescue watchdog: ${job.payload.monitoredProfile}`
+          : "";
   const firstLine =
     text
       .split("\n")
@@ -83,5 +86,12 @@ export function normalizePayloadToSystemText(payload: CronPayload) {
   if (payload.kind === "systemEvent") {
     return payload.text.trim();
   }
-  return payload.message.trim();
+  if (payload.kind === "agentTurn") {
+    return payload.message.trim();
+  }
+  if (payload.kind === "rescueWatchdog") {
+    return `Rescue watchdog: ${payload.monitoredProfile}`.trim();
+  }
+  const _exhaustive: never = payload;
+  return String(_exhaustive);
 }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -103,6 +103,11 @@ export type CronServiceDeps = {
     } & CronRunOutcome &
       CronRunTelemetry
   >;
+  runRescueWatchdogJob?: (params: {
+    job: CronJob;
+    monitoredProfile: string;
+    abortSignal?: AbortSignal;
+  }) => Promise<CronRunOutcome & CronRunTelemetry>;
   sendCronFailureAlert?: (params: {
     job: CronJob;
     text: string;

--- a/src/cron/service/timeout-policy.ts
+++ b/src/cron/service/timeout-policy.ts
@@ -15,7 +15,8 @@ export const AGENT_TURN_SAFETY_TIMEOUT_MS = 60 * 60_000; // 60 minutes
 
 export function resolveCronJobTimeoutMs(job: CronJob): number | undefined {
   const configuredTimeoutMs =
-    job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+    (job.payload.kind === "agentTurn" || job.payload.kind === "rescueWatchdog") &&
+    typeof job.payload.timeoutSeconds === "number"
       ? Math.floor(job.payload.timeoutSeconds * 1_000)
       : undefined;
   if (configuredTimeoutMs === undefined) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1123,8 +1123,29 @@ export async function executeJobCore(
     }
   }
 
+  if (job.payload.kind === "rescueWatchdog") {
+    if (abortSignal?.aborted) {
+      return resolveAbortError();
+    }
+    if (!state.deps.runRescueWatchdogJob) {
+      return { status: "skipped", error: "isolated rescue watchdog runner unavailable" };
+    }
+    const res = await state.deps.runRescueWatchdogJob({
+      job,
+      monitoredProfile: job.payload.monitoredProfile,
+      abortSignal,
+    });
+    if (abortSignal?.aborted) {
+      return { status: "error", error: timeoutErrorMessage() };
+    }
+    return res;
+  }
+
   if (job.payload.kind !== "agentTurn") {
-    return { status: "skipped", error: "isolated job requires payload.kind=agentTurn" };
+    return {
+      status: "skipped",
+      error: 'isolated job requires payload.kind="agentTurn" or "rescueWatchdog"',
+    };
   }
   if (abortSignal?.aborted) {
     return resolveAbortError();

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -36,6 +36,10 @@ function normalizePayloadKind(payload: Record<string, unknown>) {
     }
     return false;
   }
+  if (raw === "rescuewatchdog") {
+    payload.kind = "rescueWatchdog";
+    return true;
+  }
   if (raw === "systemevent") {
     if (payload.kind !== "systemEvent") {
       payload.kind = "systemEvent";
@@ -473,7 +477,8 @@ export function normalizeStoredCronJobs(
         mutated = true;
       }
     } else {
-      const inferredSessionTarget = payloadKind === "agentTurn" ? "isolated" : "main";
+      const inferredSessionTarget =
+        payloadKind === "agentTurn" || payloadKind === "rescueWatchdog" ? "isolated" : "main";
       if (raw.sessionTarget !== inferredSessionTarget) {
         raw.sessionTarget = inferredSessionTarget;
         mutated = true;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -78,9 +78,15 @@ export type CronFailureAlert = {
   accountId?: string;
 };
 
-export type CronPayload = { kind: "systemEvent"; text: string } | CronAgentTurnPayload;
+export type CronPayload =
+  | { kind: "systemEvent"; text: string }
+  | CronAgentTurnPayload
+  | CronRescueWatchdogPayload;
 
-export type CronPayloadPatch = { kind: "systemEvent"; text?: string } | CronAgentTurnPayloadPatch;
+export type CronPayloadPatch =
+  | { kind: "systemEvent"; text?: string }
+  | CronAgentTurnPayloadPatch
+  | CronRescueWatchdogPayloadPatch;
 
 type CronAgentTurnPayloadFields = {
   message: string;
@@ -106,6 +112,19 @@ type CronAgentTurnPayload = {
 type CronAgentTurnPayloadPatch = {
   kind: "agentTurn";
 } & Partial<CronAgentTurnPayloadFields>;
+
+type CronRescueWatchdogPayloadFields = {
+  monitoredProfile: string;
+  timeoutSeconds?: number;
+};
+
+type CronRescueWatchdogPayload = {
+  kind: "rescueWatchdog";
+} & CronRescueWatchdogPayloadFields;
+
+type CronRescueWatchdogPayloadPatch = {
+  kind: "rescueWatchdog";
+} & Partial<CronRescueWatchdogPayloadFields>;
 export type CronJobState = {
   nextRunAtMs?: number;
   runningAtMs?: number;

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -21,9 +22,19 @@ const state = vi.hoisted(() => ({
   kickstartError: "",
   kickstartFailuresRemaining: 0,
   dirs: new Set<string>(),
+  symlinks: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
   fileModes: new Map<string, number>(),
+}));
+
+vi.mock("node:os", () => ({
+  default: {
+    homedir: vi.fn(() => "/Users/test"),
+    userInfo: vi.fn(() => ({ homedir: "/Users/test" })),
+  },
+  homedir: vi.fn(() => "/Users/test"),
+  userInfo: vi.fn(() => ({ homedir: "/Users/test" })),
 }));
 const launchdRestartHandoffState = vi.hoisted(() => ({
   isCurrentProcessLaunchdServiceLabel: vi.fn<(label: string) => boolean>(() => false),
@@ -102,8 +113,40 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     }),
     mkdir: vi.fn(async (p: string, opts?: { mode?: number }) => {
       const key = String(p);
+      if (state.symlinks.has(key)) {
+        return;
+      }
       state.dirs.add(key);
       state.dirModes.set(key, opts?.mode ?? 0o777);
+    }),
+    lstat: vi.fn(async (p: string) => {
+      const key = String(p);
+      if (state.symlinks.has(key)) {
+        return {
+          mode: 0o777,
+          isDirectory: () => false,
+          isSymbolicLink: () => true,
+        };
+      }
+      if (state.dirs.has(key)) {
+        return {
+          mode: state.dirModes.get(key) ?? 0o777,
+          isDirectory: () => true,
+          isSymbolicLink: () => false,
+        };
+      }
+      if (state.files.has(key)) {
+        return {
+          mode: state.fileModes.get(key) ?? 0o666,
+          isDirectory: () => false,
+          isSymbolicLink: () => false,
+        };
+      }
+      const error = new Error(
+        `ENOENT: no such file or directory, lstat '${key}'`,
+      ) as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      throw error;
     }),
     stat: vi.fn(async (p: string) => {
       const key = String(p);
@@ -127,8 +170,41 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       }
       throw new Error(`ENOENT: no such file or directory, chmod '${key}'`);
     }),
+    open: vi.fn(async (p: string, _flags?: number, mode?: number) => {
+      const key = String(p);
+      if (state.symlinks.has(key)) {
+        const error = new Error(
+          `ELOOP: too many symbolic links encountered, open '${key}'`,
+        ) as NodeJS.ErrnoException;
+        error.code = "ELOOP";
+        throw error;
+      }
+      state.fileModes.set(key, typeof mode === "number" ? mode : 0o666);
+      return {
+        writeFile: async (data: string) => {
+          state.files.set(key, data);
+          state.fileModes.set(key, typeof mode === "number" ? mode : 0o666);
+        },
+        close: async () => {},
+      };
+    }),
+    rename: vi.fn(async (from: string, to: string) => {
+      const fromKey = String(from);
+      const toKey = String(to);
+      const content = state.files.get(fromKey);
+      if (content === undefined) {
+        throw new Error(`ENOENT: no such file or directory, rename '${fromKey}'`);
+      }
+      state.files.set(toKey, content);
+      state.fileModes.set(toKey, state.fileModes.get(fromKey) ?? 0o666);
+      state.files.delete(fromKey);
+      state.fileModes.delete(fromKey);
+      state.symlinks.delete(toKey);
+    }),
     unlink: vi.fn(async (p: string) => {
-      state.files.delete(String(p));
+      const key = String(p);
+      state.files.delete(key);
+      state.symlinks.delete(key);
     }),
     writeFile: vi.fn(async (p: string, data: string, opts?: { mode?: number }) => {
       const key = String(p);
@@ -148,6 +224,7 @@ beforeEach(() => {
   state.kickstartError = "";
   state.kickstartFailuresRemaining = 0;
   state.dirs.clear();
+  state.symlinks.clear();
   state.dirModes.clear();
   state.files.clear();
   state.fileModes.clear();
@@ -242,7 +319,6 @@ describe("launchd bootstrap repair", () => {
     const kickstartIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
-
     expect(kickstartIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeLessThan(kickstartIndex);
   });
@@ -288,6 +364,54 @@ describe("launchd install", () => {
     expect(plist).toContain(`<string>${tmpDir}</string>`);
   });
 
+  it("uses the process homedir instead of a conflicting HOME override for plist paths", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      HOME: "/tmp/attacker-home",
+    };
+
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+    });
+
+    expect(resolveLaunchAgentPlistPath(env)).toBe(
+      "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist",
+    );
+    expect(
+      state.files.has("/tmp/attacker-home/Library/LaunchAgents/ai.openclaw.gateway.plist"),
+    ).toBe(false);
+  });
+
+  it("falls back to os.homedir when userInfo lookup is unavailable", () => {
+    vi.mocked(os.userInfo).mockImplementationOnce(() => {
+      throw new Error("user lookup failed");
+    });
+    vi.mocked(os.homedir).mockReturnValueOnce("/Users/fallback-home");
+
+    expect(
+      resolveLaunchAgentPlistPath({
+        ...createDefaultLaunchdEnv(),
+        HOME: "/tmp/attacker-home",
+      }),
+    ).toBe("/Users/fallback-home/Library/LaunchAgents/ai.openclaw.gateway.plist");
+  });
+
+  it("fails closed when trusted homedir cannot be resolved", () => {
+    vi.mocked(os.userInfo).mockImplementationOnce(() => {
+      throw new Error("user lookup failed");
+    });
+    vi.mocked(os.homedir).mockReturnValueOnce("   ");
+
+    expect(() =>
+      resolveLaunchAgentPlistPath({
+        ...createDefaultLaunchdEnv(),
+        HOME: "/tmp/attacker-home",
+      }),
+    ).toThrow("Unable to resolve trusted user home for launchd operations.");
+  });
+
   it("writes KeepAlive=true policy with restrictive umask", async () => {
     const env = createDefaultLaunchdEnv();
     await installLaunchAgent({
@@ -309,8 +433,6 @@ describe("launchd install", () => {
 
   it("tightens writable bits on launch agent dirs and plist", async () => {
     const env = createDefaultLaunchdEnv();
-    state.dirs.add(env.HOME!);
-    state.dirModes.set(env.HOME!, 0o777);
     state.dirs.add("/Users/test/Library");
     state.dirModes.set("/Users/test/Library", 0o777);
 
@@ -321,10 +443,44 @@ describe("launchd install", () => {
     });
 
     const plistPath = resolveLaunchAgentPlistPath(env);
-    expect(state.dirModes.get(env.HOME!)).toBe(0o755);
-    expect(state.dirModes.get("/Users/test/Library")).toBe(0o755);
+    expect(state.dirModes.get("/Users/test/Library")).toBe(0o777);
     expect(state.dirModes.get("/Users/test/Library/LaunchAgents")).toBe(0o755);
-    expect(state.fileModes.get(plistPath)).toBe(0o644);
+    expect(state.fileModes.get(plistPath)).toBe(0o600);
+  });
+
+  it("rejects symlinked launch agent directories", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.dirs.add("/Users/test/Library");
+    state.dirModes.set("/Users/test/Library", 0o755);
+    state.symlinks.add("/Users/test/Library/LaunchAgents");
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow(
+      "Refusing to use symlinked LaunchAgent path: /Users/test/Library/LaunchAgents",
+    );
+  });
+
+  it("rejects symlinked launch agent plist targets", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.dirs.add("/Users/test/Library");
+    state.dirModes.set("/Users/test/Library", 0o755);
+    state.dirs.add("/Users/test/Library/LaunchAgents");
+    state.dirModes.set("/Users/test/Library/LaunchAgents", 0o755);
+    state.symlinks.add(plistPath);
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow(`Refusing to use symlinked LaunchAgent path: ${plistPath}`);
   });
 
   it("restarts LaunchAgent with kickstart and no bootout", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,4 +1,6 @@
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import {
@@ -17,7 +19,7 @@ import {
   scheduleDetachedLaunchdRestartHandoff,
 } from "./launchd-restart-handoff.js";
 import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
-import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
+import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type {
@@ -31,7 +33,23 @@ import type {
 } from "./service-types.js";
 
 const LAUNCH_AGENT_DIR_MODE = 0o755;
-const LAUNCH_AGENT_PLIST_MODE = 0o644;
+const LAUNCH_AGENT_PLIST_MODE = 0o600;
+
+function resolveTrustedLaunchAgentHome(): string {
+  const home = (() => {
+    try {
+      const fromUserInfo = os.userInfo().homedir.trim();
+      if (fromUserInfo) {
+        return fromUserInfo;
+      }
+    } catch {}
+    return os.homedir().trim();
+  })();
+  if (!home) {
+    throw new Error("Unable to resolve trusted user home for launchd operations.");
+  }
+  return toPosixPath(home);
+}
 
 function resolveLaunchAgentLabel(args?: { env?: Record<string, string | undefined> }): string {
   const envLabel = args?.env?.OPENCLAW_LAUNCHD_LABEL?.trim();
@@ -45,7 +63,7 @@ function resolveLaunchAgentPlistPathForLabel(
   env: Record<string, string | undefined>,
   label: string,
 ): string {
-  const home = toPosixPath(resolveHomeDir(env));
+  const home = resolveTrustedLaunchAgentHome();
   return path.posix.join(home, "Library", "LaunchAgents", `${label}.plist`);
 }
 
@@ -106,11 +124,16 @@ export function buildLaunchAgentPlist({
 
 async function execLaunchctl(
   args: string[],
+  options?: { signal?: AbortSignal },
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const isWindows = process.platform === "win32";
   const file = isWindows ? (process.env.ComSpec ?? "cmd.exe") : "launchctl";
   const fileArgs = isWindows ? ["/d", "/s", "/c", "launchctl", ...args] : args;
-  return await execFileUtf8(file, fileArgs, isWindows ? { windowsHide: true } : {});
+  const opts: Record<string, unknown> = isWindows ? { windowsHide: true } : {};
+  if (options?.signal) {
+    opts.signal = options.signal;
+  }
+  return await execFileUtf8(file, fileArgs, opts);
 }
 
 function resolveGuiDomain(): string {
@@ -155,9 +178,11 @@ async function bootstrapLaunchAgentOrThrow(params: {
   serviceTarget: string;
   plistPath: string;
   actionHint: string;
+  signal?: AbortSignal;
 }) {
-  await execLaunchctl(["enable", params.serviceTarget]);
-  const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath]);
+  const options = params.signal ? { signal: params.signal } : undefined;
+  await execLaunchctl(["enable", params.serviceTarget], options);
+  const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath], options);
   if (boot.code === 0) {
     return;
   }
@@ -174,16 +199,54 @@ async function bootstrapLaunchAgentOrThrow(params: {
 
 async function ensureSecureDirectory(targetPath: string): Promise<void> {
   await fs.mkdir(targetPath, { recursive: true, mode: LAUNCH_AGENT_DIR_MODE });
-  try {
-    const stat = await fs.stat(targetPath);
-    const mode = stat.mode & 0o777;
-    const tightenedMode = mode & ~0o022;
-    if (tightenedMode !== mode) {
-      await fs.chmod(targetPath, tightenedMode);
-    }
-  } catch {
-    // Best effort: keep install working even if chmod/stat is unavailable.
+  const stat = await fs.lstat(targetPath);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Refusing to use symlinked LaunchAgent path: ${targetPath}`);
   }
+  if (!stat.isDirectory()) {
+    throw new Error(`Expected LaunchAgent directory at ${targetPath}`);
+  }
+  const mode = stat.mode & 0o777;
+  const tightenedMode = mode & ~0o022;
+  if (tightenedMode !== mode) {
+    await fs.chmod(targetPath, tightenedMode).catch(() => undefined);
+  }
+}
+
+async function assertNotSymlink(targetPath: string): Promise<void> {
+  try {
+    const stat = await fs.lstat(targetPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to use symlinked LaunchAgent path: ${targetPath}`);
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function writeLaunchAgentPlistSecure(plistPath: string, plist: string): Promise<void> {
+  await assertNotSymlink(plistPath);
+  const dir = path.dirname(plistPath);
+  const tempPath = path.join(dir, `.${path.basename(plistPath)}.${process.pid}.tmp`);
+  await assertNotSymlink(tempPath);
+  const handle = await fs.open(
+    tempPath,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW,
+    LAUNCH_AGENT_PLIST_MODE,
+  );
+  try {
+    await handle.writeFile(plist, { encoding: "utf8" });
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    await fs.unlink(tempPath).catch(() => undefined);
+    throw error;
+  }
+  await handle.close();
+  await fs.rename(tempPath, plistPath);
 }
 
 export type LaunchctlPrintInfo = {
@@ -333,8 +396,8 @@ export async function uninstallLegacyLaunchAgents({
     return agents;
   }
 
-  const home = toPosixPath(resolveHomeDir(env));
-  const trashDir = path.posix.join(home, ".Trash");
+  const trustedHome = resolveTrustedLaunchAgentHome();
+  const trashDir = path.posix.join(trustedHome, ".Trash");
   try {
     await fs.mkdir(trashDir, { recursive: true });
   } catch {
@@ -380,8 +443,7 @@ export async function uninstallLaunchAgent({
     return;
   }
 
-  const home = toPosixPath(resolveHomeDir(env));
-  const trashDir = path.posix.join(home, ".Trash");
+  const trashDir = path.posix.join(resolveTrustedLaunchAgentHome(), ".Trash");
   const dest = path.join(trashDir, `${label}.plist`);
   try {
     await fs.mkdir(trashDir, { recursive: true });
@@ -444,10 +506,6 @@ export async function installLaunchAgent({
   }
 
   const plistPath = resolveLaunchAgentPlistPathForLabel(env, label);
-  const home = toPosixPath(resolveHomeDir(env));
-  const libraryDir = path.posix.join(home, "Library");
-  await ensureSecureDirectory(home);
-  await ensureSecureDirectory(libraryDir);
   await ensureSecureDirectory(path.dirname(plistPath));
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
@@ -460,8 +518,7 @@ export async function installLaunchAgent({
     stderrPath,
     environment,
   });
-  await fs.writeFile(plistPath, plist, { encoding: "utf8", mode: LAUNCH_AGENT_PLIST_MODE });
-  await fs.chmod(plistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
+  await writeLaunchAgentPlistSecure(plistPath, plist);
 
   await execLaunchctl(["bootout", domain, plistPath]);
   await execLaunchctl(["unload", plistPath]);
@@ -491,11 +548,13 @@ export async function installLaunchAgent({
 export async function restartLaunchAgent({
   stdout,
   env,
+  signal,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  const sig = { signal };
   const serviceTarget = `${domain}/${label}`;
 
   // Restart requests issued from inside the managed gateway process tree need a
@@ -514,7 +573,7 @@ export async function restartLaunchAgent({
     return { outcome: "scheduled" };
   }
 
-  const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
+  const start = await execLaunchctl(["kickstart", "-k", serviceTarget], sig);
   if (start.code === 0) {
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
     return { outcome: "completed" };
@@ -530,9 +589,10 @@ export async function restartLaunchAgent({
     serviceTarget,
     plistPath,
     actionHint: "openclaw gateway restart",
+    signal,
   });
 
-  const retry = await execLaunchctl(["kickstart", "-k", serviceTarget]);
+  const retry = await execLaunchctl(["kickstart", "-k", serviceTarget], sig);
   if (retry.code !== 0) {
     throw new Error(`launchctl kickstart failed: ${retry.stderr || retry.stdout}`.trim());
   }

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -60,7 +60,7 @@ function resolveLaunchAgentLabel(args?: { env?: Record<string, string | undefine
 }
 
 function resolveLaunchAgentPlistPathForLabel(
-  env: Record<string, string | undefined>,
+  _env: Record<string, string | undefined>,
   label: string,
 ): string {
   const home = resolveTrustedLaunchAgentHome();
@@ -246,7 +246,12 @@ async function writeLaunchAgentPlistSecure(plistPath: string, plist: string): Pr
     throw error;
   }
   await handle.close();
-  await fs.rename(tempPath, plistPath);
+  try {
+    await fs.rename(tempPath, plistPath);
+  } catch (error) {
+    await fs.unlink(tempPath).catch(() => undefined);
+    throw error;
+  }
 }
 
 export type LaunchctlPrintInfo = {

--- a/src/daemon/schtasks-exec.ts
+++ b/src/daemon/schtasks-exec.ts
@@ -5,10 +5,12 @@ const SCHTASKS_NO_OUTPUT_TIMEOUT_MS = 5_000;
 
 export async function execSchtasks(
   args: string[],
+  options?: { signal?: AbortSignal },
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const result = await runCommandWithTimeout(["schtasks", ...args], {
     timeoutMs: SCHTASKS_TIMEOUT_MS,
     noOutputTimeoutMs: SCHTASKS_NO_OUTPUT_TIMEOUT_MS,
+    signal: options?.signal,
   });
   const timeoutDetail =
     result.termination === "timeout"

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -694,6 +694,7 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
 export async function restartScheduledTask({
   stdout,
   env,
+  signal,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   const effectiveEnv = env ?? (process.env as GatewayServiceEnv);
   try {
@@ -710,7 +711,8 @@ export async function restartScheduledTask({
     }
   }
   const taskName = resolveTaskName(effectiveEnv);
-  await execSchtasks(["/End", "/TN", taskName]);
+  const sig = signal ? { signal } : undefined;
+  await execSchtasks(["/End", "/TN", taskName], sig);
   const restartPort = await resolveScheduledTaskPort(effectiveEnv);
   await terminateScheduledTaskGatewayListeners(effectiveEnv);
   await terminateInstalledStartupRuntime(effectiveEnv);
@@ -724,7 +726,7 @@ export async function restartScheduledTask({
       }
     }
   }
-  const res = await execSchtasks(["/Run", "/TN", taskName]);
+  const res = await execSchtasks(["/Run", "/TN", taskName], sig);
   if (res.code !== 0) {
     throw new Error(`schtasks run failed: ${res.stderr || res.stdout}`.trim());
   }

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -17,6 +17,8 @@ export type GatewayServiceManageArgs = {
 export type GatewayServiceControlArgs = {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
+  /** When aborted, child processes spawned by the operation should be killed. */
+  signal?: AbortSignal;
 };
 
 export type GatewayServiceRestartResult = { outcome: "completed" } | { outcome: "scheduled" };

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -254,8 +254,9 @@ export function parseSystemdShow(output: string): SystemdServiceInfo {
 
 async function execSystemctl(
   args: string[],
+  options?: { signal?: AbortSignal },
 ): Promise<{ stdout: string; stderr: string; code: number }> {
-  return await execFileUtf8("systemctl", args);
+  return await execFileUtf8("systemctl", args, options?.signal ? { signal: options.signal } : {});
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
@@ -388,6 +389,7 @@ function shouldFallbackToMachineUserScope(detail: string): boolean {
 async function execSystemctlUser(
   env: GatewayServiceEnv,
   args: string[],
+  options?: { signal?: AbortSignal },
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const machineUser = resolveSystemctlMachineScopeUser(env);
   const sudoUser = env.SUDO_USER?.trim();
@@ -396,11 +398,14 @@ async function execSystemctlUser(
   if (sudoUser && sudoUser !== "root" && machineUser) {
     const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
     if (machineScopeArgs.length > 0) {
-      return await execSystemctl([...machineScopeArgs, ...args]);
+      return await execSystemctl([...machineScopeArgs, ...args], options);
     }
   }
 
-  const directResult = await execSystemctl([...resolveSystemctlDirectUserScopeArgs(), ...args]);
+  const directResult = await execSystemctl(
+    [...resolveSystemctlDirectUserScopeArgs(), ...args],
+    options,
+  );
   if (directResult.code === 0) {
     return directResult;
   }
@@ -414,7 +419,7 @@ async function execSystemctlUser(
   if (machineScopeArgs.length === 0) {
     return directResult;
   }
-  return await execSystemctl([...machineScopeArgs, ...args]);
+  return await execSystemctl([...machineScopeArgs, ...args], options);
 }
 
 export async function isSystemdUserServiceAvailable(
@@ -542,6 +547,7 @@ export async function uninstallSystemdService({
 async function runSystemdServiceAction(params: {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
+  signal?: AbortSignal;
   action: "stop" | "restart";
   label: string;
 }) {
@@ -549,7 +555,7 @@ async function runSystemdServiceAction(params: {
   await assertSystemdAvailable(env);
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, [params.action, unitName]);
+  const res = await execSystemctlUser(env, [params.action, unitName], { signal: params.signal });
   if (res.code !== 0) {
     throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
   }
@@ -559,10 +565,12 @@ async function runSystemdServiceAction(params: {
 export async function stopSystemdService({
   stdout,
   env,
+  signal,
 }: GatewayServiceControlArgs): Promise<void> {
   await runSystemdServiceAction({
     stdout,
     env,
+    signal,
     action: "stop",
     label: "Stopped systemd service",
   });
@@ -571,10 +579,12 @@ export async function stopSystemdService({
 export async function restartSystemdService({
   stdout,
   env,
+  signal,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   await runSystemdServiceAction({
     stdout,
     env,
+    signal,
     action: "restart",
     label: "Restarted systemd service",
   });

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -21,6 +21,17 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
   );
 }
 
+function cronRescueWatchdogPayloadSchema(params: { monitoredProfile: TSchema }) {
+  return Type.Object(
+    {
+      kind: Type.Literal("rescueWatchdog"),
+      monitoredProfile: params.monitoredProfile,
+      timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
+    },
+    { additionalProperties: false },
+  );
+}
+
 const CronSessionTargetSchema = Type.Union([
   Type.Literal("main"),
   Type.Literal("isolated"),
@@ -139,6 +150,7 @@ export const CronPayloadSchema = Type.Union([
     { additionalProperties: false },
   ),
   cronAgentTurnPayloadSchema({ message: NonEmptyString }),
+  cronRescueWatchdogPayloadSchema({ monitoredProfile: NonEmptyString }),
 ]);
 
 export const CronPayloadPatchSchema = Type.Union([
@@ -150,6 +162,7 @@ export const CronPayloadPatchSchema = Type.Union([
     { additionalProperties: false },
   ),
   cronAgentTurnPayloadSchema({ message: Type.Optional(NonEmptyString) }),
+  cronRescueWatchdogPayloadSchema({ monitoredProfile: Type.Optional(NonEmptyString) }),
 ]);
 
 export const CronFailureAlertSchema = Type.Object(

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -11,6 +11,7 @@ import { resolveStorePath } from "../config/sessions/paths.js";
 import { resolveFailureDestination, sendFailureNotificationAnnounce } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { resolveDeliveryTarget } from "../cron/isolated-agent/delivery-target.js";
+import { runRescueWatchdogJob } from "../cron/rescue-watchdog.js";
 import {
   appendCronRunLog,
   resolveCronRunLogPath,
@@ -300,6 +301,13 @@ export function buildGatewayCronService(params: {
         agentId,
         sessionKey,
         lane: "cron",
+      });
+    },
+    runRescueWatchdogJob: async ({ job, monitoredProfile, abortSignal }) => {
+      return await runRescueWatchdogJob({
+        job,
+        monitoredProfile,
+        abortSignal,
       });
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -171,6 +171,7 @@ export type CommandOptions = {
   env?: NodeJS.ProcessEnv;
   windowsVerbatimArguments?: boolean;
   noOutputTimeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 export function resolveCommandEnv(params: {
@@ -215,7 +216,7 @@ export async function runCommandWithTimeout(
 ): Promise<SpawnResult> {
   const options: CommandOptions =
     typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
-  const { timeoutMs, cwd, input, env, noOutputTimeoutMs } = options;
+  const { timeoutMs, cwd, input, env, noOutputTimeoutMs, signal } = options;
   const { windowsVerbatimArguments } = options;
   const hasInput = input !== undefined;
   const resolvedEnv = resolveCommandEnv({ argv, env });
@@ -247,6 +248,7 @@ export async function runCommandWithTimeout(
     let timedOut = false;
     let noOutputTimedOut = false;
     let noOutputTimer: NodeJS.Timeout | null = null;
+    let onAbort: (() => void) | undefined;
     const shouldTrackOutputTimeout =
       typeof noOutputTimeoutMs === "number" &&
       Number.isFinite(noOutputTimeoutMs) &&
@@ -284,6 +286,22 @@ export async function runCommandWithTimeout(
     }, timeoutMs);
     armNoOutputTimer();
 
+    if (signal) {
+      onAbort = () => {
+        if (settled) {
+          return;
+        }
+        if (typeof child.kill === "function") {
+          child.kill("SIGKILL");
+        }
+      };
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
     if (hasInput && child.stdin) {
       child.stdin.write(input ?? "");
       child.stdin.end();
@@ -304,6 +322,9 @@ export async function runCommandWithTimeout(
       settled = true;
       clearTimeout(timer);
       clearNoOutputTimer();
+      if (signal && onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
       reject(err);
     });
     child.on("close", (code, signal) => {
@@ -313,6 +334,9 @@ export async function runCommandWithTimeout(
       settled = true;
       clearTimeout(timer);
       clearNoOutputTimer();
+      if (options.signal && onAbort) {
+        options.signal.removeEventListener("abort", onAbort);
+      }
       const termination = noOutputTimedOut
         ? "no-output-timeout"
         : timedOut

--- a/src/rescue/watchdog-shared.test.ts
+++ b/src/rescue/watchdog-shared.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildRescueProfileEnv, canEnableRescueWatchdog } from "./watchdog-shared.js";
+
+function toPosixPath(value: string | undefined): string {
+  return (value ?? "").replaceAll("\\", "/");
+}
+
+describe("buildRescueProfileEnv", () => {
+  it("recomputes state/config paths for the requested profile", () => {
+    const env = buildRescueProfileEnv("work", {
+      OPENCLAW_HOME: "/srv/openclaw-home",
+      HOME: "/home/tester",
+      OPENCLAW_STATE_DIR: "/srv/openclaw-home/.openclaw-rescue",
+      OPENCLAW_CONFIG_PATH: "/srv/openclaw-home/.openclaw-rescue/openclaw.json",
+    });
+
+    expect(env.OPENCLAW_PROFILE).toBe("work");
+    expect(toPosixPath(env.OPENCLAW_STATE_DIR)).toMatch(/\/srv\/openclaw-home\/\.openclaw-work$/);
+    expect(toPosixPath(env.OPENCLAW_CONFIG_PATH)).toMatch(
+      /\/srv\/openclaw-home\/\.openclaw-work\/openclaw\.json$/,
+    );
+  });
+
+  it("preserves daemon service identity overrides", () => {
+    const env = buildRescueProfileEnv("work", {
+      HOME: "/home/tester",
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_LAUNCHD_LABEL: "com.example.openclaw-work",
+      OPENCLAW_SYSTEMD_UNIT: "openclaw-work-custom.service",
+      OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Gateway (work custom)",
+    });
+
+    expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("com.example.openclaw-work");
+    expect(env.OPENCLAW_SYSTEMD_UNIT).toBe("openclaw-work-custom.service");
+    expect(env.OPENCLAW_WINDOWS_TASK_NAME).toBe("OpenClaw Gateway (work custom)");
+  });
+
+  it("drops service identity overrides when deriving a different target profile", () => {
+    const env = buildRescueProfileEnv("work", {
+      HOME: "/home/tester",
+      OPENCLAW_PROFILE: "rescue",
+      OPENCLAW_LAUNCHD_LABEL: "com.example.openclaw-rescue",
+      OPENCLAW_SYSTEMD_UNIT: "openclaw-rescue-custom.service",
+      OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Gateway (rescue custom)",
+    });
+
+    expect(env.OPENCLAW_LAUNCHD_LABEL).toBeUndefined();
+    expect(env.OPENCLAW_SYSTEMD_UNIT).toBeUndefined();
+    expect(env.OPENCLAW_WINDOWS_TASK_NAME).toBeUndefined();
+  });
+
+  it("preserves gateway port overrides for the target profile env", () => {
+    const env = buildRescueProfileEnv("work", {
+      HOME: "/home/tester",
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_GATEWAY_PORT: "29999",
+    });
+
+    expect(env.OPENCLAW_GATEWAY_PORT).toBe("29999");
+  });
+
+  it("drops gateway port override when deriving a different target profile", () => {
+    const env = buildRescueProfileEnv("work", {
+      HOME: "/home/tester",
+      OPENCLAW_PROFILE: "rescue",
+      OPENCLAW_GATEWAY_PORT: "29998",
+    });
+
+    expect(env.OPENCLAW_GATEWAY_PORT).toBeUndefined();
+  });
+});
+
+describe("canEnableRescueWatchdog", () => {
+  it("rejects rescue profile shapes", () => {
+    expect(canEnableRescueWatchdog("rescue")).toBe(false);
+    expect(canEnableRescueWatchdog("work-rescue")).toBe(false);
+  });
+});

--- a/src/rescue/watchdog-shared.ts
+++ b/src/rescue/watchdog-shared.ts
@@ -1,0 +1,81 @@
+import { applyCliProfileEnv } from "../cli/profile.js";
+
+export const RESCUE_WATCHDOG_AGENT_ID = "rescue-watchdog";
+export const DEFAULT_RESCUE_INTERVAL_MS = 5 * 60_000;
+export const DEFAULT_RESCUE_TIMEOUT_SECONDS = 120;
+const RESCUE_PROFILE_SUFFIX = "-rescue";
+
+const RESCUE_ENV_ALLOWLIST = [
+  "APPDATA",
+  "ASDF_DATA_DIR",
+  "BUN_INSTALL",
+  "COMSPEC",
+  "FNM_DIR",
+  "HOME",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LOCALAPPDATA",
+  "NPM_CONFIG_PREFIX",
+  "OPENCLAW_HOME",
+  "OPENCLAW_GATEWAY_PORT",
+  "OPENCLAW_LAUNCHD_LABEL",
+  "OPENCLAW_SYSTEMD_UNIT",
+  "OPENCLAW_WINDOWS_TASK_NAME",
+  "PATH",
+  "PATHEXT",
+  "PNPM_HOME",
+  "ProgramData",
+  "ProgramFiles",
+  "ProgramFiles(x86)",
+  "SystemRoot",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "USERPROFILE",
+  "VOLTA_HOME",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+] as const;
+const RESCUE_SERVICE_IDENTITY_ENV_KEYS = [
+  "OPENCLAW_GATEWAY_PORT",
+  "OPENCLAW_LAUNCHD_LABEL",
+  "OPENCLAW_SYSTEMD_UNIT",
+  "OPENCLAW_WINDOWS_TASK_NAME",
+] as const;
+const RESCUE_SERVICE_IDENTITY_ENV_KEY_SET = new Set<string>(RESCUE_SERVICE_IDENTITY_ENV_KEYS);
+
+export function resolveMonitoredProfileName(raw = process.env.OPENCLAW_PROFILE): string {
+  const trimmed = raw?.trim();
+  if (!trimmed || trimmed.toLowerCase() === "default") {
+    return "default";
+  }
+  return trimmed;
+}
+
+export function canEnableRescueWatchdog(monitoredProfile: string): boolean {
+  const normalized = resolveMonitoredProfileName(monitoredProfile).toLowerCase();
+  return normalized !== "rescue" && !normalized.endsWith(RESCUE_PROFILE_SUFFIX);
+}
+
+export function buildRescueProfileEnv(
+  profile: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: Record<string, string | undefined> = {};
+  const targetProfile = resolveMonitoredProfileName(profile);
+  const currentProfile = resolveMonitoredProfileName(baseEnv.OPENCLAW_PROFILE);
+  const preserveServiceIdentityOverrides = targetProfile === currentProfile;
+  for (const key of RESCUE_ENV_ALLOWLIST) {
+    if (!preserveServiceIdentityOverrides && RESCUE_SERVICE_IDENTITY_ENV_KEY_SET.has(key)) {
+      continue;
+    }
+    const value = baseEnv[key];
+    if (typeof value === "string" && value.length > 0) {
+      env[key] = value;
+    }
+  }
+  applyCliProfileEnv({ profile, env });
+  return env as NodeJS.ProcessEnv;
+}


### PR DESCRIPTION
## Summary

- Problem: OpenClaw had no built-in isolated rescue watchdog that could detect an unhealthy managed gateway profile and repair it without going through the failing primary session.
- Why it matters: the larger rescue-watchdog feature is hard to review as one PR; this split lands the core runtime/service layer first so maintainers can review the actual watchdog mechanism without onboarding/UI noise.
- What changed: adds daemon/service hardening needed by the watchdog, introduces a new isolated `rescueWatchdog` cron payload + runner, and wires the gateway cron service to execute that watchdog job against a monitored profile.
- What did NOT change (scope boundary): no onboarding wizard flow, no CLI `openclaw onboard --rescue-watchdog` UX, and no docs changes in this PR.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #31480
- Supersedes #44113
- Supersedes #46493

## User-visible / Behavior Changes

- Adds a new internal isolated cron payload kind, `rescueWatchdog`, for watchdog jobs that monitor a target profile and repair it when unhealthy.
- Hardens LaunchAgent plist writes: trusted-home resolution, symlink rejection, atomic writes, and `0600` plist permissions.
- Managed service restart helpers now accept `AbortSignal`, so watchdog restart attempts can be canceled cleanly instead of hanging until command timeouts.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  The new capability is intentionally narrow: an isolated cron job can probe and repair a monitored local profile. Risk is bounded by restricting the payload shape, disallowing delivery targets for `rescueWatchdog`, resolving the monitored profile explicitly, and hardening the underlying managed-service restart and launchd plist write paths. The repair fallback uses exact argv via `process.execPath` and avoids shell-based PATH resolution.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): local managed gateway service / cron service only

### Steps

1. Run the daemon/unit tests covering launchd, systemd, schtasks, and process-exec timeout behavior.
2. Run the cron/rescue unit tests covering payload normalization, job validation, watchdog execution, and gateway cron wiring.
3. Build the repo and validate config to confirm the combined core layer compiles and loads cleanly.

### Expected

- A `rescueWatchdog` cron job can be normalized, stored, validated, and executed as an isolated job.
- Managed service restart helpers are abortable and launchd plist writes fail closed on unsafe targets.

### Actual

- Verified by targeted tests and local build/config validation; behavior matches the expected outcomes above.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - launchd plist path resolution ignores a conflicting `HOME` override, rejects symlink targets, and writes plist files with `0600` permissions via temp-file + rename.
  - `AbortSignal` now propagates through launchd/systemd/schtasks restart helpers into the process exec layer.
  - `rescueWatchdog` cron payloads normalize correctly, are forced to isolated session targets, and reject delivery/failureDestination config.
  - the rescue watchdog runner probes the monitored profile, attempts managed service restart, falls back to `doctor --repair --non-interactive`, and reports success/error summaries correctly.
- Edge cases checked:
  - `os.userInfo()` failure falls back to `os.homedir()`, and unresolved trusted home fails closed.
  - monitored rescue-profile names are rejected.
  - restart/repair flows respect cron timeout budget and abort behavior.
  - `launchd` temp plist files are cleaned up if rename fails.
- What you did **not** verify:
  - manual end-to-end watchdog repair on a real long-running host with an actually failing managed gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/daemon/*`, `src/process/exec.ts`, `src/cron/*`, `src/rescue/watchdog-shared.ts`, `src/gateway/server-cron.ts`
- Known bad symptoms reviewers should watch for: launchd install unexpectedly failing on valid paths, or isolated cron jobs rejecting valid `agentTurn` jobs after the new payload kind was added.

## Risks and Mitigations

- Risk: LaunchAgent path hardening could reject previously tolerated but unsafe filesystem layouts.
  - Mitigation: the checks are limited to symlinked/non-directory targets in the LaunchAgents path and have focused test coverage.
- Risk: adding a new cron payload kind could accidentally loosen validation or delivery behavior.
  - Mitigation: `rescueWatchdog` is explicitly restricted to isolated jobs, delivery is rejected, and schema/service/normalization paths have dedicated tests.
- Risk: watchdog repair code could leave stuck restart attempts behind.
  - Mitigation: abort propagation is threaded through the restart backends and the watchdog enforces bounded restart/repair timeouts.
