### PR TITLE
fix(sessions): reject empty provider/model IDs in model override selection

### DIFF
--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -92,6 +92,34 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.updatedAt).toBe(before);
   });
 
+  it("rejects empty provider or model IDs without mutating the entry", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-empty",
+      updatedAt: before,
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-6",
+    };
+
+    const emptyProvider = applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider: "", model: "gpt-5.2" },
+    });
+    expect(emptyProvider.updated).toBe(false);
+    expect(entry.providerOverride).toBe("anthropic");
+    expect(entry.modelOverride).toBe("claude-sonnet-4-6");
+    expect(entry.updatedAt).toBe(before);
+
+    const emptyModel = applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider: "openai", model: "  " },
+    });
+    expect(emptyModel.updated).toBe(false);
+    expect(entry.providerOverride).toBe("anthropic");
+    expect(entry.modelOverride).toBe("claude-sonnet-4-6");
+    expect(entry.updatedAt).toBe(before);
+  });
+
   it("clears stale contextTokens when switching back to the default model", () => {
     const before = Date.now() - 5_000;
     const entry: SessionEntry = {

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -17,6 +17,12 @@ export function applyModelOverrideToSessionEntry(params: {
   let updated = false;
   let selectionUpdated = false;
 
+  // Guard against empty/whitespace-only provider or model IDs that can result
+  // from truncated picker payloads or malformed directive parsing (#46700).
+  if (!selection.isDefault && (!selection.provider.trim() || !selection.model.trim())) {
+    return { updated: false };
+  }
+
   if (selection.isDefault) {
     if (entry.providerOverride) {
       delete entry.providerOverride;


### PR DESCRIPTION
## Summary

- Guard `applyModelOverrideToSessionEntry()` against empty/whitespace-only provider or model IDs
- Prevents corrupt session entries when model picker sends truncated payloads or directive parsing strips the identifier

## Problem

When a model override selection arrives with an empty `provider` or `model` string (e.g. from a truncated picker payload, a malformed `/model` directive, or a race during provider list refresh), `applyModelOverrideToSessionEntry()` happily writes the empty string into the session entry. This leaves the session in a broken state where:

1. The status bar shows no model info
2. Subsequent runs may fail with "model not found" from the provider API
3. The user must manually reset the session or switch models again to recover

**Root cause:** No input validation on the `selection.provider` and `selection.model` fields before persisting them.

## Fix

Added an early guard at the top of `applyModelOverrideToSessionEntry()` that rejects non-default selections with empty or whitespace-only provider/model IDs, returning `{ updated: false }` without mutating the entry.

## Test plan

- Added test case `rejects empty provider or model IDs without mutating the entry` covering both empty provider and whitespace-only model scenarios
- Verified existing tests still pass (5/5 green)
- `pnpm vitest run src/sessions/model-overrides.test.ts` — all pass

Closes #46700

🤖 Generated with [Claude Code](https://claude.com/claude-code)
