### PR TITLE
Improve runtime legibility and reply suppression

### DIFF
--- a/src/agents/sandbox-explain.test.ts
+++ b/src/agents/sandbox-explain.test.ts
@@ -108,8 +108,10 @@ describe("sandbox explain helpers", () => {
       toolName: "browser",
     });
     expect(msg).toBeTruthy();
-    expect(msg).toContain('Tool "browser" blocked by sandbox tool policy');
+    expect(msg).toContain('blocked by sandbox: tool "browser" is not allowed in this session');
     expect(msg).toContain("mode=non-main");
+    expect(msg).toContain("Next:");
+    expect(msg).toContain("/workspace/memory/...");
     expect(msg).toContain("tools.sandbox.tools.deny");
     expect(msg).toContain("agents.defaults.sandbox.mode=off");
     expect(msg).toContain("Use main session key (direct): agent:main:main");

--- a/src/agents/sandbox/runtime-status.ts
+++ b/src/agents/sandbox/runtime-status.ts
@@ -119,9 +119,13 @@ export function formatSandboxToolPolicyBlockedMessage(params: {
   }
 
   const lines: string[] = [];
-  lines.push(`Tool "${tool}" blocked by sandbox tool policy (mode=${runtime.mode}).`);
+  lines.push(
+    `blocked by sandbox: tool "${tool}" is not allowed in this session (mode=${runtime.mode}).`,
+  );
   lines.push(`Session: ${runtime.sessionKey || "(unknown)"}`);
   lines.push(`Reason: ${reasons.join(" + ")}`);
+  lines.push("Next:");
+  lines.push(`- Stay inside workspace tools when possible (memory/... or /workspace/memory/...).`);
   lines.push("Fix:");
   lines.push(`- agents.defaults.sandbox.mode=off (disable sandbox)`);
   for (const fix of fixes) {

--- a/src/auto-reply/reply/elevated-unavailable.test.ts
+++ b/src/auto-reply/reply/elevated-unavailable.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { formatElevatedUnavailableMessage } from "./elevated-unavailable.js";
+
+describe("formatElevatedUnavailableMessage", () => {
+  it("explains sandboxed elevation failures with next-step guidance", () => {
+    const text = formatElevatedUnavailableMessage({
+      runtimeSandboxed: true,
+      failures: [{ gate: "allowFrom", key: "tools.elevated.allowFrom.discord" }],
+      sessionKey: "agent:trinity:discord:channel:123",
+    });
+
+    expect(text).toContain("blocked by policy + sandbox");
+    expect(text).toContain("runtime=sandboxed");
+    expect(text).toContain("Next:");
+    expect(text).toContain("/workspace/memory/...");
+    expect(text).toContain("Retryable: yes");
+  });
+
+  it("explains direct elevation failures as policy-gated", () => {
+    const text = formatElevatedUnavailableMessage({
+      runtimeSandboxed: false,
+      failures: [],
+      sessionKey: "agent:morpheus:main",
+    });
+
+    expect(text).toContain("blocked by policy");
+    expect(text).toContain("runtime=direct");
+    expect(text).toContain("Check session/channel policy or approval state");
+    expect(text).toContain("Retryable: yes");
+  });
+});

--- a/src/auto-reply/reply/elevated-unavailable.ts
+++ b/src/auto-reply/reply/elevated-unavailable.ts
@@ -6,8 +6,9 @@ export function formatElevatedUnavailableMessage(params: {
   sessionKey?: string;
 }): string {
   const lines: string[] = [];
+  const layer = params.runtimeSandboxed ? "policy + sandbox" : "policy";
   lines.push(
-    `elevated is not available right now (runtime=${params.runtimeSandboxed ? "sandboxed" : "direct"}).`,
+    `blocked by ${layer}: elevated host exec is not available in this session (runtime=${params.runtimeSandboxed ? "sandboxed" : "direct"}).`,
   );
   if (params.failures.length > 0) {
     lines.push(`Failing gates: ${params.failures.map((f) => `${f.gate} (${f.key})`).join(", ")}`);
@@ -16,6 +17,13 @@ export function formatElevatedUnavailableMessage(params: {
       "Failing gates: enabled (tools.elevated.enabled / agents.list[].tools.elevated.enabled), allowFrom (tools.elevated.allowFrom.<provider>).",
     );
   }
+  lines.push("Next:");
+  lines.push(
+    params.runtimeSandboxed
+      ? "- Stay in workspace tools (memory/... or /workspace/memory/...) or route host/admin work to Morpheus or Cipher."
+      : "- Check session/channel policy or approval state, then retry.",
+  );
+  lines.push("Retryable: yes, after the failing gate changes.");
   lines.push("Fix-it keys:");
   lines.push("- tools.elevated.enabled");
   lines.push("- tools.elevated.allowFrom.<provider>");

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -27,6 +27,31 @@ export type NormalizeReplyOptions = {
   onSkip?: (reason: NormalizeReplySkipReason) => void;
 };
 
+function shouldSuppressSanitizedText(text: string): boolean {
+  const trimmed = text.trimStart();
+  if (!trimmed) {
+    return false;
+  }
+  if (
+    isSilentReplyText(trimmed, SILENT_REPLY_TOKEN) ||
+    isSilentReplyText(trimmed, HEARTBEAT_TOKEN)
+  ) {
+    return true;
+  }
+  const hasFunctionDirective =
+    /to=functions\.(?:exec_command|write_stdin|update_plan|apply_patch|parallel)\b/i.test(trimmed);
+  if (
+    /^(?:assistant|commentary)\s+to=functions\./i.test(trimmed) ||
+    /^to=functions\./i.test(trimmed)
+  ) {
+    return true;
+  }
+  if (/^NO_REPLY\b/i.test(trimmed) || /^HEARTBEAT_OK\b/i.test(trimmed)) {
+    return hasFunctionDirective;
+  }
+  return hasFunctionDirective && /^(?:assistant|commentary)\b/i.test(trimmed);
+}
+
 export function normalizeReplyPayload(
   payload: ReplyPayload,
   opts: NormalizeReplyOptions = {},
@@ -80,6 +105,13 @@ export function normalizeReplyPayload(
 
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
+    if (text && shouldSuppressSanitizedText(text)) {
+      if (!hasMedia && !hasChannelData) {
+        opts.onSkip?.("silent");
+        return null;
+      }
+      text = "";
+    }
   }
   if (!text?.trim() && !hasMedia && !hasChannelData) {
     opts.onSkip?.("empty");

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -141,9 +141,39 @@ describe("normalizeReplyPayload", () => {
     expect(reasons).toEqual(["silent"]);
   });
 
+  it("suppresses leaked tool-call control syntax after sanitization", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      { text: 'assistant to=functions.exec_command {"cmd":"id"}' },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
+
+  it("suppresses NO_REPLY-prefixed control leakage after sanitization", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      { text: 'NO_REPLY to=functions.exec_command {"cmd":"id"}' },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
+
   it("strips NO_REPLY but keeps media payload", () => {
     const result = normalizeReplyPayload({
       text: "NO_REPLY",
+      mediaUrl: "https://example.com/img.png",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("");
+    expect(result!.mediaUrl).toBe("https://example.com/img.png");
+  });
+
+  it("drops leaked control text but keeps media payloads", () => {
+    const result = normalizeReplyPayload({
+      text: 'commentary to=functions.write_stdin {"session_id":1}',
       mediaUrl: "https://example.com/img.png",
     });
     expect(result).not.toBeNull();

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -258,6 +258,74 @@ describe("buildStatusMessage", () => {
     expect(text).toContain("elevated");
   });
 
+  it("shows workspace path and capability hints for sandboxed discord sessions", () => {
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          defaults: {
+            sandbox: { mode: "all", scope: "agent" },
+          },
+          list: [{ id: "trinity" }],
+        },
+      } as unknown as OpenClawConfig,
+      agent: {},
+      sessionEntry: {
+        sessionId: "trinity-discord",
+        updatedAt: 0,
+        channel: "discord",
+      },
+      agentId: "trinity",
+      sessionKey: "agent:trinity:discord:channel:123",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Paths: file memory/... ↔ shell /workspace/memory/...");
+    expect(normalized).toContain("Lane: discord · workspace-only lane");
+    expect(normalized).toContain(
+      "Capability: workspace tools active; host exec is not configured for this agent/session",
+    );
+    expect(normalized).toContain(
+      "Blocking layers: sandbox | policy | permissions | bridge | delivery",
+    );
+  });
+
+  it("shows host lane capability hints for high-power discord sessions", () => {
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          list: [
+            {
+              id: "morpheus",
+              tools: {
+                elevated: {
+                  enabled: true,
+                },
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      agent: {},
+      sessionEntry: {
+        sessionId: "morpheus-discord",
+        updatedAt: 0,
+        channel: "discord",
+      },
+      agentId: "morpheus",
+      sessionKey: "agent:morpheus:discord:channel:456",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Lane: discord · host lane configured");
+    expect(normalized).toContain(
+      "Capability: host/runtime authority configured; a Discord session or channel policy may still gate elevated exec on this turn",
+    );
+  });
+
   it("includes media understanding decisions when present", () => {
     const text = buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5" },

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -520,6 +520,23 @@ export function buildStatusMessage(args: StatusArgs): string {
     "on";
 
   const runtime = { label: resolveRuntimeLabel(args) };
+  const runtimeStatus =
+    args.config && args.sessionKey
+      ? resolveSandboxRuntimeStatus({
+          cfg: args.config,
+          sessionKey: args.sessionKey,
+        })
+      : null;
+  const resolvedAgentId =
+    args.agentId ?? (args.sessionKey ? resolveAgentIdFromSessionKey(args.sessionKey) : undefined);
+  const agentRecord =
+    resolvedAgentId && Array.isArray(args.config?.agents?.list)
+      ? args.config.agents.list.find((record) => record?.id === resolvedAgentId)
+      : null;
+  const agentElevatedEnabled = agentRecord?.tools?.elevated?.enabled === true;
+  const deliveryChannel = entry?.channel ?? entry?.origin?.provider ?? "unknown";
+  const isDiscordSession =
+    deliveryChannel === "discord" || Boolean(args.sessionKey?.includes(":discord:"));
 
   const updatedAt = entry?.updatedAt;
   const sessionLine = [
@@ -569,6 +586,18 @@ export function buildStatusMessage(args: StatusArgs): string {
     `🪢 Queue: ${queueMode}${queueDetails}`,
   ];
   const activationLine = activationParts.filter(Boolean).join(" · ");
+  const pathLine = `🗂️ Paths: file memory/... ↔ shell /workspace/memory/...`;
+  const laneLine = `📮 Lane: ${deliveryChannel}${isDiscordSession ? ` · ${agentElevatedEnabled ? "host lane configured" : "workspace-only lane"}` : ""}`;
+  const capabilityLine = `🔐 Capability: ${
+    agentElevatedEnabled
+      ? isDiscordSession
+        ? "host/runtime authority configured; a Discord session or channel policy may still gate elevated exec on this turn"
+        : "host/runtime authority configured for this agent"
+      : runtimeStatus?.sandboxed
+        ? "workspace tools active; host exec is not configured for this agent/session"
+        : "workspace tools active; host exec is not configured for this agent"
+  }`;
+  const blockHintLine = `🚧 Blocking layers: sandbox | policy | permissions | bridge | delivery`;
 
   const selectedAuthMode =
     normalizeAuthMode(args.modelAuth) ?? resolveModelAuthMode(selectedProvider, args.config);
@@ -679,6 +708,10 @@ export function buildStatusMessage(args: StatusArgs): string {
     mediaLine,
     args.usageLine,
     `🧵 ${sessionLine}`,
+    pathLine,
+    laneLine,
+    capabilityLine,
+    blockHintLine,
     args.subagentsLine,
     `⚙️ ${optionsLine}`,
     voiceLine,


### PR DESCRIPTION
## Summary
- improve sanitized reply suppression for leaked control syntax and silent tokens
- improve `session_status` output with path mapping, lane, capability, and blocking-layer visibility
- improve elevated-unavailable and sandbox-denial guidance
- add focused tests covering the new runtime-legibility and reply-suppression behavior

## Testing
- corepack pnpm exec vitest run src/agents/sandbox-explain.test.ts src/auto-reply/reply/elevated-unavailable.test.ts src/auto-reply/reply/reply-utils.test.ts src/auto-reply/status.test.ts
