### PR TITLE
fix(telegram): increase dedup TTL to prevent duplicate messages on polling restart

### DIFF
--- a/extensions/telegram/src/bot-updates.ts
+++ b/extensions/telegram/src/bot-updates.ts
@@ -3,8 +3,11 @@ import { createDedupeCache } from "openclaw/plugin-sdk/infra-runtime";
 import type { TelegramContext } from "./bot/types.js";
 
 const MEDIA_GROUP_TIMEOUT_MS = 500;
-const RECENT_TELEGRAM_UPDATE_TTL_MS = 5 * 60_000;
-const RECENT_TELEGRAM_UPDATE_MAX = 2000;
+// Dedup cache TTL must survive the longest possible polling restart cycle
+// (backoff up to 30s × multiple attempts + 90s stall threshold + 15s grace).
+// 30 minutes keeps entries alive well past any realistic restart window (#46674).
+const RECENT_TELEGRAM_UPDATE_TTL_MS = 30 * 60_000;
+const RECENT_TELEGRAM_UPDATE_MAX = 5000;
 
 export type MediaGroupEntry = {
   messages: Array<{

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -177,8 +177,12 @@ export class TelegramPollingSession {
     }
     try {
       await bot.api.getUpdates({ offset: lastUpdateId + 1, limit: 1, timeout: 0 });
-    } catch {
+    } catch (err) {
       // Non-fatal: runner middleware still skips duplicates via shouldSkipUpdate.
+      // Log a warning so operators can diagnose duplicate-message issues (#46674).
+      this.opts.log(
+        `[telegram] failed to confirm persisted offset ${lastUpdateId}: ${formatErrorMessage(err)}; relying on dedup cache.`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Increase Telegram update dedup cache TTL from 5 to 30 minutes to prevent duplicate messages on polling restart
- Log a warning when offset confirmation fails

## Problem
When Telegram polling restarts (due to network errors, stalls, or conflict errors), already-processed messages can be re-delivered if:
1. The `confirmPersistedOffset()` call fails (silently caught)
2. The dedup cache entries have expired (5-minute TTL)

With the default backoff policy (up to 30s per attempt, 90s stall threshold, 15s grace period), a restart cycle can easily exceed 5 minutes, especially with multiple consecutive failures.

## Root Cause
- `RECENT_TELEGRAM_UPDATE_TTL_MS` was set to `5 * 60_000` (5 minutes), which is too short for extended restart cycles
- `confirmPersistedOffset()` failures were silently caught with no logging, making it hard to diagnose duplicate-message issues

## Fix
- Increase dedup cache TTL from 5 to 30 minutes (`30 * 60_000`)
- Increase max cache size from 2000 to 5000 to accommodate the longer TTL
- Add warning log when `confirmPersistedOffset()` fails, including the offset value and error message

## Test Plan
- [x] Verified the TTL increase covers all realistic restart scenarios
- [x] Verified the warning log includes actionable information (offset + error)
- [x] Existing Telegram tests still pass (offset-based `shouldSkipUpdate` logic is unchanged)

Closes #46674

🤖 Generated with [Claude Code](https://claude.com/claude-code)
