### PR TITLE
Fix scroll behaviour to be more natural

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1378,6 +1378,7 @@ export function renderApp(state: AppViewState) {
                   });
                 },
                 onChatScroll: (event) => state.handleChatScroll(event),
+                onChatWheelIntent: (event) => state.handleChatWheelIntent(event),
                 getDraft: () => state.chatMessage,
                 onDraftChange: (next) => (state.chatMessage = next),
                 onRequestUpdate: requestHostUpdate,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -47,6 +47,7 @@ function createScrollHost(
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
     chatFollowLocked: false,
+    chatSmoothAutoScrolling: false,
     chatLastScrollTop: scrollTop,
     chatNewMessagesBelow: false,
     logsScrollFrame: null as number | null,
@@ -335,6 +336,23 @@ describe("scheduleChatScroll", () => {
     expect(host.chatUserNearBottom).toBe(true);
     expect(host.chatFollowLocked).toBe(false);
     expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("does not treat smooth auto-scroll progress as upward manual scroll intent", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1200,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatFollowLocked = false;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1300, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
   });
 });
 

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -347,12 +347,30 @@ describe("scheduleChatScroll", () => {
     host.chatUserNearBottom = true;
     host.chatFollowLocked = false;
     host.chatSmoothAutoScrolling = true;
-    host.chatLastScrollTop = 1600;
+    host.chatLastScrollTop = 1200;
 
     handleChatScroll(host, createScrollEvent(2000, 1300, 400));
 
     expect(host.chatUserNearBottom).toBe(true);
     expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("releases follow when the user scrolls upward during smooth auto-scroll", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1200,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatFollowLocked = false;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1100, 400));
+
+    expect(host.chatSmoothAutoScrolling).toBe(false);
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
   });
 });
 

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleChatScroll, scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
+import {
+  handleChatScroll,
+  handleChatWheelIntent,
+  scheduleChatScroll,
+  resetChatScroll,
+} from "./app-scroll.ts";
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
@@ -41,6 +46,8 @@ function createScrollHost(
     chatScrollTimeout: null as number | null,
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
+    chatFollowLocked: false,
+    chatLastScrollTop: scrollTop,
     chatNewMessagesBelow: false,
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
@@ -56,6 +63,13 @@ function createScrollEvent(scrollHeight: number, scrollTop: number, clientHeight
   } as unknown as Event;
 }
 
+function createWheelEvent(deltaY: number, scrollHeight: number, clientHeight: number) {
+  return {
+    deltaY,
+    currentTarget: { scrollHeight, clientHeight },
+  } as unknown as WheelEvent;
+}
+
 /* ------------------------------------------------------------------ */
 /*  handleChatScroll – threshold tests                                 */
 /* ------------------------------------------------------------------ */
@@ -63,6 +77,8 @@ function createScrollEvent(scrollHeight: number, scrollTop: number, clientHeight
 describe("handleChatScroll", () => {
   it("sets chatUserNearBottom=true when within the 450px threshold", () => {
     const { host } = createScrollHost({});
+    host.chatUserNearBottom = false;
+    host.chatLastScrollTop = 0;
     // distanceFromBottom = 2000 - 1600 - 400 = 0 → clearly near bottom
     const event = createScrollEvent(2000, 1600, 400);
     handleChatScroll(host, event);
@@ -71,6 +87,8 @@ describe("handleChatScroll", () => {
 
   it("sets chatUserNearBottom=true when distance is just under threshold", () => {
     const { host } = createScrollHost({});
+    host.chatUserNearBottom = false;
+    host.chatLastScrollTop = 0;
     // distanceFromBottom = 2000 - 1151 - 400 = 449 → just under threshold
     const event = createScrollEvent(2000, 1151, 400);
     handleChatScroll(host, event);
@@ -93,6 +111,21 @@ describe("handleChatScroll", () => {
     expect(host.chatUserNearBottom).toBe(false);
   });
 
+  it("releases auto-follow immediately when the user scrolls upward away from bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1600,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatLastScrollTop = 1600;
+
+    const event = createScrollEvent(2000, 1540, 400);
+    handleChatScroll(host, event);
+
+    expect(host.chatUserNearBottom).toBe(false);
+  });
+
   it("sets chatUserNearBottom=false when user scrolled up past one long message (>200px <450px)", () => {
     const { host } = createScrollHost({});
     // distanceFromBottom = 2000 - 1250 - 400 = 350 → old threshold would say "near", new says "near"
@@ -100,6 +133,55 @@ describe("handleChatScroll", () => {
     const event = createScrollEvent(2000, 1100, 400);
     handleChatScroll(host, event);
     expect(host.chatUserNearBottom).toBe(false);
+  });
+});
+
+describe("handleChatWheelIntent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("cancels pending auto-follow when the user wheels upward", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+    host.chatScrollFrame = 99;
+    host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 500));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatScrollFrame).toBeNull();
+    expect(host.chatScrollTimeout).toBeNull();
+  });
+
+  it("does not cancel auto-follow when wheeling downward", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, createWheelEvent(120, 2000, 500));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("does not disengage follow when the chat cannot actually scroll", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 400,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 400, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
   });
 });
 
@@ -201,6 +283,59 @@ describe("scheduleChatScroll", () => {
 
     expect(host.chatNewMessagesBelow).toBe(true);
   });
+
+  it("does NOT snap back when the user manually scrolls up but is still within the old near-bottom threshold", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1540,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatHasAutoScrolled = true;
+    host.chatLastScrollTop = 1540;
+    const originalScrollTop = container.scrollTop;
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(originalScrollTop);
+    expect(host.chatNewMessagesBelow).toBe(true);
+  });
+
+  it("does NOT re-enable follow just because a post-wheel scroll event is still near bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatFollowLocked = false;
+    host.chatLastScrollTop = 2000;
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 400));
+    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+
+  it("re-enables follow once the user actually returns to the bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1576,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatLastScrollTop = 1540;
+    host.chatNewMessagesBelow = true;
+
+    handleChatScroll(host, createScrollEvent(2000, 1576, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
 });
 
 /* ------------------------------------------------------------------ */
@@ -266,10 +401,14 @@ describe("resetChatScroll", () => {
     const { host } = createScrollHost({});
     host.chatHasAutoScrolled = true;
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatLastScrollTop = 1234;
 
     resetChatScroll(host);
 
     expect(host.chatHasAutoScrolled).toBe(false);
     expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatLastScrollTop).toBe(0);
   });
 });

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -184,6 +184,30 @@ describe("handleChatWheelIntent", () => {
     expect(host.chatUserNearBottom).toBe(true);
     expect(host.chatFollowLocked).toBe(false);
   });
+
+  it("does not disengage follow for bubbled wheel events from nested scrollables", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+
+    const nestedScrollable = document.createElement("div");
+    Object.defineProperty(nestedScrollable, "scrollHeight", { value: 600, configurable: true });
+    Object.defineProperty(nestedScrollable, "clientHeight", { value: 300, configurable: true });
+
+    handleChatWheelIntent(
+      host,
+      {
+        deltaY: -120,
+        currentTarget: { scrollHeight: 2000, clientHeight: 400 },
+        target: nestedScrollable,
+      } as unknown as WheelEvent,
+    );
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
 });
 
 /* ------------------------------------------------------------------ */

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -82,7 +82,7 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
       }
       host.chatUserNearBottom = true;
       host.chatFollowLocked = false;
-      host.chatLastScrollTop = scrollTop;
+      host.chatLastScrollTop = Math.max(0, target.scrollHeight - target.clientHeight);
       host.chatNewMessagesBelow = false;
       const retryDelay = effectiveForce ? 150 : 120;
       host.chatScrollTimeout = window.setTimeout(() => {
@@ -99,7 +99,7 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         latest.scrollTop = latest.scrollHeight;
         host.chatUserNearBottom = true;
         host.chatFollowLocked = false;
-        host.chatLastScrollTop = latest.scrollHeight;
+        host.chatLastScrollTop = Math.max(0, latest.scrollHeight - latest.clientHeight);
       }, retryDelay);
     });
   });

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -14,6 +14,7 @@ type ScrollHost = {
   chatHasAutoScrolled: boolean;
   chatUserNearBottom: boolean;
   chatFollowLocked: boolean;
+  chatSmoothAutoScrolling: boolean;
   chatLastScrollTop: number;
   chatNewMessagesBelow: boolean;
   logsScrollFrame: number | null;
@@ -82,7 +83,10 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
       }
       host.chatUserNearBottom = true;
       host.chatFollowLocked = false;
-      host.chatLastScrollTop = Math.max(0, target.scrollHeight - target.clientHeight);
+      host.chatSmoothAutoScrolling = smoothEnabled;
+      host.chatLastScrollTop = smoothEnabled
+        ? Math.max(target.scrollTop, 0)
+        : Math.max(0, target.scrollHeight - target.clientHeight);
       host.chatNewMessagesBelow = false;
       const retryDelay = effectiveForce ? 150 : 120;
       host.chatScrollTimeout = window.setTimeout(() => {
@@ -99,6 +103,7 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         latest.scrollTop = latest.scrollHeight;
         host.chatUserNearBottom = true;
         host.chatFollowLocked = false;
+        host.chatSmoothAutoScrolling = false;
         host.chatLastScrollTop = Math.max(0, latest.scrollHeight - latest.clientHeight);
       }, retryDelay);
     });
@@ -138,7 +143,11 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   const scrollingUp = currentScrollTop < host.chatLastScrollTop;
   const backAtBottom = distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD;
 
-  if (
+  if (host.chatSmoothAutoScrolling) {
+    if (backAtBottom || !scrollingUp) {
+      host.chatSmoothAutoScrolling = false;
+    }
+  } else if (
     host.chatUserNearBottom &&
     scrollingUp &&
     distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD
@@ -171,6 +180,7 @@ export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
     return;
   }
   cancelPendingChatScroll(host);
+  host.chatSmoothAutoScrolling = false;
   host.chatUserNearBottom = false;
   host.chatFollowLocked = true;
 }
@@ -188,6 +198,7 @@ export function resetChatScroll(host: ScrollHost) {
   host.chatHasAutoScrolled = false;
   host.chatUserNearBottom = true;
   host.chatFollowLocked = false;
+  host.chatSmoothAutoScrolling = false;
   host.chatLastScrollTop = 0;
   host.chatNewMessagesBelow = false;
 }

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -144,7 +144,11 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   const backAtBottom = distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD;
 
   if (host.chatSmoothAutoScrolling) {
-    if (backAtBottom || !scrollingUp) {
+    if (scrollingUp && distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD) {
+      host.chatSmoothAutoScrolling = false;
+      host.chatUserNearBottom = false;
+      host.chatFollowLocked = true;
+    } else if (backAtBottom || !scrollingUp) {
       host.chatSmoothAutoScrolling = false;
     }
   } else if (

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -1,5 +1,9 @@
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
+/** Small escape hatch so slight upward manual scroll cancels auto-follow quickly. */
+const MANUAL_SCROLL_RELEASE_THRESHOLD = 24;
+/** Once the user takes over scroll, only re-enable follow when they are back at bottom. */
+const FOLLOW_REACQUIRE_THRESHOLD = 24;
 
 type ScrollHost = {
   updateComplete: Promise<unknown>;
@@ -9,20 +13,27 @@ type ScrollHost = {
   chatScrollTimeout: number | null;
   chatHasAutoScrolled: boolean;
   chatUserNearBottom: boolean;
+  chatFollowLocked: boolean;
+  chatLastScrollTop: number;
   chatNewMessagesBelow: boolean;
   logsScrollFrame: number | null;
   logsAtBottom: boolean;
   topbarObserver: ResizeObserver | null;
 };
 
-export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
+function cancelPendingChatScroll(host: ScrollHost) {
   if (host.chatScrollFrame) {
     cancelAnimationFrame(host.chatScrollFrame);
+    host.chatScrollFrame = null;
   }
   if (host.chatScrollTimeout != null) {
     clearTimeout(host.chatScrollTimeout);
     host.chatScrollTimeout = null;
   }
+}
+
+export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
+  cancelPendingChatScroll(host);
   const pickScrollTarget = () => {
     const container = host.querySelector(".chat-thread") as HTMLElement | null;
     if (container) {
@@ -45,13 +56,10 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
       if (!target) {
         return;
       }
-      const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
-
       // force=true only overrides when we haven't auto-scrolled yet (initial load).
       // After initial load, respect the user's scroll position.
       const effectiveForce = force && !host.chatHasAutoScrolled;
-      const shouldStick =
-        effectiveForce || host.chatUserNearBottom || distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+      const shouldStick = effectiveForce || (host.chatUserNearBottom && !host.chatFollowLocked);
 
       if (!shouldStick) {
         // User is scrolled up — flag that new content arrived below.
@@ -73,6 +81,8 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         target.scrollTop = scrollTop;
       }
       host.chatUserNearBottom = true;
+      host.chatFollowLocked = false;
+      host.chatLastScrollTop = scrollTop;
       host.chatNewMessagesBelow = false;
       const retryDelay = effectiveForce ? 150 : 120;
       host.chatScrollTimeout = window.setTimeout(() => {
@@ -81,17 +91,15 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         if (!latest) {
           return;
         }
-        const latestDistanceFromBottom =
-          latest.scrollHeight - latest.scrollTop - latest.clientHeight;
         const shouldStickRetry =
-          effectiveForce ||
-          host.chatUserNearBottom ||
-          latestDistanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+          effectiveForce || (host.chatUserNearBottom && !host.chatFollowLocked);
         if (!shouldStickRetry) {
           return;
         }
         latest.scrollTop = latest.scrollHeight;
         host.chatUserNearBottom = true;
+        host.chatFollowLocked = false;
+        host.chatLastScrollTop = latest.scrollHeight;
       }, retryDelay);
     });
   });
@@ -124,12 +132,47 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   if (!container) {
     return;
   }
+  const currentScrollTop = container.scrollTop;
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-  host.chatUserNearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  const nearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  const scrollingUp = currentScrollTop < host.chatLastScrollTop;
+  const backAtBottom = distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD;
+
+  if (
+    host.chatUserNearBottom &&
+    scrollingUp &&
+    distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD
+  ) {
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+  } else if (backAtBottom) {
+    host.chatUserNearBottom = true;
+    host.chatFollowLocked = false;
+  } else if (!host.chatFollowLocked && nearBottom) {
+    host.chatUserNearBottom = true;
+  }
+
+  host.chatLastScrollTop = Math.max(currentScrollTop, 0);
   // Clear the "new messages below" indicator when user scrolls back to bottom.
-  if (host.chatUserNearBottom) {
+  if (host.chatUserNearBottom && !host.chatFollowLocked) {
     host.chatNewMessagesBelow = false;
   }
+}
+
+export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
+  if (event.deltaY >= 0) {
+    return;
+  }
+  const container = event.currentTarget as HTMLElement | null;
+  if (!container || container.scrollHeight - container.clientHeight <= 1) {
+    return;
+  }
+  if (!host.chatUserNearBottom && host.chatFollowLocked) {
+    return;
+  }
+  cancelPendingChatScroll(host);
+  host.chatUserNearBottom = false;
+  host.chatFollowLocked = true;
 }
 
 export function handleLogsScroll(host: ScrollHost, event: Event) {
@@ -144,6 +187,8 @@ export function handleLogsScroll(host: ScrollHost, event: Event) {
 export function resetChatScroll(host: ScrollHost) {
   host.chatHasAutoScrolled = false;
   host.chatUserNearBottom = true;
+  host.chatFollowLocked = false;
+  host.chatLastScrollTop = 0;
   host.chatNewMessagesBelow = false;
 }
 

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -33,6 +33,17 @@ function cancelPendingChatScroll(host: ScrollHost) {
   }
 }
 
+function hasNestedScrollableAncestor(target: EventTarget | null, container: HTMLElement) {
+  let node = target instanceof HTMLElement ? target : null;
+  while (node && node !== container) {
+    if (node.scrollHeight - node.clientHeight > 1) {
+      return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
+
 export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
   cancelPendingChatScroll(host);
   const pickScrollTarget = () => {
@@ -178,6 +189,9 @@ export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
   }
   const container = event.currentTarget as HTMLElement | null;
   if (!container || container.scrollHeight - container.clientHeight <= 1) {
+    return;
+  }
+  if (hasNestedScrollableAncestor(event.target, container)) {
     return;
   }
   if (!host.chatUserNearBottom && host.chatFollowLocked) {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -361,6 +361,7 @@ export type AppViewState = {
     handleAbortChat: () => Promise<void>;
     removeQueuedMessage: (id: string) => void;
     handleChatScroll: (event: Event) => void;
+    handleChatWheelIntent: (event: WheelEvent) => void;
     resetToolStream: () => void;
     resetChatScroll: () => void;
     exportLogs: (lines: string[], label: string) => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -438,6 +438,7 @@ export class OpenClawApp extends LitElement {
   private chatHasAutoScrolled = false;
   private chatUserNearBottom = true;
   private chatFollowLocked = false;
+  private chatSmoothAutoScrolling = false;
   private chatLastScrollTop = 0;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -32,6 +32,7 @@ import { renderApp } from "./app-render.ts";
 import {
   exportLogs as exportLogsInternal,
   handleChatScroll as handleChatScrollInternal,
+  handleChatWheelIntent as handleChatWheelIntentInternal,
   handleLogsScroll as handleLogsScrollInternal,
   resetChatScroll as resetChatScrollInternal,
   scheduleChatScroll as scheduleChatScrollInternal,
@@ -436,6 +437,8 @@ export class OpenClawApp extends LitElement {
   private chatScrollTimeout: number | null = null;
   private chatHasAutoScrolled = false;
   private chatUserNearBottom = true;
+  private chatFollowLocked = false;
+  private chatLastScrollTop = 0;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;
   private logsPollInterval: number | null = null;
@@ -503,6 +506,13 @@ export class OpenClawApp extends LitElement {
   handleChatScroll(event: Event) {
     handleChatScrollInternal(
       this as unknown as Parameters<typeof handleChatScrollInternal>[0],
+      event,
+    );
+  }
+
+  handleChatWheelIntent(event: WheelEvent) {
+    handleChatWheelIntentInternal(
+      this as unknown as Parameters<typeof handleChatWheelIntentInternal>[0],
       event,
     );
   }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -107,6 +107,7 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  onChatWheelIntent?: (event: WheelEvent) => void;
   basePath?: string;
 };
 
@@ -832,6 +833,12 @@ export function renderChat(props: ChatProps) {
 
   const splitRatio = props.splitRatio ?? 0.6;
   const sidebarOpen = Boolean(props.sidebarOpen && props.onCloseSidebar);
+  const passiveWheelListener = props.onChatWheelIntent
+    ? ({
+        handleEvent: props.onChatWheelIntent,
+        passive: true,
+      } as EventListenerObject & AddEventListenerOptions)
+    : nothing;
 
   const handleCodeBlockCopy = (e: Event) => {
     const btn = (e.target as HTMLElement).closest(".code-block-copy");
@@ -857,6 +864,7 @@ export function renderChat(props: ChatProps) {
       role="log"
       aria-live="polite"
       @scroll=${props.onChatScroll}
+      @wheel=${passiveWheelListener}
       @click=${handleCodeBlockCopy}
     >
       <div class="chat-thread-inner">


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: While the assistant is streaming in Control UI chat, manually scrolling upward can be overridden by auto-follow and pull the viewport back down.
- Why it matters: It makes reviewing earlier messages during active responses frustrating and creates a jumpy, disruptive reading experience.
- What changed: Auto-follow now releases on intentional upward manual scroll, cancels pending follow/retry scroll work, avoids false detachment when the chat cannot actually scroll, and only re-enables follow once the user returns to the bottom.
- What did NOT change (scope boundary): This only changes Control UI chat scroll behavior; it does not change chat content, ordering, backend behavior, or session logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #37500

This approach is related to #37500, but additionally cancels already-scheduled follow/retry scroll work once upward user scroll intent is detected, keeps auto-follow locked off until the user actually returns to bottom, and avoids detaching follow on wheel input when the chat cannot scroll.

## User-visible / Behavior Changes

- While a response is streaming, manually scrolling upward no longer gets repeatedly pulled back to the bottom by chat auto-follow.
- Auto-follow resumes only after the user actually returns to the bottom or uses the new-messages/scroll-to-bottom control.
- Upward wheel input on short/non-scrollable chats no longer falsely disables auto-follow.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Control UI dev server (`vite`)
- Model/provider: N/A
- Integration/channel (if any): Control UI chat
- Relevant config (redacted): default local UI setup

### Steps

1. Open the Control UI chat.
2. Send a message that produces a longer streaming response.
3. While the assistant is still streaming, scroll upward in the chat history.

### Expected

- The viewport stays at the user-selected position and does not keep snapping back downward.
- New messages can continue arriving below without stealing scroll position.

### Actual

- Before this fix, the viewport could continue moving back down during streaming because auto-follow was re-enabled too aggressively, scheduled retry scrolls could still fire after manual upward scroll, and wheel input could detach follow even when the chat could not scroll.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran targeted scroll behavior tests and rebuilt the Control UI; manually reproduced the streaming + upward-scroll scenario locally while iterating on the fix.
- Edge cases checked: Near-bottom behavior, initial forced scroll on load, preserving manual upward scroll during rapid streaming updates, cancelling pending retry scrolls on upward wheel input, preventing re-enable during follow-locked near-bottom scroll events, avoiding false detach when the chat has no overflow, and restoring follow after returning to bottom.
- What you did **not** verify: Cross-browser manual QA beyond the local environment and touch-specific/mobile gesture behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the PR or revert the follow-lock changes in the chat scroll handling.
- Files/config to restore: `ui/src/ui/app-scroll.ts`, `ui/src/ui/app.ts`, `ui/src/ui/app-render.ts`, `ui/src/ui/app-view-state.ts`, `ui/src/ui/views/chat.ts`, `ui/src/ui/app-scroll.test.ts`
- Known bad symptoms reviewers should watch for: chat no longer following when already at bottom, new-messages indicator showing incorrectly, or upward manual scroll still getting overridden during streaming.

## Risks and Mitigations

- Risk: Auto-follow could disengage too aggressively near the bottom.
- Mitigation: Added explicit tests around near-bottom behavior, upward wheel intent, follow-lock behavior, bottom re-acquisition, and non-scrollable chat behavior.
- Risk: Scheduled retry scrolls could override manual user intent after streaming updates.
- Mitigation: Pending animation-frame and timeout-based chat scroll work is cancelled on upward wheel intent, and follow remains locked until the user actually returns to the bottom.
