### PR TITLE
fix(ollama): parse stringified tool_calls arguments for native API

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -54,6 +54,32 @@ describe("convertToOllamaMessages", () => {
     ]);
   });
 
+  it("parses stringified JSON arguments from OpenAI-compat tool calls", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_2", name: "bash", arguments: '{"command":"ls -la"}' },
+        ],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls).toEqual([
+      { function: { name: "bash", arguments: { command: "ls -la" } } },
+    ]);
+  });
+
+  it("handles malformed JSON string arguments gracefully", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_3", name: "bash", arguments: "not-json" }],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls).toEqual([{ function: { name: "bash", arguments: {} } }]);
+  });
+
   it("converts tool result messages with 'tool' role", () => {
     const messages = [{ role: "tool", content: "file1.txt\nfile2.txt" }];
     const result = convertToOllamaMessages(messages);

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -246,6 +246,25 @@ function extractOllamaImages(content: unknown): string[] {
     .map((part) => part.data);
 }
 
+/** Parse arguments that may arrive as a JSON string (OpenAI-compat endpoints) into an object. */
+function ensureArgsObject(args: unknown): Record<string, unknown> {
+  if (typeof args === "string") {
+    try {
+      const parsed = JSON.parse(args);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Malformed JSON – return empty args so the call can still proceed.
+    }
+    return {};
+  }
+  if (args && typeof args === "object" && !Array.isArray(args)) {
+    return args as Record<string, unknown>;
+  }
+  return {};
+}
+
 function extractToolCalls(content: unknown): OllamaToolCall[] {
   if (!Array.isArray(content)) {
     return [];
@@ -254,9 +273,9 @@ function extractToolCalls(content: unknown): OllamaToolCall[] {
   const result: OllamaToolCall[] = [];
   for (const part of parts) {
     if (part.type === "toolCall") {
-      result.push({ function: { name: part.name, arguments: part.arguments } });
+      result.push({ function: { name: part.name, arguments: ensureArgsObject(part.arguments) } });
     } else if (part.type === "tool_use") {
-      result.push({ function: { name: part.name, arguments: part.input } });
+      result.push({ function: { name: part.name, arguments: ensureArgsObject(part.input) } });
     }
   }
   return result;


### PR DESCRIPTION
## Summary
- Fix Ollama native API rejecting tool_calls when arguments are JSON strings instead of objects

## Problem
When messages pass through the pi-ai SDK's OpenAI-compatible endpoint handling, `tool_calls[].function.arguments` is serialized to a JSON string per the OpenAI spec. However, Ollama's native `/api/chat` endpoint expects `arguments` to be a JSON **object**, not a string. This causes 400 errors or silent tool call failures.

## Root Cause
The `extractToolCalls()` function in `ollama-stream.ts` directly passes `part.arguments` and `part.input` to the Ollama request body without checking their type. When these values arrive as strings from upstream SDK processing, the native API rejects them.

## Fix
Add an `ensureArgsObject()` helper that:
- Parses JSON string arguments back to objects
- Returns the original value if already an object
- Falls back to `{}` for malformed inputs to prevent crashes

## Test Plan
- [x] Added test: stringified JSON arguments from OpenAI-compat tool calls are parsed to objects
- [x] Added test: malformed JSON string arguments degrade gracefully to `{}`
- [x] Existing `convertToOllamaMessages` tests still pass

Closes #46679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
