### PR TITLE
fix(reply): use isSilentTokenOnOwnLine in all delivery paths

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -3,6 +3,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   HEARTBEAT_TOKEN,
   isSilentReplyText,
+  isSilentTokenOnOwnLine,
   SILENT_REPLY_TOKEN,
   stripSilentToken,
 } from "../tokens.js";
@@ -48,14 +49,25 @@ export function normalizeReplyPayload(
     }
     text = "";
   }
-  // Strip NO_REPLY from mixed-content messages (e.g. "😄 NO_REPLY") so the
-  // token never leaks to end users.  If stripping leaves nothing, treat it as
-  // silent just like the exact-match path above.  (#30916, #30955)
+  // When NO_REPLY appears on its own line (preceded by \n), the model intended
+  // silence — the preceding text is internal narration, not user-facing content.
+  // Suppress the entire message.  (#42472, #30916)
+  //
+  // When NO_REPLY appears inline (e.g. "😄 NO_REPLY"), strip only the token so
+  // the non-token text can still be delivered.  (#30916, #30955)
   if (text && text.includes(silentToken) && !isSilentReplyText(text, silentToken)) {
-    text = stripSilentToken(text, silentToken);
-    if (!text && !hasMedia && !hasChannelData) {
-      opts.onSkip?.("silent");
-      return null;
+    if (isSilentTokenOnOwnLine(text, silentToken)) {
+      if (!hasMedia && !hasChannelData) {
+        opts.onSkip?.("silent");
+        return null;
+      }
+      text = "";
+    } else {
+      text = stripSilentToken(text, silentToken);
+      if (!text && !hasMedia && !hasChannelData) {
+        opts.onSkip?.("silent");
+        return null;
+      }
     }
   }
   if (text && !trimmed) {

--- a/src/auto-reply/reply/reply-directives.test.ts
+++ b/src/auto-reply/reply/reply-directives.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { parseReplyDirectives } from "./reply-directives.js";
+
+describe("parseReplyDirectives", () => {
+  it("marks exact NO_REPLY as silent", () => {
+    const result = parseReplyDirectives("NO_REPLY");
+    expect(result.isSilent).toBe(true);
+    expect(result.text).toBe("");
+  });
+
+  it("marks own-line NO_REPLY as silent", () => {
+    const result = parseReplyDirectives("Checked inbox, nothing new.\n\nNO_REPLY");
+    expect(result.isSilent).toBe(true);
+    expect(result.text).toBe("");
+  });
+
+  it("marks own-line NO_REPLY with single newline as silent", () => {
+    const result = parseReplyDirectives("Status update.\nNO_REPLY");
+    expect(result.isSilent).toBe(true);
+    expect(result.text).toBe("");
+  });
+
+  it("marks own-line NO_REPLY with leading whitespace as silent", () => {
+    const result = parseReplyDirectives("Nothing to report.\n  NO_REPLY  ");
+    expect(result.isSilent).toBe(true);
+    expect(result.text).toBe("");
+  });
+
+  it("strips inline NO_REPLY but delivers surrounding text", () => {
+    const result = parseReplyDirectives("😄 NO_REPLY");
+    expect(result.isSilent).toBe(false);
+    expect(result.text).not.toContain("NO_REPLY");
+  });
+
+  it("delivers normal text without NO_REPLY", () => {
+    const result = parseReplyDirectives("Hello, here is your update.");
+    expect(result.isSilent).toBe(false);
+    expect(result.text).toBe("Hello, here is your update.");
+  });
+});

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -1,6 +1,6 @@
 import { splitMediaFromOutput } from "../../media/parse.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { isSilentReplyText, isSilentTokenOnOwnLine, SILENT_REPLY_TOKEN } from "../tokens.js";
 
 export type ReplyDirectiveParseResult = {
   text: string;
@@ -31,7 +31,7 @@ export function parseReplyDirectives(
   }
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
-  const isSilent = isSilentReplyText(text, silentToken);
+  const isSilent = isSilentReplyText(text, silentToken) || isSilentTokenOnOwnLine(text, silentToken);
   if (isSilent) {
     text = "";
   }

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -116,13 +116,26 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).not.toContain("NO_REPLY");
   });
 
-  it("strips NO_REPLY appended after substantive text (#30916)", () => {
-    const result = normalizeReplyPayload({
-      text: "File's there. Not urgent.\n\nNO_REPLY",
-    });
-    expect(result).not.toBeNull();
-    expect(result!.text).toContain("File's there");
-    expect(result!.text).not.toContain("NO_REPLY");
+  it("suppresses entire message when NO_REPLY is on its own line (#42472)", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      { text: "File's there. Not urgent.\n\nNO_REPLY" },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
+
+  it("suppresses heartbeat narration followed by newline NO_REPLY (#42472)", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      {
+        text: "All tasks completed:\n• infra: 0 alerts\n• gmail: 0 new\nNO_REPLY",
+      },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
   });
 
   it("keeps NO_REPLY when used as leading substantive text", () => {

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isSilentReplyPrefixText, isSilentReplyText, stripSilentToken } from "./tokens.js";
+import {
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  isSilentTokenOnOwnLine,
+  stripSilentToken,
+} from "./tokens.js";
 
 describe("isSilentReplyText", () => {
   it("returns true for exact token", () => {
@@ -70,6 +75,42 @@ describe("stripSilentToken", () => {
 
   it("works with custom token", () => {
     expect(stripSilentToken("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe("done");
+  });
+});
+
+describe("isSilentTokenOnOwnLine", () => {
+  it("matches token on its own line after text (#42472)", () => {
+    expect(isSilentTokenOnOwnLine("Checked inbox.\n\nNO_REPLY")).toBe(true);
+    expect(isSilentTokenOnOwnLine("All done.\nNO_REPLY")).toBe(true);
+    expect(isSilentTokenOnOwnLine("tasks:\n• email: ok\n• wa: ok\nNO_REPLY")).toBe(true);
+  });
+
+  it("matches token with leading whitespace on its line", () => {
+    expect(isSilentTokenOnOwnLine("Some text.\n  NO_REPLY")).toBe(true);
+    expect(isSilentTokenOnOwnLine("Some text.\n  NO_REPLY  ")).toBe(true);
+  });
+
+  it("matches standalone token (no preceding text)", () => {
+    expect(isSilentTokenOnOwnLine("NO_REPLY")).toBe(true);
+  });
+
+  it("does not match inline token (same line as content)", () => {
+    expect(isSilentTokenOnOwnLine("😄 NO_REPLY")).toBe(false);
+    expect(isSilentTokenOnOwnLine("ok NO_REPLY")).toBe(false);
+  });
+
+  it("does not match token in the middle of text", () => {
+    expect(isSilentTokenOnOwnLine("NO_REPLY but here is more")).toBe(false);
+    expect(isSilentTokenOnOwnLine("Please NO_REPLY to this")).toBe(false);
+  });
+
+  it("returns false for empty/undefined input", () => {
+    expect(isSilentTokenOnOwnLine("")).toBe(false);
+  });
+
+  it("works with custom token", () => {
+    expect(isSilentTokenOnOwnLine("done\nHEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
+    expect(isSilentTokenOnOwnLine("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
   });
 });
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -56,10 +56,7 @@ export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKE
  * not user-facing content.  Inline occurrences like `"😄 NO_REPLY"` are left to
  * {@link stripSilentToken} so the non-token text can still be delivered.
  */
-export function isSilentTokenOnOwnLine(
-  text: string,
-  token: string = SILENT_REPLY_TOKEN,
-): boolean {
+export function isSilentTokenOnOwnLine(text: string, token: string = SILENT_REPLY_TOKEN): boolean {
   if (!text) {
     return false;
   }

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -49,6 +49,24 @@ export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKE
   return text.replace(getSilentTrailingRegex(token), "").trim();
 }
 
+/**
+ * Check whether the silent token appears on its own line at the end of the text.
+ * When the model outputs reasoning/narration followed by `\nNO_REPLY`, the entire
+ * response should be treated as silent — the preceding text is internal narration,
+ * not user-facing content.  Inline occurrences like `"😄 NO_REPLY"` are left to
+ * {@link stripSilentToken} so the non-token text can still be delivered.
+ */
+export function isSilentTokenOnOwnLine(
+  text: string,
+  token: string = SILENT_REPLY_TOKEN,
+): boolean {
+  if (!text) {
+    return false;
+  }
+  const escaped = escapeRegExp(token);
+  return new RegExp(`(\\n|^)\\s*${escaped}\\s*$`).test(text);
+}
+
 export function isSilentReplyPrefixText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,5 +1,5 @@
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentTokenOnOwnLine, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -367,7 +367,8 @@ export async function dispatchCronDelivery(
       hadDescendants &&
       synthesizedText.trim() === initialSynthesizedText &&
       isLikelyInterimCronMessage(initialSynthesizedText) &&
-      initialSynthesizedText.toUpperCase() !== SILENT_REPLY_TOKEN.toUpperCase()
+      initialSynthesizedText.toUpperCase() !== SILENT_REPLY_TOKEN.toUpperCase() &&
+      !isSilentTokenOnOwnLine(initialSynthesizedText, SILENT_REPLY_TOKEN)
     ) {
       // Descendants existed but no post-orchestration synthesis arrived AND
       // no descendant fallback reply was available. Suppress stale parent
@@ -382,7 +383,10 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-    if (synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
+    if (
+      synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase() ||
+      isSilentTokenOnOwnLine(synthesizedText, SILENT_REPLY_TOKEN)
+    ) {
       return params.withRunSession({
         status: "ok",
         summary,

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -1,6 +1,6 @@
 import { listDescendantRunsForRequester } from "../../agents/subagent-registry.js";
 import { readLatestAssistantReply } from "../../agents/tools/agent-step.js";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentTokenOnOwnLine, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { callGateway } from "../../gateway/call.js";
 
 const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
@@ -95,7 +95,11 @@ export async function readDescendantSubagentFallbackReply(params: {
     if (!reply && typeof entry.frozenResultText === "string" && entry.frozenResultText.trim()) {
       reply = entry.frozenResultText.trim();
     }
-    if (!reply || reply.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
+    if (
+      !reply ||
+      reply.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase() ||
+      isSilentTokenOnOwnLine(reply, SILENT_REPLY_TOKEN)
+    ) {
       continue;
     }
     replies.push(reply);
@@ -174,6 +178,7 @@ export async function waitForDescendantSubagentSummary(params: {
     if (
       latest &&
       latest.toUpperCase() !== SILENT_REPLY_TOKEN.toUpperCase() &&
+      !isSilentTokenOnOwnLine(latest, SILENT_REPLY_TOKEN) &&
       (latest !== initialReply || !isLikelyInterimCronMessage(latest))
     ) {
       return latest;
@@ -186,6 +191,7 @@ export async function waitForDescendantSubagentSummary(params: {
   if (
     latest &&
     latest.toUpperCase() !== SILENT_REPLY_TOKEN.toUpperCase() &&
+    !isSilentTokenOnOwnLine(latest, SILENT_REPLY_TOKEN) &&
     (latest !== initialReply || !isLikelyInterimCronMessage(latest))
   ) {
     return latest;

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../auto-reply/heartbeat.js";
 import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { isSilentReplyText, isSilentTokenOnOwnLine, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
@@ -359,7 +359,7 @@ export function createAgentEventHandler({
       return;
     }
     chatRunState.buffers.set(clientRunId, mergedText);
-    if (isSilentReplyText(mergedText, SILENT_REPLY_TOKEN)) {
+    if (isSilentReplyText(mergedText, SILENT_REPLY_TOKEN) || isSilentTokenOnOwnLine(mergedText, SILENT_REPLY_TOKEN)) {
       return;
     }
     if (isSilentReplyLeadFragment(mergedText)) {
@@ -406,7 +406,9 @@ export function createAgentEventHandler({
     });
     const text = normalizedHeartbeatText.text.trim();
     const shouldSuppressSilent =
-      normalizedHeartbeatText.suppress || isSilentReplyText(text, SILENT_REPLY_TOKEN);
+      normalizedHeartbeatText.suppress ||
+      isSilentReplyText(text, SILENT_REPLY_TOKEN) ||
+      isSilentTokenOnOwnLine(text, SILENT_REPLY_TOKEN);
     const shouldSuppressSilentLeadFragment = isSilentReplyLeadFragment(text);
     const shouldSuppressHeartbeatStreaming = shouldHideHeartbeatChatOutput(
       clientRunId,
@@ -463,7 +465,9 @@ export function createAgentEventHandler({
     });
     const text = normalizedHeartbeatText.text.trim();
     const shouldSuppressSilent =
-      normalizedHeartbeatText.suppress || isSilentReplyText(text, SILENT_REPLY_TOKEN);
+      normalizedHeartbeatText.suppress ||
+      isSilentReplyText(text, SILENT_REPLY_TOKEN) ||
+      isSilentTokenOnOwnLine(text, SILENT_REPLY_TOKEN);
     // Flush any throttled delta so streaming clients receive the complete text
     // before the final event. The 150 ms throttle in emitChatDelta may have
     // suppressed the most recent chunk, leaving the client with stale text.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -7,7 +7,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyText, isSilentTokenOnOwnLine, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
@@ -406,7 +406,7 @@ function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
     changed ||= res.changed;
     // Drop assistant messages whose entire visible text is the silent reply token.
     const text = extractAssistantTextForSilentCheck(res.message);
-    if (text !== undefined && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+    if (text !== undefined && (isSilentReplyText(text, SILENT_REPLY_TOKEN) || isSilentTokenOnOwnLine(text, SILENT_REPLY_TOKEN))) {
       changed = true;
       continue;
     }


### PR DESCRIPTION
## Problem

PR #42873 introduced `isSilentTokenOnOwnLine()` and applied it to `normalizeReplyPayload`, but several other code paths still use exact-match checks (`isSilentReplyText` or `.toUpperCase() === SILENT_REPLY_TOKEN`) that miss the `"text\n\nNO_REPLY"` pattern. This causes the preceding text to leak to the user as a visible message.

Confirmed in production: after applying #42873 locally (which fixes `normalizeReplyPayload`), the bug persisted through at least three other paths — the deliver layer, cron delivery dispatch, and gateway chat event handlers.

```
Model output:    "15 min since last check, nothing new.\n\nNO_REPLY"
User sees:       "15 min since last check, nothing new.\n\nNO_REPLY"
Expected:        (nothing — the model intended silence)
```

## Root cause

`isSilentTokenOnOwnLine()` was only applied in one place. Six other files gate NO_REPLY suppression with exact-match checks that don't recognize the own-line pattern.

## Fix

Import and use `isSilentTokenOnOwnLine()` alongside existing checks in all remaining paths:

| File | Function | What it gates |
|------|----------|---------------|
| `src/auto-reply/reply/reply-directives.ts` | `parseReplyDirectives` | Final delivery layer — last gate before messages reach the channel |
| `src/cron/isolated-agent/delivery-dispatch.ts` | Synthesized text checks | Cron job output suppression (interim + final) |
| `src/cron/isolated-agent/subagent-followup.ts` | Descendant reply collection + grace period | Cron sub-agent reply filtering |
| `src/gateway/server-chat.ts` | `emitChatDelta`, `flushBufferedChatDelta`, `emitChatFinal` | Streaming text suppression |
| `src/gateway/server-methods/chat.ts` | Chat history sanitization | Assistant message filtering |

## Changes

- 6 source files updated (+67/-13)
- 1 new test file: `reply-directives.test.ts` with 6 tests covering exact, own-line, inline, and normal text patterns
- All changes are additive: existing exact-match checks are preserved, own-line check is added with `||`

## Testing

- Locally tested via compiled dist patches on production gateway for 3 days
- Confirmed the deliver layer (`parseReplyDirectives`) was the final leak path after applying #42873
- New unit tests cover the key scenarios

## Relationship to #42873

This PR depends on `isSilentTokenOnOwnLine()` introduced in #42873. It extends the fix to the remaining 6 code paths. Together they provide complete coverage.

**AI-assisted** (Claude Opus 4.6) — fully tested, confirmed understanding of all changes.

Refs #42873, #42472, #30916, #33544