### PR TITLE
fix(zalouser): stop inheriting dm allowlist for groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Z.AI/onboarding: detect a working default model even for explicit `zai-coding-*` endpoint choices, so Coding Plan setup can keep the selected endpoint while defaulting to `glm-5` when available or `glm-4.7` as fallback. (#45969)
 - Control UI/chat sessions: show human-readable labels in the grouped session dropdown again, keep unique scoped fallbacks when metadata is missing, and disambiguate duplicate labels only when needed. (#45130) thanks @luzhidong.
 - Configure/startup: move outbound send-deps resolution into a lightweight helper so `openclaw configure` no longer stalls after the banner while eagerly loading channel plugins. (#46301) thanks @scoootscooob.
+- Zalo Personal/group gating: stop reapplying `dmPolicy.allowFrom` as a sender gate for already-allowlisted groups when `groupAllowFrom` is unset, so any member of an allowed group can trigger replies while DMs stay restricted. (#40146)
 
 ### Fixes
 

--- a/extensions/zalouser/src/monitor.group-gating.test.ts
+++ b/extensions/zalouser/src/monitor.group-gating.test.ts
@@ -477,7 +477,37 @@ describe("zalouser monitor group mention gating", () => {
     });
   });
 
-  it("blocks group messages when sender is not in groupAllowFrom/allowFrom", async () => {
+  it("allows allowlisted group replies without inheriting the DM allowlist", async () => {
+    const { dispatchReplyWithBufferedBlockDispatcher } = installRuntime({
+      commandAuthorized: false,
+      replyPayload: { text: "ok" },
+    });
+    await __testing.processMessage({
+      message: createGroupMessage({
+        content: "ping @bot",
+        hasAnyMention: true,
+        wasExplicitlyMentioned: true,
+        senderId: "456",
+      }),
+      account: {
+        ...createAccount(),
+        config: {
+          ...createAccount().config,
+          groupPolicy: "allowlist",
+          allowFrom: ["123"],
+          groups: {
+            "group:g-1": { allow: true, requireMention: true },
+          },
+        },
+      },
+      config: createConfig(),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks group messages when sender is not in groupAllowFrom", async () => {
     const { dispatchReplyWithBufferedBlockDispatcher } = installRuntime({
       commandAuthorized: false,
     });
@@ -493,6 +523,7 @@ describe("zalouser monitor group mention gating", () => {
           ...createAccount().config,
           groupPolicy: "allowlist",
           allowFrom: ["999"],
+          groupAllowFrom: ["999"],
         },
       },
       config: createConfig(),

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -27,6 +27,7 @@ import {
   resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   resolveSenderCommandAuthorization,
+  resolveSenderScopedGroupPolicy,
   sendMediaWithLeadingCaption,
   summarizeMapping,
   warnMissingProviderGroupPolicyFallbackOnce,
@@ -349,6 +350,10 @@ async function processMessage(
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const configAllowFrom = (account.config.allowFrom ?? []).map((v) => String(v));
   const configGroupAllowFrom = (account.config.groupAllowFrom ?? []).map((v) => String(v));
+  const senderGroupPolicy = resolveSenderScopedGroupPolicy({
+    groupPolicy,
+    groupAllowFrom: configGroupAllowFrom,
+  });
   const shouldComputeCommandAuth = core.channel.commands.shouldComputeCommandAuthorized(
     commandBody,
     config,
@@ -360,10 +365,11 @@ async function processMessage(
   const accessDecision = resolveDmGroupAccessWithLists({
     isGroup,
     dmPolicy,
-    groupPolicy,
+    groupPolicy: senderGroupPolicy,
     allowFrom: configAllowFrom,
     groupAllowFrom: configGroupAllowFrom,
     storeAllowFrom,
+    groupAllowFromFallbackToAllowFrom: false,
     isSenderAllowed: (allowFrom) => isSenderAllowed(senderId, allowFrom),
   });
   if (isGroup && accessDecision.decision !== "allow") {

--- a/src/plugin-sdk/zalouser.ts
+++ b/src/plugin-sdk/zalouser.ts
@@ -61,7 +61,10 @@ export type { WizardPrompter } from "../wizard/prompts.js";
 export { formatAllowFromLowercase } from "./allow-from.js";
 export { resolveSenderCommandAuthorization } from "./command-auth.js";
 export { resolveChannelAccountConfigBasePath } from "./config-paths.js";
-export { evaluateGroupRouteAccessForPolicy } from "./group-access.js";
+export {
+  evaluateGroupRouteAccessForPolicy,
+  resolveSenderScopedGroupPolicy,
+} from "./group-access.js";
 export { loadOutboundMediaFromUrl } from "./outbound-media.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
 export { issuePairingChallenge } from "../pairing/pairing-challenge.js";


### PR DESCRIPTION
## Summary

- Problem: allowlisted `zalouser` groups were still reapplying DM `allowFrom` sender gating, so only DM-allowlisted users could trigger replies inside an already-allowlisted group.
- Why it matters: this breaks the expected split between DM restrictions and group allowlisting, matching Issue #40146's repro.
- What changed: switched the secondary group access decision to sender-scoped group policy, disabled fallback from `groupAllowFrom` to DM `allowFrom` for group message access, added a regression test, and exported the reused helper through the `zalouser` plugin-sdk subpath.
- What did NOT change (scope boundary): no changes to DM policy behavior, pairing flows, status/auth reporting, or other channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40146
- Related #33992
- Adjacent context: #42400

## User-visible / Behavior Changes

- In `zalouser`, an allowlisted group now behaves independently from DM `allowFrom` when `groupAllowFrom` is unset.
- Any member of an allowed group can trigger replies according to group settings, while DMs remain restricted by `dmPolicy` / `allowFrom`.
- If operators want per-member restrictions inside a group, they must use `groupAllowFrom` explicitly.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS sandbox runner
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): `@openclaw/zalouser`
- Relevant config (redacted): `dmPolicy: "allowlist"`, `groupPolicy: "allowlist"`, one allowlisted group, no `groupAllowFrom`

### Steps

1. Configure `zalouser` with restricted DMs and one allowlisted group.
2. Mention the bot in that group from a user not present in DM `allowFrom`.
3. Observe reply behavior before and after the patch.

### Expected

- Any member of the allowlisted group can trigger replies unless `groupAllowFrom` restricts that group explicitly.

### Actual

- Verified via regression test after the patch; the allowlisted group no longer inherits DM `allowFrom` sender gating.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted `zalouser` regression coverage for allowlisted groups, explicit `groupAllowFrom`, mention gating, group control-command auth, and DM session behavior.
- Edge cases checked: `groupAllowFrom` still blocks non-allowed senders when explicitly configured; DM `allowFrom` still authorizes group control commands where intended.
- What you did **not** verify: live Zalo end-to-end behavior against a real account/group.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or temporarily use explicit `groupAllowFrom` to restrict group senders.
- Files/config to restore: `extensions/zalouser/src/monitor.ts`, `src/plugin-sdk/zalouser.ts`
- Known bad symptoms reviewers should watch for: allowlisted groups unexpectedly becoming sender-restricted again, or explicit `groupAllowFrom` no longer taking effect.

## Risks and Mitigations

- Risk: changing sender-group policy resolution could accidentally open groups that were relying on the old DM-allowlist inheritance.
  - Mitigation: the new behavior matches the documented issue expectation, keeps explicit `groupAllowFrom` enforcement, and adds regression coverage for both open and restricted group cases.

## Gate Notes

- `pnpm install --frozen-lockfile`: passed
- `pnpm build`: passed
- `pnpm check`: passed
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/zalouser/src/monitor.group-gating.test.ts extensions/zalouser/src/status-issues.test.ts`: passed
- `pnpm test:macmini`: not green in this sandbox due unrelated failures outside the changed surface (`src/infra/ports.test.ts`, `src/media/server.test.ts`, `src/memory/batch-gemini.test.ts`); proceeding under explicit reviewer-approved gate waiver for this run
