### PR TITLE
Docs: fix MDX markers blocking page refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/dashboard: preserve structured gateway shutdown reasons across restart disconnects so config-triggered restarts no longer fall back to `disconnected (1006): no reason`. (#46532) Thanks @vincentkoc.
 - Feishu/topic threads: fetch full thread context, including prior bot replies, when starting a topic-thread session so follow-up turns in Feishu topics keep the right conversation state. Thanks @Coobiw.
 - Browser/profiles: drop the auto-created `chrome-relay` browser profile; users who need the Chrome extension relay must now create their own profile via `openclaw browser create-profile`. (#45777) Thanks @odysseus0.
+- Docs/Mintlify: fix MDX marker syntax on Perplexity, Model Providers, Moonshot, and exec approvals pages so local docs preview no longer breaks rendering or leaves stale pages unpublished. (#46695) Thanks @velvet-shark.
 
 ## 2026.3.13
 

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -193,7 +193,8 @@ Kimi K2 model IDs:
 - `moonshot/kimi-k2-turbo-preview`
 - `moonshot/kimi-k2-thinking`
 - `moonshot/kimi-k2-thinking-turbo`
-  [//]: # (moonshot-kimi-k2-model-refs:end)
+
+[//]: # "moonshot-kimi-k2-model-refs:end"
 
 ```json5
 {

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -186,14 +186,14 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 
 Kimi K2 model IDs:
 
-{/_ moonshot-kimi-k2-model-refs:start _/}
+[//]: # "moonshot-kimi-k2-model-refs:start"
 
 - `moonshot/kimi-k2.5`
 - `moonshot/kimi-k2-0905-preview`
 - `moonshot/kimi-k2-turbo-preview`
 - `moonshot/kimi-k2-thinking`
 - `moonshot/kimi-k2-thinking-turbo`
-  {/_ moonshot-kimi-k2-model-refs:end _/}
+  [//]: # (moonshot-kimi-k2-model-refs:end)
 
 ```json5
 {

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -186,20 +186,14 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 
 Kimi K2 model IDs:
 
-<!-- markdownlint-disable MD037 -->
-
-{/_ moonshot-kimi-k2-model-refs:start _/ && null}
-
-<!-- markdownlint-enable MD037 -->
+{/_ moonshot-kimi-k2-model-refs:start _/}
 
 - `moonshot/kimi-k2.5`
 - `moonshot/kimi-k2-0905-preview`
 - `moonshot/kimi-k2-turbo-preview`
 - `moonshot/kimi-k2-thinking`
 - `moonshot/kimi-k2-thinking-turbo`
-  <!-- markdownlint-disable MD037 -->
-  {/_ moonshot-kimi-k2-model-refs:end _/ && null}
-  <!-- markdownlint-enable MD037 -->
+  {/_ moonshot-kimi-k2-model-refs:end _/}
 
 ```json5
 {

--- a/docs/perplexity.md
+++ b/docs/perplexity.md
@@ -16,7 +16,7 @@ If you use `OPENROUTER_API_KEY`, an `sk-or-...` key in `tools.web.search.perplex
 
 ## Getting a Perplexity API key
 
-1. Create a Perplexity account at <https://www.perplexity.ai/settings/api>
+1. Create a Perplexity account at [perplexity.ai/settings/api](https://www.perplexity.ai/settings/api)
 2. Generate an API key in the dashboard
 3. Store the key in config or set `PERPLEXITY_API_KEY` in the Gateway environment.
 

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -22,7 +22,8 @@ Current Kimi K2 model IDs:
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-  [//]: # (moonshot-kimi-k2-ids:end)
+
+[//]: # "moonshot-kimi-k2-ids:end"
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -15,20 +15,14 @@ Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
 
-<!-- markdownlint-disable MD037 -->
-
-{/_ moonshot-kimi-k2-ids:start _/ && null}
-
-<!-- markdownlint-enable MD037 -->
+{/_ moonshot-kimi-k2-ids:start _/}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-  <!-- markdownlint-disable MD037 -->
-  {/_ moonshot-kimi-k2-ids:end _/ && null}
-  <!-- markdownlint-enable MD037 -->
+  {/_ moonshot-kimi-k2-ids:end _/}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -15,14 +15,14 @@ Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
 
-{/_ moonshot-kimi-k2-ids:start _/}
+[//]: # "moonshot-kimi-k2-ids:start"
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-  {/_ moonshot-kimi-k2-ids:end _/}
+  [//]: # (moonshot-kimi-k2-ids:end)
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -166,7 +166,8 @@ Denied flags by safe-bin profile:
 - `jq`: `--argfile`, `--from-file`, `--library-path`, `--rawfile`, `--slurpfile`, `-L`, `-f`
 - `sort`: `--compress-program`, `--files0-from`, `--output`, `--random-source`, `--temporary-directory`, `-T`, `-o`
 - `wc`: `--files0-from`
-  [//]: # (SAFE_BIN_DENIED_FLAGS:END)
+
+[//]: # "SAFE_BIN_DENIED_FLAGS:END"
 
 Safe bins also force argv tokens to be treated as **literal text** at execution time (no globbing
 and no `$VARS` expansion) for stdin-only segments, so patterns like `*` or `$HOME/...` cannot be

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -160,13 +160,13 @@ Long options are validated fail-closed in safe-bin mode: unknown flags and ambig
 abbreviations are rejected.
 Denied flags by safe-bin profile:
 
-<!-- SAFE_BIN_DENIED_FLAGS:START -->
+{/_ SAFE_BIN_DENIED_FLAGS:START _/}
 
 - `grep`: `--dereference-recursive`, `--directories`, `--exclude-from`, `--file`, `--recursive`, `-R`, `-d`, `-f`, `-r`
 - `jq`: `--argfile`, `--from-file`, `--library-path`, `--rawfile`, `--slurpfile`, `-L`, `-f`
 - `sort`: `--compress-program`, `--files0-from`, `--output`, `--random-source`, `--temporary-directory`, `-T`, `-o`
 - `wc`: `--files0-from`
-<!-- SAFE_BIN_DENIED_FLAGS:END -->
+  {/_ SAFE_BIN_DENIED_FLAGS:END _/}
 
 Safe bins also force argv tokens to be treated as **literal text** at execution time (no globbing
 and no `$VARS` expansion) for stdin-only segments, so patterns like `*` or `$HOME/...` cannot be

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -160,13 +160,13 @@ Long options are validated fail-closed in safe-bin mode: unknown flags and ambig
 abbreviations are rejected.
 Denied flags by safe-bin profile:
 
-{/_ SAFE_BIN_DENIED_FLAGS:START _/}
+[//]: # "SAFE_BIN_DENIED_FLAGS:START"
 
 - `grep`: `--dereference-recursive`, `--directories`, `--exclude-from`, `--file`, `--recursive`, `-R`, `-d`, `-f`, `-r`
 - `jq`: `--argfile`, `--from-file`, `--library-path`, `--rawfile`, `--slurpfile`, `-L`, `-f`
 - `sort`: `--compress-program`, `--files0-from`, `--output`, `--random-source`, `--temporary-directory`, `-T`, `-o`
 - `wc`: `--files0-from`
-  {/_ SAFE_BIN_DENIED_FLAGS:END _/}
+  [//]: # (SAFE_BIN_DENIED_FLAGS:END)
 
 Safe bins also force argv tokens to be treated as **literal text** at execution time (no globbing
 and no `$VARS` expansion) for stdin-only segments, so patterns like `*` or `$HOME/...` cannot be

--- a/scripts/sync-moonshot-docs.ts
+++ b/scripts/sync-moonshot-docs.ts
@@ -51,7 +51,7 @@ function replaceBlockLines(
 }
 
 function renderKimiK2Ids(prefix: string) {
-  return MOONSHOT_KIMI_K2_MODELS.map((model) => `- \`${prefix}${model.id}\``);
+  return [...MOONSHOT_KIMI_K2_MODELS.map((model) => `- \`${prefix}${model.id}\``), ""];
 }
 
 function renderMoonshotAliases() {

--- a/scripts/sync-moonshot-docs.ts
+++ b/scripts/sync-moonshot-docs.ts
@@ -91,7 +91,7 @@ async function syncMoonshotDocs() {
   moonshotText = replaceBlockLines(
     moonshotText,
     '[//]: # "moonshot-kimi-k2-ids:start"',
-    "[//]: # (moonshot-kimi-k2-ids:end)",
+    '[//]: # "moonshot-kimi-k2-ids:end"',
     renderKimiK2Ids(""),
   );
   moonshotText = replaceBlockLines(
@@ -111,7 +111,7 @@ async function syncMoonshotDocs() {
   conceptsText = replaceBlockLines(
     conceptsText,
     '[//]: # "moonshot-kimi-k2-model-refs:start"',
-    "[//]: # (moonshot-kimi-k2-model-refs:end)",
+    '[//]: # "moonshot-kimi-k2-model-refs:end"',
     renderKimiK2Ids("moonshot/"),
   );
 

--- a/scripts/sync-moonshot-docs.ts
+++ b/scripts/sync-moonshot-docs.ts
@@ -90,8 +90,8 @@ async function syncMoonshotDocs() {
   let moonshotText = await readFile(moonshotDoc, "utf8");
   moonshotText = replaceBlockLines(
     moonshotText,
-    "{/* moonshot-kimi-k2-ids:start */}",
-    "{/* moonshot-kimi-k2-ids:end */}",
+    '[//]: # "moonshot-kimi-k2-ids:start"',
+    "[//]: # (moonshot-kimi-k2-ids:end)",
     renderKimiK2Ids(""),
   );
   moonshotText = replaceBlockLines(
@@ -110,8 +110,8 @@ async function syncMoonshotDocs() {
   let conceptsText = await readFile(conceptsDoc, "utf8");
   conceptsText = replaceBlockLines(
     conceptsText,
-    "{/* moonshot-kimi-k2-model-refs:start */}",
-    "{/* moonshot-kimi-k2-model-refs:end */}",
+    '[//]: # "moonshot-kimi-k2-model-refs:start"',
+    "[//]: # (moonshot-kimi-k2-model-refs:end)",
     renderKimiK2Ids("moonshot/"),
   );
 

--- a/scripts/sync-moonshot-docs.ts
+++ b/scripts/sync-moonshot-docs.ts
@@ -90,8 +90,8 @@ async function syncMoonshotDocs() {
   let moonshotText = await readFile(moonshotDoc, "utf8");
   moonshotText = replaceBlockLines(
     moonshotText,
-    "{/_ moonshot-kimi-k2-ids:start _/ && null}",
-    "{/_ moonshot-kimi-k2-ids:end _/ && null}",
+    "{/* moonshot-kimi-k2-ids:start */}",
+    "{/* moonshot-kimi-k2-ids:end */}",
     renderKimiK2Ids(""),
   );
   moonshotText = replaceBlockLines(
@@ -110,8 +110,8 @@ async function syncMoonshotDocs() {
   let conceptsText = await readFile(conceptsDoc, "utf8");
   conceptsText = replaceBlockLines(
     conceptsText,
-    "{/_ moonshot-kimi-k2-model-refs:start _/ && null}",
-    "{/_ moonshot-kimi-k2-model-refs:end _/ && null}",
+    "{/* moonshot-kimi-k2-model-refs:start */}",
+    "{/* moonshot-kimi-k2-model-refs:end */}",
     renderKimiK2Ids("moonshot/"),
   );
 

--- a/src/infra/exec-safe-bin-policy.test.ts
+++ b/src/infra/exec-safe-bin-policy.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./exec-safe-bin-policy.js";
 
 const SAFE_BIN_DOC_DENIED_FLAGS_START = '[//]: # "SAFE_BIN_DENIED_FLAGS:START"';
-const SAFE_BIN_DOC_DENIED_FLAGS_END = "[//]: # (SAFE_BIN_DENIED_FLAGS:END)";
+const SAFE_BIN_DOC_DENIED_FLAGS_END = '[//]: # "SAFE_BIN_DENIED_FLAGS:END"';
 
 function buildDeniedFlagArgvVariants(flag: string): string[][] {
   const value = "blocked";

--- a/src/infra/exec-safe-bin-policy.test.ts
+++ b/src/infra/exec-safe-bin-policy.test.ts
@@ -10,8 +10,8 @@ import {
   validateSafeBinArgv,
 } from "./exec-safe-bin-policy.js";
 
-const SAFE_BIN_DOC_DENIED_FLAGS_START = "{/* SAFE_BIN_DENIED_FLAGS:START */}";
-const SAFE_BIN_DOC_DENIED_FLAGS_END = "{/* SAFE_BIN_DENIED_FLAGS:END */}";
+const SAFE_BIN_DOC_DENIED_FLAGS_START = '[//]: # "SAFE_BIN_DENIED_FLAGS:START"';
+const SAFE_BIN_DOC_DENIED_FLAGS_END = "[//]: # (SAFE_BIN_DENIED_FLAGS:END)";
 
 function buildDeniedFlagArgvVariants(flag: string): string[][] {
   const value = "blocked";

--- a/src/infra/exec-safe-bin-policy.test.ts
+++ b/src/infra/exec-safe-bin-policy.test.ts
@@ -10,8 +10,8 @@ import {
   validateSafeBinArgv,
 } from "./exec-safe-bin-policy.js";
 
-const SAFE_BIN_DOC_DENIED_FLAGS_START = "<!-- SAFE_BIN_DENIED_FLAGS:START -->";
-const SAFE_BIN_DOC_DENIED_FLAGS_END = "<!-- SAFE_BIN_DENIED_FLAGS:END -->";
+const SAFE_BIN_DOC_DENIED_FLAGS_START = "{/* SAFE_BIN_DENIED_FLAGS:START */}";
+const SAFE_BIN_DOC_DENIED_FLAGS_END = "{/* SAFE_BIN_DENIED_FLAGS:END */}";
 
 function buildDeniedFlagArgvVariants(flag: string): string[][] {
   const value = "blocked";


### PR DESCRIPTION
## Summary

- Problem: several docs pages used MDX-invalid comment/marker syntax, so Mintlify failed to parse them during local validation and those routes could remain stale on the live site.
- Why it matters: affected pages such as `perplexity`, `providers/moonshot`, `concepts/model-providers`, and `tools/exec-approvals` were not reliably rebuilding to the latest version, which matched the stale live content we verified.
- What changed: replaced the invalid MDX markers with JSX-style MDX comments, updated the Moonshot sync script and exec-safe-bin doc test to use the new marker format, and fixed the Perplexity docs link syntax.
- What did NOT change (scope boundary): no runtime web-search behavior, provider behavior, or docs navigation structure changed in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Mintlify can parse the affected docs pages again.
- Previously stale docs pages can now rebuild to the latest page content after deploy.
- The Perplexity docs route is no longer blocked by MDX parsing errors.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, Mintlify local preview
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default docs setup

### Steps

1. Run `pnpm docs:dev` or `cd docs && mint validate` on `main` before this fix.
2. Observe MDX parse errors for `concepts/model-providers.md`, `perplexity.md`, `providers/moonshot.md`, and `tools/exec-approvals.md`.
3. Compare live docs routes like `/perplexity` against the current repo content.

### Expected

- Docs pages parse successfully and Mintlify can rebuild the latest page content.

### Actual

- MDX parse errors caused affected pages to fail validation and left live docs content/sidebar labels stale.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `cd docs && mint validate` passes; `pnpm test -- src/infra/exec-safe-bin-policy.test.ts` passes; local Mint preview serves `/perplexity` successfully after the fix.
- Edge cases checked: Moonshot doc sync markers still match `scripts/sync-moonshot-docs.ts`; exec-safe-bin doc markers still match the validation test expectations.
- What you did **not** verify: Mintlify production redeploy behavior after merge.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: restore the affected docs pages, `scripts/sync-moonshot-docs.ts`, and `src/infra/exec-safe-bin-policy.test.ts`.
- Known bad symptoms reviewers should watch for: Mintlify parse failures returning on these routes or the sync/test marker expectations drifting again.

## Risks and Mitigations

- Risk: the new marker format could drift from the sync/test helpers later.
  - Mitigation: this PR updates both the docs sources and the code that reads/replaces those markers.
