### PR TITLE
fix(docs): align AGENTS.md template memory paths with session-memory hook

### DIFF
--- a/docs/reference/AGENTS.default.md
+++ b/docs/reference/AGENTS.default.md
@@ -65,10 +65,10 @@ cp docs/reference/AGENTS.default.md ~/.openclaw/workspace/AGENTS.md
 
 ## Memory system (recommended)
 
-- Daily log: `memory/YYYY-MM-DD.md` (create `memory/` if needed).
+- Session notes: `memory/YYYY-MM-DD*.md` (create `memory/` if needed). The session-memory hook generates files like `memory/2026-03-15-bug-fix.md`.
 - Long-term memory: `MEMORY.md` for durable facts, preferences, and decisions.
 - Lowercase `memory.md` is legacy fallback only; do not keep both root files on purpose.
-- On session start, read today + yesterday + `MEMORY.md` when present, otherwise `memory.md`.
+- On session start, glob `memory/YYYY-MM-DD*.md` for today + yesterday, plus `MEMORY.md` when present, otherwise `memory.md`.
 - Capture: decisions, preferences, constraints, open loops.
 - Avoid secrets unless explicitly requested.
 

--- a/docs/reference/templates/AGENTS.dev.md
+++ b/docs/reference/templates/AGENTS.dev.md
@@ -34,8 +34,8 @@ git commit -m "Add agent workspace"
 
 ## Daily memory (recommended)
 
-- Keep a short daily log at memory/YYYY-MM-DD.md (create memory/ if needed).
-- On session start, read today + yesterday if present.
+- Session notes are saved as memory/YYYY-MM-DD-slug.md (create memory/ if needed).
+- On session start, glob memory/YYYY-MM-DD\*.md for today + yesterday if present.
 - Capture durable facts, preferences, and decisions; avoid secrets.
 
 ## Heartbeats (optional)

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -19,7 +19,7 @@ Before doing anything else:
 
 1. Read `SOUL.md` — this is who you are
 2. Read `USER.md` — this is who you're helping
-3. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
+3. Read `memory/YYYY-MM-DD*.md` (today + yesterday) for recent context
 4. **If in MAIN SESSION** (direct chat with your human): Also read `MEMORY.md`
 
 Don't ask permission. Just do it.
@@ -28,7 +28,7 @@ Don't ask permission. Just do it.
 
 You wake up fresh each session. These files are your continuity:
 
-- **Daily notes:** `memory/YYYY-MM-DD.md` (create `memory/` if needed) — raw logs of what happened
+- **Session notes:** `memory/YYYY-MM-DD*.md` (create `memory/` if needed) — auto-generated per session (e.g. `2026-03-15-bug-fix.md`)
 - **Long-term:** `MEMORY.md` — your curated memories, like a human's long-term memory
 
 Capture what matters. Decisions, context, things to remember. Skip the secrets unless asked to keep them.
@@ -47,7 +47,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 
 - **Memory is limited** — if you want to remember something, WRITE IT TO A FILE
 - "Mental notes" don't survive session restarts. Files do.
-- When someone says "remember this" → update `memory/YYYY-MM-DD.md` or relevant file
+- When someone says "remember this" → update `memory/YYYY-MM-DD*.md` or relevant file
 - When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Text > Brain** 📝
@@ -205,7 +205,7 @@ You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it
 
 Periodically (every few days), use a heartbeat to:
 
-1. Read through recent `memory/YYYY-MM-DD.md` files
+1. Read through recent `memory/YYYY-MM-DD*.md` files
 2. Identify significant events, lessons, or insights worth keeping long-term
 3. Update `MEMORY.md` with distilled learnings
 4. Remove outdated info from MEMORY.md that's no longer relevant


### PR DESCRIPTION
## Summary
- Align AGENTS.md template memory file paths with the actual session-memory hook naming convention

## Problem
The session-memory hook generates files as `memory/YYYY-MM-DD-slug.md` (e.g. `2026-03-15-bug-fix.md`), but AGENTS.md templates instructed agents to read `memory/YYYY-MM-DD.md` (no slug suffix). Agents following the template attempted to read non-existent files, causing ENOENT warnings in logs and missing session context on startup.

## Root Cause
The AGENTS.md template was written assuming a one-file-per-day naming pattern (`YYYY-MM-DD.md`), but the session-memory hook (introduced later) creates one file per session with a descriptive LLM-generated slug (`YYYY-MM-DD-slug.md`).

## Fix
- Update `docs/reference/templates/AGENTS.md` to use glob pattern `memory/YYYY-MM-DD*.md`
- Update `docs/reference/templates/AGENTS.dev.md` to reflect the actual naming
- Update `docs/reference/AGENTS.default.md` to use glob pattern and describe the slug format
- All three templates now correctly match both legacy daily files and new per-session files

## Test Plan
- [x] Verified glob pattern `YYYY-MM-DD*.md` matches both `2026-03-15.md` (legacy) and `2026-03-15-bug-fix.md` (current)
- [x] Verified no zh-CN files were edited (auto-generated per pipeline)

Closes #46687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
