### PR TITLE
fix(cli): warn when system-level install shadows updated user-global install

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -987,6 +987,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   if (
     result.status === "ok" &&
     result.root &&
+    !switchToPackage &&
     (result.mode === "npm" || result.mode === "pnpm" || result.mode === "bun")
   ) {
     try {
@@ -999,12 +1000,8 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   if (opts.json) {
     // Emit a single JSON document. Merge shadowInstallWarning into the result
     // object so callers never have to parse two top-level objects from stdout.
-    defaultRuntime.log(
-      JSON.stringify(
-        shadowWarning ? { ...result, shadowInstallWarning: shadowWarning } : result,
-        null,
-        2,
-      ),
+    defaultRuntime.writeJson(
+      shadowWarning ? { ...result, shadowInstallWarning: shadowWarning } : result,
     );
   } else {
     printResult(result, { ...opts, hideSteps: showProgress });

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -13,6 +13,7 @@ import {
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { nodeVersionSatisfiesEngine } from "../../infra/runtime-guard.js";
+import { detectShadowInstall } from "../../infra/shadow-install.js";
 import {
   channelToNpmTag,
   DEFAULT_GIT_CHANNEL,
@@ -979,7 +980,35 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
         });
 
   stop();
-  printResult(result, { ...opts, hideSteps: showProgress });
+
+  // Detect shadow installs for package-manager updates before printResult so
+  // the warning can be included in the --json output as a single document.
+  let shadowWarning: Awaited<ReturnType<typeof detectShadowInstall>> = null;
+  if (
+    result.status === "ok" &&
+    result.root &&
+    (result.mode === "npm" || result.mode === "pnpm" || result.mode === "bun")
+  ) {
+    try {
+      shadowWarning = await detectShadowInstall({ updatedRoot: result.root });
+    } catch {
+      // Shadow detection is best-effort — never block the update flow.
+    }
+  }
+
+  if (opts.json) {
+    // Emit a single JSON document. Merge shadowInstallWarning into the result
+    // object so callers never have to parse two top-level objects from stdout.
+    defaultRuntime.log(
+      JSON.stringify(
+        shadowWarning ? { ...result, shadowInstallWarning: shadowWarning } : result,
+        null,
+        2,
+      ),
+    );
+  } else {
+    printResult(result, { ...opts, hideSteps: showProgress });
+  }
 
   if (result.status === "error") {
     defaultRuntime.exit(1);
@@ -1029,6 +1058,27 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     if (!opts.json) {
       defaultRuntime.log(theme.muted(`Update channel set to ${requestedChannel}.`));
     }
+  }
+
+  if (!opts.json && shadowWarning) {
+    defaultRuntime.log("");
+    defaultRuntime.log(
+      theme.warn(
+        "⚠ Shadow install detected: the running binary is NOT from the install that was just updated.",
+      ),
+    );
+    defaultRuntime.log(theme.warn(`  Active binary:   ${shadowWarning.activeBinaryPath}`));
+    defaultRuntime.log(theme.warn(`  Active install:  ${shadowWarning.activeInstallRoot}`));
+    defaultRuntime.log(theme.warn(`  Updated install: ${shadowWarning.updatedInstallRoot}`));
+    defaultRuntime.log("");
+    defaultRuntime.log(
+      theme.warn("  The update succeeded, but your shell will keep running the old version."),
+    );
+    defaultRuntime.log(
+      theme.warn(
+        `  Fix: remove the shadowing install at ${shadowWarning.activeInstallRoot} or update it directly.`,
+      ),
+    );
   }
 
   await updatePluginsAfterCoreUpdate({

--- a/src/infra/openclaw-root.ts
+++ b/src/infra/openclaw-root.ts
@@ -26,7 +26,7 @@ function readPackageNameSync(dir: string): string | null {
   }
 }
 
-async function findPackageRoot(startDir: string, maxDepth = 12): Promise<string | null> {
+export async function findPackageRoot(startDir: string, maxDepth = 12): Promise<string | null> {
   for (const current of iterAncestorDirs(startDir, maxDepth)) {
     const name = await readPackageName(current);
     if (name && CORE_PACKAGE_NAMES.has(name)) {

--- a/src/infra/shadow-install.test.ts
+++ b/src/infra/shadow-install.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { detectShadowInstall } from "./shadow-install.js";
+
+/** Resolve symlinks so assertions match on macOS (/tmp → /private/tmp). */
+async function real(p: string): Promise<string> {
+  try {
+    return await fs.realpath(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+describe("detectShadowInstall", () => {
+  let fixtureRoot: string;
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-shadow-")));
+  });
+
+  afterAll(async () => {
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  async function seedInstall(name: string, version = "1.0.0"): Promise<string> {
+    const root = path.join(fixtureRoot, name, "node_modules", "openclaw");
+    await fs.mkdir(root, { recursive: true });
+    await fs.writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "openclaw", version }),
+      "utf-8",
+    );
+    // Create a fake dist/entry.js so the binary path resolves inside the tree.
+    const distDir = path.join(root, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    await fs.writeFile(path.join(distDir, "entry.js"), "// stub\n", "utf-8");
+    return root;
+  }
+
+  it("returns null when active binary is inside the updated root", async () => {
+    const root = await seedInstall("same");
+    // Simulate argv[1] pointing inside this root.
+    const originalArgv1 = process.argv[1];
+    try {
+      process.argv[1] = path.join(root, "dist", "entry.js");
+      const result = await detectShadowInstall({ updatedRoot: root });
+      expect(result).toBeNull();
+    } finally {
+      process.argv[1] = originalArgv1!;
+    }
+  });
+
+  it("returns a warning when active binary lives in a different root", async () => {
+    const systemRoot = await seedInstall("system-global");
+    const userRoot = await seedInstall("user-global");
+
+    const originalArgv1 = process.argv[1];
+    try {
+      // Simulate the shell running the system-level binary...
+      process.argv[1] = path.join(systemRoot, "dist", "entry.js");
+      // ...while the update targeted the user-level root.
+      const result = await detectShadowInstall({ updatedRoot: userRoot });
+      expect(result).not.toBeNull();
+      expect(result!.activeBinaryPath).toBe(await real(path.join(systemRoot, "dist", "entry.js")));
+      expect(result!.activeInstallRoot).toBe(await real(systemRoot));
+      expect(result!.updatedInstallRoot).toBe(await real(userRoot));
+    } finally {
+      process.argv[1] = originalArgv1!;
+    }
+  });
+
+  it("returns null when process.argv[1] cannot be resolved", async () => {
+    const root = await seedInstall("unresolvable");
+    const originalArgv1 = process.argv[1];
+    try {
+      process.argv[1] = path.join(fixtureRoot, "nonexistent", "binary.js");
+      const result = await detectShadowInstall({ updatedRoot: root });
+      expect(result).toBeNull();
+    } finally {
+      process.argv[1] = originalArgv1!;
+    }
+  });
+
+  it("returns null when argv[1] is outside any openclaw package tree", async () => {
+    const root = await seedInstall("outside");
+    // Create a file that's not under any openclaw package.json.
+    const strayDir = path.join(fixtureRoot, "stray");
+    await fs.mkdir(strayDir, { recursive: true });
+    const strayBin = path.join(strayDir, "openclaw.js");
+    await fs.writeFile(strayBin, "// stub\n", "utf-8");
+
+    const originalArgv1 = process.argv[1];
+    try {
+      process.argv[1] = strayBin;
+      const result = await detectShadowInstall({ updatedRoot: root });
+      expect(result).toBeNull();
+    } finally {
+      process.argv[1] = originalArgv1!;
+    }
+  });
+
+  it("returns null when updatedRoot is a symlink to the active root", async () => {
+    const root = await seedInstall("symlinked");
+    const linkPath = path.join(fixtureRoot, "symlink-to-root");
+    // Remove stale symlink from prior runs (shouldn't exist, but guard).
+    await fs.rm(linkPath, { force: true });
+    await fs.symlink(root, linkPath);
+
+    const originalArgv1 = process.argv[1];
+    try {
+      process.argv[1] = path.join(root, "dist", "entry.js");
+      // updatedRoot is a symlink, but realpath resolves to the same place.
+      const result = await detectShadowInstall({ updatedRoot: linkPath });
+      expect(result).toBeNull();
+    } finally {
+      process.argv[1] = originalArgv1!;
+    }
+  });
+});

--- a/src/infra/shadow-install.ts
+++ b/src/infra/shadow-install.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { findPackageRoot } from "./openclaw-root.js";
+
+export type ShadowInstallWarning = {
+  /** Resolved real path of the currently running binary (process.argv[1]). */
+  activeBinaryPath: string;
+  /** Package root that owns the currently running binary. */
+  activeInstallRoot: string;
+  /** Package root that was just updated. */
+  updatedInstallRoot: string;
+};
+
+/**
+ * After a successful global-package update, detect whether the binary that
+ * the shell will actually invoke (`process.argv[1]`, resolved through
+ * symlinks) lives inside a *different* install root than the one we just
+ * updated.
+ *
+ * Returns a warning descriptor when a shadow is detected, or `null` when
+ * everything looks fine (or when we can't determine the answer).
+ */
+export async function detectShadowInstall(params: {
+  updatedRoot: string;
+}): Promise<ShadowInstallWarning | null> {
+  const argv1 = process.argv[1];
+  if (!argv1) {
+    return null;
+  }
+
+  let resolvedBinary: string;
+  try {
+    resolvedBinary = await fs.realpath(argv1);
+  } catch {
+    // Can't resolve the binary (e.g. deleted after exec) — nothing to warn about.
+    return null;
+  }
+
+  let activeRoot: string | null;
+  try {
+    activeRoot = await findPackageRoot(path.dirname(resolvedBinary));
+  } catch {
+    return null;
+  }
+  if (!activeRoot) {
+    // Binary doesn't sit inside a recognisable openclaw package tree.
+    return null;
+  }
+
+  // Note: if realpath fails for one path but not the other, comparison may
+  // false-positive. Acceptable since the feature is best-effort and a false
+  // warning is safer than a missed shadow.
+
+  // Both paths must be realpath'd for a reliable comparison — the updated
+  // root comes from `npm root -g` / findPackageRoot which may contain
+  // symlinks, while activeRoot was already found via a realpath'd binary.
+  let normalizedUpdated: string;
+  try {
+    normalizedUpdated = await fs.realpath(params.updatedRoot);
+  } catch {
+    normalizedUpdated = path.resolve(params.updatedRoot);
+  }
+  let normalizedActive: string;
+  try {
+    normalizedActive = await fs.realpath(activeRoot);
+  } catch {
+    normalizedActive = path.resolve(activeRoot);
+  }
+
+  if (normalizedActive === normalizedUpdated) {
+    return null;
+  }
+
+  return {
+    activeBinaryPath: resolvedBinary,
+    activeInstallRoot: normalizedActive,
+    updatedInstallRoot: normalizedUpdated,
+  };
+}


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw update` silently succeeds when a system-level install (`/usr/lib/node_modules/openclaw`) shadows the user-global install (`~/.npm-global/lib/node_modules/openclaw`). The user believes they are updated, but `which openclaw` still points at the stale system binary. Security patches appear applied when they are not.
- **Why it matters:** A user who runs `openclaw update` after a security advisory has false confidence they are patched. The tool lies about success.
- **What changed:** Added post-update shadow detection that compares `fs.realpath(process.argv[1])` against `fs.realpath(result.root)`. When they resolve to different package roots, a warning is printed with paths and a fix suggestion. Reuses the existing `findPackageRoot` from `openclaw-root.ts` (exported it, 1-line change).
- **What did NOT change (scope boundary):** The update flow itself is never altered or blocked. Gateway `update.run` path is not touched (this is CLI-only). No new dependencies.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #46521

## User-visible / Behavior Changes

After a successful `npm`/`pnpm`/`bun` global update, if the running binary resolves to a different install root than the one updated, the user sees:

```
⚠ Shadow install detected: the running binary is NOT from the install that was just updated.
  Active binary:   /usr/lib/node_modules/openclaw/dist/entry.js
  Active install:  /usr/lib/node_modules/openclaw
  Updated install: /home/user/.npm-global/lib/node_modules/openclaw

  The update succeeded, but your shell will keep running the old version.
  Fix: remove the shadowing install (e.g. `sudo npm rm -g openclaw`) or update it directly.
```

In `--json` mode, a `{ shadowInstallWarning: { activeBinaryPath, activeInstallRoot, updatedInstallRoot } }` line is emitted.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

Impact is *positive*: makes a silent security gap visible.

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (Linux 5.15)
- Runtime/container: Node.js 22.22.1
- Model/provider: n/a (affects CLI startup, independent of model)
- Integration/channel: n/a

### Steps

1. `sudo npm install -g openclaw` (creates `/usr/lib/node_modules/openclaw`)
2. `npm install -g openclaw` (creates `~/.npm-global/lib/node_modules/openclaw`)
3. `openclaw update` → reports success
4. `which openclaw` → `/usr/bin/openclaw` (system, old version)
5. `openclaw --version` → shows old version

### Expected

Warning that the running binary is not from the updated install.

### Actual (before this PR)

No warning. User believes they are updated.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Unit tests (`src/infra/shadow-install.test.ts`):
- Same root → `null` (no false positive)
- Different roots → warning with correct realpath'd paths
- Unresolvable binary → graceful `null`
- Binary outside any openclaw tree → graceful `null`

All tests use `fs.realpath` on tmpdir to handle macOS `/tmp` → `/private/tmp` symlinks.

## Human Verification (required)

- Verified scenarios: all four test cases above, lint (`oxlint`), format (`oxfmt --check`)
- Edge cases checked: symlinked npm prefixes (realpath both sides), unresolvable paths, missing package.json
- What I did **not** verify: full `pnpm build && pnpm check && pnpm test` (requires full dev environment with all deps installed)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit (single squashed commit)
- Files/config to restore: `src/infra/shadow-install.ts`, `src/infra/shadow-install.test.ts`, `src/infra/openclaw-root.ts` (1-line export), `src/cli/update-cli/update-command.ts` (46-line block)
- Known bad symptoms: false positive warnings on systems where realpath still differs unexpectedly

## Risks and Mitigations

- Risk: `fs.realpath` behaves differently across OS/filesystem setups (Windows junctions, network mounts).
  - Mitigation: falls back to `path.resolve` on failure; detection is advisory-only and wrapped in try/catch.
- Risk: exporting `findPackageRoot` from `openclaw-root.ts` widens the internal API surface.
  - Mitigation: additive non-breaking change; function had clear public-ready semantics already.

---
AI-assisted: yes (code generation and review with AI assistance; lightly tested with unit tests + lint/format checks). The contributor understands the code and manually traced the full update flow through `update-runner.ts`, `update-global.ts`, `update-command.ts`, and `openclaw-root.ts` to verify correctness.