### PR TITLE
fix: pass through explicit OpenAI cache retention

### DIFF
--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -22,7 +22,9 @@ const PI_AI_OAUTH_ANTHROPIC_BETAS = [
 ] as const;
 type AnthropicServiceTier = "auto" | "standard_only";
 
-type CacheRetention = "none" | "short" | "long";
+// CacheRetention type and resolveCacheRetention now live in cache-retention.ts;
+// re-export for backward compatibility with existing callers.
+export { type CacheRetention, resolveCacheRetention } from "./cache-retention.js";
 
 function isAnthropic1MModel(modelId: string): boolean {
   const normalized = modelId.trim().toLowerCase();
@@ -192,34 +194,7 @@ function normalizeOpenAiStringModeAnthropicToolChoice(toolChoice: unknown): unkn
   return toolChoice;
 }
 
-export function resolveCacheRetention(
-  extraParams: Record<string, unknown> | undefined,
-  provider: string,
-): CacheRetention | undefined {
-  const isAnthropicDirect = provider === "anthropic";
-  const hasBedrockOverride =
-    extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
-  const isAnthropicBedrock = provider === "amazon-bedrock" && hasBedrockOverride;
-
-  if (!isAnthropicDirect && !isAnthropicBedrock) {
-    return undefined;
-  }
-
-  const newVal = extraParams?.cacheRetention;
-  if (newVal === "none" || newVal === "short" || newVal === "long") {
-    return newVal;
-  }
-
-  const legacy = extraParams?.cacheControlTtl;
-  if (legacy === "5m") {
-    return "short";
-  }
-  if (legacy === "1h") {
-    return "long";
-  }
-
-  return isAnthropicDirect ? "short" : undefined;
-}
+// resolveCacheRetention has moved to ./cache-retention.ts (re-exported above).
 
 export function resolveAnthropicBetas(
   extraParams: Record<string, unknown> | undefined,

--- a/src/agents/pi-embedded-runner/cache-retention.test.ts
+++ b/src/agents/pi-embedded-runner/cache-retention.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { resolveCacheRetention } from "./cache-retention.js";
+
+describe("resolveCacheRetention", () => {
+  // ── Anthropic ──
+
+  describe("anthropic provider", () => {
+    it("defaults to 'short' when no config", () => {
+      expect(resolveCacheRetention(undefined, "anthropic")).toBe("short");
+      expect(resolveCacheRetention({}, "anthropic")).toBe("short");
+    });
+
+    it("honors explicit cacheRetention", () => {
+      expect(resolveCacheRetention({ cacheRetention: "none" }, "anthropic")).toBe("none");
+      expect(resolveCacheRetention({ cacheRetention: "short" }, "anthropic")).toBe("short");
+      expect(resolveCacheRetention({ cacheRetention: "long" }, "anthropic")).toBe("long");
+    });
+
+    it("maps legacy cacheControlTtl '5m' → 'short'", () => {
+      expect(resolveCacheRetention({ cacheControlTtl: "5m" }, "anthropic")).toBe("short");
+    });
+
+    it("maps legacy cacheControlTtl '1h' → 'long'", () => {
+      expect(resolveCacheRetention({ cacheControlTtl: "1h" }, "anthropic")).toBe("long");
+    });
+
+    it("prefers cacheRetention over legacy cacheControlTtl", () => {
+      expect(
+        resolveCacheRetention({ cacheRetention: "long", cacheControlTtl: "5m" }, "anthropic"),
+      ).toBe("long");
+    });
+  });
+
+  // ── Bedrock ──
+
+  describe("amazon-bedrock provider", () => {
+    it("returns undefined when no config (explicit-only)", () => {
+      expect(resolveCacheRetention(undefined, "amazon-bedrock")).toBeUndefined();
+      expect(resolveCacheRetention({}, "amazon-bedrock")).toBeUndefined();
+    });
+
+    it("honors explicit cacheRetention", () => {
+      expect(resolveCacheRetention({ cacheRetention: "short" }, "amazon-bedrock")).toBe("short");
+      expect(resolveCacheRetention({ cacheRetention: "long" }, "amazon-bedrock")).toBe("long");
+      expect(resolveCacheRetention({ cacheRetention: "none" }, "amazon-bedrock")).toBe("none");
+    });
+
+    it("honors legacy cacheControlTtl", () => {
+      expect(resolveCacheRetention({ cacheControlTtl: "5m" }, "amazon-bedrock")).toBe("short");
+      expect(resolveCacheRetention({ cacheControlTtl: "1h" }, "amazon-bedrock")).toBe("long");
+    });
+  });
+
+  // ── OpenAI ──
+
+  describe("openai provider", () => {
+    it("returns undefined when no config (no implicit default)", () => {
+      expect(resolveCacheRetention(undefined, "openai")).toBeUndefined();
+      expect(resolveCacheRetention({}, "openai")).toBeUndefined();
+    });
+
+    it("passes through explicit cacheRetention", () => {
+      expect(resolveCacheRetention({ cacheRetention: "short" }, "openai")).toBe("short");
+      expect(resolveCacheRetention({ cacheRetention: "long" }, "openai")).toBe("long");
+      expect(resolveCacheRetention({ cacheRetention: "none" }, "openai")).toBe("none");
+    });
+
+    it("ignores legacy cacheControlTtl (not an Anthropic-family provider)", () => {
+      expect(resolveCacheRetention({ cacheControlTtl: "5m" }, "openai")).toBeUndefined();
+    });
+  });
+
+  // ── OpenAI Codex ──
+
+  describe("openai-codex provider", () => {
+    it("returns undefined when no config (no implicit default)", () => {
+      expect(resolveCacheRetention(undefined, "openai-codex")).toBeUndefined();
+      expect(resolveCacheRetention({}, "openai-codex")).toBeUndefined();
+    });
+
+    it("passes through explicit cacheRetention", () => {
+      expect(resolveCacheRetention({ cacheRetention: "short" }, "openai-codex")).toBe("short");
+      expect(resolveCacheRetention({ cacheRetention: "long" }, "openai-codex")).toBe("long");
+      expect(resolveCacheRetention({ cacheRetention: "none" }, "openai-codex")).toBe("none");
+    });
+
+    it("ignores legacy cacheControlTtl", () => {
+      expect(resolveCacheRetention({ cacheControlTtl: "1h" }, "openai-codex")).toBeUndefined();
+    });
+  });
+
+  // ── Unsupported providers ──
+
+  describe("unsupported providers", () => {
+    const unsupported = ["google", "openrouter", "ollama", "deepseek", "mistral"];
+
+    for (const provider of unsupported) {
+      it(`returns undefined for '${provider}' even with explicit config`, () => {
+        expect(resolveCacheRetention(undefined, provider)).toBeUndefined();
+        expect(resolveCacheRetention({ cacheRetention: "long" }, provider)).toBeUndefined();
+        expect(resolveCacheRetention({ cacheControlTtl: "5m" }, provider)).toBeUndefined();
+      });
+    }
+  });
+
+  // ── Edge cases ──
+
+  describe("edge cases", () => {
+    it("ignores invalid cacheRetention values", () => {
+      expect(resolveCacheRetention({ cacheRetention: "forever" }, "anthropic")).toBe("short");
+      expect(resolveCacheRetention({ cacheRetention: 42 }, "anthropic")).toBe("short");
+      expect(resolveCacheRetention({ cacheRetention: true }, "openai")).toBeUndefined();
+    });
+
+    it("ignores invalid legacy cacheControlTtl values", () => {
+      expect(resolveCacheRetention({ cacheControlTtl: "10m" }, "anthropic")).toBe("short");
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/cache-retention.ts
+++ b/src/agents/pi-embedded-runner/cache-retention.ts
@@ -1,0 +1,70 @@
+/**
+ * Provider-aware cache retention resolver.
+ *
+ * Moved out of anthropic-stream-wrappers.ts so the logic is not conceptually
+ * trapped in an Anthropic-specific module.  Each provider family declares its
+ * own resolution strategy:
+ *
+ *  - anthropic:      defaults to "short"; explicit config honored
+ *  - amazon-bedrock: explicit-only (Anthropic models on Bedrock)
+ *  - openai / openai-codex: explicit passthrough, no implicit default
+ *  - everything else: undefined (no cache retention)
+ */
+
+export type CacheRetention = "none" | "short" | "long";
+
+function isValidCacheRetention(val: unknown): val is CacheRetention {
+  return val === "none" || val === "short" || val === "long";
+}
+
+function resolveLegacyCacheControlTtl(ttl: unknown): CacheRetention | undefined {
+  if (ttl === "5m") {
+    return "short";
+  }
+  if (ttl === "1h") {
+    return "long";
+  }
+  return undefined;
+}
+
+/** Providers that pass through an explicit cacheRetention without adding a default. */
+const EXPLICIT_PASSTHROUGH_PROVIDERS = new Set(["openai", "openai-codex"]);
+
+export function resolveCacheRetention(
+  extraParams: Record<string, unknown> | undefined,
+  provider: string,
+): CacheRetention | undefined {
+  // ── Explicit value (new key) ──
+  const newVal = extraParams?.cacheRetention;
+  if (isValidCacheRetention(newVal)) {
+    // Anthropic-direct and Bedrock-Anthropic always accept explicit values.
+    // OpenAI/OpenAI-Codex pass through explicit values (no default added).
+    if (
+      provider === "anthropic" ||
+      provider === "amazon-bedrock" ||
+      EXPLICIT_PASSTHROUGH_PROVIDERS.has(provider)
+    ) {
+      return newVal;
+    }
+    // Other providers: ignore cache retention entirely.
+    return undefined;
+  }
+
+  // ── Legacy key (cacheControlTtl) ──
+  const legacy = resolveLegacyCacheControlTtl(extraParams?.cacheControlTtl);
+  if (legacy !== undefined) {
+    if (provider === "anthropic" || provider === "amazon-bedrock") {
+      return legacy;
+    }
+    // Legacy key only meaningful for Anthropic family.
+    return undefined;
+  }
+
+  // ── Implicit defaults ──
+  if (provider === "anthropic") {
+    return "short";
+  }
+
+  // amazon-bedrock, openai, openai-codex, and everything else: no implicit default.
+  return undefined;
+}

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -15,8 +15,8 @@ import {
   isAnthropicBedrockModel,
   resolveAnthropicFastMode,
   resolveAnthropicBetas,
-  resolveCacheRetention,
 } from "./anthropic-stream-wrappers.js";
+import { resolveCacheRetention } from "./cache-retention.js";
 import { log } from "./logger.js";
 import {
   createMoonshotThinkingWrapper,


### PR DESCRIPTION
## Summary

Support explicit `cacheRetention` passthrough for **OpenAI** and **OpenAI-Codex** models.

Today, OpenClaw forwards cache retention for direct Anthropic and Anthropic-on-Bedrock, but drops it for OpenAI providers before the value reaches pi-ai. That prevents pi-ai from applying its existing OpenAI Responses mapping to `prompt_cache_retention: "24h"` when `cacheRetention: "long"` is configured.

This PR fixes that by making cache retention resolution provider-aware rather than Anthropic-only.

## What changed

- extracted cache retention resolution into a new provider-neutral helper:
  - `src/agents/pi-embedded-runner/cache-retention.ts`
- updated `extra-params.ts` to import from the new helper
- kept a re-export from `anthropic-stream-wrappers.ts` for compatibility
- added focused tests for:
  - Anthropic default + explicit behavior
  - legacy `cacheControlTtl` mapping
  - Bedrock explicit-only behavior
  - OpenAI explicit passthrough
  - OpenAI-Codex explicit passthrough
  - unsupported providers remaining unchanged

## Behavior

### Anthropic
- unchanged
- still defaults to `"short"`
- still honors explicit `cacheRetention`
- still supports legacy `cacheControlTtl`

### Amazon Bedrock
- unchanged
- still explicit-only
- no implicit default added

### OpenAI / OpenAI-Codex
- new behavior: explicitly configured `cacheRetention` is now forwarded
- no implicit default added
- API-specific translation remains downstream in pi-ai

### Other providers
- unchanged
- `cacheRetention` remains ignored

## Motivation / credit

Inspired by the debugging and analysis in #27515.

Thanks to @sprfrkr for surfacing the OpenAI passthrough gap and tracing the path down to pi-ai's existing prompt-cache retention support. This PR implements the fix as a broader provider-aware resolver instead of a narrow provider-specific exception.

## Tests

Ran:

- `pnpm vitest run src/agents/pi-embedded-runner/cache-retention.test.ts`
- `pnpm vitest run src/agents/pi-embedded-runner/cache-retention.test.ts src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts`
