### PR TITLE
fix(gateway): handle opaque origins for custom URL schemes in allowedOrigins

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -92,6 +92,36 @@ describe("checkBrowserOrigin", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts custom URL schemes (tauri://) in allowedOrigins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.local:18789",
+      origin: "tauri://localhost",
+      allowedOrigins: ["tauri://localhost", "https://example.com"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.matchedBy).toBe("allowlist");
+    }
+  });
+
+  it("accepts custom URL schemes (electron://) in allowedOrigins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.local:18789",
+      origin: "electron://app",
+      allowedOrigins: ["electron://app"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects custom URL schemes not in allowedOrigins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.local:18789",
+      origin: "tauri://localhost",
+      allowedOrigins: ["https://example.com"],
+    });
+    expect(result.ok).toBe(false);
+  });
+
   it("accepts wildcard entries with surrounding whitespace", () => {
     const result = checkBrowserOrigin({
       requestHost: "100.86.79.37:18789",

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -16,8 +16,12 @@ function parseOrigin(
   }
   try {
     const url = new URL(trimmed);
+    // Non-standard schemes (tauri://, electron://) produce an opaque "null"
+    // origin per the URL spec.  Reconstruct it from protocol + host so the
+    // allowlist comparison works.
+    const derived = url.origin === "null" ? `${url.protocol}//${url.host}` : url.origin;
     return {
-      origin: url.origin.toLowerCase(),
+      origin: derived.toLowerCase(),
       host: url.host.toLowerCase(),
       hostname: url.hostname.toLowerCase(),
     };


### PR DESCRIPTION
When `allowedOrigins` includes a non-standard scheme like `tauri://localhost` or `electron://app`, the origin check always rejects them — even though the wildcard (`"*"`) path works fine.

The root cause is that `new URL("tauri://localhost").origin` returns the string `"null"` per the URL spec (opaque origin for unknown schemes).  So the parsed origin never matches the allowlist entry.

This reconstructs the origin from `protocol + "//" + host` when the URL parser gives back an opaque origin, making the allowlist comparison work as expected.

Added tests for tauri:// and electron:// schemes (both accepted and rejected cases).

Closes #46520