### PR TITLE
fix(feishu): keep sender-scoped thread bootstrap across id types

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -77,11 +77,13 @@ function createRuntimeEnv(): RuntimeEnv {
 }
 
 async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessageEvent }) {
+  const runtime = createRuntimeEnv();
   await handleFeishuMessage({
     cfg: params.cfg,
     event: params.event,
-    runtime: createRuntimeEnv(),
+    runtime,
   });
+  return runtime;
 }
 
 describe("buildFeishuAgentBody", () => {
@@ -147,6 +149,8 @@ describe("handleFeishuMessage command authorization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockShouldComputeCommandAuthorized.mockReset().mockReturnValue(true);
+    mockGetMessageFeishu.mockReset().mockResolvedValue(null);
+    mockListFeishuThreadMessages.mockReset().mockResolvedValue([]);
     mockReadSessionUpdatedAt.mockReturnValue(undefined);
     mockResolveStorePath.mockReturnValue("/tmp/feishu-sessions.json");
     mockResolveAgentRoute.mockReturnValue({
@@ -1835,6 +1839,76 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: undefined,
         ThreadHistoryBody: undefined,
+        ThreadLabel: "Feishu thread in oc-group",
+        MessageThreadId: "om_topic_root",
+      }),
+    );
+  });
+
+  it("keeps sender-scoped thread history when the inbound event and thread history use different sender ids", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValue({
+      messageId: "om_topic_root",
+      chatId: "oc-group",
+      content: "root starter",
+      contentType: "text",
+      threadId: "omt_topic_1",
+    });
+    mockListFeishuThreadMessages.mockResolvedValue([
+      {
+        messageId: "om_bot_reply",
+        senderId: "app_1",
+        senderType: "app",
+        content: "assistant reply",
+        contentType: "text",
+        createTime: 1710000000000,
+      },
+      {
+        messageId: "om_follow_up",
+        senderId: "user_topic_1",
+        senderType: "user",
+        content: "follow-up question",
+        contentType: "text",
+        createTime: 1710000001000,
+      },
+    ]);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic_sender",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-topic-user",
+          user_id: "user_topic_1",
+        },
+      },
+      message: {
+        message_id: "om_topic_followup_mixed_ids",
+        root_id: "om_topic_root",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "current turn" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ThreadStarterBody: "root starter",
+        ThreadHistoryBody: "assistant reply\n\nfollow-up question",
         ThreadLabel: "Feishu thread in oc-group",
         MessageThreadId: "om_topic_root",
       }),

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1406,15 +1406,25 @@ export async function handleFeishuMessage(params: {
           accountId: account.accountId,
         });
         const senderScoped = groupSession?.groupSessionScope === "group_topic_sender";
-        const relevantMessages = senderScoped
-          ? threadMessages.filter(
-              (msg) => msg.senderType === "app" || msg.senderId === ctx.senderOpenId,
-            )
-          : threadMessages;
+        const senderIds = new Set(
+          [ctx.senderOpenId, senderUserId]
+            .map((id) => id?.trim())
+            .filter((id): id is string => id !== undefined && id.length > 0),
+        );
+        const relevantMessages =
+          (senderScoped
+            ? threadMessages.filter(
+                (msg) =>
+                  msg.senderType === "app" ||
+                  (msg.senderId !== undefined && senderIds.has(msg.senderId.trim())),
+              )
+            : threadMessages) ?? [];
 
         const threadStarterBody = rootMsg?.content ?? relevantMessages[0]?.content;
-        const historyMessages =
-          rootMsg?.content || ctx.rootId ? relevantMessages : relevantMessages.slice(1);
+        const includeStarterInHistory = Boolean(rootMsg?.content || ctx.rootId);
+        const historyMessages = includeStarterInHistory
+          ? relevantMessages
+          : relevantMessages.slice(1);
         const historyParts = historyMessages.map((msg) => {
           const role = msg.senderType === "app" ? "assistant" : "user";
           return core.channel.reply.formatAgentEnvelope({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `group_topic_sender` thread bootstrap compared thread-history `senderId` only against `ctx.senderOpenId`, even though inbound Feishu events can fall back to `user_id` while thread-history messages may carry a different id type for the same user.
- Why it matters: sender-scoped Feishu topic sessions could lose the user's own prior turns from `ThreadHistoryBody`, leaving incomplete bootstrap context.
- What changed: sender-scoped history matching now accepts both inbound sender ids already available on the event (`open_id` and `user_id`), and the bot test suite now covers the mixed-id case.
- What did NOT change (scope boundary): no routing/session-key format changes, no new API calls, and no changes outside the Feishu thread-bootstrap filter and its tests.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #45254

## User-visible / Behavior Changes

Feishu `group_topic_sender` sessions now keep prior thread turns when the triggering event uses one sender id type and thread history returns the same sender under another Feishu id type.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm repo checkout
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): `channels.feishu.groups.<id>.groupSessionScope=group_topic_sender`

### Steps

1. Configure a Feishu group with `group_topic_sender` session scope.
2. Receive a topic-thread event where the inbound sender is represented with one id type while thread-history messages for the same user are represented with another (for example inbound `open_id` plus `user_id` fallback available, history returned under `user_id`).
3. Bootstrap thread context for the first sender-scoped turn.

### Expected

- The sender's prior thread turns are retained in `ThreadHistoryBody` for bootstrap.

### Actual

- Before this fix, the same user could be filtered out of sender-scoped history, leaving incomplete bootstrap context.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: mixed-id sender-scoped bootstrap in `extensions/feishu/src/bot.test.ts`
- Edge cases checked: sender-scoped bootstrap still includes bot messages and standard same-id history; formatting check on touched files
- What you did **not** verify: live Feishu traffic against a real tenant

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit
- Files/config to restore: `extensions/feishu/src/bot.ts`, `extensions/feishu/src/bot.test.ts`
- Known bad symptoms reviewers should watch for: missing sender turns in `ThreadHistoryBody` for Feishu `group_topic_sender` topic bootstrap

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: sender-scoped matching could still miss identities if Feishu returns only a third id form not present on the inbound event.
  - Mitigation: the fix covers both ids already available on the inbound event without changing routing/session semantics, and the new regression test locks in the mixed `open_id` / `user_id` case that prompted this PR.
