### PR TITLE
feat(onboard): run preflight checks after setup completes

### DIFF
--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -237,6 +237,10 @@ export async function runNonInteractiveOnboardingLocal(params: {
       return;
     }
     await healthCommand({ json: false, timeoutMs: 10_000 }, runtime);
+
+    // Post-onboard preflight: validate config, auth, workspace, and model after full setup.
+    const { runPostOnboardPreflight } = await import("../onboard-preflight.js");
+    await runPostOnboardPreflight(nextConfig, runtime);
   }
 
   logNonInteractiveOnboardingJson({

--- a/src/commands/onboard-preflight.test.ts
+++ b/src/commands/onboard-preflight.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+const readConfigFileSnapshot = vi.hoisted(() =>
+  vi.fn(async () => ({
+    path: "/mock/.openclaw/openclaw.json",
+    exists: true,
+    raw: "{}",
+    parsed: {},
+    resolved: {} as OpenClawConfig,
+    valid: true,
+    config: {} as OpenClawConfig,
+    issues: [],
+  })),
+);
+
+const probeGatewayReachable = vi.hoisted(() => vi.fn(async () => ({ ok: true })));
+
+const resolveControlUiLinks = vi.hoisted(() =>
+  vi.fn(() => ({ wsUrl: "ws://localhost:18789", httpUrl: "http://localhost:18789" })),
+);
+
+const buildAuthHealthSummary = vi.hoisted(() =>
+  vi.fn(
+    () =>
+      ({
+        now: Date.now(),
+        warnAfterMs: 86400000,
+        profiles: [],
+        providers: [],
+      }) as {
+        now: number;
+        warnAfterMs: number;
+        profiles: unknown[];
+        providers: { provider: string; status: string; profiles: unknown[] }[];
+      },
+  ),
+);
+
+const loadAuthProfileStore = vi.hoisted(() => vi.fn(() => ({})));
+
+const loadModelCatalog = vi.hoisted(() => vi.fn(async () => []));
+
+const resolveConfiguredModelRef = vi.hoisted(() =>
+  vi.fn(() => ({ provider: "anthropic", model: "claude-sonnet-4-5-20250514" })),
+);
+
+const getModelRefStatus = vi.hoisted(() =>
+  vi.fn(() => ({
+    key: "anthropic/claude-sonnet-4-5-20250514",
+    inCatalog: true,
+    allowAny: false,
+    allowed: true,
+  })),
+);
+
+const formatCliCommand = vi.hoisted(() => vi.fn((cmd: string) => cmd));
+
+const fsAccess = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("node:fs/promises", () => ({ access: fsAccess, constants: { W_OK: 2 } }));
+vi.mock("../config/io.js", () => ({ readConfigFileSnapshot }));
+vi.mock("./onboard-helpers.js", () => ({ probeGatewayReachable, resolveControlUiLinks }));
+vi.mock("../agents/auth-health.js", () => ({ buildAuthHealthSummary }));
+vi.mock("../agents/auth-profiles/store.js", () => ({ loadAuthProfileStore }));
+vi.mock("../agents/model-catalog.js", () => ({ loadModelCatalog }));
+vi.mock("../agents/model-selection.js", () => ({ resolveConfiguredModelRef, getModelRefStatus }));
+vi.mock("../agents/defaults.js", () => ({
+  DEFAULT_MODEL: "claude-sonnet-4-5-20250514",
+  DEFAULT_PROVIDER: "anthropic",
+}));
+vi.mock("../cli/command-format.js", () => ({ formatCliCommand }));
+vi.mock("../utils.js", () => ({ resolveUserPath: (p: string) => p.replace("~", "/mock") }));
+
+import { runPostOnboardPreflight } from "./onboard-preflight.js";
+
+function createRuntime(): RuntimeEnv {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as unknown as RuntimeEnv;
+}
+
+describe("runPostOnboardPreflight", () => {
+  let runtime: RuntimeEnv;
+
+  beforeEach(() => {
+    runtime = createRuntime();
+    vi.clearAllMocks();
+
+    // Reset to passing defaults
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/mock/.openclaw/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      resolved: {} as OpenClawConfig,
+      valid: true,
+      config: {} as OpenClawConfig,
+      issues: [],
+    });
+    probeGatewayReachable.mockResolvedValue({ ok: true });
+    buildAuthHealthSummary.mockReturnValue({
+      now: Date.now(),
+      warnAfterMs: 86400000,
+      profiles: [],
+      providers: [{ provider: "anthropic", status: "ok", profiles: [] }],
+    });
+    getModelRefStatus.mockReturnValue({
+      key: "anthropic/claude-sonnet-4-5-20250514",
+      inCatalog: true,
+      allowAny: false,
+      allowed: true,
+    });
+  });
+
+  it("prints all-pass when every check succeeds", async () => {
+    await runPostOnboardPreflight({} as OpenClawConfig, runtime);
+
+    const output = (runtime.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(output).toContain("[PASS] Config");
+    expect(output).toContain("[PASS] Gateway");
+    expect(output).toContain("[PASS] Auth");
+    expect(output).toContain("[PASS] Workspace");
+    expect(output).toContain("[PASS] Model");
+    expect(output).not.toContain("issue");
+  });
+
+  it("shows WARN and doctor hint for failed config", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/mock/.openclaw/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      resolved: {} as OpenClawConfig,
+      valid: false,
+      config: {} as OpenClawConfig,
+      issues: [{ message: "unknown key: hooks" } as never],
+    });
+
+    await runPostOnboardPreflight({} as OpenClawConfig, runtime);
+
+    const output = (runtime.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(output).toContain("[FAIL] Config");
+    expect(output).toContain("unknown key: hooks");
+    expect(output).toContain("openclaw doctor");
+  });
+
+  it("shows WARN for unreachable gateway", async () => {
+    probeGatewayReachable.mockResolvedValue({ ok: false, detail: "connection refused" } as never);
+
+    await runPostOnboardPreflight({} as OpenClawConfig, runtime);
+
+    const output = (runtime.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(output).toContain("[WARN] Gateway");
+    expect(output).toContain("connection refused");
+  });
+
+  it("shows WARN for expired auth", async () => {
+    buildAuthHealthSummary.mockReturnValue({
+      now: Date.now(),
+      warnAfterMs: 86400000,
+      profiles: [],
+      providers: [{ provider: "anthropic", status: "expired", profiles: [] }],
+    });
+
+    await runPostOnboardPreflight({} as OpenClawConfig, runtime);
+
+    const output = (runtime.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(output).toContain("[WARN] Auth");
+    expect(output).toContain("token expired");
+  });
+
+  it("skips gateway and workspace checks in remote mode", async () => {
+    await runPostOnboardPreflight({} as OpenClawConfig, runtime, { isRemote: true });
+
+    expect(probeGatewayReachable).not.toHaveBeenCalled();
+    const output = (runtime.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(output).not.toContain("Gateway");
+    expect(output).not.toContain("Workspace");
+    expect(output).toContain("[PASS] Config");
+    expect(output).toContain("[PASS] Model");
+  });
+
+  it("shows WARN for model not in catalog", async () => {
+    getModelRefStatus.mockReturnValue({
+      key: "anthropic/nonexistent-model",
+      inCatalog: false,
+      allowAny: false,
+      allowed: false,
+    });
+
+    await runPostOnboardPreflight({} as OpenClawConfig, runtime);
+
+    const output = (runtime.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(output).toContain("[WARN] Model");
+    expect(output).toContain("not in catalog");
+  });
+
+  it("treats empty auth store as passing", async () => {
+    loadAuthProfileStore.mockImplementation(() => {
+      throw new Error("no store");
+    });
+
+    await runPostOnboardPreflight({} as OpenClawConfig, runtime);
+
+    const output = (runtime.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(output).toContain("[PASS] Auth");
+    expect(output).toContain("no auth profiles configured");
+  });
+});

--- a/src/commands/onboard-preflight.ts
+++ b/src/commands/onboard-preflight.ts
@@ -1,0 +1,226 @@
+import { access, constants } from "node:fs/promises";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+type PreflightCheckResult = {
+  name: string;
+  status: "pass" | "warn" | "fail";
+  detail: string;
+};
+
+/**
+ * Run lightweight preflight checks after onboarding completes.
+ * Each check reuses existing subsystem code and has a 3-second timeout.
+ * Results are printed but never block setup completion.
+ */
+export async function runPostOnboardPreflight(
+  cfg: OpenClawConfig,
+  runtime: RuntimeEnv,
+  opts?: { isRemote?: boolean },
+): Promise<void> {
+  const checks: Promise<PreflightCheckResult>[] = [checkConfig()];
+
+  if (!opts?.isRemote) {
+    checks.push(checkGateway(cfg));
+    checks.push(checkWorkspace(cfg));
+  }
+
+  checks.push(checkAuth(cfg));
+  checks.push(checkModel(cfg));
+
+  const results = await Promise.allSettled(checks);
+  const resolved: PreflightCheckResult[] = results.map((r, i) =>
+    r.status === "fulfilled"
+      ? r.value
+      : { name: `check-${i}`, status: "fail" as const, detail: String(r.reason) },
+  );
+
+  const warnCount = resolved.filter((r) => r.status === "warn").length;
+  const failCount = resolved.filter((r) => r.status === "fail").length;
+  const issueCount = warnCount + failCount;
+
+  const lines = ["", "Preflight checks:"];
+  for (const r of resolved) {
+    const icon = r.status === "pass" ? "PASS" : r.status === "warn" ? "WARN" : "FAIL";
+    lines.push(`  [${icon}] ${r.name} (${r.detail})`);
+  }
+
+  if (issueCount > 0) {
+    const { formatCliCommand } = await import("../cli/command-format.js");
+    lines.push(
+      "",
+      `${issueCount} issue${issueCount > 1 ? "s" : ""} found. Run ${formatCliCommand("openclaw doctor")} for detailed diagnostics.`,
+    );
+  }
+
+  runtime.log(lines.join("\n"));
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
+  ]);
+}
+
+const TIMEOUT_MS = 3_000;
+
+async function checkConfig(): Promise<PreflightCheckResult> {
+  return withTimeout(
+    (async (): Promise<PreflightCheckResult> => {
+      const { readConfigFileSnapshot } = await import("../config/io.js");
+      const snapshot = await readConfigFileSnapshot();
+
+      if (!snapshot.exists) {
+        return { name: "Config", status: "fail", detail: "openclaw.json not found" };
+      }
+      if (!snapshot.valid) {
+        const firstIssue = snapshot.issues?.[0];
+        const detail = firstIssue ? (firstIssue.message ?? "validation error") : "invalid config";
+        return { name: "Config", status: "fail", detail };
+      }
+      return { name: "Config", status: "pass", detail: "openclaw.json valid" };
+    })(),
+    TIMEOUT_MS,
+    { name: "Config", status: "warn", detail: "check timed out" },
+  );
+}
+
+async function checkGateway(cfg: OpenClawConfig): Promise<PreflightCheckResult> {
+  return withTimeout(
+    (async (): Promise<PreflightCheckResult> => {
+      const { probeGatewayReachable, resolveControlUiLinks } = await import("./onboard-helpers.js");
+
+      const port = cfg.gateway?.port ?? 18789;
+      const bind = cfg.gateway?.bind ?? "loopback";
+      const links = resolveControlUiLinks({
+        bind: bind as "auto" | "lan" | "loopback" | "custom" | "tailnet",
+        port,
+        customBindHost: cfg.gateway?.customBindHost,
+        basePath: undefined,
+      });
+
+      const probe = await probeGatewayReachable({
+        url: links.wsUrl,
+        timeoutMs: 2_500,
+      });
+
+      return probe.ok
+        ? { name: "Gateway", status: "pass", detail: `reachable at port ${port}` }
+        : {
+            name: "Gateway",
+            status: "warn",
+            detail: probe.detail ?? "not reachable",
+          };
+    })(),
+    TIMEOUT_MS,
+    { name: "Gateway", status: "warn", detail: "check timed out" },
+  );
+}
+
+async function checkAuth(cfg: OpenClawConfig): Promise<PreflightCheckResult> {
+  return withTimeout(
+    (async (): Promise<PreflightCheckResult> => {
+      const { buildAuthHealthSummary } = await import("../agents/auth-health.js");
+      const { loadAuthProfileStore } = await import("../agents/auth-profiles/store.js");
+
+      let store;
+      try {
+        store = loadAuthProfileStore();
+      } catch {
+        // No auth store is valid (e.g. --auth-choice skip).
+        return { name: "Auth", status: "pass", detail: "no auth profiles configured" };
+      }
+
+      const summary = buildAuthHealthSummary({ store, cfg });
+
+      if (summary.providers.length === 0) {
+        return { name: "Auth", status: "pass", detail: "no providers configured" };
+      }
+
+      const expired = summary.providers.filter((p) => p.status === "expired");
+      const missing = summary.providers.filter((p) => p.status === "missing");
+
+      if (expired.length > 0) {
+        return {
+          name: "Auth",
+          status: "warn",
+          detail: `${expired[0].provider} token expired`,
+        };
+      }
+      if (missing.length > 0) {
+        return {
+          name: "Auth",
+          status: "warn",
+          detail: `${missing[0].provider} credentials missing`,
+        };
+      }
+      return { name: "Auth", status: "pass", detail: "credentials valid" };
+    })(),
+    TIMEOUT_MS,
+    { name: "Auth", status: "warn", detail: "check timed out" },
+  );
+}
+
+async function checkWorkspace(cfg: OpenClawConfig): Promise<PreflightCheckResult> {
+  return withTimeout(
+    (async (): Promise<PreflightCheckResult> => {
+      const workspaceDir = cfg.agents?.defaults?.workspace ?? "~/.openclaw/workspace";
+      const { resolveUserPath } = await import("../utils.js");
+      const resolved = resolveUserPath(workspaceDir);
+
+      try {
+        await access(resolved, constants.W_OK);
+        return { name: "Workspace", status: "pass", detail: "writable" };
+      } catch {
+        return {
+          name: "Workspace",
+          status: "warn",
+          detail: `${workspaceDir} not writable`,
+        };
+      }
+    })(),
+    TIMEOUT_MS,
+    { name: "Workspace", status: "warn", detail: "check timed out" },
+  );
+}
+
+async function checkModel(cfg: OpenClawConfig): Promise<PreflightCheckResult> {
+  return withTimeout(
+    (async (): Promise<PreflightCheckResult> => {
+      const { loadModelCatalog } = await import("../agents/model-catalog.js");
+      const { resolveConfiguredModelRef, getModelRefStatus } =
+        await import("../agents/model-selection.js");
+      const { DEFAULT_MODEL, DEFAULT_PROVIDER } = await import("../agents/defaults.js");
+
+      const catalog = await loadModelCatalog({ config: cfg });
+      const ref = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      });
+      const status = getModelRefStatus({
+        cfg,
+        catalog,
+        ref,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      });
+
+      if (status.inCatalog || status.allowAny) {
+        return {
+          name: "Model",
+          status: "pass",
+          detail: `${ref.provider}/${ref.model}`,
+        };
+      }
+      return {
+        name: "Model",
+        status: "warn",
+        detail: `${ref.provider}/${ref.model} not in catalog`,
+      };
+    })(),
+    TIMEOUT_MS,
+    { name: "Model", status: "warn", detail: "check timed out" },
+  );
+}

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -684,7 +684,8 @@ export function attachGatewayWsMessageHandler(params: {
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,
-          }) || shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
+          }) ||
+          shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -249,6 +249,10 @@ export async function finalizeOnboardingWizard(
         "Health check help",
       );
     }
+
+    // Post-onboard preflight: validate config, auth, workspace, and model after full setup.
+    const { runPostOnboardPreflight } = await import("../commands/onboard-preflight.js");
+    await runPostOnboardPreflight(nextConfig, runtime);
   }
 
   const controlUiEnabled =


### PR DESCRIPTION
## Summary

- Add `runPostOnboardPreflight()` that runs 5 focused checks at the end of `openclaw onboard` to catch common first-run failures before the user's first session
- Checks: config valid, gateway reachable, provider auth valid, workspace writable, default model available
- Each check reuses existing subsystem code, runs in parallel with 3s timeout, non-blocking
- Gated by existing `skipHealth` flag, remote mode skips gateway + workspace checks

## Problem

New users complete onboarding "successfully" but hit failures on their first agent run. The onboard finalize flow probes gateway reachability but does NOT validate config keys, auth tokens, workspace integrity, or model availability. Users only discover `openclaw doctor` after hours of debugging.

Community evidence that first-run setup is a pain point:
- [r/openclaw: "I've helped 50+ people debug their OpenClaw"](https://www.reddit.com/r/openclaw/comments/1rp8t9r/) (347 upvotes, 65 comments) - same 5 mistakes in every setup
- [r/openclaw: "thought i'd spend a weekend setting up openclaw. its been 3 weekends"](https://www.reddit.com/r/openclaw/comments/1ro99no/) (63 upvotes)

## What this PR does and does not do

**Does:** Surface warnings immediately after onboard completes, so users know something is wrong before their first agent run. Points them to `openclaw doctor` for fixes.

**Does not:** Fix the underlying issues. Config crash-loops (#25007, #40268), late workspace validation (#25622), and silent model acceptance (#20522) are separate bugs that need their own fixes. This PR is a detection layer, not a repair tool.

## Changes

**New files:**
- `src/commands/onboard-preflight.ts` (~190 lines) - preflight check runner with 5 checks
- `src/commands/onboard-preflight.test.ts` (~170 lines) - 7 test cases

**Modified files:**
- `src/wizard/onboarding.finalize.ts` - call preflight after existing health check (+4 lines)
- `src/commands/onboard-non-interactive/local.ts` - same for non-interactive path (+4 lines)

## Output

```
Preflight checks:
  [PASS] Config (openclaw.json valid)
  [PASS] Gateway (reachable at port 18789)
  [WARN] Auth (anthropic token expired)
  [PASS] Workspace (writable)
  [PASS] Model (anthropic/claude-sonnet-4-5-20250514)

1 issue found. Run openclaw doctor for detailed diagnostics.
```

## Design decisions

- **No new CLI command** - `openclaw doctor` serves as the recheck tool. Avoids adding surface area.
- **No new options** - reuses existing `skipHealth` flag instead of adding `--skip-preflight`.
- **Dynamic imports only** - follows repo convention to avoid bloating onboard module startup.
- **Read-only checks** - preflight validates but never creates/fixes (that's `openclaw doctor --fix`).
- **File named `onboard-preflight.ts`** - follows existing `onboard-*.ts` convention.

<details>
<summary>Research & Context</summary>

### Motivation (related issues - not fixed by this PR, but motivate why early detection matters)
- #25007 - Config SPOF: one bad key kills gateway. Preflight would warn about invalid config before first run.
- #40268, #40264, #27455 - Config crash-loop variants. Preflight catches the symptom (invalid config) but not the root cause (strict schema, no backoff).
- #20522 - Invalid model identifier accepted silently. Preflight warns if model isn't in catalog, but doesn't block config writes.
- #25622 - Workspace validation too late. Preflight checks writability post-onboard, but doesn't move the validation earlier in the wizard.
- #23538 - Auth 401 failures. Preflight checks credential status, but can't verify tokens actually authenticate.
- #41372 - Field report: 25 findings. Config crashes listed as #1 critical. Preflight gives users an earlier signal.

### Social Signals
- Reddit r/openclaw: 347 upvotes on "5 mistakes in every setup"
- X: Users reporting $800-$1000 burned from wrong model defaults
- X: @steipete promoting third-party memory plugin (signals stock DX gaps)

### Competitive Analysis
OpenClaw has 10-20x larger config surface than Claude Code or Cursor (gateway, channels, skills, plugins, workspace, model routing). Neither competitor needs preflight checks because their config surface is tiny. This is why early detection matters here.

</details>

## Test plan

- [x] `pnpm test -- src/commands/onboard-preflight.test.ts` - 7 tests pass
- [x] `pnpm tsgo` - no type errors
- [x] `pnpm format` - clean
- [ ] Manual: run `openclaw onboard` and verify preflight output appears after health check
- [ ] Manual: run with `--skip-health` and verify preflight is skipped

This contribution was developed with AI assistance (Claude Code).