### PR TITLE
fix(memory): include sessions in full reindex triggered by session-start (closes #44028)

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -683,12 +683,12 @@ export abstract class MemoryManagerSyncOps {
     if (params?.force) {
       return true;
     }
+    if (needsFullReindex) {
+      return true;
+    }
     const reason = params?.reason;
     if (reason === "session-start" || reason === "watch") {
       return false;
-    }
-    if (needsFullReindex) {
-      return true;
     }
     return this.sessionsDirty && this.sessionsDirtyFiles.size > 0;
   }


### PR DESCRIPTION
## Summary
`shouldSyncSessions()` short-circuited on `reason === 'session-start'` before checking `needsFullReindex`, so full reindexes triggered during session-start (e.g., embedding model mismatch after gateway restart) silently dropped session transcript data. The metadata still reported `sources: ['memory', 'sessions']`, masking the data loss.

Reordered the checks so `needsFullReindex` takes priority over the incremental-sync skip. The `session-start`/`watch` skip is still correct for incremental syncs.

## Change Type
Bug fix

## Scope
`src/memory/manager-sync-ops.ts` — `shouldSyncSessions()`

## Linked Issue
Closes #44028

## Security Impact
None.

## Evidence
- `pnpm build` passes
- 3-line reorder: moved `needsFullReindex` check before `session-start` early return

## Human Verification
1. Configure agent with `experimental.sessionMemory: true` and `sources: ['memory', 'sessions']`
2. Create embedding model mismatch (e.g., change model in config)
3. Restart gateway, send message (triggers session-start sync)
4. Before fix: reindex drops sessions. After fix: reindex includes sessions.

## Compatibility
Backward-compatible. Only changes behavior when `needsFullReindex=true` AND reason is `session-start`/`watch`.

## Risks
None — full reindexes should always include all configured sources.

*This PR was AI-assisted (fully tested with pnpm build/check/test).*