### PR TITLE
feat(thinking): enable xhigh/max adaptive effort for Anthropic Opus 4.6

### DIFF
--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeReasoningLevel,
   normalizeThinkLevel,
   resolveThinkingDefaultForModel,
+  supportsXHighThinking,
 } from "./thinking.js";
 
 describe("normalizeThinkLevel", () => {
@@ -40,6 +41,10 @@ describe("normalizeThinkLevel", () => {
     expect(normalizeThinkLevel("auto")).toBe("adaptive");
     expect(normalizeThinkLevel("Adaptive")).toBe("adaptive");
   });
+
+  it('maps "max" to xhigh', () => {
+    expect(normalizeThinkLevel("max")).toBe("xhigh");
+  });
 });
 
 describe("listThinkingLevels", () => {
@@ -62,6 +67,11 @@ describe("listThinkingLevels", () => {
   it("includes xhigh for github-copilot gpt-5.2 refs", () => {
     expect(listThinkingLevels("github-copilot", "gpt-5.2")).toContain("xhigh");
     expect(listThinkingLevels("github-copilot", "gpt-5.2-codex")).toContain("xhigh");
+  });
+
+  it("includes xhigh for anthropic claude-opus-4-6", () => {
+    expect(listThinkingLevels("anthropic", "claude-opus-4-6")).toContain("xhigh");
+    expect(supportsXHighThinking("anthropic", "claude-opus-4-6")).toBe(true);
   });
 
   it("excludes xhigh for non-codex models", () => {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -42,6 +42,8 @@ export const XHIGH_MODEL_REFS = [
   "openai-codex/gpt-5.1-codex",
   "github-copilot/gpt-5.2-codex",
   "github-copilot/gpt-5.2",
+  // Anthropic Opus 4.6: xhigh maps to adaptive thinking with effort "max"
+  "anthropic/claude-opus-4-6",
 ] as const;
 
 const XHIGH_MODEL_SET = new Set(XHIGH_MODEL_REFS.map((entry) => entry.toLowerCase()));
@@ -79,10 +81,11 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
   if (["mid", "med", "medium", "thinkharder", "think-harder", "harder"].includes(key)) {
     return "medium";
   }
-  if (
-    ["high", "ultra", "ultrathink", "think-hard", "thinkhardest", "highest", "max"].includes(key)
-  ) {
+  if (["high", "ultra", "ultrathink", "think-hard", "thinkhardest", "highest"].includes(key)) {
     return "high";
+  }
+  if (key === "max") {
+    return "xhigh";
   }
   if (["think"].includes(key)) {
     return "minimal";


### PR DESCRIPTION
## Summary

- Add `anthropic/claude-opus-4-6` to `XHIGH_MODEL_REFS` so `/think xhigh` unlocks adaptive thinking with `effort: "max"` via the Anthropic Messages API (pi-ai already maps `xhigh` → `max` for Opus 4.6).
- Map the `"max"` keyword to `xhigh` in `normalizeThinkLevel()` so Anthropic-only users can `/think max` to get maximum effort, with graceful downgrade to `high` on models that don't support it.

### Before

- `/think xhigh` on Opus 4.6: blocked by `supportsXHighThinking()` (only OpenAI models allowed), silently downgraded to `high`
- `/think max` on any model: normalized to `high` — no way to reach `effort: "max"` on the Anthropic API

### After

- `/think xhigh` on Opus 4.6: passes gate → pi-ai sends `thinking: {type: "adaptive"}, output_config: {effort: "max"}`
- `/think max` on Opus 4.6: normalized to `xhigh` → same as above
- `/think max` on non-Opus: normalized to `xhigh` → gate downgrades to `high` (config: silent; directive: informative error with model hint)

## Changes

`src/auto-reply/thinking.ts` only:
- `XHIGH_MODEL_REFS`: added `anthropic/claude-opus-4-6`
- `normalizeThinkLevel()`: moved `"max"` from the `→ high` bucket to its own `→ xhigh` mapping

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm check` (format/lint/typecheck) — passes on changed file
- [x] `src/auto-reply/thinking.test.ts` — 21/21 pass
- [x] `src/gateway/sessions-patch.test.ts` — 27/27 pass
- [x] `src/agents/pi-embedded-runner-extraparams.test.ts` + `src/auto-reply/reply/directives.test.ts` — 100/100 pass
- [ ] Verify on live gateway: set `thinkingLevel: "xhigh"` on an Opus 4.6 session, confirm API receives `effort: "max"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)