### PR TITLE
docs(feishu): update permissions docs from official Lark guidance

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -96,35 +96,44 @@ From **Credentials & Basic Info**, copy:
 
 ### 4. Configure permissions
 
-On **Permissions**, click **Batch import** and paste:
+Lark's permissions UI has changed over time, and some official examples now show a much larger
+`user` scope list. OpenClaw's Feishu/Lark channel uses a self-built app with `App ID` +
+`App Secret` and `tenant_access_token`, so you do **not** need `offline_access` or the generic
+user-OAuth scope bundle for normal bot messaging.
+
+On **Permissions**, click **Batch import** and start with this tenant-scope set:
 
 ```json
 {
   "scopes": {
     "tenant": [
-      "aily:file:read",
-      "aily:file:write",
-      "application:application.app_message_stats.overview:readonly",
       "application:application:self_manage",
-      "application:bot.menu:write",
       "cardkit:card:read",
       "cardkit:card:write",
-      "contact:user.employee_id:readonly",
-      "corehr:file:download",
-      "event:ip_list",
-      "im:chat.access_event.bot_p2p_chat:read",
-      "im:chat.members:bot_access",
-      "im:message",
+      "contact:user.base:readonly",
+      "im:chat.members:read",
+      "im:chat:read",
       "im:message.group_at_msg:readonly",
       "im:message.p2p_msg:readonly",
       "im:message:readonly",
       "im:message:send_as_bot",
+      "im:message:update",
       "im:resource"
-    ],
-    "user": ["aily:file:read", "aily:file:write", "im:chat.access_event.bot_p2p_chat:read"]
+    ]
   }
 }
 ```
+
+Notes:
+
+- Some Lark pages still use older or inconsistent names such as `im:chat` or
+  `im:message.group_msg`. Use the current scope name that your Lark console accepts.
+- Use `contact:user.base:readonly` as the canonical contact scope in app configuration. You may
+  still see the stale alias `contact:contact.base:readonly` in older docs or error text; OpenClaw
+  rewrites that alias internally when building permission-help links.
+- If you enable OpenClaw's optional Feishu tools, add the matching Lark scopes for the APIs you
+  plan to use. Common examples are document (`docx:*`), drive/file (`drive:*`), wiki (`wiki:*`),
+  and bitable/base (`base:*`) permissions.
 
 ![Configure permissions](../images/feishu-step4-permissions.png)
 

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -94,39 +94,36 @@ Lark（国际版）请使用 https://open.larksuite.com/app，并在配置中设
 
 ### 4. 配置应用权限
 
-在 **权限管理** 页面，点击 **批量导入** 按钮，粘贴以下 JSON 配置一键导入所需权限：
+Lark 的权限界面这些年有过调整，官方示例里现在也经常会出现一大串 `user` scopes。OpenClaw 的 Feishu/Lark 渠道使用的是自建应用 + `App ID` + `App Secret` + `tenant_access_token`，因此正常的机器人收发消息**不需要** `offline_access`，也不需要那套通用的 user OAuth 权限。
+
+在 **权限管理** 页面，点击 **批量导入** 按钮，先导入下面这组 tenant scopes：
 
 ```json
 {
   "scopes": {
     "tenant": [
-      "aily:file:read",
-      "aily:file:write",
-      "application:application.app_message_stats.overview:readonly",
       "application:application:self_manage",
-      "application:bot.menu:write",
+      "cardkit:card:read",
       "cardkit:card:write",
-      "contact:user.employee_id:readonly",
-      "corehr:file:download",
-      "docs:document.content:read",
-      "event:ip_list",
-      "im:chat",
-      "im:chat.access_event.bot_p2p_chat:read",
-      "im:chat.members:bot_access",
-      "im:message",
+      "contact:user.base:readonly",
+      "im:chat.members:read",
+      "im:chat:read",
       "im:message.group_at_msg:readonly",
-      "im:message.group_msg",
       "im:message.p2p_msg:readonly",
       "im:message:readonly",
       "im:message:send_as_bot",
-      "im:resource",
-      "sheets:spreadsheet",
-      "wiki:wiki:readonly"
-    ],
-    "user": ["aily:file:read", "aily:file:write", "im:chat.access_event.bot_p2p_chat:read"]
+      "im:message:update",
+      "im:resource"
+    ]
   }
 }
 ```
+
+说明：
+
+- 一些 Lark 页面仍会出现较旧或不一致的权限名，例如 `im:chat` 或 `im:message.group_msg`。请以你的 Lark 控制台当前实际接受的权限名为准。
+- 在应用配置里，联系人权限请以 `contact:user.base:readonly` 作为标准写法。你仍然可能在旧文档或错误信息里看到过时别名 `contact:contact.base:readonly`；OpenClaw 在构造权限修复链接时会把它重写成正确名称。
+- 如果你启用了 OpenClaw 的可选 Feishu 工具，还需要额外补上对应 API 所需的 Lark 权限。常见的有文档（`docx:*`）、云盘文件（`drive:*`）、知识库（`wiki:*`）以及多维表格/应用（`base:*`）。
 
 ![配置应用权限](/images/feishu-step4-permissions.png)
 

--- a/extensions/feishu/src/onboarding.ts
+++ b/extensions/feishu/src/onboarding.ts
@@ -88,7 +88,7 @@ async function noteFeishuCredentialHelp(prompter: WizardPrompter): Promise<void>
       "1) Go to Feishu Open Platform (open.feishu.cn)",
       "2) Create a self-built app",
       "3) Get App ID and App Secret from Credentials page",
-      "4) Enable required permissions: im:message, im:chat, contact:user.base:readonly",
+      "4) Enable the required tenant permissions from the channel docs",
       "5) Publish the app or add it to a test group",
       "Tip: you can also set FEISHU_APP_ID / FEISHU_APP_SECRET env vars.",
       `Docs: ${formatDocsLink("/channels/feishu", "feishu")}`,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:  The Lark permission configuration JSON in the document is out of date.
<img width="1584" height="1318" alt="image" src="https://github.com/user-attachments/assets/2a850f35-076a-460d-a4a3-028ae164eefa" />

- Why it matters: Users cannot copy and paste to use directly

- What changed: Doc files

- What did NOT change (scope boundary):   Only update the document forthe  Feishu channel, but not the code for the Feishu channel.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [✔ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

None

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

<img width="1136" height="1100" alt="image" src="https://github.com/user-attachments/assets/744ae335-0209-4c69-96f6-01a3e0fda756" />
<img width="1705" height="1277" alt="image" src="https://github.com/user-attachments/assets/9ef87234-db50-42ee-86da-fc3fd6e6cbf8" />
Permissions in the document can now be directly copied and pasted for use, there will be no deprecated permissions.

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ✔] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Openclaw operates normally by setting this permission JSON file for Lark.
- Edge cases checked: The documentation hasn't been updated in a long time, and the Lark API has changed.
- What you did **not** verify: Feishu (not Lark the intertuibak version). But it should use the same API with the same permission settings.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No 
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: None
