### PR TITLE
feat(cron): add execution logging and health warnings (closes #13593)

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -152,6 +152,80 @@ describe("printCronList", () => {
     expect(dataLine).toContain("opus");
   });
 
+  it("does not flag running jobs as overdue", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const now = Date.now();
+    const everyMs = 60_000;
+    const job = createBaseJob({
+      id: "running-job",
+      name: "Running",
+      schedule: { kind: "every", everyMs },
+      state: {
+        lastRunAtMs: now - everyMs * 5,
+        runningAtMs: now - everyMs * 3,
+        nextRunAtMs: now - everyMs * 4,
+      },
+    });
+
+    printCronList([job], runtime);
+    expect(logs.every((line) => !line.includes("overdue"))).toBe(true);
+  });
+
+  it("uses nextRunAtMs for overdue threshold when available", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const now = Date.now();
+    const everyMs = 60_000;
+    // nextRunAtMs is in the recent past but within nextRunAtMs + everyMs
+    const job = createBaseJob({
+      id: "backoff-job",
+      name: "Backoff",
+      schedule: { kind: "every", everyMs },
+      state: {
+        lastRunAtMs: now - everyMs * 5,
+        nextRunAtMs: now - everyMs * 0.5,
+      },
+    });
+
+    printCronList([job], runtime);
+    // nextRunAtMs + everyMs is still in the future, so not overdue
+    expect(logs.every((line) => !line.includes("overdue"))).toBe(true);
+  });
+
+  it("flags overdue when past nextRunAtMs + everyMs", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const now = Date.now();
+    const everyMs = 60_000;
+    const job = createBaseJob({
+      id: "overdue-job",
+      name: "Overdue",
+      schedule: { kind: "every", everyMs },
+      state: {
+        lastRunAtMs: now - everyMs * 5,
+        nextRunAtMs: now - everyMs * 3,
+      },
+    });
+
+    printCronList([job], runtime);
+    expect(logs.some((line) => line.includes("overdue"))).toBe(true);
+  });
+
+  it("falls back to lastRunAtMs + 2×everyMs when nextRunAtMs is absent", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const now = Date.now();
+    const everyMs = 60_000;
+    const job = createBaseJob({
+      id: "fallback-job",
+      name: "Fallback",
+      schedule: { kind: "every", everyMs },
+      state: {
+        lastRunAtMs: now - everyMs * 3,
+      },
+    });
+
+    printCronList([job], runtime);
+    expect(logs.some((line) => line.includes("overdue"))).toBe(true);
+  });
+
   it("shows exact label for cron schedules with stagger disabled", () => {
     const { logs, runtime } = createRuntimeLogCapture();
     const job = createBaseJob({

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -269,5 +269,27 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     ].join(" ");
 
     runtime.log(line.trimEnd());
+
+    // Flag unhealthy jobs: consecutive errors or overdue execution
+    const warnings: string[] = [];
+    const consecutiveErrors = job.state.consecutiveErrors ?? 0;
+    if (consecutiveErrors >= 3) {
+      warnings.push(`${consecutiveErrors} consecutive errors`);
+    }
+    if (job.enabled && !job.state.runningAtMs && job.schedule.kind === "every") {
+      const overdueThreshold =
+        typeof job.state.nextRunAtMs === "number"
+          ? job.state.nextRunAtMs + job.schedule.everyMs
+          : typeof job.state.lastRunAtMs === "number"
+            ? job.state.lastRunAtMs + job.schedule.everyMs * 2
+            : undefined;
+      if (overdueThreshold !== undefined && now > overdueThreshold) {
+        warnings.push("overdue (>2× interval since last run)");
+      }
+    }
+    if (warnings.length > 0) {
+      const warnText = `  ⚠ ${warnings.join("; ")}`;
+      runtime.log(rich ? theme.warn(warnText) : warnText);
+    }
   }
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -633,7 +633,23 @@ export async function onTimer(state: CronServiceState) {
 
       try {
         const result = await executeJobCoreWithTimeout(state, job);
-        return { jobId: id, ...result, startedAt, endedAt: state.deps.nowMs() };
+        const endedAt = state.deps.nowMs();
+        const durationMs = endedAt - startedAt;
+        const meta = { jobId: id, jobName: job.name, status: result.status, durationMs };
+        if (result.status === "ok") {
+          state.deps.log.info(meta, "cron: job completed");
+        } else if (result.status === "skipped") {
+          state.deps.log.warn(
+            { ...meta, reason: result.error },
+            `cron: job skipped: ${result.error ?? "unknown reason"}`,
+          );
+        } else {
+          state.deps.log.warn(
+            { ...meta, error: result.error },
+            `cron: job failed: ${result.error ?? "unknown error"}`,
+          );
+        }
+        return { jobId: id, ...result, startedAt, endedAt };
       } catch (err) {
         const errorText = isAbortError(err) ? timeoutErrorMessage() : String(err);
         state.deps.log.warn(


### PR DESCRIPTION
## Summary
Cron job executions could fail silently — `nextRunAtMs` would advance without any log trace. This PR adds two observability improvements:

### 1. Structured execution logging (`timer.ts`)
Every completed job now gets a log line:
- **`info`**: `cron: job completed` — on success, with jobId, jobName, durationMs
- **`warn`**: `cron: job skipped: <reason>` — for skipped executions
- **`warn`**: `cron: job failed: <error>` — for error results (non-throwing path)
- The existing `catch` path (throwing errors) already logged warnings and is unchanged.

### 2. CLI health warnings (`shared.ts`)
`openclaw cron list` now prints a ⚠ warning line after unhealthy jobs:
- **Consecutive errors**: shown when ≥3 consecutive errors tracked in `job.state.consecutiveErrors`
- **Overdue**: shown when last run was >2× the `every` schedule interval ago

## Change Type
Feature / enhancement

## Scope
- `src/cron/service/timer.ts` — structured execution logging in `runDueJob`
- `src/cli/cron-cli/shared.ts` — warning annotations in `printCronList`

## Linked Issue
Closes #13593

## Security Impact
None — logging only, no auth or permission changes.

## Evidence
- `pnpm build` passes
- `npx vitest run src/cli/cron-cli/shared.test.ts` — 9 tests pass

## Human Verification
1. Run a cron job successfully → check logs for `cron: job completed` at info level
2. Run a job that errors → check logs for `cron: job failed: ...` at warn level
3. Create a job with 3+ consecutive errors → run `openclaw cron list` → see ⚠ warning
4. Create an `every` job, wait >2× interval without execution → see overdue warning

## Compatibility
Fully backward-compatible. New log lines don't change any behavior; CLI warnings are additive.

## Failure Recovery
N/A — observability-only changes.

## Risks
Slightly more log volume in info level for frequent cron jobs. The structured format with jobId makes filtering easy.

*This PR was AI-assisted (fully tested with pnpm build/check/test).*