### PR TITLE
fix(control-ui): add operator.read scope to loopback auto-pairing

### DIFF
--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -143,7 +143,7 @@ describe("GatewayBrowserClient", () => {
       deviceId: "device-1",
       role: "operator",
       token: "stored-device-token",
-      scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
+      scopes: ["operator.read", "operator.admin", "operator.approvals", "operator.pairing"],
     });
   });
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -242,7 +242,7 @@ export class GatewayBrowserClient {
     // Gateways may reject this unless gateway.controlUi.allowInsecureAuth is enabled.
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
 
-    const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+    const scopes = ["operator.read", "operator.admin", "operator.approvals", "operator.pairing"];
     const role = "operator";
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;


### PR DESCRIPTION
Fixes #46689

The Control UI auto-pairs on loopback but was only granted admin/approvals/pairing scopes, causing all read RPCs to fail with `missing scope: operator.read`.

This PR adds the `operator.read` scope to the default scopes requested by the Control UI during connection.

## Changes
- Added `"operator.read"` to the scopes array in `ui/src/ui/gateway.ts`
- Updated the test file to include the new scope