### PR TITLE
fix(plugins): warn when extensions are auto-discovered from workspace

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -702,6 +702,17 @@ export function discoverOpenClawPlugins(params: {
       diagnostics,
       seen,
     });
+    // Warn when workspace-local extensions are auto-discovered so operators
+    // know untrusted workspace code is being loaded (#46688).
+    const workspaceCandidates = candidates.filter((c) => c.origin === "workspace");
+    if (workspaceCandidates.length > 0) {
+      const names = workspaceCandidates.map((c) => c.pluginId).join(", ");
+      diagnostics.push({
+        level: "warn",
+        message: `workspace-local extensions auto-discovered from ${roots.workspace}: ${names}. Pin trust via plugins.allow or move to the global extensions directory.`,
+        source: roots.workspace,
+      });
+    }
   }
 
   if (roots.stock) {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -706,7 +706,7 @@ export function discoverOpenClawPlugins(params: {
     // know untrusted workspace code is being loaded (#46688).
     const workspaceCandidates = candidates.filter((c) => c.origin === "workspace");
     if (workspaceCandidates.length > 0) {
-      const names = workspaceCandidates.map((c) => c.pluginId).join(", ");
+      const names = workspaceCandidates.map((c) => c.idHint).join(", ");
       diagnostics.push({
         level: "warn",
         message: `workspace-local extensions auto-discovered from ${roots.workspace}: ${names}. Pin trust via plugins.allow or move to the global extensions directory.`,


### PR DESCRIPTION
## Summary
- Warn when extensions are auto-discovered from workspace-local paths

## Problem
Extensions in `workspace/.openclaw/extensions/` were silently loaded without any diagnostic message. Operators had no way to know that untrusted workspace-local code was being auto-discovered and executed, which is a security/UX concern.

## Root Cause
The `discoverOpenClawPlugins()` function in `discovery.ts` calls `discoverInDirectory()` for workspace extensions with `origin: "workspace"` but never emits a diagnostic to alert operators about the discovery.

## Fix
After workspace extension discovery, check if any candidates with `origin: "workspace"` were found. If so, push a `warn`-level diagnostic listing the discovered plugin IDs and advising operators to pin trust via `plugins.allow` or move extensions to the global directory.

## Test Plan
- [x] Verified the warning diagnostic is pushed only when workspace extensions are found
- [x] Verified the diagnostic includes plugin IDs and the source directory
- [x] Verified no warning is emitted when the workspace directory is empty or not configured

Closes #46688

🤖 Generated with [Claude Code](https://claude.com/claude-code)
