### PR TITLE
fix(memory): skip Han bigram rewrite for QMD BM25 queries (closes #42801)

### DIFF
--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -32,7 +32,6 @@ import type {
   ResolvedQmdMcporterConfig,
 } from "./backend-config.js";
 import { parseQmdQueryJson, type QmdQueryResult } from "./qmd-query-parser.js";
-import { extractKeywords } from "./query-expansion.js";
 
 const log = createSubsystemLogger("memory");
 
@@ -43,7 +42,6 @@ const NUL_MARKER_RE = /(?:\^@|\\0|\\x00|\\u0000|null\s*byte|nul\s*byte)/i;
 const QMD_EMBED_BACKOFF_BASE_MS = 60_000;
 const QMD_EMBED_BACKOFF_MAX_MS = 60 * 60 * 1000;
 const HAN_SCRIPT_RE = /[\u3400-\u9fff]/u;
-const QMD_BM25_HAN_KEYWORD_LIMIT = 12;
 
 let qmdEmbedQueueTail: Promise<void> = Promise.resolve();
 
@@ -56,29 +54,9 @@ function normalizeHanBm25Query(query: string): string {
   if (!trimmed || !hasHanScript(trimmed)) {
     return trimmed;
   }
-  const keywords = extractKeywords(trimmed);
-  const normalizedKeywords: string[] = [];
-  const seen = new Set<string>();
-  for (const keyword of keywords) {
-    const token = keyword.trim();
-    if (!token || seen.has(token)) {
-      continue;
-    }
-    const includesHan = hasHanScript(token);
-    // Han unigrams are usually too broad for BM25 and can drown signal.
-    if (includesHan && Array.from(token).length < 2) {
-      continue;
-    }
-    if (!includesHan && token.length < 2) {
-      continue;
-    }
-    seen.add(token);
-    normalizedKeywords.push(token);
-    if (normalizedKeywords.length >= QMD_BM25_HAN_KEYWORD_LIMIT) {
-      break;
-    }
-  }
-  return normalizedKeywords.length > 0 ? normalizedKeywords.join(" ") : trimmed;
+  // QMD handles CJK tokenization natively. Applying extractKeywords here
+  // splits Han text into overlapping bigrams that degrade BM25 retrieval.
+  return trimmed;
 }
 
 async function runWithQmdEmbedLock<T>(task: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary
`normalizeHanBm25Query()` called `extractKeywords()` which split Chinese text into overlapping bigrams (e.g., `高级感` → `高级 级感`), then passed the degraded query to QMD. This caused empty results for valid Chinese memory searches, even though direct `qmd search` with the original query returned matches.

QMD handles CJK tokenization natively via its own BM25 engine, so the bigram rewrite is both unnecessary and harmful. Changed `normalizeHanBm25Query` to pass Han queries through directly.

## Change Type
Bug fix

## Scope
`src/memory/qmd-manager.ts` — `normalizeHanBm25Query()`

## Linked Issue
Closes #42801

## Security Impact
None.

## Evidence
- `pnpm build` passes
- Removed 25 lines of broken bigram rewrite logic

## Human Verification
1. `openclaw memory search "自然 高级感 结论先行 搜索偏好"`
2. Before fix: no matches. After fix: matches found (same as direct `qmd search`).

## Compatibility

## Risks
None — the bigram rewrite was demonstrably harmful for CJK queries.

*This PR was AI-assisted (fully tested with pnpm build/check/test).*