### PR TITLE
fix(gateway): use device identity for loopback probe

### DIFF
--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -4,7 +4,6 @@ import type { SystemPresence } from "../infra/system-presence.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
 import { READ_SCOPE } from "./method-scopes.js";
-import { isLoopbackHost } from "./net.js";
 
 export type GatewayProbeAuth = {
   token?: string;
@@ -41,14 +40,6 @@ export async function probeGateway(opts: {
   let connectError: string | null = null;
   let close: GatewayProbeClose | null = null;
 
-  const disableDeviceIdentity = (() => {
-    try {
-      return isLoopbackHost(new URL(opts.url).hostname);
-    } catch {
-      return false;
-    }
-  })();
-
   return await new Promise<GatewayProbeResult>((resolve) => {
     let settled = false;
     const settle = (result: Omit<GatewayProbeResult, "url">) => {
@@ -70,7 +61,10 @@ export async function probeGateway(opts: {
       clientVersion: "dev",
       mode: GATEWAY_CLIENT_MODES.PROBE,
       instanceId,
-      deviceIdentity: disableDeviceIdentity ? null : undefined,
+      // Keep device identity enabled on loopback so local paired operator tokens
+      // can satisfy operator.read for status/probe instead of falling back to the
+      // shared gateway token path.
+      deviceIdentity: undefined,
       onConnectError: (err) => {
         connectError = formatErrorMessage(err);
       },


### PR DESCRIPTION
## Summary
- keep device identity enabled for loopback gateway probes
- allow local paired operator tokens to satisfy `operator.read` for `openclaw gateway probe` and `openclaw status`
- stop local status/probe from falling back to the degraded shared-token path on localhost

## Problem
Local loopback probe/status was reporting degraded reachability with:
- `missing scope: operator.read`

Even when the local paired device token had the correct operator scopes, loopback probes explicitly disabled device identity in `src/gateway/probe.ts`. That prevented the CLI from using the paired local device token on `ws://127.0.0.1:<port>`.

## Fix
- remove the loopback-specific device-identity disable in `src/gateway/probe.ts`
- let the normal gateway client auth selection use stored device auth on trusted local loopback targets

## Validation
- `pnpm build`
- `openclaw gateway probe` → `RPC: ok`
- `openclaw status` → gateway reachable without the false `missing scope: operator.read` warning
