### PR TITLE
docs(browser): clarify existing-session setup for profile="user"

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -381,6 +381,14 @@ Then in Chrome:
 2. Enable remote debugging
 3. Keep Chrome running and approve the connection prompt when OpenClaw attaches
 
+Important:
+
+- Do **not** use `--remote-debugging-port` for this flow. On modern Chrome,
+  default-profile launches reject that mode unless you use a separate
+  non-default user data directory, which defeats signed-in session reuse.
+- `driver: "existing-session"` uses Chrome DevTools MCP attach (consent prompt),
+  not the legacy raw-CDP port workflow.
+
 Live attach smoke test:
 
 ```bash


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: docs for `profile="user"`/`driver: "existing-session"` did not explicitly warn against using `--remote-debugging-port`, which led to setup confusion.
- Why it matters: users trying to reuse signed-in Chrome sessions can get blocked by Chrome’s default-profile restrictions and assume OpenClaw is misconfigured.
- What changed: added an explicit **Important** note in `docs/tools/browser.md` under "Chrome existing-session via MCP" clarifying this flow uses MCP attach, not legacy raw CDP port.
- What did NOT change (scope boundary): no runtime behavior, config keys, drivers, or CLI behavior changed; docs-only update.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46483
- Related #46495

## User-visible / Behavior Changes

Docs now explicitly state that `profile="user"` (`driver: "existing-session"`) should not be set up with `--remote-debugging-port`; this mode uses Chrome DevTools MCP attach and consent prompts.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: local node/pnpm workspace
- Model/provider: N/A (docs-only)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Update docs note under `docs/tools/browser.md` in "Chrome existing-session via MCP".
2. Run `pnpm dlx markdownlint-cli2 docs/tools/browser.md`.
3. Confirm lint passes with zero errors.

### Expected

- Updated docs clearly distinguish MCP attach from legacy `--remote-debugging-port` workflow.
- Markdown lint passes.

### Actual

- Note added as intended.
- `markdownlint-cli2` summary: `0 error(s)`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the existing-session setup section end-to-end to ensure flow is consistent with MCP attach semantics and related notes.
- Edge cases checked: wording avoids claiming runtime changes; note explains why default-profile `--remote-debugging-port` path is unsuitable for signed-in session reuse.
- What you did **not** verify: live Chrome attach flow on all OS variants (not needed for docs-only wording update).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `docs/tools/browser.md`.
- Known bad symptoms reviewers should watch for: none beyond potential wording ambiguity.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: wording could still be interpreted as generic Chrome guidance outside OpenClaw context.
  - Mitigation: note is scoped to `driver: "existing-session"` section and explicitly references MCP attach flow.
