### PR TITLE
feat(cron): add `exec` payload kind for LLM-free script execution

### DIFF
--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -238,33 +238,34 @@ function isSameDeliveryTarget(
 const FAILURE_NOTIFICATION_TIMEOUT_MS = 30_000;
 const cronDeliveryLogger = getChildLogger({ subsystem: "cron-delivery" });
 
-export async function sendFailureNotificationAnnounce(
-  deps: CliDeps,
-  cfg: OpenClawConfig,
-  agentId: string,
-  jobId: string,
-  target: { channel?: string; to?: string; accountId?: string },
-  message: string,
-): Promise<void> {
-  const resolvedTarget = await resolveDeliveryTarget(cfg, agentId, {
-    channel: target.channel as CronMessageChannel | undefined,
-    to: target.to,
-    accountId: target.accountId,
+async function sendCronAnnounceMessage(params: {
+  deps: CliDeps;
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+  target: { channel?: string; to?: string; accountId?: string };
+  message: string;
+  errorLog: string;
+}) {
+  const resolvedTarget = await resolveDeliveryTarget(params.cfg, params.agentId, {
+    channel: params.target.channel as CronMessageChannel | undefined,
+    to: params.target.to,
+    accountId: params.target.accountId,
   });
 
   if (!resolvedTarget.ok) {
     cronDeliveryLogger.warn(
       { error: resolvedTarget.error.message },
-      "cron: failed to resolve failure destination target",
+      "cron: failed to resolve announce delivery target",
     );
     return;
   }
 
-  const identity = resolveAgentOutboundIdentity(cfg, agentId);
+  const identity = resolveAgentOutboundIdentity(params.cfg, params.agentId);
   const session = buildOutboundSessionContext({
-    cfg,
-    agentId,
-    sessionKey: `cron:${jobId}:failure`,
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
   });
 
   const abortController = new AbortController();
@@ -274,16 +275,16 @@ export async function sendFailureNotificationAnnounce(
 
   try {
     await deliverOutboundPayloads({
-      cfg,
+      cfg: params.cfg,
       channel: resolvedTarget.channel,
       to: resolvedTarget.to,
       accountId: resolvedTarget.accountId,
       threadId: resolvedTarget.threadId,
-      payloads: [{ text: message }],
+      payloads: [{ text: params.message }],
       session,
       identity,
       bestEffort: false,
-      deps: createOutboundSendDeps(deps),
+      deps: createOutboundSendDeps(params.deps),
       abortSignal: abortController.signal,
     });
   } catch (err) {
@@ -293,9 +294,47 @@ export async function sendFailureNotificationAnnounce(
         channel: resolvedTarget.channel,
         to: resolvedTarget.to,
       },
-      "cron: failure destination announce failed",
+      params.errorLog,
     );
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export async function sendCronResultAnnounce(
+  deps: CliDeps,
+  cfg: OpenClawConfig,
+  agentId: string,
+  jobId: string,
+  target: { channel?: string; to?: string; accountId?: string },
+  message: string,
+): Promise<void> {
+  await sendCronAnnounceMessage({
+    deps,
+    cfg,
+    agentId,
+    sessionKey: `cron:${jobId}`,
+    target,
+    message,
+    errorLog: "cron: announce delivery failed",
+  });
+}
+
+export async function sendFailureNotificationAnnounce(
+  deps: CliDeps,
+  cfg: OpenClawConfig,
+  agentId: string,
+  jobId: string,
+  target: { channel?: string; to?: string; accountId?: string },
+  message: string,
+): Promise<void> {
+  await sendCronAnnounceMessage({
+    deps,
+    cfg,
+    agentId,
+    sessionKey: `cron:${jobId}:failure`,
+    target,
+    message,
+    errorLog: "cron: failure destination announce failed",
+  });
 }

--- a/src/cron/exec-runner.test.ts
+++ b/src/cron/exec-runner.test.ts
@@ -1,0 +1,74 @@
+import process from "node:process";
+import { describe, expect, it } from "vitest";
+import { runCronExec } from "./exec-runner.js";
+
+function quoteArg(value: string) {
+  return JSON.stringify(value);
+}
+
+function buildNodeCommand(source: string) {
+  return `${quoteArg(process.execPath)} -e ${quoteArg(source)}`;
+}
+
+describe("runCronExec", () => {
+  it("captures stdout and stderr for successful commands", async () => {
+    const result = await runCronExec({
+      payload: {
+        kind: "exec",
+        command: buildNodeCommand(
+          "process.stdout.write('hello\\n'); process.stderr.write('warn\\n');",
+        ),
+      },
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.error).toBeUndefined();
+    expect(result.summary).toContain("Command exited with code 0.");
+    expect(result.summary).toContain("stdout:\nhello");
+    expect(result.summary).toContain("stderr:\nwarn");
+  });
+
+  it("reports non-zero exits as errors", async () => {
+    const result = await runCronExec({
+      payload: {
+        kind: "exec",
+        command: buildNodeCommand(
+          "process.stdout.write('before-fail\\n'); process.stderr.write('boom\\n'); process.exit(7);",
+        ),
+      },
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("cron exec command exited with code 7");
+    expect(result.summary).toContain("Command exited with code 7.");
+    expect(result.summary).toContain("stdout:\nbefore-fail");
+    expect(result.summary).toContain("stderr:\nboom");
+  });
+
+  it("kills commands that exceed the payload timeout", async () => {
+    const result = await runCronExec({
+      payload: {
+        kind: "exec",
+        command: buildNodeCommand("setTimeout(() => process.stdout.write('late'), 10_000);"),
+        timeout: 50,
+      },
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("cron exec command timed out after 50ms");
+    expect(result.summary).toContain("Command timed out after 50ms.");
+  });
+
+  it("supports shell execution when requested", async () => {
+    const result = await runCronExec({
+      payload: {
+        kind: "exec",
+        shell: true,
+        command: `${quoteArg(process.execPath)} -e ${quoteArg("process.stdout.write('shell-ok')")}`,
+      },
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("stdout:\nshell-ok");
+  });
+});

--- a/src/cron/exec-runner.ts
+++ b/src/cron/exec-runner.ts
@@ -1,0 +1,282 @@
+import { spawn } from "node:child_process";
+import type { CronExecPayload, CronRunOutcome } from "./types.js";
+
+const DEFAULT_ABORT_ERROR = "cron: job execution timed out";
+const MAX_CAPTURE_BYTES = 128 * 1024;
+
+type ParsedCommand = {
+  command: string;
+  args: string[];
+};
+
+function trimCapturedOutput(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function appendChunk(state: { text: string; truncated: boolean }, chunk: string) {
+  if (!chunk || state.truncated) {
+    return;
+  }
+  const remaining = MAX_CAPTURE_BYTES - state.text.length;
+  if (remaining <= 0) {
+    state.truncated = true;
+    return;
+  }
+  if (chunk.length <= remaining) {
+    state.text += chunk;
+    return;
+  }
+  state.text += chunk.slice(0, remaining);
+  state.truncated = true;
+}
+
+function formatCapturedOutput(label: "stdout" | "stderr", value: string, truncated: boolean) {
+  const trimmed = trimCapturedOutput(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  const suffix = truncated ? "\n[truncated]" : "";
+  return `${label}:\n${trimmed}${suffix}`;
+}
+
+function formatCommandSummary(params: {
+  exitCode?: number;
+  signal?: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
+  timedOut?: boolean;
+  timeoutMs?: number;
+  spawnError?: string;
+}) {
+  const header = params.spawnError
+    ? `Command failed to start: ${params.spawnError}`
+    : params.timedOut
+      ? `Command timed out after ${params.timeoutMs ?? 0}ms.`
+      : typeof params.exitCode === "number"
+        ? `Command exited with code ${params.exitCode}.`
+        : params.signal
+          ? `Command terminated by signal ${params.signal}.`
+          : "Command finished.";
+
+  const sections = [
+    header,
+    formatCapturedOutput("stdout", params.stdout, params.stdoutTruncated),
+    formatCapturedOutput("stderr", params.stderr, params.stderrTruncated),
+  ].filter((value): value is string => typeof value === "string" && value.length > 0);
+
+  return sections.join("\n\n");
+}
+
+function parseExecCommand(command: string): ParsedCommand {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    throw new Error('cron exec payload requires a non-empty "command"');
+  }
+
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+
+  for (const char of trimmed) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+    if (char === "\\") {
+      if (quote === "'") {
+        current += char;
+      } else {
+        escaping = true;
+      }
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+  if (quote) {
+    throw new Error(`cron exec command has an unterminated ${quote} quote`);
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  const [resolvedCommand, ...args] = tokens;
+  if (!resolvedCommand) {
+    throw new Error('cron exec payload requires a non-empty "command"');
+  }
+  return { command: resolvedCommand, args };
+}
+
+export async function runCronExec(params: {
+  payload: CronExecPayload;
+  abortSignal?: AbortSignal;
+}): Promise<CronRunOutcome> {
+  const timeoutMs =
+    typeof params.payload.timeout === "number" && Number.isFinite(params.payload.timeout)
+      ? Math.max(0, Math.floor(params.payload.timeout))
+      : 0;
+
+  let parsed: ParsedCommand;
+  try {
+    parsed = parseExecCommand(params.payload.command);
+  } catch (err) {
+    return { status: "error", error: err instanceof Error ? err.message : String(err) };
+  }
+
+  const stdoutState = { text: "", truncated: false };
+  const stderrState = { text: "", truncated: false };
+
+  return await new Promise<CronRunOutcome>((resolve) => {
+    let settled = false;
+    let timedOut = false;
+
+    const child = spawn(
+      params.payload.shell ? params.payload.command : parsed.command,
+      params.payload.shell ? [] : parsed.args,
+      {
+        shell: params.payload.shell === true,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    const settle = (result: CronRunOutcome) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const killChild = () => {
+      if (child.killed) {
+        return;
+      }
+      child.kill("SIGKILL");
+    };
+
+    const onAbort = () => {
+      killChild();
+    };
+
+    const timeoutId =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            timedOut = true;
+            killChild();
+          }, timeoutMs)
+        : undefined;
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      params.abortSignal?.removeEventListener("abort", onAbort);
+    };
+
+    params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+
+    child.stdout?.on("data", (chunk: string | Buffer) => {
+      appendChunk(stdoutState, chunk.toString());
+    });
+    child.stderr?.on("data", (chunk: string | Buffer) => {
+      appendChunk(stderrState, chunk.toString());
+    });
+
+    child.on("error", (err) => {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      settle({
+        status: "error",
+        error: errorMessage,
+        summary: formatCommandSummary({
+          spawnError: errorMessage,
+          stdout: stdoutState.text,
+          stderr: stderrState.text,
+          stdoutTruncated: stdoutState.truncated,
+          stderrTruncated: stderrState.truncated,
+        }),
+      });
+    });
+
+    child.on("close", (code, signal) => {
+      const summary = formatCommandSummary({
+        exitCode: code ?? undefined,
+        signal,
+        stdout: stdoutState.text,
+        stderr: stderrState.text,
+        stdoutTruncated: stdoutState.truncated,
+        stderrTruncated: stderrState.truncated,
+        timedOut,
+        timeoutMs: timeoutId ? timeoutMs : undefined,
+      });
+
+      if (timedOut) {
+        settle({
+          status: "error",
+          error: `cron exec command timed out after ${timeoutMs}ms`,
+          summary,
+        });
+        return;
+      }
+
+      if (params.abortSignal?.aborted) {
+        const reason = params.abortSignal.reason;
+        settle({
+          status: "error",
+          error:
+            typeof reason === "string" && reason.trim().length > 0
+              ? reason.trim()
+              : DEFAULT_ABORT_ERROR,
+          summary,
+        });
+        return;
+      }
+
+      if (typeof code === "number" && code !== 0) {
+        settle({
+          status: "error",
+          error: `cron exec command exited with code ${code}`,
+          summary,
+        });
+        return;
+      }
+
+      if (signal) {
+        settle({
+          status: "error",
+          error: `cron exec command terminated by signal ${signal}`,
+          summary,
+        });
+        return;
+      }
+
+      settle({ status: "ok", summary });
+    });
+  });
+}

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -219,6 +219,27 @@ describe("normalizeCronJobCreate", () => {
     expect(normalized.deleteAfterRun).toBe(true);
   });
 
+  it('defaults exec payloads to sessionTarget="isolated"', () => {
+    const normalized = normalizeCronJobCreate({
+      name: "exec default",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      wakeMode: "now",
+      payload: {
+        kind: "exec",
+        command: "  echo hi  ",
+        timeout: 42.9,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("isolated");
+    expect(normalized.payload).toEqual({
+      kind: "exec",
+      command: "echo hi",
+      timeout: 42,
+    });
+  });
+
   it("normalizes delivery mode and channel", () => {
     const normalized = normalizeIsolatedAgentTurnCreateJob({
       name: "delivery",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -89,6 +89,8 @@ function coercePayload(payload: UnknownRecord) {
   const kindRaw = typeof next.kind === "string" ? next.kind.trim().toLowerCase() : "";
   if (kindRaw === "agentturn") {
     next.kind = "agentTurn";
+  } else if (kindRaw === "exec") {
+    next.kind = "exec";
   } else if (kindRaw === "systemevent") {
     next.kind = "systemEvent";
   } else if (kindRaw) {
@@ -97,6 +99,7 @@ function coercePayload(payload: UnknownRecord) {
   if (!next.kind) {
     const hasMessage = typeof next.message === "string" && next.message.trim().length > 0;
     const hasText = typeof next.text === "string" && next.text.trim().length > 0;
+    const hasCommand = typeof next.command === "string" && next.command.trim().length > 0;
     const hasAgentTurnHint =
       typeof next.model === "string" ||
       typeof next.thinking === "string" ||
@@ -104,6 +107,8 @@ function coercePayload(payload: UnknownRecord) {
       typeof next.allowUnsafeExternalContent === "boolean";
     if (hasMessage) {
       next.kind = "agentTurn";
+    } else if (hasCommand) {
+      next.kind = "exec";
     } else if (hasText) {
       next.kind = "systemEvent";
     } else if (hasAgentTurnHint) {
@@ -121,6 +126,12 @@ function coercePayload(payload: UnknownRecord) {
     const trimmed = next.text.trim();
     if (trimmed) {
       next.text = trimmed;
+    }
+  }
+  if (typeof next.command === "string") {
+    const trimmed = next.command.trim();
+    if (trimmed) {
+      next.command = trimmed;
     }
   }
   if ("model" in next) {
@@ -159,6 +170,16 @@ function coercePayload(payload: UnknownRecord) {
     typeof next.allowUnsafeExternalContent !== "boolean"
   ) {
     delete next.allowUnsafeExternalContent;
+  }
+  if ("shell" in next && typeof next.shell !== "boolean") {
+    delete next.shell;
+  }
+  if ("timeout" in next) {
+    if (typeof next.timeout === "number" && Number.isFinite(next.timeout)) {
+      next.timeout = Math.max(0, Math.floor(next.timeout));
+    } else {
+      delete next.timeout;
+    }
   }
   return next;
 }
@@ -299,6 +320,22 @@ function copyTopLevelLegacyDeliveryFields(next: UnknownRecord, payload: UnknownR
   }
 }
 
+function copyTopLevelExecFields(next: UnknownRecord, payload: UnknownRecord) {
+  if (
+    typeof payload.command !== "string" &&
+    typeof next.command === "string" &&
+    next.command.trim()
+  ) {
+    payload.command = next.command.trim();
+  }
+  if (typeof payload.shell !== "boolean" && typeof next.shell === "boolean") {
+    payload.shell = next.shell;
+  }
+  if (typeof payload.timeout !== "number" && typeof next.timeout === "number") {
+    payload.timeout = Math.max(0, Math.floor(next.timeout));
+  }
+}
+
 function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.model;
   delete next.thinking;
@@ -311,6 +348,9 @@ function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.to;
   delete next.bestEffortDeliver;
   delete next.provider;
+  delete next.command;
+  delete next.timeout;
+  delete next.shell;
 }
 
 export function normalizeCronJobInput(
@@ -391,8 +431,11 @@ export function normalizeCronJobInput(
   if (!("payload" in next) || !isRecord(next.payload)) {
     const message = typeof next.message === "string" ? next.message.trim() : "";
     const text = typeof next.text === "string" ? next.text.trim() : "";
+    const command = typeof next.command === "string" ? next.command.trim() : "";
     if (message) {
       next.payload = { kind: "agentTurn", message };
+    } else if (command) {
+      next.payload = { kind: "exec", command };
     } else if (text) {
       next.payload = { kind: "systemEvent", text };
     }
@@ -414,6 +457,8 @@ export function normalizeCronJobInput(
   if (payload && payload.kind === "agentTurn") {
     copyTopLevelAgentTurnFields(next, payload);
     copyTopLevelLegacyDeliveryFields(next, payload);
+  } else if (payload && payload.kind === "exec") {
+    copyTopLevelExecFields(next, payload);
   }
   stripLegacyTopLevelFields(next);
 
@@ -443,11 +488,12 @@ export function normalizeCronJobInput(
       const kind = typeof next.payload.kind === "string" ? next.payload.kind : "";
       // Keep default behavior unchanged for backward compatibility:
       // - systemEvent defaults to "main"
+      // - exec defaults to "isolated"
       // - agentTurn defaults to "isolated" (NOT "current", to avoid token accumulation)
       // Users must explicitly specify "current" or "session:xxx" for custom session binding
       if (kind === "systemEvent") {
         next.sessionTarget = "main";
-      } else if (kind === "agentTurn") {
+      } else if (kind === "exec" || kind === "agentTurn") {
         next.sessionTarget = "isolated";
       }
     }

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -70,6 +70,24 @@ describe("applyJobPatch", () => {
     expect(job.delivery).toEqual({ mode: "webhook", to: "https://example.invalid/cron" });
   });
 
+  it('rejects exec payloads outside sessionTarget="isolated"', () => {
+    const job = createIsolatedAgentTurnJob("job-exec-invalid", { mode: "none" });
+
+    expect(() =>
+      applyJobPatch(job, {
+        sessionTarget: "main",
+        payload: { kind: "exec", command: "echo bad" },
+      }),
+    ).toThrow('exec cron jobs require sessionTarget="isolated"');
+
+    expect(() =>
+      applyJobPatch(job, {
+        sessionTarget: "session:ops",
+        payload: { kind: "exec", command: "echo bad" },
+      }),
+    ).toThrow('exec cron jobs require sessionTarget="isolated"');
+  });
+
   it("maps legacy payload delivery updates onto delivery", () => {
     const job = createIsolatedAgentTurnJob("job-2", {
       mode: "announce",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -136,6 +136,12 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
     job.sessionTarget === "isolated" ||
     job.sessionTarget === "current" ||
     job.sessionTarget.startsWith("session:");
+  if (job.payload.kind === "exec") {
+    if (job.sessionTarget !== "isolated") {
+      throw new Error('exec cron jobs require sessionTarget="isolated"');
+    }
+    return;
+  }
   if (job.sessionTarget === "main" && job.payload.kind !== "systemEvent") {
     throw new Error('main cron jobs require payload.kind="systemEvent"');
   }
@@ -669,6 +675,18 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
     return { kind: "systemEvent", text };
   }
 
+  if (patch.kind === "exec") {
+    if (existing.kind !== "exec") {
+      return buildPayloadFromPatch(patch);
+    }
+    return {
+      kind: "exec",
+      command: typeof patch.command === "string" ? patch.command : existing.command,
+      shell: typeof patch.shell === "boolean" ? patch.shell : existing.shell,
+      timeout: typeof patch.timeout === "number" ? patch.timeout : existing.timeout,
+    };
+  }
+
   if (existing.kind !== "agentTurn") {
     return buildPayloadFromPatch(patch);
   }
@@ -754,6 +772,18 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
       throw new Error('cron.update payload.kind="systemEvent" requires text');
     }
     return { kind: "systemEvent", text: patch.text };
+  }
+
+  if (patch.kind === "exec") {
+    if (typeof patch.command !== "string" || patch.command.length === 0) {
+      throw new Error('cron.update payload.kind="exec" requires command');
+    }
+    return {
+      kind: "exec",
+      command: patch.command,
+      shell: patch.shell,
+      timeout: patch.timeout,
+    };
   }
 
   if (typeof patch.message !== "string" || patch.message.length === 0) {

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -49,14 +49,16 @@ export function normalizeOptionalSessionKey(raw: unknown) {
 
 export function inferLegacyName(job: {
   schedule?: { kind?: unknown; everyMs?: unknown; expr?: unknown };
-  payload?: { kind?: unknown; text?: unknown; message?: unknown };
+  payload?: { kind?: unknown; text?: unknown; message?: unknown; command?: unknown };
 }) {
   const text =
     job?.payload?.kind === "systemEvent" && typeof job.payload.text === "string"
       ? job.payload.text
-      : job?.payload?.kind === "agentTurn" && typeof job.payload.message === "string"
-        ? job.payload.message
-        : "";
+      : job?.payload?.kind === "exec" && typeof job.payload.command === "string"
+        ? job.payload.command
+        : job?.payload?.kind === "agentTurn" && typeof job.payload.message === "string"
+          ? job.payload.message
+          : "";
   const firstLine =
     text
       .split("\n")
@@ -82,6 +84,9 @@ export function inferLegacyName(job: {
 export function normalizePayloadToSystemText(payload: CronPayload) {
   if (payload.kind === "systemEvent") {
     return payload.text.trim();
+  }
+  if (payload.kind === "exec") {
+    return payload.command.trim();
   }
   return payload.message.trim();
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -3,6 +3,7 @@ import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
+import { runCronExec } from "../exec-runner.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
 import type {
   CronDeliveryStatus,
@@ -1121,6 +1122,13 @@ export async function executeJobCore(
       });
       return { status: "ok", summary: text };
     }
+  }
+
+  if (job.payload.kind === "exec") {
+    return await runCronExec({
+      payload: job.payload,
+      abortSignal,
+    });
   }
 
   if (job.payload.kind !== "agentTurn") {

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -130,4 +130,40 @@ describe("normalizeStoredCronJobs", () => {
     expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn", message: "ping" });
     expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent", text: "pong" });
   });
+
+  it("preserves exec payload kinds and migrates legacy top-level command fields", () => {
+    const jobs = [
+      {
+        id: "normalized-exec",
+        name: "exec",
+        enabled: true,
+        wakeMode: "now",
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
+        payload: { kind: " exec ", command: "echo ok", timeout: 15 },
+        sessionTarget: "isolated",
+        state: {},
+      },
+      {
+        id: "legacy-exec",
+        enabled: true,
+        wakeMode: "now",
+        schedule: { kind: "every", everyMs: 60_000 },
+        command: "echo legacy",
+        timeout: 25,
+        shell: true,
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.legacyPayloadKind).toBe(1);
+    expect(jobs[0]?.payload).toMatchObject({ kind: "exec", command: "echo ok", timeout: 15 });
+    expect(jobs[1]?.payload).toMatchObject({
+      kind: "exec",
+      command: "echo legacy",
+      timeout: 25,
+      shell: true,
+    });
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -43,6 +43,13 @@ function normalizePayloadKind(payload: Record<string, unknown>) {
     }
     return false;
   }
+  if (raw === "exec") {
+    if (payload.kind !== "exec") {
+      payload.kind = "exec";
+      return true;
+    }
+    return false;
+  }
   return false;
 }
 
@@ -59,7 +66,7 @@ function inferPayloadIfMissing(raw: Record<string, unknown>) {
     return true;
   }
   if (command) {
-    raw.payload = { kind: "systemEvent", text: command };
+    raw.payload = { kind: "exec", command };
     return true;
   }
   return false;
@@ -137,6 +144,35 @@ function copyTopLevelAgentTurnFields(
   return mutated;
 }
 
+function copyTopLevelExecFields(raw: Record<string, unknown>, payload: Record<string, unknown>) {
+  let mutated = false;
+
+  if (
+    typeof payload.command !== "string" &&
+    typeof raw.command === "string" &&
+    raw.command.trim()
+  ) {
+    payload.command = raw.command.trim();
+    mutated = true;
+  }
+
+  if (typeof payload.shell !== "boolean" && typeof raw.shell === "boolean") {
+    payload.shell = raw.shell;
+    mutated = true;
+  }
+
+  if (
+    typeof payload.timeout !== "number" &&
+    typeof raw.timeout === "number" &&
+    Number.isFinite(raw.timeout)
+  ) {
+    payload.timeout = Math.max(0, Math.floor(raw.timeout));
+    mutated = true;
+  }
+
+  return mutated;
+}
+
 function stripLegacyTopLevelFields(raw: Record<string, unknown>) {
   if ("model" in raw) {
     delete raw.model;
@@ -176,6 +212,9 @@ function stripLegacyTopLevelFields(raw: Record<string, unknown>) {
   }
   if ("timeout" in raw) {
     delete raw.timeout;
+  }
+  if ("shell" in raw) {
+    delete raw.shell;
   }
 }
 
@@ -295,6 +334,10 @@ export function normalizeStoredCronJobs(
           payloadRecord.kind = "agentTurn";
           mutated = true;
           trackIssue("legacyPayloadKind");
+        } else if (typeof payloadRecord.command === "string" && payloadRecord.command.trim()) {
+          payloadRecord.kind = "exec";
+          mutated = true;
+          trackIssue("legacyPayloadKind");
         } else if (typeof payloadRecord.text === "string" && payloadRecord.text.trim()) {
           payloadRecord.kind = "systemEvent";
           mutated = true;
@@ -302,6 +345,9 @@ export function normalizeStoredCronJobs(
         }
       }
       if (payloadRecord.kind === "agentTurn" && copyTopLevelAgentTurnFields(raw, payloadRecord)) {
+        mutated = true;
+      }
+      if (payloadRecord.kind === "exec" && copyTopLevelExecFields(raw, payloadRecord)) {
         mutated = true;
       }
     }
@@ -314,7 +360,8 @@ export function normalizeStoredCronJobs(
       "message" in raw ||
       "text" in raw ||
       "command" in raw ||
-      "timeout" in raw;
+      "timeout" in raw ||
+      "shell" in raw;
     const hadLegacyTopLevelDeliveryFields =
       "deliver" in raw ||
       "channel" in raw ||

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -78,9 +78,29 @@ export type CronFailureAlert = {
   accountId?: string;
 };
 
-export type CronPayload = { kind: "systemEvent"; text: string } | CronAgentTurnPayload;
+export type CronPayload =
+  | { kind: "systemEvent"; text: string }
+  | CronExecPayload
+  | CronAgentTurnPayload;
 
-export type CronPayloadPatch = { kind: "systemEvent"; text?: string } | CronAgentTurnPayloadPatch;
+export type CronPayloadPatch =
+  | { kind: "systemEvent"; text?: string }
+  | CronExecPayloadPatch
+  | CronAgentTurnPayloadPatch;
+
+export type CronExecPayload = {
+  kind: "exec";
+  command: string;
+  shell?: boolean;
+  timeout?: number;
+};
+
+export type CronExecPayloadPatch = {
+  kind: "exec";
+  command?: string;
+  shell?: boolean;
+  timeout?: number;
+};
 
 type CronAgentTurnPayloadFields = {
   message: string;

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -44,6 +44,16 @@ describe("cron protocol validators", () => {
     ).toBe(true);
   });
 
+  it("accepts exec payloads", () => {
+    expect(
+      validateCronAddParams({
+        ...minimalAddParams,
+        sessionTarget: "isolated",
+        payload: { kind: "exec", command: "echo hi", timeout: 5_000 },
+      }),
+    ).toBe(true);
+  });
+
   it("rejects add params when required scheduling fields are missing", () => {
     const { wakeMode: _wakeMode, ...withoutWakeMode } = minimalAddParams;
     expect(validateCronAddParams(withoutWakeMode)).toBe(false);

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -21,6 +21,18 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
   );
 }
 
+function cronExecPayloadSchema(params?: { command?: TSchema }) {
+  return Type.Object(
+    {
+      kind: Type.Literal("exec"),
+      command: params?.command ?? NonEmptyString,
+      shell: Type.Optional(Type.Boolean()),
+      timeout: Type.Optional(Type.Integer({ minimum: 0 })),
+    },
+    { additionalProperties: false },
+  );
+}
+
 const CronSessionTargetSchema = Type.Union([
   Type.Literal("main"),
   Type.Literal("isolated"),
@@ -138,6 +150,7 @@ export const CronPayloadSchema = Type.Union([
     },
     { additionalProperties: false },
   ),
+  cronExecPayloadSchema(),
   cronAgentTurnPayloadSchema({ message: NonEmptyString }),
 ]);
 
@@ -149,6 +162,7 @@ export const CronPayloadPatchSchema = Type.Union([
     },
     { additionalProperties: false },
   ),
+  cronExecPayloadSchema({ command: Type.Optional(NonEmptyString) }),
   cronAgentTurnPayloadSchema({ message: Type.Optional(NonEmptyString) }),
 ]);
 

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -11,12 +12,14 @@ const {
   loadConfigMock,
   fetchWithSsrFGuardMock,
   runCronIsolatedAgentTurnMock,
+  sendCronResultAnnounceMock,
 } = vi.hoisted(() => ({
   enqueueSystemEventMock: vi.fn(),
   requestHeartbeatNowMock: vi.fn(),
   loadConfigMock: vi.fn(),
   fetchWithSsrFGuardMock: vi.fn(),
   runCronIsolatedAgentTurnMock: vi.fn(async () => ({ status: "ok" as const, summary: "ok" })),
+  sendCronResultAnnounceMock: vi.fn(async () => {}),
 }));
 
 function enqueueSystemEvent(...args: unknown[]) {
@@ -51,6 +54,14 @@ vi.mock("../cron/isolated-agent.js", () => ({
   runCronIsolatedAgentTurn: runCronIsolatedAgentTurnMock,
 }));
 
+vi.mock("../cron/delivery.js", async () => {
+  const actual = await vi.importActual<typeof import("../cron/delivery.js")>("../cron/delivery.js");
+  return {
+    ...actual,
+    sendCronResultAnnounce: sendCronResultAnnounceMock,
+  };
+});
+
 import { buildGatewayCronService } from "./server-cron.js";
 
 function createCronConfig(name: string): OpenClawConfig {
@@ -72,6 +83,7 @@ describe("buildGatewayCronService", () => {
     loadConfigMock.mockClear();
     fetchWithSsrFGuardMock.mockClear();
     runCronIsolatedAgentTurnMock.mockClear();
+    sendCronResultAnnounceMock.mockClear();
   });
 
   it("routes main-target jobs to the scoped session for enqueue + wake", async () => {
@@ -191,6 +203,54 @@ describe("buildGatewayCronService", () => {
           job: expect.objectContaining({ id: job.id }),
           sessionKey: "project-alpha-monitor",
         }),
+      );
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("announces exec results without starting an isolated agent run", async () => {
+    const cfg = createCronConfig("server-cron-exec-announce");
+    loadConfigMock.mockReturnValue(cfg);
+    const deps = {} as CliDeps;
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "exec-announce",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: {
+          kind: "exec",
+          command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify("process.stdout.write('hello')")}`,
+        },
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "12345",
+        },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      expect(runCronIsolatedAgentTurnMock).not.toHaveBeenCalled();
+      expect(sendCronResultAnnounceMock).toHaveBeenCalledWith(
+        deps,
+        expect.anything(),
+        expect.any(String),
+        job.id,
+        {
+          channel: "telegram",
+          to: "12345",
+          accountId: undefined,
+        },
+        expect.stringContaining("stdout:\nhello"),
       );
     } finally {
       state.cron.stop();

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -8,7 +8,11 @@ import {
   resolveAgentMainSessionKey,
 } from "../config/sessions.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { resolveFailureDestination, sendFailureNotificationAnnounce } from "../cron/delivery.js";
+import {
+  resolveFailureDestination,
+  sendCronResultAnnounce,
+  sendFailureNotificationAnnounce,
+} from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { resolveDeliveryTarget } from "../cron/isolated-agent/delivery-target.js";
 import {
@@ -368,6 +372,28 @@ export function buildGatewayCronService(params: {
         const webhookToken = trimToOptionalString(params.cfg.cron?.webhookToken);
         const legacyWebhook = trimToOptionalString(params.cfg.cron?.webhook);
         const job = cron.getJob(evt.jobId);
+
+        if (
+          job?.payload.kind === "exec" &&
+          job.delivery?.mode === "announce" &&
+          typeof evt.summary === "string" &&
+          evt.summary.trim()
+        ) {
+          const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
+          void sendCronResultAnnounce(
+            params.deps,
+            runtimeConfig,
+            agentId,
+            job.id,
+            {
+              channel: job.delivery.channel,
+              to: job.delivery.to,
+              accountId: job.delivery.accountId,
+            },
+            evt.summary,
+          );
+        }
+
         const legacyNotify = (job as { notify?: unknown } | undefined)?.notify === true;
         const webhookTarget = resolveCronWebhookTarget({
           delivery:


### PR DESCRIPTION
## Summary

Add `payload.kind: "exec"` to the cron system, enabling direct shell command execution without spinning up an LLM session. This eliminates model token costs and dramatically reduces latency for the many cron jobs that simply run a script.

Closes #29907

## Problem

OpenClaw's cron system currently supports only two payload kinds: `systemEvent` and `agentTurn`. **Both require an LLM session**, even when the job just runs a shell script. This means:

- Every `agentTurn` job that wraps a simple `python3 myscript.py` call still boots a full LLM context, consuming tokens just to parse the instruction and call `exec`
- Typical overhead: **5-15 seconds** of LLM processing + **$0.01-0.05 per run** (model-dependent) for what is fundamentally a `child_process.spawn` call
- At scale this compounds: a deployment with **20+ script-only cron jobs** running multiple times daily wastes **$5-10/day ($150-300/month)** on LLM tokens that add zero value

This is a widely-requested capability — any OpenClaw user running scheduled scripts (backups, syncs, health checks, data pipelines) hits this cost/latency wall.

## Solution

A new `payload.kind: "exec"` that runs shell commands directly via `child_process.spawn`, bypassing the LLM entirely:

```json
{
  "name": "Sync Dashboard",
  "schedule": { "kind": "every", "everyMs": 900000 },
  "sessionTarget": "isolated",
  "payload": {
    "kind": "exec",
    "command": "python3 /path/to/sync-status.py",
    "timeout": 30000
  }
}
```

### Performance comparison (real-world test)

Running `python3 sync-cron-status.py` (a lightweight status sync script):

| Metric | `agentTurn` (before) | `exec` (after) | Improvement |
|--------|---------------------|----------------|-------------|
| Duration | ~5,000ms | **930ms** | **5.4x faster** |
| LLM tokens | ~1,000-3,000 | **0** | **100% reduction** |
| Cost per run | ~$0.01-0.05 | **$0.00** | **100% savings** |

For a deployment with 20 script-only jobs averaging 4 runs/day:
- **Before**: ~$4-8/day on LLM tokens for script execution
- **After**: $0.00 — exec jobs consume no model tokens

## Changes

### New files
- **`src/cron/exec-runner.ts`** (280 lines) — Self-contained shell runner with:
  - `child_process.spawn` with configurable shell mode
  - Timeout enforcement via `SIGKILL`
  - stdout/stderr capture (128KB cap with truncation indicator)
  - `AbortSignal` support for graceful cancellation
  - Command string parsing with quote/escape handling
  - Result compatible with `CronRunOutcome`

- **`src/cron/exec-runner.test.ts`** — Tests covering success, non-zero exit, timeout, and shell mode

### Modified files (minimal diff strategy)

The `src/cron/` directory has ~400 commits in 6 weeks, so changes to existing files are kept surgical to minimize rebase friction:

- **Schema** (`src/gateway/protocol/schema/cron.ts`, +14 lines) — Add `exec` to payload kind union
- **Types** (`src/cron/types.ts`, +24 lines) — `CronExecPayload` and patch types
- **Normalization** (`src/cron/normalize.ts`, +48 lines) — Recognize and preserve `exec` kind through coercion
- **Store migration** (`src/cron/store-migration.ts`, +51 lines) — Prevent `exec` jobs from being rewritten to `agentTurn` on reload
- **Validation** (`src/cron/service/jobs.ts`, +30 lines) — Require `sessionTarget: "isolated"` for exec, plus merge/build helpers
- **Dispatch** (`src/cron/service/timer.ts`, +8 lines) — Route exec payloads before isolated-agent path
- **Naming** (`src/cron/service/normalize.ts`, +13 lines) — Use command text for job name inference
- **Delivery** (`src/cron/delivery.ts`, refactored) — Extract shared announce helper, add `sendCronResultAnnounce` for exec
- **Gateway** (`src/gateway/server-cron.ts`, +28 lines) — Announce exec results via finished-event handler

### Tests added
- `src/cron/exec-runner.test.ts` — Runner unit tests (4 cases)
- `src/cron/normalize.test.ts` — Normalization for exec payloads
- `src/cron/service.jobs.test.ts` — Validation: exec requires isolated
- `src/cron/store-migration.test.ts` — Migration preserves exec kind
- `src/gateway/protocol/cron-validators.test.ts` — Schema validation
- `src/gateway/server-cron.test.ts` — Gateway announce delivery

## Design decisions

1. **New file for execution logic** — All spawn/timeout/capture code lives in `exec-runner.ts`, keeping the diff on hot files (`timer.ts`, `jobs.ts`) minimal

2. **No LLM session at all** — exec jobs bypass the entire isolated-agent path. No model selection, no token accounting, no session creation

3. **Delivery via finished-event** — Instead of threading delivery through the agent runner, exec results are announced from `server-cron.ts`'s finished-event handler, keeping the execution path clean

4. **v1 scope** — Just command + exit code. No condition DSL, no jsonPath evaluation, no conditional agentTurn chaining. Those can follow as separate PRs

## Testing

```bash
# Unit tests
pnpm test -- src/cron/exec-runner.test.ts

# All related tests
pnpm test -- src/cron/normalize.test.ts src/cron/service.jobs.test.ts \
  src/cron/store-migration.test.ts src/gateway/protocol/cron-validators.test.ts \
  src/gateway/server-cron.test.ts

# Type check
pnpm tsgo
```

All 88 tests pass. Type check clean. Format check clean (oxfmt).
