### PR TITLE
Fix QMD memory status count display

### DIFF
--- a/src/cli/memory-cli.test.ts
+++ b/src/cli/memory-cli.test.ts
@@ -147,6 +147,15 @@ describe("memory cli", () => {
     }
   }
 
+  async function withTempWorkspace(run: (workspaceDir: string) => Promise<void>) {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-cli-workspace-"));
+    try {
+      await run(tmpDir);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  }
+
   async function expectCloseFailureAfterCommand(params: {
     args: string[];
     manager: Record<string, unknown>;
@@ -430,6 +439,38 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
     expect(error).toHaveBeenCalledWith(expect.stringContaining("Memory search failed: boom"));
     expect(process.exitCode).toBe(1);
+  });
+
+  it("prints qmd status counts without impossible scanned denominators", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "root\n", "utf-8");
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        probeVectorAvailability: vi.fn(async () => true),
+        status: () =>
+          makeMemoryStatus({
+            backend: "qmd",
+            provider: "qmd",
+            model: "qmd",
+            requestedProvider: "qmd",
+            workspaceDir,
+            files: 5,
+            chunks: 5,
+            sourceCounts: [{ source: "memory", files: 5, chunks: 5 }],
+          }),
+        close,
+      });
+
+      const log = spyRuntimeLogs();
+      await runMemoryCli(["status"]);
+
+      const output = log.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(output).toContain("Indexed: 5/5 files · 5 chunks");
+      expect(output).toContain("memory · 5/5 files · 5 chunks");
+      expect(close).toHaveBeenCalled();
+    });
   });
 
   it("prints status json output when requested", async () => {

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -332,6 +332,21 @@ async function scanMemorySources(params: {
   return { sources: scans, totalFiles, issues };
 }
 
+function getDisplayedTotalFiles(params: {
+  backend: "builtin" | "qmd";
+  indexedFiles: number;
+  scannedTotalFiles: number | null;
+}): number | null {
+  const { backend, indexedFiles, scannedTotalFiles } = params;
+  if (scannedTotalFiles === null) {
+    return null;
+  }
+  if (backend === "qmd" && indexedFiles > scannedTotalFiles) {
+    return indexedFiles;
+  }
+  return scannedTotalFiles;
+}
+
 export async function runMemoryStatus(opts: MemoryCommandOptions) {
   setVerbose(Boolean(opts.verbose));
   const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory status");
@@ -439,7 +454,11 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
     const { agentId, status, embeddingProbe, indexError, scan } = result;
     const filesIndexed = status.files ?? 0;
     const chunksIndexed = status.chunks ?? 0;
-    const totalFiles = scan?.totalFiles ?? null;
+    const totalFiles = getDisplayedTotalFiles({
+      backend: status.backend,
+      indexedFiles: filesIndexed,
+      scannedTotalFiles: scan?.totalFiles ?? null,
+    });
     const indexedLabel =
       totalFiles === null
         ? `${filesIndexed}/? files · ${chunksIndexed} chunks`
@@ -478,9 +497,13 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
     if (status.sourceCounts?.length) {
       lines.push(label("By source"));
       for (const entry of status.sourceCounts) {
-        const total = scan?.sources?.find(
-          (scanEntry) => scanEntry.source === entry.source,
-        )?.totalFiles;
+        const total = getDisplayedTotalFiles({
+          backend: status.backend,
+          indexedFiles: entry.files,
+          scannedTotalFiles:
+            scan?.sources?.find((scanEntry) => scanEntry.source === entry.source)?.totalFiles ??
+            null,
+        });
         const counts =
           total === null
             ? `${entry.files}/? files · ${entry.chunks} chunks`


### PR DESCRIPTION
## Summary\n- avoid impossible file-count denominators in `openclaw memory status` when QMD indexes more documents than the filesystem scan can see\n- apply the same guard to per-source count rendering\n- add a regression test covering QMD status output\n\n## Testing\n- npx vitest run --config vitest.unit.config.ts src/cli/memory-cli.test.ts\n