### PR TITLE
fix(macos): restore CronJob initializers for cron testing helpers

### DIFF
--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -254,6 +254,71 @@ struct CronJob: Identifiable, Codable, Equatable {
         case state
     }
 
+    init(
+        id: String,
+        agentId: String?,
+        name: String,
+        description: String?,
+        enabled: Bool,
+        deleteAfterRun: Bool?,
+        createdAtMs: Int,
+        updatedAtMs: Int,
+        schedule: CronSchedule,
+        sessionTarget: CronSessionTarget,
+        wakeMode: CronWakeMode,
+        payload: CronPayload,
+        delivery: CronDelivery?,
+        state: CronJobState)
+    {
+        self.init(
+            id: id,
+            agentId: agentId,
+            name: name,
+            description: description,
+            enabled: enabled,
+            deleteAfterRun: deleteAfterRun,
+            createdAtMs: createdAtMs,
+            updatedAtMs: updatedAtMs,
+            schedule: schedule,
+            sessionTargetRaw: sessionTarget.rawValue,
+            wakeMode: wakeMode,
+            payload: payload,
+            delivery: delivery,
+            state: state)
+    }
+
+    init(
+        id: String,
+        agentId: String?,
+        name: String,
+        description: String?,
+        enabled: Bool,
+        deleteAfterRun: Bool?,
+        createdAtMs: Int,
+        updatedAtMs: Int,
+        schedule: CronSchedule,
+        sessionTargetRaw: String,
+        wakeMode: CronWakeMode,
+        payload: CronPayload,
+        delivery: CronDelivery?,
+        state: CronJobState)
+    {
+        self.id = id
+        self.agentId = agentId
+        self.name = name
+        self.description = description
+        self.enabled = enabled
+        self.deleteAfterRun = deleteAfterRun
+        self.createdAtMs = createdAtMs
+        self.updatedAtMs = updatedAtMs
+        self.schedule = schedule
+        self.sessionTargetRaw = sessionTargetRaw
+        self.wakeMode = wakeMode
+        self.payload = payload
+        self.delivery = delivery
+        self.state = state
+    }
+
     /// Parsed session target (predefined or custom session ID)
     var parsedSessionTarget: CronCustomSessionTarget {
         CronCustomSessionTarget.from(self.sessionTargetRaw)


### PR DESCRIPTION
## Summary

- Problem: `CronJob` switched from `sessionTarget` to `private sessionTargetRaw`, which made the synthesized memberwise initializer inaccessible.
- Why it matters: macOS cron testing helpers (`CronSettings+Testing.swift`) and related smoke paths construct `CronJob(...)` directly and failed to compile.
- What changed: Added explicit internal `CronJob` initializers in `apps/macos/Sources/OpenClaw/CronModels.swift` for both `sessionTarget` and `sessionTargetRaw`.
- What did NOT change (scope boundary): No runtime cron scheduling logic, payload semantics, delivery behavior, or gateway protocol changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #16511

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Swift Package Manager (`apps/macos`)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build mac app package before fix (`cd apps/macos && swift build -q`).
2. Observe compile failure from `CronSettings+Testing.swift` when constructing `CronJob(...)`.
3. Add explicit `CronJob` initializers in `CronModels.swift`.
4. Rebuild and run cron-related tests.

### Expected

- `CronJob(...)` construction in testing helpers compiles.
- macOS package builds successfully.

### Actual

- Build succeeds after fix.
- Cron-related tests pass.

## Evidence

- [x] Failing build log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `cd apps/macos && swift build -q` passes.
  - `cd apps/macos && swift test --filter OpenClawIPCTests.Cron` passes.
  - `cd apps/macos && swift test --filter OpenClawIPCTests.SettingsViewSmokeTests` passes.
  - `cd apps/macos && swift test -q` was run locally.
- Edge cases checked:
  - Both initializer entry points are available (`sessionTarget` and `sessionTargetRaw`).
- What you did **not** verify:
  - Full repository CI matrix.
- Additional baseline note:
  - `swift test -q` currently reports existing failures in `ExecAllowlistTests`, `ExecSystemRunCommandValidatorTests`, and `CommandResolverTests`.
  - Checked latest `origin/main` and there are no newer commits touching those failing paths; this PR only changes `apps/macos/Sources/OpenClaw/CronModels.swift`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `apps/macos/Sources/OpenClaw/CronModels.swift`
- Known bad symptoms reviewers should watch for:
  - Reappearance of `CronJob(...)` compile errors in `CronSettings+Testing.swift` and cron smoke tests.

## Risks and Mitigations

- Risk: Explicit initializers could drift from stored properties if `CronJob` fields change in future.
- Mitigation: Keep initializers aligned with `CronJob` fields and rely on existing cron model/smoke tests to catch regressions.
