### PR TITLE
fix: use actual prompt size for context banner instead of cumulative session total (#46582)

### DIFF
--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -500,7 +500,7 @@ export function buildModelStudioProvider(): ProviderConfig {
       // Without this, pi-agent-core skips usage extraction for non-native
       // OpenAI endpoints, leaving token stats null in session data.
       // See: https://github.com/openclaw/openclaw/issues/46616
-      compat: { supportsUsageInStreaming: true },
+      compat: { ...model.compat, supportsUsageInStreaming: true },
     })),
   };
 }

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -494,7 +494,14 @@ export function buildModelStudioProvider(): ProviderConfig {
   return {
     baseUrl: MODELSTUDIO_BASE_URL,
     api: "openai-completions",
-    models: MODELSTUDIO_MODEL_CATALOG.map((model) => ({ ...model })),
+    models: MODELSTUDIO_MODEL_CATALOG.map((model) => ({
+      ...model,
+      // DashScope/Bailian supports OpenAI-format usage in streaming chunks.
+      // Without this, pi-agent-core skips usage extraction for non-native
+      // OpenAI endpoints, leaving token stats null in session data.
+      // See: https://github.com/openclaw/openclaw/issues/46616
+      compat: { supportsUsageInStreaming: true },
+    })),
   };
 }
 

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -550,7 +550,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     : undefined;
 
   const contextLine = [
-    `Context: ${formatTokens(actualContextTokens ?? totalTokens, contextTokens ?? null)}`,
+    `Context: ${formatTokens(actualContextTokens ?? entry?.inputTokens ?? totalTokens, contextTokens ?? null)}`,
     `🧹 Compactions: ${entry?.compactionCount ?? 0}`,
   ]
     .filter(Boolean)

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -293,7 +293,11 @@ const readUsageFromSessionLog = (
     }
     input = lastUsage.input ?? 0;
     output = lastUsage.output ?? 0;
-    promptTokens = derivePromptTokens(lastUsage) ?? lastUsage.total ?? input + output;
+    // Use only derivePromptTokens (input + cacheRead + cacheWrite) for context size.
+    // Do NOT fall back to lastUsage.total which includes output tokens and is
+    // cumulative across API calls, inflating the context percentage.
+    // See: https://github.com/openclaw/openclaw/issues/46582
+    promptTokens = derivePromptTokens(lastUsage) ?? 0;
     const total = lastUsage.total ?? promptTokens + output;
     if (promptTokens === 0 && total === 0) {
       return undefined;
@@ -462,8 +466,10 @@ export function buildStatusMessage(args: StatusArgs): string {
   let cacheWrite = entry?.cacheWrite;
   let totalTokens = entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
 
-  // Prefer prompt-size tokens from the session transcript when it looks larger
-  // (cached prompt tokens are often missing from agent meta/store).
+  // Track actual context size separately from cumulative session total.
+  // totalTokens = cumulative session usage (for Tokens line)
+  // actualContextTokens = last message's prompt size (for Context line)
+  let actualContextTokens: number | undefined;
   if (args.includeTranscriptUsage) {
     const logUsage = readUsageFromSessionLog(
       entry?.sessionId,
@@ -476,6 +482,11 @@ export function buildStatusMessage(args: StatusArgs): string {
       const candidate = logUsage.promptTokens || logUsage.total;
       if (!totalTokens || totalTokens === 0 || candidate > totalTokens) {
         totalTokens = candidate;
+      }
+      // Use the last prompt's token count as actual context size
+      // (it represents the real context window usage, not cumulative session total)
+      if (logUsage.promptTokens > 0) {
+        actualContextTokens = logUsage.promptTokens;
       }
       if (!entry?.model && logUsage.model) {
         const slashIndex = logUsage.model.indexOf("/");
@@ -539,7 +550,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     : undefined;
 
   const contextLine = [
-    `Context: ${formatTokens(totalTokens, contextTokens ?? null)}`,
+    `Context: ${formatTokens(actualContextTokens ?? totalTokens, contextTokens ?? null)}`,
     `🧹 Compactions: ${entry?.compactionCount ?? 0}`,
   ]
     .filter(Boolean)


### PR DESCRIPTION
Fixes #46582

The /status banner was showing cumulative session tokens (e.g. 452k) divided by context window size (e.g. 256k), resulting in misleading percentages like 176%.

This PR tracks actualContextTokens (last message's prompt size) separately from totalTokens (cumulative session total) and uses the actual context size for the Context line display.

**Before:** 📚 Context: 452k/256k (176%)
**After:** 📚 Context: 76k/256k (30%)