### PR TITLE
ACP: classify silent acpx exits as backend unavailable

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -722,4 +722,19 @@ describe("AcpxRuntime", () => {
       delete process.env.MOCK_ACPX_NEW_EMPTY;
     }
   });
+
+  it("preserves ACP_SESSION_INIT_FAILED for silent exits during session init", async () => {
+    const { runtime } = await createMockRuntimeFixture();
+
+    await expect(
+      runtime.ensureSession({
+        sessionKey: "agent:claude:acp:silent-init",
+        agent: "claude",
+        mode: "persistent",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_SESSION_INIT_FAILED",
+      message: "acpx exited with code 1",
+    });
+  });
 });

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -439,6 +439,37 @@ describe("AcpxRuntime", () => {
     );
   });
 
+  it("classifies silent acpx exits as backend-unavailable errors", async () => {
+    const runtime = sharedFixture?.runtime;
+    expect(runtime).toBeDefined();
+    if (!runtime) {
+      throw new Error("shared runtime fixture missing");
+    }
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:silent-exit",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    const events = [];
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "silent-exit",
+      mode: "prompt",
+      requestId: "req-silent-exit",
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        code: "ACP_BACKEND_UNAVAILABLE",
+        message: "acpx exited with code 1",
+      }),
+    );
+  });
+
   it("supports cancel and close using encoded runtime handle state", async () => {
     const { runtime, logPath, config } = await createMockRuntimeFixture();
     const handle = await runtime.ensureSession({

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -726,6 +726,7 @@ describe("AcpxRuntime", () => {
   it("preserves ACP_SESSION_INIT_FAILED for silent exits during session init", async () => {
     const { runtime } = await createMockRuntimeFixture();
 
+    // Session-init silent exits should keep stale-session guidance instead of turn-failure guidance.
     await expect(
       runtime.ensureSession({
         sessionKey: "agent:claude:acp:silent-init",

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -131,6 +131,23 @@ function resolveSilentAcpxControlExitErrorCode(params: {
     : params.fallbackCode;
 }
 
+function shouldAttemptEnsureRecovery(error: unknown): boolean {
+  if (!(error instanceof AcpRuntimeError)) {
+    return true;
+  }
+  if (error.code !== "ACP_SESSION_INIT_FAILED") {
+    return false;
+  }
+  if (isRecord(error.cause)) {
+    const causeKind = asTrimmedString(error.cause.kind);
+    const eventCount = error.cause.eventCount;
+    if (causeKind === "acpx-control-exit" && typeof eventCount === "number") {
+      return eventCount > 0;
+    }
+  }
+  return !/\bacpx exited with code\s+[1-9]\d*\b/i.test(error.message);
+}
+
 export function encodeAcpxRuntimeHandleState(state: AcpxHandleState): string {
   const payload = Buffer.from(JSON.stringify(state), "utf8").toString("base64url");
   return `${ACPX_RUNTIME_HANDLE_PREFIX}${payload}`;
@@ -463,6 +480,9 @@ export class AcpxRuntime implements AcpRuntime {
           fallbackCode: "ACP_SESSION_INIT_FAILED",
         });
       } catch (error) {
+        if (!shouldAttemptEnsureRecovery(error)) {
+          throw error;
+        }
         const recovered = await this.recoverEnsureFailure({
           sessionName,
           agent,
@@ -1026,6 +1046,13 @@ export class AcpxRuntime implements AcpRuntime {
           stderr: result.stderr,
           exitCode: result.code,
         }),
+        {
+          cause: {
+            kind: "acpx-control-exit",
+            exitCode: result.code ?? null,
+            eventCount: events.length,
+          },
+        },
       );
     }
     return events;

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -119,6 +119,18 @@ function resolveSilentAcpxExitErrorCode(exitCode: number | null | undefined): Ac
   return "ACP_BACKEND_UNAVAILABLE";
 }
 
+function resolveSilentAcpxControlExitErrorCode(params: {
+  exitCode: number | null | undefined;
+  fallbackCode: AcpRuntimeErrorCode;
+}): AcpRuntimeErrorCode {
+  if (params.exitCode === ACPX_EXIT_CODE_PERMISSION_DENIED) {
+    return params.fallbackCode;
+  }
+  return params.fallbackCode === "ACP_TURN_FAILED"
+    ? "ACP_BACKEND_UNAVAILABLE"
+    : params.fallbackCode;
+}
+
 export function encodeAcpxRuntimeHandleState(state: AcpxHandleState): string {
   const payload = Buffer.from(JSON.stringify(state), "utf8").toString("base64url");
   return `${ACPX_RUNTIME_HANDLE_PREFIX}${payload}`;
@@ -1006,7 +1018,10 @@ export class AcpxRuntime implements AcpRuntime {
 
     if ((result.code ?? 0) !== 0) {
       throw new AcpRuntimeError(
-        resolveSilentAcpxExitErrorCode(result.code),
+        resolveSilentAcpxControlExitErrorCode({
+          exitCode: result.code,
+          fallbackCode: params.fallbackCode,
+        }),
         formatAcpxExitMessage({
           stderr: result.stderr,
           exitCode: result.code,

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -112,6 +112,13 @@ function findSessionIdentifierEvent(events: AcpxJsonObject[]): AcpxJsonObject | 
   );
 }
 
+function resolveSilentAcpxExitErrorCode(exitCode: number | null | undefined): AcpRuntimeErrorCode {
+  if (exitCode === ACPX_EXIT_CODE_PERMISSION_DENIED) {
+    return "ACP_TURN_FAILED";
+  }
+  return "ACP_BACKEND_UNAVAILABLE";
+}
+
 export function encodeAcpxRuntimeHandleState(state: AcpxHandleState): string {
   const payload = Buffer.from(JSON.stringify(state), "utf8").toString("base64url");
   return `${ACPX_RUNTIME_HANDLE_PREFIX}${payload}`;
@@ -637,6 +644,7 @@ export class AcpxRuntime implements AcpRuntime {
       if ((exit.code ?? 0) !== 0 && !sawError) {
         yield {
           type: "error",
+          code: resolveSilentAcpxExitErrorCode(exit.code),
           message: formatAcpxExitMessage({
             stderr,
             exitCode: exit.code,
@@ -998,7 +1006,7 @@ export class AcpxRuntime implements AcpRuntime {
 
     if ((result.code ?? 0) !== 0) {
       throw new AcpRuntimeError(
-        params.fallbackCode,
+        resolveSilentAcpxExitErrorCode(result.code),
         formatAcpxExitMessage({
           stderr: result.stderr,
           exitCode: result.code,

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -75,6 +75,9 @@ const setKey = command === "set" ? String(args[commandIndex + 1] || "") : "";
 const setValue = command === "set" ? String(args[commandIndex + 2] || "") : "";
 
 if (command === "sessions" && args[commandIndex + 1] === "ensure") {
+  if (ensureName.includes("silent-init")) {
+    process.exit(1);
+  }
   writeLog({ kind: "ensure", agent, args, sessionName: ensureName });
   if (process.env.MOCK_ACPX_ENSURE_EXIT_1 === "1") {
     emitJson({

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -270,6 +270,10 @@ if (command === "prompt") {
     process.exit(5);
   }
 
+  if (stdinText.includes("silent-exit")) {
+    process.exit(1);
+  }
+
   if (stdinText.includes("split-spacing")) {
     emitUpdate(sessionFromOption, {
       sessionUpdate: "agent_message_chunk",

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -76,6 +76,17 @@ const ACP_TURN_TIMEOUT_GRACE_MS = 1_000;
 const ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS = 2_000;
 const ACP_TURN_TIMEOUT_REASON = "turn-timeout";
 
+const ACPX_EXIT_ERROR_RE = /\bacpx exited with code\s+\d+\b/i;
+
+function resolveTurnFailureFallbackCode(error: unknown): AcpRuntimeError["code"] {
+  if (error instanceof Error && !(error instanceof AcpRuntimeError)) {
+    if (ACPX_EXIT_ERROR_RE.test(error.message)) {
+      return "ACP_BACKEND_UNAVAILABLE";
+    }
+  }
+  return "ACP_TURN_FAILED";
+}
+
 export class AcpSessionManager {
   private readonly actorQueue = new SessionActorQueue();
   private readonly actorTailBySession = this.actorQueue.getTailMapForTesting();
@@ -609,6 +620,7 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
+<<<<<<< HEAD
     await this.withSessionActor(
       sessionKey,
       async () => {
@@ -616,6 +628,121 @@ export class AcpSessionManager {
         const actorKey = normalizeActorKey(sessionKey);
         for (let attempt = 0; attempt < 2; attempt += 1) {
           const resolution = this.resolveSession({
+=======
+    await this.withSessionActor(sessionKey, async () => {
+      const resolution = this.resolveSession({
+        cfg: input.cfg,
+        sessionKey,
+      });
+      const resolvedMeta = requireReadySessionMeta(resolution);
+
+      const {
+        runtime,
+        handle: ensuredHandle,
+        meta: ensuredMeta,
+      } = await this.ensureRuntimeHandle({
+        cfg: input.cfg,
+        sessionKey,
+        meta: resolvedMeta,
+      });
+      let handle = ensuredHandle;
+      const meta = ensuredMeta;
+      await this.applyRuntimeControls({
+        sessionKey,
+        runtime,
+        handle,
+        meta,
+      });
+      const turnStartedAt = Date.now();
+      const actorKey = normalizeActorKey(sessionKey);
+
+      await this.setSessionState({
+        cfg: input.cfg,
+        sessionKey,
+        state: "running",
+        clearLastError: true,
+      });
+
+      const internalAbortController = new AbortController();
+      const onCallerAbort = () => {
+        internalAbortController.abort();
+      };
+      if (input.signal?.aborted) {
+        internalAbortController.abort();
+      } else if (input.signal) {
+        input.signal.addEventListener("abort", onCallerAbort, { once: true });
+      }
+
+      const activeTurn: ActiveTurnState = {
+        runtime,
+        handle,
+        abortController: internalAbortController,
+      };
+      this.activeTurnBySession.set(actorKey, activeTurn);
+
+      let streamError: AcpRuntimeError | null = null;
+      try {
+        const combinedSignal =
+          input.signal && typeof AbortSignal.any === "function"
+            ? AbortSignal.any([input.signal, internalAbortController.signal])
+            : internalAbortController.signal;
+        for await (const event of runtime.runTurn({
+          handle,
+          text: input.text,
+          attachments: input.attachments,
+          mode: input.mode,
+          requestId: input.requestId,
+          signal: combinedSignal,
+        })) {
+          if (event.type === "error") {
+            streamError = new AcpRuntimeError(
+              normalizeAcpErrorCode(event.code),
+              event.message?.trim() || "ACP turn failed before completion.",
+            );
+          }
+          if (input.onEvent) {
+            await input.onEvent(event);
+          }
+        }
+        if (streamError) {
+          throw streamError;
+        }
+        this.recordTurnCompletion({
+          startedAt: turnStartedAt,
+        });
+        await this.setSessionState({
+          cfg: input.cfg,
+          sessionKey,
+          state: "idle",
+          clearLastError: true,
+        });
+      } catch (error) {
+        const acpError = toAcpRuntimeError({
+          error,
+          fallbackCode: resolveTurnFailureFallbackCode(error),
+          fallbackMessage: "ACP turn failed before completion.",
+        });
+        this.recordTurnCompletion({
+          startedAt: turnStartedAt,
+          errorCode: acpError.code,
+        });
+        await this.setSessionState({
+          cfg: input.cfg,
+          sessionKey,
+          state: "error",
+          lastError: acpError.message,
+        });
+        throw acpError;
+      } finally {
+        if (input.signal) {
+          input.signal.removeEventListener("abort", onCallerAbort);
+        }
+        if (this.activeTurnBySession.get(actorKey) === activeTurn) {
+          this.activeTurnBySession.delete(actorKey);
+        }
+        if (meta.mode !== "oneshot") {
+          ({ handle } = await this.reconcileRuntimeSessionIdentifiers({
+>>>>>>> c50968f53c (ACP: classify silent acpx exits as backend unavailable)
             cfg: input.cfg,
             sessionKey,
           });

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -622,7 +622,6 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-<<<<<<< HEAD
     await this.withSessionActor(
       sessionKey,
       async () => {
@@ -630,121 +629,6 @@ export class AcpSessionManager {
         const actorKey = normalizeActorKey(sessionKey);
         for (let attempt = 0; attempt < 2; attempt += 1) {
           const resolution = this.resolveSession({
-=======
-    await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: input.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-
-      const {
-        runtime,
-        handle: ensuredHandle,
-        meta: ensuredMeta,
-      } = await this.ensureRuntimeHandle({
-        cfg: input.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      let handle = ensuredHandle;
-      const meta = ensuredMeta;
-      await this.applyRuntimeControls({
-        sessionKey,
-        runtime,
-        handle,
-        meta,
-      });
-      const turnStartedAt = Date.now();
-      const actorKey = normalizeActorKey(sessionKey);
-
-      await this.setSessionState({
-        cfg: input.cfg,
-        sessionKey,
-        state: "running",
-        clearLastError: true,
-      });
-
-      const internalAbortController = new AbortController();
-      const onCallerAbort = () => {
-        internalAbortController.abort();
-      };
-      if (input.signal?.aborted) {
-        internalAbortController.abort();
-      } else if (input.signal) {
-        input.signal.addEventListener("abort", onCallerAbort, { once: true });
-      }
-
-      const activeTurn: ActiveTurnState = {
-        runtime,
-        handle,
-        abortController: internalAbortController,
-      };
-      this.activeTurnBySession.set(actorKey, activeTurn);
-
-      let streamError: AcpRuntimeError | null = null;
-      try {
-        const combinedSignal =
-          input.signal && typeof AbortSignal.any === "function"
-            ? AbortSignal.any([input.signal, internalAbortController.signal])
-            : internalAbortController.signal;
-        for await (const event of runtime.runTurn({
-          handle,
-          text: input.text,
-          attachments: input.attachments,
-          mode: input.mode,
-          requestId: input.requestId,
-          signal: combinedSignal,
-        })) {
-          if (event.type === "error") {
-            streamError = new AcpRuntimeError(
-              normalizeAcpErrorCode(event.code),
-              event.message?.trim() || "ACP turn failed before completion.",
-            );
-          }
-          if (input.onEvent) {
-            await input.onEvent(event);
-          }
-        }
-        if (streamError) {
-          throw streamError;
-        }
-        this.recordTurnCompletion({
-          startedAt: turnStartedAt,
-        });
-        await this.setSessionState({
-          cfg: input.cfg,
-          sessionKey,
-          state: "idle",
-          clearLastError: true,
-        });
-      } catch (error) {
-        const acpError = toAcpRuntimeError({
-          error,
-          fallbackCode: resolveTurnFailureFallbackCode(error),
-          fallbackMessage: "ACP turn failed before completion.",
-        });
-        this.recordTurnCompletion({
-          startedAt: turnStartedAt,
-          errorCode: acpError.code,
-        });
-        await this.setSessionState({
-          cfg: input.cfg,
-          sessionKey,
-          state: "error",
-          lastError: acpError.message,
-        });
-        throw acpError;
-      } finally {
-        if (input.signal) {
-          input.signal.removeEventListener("abort", onCallerAbort);
-        }
-        if (this.activeTurnBySession.get(actorKey) === activeTurn) {
-          this.activeTurnBySession.delete(actorKey);
-        }
-        if (meta.mode !== "oneshot") {
-          ({ handle } = await this.reconcileRuntimeSessionIdentifiers({
->>>>>>> c50968f53c (ACP: classify silent acpx exits as backend unavailable)
             cfg: input.cfg,
             sessionKey,
           });
@@ -873,7 +757,9 @@ export class AcpSessionManager {
           } catch (error) {
             const acpError = toAcpRuntimeError({
               error,
-              fallbackCode: activeTurnStarted ? "ACP_TURN_FAILED" : "ACP_SESSION_INIT_FAILED",
+              fallbackCode: activeTurnStarted
+                ? resolveTurnFailureFallbackCode(error)
+                : "ACP_SESSION_INIT_FAILED",
               fallbackMessage: activeTurnStarted
                 ? "ACP turn failed before completion."
                 : "Could not initialize ACP session runtime.",

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -76,7 +76,9 @@ const ACP_TURN_TIMEOUT_GRACE_MS = 1_000;
 const ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS = 2_000;
 const ACP_TURN_TIMEOUT_REASON = "turn-timeout";
 
-const ACPX_EXIT_ERROR_RE = /\bacpx exited with code\s+\d+\b/i;
+// Defensive fallback only: the runtime should normally surface an AcpRuntimeError
+// or a structured event code before manager-level handling gets involved.
+const ACPX_EXIT_ERROR_RE = /\bacpx exited with code\s+[1-9]\d*\b/i;
 
 function resolveTurnFailureFallbackCode(error: unknown): AcpRuntimeError["code"] {
   if (error instanceof Error && !(error instanceof AcpRuntimeError)) {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1328,7 +1328,7 @@ describe("AcpSessionManager", () => {
         requestId: "run-1",
       }),
     ).rejects.toMatchObject({
-      code: "ACP_TURN_FAILED",
+      code: "ACP_BACKEND_UNAVAILABLE",
       message: "acpx exited with code 1",
     });
 

--- a/src/acp/runtime/error-text.test.ts
+++ b/src/acp/runtime/error-text.test.ts
@@ -16,4 +16,13 @@ describe("formatAcpRuntimeErrorText", () => {
     expect(text).toContain("ACP error (ACP_TURN_FAILED): turn failed");
     expect(text).toContain("next:");
   });
+
+  it("routes backend-unavailable failures to ACP doctor guidance", () => {
+    const text = formatAcpRuntimeErrorText(
+      new AcpRuntimeError("ACP_BACKEND_UNAVAILABLE", "acpx exited with code 1"),
+    );
+    expect(text).toContain("ACP error (ACP_BACKEND_UNAVAILABLE): acpx exited with code 1");
+    expect(text).toContain("/acp doctor");
+    expect(text).not.toContain("/acp cancel");
+  });
 });


### PR DESCRIPTION
## Summary
- classify silent non-zero acpx exits as `ACP_BACKEND_UNAVAILABLE` instead of generic `ACP_TURN_FAILED`
- preserve the existing permission-denied guidance while improving the fallback used when the runtime backend exits without a structured ACP error
- cover the runtime, manager, and user-facing error text regressions for `acpx exited with code 1`

## Testing
- pnpm exec vitest run --config vitest.config.ts extensions/acpx/src/runtime.test.ts src/acp/control-plane/manager.test.ts src/acp/runtime/error-text.test.ts