### PR TITLE
macOS: restrict canvas agent actions to trusted surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Configure/startup: move outbound send-deps resolution into a lightweight helper so `openclaw configure` no longer stalls after the banner while eagerly loading channel plugins. (#46301) thanks @scoootscooob.
 - Zalo Personal/group gating: stop reapplying `dmPolicy.allowFrom` as a sender gate for already-allowlisted groups when `groupAllowFrom` is unset, so any member of an allowed group can trigger replies while DMs stay restricted. (#40146)
 - Plugins/install precedence: keep bundled plugins ahead of auto-discovered globals by default, but let an explicitly installed plugin record win its own duplicate-id tie so installed channel plugins load from `~/.openclaw/extensions` after `openclaw plugins install`.
+- macOS/canvas actions: keep unattended local agent actions on trusted in-app canvas surfaces only, and stop exposing the deep-link fallback key to arbitrary page scripts. Thanks @vincentkoc.
 
 ### Fixes
 

--- a/apps/macos/Sources/OpenClaw/CanvasA2UIActionMessageHandler.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasA2UIActionMessageHandler.swift
@@ -18,13 +18,10 @@ final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {
     func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
         guard Self.allMessageNames.contains(message.name) else { return }
 
-        // Only accept actions from local Canvas content (not arbitrary web pages).
+        // Only accept actions from the in-app canvas scheme. Local-network HTTP
+        // pages are regular web content and must not get direct agent dispatch.
         guard let webView = message.webView, let url = webView.url else { return }
-        if let scheme = url.scheme, CanvasScheme.allSchemes.contains(scheme) {
-            // ok
-        } else if Self.isLocalNetworkCanvasURL(url) {
-            // ok
-        } else {
+        guard let scheme = url.scheme, CanvasScheme.allSchemes.contains(scheme) else {
             return
         }
 
@@ -107,10 +104,5 @@ final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {
             }
         }
     }
-
-    static func isLocalNetworkCanvasURL(_ url: URL) -> Bool {
-        LocalNetworkURLSupport.isLocalNetworkHTTPURL(url)
-    }
-
     // Formatting helpers live in OpenClawKit (`OpenClawCanvasA2UIAction`).
 }

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -54,10 +54,15 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
         // expose unattended deep-link credentials to page JavaScript.
         canvasWindowLogger.debug("CanvasWindowController init building A2UI bridge script")
         let injectedSessionKey = sessionKey.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ?? "main"
+        let allowedSchemesJSON = (
+            try? String(
+                data: JSONSerialization.data(withJSONObject: CanvasScheme.allSchemes),
+                encoding: .utf8)
+        ) ?? "[]"
         let bridgeScript = """
         (() => {
           try {
-            const allowedSchemes = \(String(describing: CanvasScheme.allSchemes));
+            const allowedSchemes = \(allowedSchemesJSON);
             const protocol = location.protocol.replace(':', '');
             if (!allowedSchemes.includes(protocol)) return;
             if (globalThis.__openclawA2UIBridgeInstalled) return;

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -50,10 +50,9 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
 
         // Bridge A2UI "a2uiaction" DOM events back into the native agent loop.
         //
-        // Prefer WKScriptMessageHandler when WebKit exposes it, otherwise fall back to an unattended deep link
-        // (includes the app-generated key so it won't prompt).
+        // Keep the bridge on the trusted in-app canvas scheme only, and do not
+        // expose unattended deep-link credentials to page JavaScript.
         canvasWindowLogger.debug("CanvasWindowController init building A2UI bridge script")
-        let deepLinkKey = DeepLinkHandler.currentCanvasKey()
         let injectedSessionKey = sessionKey.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ?? "main"
         let bridgeScript = """
         (() => {
@@ -64,7 +63,6 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
             if (globalThis.__openclawA2UIBridgeInstalled) return;
             globalThis.__openclawA2UIBridgeInstalled = true;
 
-            const deepLinkKey = \(Self.jsStringLiteral(deepLinkKey));
             const sessionKey = \(Self.jsStringLiteral(injectedSessionKey));
             const machineName = \(Self.jsStringLiteral(InstanceIdentity.displayName));
             const instanceId = \(Self.jsStringLiteral(InstanceIdentity.instanceId));
@@ -104,24 +102,8 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
                   return;
                 }
 
-                const ctx = userAction.context ? (' ctx=' + JSON.stringify(userAction.context)) : '';
-                const message =
-                  'CANVAS_A2UI action=' + userAction.name +
-                  ' session=' + sessionKey +
-                  ' surface=' + userAction.surfaceId +
-                  ' component=' + (userAction.sourceComponentId || '-') +
-                  ' host=' + machineName.replace(/\\s+/g, '_') +
-                  ' instance=' + instanceId +
-                  ctx +
-                  ' default=update_canvas';
-                const params = new URLSearchParams();
-                params.set('message', message);
-                params.set('sessionKey', sessionKey);
-                params.set('thinking', 'low');
-                params.set('deliver', 'false');
-                params.set('channel', 'last');
-                params.set('key', deepLinkKey);
-                location.href = 'openclaw://agent?' + params.toString();
+                // Without the native handler, fail closed instead of exposing an
+                // unattended deep-link credential to page JavaScript.
               } catch {}
             }, true);
           } catch {}


### PR DESCRIPTION
## Summary

- Problem: the macOS canvas bridge still accepted page-provided deep-link fallback data outside the trusted in-app canvas surface.
- Why it matters: unattended local agent actions should only come from the native bridge path, not arbitrary page script fallback.
- What changed: removed the page-script deep-link fallback, stopped exposing the deep-link key to page JS, and limited accepted bridge origins to trusted canvas schemes.
- What did NOT change: normal native canvas message handling and trusted in-app canvas flows still work through the existing handler path.

## Change Type

- [x] Bug fix
- [x] UI / DX

## User-visible / Behavior Changes

- Canvas pages can no longer trigger the unattended agent fallback path through page-managed deep links.
- Trusted native canvas actions continue through the existing handler.

## Verification

### Environment

- OS: macOS source tree
- Runtime/container: local repo branch
- Integration/channel (if any): macOS app canvas bridge

### Steps

1. Review the canvas action bridge path in `apps/macos/Sources/OpenClaw/CanvasA2UIActionMessageHandler.swift` and `apps/macos/Sources/OpenClaw/CanvasWindowController.swift`.
2. Confirm that only trusted canvas schemes are accepted and that the page-level deep-link fallback is removed.
3. Confirm that native message-handler dispatch remains intact.

### Expected

- Untrusted page scripts cannot construct unattended local agent actions through the old fallback path.

### Actual

- The bridge now fails closed unless the trusted native message handler is available.

## Human Verification

- Verified scenarios: trusted canvas schemes still map into the native bridge path; page-managed fallback dispatch was removed.
- Edge cases checked: local-network HTTP URLs are no longer treated as trusted canvas origins.
- What I did not verify: no automated Swift test coverage was added for this bridge path yet.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: revert this PR.
- Known bad symptoms reviewers should watch for: canvas actions that depended on the removed page fallback would stop dispatching until moved onto the native bridge path.
