### PR TITLE
feat(subagents): external worker backend for sessions_spawn

### DIFF
--- a/contrib/loa-worker-launcher
+++ b/contrib/loa-worker-launcher
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# loa-worker-launcher — Bridge between OpenClaw sessions_spawn and LOA control plane.
+#
+# OpenClaw calls this script with a JSON spawn request on stdin.
+# It translates the request into a GAP control.v1 spawn and calls
+# the LOA control socket, then returns the result as JSON on stdout.
+#
+# Configuration (environment variables):
+#   LOA_CONTROL_SOCKET  — path to LOA control socket (default: $LOA_KIT/run/control.sock)
+#   LOA_KIT             — LOA kit directory (default: /srv/loa/kit)
+#   LOA_BIN             — path to loa binary (default: loa)
+#
+# Install:
+#   chmod +x contrib/loa-worker-launcher
+#   cp contrib/loa-worker-launcher /usr/local/bin/
+#
+# OpenClaw config (openclaw.yaml):
+#   agents:
+#     defaults:
+#       subagents:
+#         workerBackend: loa
+#         workerLauncher: /usr/local/bin/loa-worker-launcher
+
+set -euo pipefail
+
+LOA_BIN="${LOA_BIN:-loa}"
+LOA_KIT="${LOA_KIT:-/srv/loa/kit}"
+
+# Read spawn request from stdin.
+REQUEST=$(cat)
+
+# Extract fields from OpenClaw's JSON request.
+AGENT_ID=$(echo "$REQUEST" | jq -r '.agentId // empty')
+REQUEST_ID=$(echo "$REQUEST" | jq -r '.requestId // empty')
+SESSION_KEY=$(echo "$REQUEST" | jq -r '.childSessionKey // empty')
+TASK=$(echo "$REQUEST" | jq -r '.task // empty')
+MODE=$(echo "$REQUEST" | jq -r '.mode // "run"')
+MODEL=$(echo "$REQUEST" | jq -r '.model // empty')
+WORKSPACE=$(echo "$REQUEST" | jq -r '.workspaceDir // empty')
+DEPTH=$(echo "$REQUEST" | jq -r '.depth // 1')
+
+if [ -z "$AGENT_ID" ] || [ -z "$REQUEST_ID" ]; then
+  echo '{"status":"error","error":"Missing agentId or requestId in spawn request"}'
+  exit 0
+fi
+
+# Build GAP control.v1 spawn request.
+GAP_REQUEST=$(jq -n \
+  --arg version "gap.control.v1" \
+  --arg request_id "$REQUEST_ID" \
+  --arg agent_id "$AGENT_ID" \
+  --arg session_id "$SESSION_KEY" \
+  --arg workload_id "$REQUEST_ID" \
+  --arg issued_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg nonce "$REQUEST_ID" \
+  --arg label "source=openclaw-gateway" \
+  '{
+    version: $version,
+    request_id: $request_id,
+    agent_id: $agent_id,
+    session_id: $session_id,
+    workload_id: $workload_id,
+    issued_at: $issued_at,
+    nonce: $nonce
+  }')
+
+# Write request to temp file.
+TMPFILE=$(mktemp /tmp/loa-spawn-XXXXXX.json)
+trap 'rm -f "$TMPFILE"' EXIT
+echo "$GAP_REQUEST" > "$TMPFILE"
+
+# Call LOA control spawn.
+RESULT=$(LOA_KIT="$LOA_KIT" "$LOA_BIN" control spawn --request-json "$TMPFILE" 2>&1) || true
+
+# Parse LOA response.
+DECISION=$(echo "$RESULT" | jq -r '.decision // empty' 2>/dev/null) || DECISION=""
+WORKER_ID=$(echo "$RESULT" | jq -r '.worker_id // empty' 2>/dev/null) || WORKER_ID=""
+REASON=$(echo "$RESULT" | jq -r '.reason // empty' 2>/dev/null) || REASON=""
+
+if [ "$DECISION" = "permit" ] && [ -n "$WORKER_ID" ]; then
+  jq -n --arg wid "$WORKER_ID" '{"status":"accepted","workerId":$wid}'
+elif [ "$DECISION" = "deny" ]; then
+  MSG="${REASON:-LOA denied the spawn request}"
+  jq -n --arg err "$MSG" '{"status":"denied","error":$err}'
+else
+  # Unexpected response — return raw output as error context.
+  jq -n --arg err "LOA control spawn failed: $RESULT" '{"status":"error","error":$err}'
+fi

--- a/src/agents/external-worker-backend.ts
+++ b/src/agents/external-worker-backend.ts
@@ -1,0 +1,156 @@
+/**
+ * External worker backend for sessions_spawn.
+ *
+ * When `agents.defaults.subagents.workerBackend` is set (e.g. "loa"),
+ * sub-agent spawns are delegated to an external launcher instead of
+ * running in-process via callGateway.
+ *
+ * The launcher is an executable specified by `workerLauncher` (path)
+ * or `workerSocket` (Unix socket for HTTP). It receives a JSON spawn
+ * request on stdin and returns a JSON response on stdout.
+ *
+ * This enables governance frameworks like LOA (Land of Agents) to
+ * manage worker lifecycle, enforce network/mount/secret policies,
+ * and maintain an auditable spawn trail.
+ */
+
+import { spawn } from "node:child_process";
+
+export type ExternalWorkerBackendConfig = {
+  /** Backend identifier (e.g. "loa"). */
+  backend: string;
+  /** Path to launcher executable. Receives JSON on stdin, returns JSON on stdout. */
+  launcher: string;
+};
+
+export type ExternalSpawnRequest = {
+  /** Protocol version for the spawn request. */
+  version: "openclaw.worker.v1";
+  /** Unique request identifier. */
+  requestId: string;
+  /** Target agent identifier. */
+  agentId: string;
+  /** Child session key assigned by OpenClaw. */
+  childSessionKey: string;
+  /** Session key of the requester (parent). */
+  requesterSessionKey: string;
+  /** Spawn depth (1 = direct child, 2 = grandchild, etc). */
+  depth: number;
+  /** The task message for the child agent. */
+  task: string;
+  /** System prompt for the child agent. */
+  systemPrompt: string;
+  /** Run timeout in seconds (0 = no timeout). */
+  runTimeoutSeconds: number;
+  /** Spawn mode: "run" (one-shot) or "session" (persistent). */
+  mode: "run" | "session";
+  /** Model selection for the child agent (if any). */
+  model?: string;
+  /** Thinking level override (if any). */
+  thinking?: string;
+  /** Label for the child agent run. */
+  label?: string;
+  /** Workspace directory to inherit. */
+  workspaceDir?: string;
+};
+
+export type ExternalSpawnResponse = {
+  /** "accepted" on success, "error" or "denied" on failure. */
+  status: "accepted" | "denied" | "error";
+  /** Worker/run identifier assigned by the external backend. */
+  workerId?: string;
+  /** Human-readable error message on failure. */
+  error?: string;
+};
+
+/**
+ * Resolve external worker backend config from OpenClaw config.
+ * Returns undefined if no external backend is configured.
+ */
+export function resolveExternalWorkerBackend(cfg: {
+  agents?: {
+    defaults?: {
+      subagents?: {
+        workerBackend?: string;
+        workerLauncher?: string;
+      };
+    };
+  };
+}): ExternalWorkerBackendConfig | undefined {
+  const backend = cfg?.agents?.defaults?.subagents?.workerBackend?.trim();
+  if (!backend) {
+    return undefined;
+  }
+  const launcher = cfg?.agents?.defaults?.subagents?.workerLauncher?.trim();
+  if (!launcher) {
+    return undefined;
+  }
+  return { backend, launcher };
+}
+
+/**
+ * Spawn a sub-agent via an external worker backend.
+ *
+ * Calls the launcher executable with the spawn request as JSON on stdin.
+ * The launcher must return a JSON response on stdout within the timeout.
+ */
+export async function spawnExternalWorker(
+  config: ExternalWorkerBackendConfig,
+  request: ExternalSpawnRequest,
+): Promise<ExternalSpawnResponse> {
+  const input = JSON.stringify(request);
+  try {
+    const result = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      const child = spawn(config.launcher, [], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          OPENCLAW_WORKER_BACKEND: config.backend,
+        },
+        timeout: 30_000,
+      });
+      const chunks: Buffer[] = [];
+      const errChunks: Buffer[] = [];
+      child.stdout.on("data", (data: Buffer) => chunks.push(data));
+      child.stderr.on("data", (data: Buffer) => errChunks.push(data));
+      child.on("error", reject);
+      child.on("close", (code) => {
+        const stdout = Buffer.concat(chunks).toString("utf8");
+        const stderr = Buffer.concat(errChunks).toString("utf8");
+        if (code !== 0 && !stdout.trim()) {
+          reject(new Error(`Launcher exited with code ${code}: ${stderr.trim()}`));
+        } else {
+          resolve({ stdout, stderr });
+        }
+      });
+      child.stdin.write(input);
+      child.stdin.end();
+    });
+    if (result.stderr.trim()) {
+      process.stderr.write(
+        `[external-worker-backend] ${config.backend}: ${result.stderr.trim()}\n`,
+      );
+    }
+    const trimmed = result.stdout.trim();
+    if (!trimmed) {
+      return {
+        status: "error",
+        error: `External worker launcher (${config.backend}) returned empty response`,
+      };
+    }
+    const parsed = JSON.parse(trimmed) as ExternalSpawnResponse;
+    if (!parsed.status) {
+      return {
+        status: "error",
+        error: `External worker launcher (${config.backend}) returned invalid response (missing status)`,
+      };
+    }
+    return parsed;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      status: "error",
+      error: `External worker launcher (${config.backend}) failed: ${message}`,
+    };
+  }
+}

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -13,6 +13,11 @@ import {
 } from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveAgentConfig } from "./agent-scope.js";
+import {
+  resolveExternalWorkerBackend,
+  spawnExternalWorker,
+  type ExternalSpawnRequest,
+} from "./external-worker-backend.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
@@ -603,94 +608,135 @@ export async function spawnSubagentDirect(
 
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
-  try {
-    const {
-      spawnedBy: _spawnedBy,
-      workspaceDir: _workspaceDir,
-      ...publicSpawnedMetadata
-    } = spawnedMetadata;
-    const response = await callGateway<{ runId: string }>({
-      method: "agent",
-      params: {
-        message: childTaskMessage,
-        sessionKey: childSessionKey,
-        channel: requesterOrigin?.channel,
-        to: requesterOrigin?.to ?? undefined,
-        accountId: requesterOrigin?.accountId ?? undefined,
-        threadId: requesterOrigin?.threadId != null ? String(requesterOrigin.threadId) : undefined,
-        idempotencyKey: childIdem,
-        deliver: false,
-        lane: AGENT_LANE_SUBAGENT,
-        extraSystemPrompt: childSystemPrompt,
-        thinking: thinkingOverride,
-        timeout: runTimeoutSeconds,
-        label: label || undefined,
-        ...publicSpawnedMetadata,
-      },
-      timeoutMs: 10_000,
-    });
-    if (typeof response?.runId === "string" && response.runId) {
-      childRunId = response.runId;
+
+  // External worker backend: delegate spawn to an external launcher (e.g. LOA)
+  // instead of running in-process via callGateway.
+  const externalBackend = resolveExternalWorkerBackend(cfg);
+  if (externalBackend) {
+    const externalRequest: ExternalSpawnRequest = {
+      version: "openclaw.worker.v1",
+      requestId: childIdem,
+      agentId: targetAgentId,
+      childSessionKey,
+      requesterSessionKey: requesterInternalKey,
+      depth: childDepth,
+      task: childTaskMessage,
+      systemPrompt: childSystemPrompt,
+      runTimeoutSeconds,
+      mode: spawnMode,
+      model: resolvedModel,
+      thinking: thinkingOverride,
+      label: label || undefined,
+      workspaceDir: spawnedMetadata.workspaceDir,
+    };
+    const externalResult = await spawnExternalWorker(externalBackend, externalRequest);
+    if (externalResult.status !== "accepted") {
+      await cleanupFailedSpawnBeforeAgentStart({
+        childSessionKey,
+        attachmentAbsDir,
+        emitLifecycleHooks: threadBindingReady,
+        deleteTranscript: true,
+      });
+      return {
+        status: externalResult.status === "denied" ? "forbidden" : "error",
+        error: externalResult.error || `External backend ${externalBackend.backend} rejected spawn`,
+        childSessionKey,
+        runId: childIdem,
+      };
     }
-  } catch (err) {
-    if (attachmentAbsDir) {
-      try {
-        await fs.rm(attachmentAbsDir, { recursive: true, force: true });
-      } catch {
-        // Best-effort cleanup only.
+    childRunId = externalResult.workerId || childIdem;
+  } else {
+    // Default: in-process spawn via gateway.
+    try {
+      const {
+        spawnedBy: _spawnedBy,
+        workspaceDir: _workspaceDir,
+        ...publicSpawnedMetadata
+      } = spawnedMetadata;
+      const response = await callGateway<{ runId: string }>({
+        method: "agent",
+        params: {
+          message: childTaskMessage,
+          sessionKey: childSessionKey,
+          channel: requesterOrigin?.channel,
+          to: requesterOrigin?.to ?? undefined,
+          accountId: requesterOrigin?.accountId ?? undefined,
+          threadId:
+            requesterOrigin?.threadId != null ? String(requesterOrigin.threadId) : undefined,
+          idempotencyKey: childIdem,
+          deliver: false,
+          lane: AGENT_LANE_SUBAGENT,
+          extraSystemPrompt: childSystemPrompt,
+          thinking: thinkingOverride,
+          timeout: runTimeoutSeconds,
+          label: label || undefined,
+          ...publicSpawnedMetadata,
+        },
+        timeoutMs: 10_000,
+      });
+      if (typeof response?.runId === "string" && response.runId) {
+        childRunId = response.runId;
       }
-    }
-    if (threadBindingReady) {
-      const hasEndedHook = hookRunner?.hasHooks("subagent_ended") === true;
-      let endedHookEmitted = false;
-      if (hasEndedHook) {
+    } catch (err) {
+      if (attachmentAbsDir) {
         try {
-          await hookRunner?.runSubagentEnded(
-            {
-              targetSessionKey: childSessionKey,
-              targetKind: "subagent",
-              reason: "spawn-failed",
-              sendFarewell: true,
-              accountId: requesterOrigin?.accountId,
-              runId: childRunId,
-              outcome: "error",
-              error: "Session failed to start",
-            },
-            {
-              runId: childRunId,
-              childSessionKey,
-              requesterSessionKey: requesterInternalKey,
-            },
-          );
-          endedHookEmitted = true;
+          await fs.rm(attachmentAbsDir, { recursive: true, force: true });
         } catch {
-          // Spawn should still return an actionable error even if cleanup hooks fail.
+          // Best-effort cleanup only.
         }
       }
-      // Always delete the provisional child session after a failed spawn attempt.
-      // If we already emitted subagent_ended above, suppress a duplicate lifecycle hook.
-      try {
-        await callGateway({
-          method: "sessions.delete",
-          params: {
-            key: childSessionKey,
-            deleteTranscript: true,
-            emitLifecycleHooks: !endedHookEmitted,
-          },
-          timeoutMs: 10_000,
-        });
-      } catch {
-        // Best-effort only.
+      if (threadBindingReady) {
+        const hasEndedHook = hookRunner?.hasHooks("subagent_ended") === true;
+        let endedHookEmitted = false;
+        if (hasEndedHook) {
+          try {
+            await hookRunner?.runSubagentEnded(
+              {
+                targetSessionKey: childSessionKey,
+                targetKind: "subagent",
+                reason: "spawn-failed",
+                sendFarewell: true,
+                accountId: requesterOrigin?.accountId,
+                runId: childRunId,
+                outcome: "error",
+                error: "Session failed to start",
+              },
+              {
+                runId: childRunId,
+                childSessionKey,
+                requesterSessionKey: requesterInternalKey,
+              },
+            );
+            endedHookEmitted = true;
+          } catch {
+            // Spawn should still return an actionable error even if cleanup hooks fail.
+          }
+        }
+        // Always delete the provisional child session after a failed spawn attempt.
+        // If we already emitted subagent_ended above, suppress a duplicate lifecycle hook.
+        try {
+          await callGateway({
+            method: "sessions.delete",
+            params: {
+              key: childSessionKey,
+              deleteTranscript: true,
+              emitLifecycleHooks: !endedHookEmitted,
+            },
+            timeoutMs: 10_000,
+          });
+        } catch {
+          // Best-effort only.
+        }
       }
+      const messageText = summarizeError(err);
+      return {
+        status: "error",
+        error: messageText,
+        childSessionKey,
+        runId: childRunId,
+      };
     }
-    const messageText = summarizeError(err);
-    return {
-      status: "error",
-      error: messageText,
-      childSessionKey,
-      runId: childRunId,
-    };
-  }
+  } // end else (in-process gateway spawn)
 
   try {
     registerSubagentRun({

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -281,6 +281,18 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
     announceTimeoutMs?: number;
+    /**
+     * External worker backend identifier (e.g. "loa").
+     * When set, sessions_spawn delegates to an external launcher instead of
+     * running in-process via callGateway. Requires workerLauncher to be set.
+     */
+    workerBackend?: string;
+    /**
+     * Path to external worker launcher executable.
+     * The launcher receives a JSON spawn request on stdin and must return
+     * a JSON response on stdout. Required when workerBackend is set.
+     */
+    workerLauncher?: string;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -188,6 +188,18 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        workerBackend: z
+          .string()
+          .optional()
+          .describe(
+            'External worker backend identifier (e.g. "loa"). When set, sessions_spawn delegates to an external launcher.',
+          ),
+        workerLauncher: z
+          .string()
+          .optional()
+          .describe(
+            "Path to external worker launcher executable. Receives JSON on stdin, returns JSON on stdout.",
+          ),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Adds support for delegating `sessions_spawn` to an external worker backend instead of running sub-agents in-process via `callGateway`.

- When `agents.defaults.subagents.workerBackend` is set (e.g. `"loa"`), spawns are routed to an external launcher executable specified by `workerLauncher`
- The launcher receives a JSON spawn request on stdin and returns a JSON response on stdout
- All existing validation (depth limits, agent allowlists, sandbox checks, model/thinking overrides, session patching) runs **before** the external backend is invoked
- When no `workerBackend` is configured, behavior is completely unchanged

This enables governance frameworks like [LOA (Land of Agents)](https://github.com/marcusmom/land-of-agents) to manage worker lifecycle externally — enforcing network/mount/secret policies and maintaining an auditable spawn trail via the GAP (Governed Agent Protocol) control plane.

### New config keys

```yaml
agents:
  defaults:
    subagents:
      workerBackend: loa
      workerLauncher: /usr/local/bin/loa-worker-launcher
```

### Protocol

The launcher receives on stdin:

```json
{
  "version": "openclaw.worker.v1",
  "requestId": "uuid",
  "agentId": "target-agent",
  "childSessionKey": "agent:target:subagent:uuid",
  "requesterSessionKey": "agent:parent:...",
  "depth": 1,
  "task": "...",
  "systemPrompt": "...",
  "runTimeoutSeconds": 300,
  "mode": "run",
  "model": "anthropic/claude-sonnet-4-6",
  "workspaceDir": "/workspace"
}
```

And must return on stdout:

```json
{"status": "accepted", "workerId": "wk_abc123"}
```

Or on failure:

```json
{"status": "denied", "error": "reason"}
```

### Files changed

- `src/agents/external-worker-backend.ts` — new module: config resolution, launcher invocation
- `src/agents/subagent-spawn.ts` — branch in `spawnSubagentDirect` before `callGateway`
- `src/config/types.agent-defaults.ts` — `workerBackend` and `workerLauncher` type fields
- `src/config/zod-schema.agent-defaults.ts` — corresponding zod validation
- `contrib/loa-worker-launcher` — reference launcher script bridging to LOA's GAP control plane

### Motivation

Related to #15342 — this provides a general-purpose extension point for external orchestrators without requiring HTTP API changes. The stdin/stdout launcher pattern is simple, composable, and works with any governance framework.

## Test plan

- [ ] Verify existing tests pass (no behavior change without config)
- [ ] Manual test with LOA worker backend: configure `workerBackend: loa`, verify spawn reaches LOA control socket and audit trail
- [ ] Test error paths: launcher not found, launcher returns error, launcher timeout
- [ ] Test that all existing validation still applies before external backend is invoked