### PR TITLE
ACP: require admin scope for mutating internal actions

### DIFF
--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpRuntimeError } from "../../acp/runtime/errors.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 
 const hoisted = vi.hoisted(() => {
   const callGatewayMock = vi.fn();
@@ -372,6 +373,24 @@ function createFeishuDmParams(commandBody: string, cfg: OpenClawConfig = baseCfg
 
 async function runFeishuDmAcpCommand(commandBody: string, cfg: OpenClawConfig = baseCfg) {
   return handleAcpCommand(createFeishuDmParams(commandBody, cfg), true);
+}
+
+async function runInternalAcpCommand(params: {
+  commandBody: string;
+  scopes: string[];
+  cfg?: OpenClawConfig;
+}) {
+  const commandParams = buildCommandTestParams(params.commandBody, params.cfg ?? baseCfg, {
+    Provider: INTERNAL_MESSAGE_CHANNEL,
+    Surface: INTERNAL_MESSAGE_CHANNEL,
+    OriginatingChannel: INTERNAL_MESSAGE_CHANNEL,
+    OriginatingTo: "webchat:conversation-1",
+    GatewayClientScopes: params.scopes,
+  });
+  commandParams.command.channel = INTERNAL_MESSAGE_CHANNEL;
+  commandParams.command.senderId = "user-1";
+  commandParams.command.senderIsOwner = true;
+  return handleAcpCommand(commandParams, true);
 }
 
 describe("/acp command", () => {
@@ -822,6 +841,38 @@ describe("/acp command", () => {
       }),
     );
     expect(result?.reply?.text).toContain("Updated ACP runtime mode");
+  });
+
+  it("blocks mutating /acp actions for internal operator.write clients", async () => {
+    const result = await runInternalAcpCommand({
+      commandBody: "/acp set-mode plan",
+      scopes: ["operator.write"],
+    });
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("requires operator.admin");
+  });
+
+  it("keeps read-only /acp actions available to internal operator.write clients", async () => {
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
+      createAcpSessionEntry({
+        identity: {
+          state: "resolved",
+          source: "status",
+          acpxSessionId: "runtime-1",
+          agentSessionId: "session-1",
+          lastUpdatedAt: Date.now(),
+        },
+      }),
+    ]);
+
+    const result = await runInternalAcpCommand({
+      commandBody: "/acp sessions",
+      scopes: ["operator.write"],
+    });
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("ACP sessions");
   });
 
   it("updates ACP config options and keeps cwd local when using /acp set", async () => {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -875,6 +875,22 @@ describe("/acp command", () => {
     expect(result?.reply?.text).toContain("ACP sessions");
   });
 
+  it("allows mutating /acp actions for internal operator.admin clients", async () => {
+    mockBoundThreadSession();
+
+    const result = await runInternalAcpCommand({
+      commandBody: "/acp set-mode plan",
+      scopes: ["operator.admin"],
+    });
+
+    expect(hoisted.setModeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "plan",
+      }),
+    );
+    expect(result?.reply?.text).toContain("Updated ACP runtime mode");
+  });
+
   it("updates ACP config options and keeps cwd local when using /acp set", async () => {
     mockBoundThreadSession();
 

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -853,6 +853,16 @@ describe("/acp command", () => {
     expect(result?.reply?.text).toContain("requires operator.admin");
   });
 
+  it("blocks /acp status for internal operator.write clients", async () => {
+    const result = await runInternalAcpCommand({
+      commandBody: "/acp status",
+      scopes: ["operator.write"],
+    });
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("requires operator.admin");
+  });
+
   it("keeps read-only /acp actions available to internal operator.write clients", async () => {
     hoisted.listAcpSessionEntriesMock.mockResolvedValue([
       createAcpSessionEntry({

--- a/src/auto-reply/reply/commands-acp.ts
+++ b/src/auto-reply/reply/commands-acp.ts
@@ -1,4 +1,5 @@
 import { logVerbose } from "../../globals.js";
+import { requireGatewayClientScopeForInternalChannel } from "./command-gates.js";
 import {
   handleAcpDoctorAction,
   handleAcpInstallAction,
@@ -56,6 +57,20 @@ const ACP_ACTION_HANDLERS: Record<Exclude<AcpAction, "help">, AcpActionHandler> 
   sessions: async (params, tokens) => handleAcpSessionsAction(params, tokens),
 };
 
+const ACP_MUTATING_ACTIONS = new Set<AcpAction>([
+  "spawn",
+  "cancel",
+  "steer",
+  "close",
+  "set-mode",
+  "set",
+  "cwd",
+  "permissions",
+  "timeout",
+  "model",
+  "reset-options",
+]);
+
 export const handleAcpCommand: CommandHandler = async (params, allowTextCommands) => {
   if (!allowTextCommands) {
     return null;
@@ -76,6 +91,17 @@ export const handleAcpCommand: CommandHandler = async (params, allowTextCommands
   const action = resolveAcpAction(tokens);
   if (action === "help") {
     return stopWithText(resolveAcpHelpText());
+  }
+
+  if (ACP_MUTATING_ACTIONS.has(action)) {
+    const scopeBlock = requireGatewayClientScopeForInternalChannel(params, {
+      label: "/acp",
+      allowedScopes: ["operator.admin"],
+      missingText: "This /acp action requires operator.admin on the internal channel.",
+    });
+    if (scopeBlock) {
+      return scopeBlock;
+    }
   }
 
   const handler = ACP_ACTION_HANDLERS[action];

--- a/src/auto-reply/reply/commands-acp.ts
+++ b/src/auto-reply/reply/commands-acp.ts
@@ -62,6 +62,7 @@ const ACP_MUTATING_ACTIONS = new Set<AcpAction>([
   "cancel",
   "steer",
   "close",
+  "status",
   "set-mode",
   "set",
   "cwd",


### PR DESCRIPTION
## Summary
- require `operator.admin` for mutating `/acp` actions on the internal channel
- keep read-only `/acp` actions available to `operator.write` clients
- add focused coverage for the internal scope gate

## Verification
- pnpm test -- src/auto-reply/reply/commands-acp.test.ts
- pnpm tsgo
