### PR TITLE
fix(tts): propagate audioAsVoice from tool results to delivery payload

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -15,7 +15,7 @@ import type {
 import {
   extractMessagingToolSend,
   extractToolErrorMessage,
-  extractToolResultMediaPaths,
+  extractToolResultMedia,
   extractToolResultText,
   filterToolResultMediaUrls,
   isToolResultError,
@@ -284,12 +284,16 @@ async function emitToolResultOutput(params: {
 
   // emitToolOutput() already handles MEDIA: directives when enabled; this path
   // only sends raw media URLs for non-verbose delivery mode.
-  const mediaPaths = filterToolResultMediaUrls(toolName, extractToolResultMediaPaths(result));
+  const extracted = extractToolResultMedia(result);
+  const mediaPaths = filterToolResultMediaUrls(toolName, extracted.paths);
   if (mediaPaths.length === 0) {
     return;
   }
   try {
-    void ctx.params.onToolResult({ mediaUrls: mediaPaths });
+    void ctx.params.onToolResult({
+      mediaUrls: mediaPaths,
+      ...(extracted.audioAsVoice ? { audioAsVoice: true } : {}),
+    });
   } catch {
     // ignore delivery failures
   }

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { extractToolResultMediaPaths } from "./pi-embedded-subscribe.tools.js";
+import {
+  extractToolResultMedia,
+  extractToolResultMediaPaths,
+} from "./pi-embedded-subscribe.tools.js";
 
 describe("extractToolResultMediaPaths", () => {
   it("returns empty array for null/undefined", () => {
@@ -228,5 +231,53 @@ describe("extractToolResultMediaPaths", () => {
       ],
     };
     expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/page1.png", "/tmp/page2.png"]);
+  });
+});
+
+describe("extractToolResultMedia", () => {
+  it("detects [[audio_as_voice]] tag and propagates audioAsVoice", () => {
+    const result = {
+      content: [
+        {
+          type: "text",
+          text: "[[audio_as_voice]]\nMEDIA:/tmp/openclaw/tts-abc/voice-123.mp3",
+        },
+      ],
+    };
+    const extracted = extractToolResultMedia(result);
+    expect(extracted.paths).toEqual(["/tmp/openclaw/tts-abc/voice-123.mp3"]);
+    expect(extracted.audioAsVoice).toBe(true);
+  });
+
+  it("does not set audioAsVoice when tag is absent", () => {
+    const result = {
+      content: [
+        {
+          type: "text",
+          text: "MEDIA:/tmp/screenshot.png",
+        },
+      ],
+    };
+    const extracted = extractToolResultMedia(result);
+    expect(extracted.paths).toEqual(["/tmp/screenshot.png"]);
+    expect(extracted.audioAsVoice).toBeUndefined();
+  });
+
+  it("detects audioAsVoice across multiple text blocks", () => {
+    const result = {
+      content: [
+        { type: "text", text: "[[audio_as_voice]]" },
+        { type: "text", text: "MEDIA:/tmp/voice.opus" },
+      ],
+    };
+    const extracted = extractToolResultMedia(result);
+    expect(extracted.paths).toEqual(["/tmp/voice.opus"]);
+    expect(extracted.audioAsVoice).toBe(true);
+  });
+
+  it("returns empty paths for null input", () => {
+    const extracted = extractToolResultMedia(null);
+    expect(extracted.paths).toEqual([]);
+    expect(extracted.audioAsVoice).toBeUndefined();
   });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -193,20 +193,40 @@ export function filterToolResultMediaUrls(
  * returns base64 image data but no file path; those need a different delivery
  * path like saving to a temp file).
  */
+export interface ExtractedToolResultMedia {
+  paths: string[];
+  audioAsVoice?: boolean;
+}
+
 export function extractToolResultMediaPaths(result: unknown): string[] {
+  return extractToolResultMedia(result).paths;
+}
+
+/**
+ * Extract media file paths **and** voice-bubble intent from a tool result.
+ *
+ * Strategy (first match wins):
+ * 1. Parse `MEDIA:` tokens from text content blocks (all OpenClaw tools).
+ * 2. Fall back to `details.path` when image content exists (OpenClaw imageResult).
+ *
+ * Additionally detects `[[audio_as_voice]]` tags in text content so callers can
+ * propagate the voice-bubble flag to the delivery payload.
+ */
+export function extractToolResultMedia(result: unknown): ExtractedToolResultMedia {
   if (!result || typeof result !== "object") {
-    return [];
+    return { paths: [] };
   }
   const record = result as Record<string, unknown>;
   const content = Array.isArray(record.content) ? record.content : null;
   if (!content) {
-    return [];
+    return { paths: [] };
   }
 
   // Extract MEDIA: paths from text content blocks using the shared parser so
   // directive matching and validation stay in sync with outbound reply parsing.
   const paths: string[] = [];
   let hasImageContent = false;
+  let audioAsVoice = false;
   for (const item of content) {
     if (!item || typeof item !== "object") {
       continue;
@@ -221,11 +241,14 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
       if (parsed.mediaUrls?.length) {
         paths.push(...parsed.mediaUrls);
       }
+      if (parsed.audioAsVoice) {
+        audioAsVoice = true;
+      }
     }
   }
 
   if (paths.length > 0) {
-    return paths;
+    return { paths, ...(audioAsVoice ? { audioAsVoice: true } : {}) };
   }
 
   // Fall back to details.path when image content exists but no MEDIA: text.
@@ -233,11 +256,11 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     const details = record.details as Record<string, unknown> | undefined;
     const p = typeof details?.path === "string" ? details.path.trim() : "";
     if (p) {
-      return [p];
+      return { paths: [p] };
     }
   }
 
-  return [];
+  return { paths: [] };
 }
 
 export function isToolResultError(result: unknown): boolean {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -334,7 +334,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!params.onToolResult) {
       return;
     }
-    const { text: cleanedText, mediaUrls } = parseReplyDirectives(message);
+    const { text: cleanedText, mediaUrls, audioAsVoice } = parseReplyDirectives(message);
     const filteredMediaUrls = filterToolResultMediaUrls(toolName, mediaUrls ?? []);
     if (!cleanedText && filteredMediaUrls.length === 0) {
       return;
@@ -343,6 +343,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       void params.onToolResult({
         text: cleanedText,
         mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
+        ...(audioAsVoice ? { audioAsVoice: true } : {}),
       });
     } catch {
       // ignore tool result delivery failures


### PR DESCRIPTION
## Problem

When the TTS tool returns `[[audio_as_voice]]` alongside a `MEDIA:` path in its tool result, the voice-bubble flag is lost during tool result extraction. This causes TTS audio to be sent as a **file attachment** instead of a **voice bubble** on Telegram (and other voice-capable channels like WhatsApp/Feishu).

## Root cause

`extractToolResultMediaPaths()` only extracts file paths from tool results, discarding the `audioAsVoice` field that `splitMediaFromOutput()` correctly parses from `[[audio_as_voice]]` tags.

The extracted media is then passed to `onToolResult({ mediaUrls })` without the voice flag, so Telegram's `sendVoice` path is never triggered — it falls through to `sendAudio` (file attachment).

Two code paths are affected:
1. **Non-verbose path** (`emitToolResultOutput` in `handlers.tools.ts`): uses `extractToolResultMediaPaths` → loses `audioAsVoice`
2. **Verbose path** (`emitToolResultMessage` in `pi-embedded-subscribe.ts`): calls `parseReplyDirectives` which returns `audioAsVoice`, but the field was not propagated to the `onToolResult` payload

## Fix

- Add `extractToolResultMedia()` that returns `{ paths: string[], audioAsVoice?: boolean }`
- Keep `extractToolResultMediaPaths()` as a backward-compatible wrapper
- Propagate `audioAsVoice` to the `onToolResult` payload in both code paths
- Add tests covering `[[audio_as_voice]]` detection in tool results

## Testing

- All 29 existing + 4 new tests pass in `pi-embedded-subscribe.tools.media.test.ts`
- Manually verified: TTS tool result with `[[audio_as_voice]]\nMEDIA:path.mp3` was arriving as file attachment on Telegram; after fix, `audioAsVoice: true` is correctly set on the delivery payload