### PR TITLE
fix(gateway): remove re-introduced auth.mode=none pairing bypass

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -674,18 +674,14 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
-        // auth.mode=none disables all authentication — device pairing is an
-        // auth mechanism and must also be skipped when the operator opted out.
         const skipPairing =
-          resolvedAuth.mode === "none" ||
           shouldSkipBackendSelfPairing({
             connectParams,
             isLocalClient,
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,
-          }) ||
-          shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
+          }) || shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {


### PR DESCRIPTION
Vincent's revert of #43478 (commit 39b4185d0b) was silently undone by 3704293e6f (browser: drop headless/remote MCP attach modes). That commit's branch was based on main before the revert, so the merge conflict resolution brought the `resolvedAuth.mode === "none"` skipPairing condition back.

This removes it again. The blanket skip disabled pairing for all websocket clients, not just Control UI behind reverse proxies.

Single file, -5 lines. No CHANGELOG entry since this is restoring the already-reverted state.