### PR TITLE
Codex/chat scroll follow fix

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1378,6 +1378,7 @@ export function renderApp(state: AppViewState) {
                   });
                 },
                 onChatScroll: (event) => state.handleChatScroll(event),
+                onChatWheelIntent: (event) => state.handleChatWheelIntent(event),
                 getDraft: () => state.chatMessage,
                 onDraftChange: (next) => (state.chatMessage = next),
                 onRequestUpdate: requestHostUpdate,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -63,6 +63,13 @@ function createScrollEvent(scrollHeight: number, scrollTop: number, clientHeight
   } as unknown as Event;
 }
 
+function createWheelEvent(deltaY: number, scrollHeight: number, clientHeight: number) {
+  return {
+    deltaY,
+    currentTarget: { scrollHeight, clientHeight },
+  } as unknown as WheelEvent;
+}
+
 /* ------------------------------------------------------------------ */
 /*  handleChatScroll – threshold tests                                 */
 /* ------------------------------------------------------------------ */
@@ -146,13 +153,7 @@ describe("handleChatWheelIntent", () => {
     host.chatScrollFrame = 99;
     host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
 
-    handleChatWheelIntent(
-      host,
-      {
-        deltaY: -120,
-        currentTarget: { scrollHeight: 2000, clientHeight: 500 },
-      } as unknown as WheelEvent,
-    );
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 500));
 
     expect(host.chatUserNearBottom).toBe(false);
     expect(host.chatFollowLocked).toBe(true);
@@ -164,13 +165,7 @@ describe("handleChatWheelIntent", () => {
     const { host } = createScrollHost({});
     host.chatUserNearBottom = true;
 
-    handleChatWheelIntent(
-      host,
-      {
-        deltaY: 120,
-        currentTarget: { scrollHeight: 2000, clientHeight: 500 },
-      } as unknown as WheelEvent,
-    );
+    handleChatWheelIntent(host, createWheelEvent(120, 2000, 500));
 
     expect(host.chatUserNearBottom).toBe(true);
     expect(host.chatFollowLocked).toBe(false);
@@ -183,13 +178,7 @@ describe("handleChatWheelIntent", () => {
     });
     host.chatUserNearBottom = true;
 
-    handleChatWheelIntent(
-      host,
-      {
-        deltaY: -120,
-        currentTarget: { scrollHeight: 400, clientHeight: 400 },
-      } as unknown as WheelEvent,
-    );
+    handleChatWheelIntent(host, createWheelEvent(-120, 400, 400));
 
     expect(host.chatUserNearBottom).toBe(true);
     expect(host.chatFollowLocked).toBe(false);
@@ -323,13 +312,7 @@ describe("scheduleChatScroll", () => {
     host.chatFollowLocked = false;
     host.chatLastScrollTop = 2000;
 
-    handleChatWheelIntent(
-      host,
-      {
-        deltaY: -120,
-        currentTarget: { scrollHeight: 2000, clientHeight: 400 },
-      } as unknown as WheelEvent,
-    );
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 400));
     handleChatScroll(host, createScrollEvent(2000, 1540, 400));
 
     expect(host.chatUserNearBottom).toBe(false);

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -46,6 +46,7 @@ function createScrollHost(
     chatScrollTimeout: null as number | null,
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
+    chatFollowLocked: false,
     chatLastScrollTop: scrollTop,
     chatNewMessagesBelow: false,
     logsScrollFrame: null as number | null,
@@ -148,6 +149,7 @@ describe("handleChatWheelIntent", () => {
     handleChatWheelIntent(host, { deltaY: -120 } as WheelEvent);
 
     expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
     expect(host.chatScrollFrame).toBeNull();
     expect(host.chatScrollTimeout).toBeNull();
   });
@@ -159,6 +161,7 @@ describe("handleChatWheelIntent", () => {
     handleChatWheelIntent(host, { deltaY: 120 } as WheelEvent);
 
     expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
   });
 });
 
@@ -278,6 +281,41 @@ describe("scheduleChatScroll", () => {
     expect(container.scrollTop).toBe(originalScrollTop);
     expect(host.chatNewMessagesBelow).toBe(true);
   });
+
+  it("does NOT re-enable follow just because a post-wheel scroll event is still near bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatFollowLocked = false;
+    host.chatLastScrollTop = 2000;
+
+    handleChatWheelIntent(host, { deltaY: -120 } as WheelEvent);
+    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+
+  it("re-enables follow once the user actually returns to the bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1576,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatLastScrollTop = 1540;
+    host.chatNewMessagesBelow = true;
+
+    handleChatScroll(host, createScrollEvent(2000, 1576, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
 });
 
 /* ------------------------------------------------------------------ */
@@ -343,12 +381,14 @@ describe("resetChatScroll", () => {
     const { host } = createScrollHost({});
     host.chatHasAutoScrolled = true;
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
     host.chatLastScrollTop = 1234;
 
     resetChatScroll(host);
 
     expect(host.chatHasAutoScrolled).toBe(false);
     expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
     expect(host.chatLastScrollTop).toBe(0);
   });
 });

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -146,7 +146,13 @@ describe("handleChatWheelIntent", () => {
     host.chatScrollFrame = 99;
     host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
 
-    handleChatWheelIntent(host, { deltaY: -120 } as WheelEvent);
+    handleChatWheelIntent(
+      host,
+      {
+        deltaY: -120,
+        currentTarget: { scrollHeight: 2000, clientHeight: 500 },
+      } as unknown as WheelEvent,
+    );
 
     expect(host.chatUserNearBottom).toBe(false);
     expect(host.chatFollowLocked).toBe(true);
@@ -158,7 +164,32 @@ describe("handleChatWheelIntent", () => {
     const { host } = createScrollHost({});
     host.chatUserNearBottom = true;
 
-    handleChatWheelIntent(host, { deltaY: 120 } as WheelEvent);
+    handleChatWheelIntent(
+      host,
+      {
+        deltaY: 120,
+        currentTarget: { scrollHeight: 2000, clientHeight: 500 },
+      } as unknown as WheelEvent,
+    );
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("does not disengage follow when the chat cannot actually scroll", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 400,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(
+      host,
+      {
+        deltaY: -120,
+        currentTarget: { scrollHeight: 400, clientHeight: 400 },
+      } as unknown as WheelEvent,
+    );
 
     expect(host.chatUserNearBottom).toBe(true);
     expect(host.chatFollowLocked).toBe(false);
@@ -292,7 +323,13 @@ describe("scheduleChatScroll", () => {
     host.chatFollowLocked = false;
     host.chatLastScrollTop = 2000;
 
-    handleChatWheelIntent(host, { deltaY: -120 } as WheelEvent);
+    handleChatWheelIntent(
+      host,
+      {
+        deltaY: -120,
+        currentTarget: { scrollHeight: 2000, clientHeight: 400 },
+      } as unknown as WheelEvent,
+    );
     handleChatScroll(host, createScrollEvent(2000, 1540, 400));
 
     expect(host.chatUserNearBottom).toBe(false);

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleChatScroll, scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
+import {
+  handleChatScroll,
+  handleChatWheelIntent,
+  scheduleChatScroll,
+  resetChatScroll,
+} from "./app-scroll.ts";
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
@@ -41,6 +46,7 @@ function createScrollHost(
     chatScrollTimeout: null as number | null,
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
+    chatLastScrollTop: scrollTop,
     chatNewMessagesBelow: false,
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
@@ -63,6 +69,8 @@ function createScrollEvent(scrollHeight: number, scrollTop: number, clientHeight
 describe("handleChatScroll", () => {
   it("sets chatUserNearBottom=true when within the 450px threshold", () => {
     const { host } = createScrollHost({});
+    host.chatUserNearBottom = false;
+    host.chatLastScrollTop = 0;
     // distanceFromBottom = 2000 - 1600 - 400 = 0 → clearly near bottom
     const event = createScrollEvent(2000, 1600, 400);
     handleChatScroll(host, event);
@@ -71,6 +79,8 @@ describe("handleChatScroll", () => {
 
   it("sets chatUserNearBottom=true when distance is just under threshold", () => {
     const { host } = createScrollHost({});
+    host.chatUserNearBottom = false;
+    host.chatLastScrollTop = 0;
     // distanceFromBottom = 2000 - 1151 - 400 = 449 → just under threshold
     const event = createScrollEvent(2000, 1151, 400);
     handleChatScroll(host, event);
@@ -93,6 +103,21 @@ describe("handleChatScroll", () => {
     expect(host.chatUserNearBottom).toBe(false);
   });
 
+  it("releases auto-follow immediately when the user scrolls upward away from bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1600,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatLastScrollTop = 1600;
+
+    const event = createScrollEvent(2000, 1540, 400);
+    handleChatScroll(host, event);
+
+    expect(host.chatUserNearBottom).toBe(false);
+  });
+
   it("sets chatUserNearBottom=false when user scrolled up past one long message (>200px <450px)", () => {
     const { host } = createScrollHost({});
     // distanceFromBottom = 2000 - 1250 - 400 = 350 → old threshold would say "near", new says "near"
@@ -100,6 +125,40 @@ describe("handleChatScroll", () => {
     const event = createScrollEvent(2000, 1100, 400);
     handleChatScroll(host, event);
     expect(host.chatUserNearBottom).toBe(false);
+  });
+});
+
+describe("handleChatWheelIntent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("cancels pending auto-follow when the user wheels upward", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+    host.chatScrollFrame = 99;
+    host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
+
+    handleChatWheelIntent(host, { deltaY: -120 } as WheelEvent);
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatScrollFrame).toBeNull();
+    expect(host.chatScrollTimeout).toBeNull();
+  });
+
+  it("does not cancel auto-follow when wheeling downward", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, { deltaY: 120 } as WheelEvent);
+
+    expect(host.chatUserNearBottom).toBe(true);
   });
 });
 
@@ -201,6 +260,24 @@ describe("scheduleChatScroll", () => {
 
     expect(host.chatNewMessagesBelow).toBe(true);
   });
+
+  it("does NOT snap back when the user manually scrolls up but is still within the old near-bottom threshold", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1540,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatHasAutoScrolled = true;
+    host.chatLastScrollTop = 1540;
+    const originalScrollTop = container.scrollTop;
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(originalScrollTop);
+    expect(host.chatNewMessagesBelow).toBe(true);
+  });
 });
 
 /* ------------------------------------------------------------------ */
@@ -266,10 +343,12 @@ describe("resetChatScroll", () => {
     const { host } = createScrollHost({});
     host.chatHasAutoScrolled = true;
     host.chatUserNearBottom = false;
+    host.chatLastScrollTop = 1234;
 
     resetChatScroll(host);
 
     expect(host.chatHasAutoScrolled).toBe(false);
     expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatLastScrollTop).toBe(0);
   });
 });

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -176,8 +176,7 @@ export function handleLogsScroll(host: ScrollHost, event: Event) {
   if (!container) {
     return;
   }
-  const distanceFromBottom =
-    container.scrollHeight - container.scrollTop - container.clientHeight;
+  const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
   host.logsAtBottom = distanceFromBottom < 80;
 }
 

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -2,6 +2,8 @@
 const NEAR_BOTTOM_THRESHOLD = 450;
 /** Small escape hatch so slight upward manual scroll cancels auto-follow quickly. */
 const MANUAL_SCROLL_RELEASE_THRESHOLD = 24;
+/** Once the user takes over scroll, only re-enable follow when they are effectively back at bottom. */
+const FOLLOW_REACQUIRE_THRESHOLD = 24;
 
 type ScrollHost = {
   updateComplete: Promise<unknown>;
@@ -11,6 +13,7 @@ type ScrollHost = {
   chatScrollTimeout: number | null;
   chatHasAutoScrolled: boolean;
   chatUserNearBottom: boolean;
+  chatFollowLocked: boolean;
   chatLastScrollTop: number;
   chatNewMessagesBelow: boolean;
   logsScrollFrame: number | null;
@@ -56,7 +59,7 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
       // force=true only overrides when we haven't auto-scrolled yet (initial load).
       // After initial load, respect the user's scroll position.
       const effectiveForce = force && !host.chatHasAutoScrolled;
-      const shouldStick = effectiveForce || host.chatUserNearBottom;
+      const shouldStick = effectiveForce || (host.chatUserNearBottom && !host.chatFollowLocked);
 
       if (!shouldStick) {
         // User is scrolled up — flag that new content arrived below.
@@ -78,6 +81,7 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         target.scrollTop = scrollTop;
       }
       host.chatUserNearBottom = true;
+      host.chatFollowLocked = false;
       host.chatLastScrollTop = scrollTop;
       host.chatNewMessagesBelow = false;
       const retryDelay = effectiveForce ? 150 : 120;
@@ -87,12 +91,14 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         if (!latest) {
           return;
         }
-        const shouldStickRetry = effectiveForce || host.chatUserNearBottom;
+        const shouldStickRetry =
+          effectiveForce || (host.chatUserNearBottom && !host.chatFollowLocked);
         if (!shouldStickRetry) {
           return;
         }
         latest.scrollTop = latest.scrollHeight;
         host.chatUserNearBottom = true;
+        host.chatFollowLocked = false;
         host.chatLastScrollTop = latest.scrollHeight;
       }, retryDelay);
     });
@@ -130,16 +136,21 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
   const nearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
   const scrollingUp = currentScrollTop < host.chatLastScrollTop;
+  const backAtBottom = distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD;
 
   if (host.chatUserNearBottom && scrollingUp && distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD) {
     host.chatUserNearBottom = false;
-  } else if (nearBottom) {
+    host.chatFollowLocked = true;
+  } else if (backAtBottom) {
+    host.chatUserNearBottom = true;
+    host.chatFollowLocked = false;
+  } else if (!host.chatFollowLocked && nearBottom) {
     host.chatUserNearBottom = true;
   }
 
   host.chatLastScrollTop = Math.max(currentScrollTop, 0);
   // Clear the "new messages below" indicator when user scrolls back to bottom.
-  if (host.chatUserNearBottom) {
+  if (host.chatUserNearBottom && !host.chatFollowLocked) {
     host.chatNewMessagesBelow = false;
   }
 }
@@ -150,6 +161,7 @@ export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
   }
   cancelPendingChatScroll(host);
   host.chatUserNearBottom = false;
+  host.chatFollowLocked = true;
 }
 
 export function handleLogsScroll(host: ScrollHost, event: Event) {
@@ -164,6 +176,7 @@ export function handleLogsScroll(host: ScrollHost, event: Event) {
 export function resetChatScroll(host: ScrollHost) {
   host.chatHasAutoScrolled = false;
   host.chatUserNearBottom = true;
+  host.chatFollowLocked = false;
   host.chatLastScrollTop = 0;
   host.chatNewMessagesBelow = false;
 }

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -163,6 +163,10 @@ export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
   if (event.deltaY >= 0) {
     return;
   }
+  const container = event.currentTarget as HTMLElement | null;
+  if (!container || container.scrollHeight - container.clientHeight <= 1) {
+    return;
+  }
   if (!host.chatUserNearBottom && host.chatFollowLocked) {
     return;
   }

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -2,7 +2,7 @@
 const NEAR_BOTTOM_THRESHOLD = 450;
 /** Small escape hatch so slight upward manual scroll cancels auto-follow quickly. */
 const MANUAL_SCROLL_RELEASE_THRESHOLD = 24;
-/** Once the user takes over scroll, only re-enable follow when they are effectively back at bottom. */
+/** Once the user takes over scroll, only re-enable follow when they are back at bottom. */
 const FOLLOW_REACQUIRE_THRESHOLD = 24;
 
 type ScrollHost = {
@@ -138,7 +138,11 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   const scrollingUp = currentScrollTop < host.chatLastScrollTop;
   const backAtBottom = distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD;
 
-  if (host.chatUserNearBottom && scrollingUp && distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD) {
+  if (
+    host.chatUserNearBottom &&
+    scrollingUp &&
+    distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD
+  ) {
     host.chatUserNearBottom = false;
     host.chatFollowLocked = true;
   } else if (backAtBottom) {
@@ -169,7 +173,8 @@ export function handleLogsScroll(host: ScrollHost, event: Event) {
   if (!container) {
     return;
   }
-  const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+  const distanceFromBottom =
+    container.scrollHeight - container.scrollTop - container.clientHeight;
   host.logsAtBottom = distanceFromBottom < 80;
 }
 

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -1,5 +1,7 @@
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
+/** Small escape hatch so slight upward manual scroll cancels auto-follow quickly. */
+const MANUAL_SCROLL_RELEASE_THRESHOLD = 24;
 
 type ScrollHost = {
   updateComplete: Promise<unknown>;
@@ -9,20 +11,26 @@ type ScrollHost = {
   chatScrollTimeout: number | null;
   chatHasAutoScrolled: boolean;
   chatUserNearBottom: boolean;
+  chatLastScrollTop: number;
   chatNewMessagesBelow: boolean;
   logsScrollFrame: number | null;
   logsAtBottom: boolean;
   topbarObserver: ResizeObserver | null;
 };
 
-export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
+function cancelPendingChatScroll(host: ScrollHost) {
   if (host.chatScrollFrame) {
     cancelAnimationFrame(host.chatScrollFrame);
+    host.chatScrollFrame = null;
   }
   if (host.chatScrollTimeout != null) {
     clearTimeout(host.chatScrollTimeout);
     host.chatScrollTimeout = null;
   }
+}
+
+export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
+  cancelPendingChatScroll(host);
   const pickScrollTarget = () => {
     const container = host.querySelector(".chat-thread") as HTMLElement | null;
     if (container) {
@@ -45,13 +53,10 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
       if (!target) {
         return;
       }
-      const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
-
       // force=true only overrides when we haven't auto-scrolled yet (initial load).
       // After initial load, respect the user's scroll position.
       const effectiveForce = force && !host.chatHasAutoScrolled;
-      const shouldStick =
-        effectiveForce || host.chatUserNearBottom || distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+      const shouldStick = effectiveForce || host.chatUserNearBottom;
 
       if (!shouldStick) {
         // User is scrolled up — flag that new content arrived below.
@@ -73,6 +78,7 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         target.scrollTop = scrollTop;
       }
       host.chatUserNearBottom = true;
+      host.chatLastScrollTop = scrollTop;
       host.chatNewMessagesBelow = false;
       const retryDelay = effectiveForce ? 150 : 120;
       host.chatScrollTimeout = window.setTimeout(() => {
@@ -81,17 +87,13 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         if (!latest) {
           return;
         }
-        const latestDistanceFromBottom =
-          latest.scrollHeight - latest.scrollTop - latest.clientHeight;
-        const shouldStickRetry =
-          effectiveForce ||
-          host.chatUserNearBottom ||
-          latestDistanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+        const shouldStickRetry = effectiveForce || host.chatUserNearBottom;
         if (!shouldStickRetry) {
           return;
         }
         latest.scrollTop = latest.scrollHeight;
         host.chatUserNearBottom = true;
+        host.chatLastScrollTop = latest.scrollHeight;
       }, retryDelay);
     });
   });
@@ -124,12 +126,30 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   if (!container) {
     return;
   }
+  const currentScrollTop = container.scrollTop;
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-  host.chatUserNearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  const nearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  const scrollingUp = currentScrollTop < host.chatLastScrollTop;
+
+  if (host.chatUserNearBottom && scrollingUp && distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD) {
+    host.chatUserNearBottom = false;
+  } else if (nearBottom) {
+    host.chatUserNearBottom = true;
+  }
+
+  host.chatLastScrollTop = Math.max(currentScrollTop, 0);
   // Clear the "new messages below" indicator when user scrolls back to bottom.
   if (host.chatUserNearBottom) {
     host.chatNewMessagesBelow = false;
   }
+}
+
+export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
+  if (event.deltaY >= 0) {
+    return;
+  }
+  cancelPendingChatScroll(host);
+  host.chatUserNearBottom = false;
 }
 
 export function handleLogsScroll(host: ScrollHost, event: Event) {
@@ -144,6 +164,7 @@ export function handleLogsScroll(host: ScrollHost, event: Event) {
 export function resetChatScroll(host: ScrollHost) {
   host.chatHasAutoScrolled = false;
   host.chatUserNearBottom = true;
+  host.chatLastScrollTop = 0;
   host.chatNewMessagesBelow = false;
 }
 

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -163,6 +163,9 @@ export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
   if (event.deltaY >= 0) {
     return;
   }
+  if (!host.chatUserNearBottom && host.chatFollowLocked) {
+    return;
+  }
   cancelPendingChatScroll(host);
   host.chatUserNearBottom = false;
   host.chatFollowLocked = true;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -361,6 +361,7 @@ export type AppViewState = {
     handleAbortChat: () => Promise<void>;
     removeQueuedMessage: (id: string) => void;
     handleChatScroll: (event: Event) => void;
+    handleChatWheelIntent: (event: WheelEvent) => void;
     resetToolStream: () => void;
     resetChatScroll: () => void;
     exportLogs: (lines: string[], label: string) => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -32,6 +32,7 @@ import { renderApp } from "./app-render.ts";
 import {
   exportLogs as exportLogsInternal,
   handleChatScroll as handleChatScrollInternal,
+  handleChatWheelIntent as handleChatWheelIntentInternal,
   handleLogsScroll as handleLogsScrollInternal,
   resetChatScroll as resetChatScrollInternal,
   scheduleChatScroll as scheduleChatScrollInternal,
@@ -436,6 +437,7 @@ export class OpenClawApp extends LitElement {
   private chatScrollTimeout: number | null = null;
   private chatHasAutoScrolled = false;
   private chatUserNearBottom = true;
+  private chatLastScrollTop = 0;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;
   private logsPollInterval: number | null = null;
@@ -503,6 +505,13 @@ export class OpenClawApp extends LitElement {
   handleChatScroll(event: Event) {
     handleChatScrollInternal(
       this as unknown as Parameters<typeof handleChatScrollInternal>[0],
+      event,
+    );
+  }
+
+  handleChatWheelIntent(event: WheelEvent) {
+    handleChatWheelIntentInternal(
+      this as unknown as Parameters<typeof handleChatWheelIntentInternal>[0],
       event,
     );
   }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -437,6 +437,7 @@ export class OpenClawApp extends LitElement {
   private chatScrollTimeout: number | null = null;
   private chatHasAutoScrolled = false;
   private chatUserNearBottom = true;
+  private chatFollowLocked = false;
   private chatLastScrollTop = 0;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -107,6 +107,7 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  onChatWheelIntent?: (event: WheelEvent) => void;
   basePath?: string;
 };
 
@@ -857,6 +858,7 @@ export function renderChat(props: ChatProps) {
       role="log"
       aria-live="polite"
       @scroll=${props.onChatScroll}
+      @wheel=${props.onChatWheelIntent}
       @click=${handleCodeBlockCopy}
     >
       <div class="chat-thread-inner">


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: While the assistant is streaming in Control UI chat, manually scrolling upward can be overridden by auto-follow and pull the viewport back down.
- Why it matters: It makes reviewing earlier messages during active responses frustrating and creates a jumpy, disruptive reading experience.
- What changed: Auto-follow now releases on intentional upward manual scroll, cancels pending follow/retry scroll work, and stays disabled until the user actually returns to the bottom.
- What did NOT change (scope boundary): This only changes Control UI chat scroll behavior; it does not change chat content, ordering, backend behavior, or session logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #45992

## User-visible / Behavior Changes

- While a response is streaming, manually scrolling upward no longer gets repeatedly pulled back to the bottom by chat auto-follow.
- Auto-follow resumes only after the user actually returns to the bottom or uses the new-messages/scroll-to-bottom control.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Control UI dev server (`vite`)
- Model/provider: N/A
- Integration/channel (if any): Control UI chat
- Relevant config (redacted): default local UI setup

### Steps

1. Open the Control UI chat.
2. Send a message that produces a longer streaming response.
3. While the assistant is still streaming, scroll upward in the chat history.

### Expected

- The viewport stays at the user-selected position and does not keep snapping back downward.
- New messages can continue arriving below without stealing scroll position.

### Actual

- Before this fix, the viewport could continue moving back down during streaming because auto-follow was re-enabled too aggressively and scheduled retry scrolls could still fire after manual upward scroll.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran targeted scroll behavior tests and rebuilt the Control UI; manually reproduced the streaming + upward-scroll scenario locally while iterating on the fix.
- Edge cases checked: Near-bottom behavior, initial forced scroll on load, preserving manual upward scroll during rapid streaming updates, cancelling pending retry scrolls on upward wheel input, preventing re-enable during follow-locked near-bottom scroll events, and restoring follow after returning to bottom.
- What you did **not** verify: Cross-browser manual QA beyond the local environment and touch-specific/mobile gesture behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the PR or revert the follow-lock changes in the chat scroll handling.
- Files/config to restore: `ui/src/ui/app-scroll.ts`, `ui/src/ui/app.ts`, `ui/src/ui/app-render.ts`, `ui/src/ui/app-view-state.ts`, `ui/src/ui/views/chat.ts`, `ui/src/ui/app-scroll.test.ts`
- Known bad symptoms reviewers should watch for: chat no longer following when already at bottom, new-messages indicator showing incorrectly, or upward manual scroll still getting overridden during streaming.

## Risks and Mitigations

- Risk: Auto-follow could disengage too aggressively near the bottom.
- Mitigation: Added explicit tests around near-bottom behavior, upward wheel intent, follow-lock behavior, and bottom re-acquisition.
- Risk: Scheduled retry scrolls could override manual user intent after streaming updates.
- Mitigation: Pending animation-frame and timeout-based chat scroll work is cancelled on upward wheel intent, and follow remains locked until the user actually returns to the bottom.
