### PR TITLE
fix(skills): log warning when skills are truncated due to prompt limits

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -620,10 +620,15 @@ function resolveWorkspaceSkillPromptState(
   );
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries.map((entry) => entry.skill);
-  const { skillsForPrompt, truncated } = applySkillsPromptLimits({
+  const { skillsForPrompt, truncated, truncatedReason } = applySkillsPromptLimits({
     skills: resolvedSkills,
     config: opts?.config,
   });
+  if (truncated) {
+    skillsLogger.warn(
+      `Skills truncated to ${skillsForPrompt.length} of ${resolvedSkills.length} (reason: ${truncatedReason ?? "unknown"}). Run \`openclaw skills check\` to audit.`,
+    );
+  }
   const truncationNote = truncated
     ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}. Run \`openclaw skills check\` to audit.`
     : "";


### PR DESCRIPTION
When `applySkillsPromptLimits` drops skills because the combined prompt text exceeds `maxSkillsPromptChars`, only an in-prompt note is generated (visible to the model). The operator has no server-side indication that skills were silently removed.

## Changes

- **`src/agents/skills/workspace.ts`**: Add `skillsLogger.warn()` when `truncated` is true, logging the count of included vs total skills and the truncation reason (`count` or `chars`).

Closes #46623

lobster-biscuit
