### PR TITLE
docs(queue): clarify steer behavior with partial streaming and tool boundaries

### DIFF
--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -62,7 +62,7 @@ Configure globally or per channel via `messages.queue`:
 
 Options apply to `followup`, `collect`, and `steer-backlog` (and to `steer` when it falls back to followup):
 
-- `debounceMs`: wait for quiet before starting a followup turn (prevents “continue, continue”).
+- `debounceMs`: wait for quiet before starting a followup turn (prevents "continue, continue").
 - `cap`: max queued messages per session.
 - `drop`: overflow policy (`old`, `new`, `summarize`).
 
@@ -83,7 +83,17 @@ Defaults: `debounceMs: 1000`, `cap: 20`, `drop: summarize`.
 - Per-session lanes guarantee that only one agent run touches a given session at a time.
 - No external dependencies or background worker threads; pure TypeScript + promises.
 
+## Steer and partial streaming
+
+When `channels.<provider>.streaming` is set to `partial` (or `block`), the agent emits intermediate draft messages as it works. This can make `steer` look like it is not working when it is:
+
+- Each steered message is picked up quickly between partial-stream flushes and triggers a small status reply immediately, so several short responses appear in sequence.
+- Without partial streaming the same behavior produces a single final response — the steer still fired, it just wasn't visible mid-run.
+
+`steer` is not a hard abort. It injects the incoming message at the next tool boundary, but any tool call already in flight (e.g. a subprocess or network request) will run to completion before the injected message takes effect. If you need to stop an in-flight tool immediately, use `interrupt` mode instead (legacy, aborts the active run).
+
 ## Troubleshooting
 
-- If commands seem stuck, enable verbose logs and look for “queued for …ms” lines to confirm the queue is draining.
+- If commands seem stuck, enable verbose logs and look for "queued for …ms" lines to confirm the queue is draining.
 - If you need queue depth, enable verbose logs and watch for queue timing lines.
+- If `steer` appears to do nothing: check that the session queue mode is actually `steer` (run `/queue` to confirm — a per-session override silently trumps the config value). Also confirm that `channels.<provider>.streaming` is not `off`; steer falls back to `followup` when the run is not streaming.

--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -89,7 +89,7 @@ When `channels.<provider>.streaming` is set to `partial` or `block`, steer can p
 
 - With `streaming: partial`, the agent continuously updates a single preview message in place. A steer injection causes that preview to be committed early and a new preview started for the injected turn, so you see several short finalized replies in sequence rather than one final response.
 - With `streaming: block`, the agent emits multiple draft-sized chunks directly, producing the same sequential appearance by a different mechanism.
-- Without streaming the same steer behavior produces a single final response — the steer still fired, it just wasn't visible mid-run.
+- Without streaming, steer falls back to `followup`: the active run completes first, then the steered message is processed as a separate turn.
 
 `steer` is not a hard abort. It injects the incoming message at the next tool boundary, but any tool call already in flight (e.g. a subprocess or network request) will run to completion before the injected message takes effect. If you need to stop an in-flight tool immediately, use `interrupt` mode instead (legacy, aborts the active run).
 

--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -62,7 +62,7 @@ Configure globally or per channel via `messages.queue`:
 
 Options apply to `followup`, `collect`, and `steer-backlog` (and to `steer` when it falls back to followup):
 
-- `debounceMs`: wait for quiet before starting a followup turn (prevents "continue, continue").
+- `debounceMs`: wait for quiet before starting a followup turn (prevents “continue, continue”).
 - `cap`: max queued messages per session.
 - `drop`: overflow policy (`old`, `new`, `summarize`).
 
@@ -95,6 +95,6 @@ When `channels.<provider>.streaming` is set to `partial` or `block`, steer can p
 
 ## Troubleshooting
 
-- If commands seem stuck, enable verbose logs and look for "queued for …ms" lines to confirm the queue is draining.
+- If commands seem stuck, enable verbose logs and look for “queued for …ms” lines to confirm the queue is draining.
 - If you need queue depth, enable verbose logs and watch for queue timing lines.
 - If `steer` appears to do nothing: check that the session queue mode is actually `steer` (run `/queue` to confirm — a per-session override silently trumps the config value). Also confirm that `channels.<provider>.streaming` is not `off`; steer falls back to `followup` when the run is not streaming.

--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -85,10 +85,11 @@ Defaults: `debounceMs: 1000`, `cap: 20`, `drop: summarize`.
 
 ## Steer and partial streaming
 
-When `channels.<provider>.streaming` is set to `partial` (or `block`), the agent emits intermediate draft messages as it works. This can make `steer` look like it is not working when it is:
+When `channels.<provider>.streaming` is set to `partial` or `block`, steer can produce visible intermediate replies that may look like sequential turns rather than a single redirected response:
 
-- Each steered message is picked up quickly between partial-stream flushes and triggers a small status reply immediately, so several short responses appear in sequence.
-- Without partial streaming the same behavior produces a single final response — the steer still fired, it just wasn't visible mid-run.
+- With `streaming: partial`, the agent continuously updates a single preview message in place. A steer injection causes that preview to be committed early and a new preview started for the injected turn, so you see several short finalized replies in sequence rather than one final response.
+- With `streaming: block`, the agent emits multiple draft-sized chunks directly, producing the same sequential appearance by a different mechanism.
+- Without streaming the same steer behavior produces a single final response — the steer still fired, it just wasn't visible mid-run.
 
 `steer` is not a hard abort. It injects the incoming message at the next tool boundary, but any tool call already in flight (e.g. a subprocess or network request) will run to completion before the injected message takes effect. If you need to stop an in-flight tool immediately, use `interrupt` mode instead (legacy, aborts the active run).
 


### PR DESCRIPTION
## What

Adds a new **Steer and partial streaming** section to `docs/concepts/queue.md` and expands the Troubleshooting section.

## Why

Users on streaming surfaces (e.g. Discord with `streaming: partial`) can observe what looks like steer not working: instead of one redirected response they see several short sequential replies. This is expected behavior — partial streaming makes intermediate turns visible — but it is not documented anywhere.

Additionally, `steer` is sometimes confused with a hard abort. The docs don't currently explain that in-flight tool calls run to completion before the injected message takes effect.

Finally, the most common `steer`-not-working cause (per-session override silently trumping config) is not mentioned in Troubleshooting.

## Changes

- New section: **Steer and partial streaming** — explains why steer + partial streaming looks sequential, distinguishing `partial` (preview committed early) from `block` (multiple chunks emitted directly), and clarifying that steer is not a hard abort.
- Expanded **Troubleshooting** — adds actionable guidance for the two most common steer failure modes.

## Context

Discovered while testing steer behavior on Discord with `streaming: partial`. Confirmed with OpenClaw team in Discord support thread.

---

## AI-Assisted PR 🤖

- **Tools used:** Claude Sonnet 4.6 via OpenClaw (Clio assistant)
- **Testing:** Lightly tested — behavior was verified hands-on in a live Discord session before writing the docs
- **Prompts/context:** Emerged from a real debugging session investigating why steer appeared non-functional; diagnosis confirmed by OpenClaw team (Krill) in support thread
- **Author understanding:** Yes — we understand the steer/streaming interaction described and confirmed it against the existing channel docs

- [x] Marked as AI-assisted
- [x] Testing level noted (lightly tested / behavior-verified)
- [x] Greptile review addressed in follow-up commit
- [x] Bot review conversations resolved after addressing