### PR TITLE
feat(plugins): add agent_to_agent_turn hook for A2A ping-pong visibility

### DIFF
--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -28,7 +28,7 @@ export async function runSessionsSendA2AFlow(params: {
   roundOneReply?: string;
   waitRunId?: string;
 }) {
-  const runContextId = params.waitRunId ?? "unknown";
+  const runContextId = params.waitRunId ?? crypto.randomUUID();
   try {
     let primaryReply = params.roundOneReply;
     let latestReply = params.roundOneReply;
@@ -84,8 +84,7 @@ export async function runSessionsSendA2AFlow(params: {
             threadId: announceTarget.threadId,
           }
         : undefined;
-      // eslint-disable-next-line no-unused-vars
-      let _hookChain: Promise<void> = Promise.resolve();
+      let hookChain: Promise<void> = Promise.resolve();
 
       // Emit turn=0 for the initial target reply (before ping-pong starts).
       if (hasA2ATurnHooks && latestReply) {
@@ -101,7 +100,7 @@ export async function runSessionsSendA2AFlow(params: {
           targetChannel: resolvedTargetChannel,
           deliveryTarget,
         };
-        _hookChain = _hookChain.then(() =>
+        hookChain = hookChain.then(() =>
           withTimeout(hookRunner!.runAgentToAgentTurn(event, hookCtx), perTurnTimeout).catch(
             () => {},
           ),
@@ -150,7 +149,7 @@ export async function runSessionsSendA2AFlow(params: {
             targetChannel: resolvedTargetChannel,
             deliveryTarget,
           };
-          _hookChain = _hookChain.then(() =>
+          hookChain = hookChain.then(() =>
             withTimeout(hookRunner!.runAgentToAgentTurn(event, hookCtx), perTurnTimeout).catch(
               () => {},
             ),
@@ -164,7 +163,8 @@ export async function runSessionsSendA2AFlow(params: {
       }
       // Wait for queued turn hooks before announce so users see intermediate
       // turns before the final conclusion.
-      await _hookChain;
+      // Bound the wait so a slow plugin cannot stall the announce step.
+      await withTimeout(hookChain, perTurnTimeout).catch(() => {});
     }
 
     const announcePrompt = buildAgentToAgentAnnounceContext({

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -2,7 +2,9 @@ import crypto from "node:crypto";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import { withTimeout } from "../../utils/with-timeout.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import { readLatestAssistantReply, runAgentStep } from "./agent-step.js";
 import { resolveAnnounceTarget } from "./sessions-announce-target.js";
@@ -65,8 +67,49 @@ export async function runSessionsSendA2AFlow(params: {
       let currentSessionKey = params.requesterSessionKey;
       let nextSessionKey = params.targetSessionKey;
       let incomingMessage = latestReply;
+      // Hook chain preserves turn delivery order without blocking the loop.
+      const hookRunner = getGlobalHookRunner();
+      const hasA2ATurnHooks = hookRunner?.hasHooks("agent_to_agent_turn") ?? false;
+      const resolvedTargetChannel = targetChannel === "unknown" ? undefined : targetChannel;
+      const perTurnTimeout = Math.min(params.announceTimeoutMs, 30_000);
+      const hookCtx = {
+        requesterSessionKey: params.requesterSessionKey,
+        targetSessionKey: params.targetSessionKey,
+      };
+      const deliveryTarget = announceTarget
+        ? {
+            to: announceTarget.to,
+            accountId: announceTarget.accountId,
+            channel: announceTarget.channel,
+            threadId: announceTarget.threadId,
+          }
+        : undefined;
+      // eslint-disable-next-line no-unused-vars
+      let _hookChain: Promise<void> = Promise.resolve();
+
+      // Emit turn=0 for the initial target reply (before ping-pong starts).
+      if (hasA2ATurnHooks && latestReply) {
+        const event = {
+          flowId: runContextId,
+          turn: 0,
+          maxTurns: params.maxPingPongTurns,
+          speakerSessionKey: params.targetSessionKey,
+          listenerSessionKey: params.requesterSessionKey,
+          speakerRole: "target" as const,
+          reply: latestReply,
+          requesterChannel: params.requesterChannel,
+          targetChannel: resolvedTargetChannel,
+          deliveryTarget,
+        };
+        _hookChain = _hookChain.then(() =>
+          withTimeout(hookRunner!.runAgentToAgentTurn(event, hookCtx), perTurnTimeout).catch(
+            () => {},
+          ),
+        );
+      }
+
       for (let turn = 1; turn <= params.maxPingPongTurns; turn += 1) {
-        const currentRole =
+        const currentRole: "requester" | "target" =
           currentSessionKey === params.requesterSessionKey ? "requester" : "target";
         const replyPrompt = buildAgentToAgentReplyContext({
           requesterSessionKey: params.requesterSessionKey,
@@ -92,11 +135,36 @@ export async function runSessionsSendA2AFlow(params: {
           break;
         }
         latestReply = replyText;
+
+        // Emit hook so channel plugins can forward A2A turns to users.
+        if (hasA2ATurnHooks) {
+          const event = {
+            flowId: runContextId,
+            turn,
+            maxTurns: params.maxPingPongTurns,
+            speakerSessionKey: currentSessionKey,
+            listenerSessionKey: nextSessionKey,
+            speakerRole: currentRole,
+            reply: replyText,
+            requesterChannel: params.requesterChannel,
+            targetChannel: resolvedTargetChannel,
+            deliveryTarget,
+          };
+          _hookChain = _hookChain.then(() =>
+            withTimeout(hookRunner!.runAgentToAgentTurn(event, hookCtx), perTurnTimeout).catch(
+              () => {},
+            ),
+          );
+        }
+
         incomingMessage = replyText;
         const swap = currentSessionKey;
         currentSessionKey = nextSessionKey;
         nextSessionKey = swap;
       }
+      // Wait for queued turn hooks before announce so users see intermediate
+      // turns before the final conclusion.
+      await _hookChain;
     }
 
     const announcePrompt = buildAgentToAgentAnnounceContext({

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -47,6 +47,8 @@ import type {
   PluginHookSubagentSpawningResult,
   PluginHookSubagentEndedEvent,
   PluginHookSubagentSpawnedEvent,
+  PluginHookA2ATurnContext,
+  PluginHookA2ATurnEvent,
   PluginHookToolContext,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
@@ -97,6 +99,8 @@ export type {
   PluginHookSubagentSpawningResult,
   PluginHookSubagentSpawnedEvent,
   PluginHookSubagentEndedEvent,
+  PluginHookA2ATurnContext,
+  PluginHookA2ATurnEvent,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
@@ -875,6 +879,22 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   // =========================================================================
+  // Agent-to-Agent Hooks
+  // =========================================================================
+
+  /**
+   * Run agent_to_agent_turn hook.
+   * Fires after each completed turn of an A2A ping-pong exchange.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runAgentToAgentTurn(
+    event: PluginHookA2ATurnEvent,
+    ctx: PluginHookA2ATurnContext,
+  ): Promise<void> {
+    return runVoidHook("agent_to_agent_turn", event, ctx);
+  }
+
+  // =========================================================================
   // Gateway Hooks
   // =========================================================================
 
@@ -949,6 +969,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runSubagentDeliveryTarget,
     runSubagentSpawned,
     runSubagentEnded,
+    // Agent-to-Agent hooks
+    runAgentToAgentTurn,
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1385,6 +1385,7 @@ export type PluginHookName =
   | "subagent_delivery_target"
   | "subagent_spawned"
   | "subagent_ended"
+  | "agent_to_agent_turn"
   | "gateway_start"
   | "gateway_stop";
 
@@ -1412,6 +1413,7 @@ export const PLUGIN_HOOK_NAMES = [
   "subagent_delivery_target",
   "subagent_spawned",
   "subagent_ended",
+  "agent_to_agent_turn",
   "gateway_start",
   "gateway_stop",
 ] as const satisfies readonly PluginHookName[];
@@ -1844,6 +1846,40 @@ export type PluginHookSubagentEndedEvent = {
   error?: string;
 };
 
+// agent_to_agent_turn hook
+export type PluginHookA2ATurnContext = {
+  requesterSessionKey?: string;
+  targetSessionKey?: string;
+};
+
+export type PluginHookA2ATurnEvent = {
+  /** Stable identifier for this A2A exchange, to distinguish overlapping exchanges between the same agent pair. */
+  flowId: string;
+  /** 0 = initial target reply before ping-pong; 1+ = ping-pong turn index. */
+  turn: number;
+  /** Maximum number of ping-pong turns configured. */
+  maxTurns: number;
+  /** Session key of the agent that just produced the reply. */
+  speakerSessionKey: string;
+  /** Session key of the agent that will receive the reply next. */
+  listenerSessionKey: string;
+  /** Role of the speaking agent in this exchange. */
+  speakerRole: "requester" | "target";
+  /** The reply text produced during this turn. */
+  reply: string;
+  /** Channel identifier for the requester agent (if any). */
+  requesterChannel?: string;
+  /** Channel identifier for the target agent (if any). */
+  targetChannel?: string;
+  /** Resolved delivery target for message routing (if available). */
+  deliveryTarget?: {
+    to: string;
+    accountId?: string;
+    channel?: string;
+    threadId?: string | number;
+  };
+};
+
 // Gateway context
 export type PluginHookGatewayContext = {
   port?: number;
@@ -1952,6 +1988,10 @@ export type PluginHookHandlerMap = {
   subagent_ended: (
     event: PluginHookSubagentEndedEvent,
     ctx: PluginHookSubagentContext,
+  ) => Promise<void> | void;
+  agent_to_agent_turn: (
+    event: PluginHookA2ATurnEvent,
+    ctx: PluginHookA2ATurnContext,
   ) => Promise<void> | void;
   gateway_start: (
     event: PluginHookGatewayStartEvent,


### PR DESCRIPTION
## Summary

- **Problem:** During agent-to-agent (A2A) ping-pong exchanges, intermediate turns are invisible to channel plugins — only the final "announce" step goes through the channel. Channel plugins (e.g., DingTalk, Discord) cannot forward intermediate expert-to-expert discussion to users in real-time.
- **Why it matters:** For multi-expert collaboration scenarios (e.g., troubleshooting in a group chat), users need to see the discussion process between experts, not just the final conclusion. Without visibility into intermediate turns, the A2A feature cannot be used for user-facing expert collaboration.
- **What changed:** Added a new `agent_to_agent_turn` plugin hook that fires after each completed turn of an A2A ping-pong exchange. Channel plugins can register handlers via `api.on("agent_to_agent_turn", handler)` to intercept and forward these messages.
- **What did NOT change:** No changes to A2A core logic, session management, or existing hook behavior. The hook is purely additive and opt-in.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Multi-expert collaboration in channel plugins (DingTalk @sub-agent feature)

## User-visible / Behavior Changes

- New plugin hook `agent_to_agent_turn` available for channel plugins
- No behavior change unless a plugin explicitly registers a handler
- Zero overhead when no handlers are registered (guarded by `hasHooks` check)

## Security Impact (required)

- New permissions/capabilities? `No` — hook is read-only, receives reply text that already exists in the session
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 24.6.0
- Runtime/container: Node.js
- Model/provider: N/A (infrastructure change)
- Integration/channel: DingTalk (primary use case)

### Steps

1. Configure two agents with `tools.agentToAgent.enabled: true` and mutual `allow` lists
2. Register a plugin handler: `api.on("agent_to_agent_turn", (event) => console.log(event))`
3. Trigger an A2A exchange via `sessions_send` with `timeoutSeconds > 0`

### Expected

- Handler is called after each ping-pong turn with `{ turn, speakerSessionKey, reply, ... }`
- A2A exchange completes normally regardless of handler success/failure

### Actual

- Verified via `pnpm build` — TypeScript compilation passes including exhaustiveness checks

## Evidence

- [x] `pnpm build` passes — TypeScript exhaustiveness check (`MissingPluginHookNames extends never`) confirms all type registrations are consistent
- [x] Hook follows exact same pattern as `subagent_spawned`/`subagent_ended` (void hook, `runVoidHook`, `hasHooks` guard)

## Human Verification (required)

- Verified scenarios: `pnpm build` compilation passes, exhaustiveness type check passes
- Edge cases checked: hook handler errors are caught silently (cannot interrupt A2A exchange), `hasHooks` guard prevents overhead when no handlers registered
- What I did **not** verify: End-to-end A2A exchange with a real channel plugin handler (requires running OpenClaw instance with DingTalk plugin)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — purely additive, no existing behavior changes
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 3-file commit; or simply don't register the hook in plugins
- Files/config to restore: `src/plugins/types.ts`, `src/plugins/hooks.ts`, `src/agents/tools/sessions-send-tool.a2a.ts`
- Known bad symptoms: If the hook runner import path is wrong, build will fail (caught by CI)

## Risks and Mitigations

- Risk: Hook handler throws an error during A2A exchange
  - Mitigation: All hook calls are wrapped in `try/catch` — errors are silently swallowed, A2A exchange continues uninterrupted

---

> **Disclosure:** This PR was developed with AI assistance (Claude). All code has been reviewed and verified by @wjueyao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)