### PR TITLE
Device pairing: bind setup codes to node approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Configure/startup: move outbound send-deps resolution into a lightweight helper so `openclaw configure` no longer stalls after the banner while eagerly loading channel plugins. (#46301) thanks @scoootscooob.
 - Zalo Personal/group gating: stop reapplying `dmPolicy.allowFrom` as a sender gate for already-allowlisted groups when `groupAllowFrom` is unset, so any member of an allowed group can trigger replies while DMs stay restricted. (#40146)
 - Plugins/install precedence: keep bundled plugins ahead of auto-discovered globals by default, but let an explicitly installed plugin record win its own duplicate-id tie so installed channel plugins load from `~/.openclaw/extensions` after `openclaw plugins install`.
+- Device pairing/setup codes: bind setup-code pairing to the intended node role and scope set so approval keeps the expected device profile. Thanks @vincentkoc.
 
 ### Fixes
 

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -407,7 +407,12 @@ export default function register(api: OpenClawPluginApi) {
 
       const payload: SetupPayload = {
         url: urlResult.url,
-        bootstrapToken: (await issueDeviceBootstrapToken()).token,
+        bootstrapToken: (
+          await issueDeviceBootstrapToken({
+            role: "node",
+            scopes: [],
+          })
+        ).token,
       };
 
       if (action === "qr") {

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -43,6 +43,22 @@ describe("device bootstrap tokens", () => {
     });
   });
 
+  it("persists an intended role and scopes when requested", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({
+      baseDir,
+      role: "node",
+      scopes: [],
+    });
+
+    const raw = await fs.readFile(resolveBootstrapPath(baseDir), "utf8");
+    const parsed = JSON.parse(raw) as Record<string, { roles?: string[]; scopes?: string[] }>;
+    expect(parsed[issued.token]).toMatchObject({
+      roles: ["node"],
+      scopes: [],
+    });
+  });
+
   it("verifies valid bootstrap tokens once and deletes them after success", async () => {
     const baseDir = await createTempDir();
     const issued = await issueDeviceBootstrapToken({ baseDir });
@@ -196,6 +212,46 @@ describe("device bootstrap tokens", () => {
         deviceId: "device-123",
         publicKey: "public-key-123",
         role: "operator.admin",
+        scopes: ["operator.admin"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+  });
+
+  it("rejects a role that does not match the issued pairing profile", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({
+      baseDir,
+      role: "node",
+      scopes: [],
+    });
+
+    await expect(
+      verifyDeviceBootstrapToken({
+        token: issued.token,
+        deviceId: "device-123",
+        publicKey: "public-key-123",
+        role: "operator",
+        scopes: [],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+  });
+
+  it("rejects scopes that do not match the issued pairing profile", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({
+      baseDir,
+      role: "node",
+      scopes: [],
+    });
+
+    await expect(
+      verifyDeviceBootstrapToken({
+        token: issued.token,
+        deviceId: "device-123",
+        publicKey: "public-key-123",
+        role: "node",
         scopes: ["operator.admin"],
         baseDir,
       }),

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -238,6 +238,26 @@ describe("device bootstrap tokens", () => {
     ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
   });
 
+  it("accepts constrained tokens when the requested role and scopes match", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({
+      baseDir,
+      role: "node",
+      scopes: [],
+    });
+
+    await expect(
+      verifyDeviceBootstrapToken({
+        token: issued.token,
+        deviceId: "device-123",
+        publicKey: "public-key-123",
+        role: "node",
+        scopes: [],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
   it("rejects scopes that do not match the issued pairing profile", async () => {
     const baseDir = await createTempDir();
     const issued = await issueDeviceBootstrapToken({

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { normalizeDeviceAuthRole, normalizeDeviceAuthScopes } from "../shared/device-auth.js";
 import { resolvePairingPaths } from "./pairing-files.js";
 import {
   createAsyncLock,
@@ -63,16 +64,24 @@ async function persistState(state: DeviceBootstrapStateFile, baseDir?: string): 
 export async function issueDeviceBootstrapToken(
   params: {
     baseDir?: string;
+    role?: string;
+    scopes?: readonly string[];
   } = {},
 ): Promise<{ token: string; expiresAtMs: number }> {
   return await withLock(async () => {
     const state = await loadState(params.baseDir);
     const token = generatePairingToken();
     const issuedAtMs = Date.now();
+    const role = params.role?.trim();
+    const scopes = normalizeDeviceAuthScopes(
+      Array.isArray(params.scopes) ? [...params.scopes] : undefined,
+    );
     state[token] = {
       token,
       ts: issuedAtMs,
       issuedAtMs,
+      ...(role ? { roles: [normalizeDeviceAuthRole(role)] } : {}),
+      ...(scopes.length > 0 || Array.isArray(params.scopes) ? { scopes } : {}),
     };
     await persistState(state, params.baseDir);
     return { token, expiresAtMs: issuedAtMs + DEVICE_BOOTSTRAP_TOKEN_TTL_MS };
@@ -102,9 +111,25 @@ export async function verifyDeviceBootstrapToken(params: {
 
     const deviceId = params.deviceId.trim();
     const publicKey = params.publicKey.trim();
-    const role = params.role.trim();
+    const role = normalizeDeviceAuthRole(params.role);
+    const requestedScopes = normalizeDeviceAuthScopes([...params.scopes]);
     if (!deviceId || !publicKey || !role) {
       return { ok: false, reason: "bootstrap_token_invalid" };
+    }
+    const allowedRoles = Array.isArray(entry.roles)
+      ? entry.roles.map((value) => normalizeDeviceAuthRole(String(value))).filter(Boolean)
+      : [];
+    if (allowedRoles.length > 0 && !allowedRoles.includes(role)) {
+      return { ok: false, reason: "bootstrap_token_invalid" };
+    }
+    if (Array.isArray(entry.scopes)) {
+      const allowedScopes = normalizeDeviceAuthScopes(entry.scopes);
+      if (
+        allowedScopes.length !== requestedScopes.length ||
+        allowedScopes.some((value, index) => value !== requestedScopes[index])
+      ) {
+        return { ok: false, reason: "bootstrap_token_invalid" };
+      }
     }
 
     // Bootstrap setup codes are single-use. Consume the record before returning

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -124,6 +124,8 @@ export async function verifyDeviceBootstrapToken(params: {
     }
     if (Array.isArray(entry.scopes)) {
       const allowedScopes = normalizeDeviceAuthScopes(entry.scopes);
+      // Both arrays are normalized through normalizeDeviceAuthScopes, which
+      // sorts and deduplicates them before comparison.
       if (
         allowedScopes.length !== requestedScopes.length ||
         allowedScopes.some((value, index) => value !== requestedScopes[index])

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -400,6 +400,8 @@ export async function resolvePairingSetupFromConfig(
       bootstrapToken: (
         await issueDeviceBootstrapToken({
           baseDir: options.pairingBaseDir,
+          role: "node",
+          scopes: [],
         })
       ).token,
     },


### PR DESCRIPTION
## Summary

- Problem: setup-code pairing did not bind the issued code to the intended node role and scope set.
- Why it matters: approval should preserve the intended pairing profile instead of accepting a wider role/scope request later in the flow.
- What changed: setup-code issuance now records the intended role and scopes, and bootstrap verification rejects mismatches.
- What did NOT change: the existing pairing flow, token lifetime, and approval UI flow remain the same.

## Change Type

- [x] Bug fix
- [x] Auth / tokens

## User-visible / Behavior Changes

- Setup-code pairing now preserves the intended node profile through verification.
- Mismatched role or scope requests are rejected instead of being accepted under the same setup code.

## Verification

- `pnpm test -- src/infra/device-bootstrap.test.ts`

## Human Verification

- Verified scenarios: matching node role/scope requests succeed; mismatched role and scope requests fail.
- Edge cases checked: empty scope lists are preserved and compared consistently.
- What I did not verify: no live device-pair approval session was exercised in this branch.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: revert this PR.
- Known bad symptoms reviewers should watch for: setup-code pairing requests failing after the requester asks for a different role or scope than the issued code allows.
