### PR TITLE
fix: only advance memoryFlushCompactionCount when compaction ran (closes #12590)

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -542,7 +542,10 @@ export async function runMemoryFlushIfNeeded(params: {
           sessionKey: params.sessionKey,
           update: async () => ({
             memoryFlushAt: Date.now(),
-            memoryFlushCompactionCount,
+            // Only advance the flush counter when compaction actually ran
+            // during this flush turn. Otherwise the counters synchronize
+            // and the next flush cycle is skipped (#12590).
+            ...(memoryCompactionCompleted ? { memoryFlushCompactionCount } : {}),
           }),
         });
         if (updatedEntry) {


### PR DESCRIPTION
## Summary
`runMemoryFlushIfNeeded` unconditionally persisted `memoryFlushCompactionCount` after every flush turn, even when compaction didn't complete during that turn. This synchronized both counters (`compactionCount === memoryFlushCompactionCount`), causing `shouldRunMemoryFlush` to return `false` on the next cycle — producing the "flush, skip, flush, skip" pattern.

Only persist the updated `memoryFlushCompactionCount` when `memoryCompactionCompleted` is true. When compaction doesn't run, the counters stay desynced, so the next compaction cycle correctly triggers a flush.

## Change Type
Bug fix

## Scope
`src/auto-reply/reply/agent-runner-memory.ts` — `runMemoryFlushIfNeeded()`

## Linked Issue
Closes #12590

## Security Impact
None.

## Evidence
- `pnpm build` passes
- 4-line change: conditional spread replaces unconditional persist

## Human Verification
1. Enable memoryFlush in config
2. Have a conversation that triggers multiple auto-compactions
3. Before fix: flush runs on alternating cycles. After fix: flush runs on every cycle.

## Compatibility
Backward-compatible. Existing sessions may have synced counters from the old bug; the next compaction after this fix will desync them naturally.

## Risks
None — the dedup logic still prevents double-flushing within the same compaction count.

*This PR was AI-assisted (fully tested with pnpm build/check/test).*