### PR TITLE
Fix lazy channel startup and onboarding imports

### DIFF
--- a/extensions/bluebubbles/index.ts
+++ b/extensions/bluebubbles/index.ts
@@ -1,7 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/bluebubbles";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/bluebubbles";
-import { bluebubblesPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setBlueBubblesRuntime } from "./src/runtime.js";
+
+const bluebubblesPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "bluebubblesPlugin",
+  pluginId: "bluebubbles",
+});
 
 const plugin = {
   id: "bluebubbles",

--- a/extensions/bluebubbles/src/runtime.ts
+++ b/extensions/bluebubbles/src/runtime.ts
@@ -1,5 +1,5 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk/bluebubbles";
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const runtimeStore = createPluginRuntimeStore<PluginRuntime>("BlueBubbles runtime not initialized");
 type LegacyRuntimeLogShape = { log?: (message: string) => void };

--- a/extensions/discord/index.ts
+++ b/extensions/discord/index.ts
@@ -1,8 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/discord";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/discord";
-import { discordPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin, loadLazyModuleExport } from "../../src/plugins/lazy-channel.js";
 import { setDiscordRuntime } from "./src/runtime.js";
-import { registerDiscordSubagentHooks } from "./src/subagent-hooks.js";
+
+const discordPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "discordPlugin",
+  pluginId: "discord",
+});
 
 const plugin = {
   id: "discord",
@@ -12,7 +18,11 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setDiscordRuntime(api.runtime);
     api.registerChannel({ plugin: discordPlugin });
-    registerDiscordSubagentHooks(api);
+    loadLazyModuleExport<(api: OpenClawPluginApi) => void>({
+      importerUrl: import.meta.url,
+      modulePath: "./src/subagent-hooks.js",
+      exportName: "registerDiscordSubagentHooks",
+    })(api);
   },
 };
 

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/discord";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setDiscordRuntime, getRuntime: getDiscordRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Discord runtime not initialized");

--- a/extensions/discord/src/subagent-hooks.ts
+++ b/extensions/discord/src/subagent-hooks.ts
@@ -1,10 +1,26 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/discord";
-import {
-  autoBindSpawnedDiscordSubagent,
-  listThreadBindingsBySessionKey,
-  resolveDiscordAccount,
-  unbindThreadBindingsBySessionKey,
-} from "openclaw/plugin-sdk/discord";
+
+type DiscordSubagentDeps = {
+  resolveDiscordAccount: typeof import("./accounts.js").resolveDiscordAccount;
+  autoBindSpawnedDiscordSubagent: typeof import("./monitor/thread-bindings.js").autoBindSpawnedDiscordSubagent;
+  listThreadBindingsBySessionKey: typeof import("./monitor/thread-bindings.js").listThreadBindingsBySessionKey;
+  unbindThreadBindingsBySessionKey: typeof import("./monitor/thread-bindings.js").unbindThreadBindingsBySessionKey;
+};
+
+let discordSubagentDepsPromise: Promise<DiscordSubagentDeps> | null = null;
+
+async function loadDiscordSubagentDeps(): Promise<DiscordSubagentDeps> {
+  discordSubagentDepsPromise ??= Promise.all([
+    import("./accounts.js"),
+    import("./monitor/thread-bindings.js"),
+  ]).then(([accountsModule, threadBindingsModule]) => ({
+    resolveDiscordAccount: accountsModule.resolveDiscordAccount,
+    autoBindSpawnedDiscordSubagent: threadBindingsModule.autoBindSpawnedDiscordSubagent,
+    listThreadBindingsBySessionKey: threadBindingsModule.listThreadBindingsBySessionKey,
+    unbindThreadBindingsBySessionKey: threadBindingsModule.unbindThreadBindingsBySessionKey,
+  }));
+  return await discordSubagentDepsPromise;
+}
 
 function summarizeError(err: unknown): string {
   if (err instanceof Error) {
@@ -17,7 +33,8 @@ function summarizeError(err: unknown): string {
 }
 
 export function registerDiscordSubagentHooks(api: OpenClawPluginApi) {
-  const resolveThreadBindingFlags = (accountId?: string) => {
+  const resolveThreadBindingFlags = async (accountId?: string) => {
+    const { resolveDiscordAccount } = await loadDiscordSubagentDeps();
     const account = resolveDiscordAccount({
       cfg: api.config,
       accountId,
@@ -48,7 +65,7 @@ export function registerDiscordSubagentHooks(api: OpenClawPluginApi) {
       // their own thread/session provisioning without Discord blocking them.
       return;
     }
-    const threadBindingFlags = resolveThreadBindingFlags(event.requester?.accountId);
+    const threadBindingFlags = await resolveThreadBindingFlags(event.requester?.accountId);
     if (!threadBindingFlags.enabled) {
       return {
         status: "error" as const,
@@ -64,6 +81,7 @@ export function registerDiscordSubagentHooks(api: OpenClawPluginApi) {
       };
     }
     try {
+      const { autoBindSpawnedDiscordSubagent } = await loadDiscordSubagentDeps();
       const binding = await autoBindSpawnedDiscordSubagent({
         accountId: event.requester?.accountId,
         channel: event.requester?.channel,
@@ -90,7 +108,8 @@ export function registerDiscordSubagentHooks(api: OpenClawPluginApi) {
     }
   });
 
-  api.on("subagent_ended", (event) => {
+  api.on("subagent_ended", async (event) => {
+    const { unbindThreadBindingsBySessionKey } = await loadDiscordSubagentDeps();
     unbindThreadBindingsBySessionKey({
       targetSessionKey: event.targetSessionKey,
       accountId: event.accountId,
@@ -100,7 +119,7 @@ export function registerDiscordSubagentHooks(api: OpenClawPluginApi) {
     });
   });
 
-  api.on("subagent_delivery_target", (event) => {
+  api.on("subagent_delivery_target", async (event) => {
     if (!event.expectsCompletionMessage) {
       return;
     }
@@ -108,6 +127,7 @@ export function registerDiscordSubagentHooks(api: OpenClawPluginApi) {
     if (requesterChannel !== "discord") {
       return;
     }
+    const { listThreadBindingsBySessionKey } = await loadDiscordSubagentDeps();
     const requesterAccountId = event.requesterOrigin?.accountId?.trim();
     const requesterThreadId =
       event.requesterOrigin?.threadId != null && event.requesterOrigin.threadId !== ""

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -11,7 +11,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./plugin.ts"
     ],
     "channel": {
       "id": "feishu",

--- a/extensions/feishu/plugin.ts
+++ b/extensions/feishu/plugin.ts
@@ -1,0 +1,119 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin, loadLazyModuleExport } from "../../src/plugins/lazy-channel.js";
+import type { OpenClawPluginToolContext } from "../../src/plugins/types.js";
+import { setFeishuRuntime } from "./src/runtime.js";
+
+type ToolRegistrar = (api: OpenClawPluginApi) => void;
+
+function createLazyToolFactory(params: {
+  api: OpenClawPluginApi;
+  importerUrl: string;
+  modulePath: string;
+  exportName: string;
+}) {
+  return (ctx: OpenClawPluginToolContext): AnyAgentTool[] => {
+    const registerTools = loadLazyModuleExport<ToolRegistrar>({
+      importerUrl: params.importerUrl,
+      modulePath: params.modulePath,
+      exportName: params.exportName,
+    });
+    const tools: AnyAgentTool[] = [];
+    registerTools({
+      ...params.api,
+      registerTool(tool) {
+        const resolved = typeof tool === "function" ? tool(ctx) : tool;
+        if (!resolved) {
+          return;
+        }
+        tools.push(...(Array.isArray(resolved) ? resolved : [resolved]));
+      },
+    });
+    return tools;
+  };
+}
+
+const feishuPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "feishuPlugin",
+  pluginId: "feishu",
+});
+
+const plugin = {
+  id: "feishu",
+  name: "Feishu",
+  description: "Feishu/Lark channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setFeishuRuntime(api.runtime);
+    api.registerChannel({ plugin: feishuPlugin });
+    api.registerTool(
+      createLazyToolFactory({
+        api,
+        importerUrl: import.meta.url,
+        modulePath: "./src/docx.js",
+        exportName: "registerFeishuDocTools",
+      }),
+      { names: ["feishu_doc", "feishu_app_scopes"] },
+    );
+    api.registerTool(
+      createLazyToolFactory({
+        api,
+        importerUrl: import.meta.url,
+        modulePath: "./src/chat.js",
+        exportName: "registerFeishuChatTools",
+      }),
+      { name: "feishu_chat" },
+    );
+    api.registerTool(
+      createLazyToolFactory({
+        api,
+        importerUrl: import.meta.url,
+        modulePath: "./src/wiki.js",
+        exportName: "registerFeishuWikiTools",
+      }),
+      { name: "feishu_wiki" },
+    );
+    api.registerTool(
+      createLazyToolFactory({
+        api,
+        importerUrl: import.meta.url,
+        modulePath: "./src/drive.js",
+        exportName: "registerFeishuDriveTools",
+      }),
+      { name: "feishu_drive" },
+    );
+    api.registerTool(
+      createLazyToolFactory({
+        api,
+        importerUrl: import.meta.url,
+        modulePath: "./src/perm.js",
+        exportName: "registerFeishuPermTools",
+      }),
+      { name: "feishu_perm" },
+    );
+    api.registerTool(
+      createLazyToolFactory({
+        api,
+        importerUrl: import.meta.url,
+        modulePath: "./src/bitable.js",
+        exportName: "registerFeishuBitableTools",
+      }),
+      {
+        names: [
+          "feishu_bitable_get_meta",
+          "feishu_bitable_list_fields",
+          "feishu_bitable_list_records",
+          "feishu_bitable_get_record",
+          "feishu_bitable_create_record",
+          "feishu_bitable_update_record",
+          "feishu_bitable_create_app",
+          "feishu_bitable_create_field",
+        ],
+      },
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/feishu/src/runtime.ts
+++ b/extensions/feishu/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/feishu";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setFeishuRuntime, getRuntime: getFeishuRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Feishu runtime not initialized");

--- a/extensions/googlechat/index.ts
+++ b/extensions/googlechat/index.ts
@@ -1,7 +1,19 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/googlechat";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/googlechat";
-import { googlechatDock, googlechatPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelDock, createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setGoogleChatRuntime } from "./src/runtime.js";
+
+const googlechatPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "googlechatPlugin",
+  pluginId: "googlechat",
+});
+const googlechatDock = createLazyChannelDock({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "googlechatDock",
+});
 
 const plugin = {
   id: "googlechat",

--- a/extensions/googlechat/src/runtime.ts
+++ b/extensions/googlechat/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/googlechat";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setGoogleChatRuntime, getRuntime: getGoogleChatRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Google Chat runtime not initialized");

--- a/extensions/imessage/index.ts
+++ b/extensions/imessage/index.ts
@@ -1,7 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/imessage";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/imessage";
-import { imessagePlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setIMessageRuntime } from "./src/runtime.js";
+
+const imessagePlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "imessagePlugin",
+  pluginId: "imessage",
+});
 
 const plugin = {
   id: "imessage",

--- a/extensions/imessage/src/runtime.ts
+++ b/extensions/imessage/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/imessage";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setIMessageRuntime, getRuntime: getIMessageRuntime } =
   createPluginRuntimeStore<PluginRuntime>("iMessage runtime not initialized");

--- a/extensions/irc/index.ts
+++ b/extensions/irc/index.ts
@@ -1,7 +1,14 @@
 import type { ChannelPlugin, OpenClawPluginApi } from "openclaw/plugin-sdk/irc";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/irc";
-import { ircPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setIrcRuntime } from "./src/runtime.js";
+
+const ircPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "ircPlugin",
+  pluginId: "irc",
+});
 
 const plugin = {
   id: "irc",

--- a/extensions/irc/src/runtime.ts
+++ b/extensions/irc/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/irc";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setIrcRuntime, getRuntime: getIrcRuntime } =
   createPluginRuntimeStore<PluginRuntime>("IRC runtime not initialized");

--- a/extensions/line/index.ts
+++ b/extensions/line/index.ts
@@ -1,8 +1,15 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/line";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/line";
-import { registerLineCardCommand } from "./src/card-command.js";
-import { linePlugin } from "./src/channel.js";
+import type { ReplyPayload } from "../../src/auto-reply/types.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin, loadLazyModuleExport } from "../../src/plugins/lazy-channel.js";
 import { setLineRuntime } from "./src/runtime.js";
+
+const linePlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "linePlugin",
+  pluginId: "line",
+});
 
 const plugin = {
   id: "line",
@@ -12,7 +19,18 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setLineRuntime(api.runtime);
     api.registerChannel({ plugin: linePlugin });
-    registerLineCardCommand(api);
+    api.registerCommand({
+      name: "card",
+      description: "Send a rich card message (LINE).",
+      acceptsArgs: true,
+      requireAuth: false,
+      handler: async (ctx) =>
+        await loadLazyModuleExport<(commandCtx: typeof ctx) => Promise<ReplyPayload>>({
+          importerUrl: import.meta.url,
+          modulePath: "./src/card-command.js",
+          exportName: "handleLineCardCommand",
+        })(ctx),
+    });
   },
 };
 

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -160,185 +160,193 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
     description: "Send a rich card message (LINE).",
     acceptsArgs: true,
     requireAuth: false,
-    handler: async (ctx) => {
-      const argsStr = ctx.args?.trim() ?? "";
-      if (!argsStr) {
-        return { text: CARD_USAGE };
-      }
-
-      const parsed = parseCardArgs(argsStr);
-      const { type, args, flags } = parsed;
-
-      if (!type) {
-        return { text: CARD_USAGE };
-      }
-
-      // Only LINE supports rich cards; fallback to text elsewhere.
-      if (ctx.channel !== "line") {
-        const fallbackText = args.join(" - ");
-        return { text: `[${type} card] ${fallbackText}`.trim() };
-      }
-
-      try {
-        switch (type) {
-          case "info": {
-            const [title = "Info", body = "", footer] = args;
-            const bubble = createInfoCard(title, body, footer);
-            return buildLineReply({
-              flexMessage: {
-                altText: `${title}: ${body}`.slice(0, 400),
-                contents: bubble,
-              },
-            });
-          }
-
-          case "image": {
-            const [title = "Image", caption = ""] = args;
-            const imageUrl = flags.url || flags.image;
-            if (!imageUrl) {
-              return { text: "Error: Image card requires --url <image-url>" };
-            }
-            const bubble = createImageCard(imageUrl, title, caption);
-            return buildLineReply({
-              flexMessage: {
-                altText: `${title}: ${caption}`.slice(0, 400),
-                contents: bubble,
-              },
-            });
-          }
-
-          case "action": {
-            const [title = "Actions", body = ""] = args;
-            const actions = parseActions(flags.actions);
-            if (actions.length === 0) {
-              return { text: 'Error: Action card requires --actions "Label1|data1,Label2|data2"' };
-            }
-            const bubble = createActionCard(title, body, actions, {
-              imageUrl: flags.url || flags.image,
-            });
-            return buildLineReply({
-              flexMessage: {
-                altText: `${title}: ${body}`.slice(0, 400),
-                contents: bubble,
-              },
-            });
-          }
-
-          case "list": {
-            const [title = "List", itemsStr = ""] = args;
-            const items = parseListItems(itemsStr || flags.items || "");
-            if (items.length === 0) {
-              return {
-                text: 'Error: List card requires items. Usage: /card list "Title" "Item1|Desc1,Item2|Desc2"',
-              };
-            }
-            const bubble = createListCard(title, items);
-            return buildLineReply({
-              flexMessage: {
-                altText: `${title}: ${items.map((i) => i.title).join(", ")}`.slice(0, 400),
-                contents: bubble,
-              },
-            });
-          }
-
-          case "receipt": {
-            const [title = "Receipt", itemsStr = ""] = args;
-            const items = parseReceiptItems(itemsStr || flags.items || "");
-            const total = flags.total ? { label: "Total", value: flags.total } : undefined;
-            const footer = flags.footer;
-
-            if (items.length === 0) {
-              return {
-                text: 'Error: Receipt card requires items. Usage: /card receipt "Title" "Item1:$10,Item2:$20" --total "$30"',
-              };
-            }
-
-            const bubble = createReceiptCard({ title, items, total, footer });
-            return buildLineReply({
-              flexMessage: {
-                altText: `${title}: ${items.map((i) => `${i.name} ${i.value}`).join(", ")}`.slice(
-                  0,
-                  400,
-                ),
-                contents: bubble,
-              },
-            });
-          }
-
-          case "confirm": {
-            const [question = "Confirm?"] = args;
-            const yesStr = flags.yes || "Yes|yes";
-            const noStr = flags.no || "No|no";
-
-            const [yesLabel, yesData] = yesStr.split("|").map((s) => s.trim());
-            const [noLabel, noData] = noStr.split("|").map((s) => s.trim());
-
-            return buildLineReply({
-              templateMessage: {
-                type: "confirm",
-                text: question,
-                confirmLabel: yesLabel || "Yes",
-                confirmData: yesData || "yes",
-                cancelLabel: noLabel || "No",
-                cancelData: noData || "no",
-                altText: question,
-              },
-            });
-          }
-
-          case "buttons": {
-            const [title = "Menu", text = "Choose an option"] = args;
-            const actionsStr = flags.actions || "";
-            const actionParts = parseActions(actionsStr);
-
-            if (actionParts.length === 0) {
-              return { text: 'Error: Buttons card requires --actions "Label1|data1,Label2|data2"' };
-            }
-
-            const templateActions: Array<{
-              type: "message" | "uri" | "postback";
-              label: string;
-              data?: string;
-              uri?: string;
-            }> = actionParts.map((a) => {
-              const action = a.action;
-              const label = action.label ?? a.label;
-              if (action.type === "uri") {
-                return { type: "uri" as const, label, uri: (action as { uri: string }).uri };
-              }
-              if (action.type === "postback") {
-                return {
-                  type: "postback" as const,
-                  label,
-                  data: (action as { data: string }).data,
-                };
-              }
-              return {
-                type: "message" as const,
-                label,
-                data: (action as { text: string }).text,
-              };
-            });
-
-            return buildLineReply({
-              templateMessage: {
-                type: "buttons",
-                title,
-                text,
-                thumbnailImageUrl: flags.url || flags.image,
-                actions: templateActions,
-              },
-            });
-          }
-
-          default:
-            return {
-              text: `Unknown card type: "${type}". Available types: info, image, action, list, receipt, confirm, buttons`,
-            };
-        }
-      } catch (err) {
-        return { text: `Error creating card: ${String(err)}` };
-      }
-    },
+    handler: handleLineCardCommand,
   });
+}
+
+export async function handleLineCardCommand(
+  ctx: Parameters<OpenClawPluginApi["registerCommand"]>[0]["handler"] extends (
+    ...args: infer T
+  ) => unknown
+    ? T[0]
+    : never,
+) {
+  const argsStr = ctx.args?.trim() ?? "";
+  if (!argsStr) {
+    return { text: CARD_USAGE };
+  }
+
+  const parsed = parseCardArgs(argsStr);
+  const { type, args, flags } = parsed;
+
+  if (!type) {
+    return { text: CARD_USAGE };
+  }
+
+  // Only LINE supports rich cards; fallback to text elsewhere.
+  if (ctx.channel !== "line") {
+    const fallbackText = args.join(" - ");
+    return { text: `[${type} card] ${fallbackText}`.trim() };
+  }
+
+  try {
+    switch (type) {
+      case "info": {
+        const [title = "Info", body = "", footer] = args;
+        const bubble = createInfoCard(title, body, footer);
+        return buildLineReply({
+          flexMessage: {
+            altText: `${title}: ${body}`.slice(0, 400),
+            contents: bubble,
+          },
+        });
+      }
+
+      case "image": {
+        const [title = "Image", caption = ""] = args;
+        const imageUrl = flags.url || flags.image;
+        if (!imageUrl) {
+          return { text: "Error: Image card requires --url <image-url>" };
+        }
+        const bubble = createImageCard(imageUrl, title, caption);
+        return buildLineReply({
+          flexMessage: {
+            altText: `${title}: ${caption}`.slice(0, 400),
+            contents: bubble,
+          },
+        });
+      }
+
+      case "action": {
+        const [title = "Actions", body = ""] = args;
+        const actions = parseActions(flags.actions);
+        if (actions.length === 0) {
+          return { text: 'Error: Action card requires --actions "Label1|data1,Label2|data2"' };
+        }
+        const bubble = createActionCard(title, body, actions, {
+          imageUrl: flags.url || flags.image,
+        });
+        return buildLineReply({
+          flexMessage: {
+            altText: `${title}: ${body}`.slice(0, 400),
+            contents: bubble,
+          },
+        });
+      }
+
+      case "list": {
+        const [title = "List", itemsStr = ""] = args;
+        const items = parseListItems(itemsStr || flags.items || "");
+        if (items.length === 0) {
+          return {
+            text: 'Error: List card requires items. Usage: /card list "Title" "Item1|Desc1,Item2|Desc2"',
+          };
+        }
+        const bubble = createListCard(title, items);
+        return buildLineReply({
+          flexMessage: {
+            altText: `${title}: ${items.map((i) => i.title).join(", ")}`.slice(0, 400),
+            contents: bubble,
+          },
+        });
+      }
+
+      case "receipt": {
+        const [title = "Receipt", itemsStr = ""] = args;
+        const items = parseReceiptItems(itemsStr || flags.items || "");
+        const total = flags.total ? { label: "Total", value: flags.total } : undefined;
+        const footer = flags.footer;
+
+        if (items.length === 0) {
+          return {
+            text: 'Error: Receipt card requires items. Usage: /card receipt "Title" "Item1:$10,Item2:$20" --total "$30"',
+          };
+        }
+
+        const bubble = createReceiptCard({ title, items, total, footer });
+        return buildLineReply({
+          flexMessage: {
+            altText: `${title}: ${items.map((i) => `${i.name} ${i.value}`).join(", ")}`.slice(
+              0,
+              400,
+            ),
+            contents: bubble,
+          },
+        });
+      }
+
+      case "confirm": {
+        const [question = "Confirm?"] = args;
+        const yesStr = flags.yes || "Yes|yes";
+        const noStr = flags.no || "No|no";
+
+        const [yesLabel, yesData] = yesStr.split("|").map((s) => s.trim());
+        const [noLabel, noData] = noStr.split("|").map((s) => s.trim());
+
+        return buildLineReply({
+          templateMessage: {
+            type: "confirm",
+            text: question,
+            confirmLabel: yesLabel || "Yes",
+            confirmData: yesData || "yes",
+            cancelLabel: noLabel || "No",
+            cancelData: noData || "no",
+            altText: question,
+          },
+        });
+      }
+
+      case "buttons": {
+        const [title = "Menu", text = "Choose an option"] = args;
+        const actionsStr = flags.actions || "";
+        const actionParts = parseActions(actionsStr);
+
+        if (actionParts.length === 0) {
+          return { text: 'Error: Buttons card requires --actions "Label1|data1,Label2|data2"' };
+        }
+
+        const templateActions: Array<{
+          type: "message" | "uri" | "postback";
+          label: string;
+          data?: string;
+          uri?: string;
+        }> = actionParts.map((a) => {
+          const action = a.action;
+          const label = action.label ?? a.label;
+          if (action.type === "uri") {
+            return { type: "uri" as const, label, uri: (action as { uri: string }).uri };
+          }
+          if (action.type === "postback") {
+            return {
+              type: "postback" as const,
+              label,
+              data: (action as { data: string }).data,
+            };
+          }
+          return {
+            type: "message" as const,
+            label,
+            data: (action as { text: string }).text,
+          };
+        });
+
+        return buildLineReply({
+          templateMessage: {
+            type: "buttons",
+            title,
+            text,
+            thumbnailImageUrl: flags.url || flags.image,
+            actions: templateActions,
+          },
+        });
+      }
+
+      default:
+        return {
+          text: `Unknown card type: "${type}". Available types: info, image, action, list, receipt, confirm, buttons`,
+        };
+    }
+  } catch (err) {
+    return { text: `Error creating card: ${String(err)}` };
+  }
 }

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/line";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setLineRuntime, getRuntime: getLineRuntime } =
   createPluginRuntimeStore<PluginRuntime>("LINE runtime not initialized - plugin not registered");

--- a/extensions/matrix/index.ts
+++ b/extensions/matrix/index.ts
@@ -1,8 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/matrix";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/matrix";
-import { matrixPlugin } from "./src/channel.js";
-import { ensureMatrixCryptoRuntime } from "./src/matrix/deps.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setMatrixRuntime } from "./src/runtime.js";
+
+const matrixPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "matrixPlugin",
+  pluginId: "matrix",
+});
 
 const plugin = {
   id: "matrix",
@@ -11,10 +17,6 @@ const plugin = {
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
     setMatrixRuntime(api.runtime);
-    void ensureMatrixCryptoRuntime({ log: api.logger.info }).catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
-      api.logger.warn?.(`matrix: crypto runtime bootstrap failed: ${message}`);
-    });
     api.registerChannel({ plugin: matrixPlugin });
   },
 };

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setMatrixRuntime, getRuntime: getMatrixRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Matrix runtime not initialized");

--- a/extensions/mattermost/index.ts
+++ b/extensions/mattermost/index.ts
@@ -1,8 +1,15 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/mattermost";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/mattermost";
-import { mattermostPlugin } from "./src/channel.js";
-import { getSlashCommandState, registerSlashCommandRoute } from "./src/mattermost/slash-state.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin, loadLazyModuleExport } from "../../src/plugins/lazy-channel.js";
+import { resolveSlashCallbackPaths } from "./src/mattermost/slash-callback-paths.js";
 import { setMattermostRuntime } from "./src/runtime.js";
+
+const mattermostPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "mattermostPlugin",
+  pluginId: "mattermost",
+});
 
 const plugin = {
   id: "mattermost",
@@ -12,11 +19,26 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setMattermostRuntime(api.runtime);
     api.registerChannel({ plugin: mattermostPlugin });
-
-    // Register the HTTP route for slash command callbacks.
-    // The actual command registration with MM happens in the monitor
-    // after the bot connects and we know the team ID.
-    registerSlashCommandRoute(api);
+    const mmConfig = api.config.channels?.mattermost as Record<string, unknown> | undefined;
+    for (const callbackPath of resolveSlashCallbackPaths(mmConfig)) {
+      api.registerHttpRoute({
+        path: callbackPath,
+        auth: "plugin",
+        handler: async (req, res) =>
+          await loadLazyModuleExport<
+            (
+              request: typeof req,
+              response: typeof res,
+              pluginApi: OpenClawPluginApi,
+            ) => Promise<void>
+          >({
+            importerUrl: import.meta.url,
+            modulePath: "./src/mattermost/slash-state.js",
+            exportName: "handleSlashCommandRoute",
+          })(req, res, api),
+      });
+      api.logger.info?.(`mattermost: registered slash command callback at ${callbackPath}`);
+    }
   },
 };
 

--- a/extensions/mattermost/src/mattermost/slash-callback-paths.ts
+++ b/extensions/mattermost/src/mattermost/slash-callback-paths.ts
@@ -1,0 +1,52 @@
+import type { MattermostSlashCommandConfig } from "./slash-commands.js";
+
+const DEFAULT_CALLBACK_PATH = "/api/channels/mattermost/command";
+
+function normalizeCallbackPath(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return DEFAULT_CALLBACK_PATH;
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+export function resolveSlashCommandConfig(
+  raw?: Partial<MattermostSlashCommandConfig>,
+): MattermostSlashCommandConfig {
+  return {
+    native: raw?.native ?? "auto",
+    nativeSkills: raw?.nativeSkills ?? "auto",
+    callbackPath: normalizeCallbackPath(raw?.callbackPath ?? DEFAULT_CALLBACK_PATH),
+    callbackUrl: raw?.callbackUrl?.trim() || undefined,
+  };
+}
+
+export function resolveSlashCallbackPaths(mmConfig: Record<string, unknown> | undefined): string[] {
+  const callbackPaths = new Set<string>();
+
+  const addCallbackPaths = (raw: Partial<MattermostSlashCommandConfig> | undefined) => {
+    const resolved = resolveSlashCommandConfig(raw);
+    callbackPaths.add(resolved.callbackPath);
+    if (!resolved.callbackUrl) {
+      return;
+    }
+    try {
+      const urlPath = new URL(resolved.callbackUrl).pathname;
+      if (urlPath && urlPath !== resolved.callbackPath) {
+        callbackPaths.add(urlPath);
+      }
+    } catch {
+      // Invalid URLs are validated later by the registration flow.
+    }
+  };
+
+  addCallbackPaths(mmConfig?.commands as Partial<MattermostSlashCommandConfig> | undefined);
+
+  const accountsRaw = (mmConfig?.accounts ?? {}) as Record<string, unknown>;
+  for (const accountId of Object.keys(accountsRaw)) {
+    const accountCfg = accountsRaw[accountId] as Record<string, unknown> | undefined;
+    addCallbackPaths(accountCfg?.commands as Partial<MattermostSlashCommandConfig> | undefined);
+  }
+
+  return [...callbackPaths];
+}

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -12,7 +12,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/mattermost";
 import type { ResolvedMattermostAccount } from "./accounts.js";
-import { resolveSlashCommandConfig, type MattermostRegisteredCommand } from "./slash-commands.js";
+import { resolveSlashCallbackPaths } from "./slash-callback-paths.js";
+import type { MattermostRegisteredCommand } from "./slash-commands.js";
 import { createSlashCommandHttpHandler } from "./slash-http.js";
 
 // ─── Per-account state ───────────────────────────────────────────────────────
@@ -148,49 +149,26 @@ export function deactivateSlashCommands(accountId?: string) {
  * The single HTTP route dispatches to the correct per-account handler
  * by matching the inbound token against each account's registered tokens.
  */
-export function registerSlashCommandRoute(api: OpenClawPluginApi) {
-  const mmConfig = api.config.channels?.mattermost as Record<string, unknown> | undefined;
-
-  // Collect callback paths from both top-level and per-account config.
-  // Command registration uses account.config.commands, so the HTTP route
-  // registration must include any account-specific callbackPath overrides.
-  // Also extract the pathname from an explicit callbackUrl when it differs
-  // from callbackPath, so that Mattermost callbacks hit a registered route.
-  const callbackPaths = new Set<string>();
-
-  const addCallbackPaths = (
-    raw: Partial<import("./slash-commands.js").MattermostSlashCommandConfig> | undefined,
-  ) => {
-    const resolved = resolveSlashCommandConfig(raw);
-    callbackPaths.add(resolved.callbackPath);
-    if (resolved.callbackUrl) {
-      try {
-        const urlPath = new URL(resolved.callbackUrl).pathname;
-        if (urlPath && urlPath !== resolved.callbackPath) {
-          callbackPaths.add(urlPath);
-        }
-      } catch {
-        // Invalid URL — ignore, will be caught during registration
-      }
-    }
-  };
-
-  const commandsRaw = mmConfig?.commands as
-    | Partial<import("./slash-commands.js").MattermostSlashCommandConfig>
-    | undefined;
-  addCallbackPaths(commandsRaw);
-
-  const accountsRaw = (mmConfig?.accounts ?? {}) as Record<string, unknown>;
-  for (const accountId of Object.keys(accountsRaw)) {
-    const accountCfg = accountsRaw[accountId] as Record<string, unknown> | undefined;
-    const accountCommandsRaw = accountCfg?.commands as
-      | Partial<import("./slash-commands.js").MattermostSlashCommandConfig>
-      | undefined;
-    addCallbackPaths(accountCommandsRaw);
+export async function handleSlashCommandRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  api: OpenClawPluginApi,
+) {
+  if (accountStates.size === 0) {
+    res.statusCode = 503;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(
+      JSON.stringify({
+        response_type: "ephemeral",
+        text: "Slash commands are not yet initialized. Please try again in a moment.",
+      }),
+    );
+    return;
   }
 
-  const routeHandler = async (req: IncomingMessage, res: ServerResponse) => {
-    if (accountStates.size === 0) {
+  if (accountStates.size === 1) {
+    const [, state] = [...accountStates.entries()][0]!;
+    if (!state.handler) {
       res.statusCode = 503;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
       res.end(
@@ -201,112 +179,88 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
       );
       return;
     }
+    await state.handler(req, res);
+    return;
+  }
 
-    // We need to peek at the token to route to the right account handler.
-    // Since each account handler also validates the token, we find the
-    // account whose token set contains the inbound token and delegate.
-
-    // If there's only one active account (common case), route directly.
-    if (accountStates.size === 1) {
-      const [, state] = [...accountStates.entries()][0]!;
-      if (!state.handler) {
-        res.statusCode = 503;
-        res.setHeader("Content-Type", "application/json; charset=utf-8");
-        res.end(
-          JSON.stringify({
-            response_type: "ephemeral",
-            text: "Slash commands are not yet initialized. Please try again in a moment.",
-          }),
-        );
-        return;
-      }
-      await state.handler(req, res);
+  const chunks: Buffer[] = [];
+  const MAX_BODY = 64 * 1024;
+  let size = 0;
+  for await (const chunk of req) {
+    size += (chunk as Buffer).length;
+    if (size > MAX_BODY) {
+      res.statusCode = 413;
+      res.end("Payload Too Large");
       return;
     }
+    chunks.push(chunk as Buffer);
+  }
+  const bodyStr = Buffer.concat(chunks).toString("utf8");
 
-    // Multi-account: buffer the body, find the matching account by token,
-    // then replay the request to the correct handler.
-    const chunks: Buffer[] = [];
-    const MAX_BODY = 64 * 1024;
-    let size = 0;
-    for await (const chunk of req) {
-      size += (chunk as Buffer).length;
-      if (size > MAX_BODY) {
-        res.statusCode = 413;
-        res.end("Payload Too Large");
-        return;
-      }
-      chunks.push(chunk as Buffer);
+  let token: string | null = null;
+  const ct = req.headers["content-type"] ?? "";
+  try {
+    if (ct.includes("application/json")) {
+      token = (JSON.parse(bodyStr) as { token?: string }).token ?? null;
+    } else {
+      token = new URLSearchParams(bodyStr).get("token");
     }
-    const bodyStr = Buffer.concat(chunks).toString("utf8");
+  } catch {
+    // parse failed — will be caught by handler
+  }
 
-    // Parse just the token to find the right account
-    let token: string | null = null;
-    const ct = req.headers["content-type"] ?? "";
-    try {
-      if (ct.includes("application/json")) {
-        token = (JSON.parse(bodyStr) as { token?: string }).token ?? null;
-      } else {
-        token = new URLSearchParams(bodyStr).get("token");
-      }
-    } catch {
-      // parse failed — will be caught by handler
-    }
+  const match = token ? resolveSlashHandlerForToken(token) : { kind: "none" as const };
 
-    const match = token ? resolveSlashHandlerForToken(token) : { kind: "none" as const };
+  if (match.kind === "none") {
+    res.statusCode = 401;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(
+      JSON.stringify({
+        response_type: "ephemeral",
+        text: "Unauthorized: invalid command token.",
+      }),
+    );
+    return;
+  }
 
-    if (match.kind === "none") {
-      // No matching account — reject
-      res.statusCode = 401;
-      res.setHeader("Content-Type", "application/json; charset=utf-8");
-      res.end(
-        JSON.stringify({
-          response_type: "ephemeral",
-          text: "Unauthorized: invalid command token.",
-        }),
-      );
-      return;
-    }
+  if (match.kind === "ambiguous") {
+    api.logger.warn?.(
+      `mattermost: slash callback token matched multiple accounts (${match.accountIds?.join(", ")})`,
+    );
+    res.statusCode = 409;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(
+      JSON.stringify({
+        response_type: "ephemeral",
+        text: "Conflict: command token is not unique across accounts.",
+      }),
+    );
+    return;
+  }
 
-    if (match.kind === "ambiguous") {
-      api.logger.warn?.(
-        `mattermost: slash callback token matched multiple accounts (${match.accountIds?.join(", ")})`,
-      );
-      res.statusCode = 409;
-      res.setHeader("Content-Type", "application/json; charset=utf-8");
-      res.end(
-        JSON.stringify({
-          response_type: "ephemeral",
-          text: "Conflict: command token is not unique across accounts.",
-        }),
-      );
-      return;
-    }
+  const matchedHandler = match.handler!;
+  const { Readable } = await import("node:stream");
+  const syntheticReq = new Readable({
+    read() {
+      this.push(Buffer.from(bodyStr, "utf8"));
+      this.push(null);
+    },
+  }) as IncomingMessage;
 
-    const matchedHandler = match.handler!;
+  syntheticReq.method = req.method;
+  syntheticReq.url = req.url;
+  syntheticReq.headers = req.headers;
 
-    // Replay: create a synthetic readable that re-emits the buffered body
-    const { Readable } = await import("node:stream");
-    const syntheticReq = new Readable({
-      read() {
-        this.push(Buffer.from(bodyStr, "utf8"));
-        this.push(null);
-      },
-    }) as IncomingMessage;
+  await matchedHandler(syntheticReq, res);
+}
 
-    // Copy necessary IncomingMessage properties
-    syntheticReq.method = req.method;
-    syntheticReq.url = req.url;
-    syntheticReq.headers = req.headers;
-
-    await matchedHandler(syntheticReq, res);
-  };
-
-  for (const callbackPath of callbackPaths) {
+export function registerSlashCommandRoute(api: OpenClawPluginApi) {
+  const mmConfig = api.config.channels?.mattermost as Record<string, unknown> | undefined;
+  for (const callbackPath of resolveSlashCallbackPaths(mmConfig)) {
     api.registerHttpRoute({
       path: callbackPath,
       auth: "plugin",
-      handler: routeHandler,
+      handler: async (req, res) => await handleSlashCommandRoute(req, res, api),
     });
     api.logger.info?.(`mattermost: registered slash command callback at ${callbackPath}`);
   }

--- a/extensions/mattermost/src/runtime.ts
+++ b/extensions/mattermost/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/mattermost";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setMattermostRuntime, getRuntime: getMattermostRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Mattermost runtime not initialized");

--- a/extensions/msteams/index.ts
+++ b/extensions/msteams/index.ts
@@ -1,7 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/msteams";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/msteams";
-import { msteamsPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setMSTeamsRuntime } from "./src/runtime.js";
+
+const msteamsPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "msteamsPlugin",
+  pluginId: "msteams",
+});
 
 const plugin = {
   id: "msteams",

--- a/extensions/msteams/src/runtime.ts
+++ b/extensions/msteams/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/msteams";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setMSTeamsRuntime, getRuntime: getMSTeamsRuntime } =
   createPluginRuntimeStore<PluginRuntime>("MSTeams runtime not initialized");

--- a/extensions/nextcloud-talk/index.ts
+++ b/extensions/nextcloud-talk/index.ts
@@ -1,7 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/nextcloud-talk";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/nextcloud-talk";
-import { nextcloudTalkPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setNextcloudTalkRuntime } from "./src/runtime.js";
+
+const nextcloudTalkPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "nextcloudTalkPlugin",
+  pluginId: "nextcloud-talk",
+});
 
 const plugin = {
   id: "nextcloud-talk",

--- a/extensions/nextcloud-talk/src/runtime.ts
+++ b/extensions/nextcloud-talk/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nextcloud-talk";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setNextcloudTalkRuntime, getRuntime: getNextcloudTalkRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Nextcloud Talk runtime not initialized");

--- a/extensions/nostr/index.ts
+++ b/extensions/nostr/index.ts
@@ -1,10 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/nostr";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/nostr";
-import { nostrPlugin } from "./src/channel.js";
-import type { NostrProfile } from "./src/config-schema.js";
-import { createNostrProfileHttpHandler } from "./src/nostr-profile-http.js";
-import { setNostrRuntime, getNostrRuntime } from "./src/runtime.js";
-import { resolveNostrAccount } from "./src/types.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin, loadLazyModuleExport } from "../../src/plugins/lazy-channel.js";
+import { setNostrRuntime } from "./src/runtime.js";
+
+const nostrPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "nostrPlugin",
+  pluginId: "nostr",
+});
 
 const plugin = {
   id: "nostr",
@@ -14,58 +18,22 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setNostrRuntime(api.runtime);
     api.registerChannel({ plugin: nostrPlugin });
-
-    // Register HTTP handler for profile management
-    const httpHandler = createNostrProfileHttpHandler({
-      getConfigProfile: (accountId: string) => {
-        const runtime = getNostrRuntime();
-        const cfg = runtime.config.loadConfig();
-        const account = resolveNostrAccount({ cfg, accountId });
-        return account.profile;
-      },
-      updateConfigProfile: async (accountId: string, profile: NostrProfile) => {
-        const runtime = getNostrRuntime();
-        const cfg = runtime.config.loadConfig();
-
-        // Build the config patch for channels.nostr.profile
-        const channels = (cfg.channels ?? {}) as Record<string, unknown>;
-        const nostrConfig = (channels.nostr ?? {}) as Record<string, unknown>;
-
-        const updatedNostrConfig = {
-          ...nostrConfig,
-          profile,
-        };
-
-        const updatedChannels = {
-          ...channels,
-          nostr: updatedNostrConfig,
-        };
-
-        await runtime.config.writeConfigFile({
-          ...cfg,
-          channels: updatedChannels,
-        });
-      },
-      getAccountInfo: (accountId: string) => {
-        const runtime = getNostrRuntime();
-        const cfg = runtime.config.loadConfig();
-        const account = resolveNostrAccount({ cfg, accountId });
-        if (!account.configured || !account.publicKey) {
-          return null;
-        }
-        return {
-          pubkey: account.publicKey,
-          relays: account.relays,
-        };
-      },
-      log: api.logger,
-    });
-
     api.registerHttpRoute({
       path: "/api/channels/nostr",
       auth: "gateway",
       match: "prefix",
-      handler: httpHandler,
+      handler: async (req, res) =>
+        await loadLazyModuleExport<
+          (
+            request: typeof req,
+            response: typeof res,
+            pluginApi: OpenClawPluginApi,
+          ) => Promise<boolean | void>
+        >({
+          importerUrl: import.meta.url,
+          modulePath: "./src/nostr-profile-http-route.js",
+          exportName: "handleNostrProfileHttpRoute",
+        })(req, res, api),
     });
   },
 };

--- a/extensions/nostr/src/nostr-profile-http-route.ts
+++ b/extensions/nostr/src/nostr-profile-http-route.ts
@@ -1,0 +1,57 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/nostr";
+import type { NostrProfile } from "./config-schema.js";
+import { createNostrProfileHttpHandler } from "./nostr-profile-http.js";
+import { getNostrRuntime } from "./runtime.js";
+import { resolveNostrAccount } from "./types.js";
+
+let cachedHandler: ((req: unknown, res: unknown) => Promise<boolean | void>) | null = null;
+
+function createHandler(api: OpenClawPluginApi) {
+  return createNostrProfileHttpHandler({
+    getConfigProfile: (accountId: string) => {
+      const runtime = getNostrRuntime();
+      const cfg = runtime.config.loadConfig();
+      const account = resolveNostrAccount({ cfg, accountId });
+      return account.profile;
+    },
+    updateConfigProfile: async (accountId: string, profile: NostrProfile) => {
+      const runtime = getNostrRuntime();
+      const cfg = runtime.config.loadConfig();
+      const channels = (cfg.channels ?? {}) as Record<string, unknown>;
+      const nostrConfig = (channels.nostr ?? {}) as Record<string, unknown>;
+
+      await runtime.config.writeConfigFile({
+        ...cfg,
+        channels: {
+          ...channels,
+          nostr: {
+            ...nostrConfig,
+            profile,
+          },
+        },
+      });
+    },
+    getAccountInfo: (accountId: string) => {
+      const runtime = getNostrRuntime();
+      const cfg = runtime.config.loadConfig();
+      const account = resolveNostrAccount({ cfg, accountId });
+      if (!account.configured || !account.publicKey) {
+        return null;
+      }
+      return {
+        pubkey: account.publicKey,
+        relays: account.relays,
+      };
+    },
+    log: api.logger,
+  });
+}
+
+export async function handleNostrProfileHttpRoute(
+  req: unknown,
+  res: unknown,
+  api: OpenClawPluginApi,
+): Promise<boolean | void> {
+  cachedHandler ??= createHandler(api);
+  return await cachedHandler(req, res);
+}

--- a/extensions/nostr/src/runtime.ts
+++ b/extensions/nostr/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nostr";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setNostrRuntime, getRuntime: getNostrRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Nostr runtime not initialized");

--- a/extensions/signal/index.ts
+++ b/extensions/signal/index.ts
@@ -1,7 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/signal";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/signal";
-import { signalPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setSignalRuntime } from "./src/runtime.js";
+
+const signalPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "signalPlugin",
+  pluginId: "signal",
+});
 
 const plugin = {
   id: "signal",

--- a/extensions/signal/src/runtime.ts
+++ b/extensions/signal/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/signal";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setSignalRuntime, getRuntime: getSignalRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Signal runtime not initialized");

--- a/extensions/slack/index.ts
+++ b/extensions/slack/index.ts
@@ -1,7 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/slack";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/slack";
-import { slackPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setSlackRuntime } from "./src/runtime.js";
+
+const slackPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "slackPlugin",
+  pluginId: "slack",
+});
 
 const plugin = {
   id: "slack",

--- a/extensions/slack/src/runtime.ts
+++ b/extensions/slack/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/slack";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setSlackRuntime, getRuntime: getSlackRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Slack runtime not initialized");

--- a/extensions/synology-chat/index.ts
+++ b/extensions/synology-chat/index.ts
@@ -1,7 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/synology-chat";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/synology-chat";
-import { createSynologyChatPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelFactoryResult } from "../../src/plugins/lazy-channel.js";
 import { setSynologyRuntime } from "./src/runtime.js";
+
+const synologyChatPlugin = createLazyChannelFactoryResult({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "createSynologyChatPlugin",
+  pluginId: "synology-chat",
+});
 
 const plugin = {
   id: "synology-chat",
@@ -10,7 +17,7 @@ const plugin = {
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
     setSynologyRuntime(api.runtime);
-    api.registerChannel({ plugin: createSynologyChatPlugin() });
+    api.registerChannel({ plugin: synologyChatPlugin });
   },
 };
 

--- a/extensions/synology-chat/src/runtime.ts
+++ b/extensions/synology-chat/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/synology-chat";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setSynologyRuntime, getRuntime: getSynologyRuntime } =
   createPluginRuntimeStore<PluginRuntime>(

--- a/extensions/telegram/index.ts
+++ b/extensions/telegram/index.ts
@@ -1,7 +1,14 @@
 import type { ChannelPlugin, OpenClawPluginApi } from "openclaw/plugin-sdk/telegram";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/telegram";
-import { telegramPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setTelegramRuntime } from "./src/runtime.js";
+
+const telegramPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "telegramPlugin",
+  pluginId: "telegram",
+});
 
 const plugin = {
   id: "telegram",

--- a/extensions/telegram/src/runtime.ts
+++ b/extensions/telegram/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/telegram";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setTelegramRuntime, getRuntime: getTelegramRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Telegram runtime not initialized");

--- a/extensions/tlon/index.ts
+++ b/extensions/tlon/index.ts
@@ -2,12 +2,22 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk/tlon";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/tlon";
-import { tlonPlugin } from "./src/channel.js";
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolContext,
+} from "openclaw/plugin-sdk/tlon";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setTlonRuntime } from "./src/runtime.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const tlonPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "tlonPlugin",
+  pluginId: "tlon",
+});
 
 // Whitelist of allowed tlon subcommands
 const ALLOWED_TLON_COMMANDS = new Set([
@@ -123,6 +133,59 @@ function runTlonCommand(binary: string, args: string[]): Promise<string> {
   });
 }
 
+function createTlonTool(api: OpenClawPluginApi): AnyAgentTool {
+  const tlonBinary = findTlonBinary();
+  api.logger.info(`[tlon] Registering tlon tool, binary: ${tlonBinary}`);
+  return {
+    name: "tlon",
+    label: "Tlon CLI",
+    description:
+      "Tlon/Urbit API operations: activity, channels, contacts, groups, messages, dms, posts, notebook, settings. " +
+      "Examples: 'activity mentions --limit 10', 'channels groups', 'contacts self', 'groups list'",
+    parameters: {
+      type: "object",
+      properties: {
+        command: {
+          type: "string",
+          description:
+            "The tlon command and arguments. " +
+            "Examples: 'activity mentions --limit 10', 'contacts get ~sampel-palnet', 'groups list'",
+        },
+      },
+      required: ["command"],
+    },
+    async execute(_id: string, params: { command: string }) {
+      try {
+        const args = shellSplit(params.command);
+
+        const subcommand = args[0];
+        if (!ALLOWED_TLON_COMMANDS.has(subcommand)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Error: Unknown tlon subcommand '${subcommand}'. Allowed: ${[...ALLOWED_TLON_COMMANDS].join(", ")}`,
+              },
+            ],
+            details: { error: true },
+          };
+        }
+
+        const output = await runTlonCommand(tlonBinary, args);
+        return {
+          content: [{ type: "text" as const, text: output }],
+          details: undefined,
+        };
+      } catch (error: any) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${error.message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  };
+}
+
 const plugin = {
   id: "tlon",
   name: "Tlon",
@@ -131,59 +194,7 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setTlonRuntime(api.runtime);
     api.registerChannel({ plugin: tlonPlugin });
-
-    // Register the tlon tool
-    const tlonBinary = findTlonBinary();
-    api.logger.info(`[tlon] Registering tlon tool, binary: ${tlonBinary}`);
-    api.registerTool({
-      name: "tlon",
-      label: "Tlon CLI",
-      description:
-        "Tlon/Urbit API operations: activity, channels, contacts, groups, messages, dms, posts, notebook, settings. " +
-        "Examples: 'activity mentions --limit 10', 'channels groups', 'contacts self', 'groups list'",
-      parameters: {
-        type: "object",
-        properties: {
-          command: {
-            type: "string",
-            description:
-              "The tlon command and arguments. " +
-              "Examples: 'activity mentions --limit 10', 'contacts get ~sampel-palnet', 'groups list'",
-          },
-        },
-        required: ["command"],
-      },
-      async execute(_id: string, params: { command: string }) {
-        try {
-          const args = shellSplit(params.command);
-
-          // Validate first argument is a whitelisted tlon subcommand
-          const subcommand = args[0];
-          if (!ALLOWED_TLON_COMMANDS.has(subcommand)) {
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: `Error: Unknown tlon subcommand '${subcommand}'. Allowed: ${[...ALLOWED_TLON_COMMANDS].join(", ")}`,
-                },
-              ],
-              details: { error: true },
-            };
-          }
-
-          const output = await runTlonCommand(tlonBinary, args);
-          return {
-            content: [{ type: "text" as const, text: output }],
-            details: undefined,
-          };
-        } catch (error: any) {
-          return {
-            content: [{ type: "text" as const, text: `Error: ${error.message}` }],
-            details: { error: true },
-          };
-        }
-      },
-    });
+    api.registerTool((_ctx: OpenClawPluginToolContext) => createTlonTool(api));
   },
 };
 

--- a/extensions/tlon/src/onboarding.ts
+++ b/extensions/tlon/src/onboarding.ts
@@ -1,12 +1,10 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/tlon";
-import {
-  formatDocsLink,
-  patchScopedAccountConfig,
-  resolveAccountIdForConfigure,
-  DEFAULT_ACCOUNT_ID,
-  type ChannelOnboardingAdapter,
-  type WizardPrompter,
-} from "openclaw/plugin-sdk/tlon";
+import type { ChannelOnboardingAdapter } from "../../../src/channels/plugins/onboarding-types.js";
+import { resolveAccountIdForConfigure } from "../../../src/channels/plugins/onboarding/helpers.js";
+import { patchScopedAccountConfig } from "../../../src/channels/plugins/setup-helpers.js";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import { DEFAULT_ACCOUNT_ID } from "../../../src/routing/session-key.js";
+import { formatDocsLink } from "../../../src/terminal/links.js";
+import type { WizardPrompter } from "../../../src/wizard/prompts.js";
 import { buildTlonAccountFields } from "./account-fields.js";
 import type { TlonResolvedAccount } from "./types.js";
 import { listTlonAccountIds, resolveTlonAccount } from "./types.js";

--- a/extensions/tlon/src/runtime.ts
+++ b/extensions/tlon/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/tlon";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setTlonRuntime, getRuntime: getTlonRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Tlon runtime not initialized");

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -11,7 +11,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./plugin.ts"
     ]
   }
 }

--- a/extensions/twitch/plugin.ts
+++ b/extensions/twitch/plugin.ts
@@ -1,0 +1,24 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/twitch";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
+import { setTwitchRuntime } from "./src/runtime.js";
+
+const twitchPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/plugin.js",
+  exportName: "twitchPlugin",
+  pluginId: "twitch",
+});
+
+const plugin = {
+  id: "twitch",
+  name: "Twitch",
+  description: "Twitch channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setTwitchRuntime(api.runtime);
+    api.registerChannel({ plugin: twitchPlugin as any });
+  },
+};
+
+export default plugin;

--- a/extensions/twitch/src/onboarding.ts
+++ b/extensions/twitch/src/onboarding.ts
@@ -2,14 +2,14 @@
  * Twitch onboarding adapter for CLI setup wizard.
  */
 
-import type { OpenClawConfig } from "openclaw/plugin-sdk/twitch";
-import {
-  formatDocsLink,
-  promptChannelAccessConfig,
-  type ChannelOnboardingAdapter,
-  type ChannelOnboardingDmPolicy,
-  type WizardPrompter,
-} from "openclaw/plugin-sdk/twitch";
+import type {
+  ChannelOnboardingAdapter,
+  ChannelOnboardingDmPolicy,
+} from "../../../src/channels/plugins/onboarding-types.js";
+import { promptChannelAccessConfig } from "../../../src/channels/plugins/onboarding/channel-access.js";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import { formatDocsLink } from "../../../src/terminal/links.js";
+import type { WizardPrompter } from "../../../src/wizard/prompts.js";
 import { DEFAULT_ACCOUNT_ID, getAccountConfig } from "./config.js";
 import type { TwitchAccountConfig, TwitchRole } from "./types.js";
 import { isAccountConfigured } from "./utils/twitch.js";

--- a/extensions/twitch/src/runtime.ts
+++ b/extensions/twitch/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/twitch";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setTwitchRuntime, getRuntime: getTwitchRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Twitch runtime not initialized");

--- a/extensions/whatsapp/index.ts
+++ b/extensions/whatsapp/index.ts
@@ -1,7 +1,14 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/whatsapp";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/whatsapp";
-import { whatsappPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setWhatsAppRuntime } from "./src/runtime.js";
+
+const whatsappPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "whatsappPlugin",
+  pluginId: "whatsapp",
+});
 
 const plugin = {
   id: "whatsapp",

--- a/extensions/whatsapp/src/onboarding.ts
+++ b/extensions/whatsapp/src/onboarding.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { loginWeb } from "../../../src/channel-web.js";
 import type { ChannelOnboardingAdapter } from "../../../src/channels/plugins/onboarding-types.js";
 import {
   normalizeAllowFromEntries,
@@ -23,6 +22,16 @@ import {
 } from "./accounts.js";
 
 const channel = "whatsapp" as const;
+
+async function loginWhatsAppWeb(
+  verbose: boolean,
+  outputDir: string | undefined,
+  runtime: RuntimeEnv,
+  accountId: string,
+) {
+  const { loginWeb } = await import("./login.js");
+  return await loginWeb(verbose, outputDir, runtime, accountId);
+}
 
 function setWhatsAppDmPolicy(cfg: OpenClawConfig, dmPolicy: DmPolicy): OpenClawConfig {
   return mergeWhatsAppConfig(cfg, { dmPolicy });
@@ -330,7 +339,7 @@ export const whatsappOnboardingAdapter: ChannelOnboardingAdapter = {
     });
     if (wantsLink) {
       try {
-        await loginWeb(false, undefined, runtime, accountId);
+        await loginWhatsAppWeb(false, undefined, runtime, accountId);
       } catch (err) {
         runtime.error(`WhatsApp login failed: ${String(err)}`);
         await prompter.note(`Docs: ${formatDocsLink("/whatsapp", "whatsapp")}`, "WhatsApp help");

--- a/extensions/whatsapp/src/runtime.ts
+++ b/extensions/whatsapp/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/whatsapp";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setWhatsAppRuntime, getRuntime: getWhatsAppRuntime } =
   createPluginRuntimeStore<PluginRuntime>("WhatsApp runtime not initialized");

--- a/extensions/zalo/index.ts
+++ b/extensions/zalo/index.ts
@@ -1,7 +1,19 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/zalo";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/zalo";
-import { zaloDock, zaloPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import { createLazyChannelDock, createLazyChannelPlugin } from "../../src/plugins/lazy-channel.js";
 import { setZaloRuntime } from "./src/runtime.js";
+
+const zaloPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "zaloPlugin",
+  pluginId: "zalo",
+});
+const zaloDock = createLazyChannelDock({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "zaloDock",
+});
 
 const plugin = {
   id: "zalo",

--- a/extensions/zalo/src/onboarding.ts
+++ b/extensions/zalo/src/onboarding.ts
@@ -1,21 +1,20 @@
 import type {
   ChannelOnboardingAdapter,
   ChannelOnboardingDmPolicy,
-  OpenClawConfig,
-  SecretInput,
-  WizardPrompter,
-} from "openclaw/plugin-sdk/zalo";
+} from "../../../src/channels/plugins/onboarding-types.js";
 import {
   buildSingleChannelSecretPromptState,
-  DEFAULT_ACCOUNT_ID,
-  hasConfiguredSecretInput,
   mergeAllowFromEntries,
-  normalizeAccountId,
   promptSingleChannelSecretInput,
   runSingleChannelSecretStep,
   resolveAccountIdForConfigure,
   setTopLevelChannelDmPolicyWithAllowFrom,
-} from "openclaw/plugin-sdk/zalo";
+} from "../../../src/channels/plugins/onboarding/helpers.js";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import type { SecretInput } from "../../../src/config/types.secrets.js";
+import { hasConfiguredSecretInput } from "../../../src/config/types.secrets.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../src/routing/session-key.js";
+import type { WizardPrompter } from "../../../src/wizard/prompts.js";
 import { listZaloAccountIds, resolveDefaultZaloAccountId, resolveZaloAccount } from "./accounts.js";
 
 const channel = "zalo" as const;

--- a/extensions/zalo/src/runtime.ts
+++ b/extensions/zalo/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalo";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setZaloRuntime, getRuntime: getZaloRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Zalo runtime not initialized");

--- a/extensions/zalouser/index.ts
+++ b/extensions/zalouser/index.ts
@@ -1,8 +1,24 @@
 import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/zalouser";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/zalouser";
-import { zalouserDock, zalouserPlugin } from "./src/channel.js";
+import { emptyPluginConfigSchema } from "../../src/plugins/config-schema.js";
+import {
+  createLazyChannelDock,
+  createLazyChannelPlugin,
+  loadLazyModuleExport,
+} from "../../src/plugins/lazy-channel.js";
 import { setZalouserRuntime } from "./src/runtime.js";
-import { ZalouserToolSchema, executeZalouserTool } from "./src/tool.js";
+import { ZalouserToolSchema } from "./src/tool-schema.js";
+
+const zalouserPlugin = createLazyChannelPlugin({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "zalouserPlugin",
+  pluginId: "zalouser",
+});
+const zalouserDock = createLazyChannelDock({
+  importerUrl: import.meta.url,
+  modulePath: "./src/channel.js",
+  exportName: "zalouserDock",
+});
 
 const plugin = {
   id: "zalouser",
@@ -12,7 +28,6 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setZalouserRuntime(api.runtime);
     api.registerChannel({ plugin: zalouserPlugin, dock: zalouserDock });
-
     api.registerTool({
       name: "zalouser",
       label: "Zalo Personal",
@@ -21,7 +36,14 @@ const plugin = {
         "Actions: send (text message), image (send image URL), link (send link), " +
         "friends (list/search friends), groups (list groups), me (profile info), status (auth check).",
       parameters: ZalouserToolSchema,
-      execute: executeZalouserTool,
+      execute: async (id, params) =>
+        await loadLazyModuleExport<
+          (toolId: string, toolParams: Record<string, unknown>) => Promise<unknown>
+        >({
+          importerUrl: import.meta.url,
+          modulePath: "./src/tool.js",
+          exportName: "executeZalouserTool",
+        })(id, params),
     } as AnyAgentTool);
   },
 };

--- a/extensions/zalouser/src/runtime.ts
+++ b/extensions/zalouser/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalouser";
+import { createPluginRuntimeStore } from "../../../src/plugin-sdk/runtime-store.js";
 
 const { setRuntime: setZalouserRuntime, getRuntime: getZalouserRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Zalouser runtime not initialized");

--- a/extensions/zalouser/src/tool-schema.ts
+++ b/extensions/zalouser/src/tool-schema.ts
@@ -1,0 +1,27 @@
+import { Type } from "@sinclair/typebox";
+
+const ACTIONS = ["send", "image", "link", "friends", "groups", "me", "status"] as const;
+
+function stringEnum<T extends readonly string[]>(
+  values: T,
+  options: { description?: string } = {},
+) {
+  return Type.Unsafe<T[number]>({
+    type: "string",
+    enum: [...values],
+    ...options,
+  });
+}
+
+export const ZalouserToolSchema = Type.Object(
+  {
+    action: stringEnum(ACTIONS, { description: `Action to perform: ${ACTIONS.join(", ")}` }),
+    threadId: Type.Optional(Type.String({ description: "Thread ID for messaging" })),
+    message: Type.Optional(Type.String({ description: "Message text" })),
+    isGroup: Type.Optional(Type.Boolean({ description: "Is group chat" })),
+    profile: Type.Optional(Type.String({ description: "Profile name" })),
+    query: Type.Optional(Type.String({ description: "Search query" })),
+    url: Type.Optional(Type.String({ description: "URL for media/link" })),
+  },
+  { additionalProperties: false },
+);

--- a/extensions/zalouser/src/tool.ts
+++ b/extensions/zalouser/src/tool.ts
@@ -1,5 +1,5 @@
-import { Type } from "@sinclair/typebox";
 import { sendImageZalouser, sendLinkZalouser, sendMessageZalouser } from "./send.js";
+import { ZalouserToolSchema } from "./tool-schema.js";
 import {
   checkZaloAuthenticated,
   getZaloUserInfo,
@@ -7,39 +7,13 @@ import {
   listZaloGroupsMatching,
 } from "./zalo-js.js";
 
-const ACTIONS = ["send", "image", "link", "friends", "groups", "me", "status"] as const;
-
 type AgentToolResult = {
   content: Array<{ type: string; text: string }>;
   details?: unknown;
 };
 
-function stringEnum<T extends readonly string[]>(
-  values: T,
-  options: { description?: string } = {},
-) {
-  return Type.Unsafe<T[number]>({
-    type: "string",
-    enum: [...values],
-    ...options,
-  });
-}
-
-export const ZalouserToolSchema = Type.Object(
-  {
-    action: stringEnum(ACTIONS, { description: `Action to perform: ${ACTIONS.join(", ")}` }),
-    threadId: Type.Optional(Type.String({ description: "Thread ID for messaging" })),
-    message: Type.Optional(Type.String({ description: "Message text" })),
-    isGroup: Type.Optional(Type.Boolean({ description: "Is group chat" })),
-    profile: Type.Optional(Type.String({ description: "Profile name" })),
-    query: Type.Optional(Type.String({ description: "Search query" })),
-    url: Type.Optional(Type.String({ description: "URL for media/link" })),
-  },
-  { additionalProperties: false },
-);
-
 type ToolParams = {
-  action: (typeof ACTIONS)[number];
+  action: "send" | "image" | "link" | "friends" | "groups" | "me" | "status";
   threadId?: string;
   message?: string;
   isGroup?: boolean;

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -1,18 +1,14 @@
-import { inspectSlackAccount } from "../../../../extensions/slack/src/account-inspect.js";
 import {
   listSlackAccountIds,
   resolveDefaultSlackAccountId,
   resolveSlackAccount,
 } from "../../../../extensions/slack/src/accounts.js";
-import { resolveSlackChannelAllowlist } from "../../../../extensions/slack/src/resolve-channels.js";
-import { resolveSlackUserAllowlist } from "../../../../extensions/slack/src/resolve-users.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { hasConfiguredSecretInput } from "../../../config/types.secrets.js";
 import { DEFAULT_ACCOUNT_ID } from "../../../routing/session-key.js";
 import { formatDocsLink } from "../../../terminal/links.js";
 import type { WizardPrompter } from "../../../wizard/prompts.js";
 import type { ChannelOnboardingAdapter, ChannelOnboardingDmPolicy } from "../onboarding-types.js";
-import { configureChannelAccessWithAllowlist } from "./channel-access-configure.js";
 import {
   parseMentionOrPrefixedId,
   noteChannelLookupFailure,
@@ -28,6 +24,43 @@ import {
 } from "./helpers.js";
 
 const channel = "slack" as const;
+
+async function inspectSlackOnboardingAccount(params: { cfg: OpenClawConfig; accountId: string }) {
+  const { inspectSlackAccount } =
+    await import("../../../../extensions/slack/src/account-inspect.js");
+  return inspectSlackAccount(params);
+}
+
+async function resolveSlackOnboardingUserAllowlist(params: { token: string; entries: string[] }) {
+  const { resolveSlackUserAllowlist } =
+    await import("../../../../extensions/slack/src/resolve-users.js");
+  return resolveSlackUserAllowlist(params);
+}
+
+async function resolveSlackOnboardingChannelAllowlist(params: {
+  token: string;
+  entries: string[];
+}) {
+  const { resolveSlackChannelAllowlist } =
+    await import("../../../../extensions/slack/src/resolve-channels.js");
+  return resolveSlackChannelAllowlist(params);
+}
+
+async function configureSlackChannelAccessWithAllowlist(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  label: string;
+  currentPolicy: "open" | "allowlist";
+  currentEntries: string[];
+  placeholder: string;
+  updatePrompt: boolean;
+  setPolicy: (cfg: OpenClawConfig, policy: "open" | "allowlist") => OpenClawConfig;
+  resolveAllowlist: (params: { cfg: OpenClawConfig; entries: string[] }) => Promise<string[]>;
+  applyAllowlist: (params: { cfg: OpenClawConfig; resolved: string[] }) => OpenClawConfig;
+}) {
+  const { configureChannelAccessWithAllowlist } = await import("./channel-access-configure.js");
+  return configureChannelAccessWithAllowlist(params);
+}
 
 function buildSlackManifest(botName: string) {
   const safeName = botName.trim() || "OpenClaw";
@@ -173,7 +206,7 @@ async function promptSlackAllowFrom(params: {
     parseId,
     invalidWithoutTokenNote: "Slack token missing; use user ids (or mention form) only.",
     resolveEntries: ({ token, entries }) =>
-      resolveSlackUserAllowlist({
+      resolveSlackOnboardingUserAllowlist({
         token,
         entries,
       }),
@@ -199,10 +232,14 @@ const dmPolicy: ChannelOnboardingDmPolicy = {
 export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
   channel,
   getStatus: async ({ cfg }) => {
-    const configured = listSlackAccountIds(cfg).some((accountId) => {
-      const account = inspectSlackAccount({ cfg, accountId });
-      return account.configured;
-    });
+    let configured = false;
+    for (const accountId of listSlackAccountIds(cfg)) {
+      const account = await inspectSlackOnboardingAccount({ cfg, accountId });
+      if (account.configured) {
+        configured = true;
+        break;
+      }
+    }
     return {
       channel,
       configured,
@@ -295,7 +332,7 @@ export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
     });
     next = appTokenStep.cfg;
 
-    next = await configureChannelAccessWithAllowlist({
+    next = await configureSlackChannelAccessWithAllowlist({
       cfg: next,
       prompter,
       label: "Slack channels",
@@ -321,7 +358,7 @@ export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
         const activeBotToken = accountWithTokens.botToken || resolvedBotTokenForAllowlist || "";
         if (activeBotToken && entries.length > 0) {
           try {
-            const resolved = await resolveSlackChannelAllowlist({
+            const resolved = await resolveSlackOnboardingChannelAllowlist({
               token: activeBotToken,
               entries,
             });

--- a/src/plugins/lazy-channel.ts
+++ b/src/plugins/lazy-channel.ts
@@ -1,0 +1,232 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createJiti } from "jiti";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+
+function resolvePluginSdkAliasCandidateOrder(params: {
+  modulePath: string;
+  isProduction: boolean;
+}): Array<"dist" | "src"> {
+  const normalizedModulePath = params.modulePath.replace(/\\/g, "/");
+  const isDistRuntime = normalizedModulePath.includes("/dist/");
+  return isDistRuntime || params.isProduction ? ["dist", "src"] : ["src", "dist"];
+}
+
+function listPluginSdkAliasCandidates(params: {
+  srcFile: string;
+  distFile: string;
+  modulePath: string;
+}): string[] {
+  const orderedKinds = resolvePluginSdkAliasCandidateOrder({
+    modulePath: params.modulePath,
+    isProduction: process.env.NODE_ENV === "production",
+  });
+  let cursor = path.dirname(params.modulePath);
+  const candidates: string[] = [];
+  for (let i = 0; i < 6; i += 1) {
+    const candidateMap = {
+      src: path.join(cursor, "src", "plugin-sdk", params.srcFile),
+      dist: path.join(cursor, "dist", "plugin-sdk", params.distFile),
+    } as const;
+    for (const kind of orderedKinds) {
+      candidates.push(candidateMap[kind]);
+    }
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+  return candidates;
+}
+
+function resolvePluginSdkAliasFile(params: {
+  srcFile: string;
+  distFile: string;
+  modulePath: string;
+}): string | null {
+  for (const candidate of listPluginSdkAliasCandidates(params)) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+const cachedPluginSdkExportedSubpaths = new Map<string, string[]>();
+
+function listPluginSdkExportedSubpaths(modulePath: string): string[] {
+  const packageRoot = resolveOpenClawPackageRootSync({
+    cwd: path.dirname(modulePath),
+  });
+  if (!packageRoot) {
+    return [];
+  }
+  const cached = cachedPluginSdkExportedSubpaths.get(packageRoot);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const pkgRaw = fs.readFileSync(path.join(packageRoot, "package.json"), "utf-8");
+    const pkg = JSON.parse(pkgRaw) as {
+      exports?: Record<string, unknown>;
+    };
+    const subpaths = Object.keys(pkg.exports ?? {})
+      .filter((key) => key.startsWith("./plugin-sdk/"))
+      .map((key) => key.slice("./plugin-sdk/".length))
+      .filter((subpath) => Boolean(subpath) && !subpath.includes("/"))
+      .toSorted();
+    cachedPluginSdkExportedSubpaths.set(packageRoot, subpaths);
+    return subpaths;
+  } catch {
+    return [];
+  }
+}
+
+function resolvePluginSdkAliasMap(modulePath: string): Record<string, string> {
+  const aliasMap: Record<string, string> = {};
+  const pluginSdkRoot = resolvePluginSdkAliasFile({
+    srcFile: "root-alias.cjs",
+    distFile: "root-alias.cjs",
+    modulePath,
+  });
+  if (pluginSdkRoot) {
+    aliasMap["openclaw/plugin-sdk"] = pluginSdkRoot;
+  }
+  for (const subpath of listPluginSdkExportedSubpaths(modulePath)) {
+    const resolved = resolvePluginSdkAliasFile({
+      srcFile: `${subpath}.ts`,
+      distFile: `${subpath}.js`,
+      modulePath,
+    });
+    if (resolved) {
+      aliasMap[`openclaw/plugin-sdk/${subpath}`] = resolved;
+    }
+  }
+  return aliasMap;
+}
+
+const jitiCache = new Map<string, ReturnType<typeof createJiti>>();
+
+function getLazyLoader(importerUrl: string): ReturnType<typeof createJiti> {
+  const cached = jitiCache.get(importerUrl);
+  if (cached) {
+    return cached;
+  }
+  const modulePath = fileURLToPath(importerUrl);
+  const aliasMap = resolvePluginSdkAliasMap(modulePath);
+  const loader = createJiti(importerUrl, {
+    interopDefault: true,
+    extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+    ...(Object.keys(aliasMap).length > 0 ? { alias: aliasMap } : {}),
+  });
+  jitiCache.set(importerUrl, loader);
+  return loader;
+}
+
+type LazyModuleObjectParams<T extends object> = {
+  importerUrl: string;
+  modulePath: string;
+  resolve: (mod: Record<string, unknown>) => T;
+  stub?: Partial<T>;
+};
+
+function createLazyModuleObject<T extends object>(params: LazyModuleObjectParams<T>): T {
+  let loaded: T | null = null;
+  const load = (): T => {
+    loaded ??= params.resolve(
+      getLazyLoader(params.importerUrl)(params.modulePath) as Record<string, unknown>,
+    );
+    return loaded;
+  };
+  const target = { ...params.stub } as T;
+  return new Proxy(target, {
+    get(_target, prop, receiver) {
+      if (params.stub && Reflect.has(params.stub, prop)) {
+        return Reflect.get(params.stub, prop, receiver);
+      }
+      return Reflect.get(load() as object, prop, receiver);
+    },
+    has(_target, prop) {
+      if (params.stub && Reflect.has(params.stub, prop)) {
+        return true;
+      }
+      return Reflect.has(load() as object, prop);
+    },
+    ownKeys() {
+      return Reflect.ownKeys(load() as object);
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      if (params.stub && Reflect.has(params.stub, prop)) {
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: false,
+          value: Reflect.get(params.stub, prop),
+        };
+      }
+      return Reflect.getOwnPropertyDescriptor(load() as object, prop);
+    },
+    set(_target, prop, value, receiver) {
+      return Reflect.set(load() as object, prop, value, receiver);
+    },
+    deleteProperty(_target, prop) {
+      return Reflect.deleteProperty(load() as object, prop);
+    },
+    defineProperty(_target, prop, attributes) {
+      return Reflect.defineProperty(load() as object, prop, attributes);
+    },
+    getPrototypeOf() {
+      return Reflect.getPrototypeOf(load() as object);
+    },
+  });
+}
+
+export function createLazyChannelPlugin<T extends { id: string }>(params: {
+  importerUrl: string;
+  modulePath: string;
+  exportName: string;
+  pluginId: string;
+}): T {
+  return createLazyModuleObject<T>({
+    importerUrl: params.importerUrl,
+    modulePath: params.modulePath,
+    resolve: (mod) => mod[params.exportName] as T,
+    stub: { id: params.pluginId, meta: {}, gatewayMethods: [] } as Partial<T>,
+  });
+}
+
+export function createLazyChannelDock<T extends object>(params: {
+  importerUrl: string;
+  modulePath: string;
+  exportName: string;
+}): T {
+  return createLazyModuleObject<T>({
+    importerUrl: params.importerUrl,
+    modulePath: params.modulePath,
+    resolve: (mod) => mod[params.exportName] as T,
+  });
+}
+
+export function createLazyChannelFactoryResult<T extends { id: string }>(params: {
+  importerUrl: string;
+  modulePath: string;
+  exportName: string;
+  pluginId: string;
+}): T {
+  return createLazyModuleObject<T>({
+    importerUrl: params.importerUrl,
+    modulePath: params.modulePath,
+    resolve: (mod) => (mod[params.exportName] as () => T)(),
+    stub: { id: params.pluginId } as Partial<T>,
+  });
+}
+
+export function loadLazyModuleExport<T>(params: {
+  importerUrl: string;
+  modulePath: string;
+  exportName: string;
+}): T {
+  return getLazyLoader(params.importerUrl)(params.modulePath)[params.exportName] as T;
+}


### PR DESCRIPTION
## Summary
- make bundled channel plugins register lazy channel proxies instead of importing full channel implementations at startup
- stop matrix crypto bootstrap from running during plugin registration and add lightweight channel metadata stubs for gateway enumeration
- lazy-load remaining onboarding/runtime hotspots for whatsapp, slack, tlon, twitch, and zalo so configure paths do not pull heavy channel graphs up front

## Testing
- pnpm vitest src/plugins/loader.test.ts (in the main worktree)
- fresh-process onboarding probes for bundled channels after the follow-up fixes
- manual smoke: `pnpm openclaw configure` reached the banner and wizard prompt without the old pre-banner stall