### PR TITLE
fix(test): remove unused expectSupportsUsageInStreamingForcedOff helper

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -87,13 +87,6 @@ function expectSupportsDeveloperRoleForcedOff(overrides?: Partial<Model<Api>>): 
   expect(supportsDeveloperRole(normalized)).toBe(false);
 }
 
-function expectSupportsUsageInStreamingForcedOff(overrides?: Partial<Model<Api>>): void {
-  const model = { ...baseModel(), ...overrides };
-  delete (model as { compat?: unknown }).compat;
-  const normalized = normalizeModelCompat(model as Model<Api>);
-  expect(supportsUsageInStreaming(normalized)).toBe(false);
-}
-
 function expectResolvedForwardCompat(
   model: Model<Api> | undefined,
   expected: { provider: string; id: string },

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -684,7 +684,8 @@ export function attachGatewayWsMessageHandler(params: {
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,
-          }) || shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
+          }) ||
+          shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {


### PR DESCRIPTION
## Summary

`expectSupportsUsageInStreamingForcedOff` in `model-compat.test.ts` is declared but never called, causing `oxlint --type-aware` to report an error on every PR CI run.

## Root Cause

Commit bb06dc7cc9 (fix(agents): restore usage tracking for non-native openai-completions providers) changed the test assertions from `toBe(false)` to `toBeUndefined()` and inlined the assertions, but left the now-unused helper function behind.

## Impact

Every PR rebased on current `main` fails the `check` CI job with:
```
Function 'expectSupportsUsageInStreamingForcedOff' is declared but never used.
```

## Changes

- Removed the unused `expectSupportsUsageInStreamingForcedOff` function (5 lines)
- No behavioral changes, no test coverage lost (the function was not called by any test)