### PR TITLE
fix(ssrf): pass pinned DNS lookup to ProxyAgent via requestTls

### DIFF
--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -210,9 +210,29 @@ describe("createPinnedDispatcher", () => {
 
     expect(proxyAgentCtor).toHaveBeenCalledWith({
       uri: "http://127.0.0.1:7890",
+      requestTls: { lookup },
       proxyTls: {
         autoSelectFamily: false,
       },
+    });
+  });
+
+  it("passes pinned lookup via requestTls when proxyTls is absent", () => {
+    const lookup = vi.fn() as unknown as PinnedHostname["lookup"];
+    const pinned: PinnedHostname = {
+      hostname: "api.telegram.org",
+      addresses: ["149.154.167.220"],
+      lookup,
+    };
+
+    createPinnedDispatcher(pinned, {
+      mode: "explicit-proxy",
+      proxyUrl: "http://127.0.0.1:7890",
+    });
+
+    expect(proxyAgentCtor).toHaveBeenCalledWith({
+      uri: "http://127.0.0.1:7890",
+      requestTls: { lookup },
     });
   });
 });

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -416,11 +416,16 @@ export function createPinnedDispatcher(
   }
 
   const proxyUrl = policy.proxyUrl.trim();
+  // Always pass the pinned lookup via requestTls so DNS resolution for the
+  // origin server goes through the SSRF-safe pinned lookup, not the default
+  // resolver.  Without this, ProxyAgent bypasses DNS pinning (#46685).
+  const requestTls = withPinnedLookup(pinned.lookup);
   if (!policy.proxyTls) {
-    return new ProxyAgent(proxyUrl);
+    return new ProxyAgent({ uri: proxyUrl, requestTls });
   }
   return new ProxyAgent({
     uri: proxyUrl,
+    requestTls,
     proxyTls: { ...policy.proxyTls },
   });
 }


### PR DESCRIPTION
## Summary
- Pass pinned DNS lookup to ProxyAgent via `requestTls` for SSRF protection

## Problem
`createPinnedDispatcher()` correctly passes the SSRF-safe pinned hostname lookup to `Agent` (direct mode) and `EnvHttpProxyAgent` (env-proxy mode) via their `connect` options. However, for `ProxyAgent` (explicit-proxy mode), the pinned lookup was never passed. This meant DNS resolution for origin servers behind an explicit proxy bypassed the pinned hostname check, potentially allowing DNS rebinding attacks.

## Root Cause
In `src/infra/net/ssrf.ts`, the explicit-proxy branch (lines 372-379) constructed `ProxyAgent` either with a plain URL string or with `{ uri, proxyTls }` — neither of which included the `requestTls` option needed to carry the pinned lookup function.

## Fix
- Always pass `requestTls: { lookup: pinned.lookup }` when constructing `ProxyAgent`
- This ensures origin server DNS resolution goes through the SSRF-safe pinned lookup for all three dispatcher modes (direct, env-proxy, explicit-proxy)
- Updated existing test to expect `requestTls` in the call
- Added new test verifying `requestTls` is passed even when `proxyTls` is absent

## Test Plan
- [x] Updated test: explicit proxy with `proxyTls` now expects `requestTls: { lookup }` 
- [x] Added test: explicit proxy without `proxyTls` also gets `requestTls: { lookup }`
- [x] Existing dispatcher tests still pass

Closes #46685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
