### PR TITLE
fix: skip Gemini CLI audio autodetect in headless flows

### DIFF
--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -27,8 +27,12 @@ OpenClaw auto-detects in this order and stops at the first working option:
    - `sherpa-onnx-offline` (requires `SHERPA_ONNX_MODEL_DIR` with encoder/decoder/joiner/tokens)
    - `whisper-cli` (from `whisper-cpp`; uses `WHISPER_CPP_MODEL` or the bundled tiny model)
    - `whisper` (Python CLI; downloads models automatically)
-2. **Gemini CLI** (`gemini`) using `read_many_files`
-3. **Provider keys** (OpenAI → Groq → Deepgram → Google)
+2. **Provider keys** (OpenAI → Groq → Deepgram → Google)
+
+> Note: Gemini CLI auto-detect is intentionally skipped for **audio** in headless flows.
+> We found `gemini -p` audio-path references can be treated as regular file context instead of
+> deterministic multimodal audio input, which makes Telegram voice-note transcription unreliable.
+> Gemini CLI auto-detect remains available for image/video understanding.
 
 To disable auto-detection, set `tools.media.audio.enabled: false`.
 To customize, set `tools.media.audio.models`.

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -678,6 +678,39 @@ describe("applyMediaUnderstanding", () => {
     expect(mockedRunExec).not.toHaveBeenCalled();
   });
 
+  it("skips Gemini CLI auto-detect for audio and prefers provider transcription", async () => {
+    const binDir = await createTempMediaDir();
+    await createMockExecutable(binDir, "gemini");
+    const ctx = await createAudioCtx({
+      fileName: "telegram-note.ogg",
+      mediaType: "audio/ogg",
+      content: createSafeAudioFixtureBuffer(2048),
+    });
+    const cfg: OpenClawConfig = { tools: { media: { audio: {} } } };
+
+    await withMediaAutoDetectEnv(
+      {
+        PATH: binDir,
+      },
+      async () => {
+        const result = await applyMediaUnderstanding({
+          ctx,
+          cfg,
+          providers: {
+            openai: {
+              id: "openai",
+              transcribeAudio: async () => ({ text: "provider transcript" }),
+            },
+          },
+        });
+        expect(result.appliedAudio).toBe(true);
+      },
+    );
+
+    expect(ctx.Transcript).toBe("provider transcript");
+    expect(mockedRunExec).not.toHaveBeenCalledWith("gemini", expect.any(Array), expect.any(Object));
+  });
+
   it("uses CLI image understanding and preserves caption for commands", async () => {
     const imagePath = await createTempMediaFile({
       fileName: "photo.jpg",

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -316,8 +316,17 @@ async function resolveLocalAudioEntry(): Promise<MediaUnderstandingModelConfig |
 }
 
 async function resolveGeminiCliEntry(
-  _capability: MediaUnderstandingCapability,
+  capability: MediaUnderstandingCapability,
 ): Promise<MediaUnderstandingModelConfig | null> {
+  // Gemini CLI headless is not a reliable audio-transcription fallback: prompts that
+  // reference audio paths (for example Telegram .ogg voice notes) can be treated as
+  // regular file context instead of multimodal audio, and may drift into invalid tool
+  // fallback behavior. Keep Gemini CLI auto-detect for image/video, but prefer
+  // deterministic local/provider audio paths until the CLI offers a stable binary-audio
+  // attachment flow for headless transcription.
+  if (capability === "audio") {
+    return null;
+  }
   if (!(await probeGeminiCli())) {
     return null;
   }


### PR DESCRIPTION
## Summary
- stop auto-selecting Gemini CLI for audio transcription in headless media-understanding flows
- keep Gemini CLI auto-detect for image/video only
- add regression coverage proving audio falls through to provider transcription even when a `gemini` binary is present

## Why
Fixes #46588.

Gemini CLI headless audio-path prompting is currently unreliable for Telegram voice notes / `.ogg` inputs: it may treat the path as plain file context instead of binary audio and drift into invalid tool fallback behavior (`run_shell_command`). Until the CLI offers a deterministic headless binary-audio path, auto-detect should prefer local/provider audio transcription backends instead of Gemini CLI for audio.

## Testing
- `corepack pnpm vitest run src/media-understanding/apply.test.ts src/media-understanding/runner.auto-audio.test.ts`