### PR TITLE
fix: enable usage extraction for modelstudio/bailian provider (#46616)

### DIFF
--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -500,7 +500,7 @@ export function buildModelStudioProvider(): ProviderConfig {
       // Without this, pi-agent-core skips usage extraction for non-native
       // OpenAI endpoints, leaving token stats null in session data.
       // See: https://github.com/openclaw/openclaw/issues/46616
-      compat: { supportsUsageInStreaming: true },
+      compat: { ...model.compat, supportsUsageInStreaming: true },
     })),
   };
 }

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -494,7 +494,14 @@ export function buildModelStudioProvider(): ProviderConfig {
   return {
     baseUrl: MODELSTUDIO_BASE_URL,
     api: "openai-completions",
-    models: MODELSTUDIO_MODEL_CATALOG.map((model) => ({ ...model })),
+    models: MODELSTUDIO_MODEL_CATALOG.map((model) => ({
+      ...model,
+      // DashScope/Bailian supports OpenAI-format usage in streaming chunks.
+      // Without this, pi-agent-core skips usage extraction for non-native
+      // OpenAI endpoints, leaving token stats null in session data.
+      // See: https://github.com/openclaw/openclaw/issues/46616
+      compat: { supportsUsageInStreaming: true },
+    })),
   };
 }
 


### PR DESCRIPTION
Fixes #46616

When using bailian (阿里百炼) provider with `api: 'openai-completions'`, token usage stats remain null because `pi-agent-core` skips usage extraction for non-native OpenAI endpoints by default.

Adding `compat: { supportsUsageInStreaming: true }` enables usage extraction from streaming chunks, since DashScope/Bailian emits usage in standard OpenAI format.