### PR TITLE
Discord: reconcile native commands without restart churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,8 +148,7 @@ Docs: https://docs.openclaw.ai
 - macOS/node service startup: use `openclaw node start/stop --json` from the Mac app instead of the removed `openclaw service node ...` command shape, so current CLI installs expose the full node exec surface again. (#46843) Fixes #43171. Thanks @Br1an67.
 - macOS/launch at login: stop emitting `KeepAlive` for the desktop app launch agent so OpenClaw no longer relaunches immediately after a manual quit while launch at login remains enabled. (#40213) Thanks @stablegenius49.
 - ACP/gateway startup: use direct Telegram and Discord startup/status helpers instead of routing probes through the plugin runtime, and prepend the selected daemon Node bin dir to service PATH so plugin-local installs can still find `npm` and `pnpm`.
-- Discord/commands: switch native command deployment to Carbon reconcile by default so Discord restarts stop churning slash commands through OpenClaw’s local deploy path. (#46597) Thanks @huntharo.
-- Discord/commands: carry the upstream Carbon reconcile integration that backs the new default deployment path. Thanks @thewilloftheshadow.
+- Discord/commands: switch native command deployment to Carbon reconcile by default so Discord restarts stop churning slash commands through OpenClaw’s local deploy path. (#46597) Thanks @huntharo and @thewilloftheshadow.
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Docs: https://docs.openclaw.ai
 - macOS/launch at login: stop emitting `KeepAlive` for the desktop app launch agent so OpenClaw no longer relaunches immediately after a manual quit while launch at login remains enabled. (#40213) Thanks @stablegenius49.
 - ACP/gateway startup: use direct Telegram and Discord startup/status helpers instead of routing probes through the plugin runtime, and prepend the selected daemon Node bin dir to service PATH so plugin-local installs can still find `npm` and `pnpm`.
 - Discord/commands: switch native command deployment to Carbon reconcile by default so Discord restarts stop churning slash commands through OpenClaw’s local deploy path. (#46597) Thanks @huntharo.
+- Discord/commands: carry the upstream Carbon reconcile integration that backs the new default deployment path. Thanks @thewilloftheshadow.
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Docs: https://docs.openclaw.ai
 - macOS/node service startup: use `openclaw node start/stop --json` from the Mac app instead of the removed `openclaw service node ...` command shape, so current CLI installs expose the full node exec surface again. (#46843) Fixes #43171. Thanks @Br1an67.
 - macOS/launch at login: stop emitting `KeepAlive` for the desktop app launch agent so OpenClaw no longer relaunches immediately after a manual quit while launch at login remains enabled. (#40213) Thanks @stablegenius49.
 - ACP/gateway startup: use direct Telegram and Discord startup/status helpers instead of routing probes through the plugin runtime, and prepend the selected daemon Node bin dir to service PATH so plugin-local installs can still find `npm` and `pnpm`.
+- Discord/commands: switch native command deployment to Carbon reconcile by default so Discord restarts stop churning slash commands through OpenClaw’s local deploy path. (#46597) Thanks @huntharo.
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,6 @@ Docs: https://docs.openclaw.ai
 - macOS/node service startup: use `openclaw node start/stop --json` from the Mac app instead of the removed `openclaw service node ...` command shape, so current CLI installs expose the full node exec surface again. (#46843) Fixes #43171. Thanks @Br1an67.
 - macOS/launch at login: stop emitting `KeepAlive` for the desktop app launch agent so OpenClaw no longer relaunches immediately after a manual quit while launch at login remains enabled. (#40213) Thanks @stablegenius49.
 - ACP/gateway startup: use direct Telegram and Discord startup/status helpers instead of routing probes through the plugin runtime, and prepend the selected daemon Node bin dir to service PATH so plugin-local installs can still find `npm` and `pnpm`.
-- Discord/commands: switch native command deployment to Carbon reconcile by default so Discord restarts stop churning slash commands through OpenClaw’s local deploy path. (#46597) Thanks @huntharo and @thewilloftheshadow.
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.
@@ -181,6 +180,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/message discovery: require `ChannelMessageActionAdapter.describeMessageTool(...)` for shared `message` tool discovery. The legacy `listActions`, `getCapabilities`, and `getToolSchema` adapter methods are removed. Plugin authors should migrate message discovery to `describeMessageTool(...)` and keep channel-specific action runtime code inside the owning plugin package. Thanks @gumadeiras.
 - Exec/env sandbox: block build-tool JVM injection (`MAVEN_OPTS`, `SBT_OPTS`, `GRADLE_OPTS`, `ANT_OPTS`), glibc tunable exploitation (`GLIBC_TUNABLES`), and .NET dependency resolution hijack (`DOTNET_ADDITIONAL_DEPS`) from the host exec environment, and restrict Gradle init script redirect (`GRADLE_USER_HOME`) as an override-only block so user-configured Gradle homes still propagate. (#49702)
 - Plugins/Matrix: add a new Matrix plugin backed by the official `matrix-js-sdk`. If you are upgrading from the previous public Matrix plugin, follow the migration guide: https://docs.openclaw.ai/install/migrating-matrix Thanks @gumadeiras.
+- Discord/commands: switch native command deployment to Carbon reconcile by default so Discord restarts stop churning slash commands through OpenClaw’s local deploy path. (#46597) Thanks @huntharo and @thewilloftheshadow.
 
 ## 2026.3.13
 

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw Discord channel plugin",
   "type": "module",
   "dependencies": {
-    "@buape/carbon": "0.0.0-beta-20260216184201",
+    "@buape/carbon": "0.0.0-beta-20260317045421",
     "@discordjs/voice": "^0.19.2",
     "discord-api-types": "^0.38.42",
     "https-proxy-agent": "^8.0.0",

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -88,9 +88,23 @@ describe("monitorDiscordProvider", () => {
   const getConstructedEventQueue = (): { listenerTimeout?: number } | undefined => {
     expect(clientConstructorOptionsMock).toHaveBeenCalledTimes(1);
     const opts = clientConstructorOptionsMock.mock.calls[0]?.[0] as {
+      commandDeploymentMode?: string;
       eventQueue?: { listenerTimeout?: number };
     };
     return opts.eventQueue;
+  };
+
+  const getConstructedClientOptions = (): {
+    commandDeploymentMode?: string;
+    eventQueue?: { listenerTimeout?: number };
+  } => {
+    expect(clientConstructorOptionsMock).toHaveBeenCalledTimes(1);
+    return (
+      (clientConstructorOptionsMock.mock.calls[0]?.[0] as {
+        commandDeploymentMode?: string;
+        eventQueue?: { listenerTimeout?: number };
+      }) ?? {}
+    );
   };
 
   const getHealthProbe = () => {
@@ -537,6 +551,18 @@ describe("monitorDiscordProvider", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       expect.stringContaining("native command deploy skipped"),
     );
+  });
+
+  it("configures Carbon reconcile deployment by default", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    expect(clientHandleDeployRequestMock).toHaveBeenCalledTimes(1);
+    expect(getConstructedClientOptions().commandDeploymentMode).toBe("reconcile");
   });
 
   it("reports connected status on startup and shutdown", async () => {

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -306,6 +306,7 @@ async function deployDiscordCommands(params: {
       // errors like Discord 30034 fail fast and don't wedge the provider.
       restClient.options.queueRequests = false;
     }
+    params.runtime.log?.("discord: native commands using Carbon reconcile path");
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       try {
         await params.client.handleDeployRequest();
@@ -762,6 +763,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         baseUrl: "http://localhost",
         deploySecret: "a",
         clientId: applicationId,
+        commandDeploymentMode: "reconcile",
         publicKey: "a",
         token,
         autoDeploy: false,
@@ -805,7 +807,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       phase: "deploy-commands:start",
       startAt: startupStartedAt,
       gateway: lifecycleGateway,
-      details: `native=${nativeEnabled ? "on" : "off"} commandCount=${commands.length}`,
+      details: `native=${nativeEnabled ? "on" : "off"} reconcile=on commandCount=${commands.length}`,
     });
     await deployDiscordCommands({
       client,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,8 +309,8 @@ importers:
   extensions/discord:
     dependencies:
       '@buape/carbon':
-        specifier: 0.0.0-beta-20260216184201
-        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)
+        specifier: 0.0.0-beta-20260317045421
+        version: 0.0.0-beta-20260317045421(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)
       '@discordjs/voice':
         specifier: ^0.19.2
         version: 0.19.2(@discordjs/opus@0.10.0)(opusscript@0.1.1)
@@ -990,6 +990,9 @@ packages:
 
   '@buape/carbon@0.0.0-beta-20260216184201':
     resolution: {integrity: sha512-u5mgYcigfPVqT7D9gVTGd+3YSflTreQmrWog7ORbb0z5w9eT8ft4rJOdw9fGwr75zMu9kXpSBaAcY2eZoJFSdA==}
+
+  '@buape/carbon@0.0.0-beta-20260317045421':
+    resolution: {integrity: sha512-yM+r5iSxA/iG8CZ2VhK+EkcBQV+y45WLgF7kuczt2Ul1yixjXSCCcM80GppsklfUv7pqM4Dui+7w1WB3f5p7Kg==}
 
   '@cacheable/memory@2.0.7':
     resolution: {integrity: sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==}
@@ -7494,7 +7497,27 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260216184201(hono@4.12.8)(opusscript@0.1.1)':
+    dependencies:
+      '@types/node': 25.5.0
+      discord-api-types: 0.38.37
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260120.0
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@hono/node-server': 1.19.10(hono@4.12.8)
+      '@types/bun': 1.3.9
+      '@types/ws': 8.18.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - bufferutil
+      - ffmpeg-static
+      - hono
+      - node-opus
+      - opusscript
+      - utf-8-validate
+
+  '@buape/carbon@0.0.0-beta-20260317045421(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)':
     dependencies:
       '@types/node': 25.5.0
       discord-api-types: 0.38.37
@@ -12415,7 +12438,7 @@ snapshots:
     dependencies:
       '@agentclientprotocol/sdk': 0.16.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.1009.0
-      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)
+      '@buape/carbon': 0.0.0-beta-20260216184201(hono@4.12.8)(opusscript@0.1.1)
       '@clack/prompts': 1.1.0
       '@discordjs/voice': 0.19.2(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@grammyjs/runner': 2.0.3(grammy@1.41.1)


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: this branch was carrying a local Discord command reconcile implementation because upstream Carbon did not have it yet.
- Why it matters: now that Carbon beta has built-in global command reconciliation, keeping our own copy would be duplicate logic and duplicate tests around library behavior we no longer own.
- What changed: I bumped `@buape/carbon` to the beta that adds built-in reconcile, removed the local OpenClaw reconcile implementation, and switched the Discord provider to configure Carbon with `commandDeploymentMode: "reconcile"`.
- What did NOT change (scope boundary): I did not try to recreate Carbon’s internal diff logic in OpenClaw tests. The remaining tests now cover our integration points only: that we configure Carbon correctly and pass it the right command set.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related:
  - https://github.com/discord/discord-api-docs/discussions/4868#discussioncomment-2671084
  - https://docs.discord.com/developers/interactions/application-commands#making-a-global-command
  - https://github.com/discord/discord-api-docs/issues/6188

## User-visible / Behavior Changes

- OpenClaw now uses Carbon’s built-in Discord native command reconcile behavior instead of a local OpenClaw implementation.
- The Discord provider now configures Carbon with `commandDeploymentMode: "reconcile"`.
- The local `native-command-state` reconcile module and its tests are gone.
- The provider-level behavior stays the same at a high level: Discord command deployment defaults to reconcile instead of blind overwrite.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo tests
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): none

### Steps

1. Install the upstream Carbon beta:
   - `pnpm -w install @buape/carbon@beta`
2. Remove the local OpenClaw reconcile implementation and switch the provider to Carbon’s built-in reconcile mode.
3. Run the focused Discord tests and repo checks.

### Expected

- OpenClaw should no longer own a duplicate reconcile implementation.
- The Discord provider should configure Carbon reconcile by default.
- Provider tests should validate OpenClaw’s integration points, not Carbon’s internal diff logic.

### Actual

- Carbon beta now contains its own `reconcileGlobalCommands()` implementation.
- OpenClaw now sets `commandDeploymentMode: "reconcile"` on the Carbon client and uses the normal Carbon deploy path.
- The local reconcile module/tests were removed, and the remaining tests now verify our provider wiring instead of mocking library internals and pretending to test reconcile behavior we no longer own.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Discord’s docs and maintainer guidance still justify why reconcile is the right deployment mode:

> There is a global rate limit of 200 application command creates per day, per guild

Source: https://docs.discord.com/developers/interactions/application-commands#making-a-global-command

> this should not be an issue unless you are doing something you shouldn't, such as constantly deleting and re-creating many commands.

Source: https://github.com/discord/discord-api-docs/discussions/4868#discussioncomment-2671084

The important change in this revision is ownership, not the end behavior:

- before: OpenClaw implemented its own reconcile logic in `extensions/discord/src/monitor/native-command-state.ts`
- after: Carbon beta owns that logic, and OpenClaw only configures and calls into it

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - I installed `@buape/carbon@beta`.
  - I verified the installed Carbon beta now contains `Client.reconcileGlobalCommands()` and `commandDeploymentMode: "reconcile"` in its built output.
  - I removed the local OpenClaw reconcile module and switched the Discord provider to rely on Carbon’s deployment mode.
  - I verified the provider tests now cover our integration layer instead of a mocked copy of reconcile internals.
- Edge cases checked:
  - the provider still handles Discord create-quota errors at startup
  - plugin commands are still included in the constructed Discord command list
  - the managed `/vc` command is still included in the constructed Discord command list
- What you did **not** verify:
  - I did not claim that OpenClaw’s remaining tests prove Carbon’s internal reconcile diff algorithm. That logic now lives in the dependency, so our local suite should not pretend to cover it.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:
  - `pnpm install`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR, which restores the previous local implementation and prior Carbon version
- Files/config to restore:
  - `package.json`
  - `pnpm-lock.yaml`
  - `extensions/discord/src/monitor/provider.ts`
- Known bad symptoms reviewers should watch for:
  - Discord command deploy behavior regressing after the Carbon beta bump
  - provider tests passing while real Discord startup behavior diverges from what Carbon now owns

## Risks and Mitigations

- Risk: Carbon’s reconcile internals are now a dependency concern rather than local OpenClaw code.
  - Mitigation: this PR removes the local duplicate implementation and keeps only provider-level coverage that we actually own.
- Risk: the beta dependency could have unrelated behavior changes outside command reconcile.
  - Mitigation: I limited the local test focus to Discord provider wiring and kept the change surface narrow around the provider and dependency bump.
