### PR TITLE
fix(health): use runtime snapshot for channel summaries

### DIFF
--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
+import type { ChannelRuntimeSnapshot } from "../gateway/server-channels.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import type { HealthSummary } from "./health.js";
@@ -221,6 +222,71 @@ describe("getHealthSnapshot", () => {
     expect(telegram.configured).toBe(true);
     expect(telegram.probe?.ok).toBe(false);
     expect(telegram.probe?.error).toMatch(/network down/i);
+  });
+
+  it("includes live runtime fields in telegram health summaries when provided", async () => {
+    testConfig = { channels: { telegram: { botToken: "t-live" } } };
+    testStore = {};
+    vi.stubEnv("DISCORD_BOT_TOKEN", "");
+
+    const startedAt = 1773508368414;
+    const runtimeSnapshot: ChannelRuntimeSnapshot = {
+      channels: {
+        telegram: {
+          accountId: "default",
+          running: true,
+          lastStartAt: startedAt,
+          lastStopAt: null,
+          lastError: null,
+          mode: "polling",
+          lastInboundAt: startedAt + 123,
+        },
+      },
+      channelAccounts: {
+        telegram: {
+          default: {
+            accountId: "default",
+            running: true,
+            lastStartAt: startedAt,
+            lastStopAt: null,
+            lastError: null,
+            mode: "polling",
+            lastInboundAt: startedAt + 123,
+          },
+        },
+      },
+    };
+
+    const snap = await getHealthSnapshot({
+      timeoutMs: 25,
+      probe: false,
+      runtimeSnapshot,
+    });
+    const telegram = snap.channels.telegram as {
+      configured?: boolean;
+      running?: boolean;
+      lastStartAt?: number | null;
+      mode?: string | null;
+      tokenSource?: string | null;
+      accounts?: Record<
+        string,
+        {
+          running?: boolean;
+          lastStartAt?: number | null;
+          mode?: string | null;
+          tokenSource?: string | null;
+        }
+      >;
+    };
+    expect(telegram.configured).toBe(true);
+    expect(telegram.running).toBe(true);
+    expect(telegram.lastStartAt).toBe(startedAt);
+    expect(telegram.mode).toBe("polling");
+    expect(telegram.tokenSource).toBe("config");
+    expect(telegram.accounts?.default?.running).toBe(true);
+    expect(telegram.accounts?.default?.lastStartAt).toBe(startedAt);
+    expect(telegram.accounts?.default?.mode).toBe("polling");
+    expect(telegram.accounts?.default?.tokenSource).toBe("config");
   });
 
   it("disables heartbeat for agents without heartbeat blocks", async () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1,12 +1,14 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
+import { buildChannelAccountSnapshot } from "../channels/plugins/status.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.js";
 import { withProgress } from "../cli/progress.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig, readBestEffortConfig } from "../config/config.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import type { ChannelRuntimeSnapshot } from "../gateway/server-channels.js";
 import { info } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -348,6 +350,7 @@ export const formatHealthChannelLines = (
 export async function getHealthSnapshot(params?: {
   timeoutMs?: number;
   probe?: boolean;
+  runtimeSnapshot?: ChannelRuntimeSnapshot;
 }): Promise<HealthSummary> {
   const timeoutMs = params?.timeoutMs;
   const cfg = loadConfig();
@@ -380,6 +383,22 @@ export async function getHealthSnapshot(params?: {
   const channels: Record<string, ChannelHealthSummary> = {};
   const channelOrder = listChannelPlugins().map((plugin) => plugin.id);
   const channelLabels: Record<string, string> = {};
+  const resolveRuntimeSnapshot = (
+    channelId: string,
+    accountId: string,
+    defaultAccountId: string,
+  ): ChannelAccountSnapshot | undefined => {
+    const runtime = params?.runtimeSnapshot;
+    if (!runtime) {
+      return undefined;
+    }
+    const channelAccounts = runtime.channelAccounts[channelId as keyof typeof runtime.channelAccounts];
+    const defaultRuntime = runtime.channels[channelId as keyof typeof runtime.channels];
+    return (
+      channelAccounts?.[accountId] ??
+      (accountId === defaultAccountId ? defaultRuntime : undefined)
+    );
+  };
 
   for (const plugin of listChannelPlugins()) {
     channelLabels[plugin.id] = plugin.meta.label ?? plugin.id;
@@ -450,13 +469,19 @@ export async function getHealthSnapshot(params?: {
         debugHealth("probe.bot", { channel: plugin.id, accountId, username: bot.username });
       }
 
-      const snapshot: ChannelAccountSnapshot = {
+      const runtimeSnapshot = resolveRuntimeSnapshot(plugin.id, accountId, defaultAccountId);
+      const snapshot = await buildChannelAccountSnapshot({
+        plugin,
+        cfg,
         accountId,
-        enabled,
-        configured,
-      };
-      if (probe !== undefined) {
-        snapshot.probe = probe;
+        runtime: runtimeSnapshot,
+        probe,
+      });
+      if (snapshot.enabled === undefined) {
+        snapshot.enabled = enabled;
+      }
+      if (snapshot.configured === undefined) {
+        snapshot.configured = configured;
       }
       if (lastProbeAt) {
         snapshot.lastProbeAt = lastProbeAt;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -106,6 +106,7 @@ import {
   getPresenceVersion,
   incrementPresenceVersion,
   refreshGatewayHealthSnapshot,
+  setHealthRuntimeSnapshotProvider,
 } from "./server/health-state.js";
 import { resolveHookClientIpConfig } from "./server/hooks.js";
 import { createReadinessChecker } from "./server/readiness.js";
@@ -657,6 +658,7 @@ export async function startGatewayServer(
 
   const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } =
     channelManager;
+  setHealthRuntimeSnapshotProvider(getRuntimeSnapshot);
 
   if (!minimalTestGateway) {
     const machineDisplayName = await getMachineDisplayName();
@@ -1064,6 +1066,7 @@ export async function startGatewayServer(
       browserAuthRateLimiter.dispose();
       channelHealthMonitor?.stop();
       clearSecretsRuntimeSnapshot();
+      setHealthRuntimeSnapshotProvider(null);
       await close(opts);
     },
   };

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelRuntimeSnapshot } from "../server-channels.js";
+
+const getHealthSnapshotMock = vi.fn();
+
+vi.mock("../../commands/health.js", () => ({
+  getHealthSnapshot: (...args: unknown[]) => getHealthSnapshotMock(...args),
+}));
+
+describe("refreshGatewayHealthSnapshot", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getHealthSnapshotMock.mockReset();
+    getHealthSnapshotMock.mockResolvedValue({
+      ok: true,
+      ts: Date.now(),
+      durationMs: 1,
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+      heartbeatSeconds: 0,
+      defaultAgentId: "main",
+      agents: [],
+      sessions: {
+        path: "/tmp/sessions.json",
+        count: 0,
+        recent: [],
+      },
+    });
+  });
+
+  it("passes the live runtime snapshot into health snapshot refreshes", async () => {
+    const mod = await import("./health-state.js");
+    const runtimeSnapshot: ChannelRuntimeSnapshot = {
+      channels: {
+        telegram: {
+          accountId: "default",
+          running: true,
+          lastStartAt: 123,
+        },
+      },
+      channelAccounts: {
+        telegram: {
+          default: {
+            accountId: "default",
+            running: true,
+            lastStartAt: 123,
+          },
+        },
+      },
+    };
+
+    mod.setHealthRuntimeSnapshotProvider(() => runtimeSnapshot);
+    await mod.refreshGatewayHealthSnapshot({ probe: false });
+
+    expect(getHealthSnapshotMock).toHaveBeenCalledWith({
+      probe: false,
+      runtimeSnapshot,
+    });
+    mod.setHealthRuntimeSnapshotProvider(null);
+  });
+});

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -7,12 +7,14 @@ import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolveGatewayAuth } from "../auth.js";
 import type { Snapshot } from "../protocol/index.js";
+import type { ChannelRuntimeSnapshot } from "../server-channels.js";
 
 let presenceVersion = 1;
 let healthVersion = 1;
 let healthCache: HealthSummary | null = null;
 let healthRefresh: Promise<HealthSummary> | null = null;
 let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
+let healthRuntimeSnapshotProvider: (() => ChannelRuntimeSnapshot) | null = null;
 
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
@@ -67,10 +69,20 @@ export function setBroadcastHealthUpdate(fn: ((snap: HealthSummary) => void) | n
   broadcastHealthUpdate = fn;
 }
 
+export function setHealthRuntimeSnapshotProvider(
+  fn: (() => ChannelRuntimeSnapshot) | null,
+) {
+  healthRuntimeSnapshotProvider = fn;
+}
+
 export async function refreshGatewayHealthSnapshot(opts?: { probe?: boolean }) {
   if (!healthRefresh) {
     healthRefresh = (async () => {
-      const snap = await getHealthSnapshot({ probe: opts?.probe });
+      const runtimeSnapshot = healthRuntimeSnapshotProvider?.();
+      const snap = await getHealthSnapshot({
+        probe: opts?.probe,
+        runtimeSnapshot,
+      });
       healthCache = snap;
       healthVersion += 1;
       if (broadcastHealthUpdate) {


### PR DESCRIPTION
## Summary

- Problem: `openclaw health --json` rebuilt channel summaries from config plus probe, but did not feed in the live gateway channel runtime snapshot.
- Why it matters: Telegram could show `running: false`, `lastStartAt: null`, and `tokenSource: "none"` in `health` while `channels status` and live traffic showed the same account running normally.
- What changed: thread the live runtime snapshot into health refreshes, build per-account health snapshots through the normal channel snapshot builder, and add focused tests for both the gateway health-state wiring and the Telegram health summary fields.
- What did NOT change (scope boundary): no channel runtime logic, probe behavior, or `channels.status` output path was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46494
- Related #31307

## User-visible / Behavior Changes

`openclaw health --json` now reflects live channel runtime fields when the gateway has them, instead of falling back to config/probe-only summaries for channels like Telegram.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.1
- Runtime/container: local gateway, npm global `openclaw@2026.3.13`
- Model/provider: not model-specific
- Integration/channel (if any): Telegram
- Relevant config (redacted): `~/.openclaw/openclaw.json5` with `channels.telegram.botToken`

### Steps

1. Configure Telegram and start the local gateway.
2. Confirm Telegram traffic is working.
3. Compare `openclaw health --json` with `openclaw channels status --json`.

### Expected

- `health` should agree with the live runtime state for fields like `running`, `lastStartAt`, `mode`, and `tokenSource`.

### Actual

- `health` reported Telegram as stopped / `tokenSource: "none"` while `channels status` reported the same account running from config.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: traced the issue repro into `getHealthSnapshot`, confirmed the missing runtime-snapshot input, added a regression test for Telegram health summary fields, added a regression test for gateway health-state wiring, ran those targeted tests plus `pnpm build`, captured a live before-state on the installed `2026.3.13` build (`health` false-negative vs `channels status` healthy), and captured an isolated after-state from this branch with the same Telegram config showing `running: true`, `tokenSource: "config"`, and `mode: "polling"`.
- Edge cases checked: health refresh still works without a runtime provider; runtime provider is cleared on gateway shutdown.
- What you did **not** verify: I did not complete a clean `openclaw health --json` round-trip against the foreground patched gateway via the stock CLI because a separate local `pairing required` RPC/auth path interfered once the managed LaunchAgent was unloaded. The after-state evidence in this PR comes from the patched branch starting the live Telegram runtime under isolated config/state and then computing the health snapshot in-process.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit f30ce95
- Files/config to restore: `src/commands/health.ts`, `src/gateway/server/health-state.ts`, `src/gateway/server.impl.ts`
- Known bad symptoms reviewers should watch for: `health` stops reflecting live channel runtime fields, or gateway shutdown leaves a stale health runtime provider behind

## Risks and Mitigations

- Risk: health summaries now depend on the gateway runtime snapshot being available during refresh.
  - Mitigation: the new code keeps the old behavior when no runtime snapshot provider exists.

AI-assisted: yes.
