### PR TITLE
perf: add contextInjection option to skip workspace re-injection (#9157)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1424,16 +1424,26 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
-      await resolveBootstrapContextForRun({
-        workspaceDir: effectiveWorkspace,
-        config: params.config,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
-        contextMode: params.bootstrapContextMode,
-        runKind: params.bootstrapContextRunKind,
-      });
+    // When contextInjection is "first-message-only", skip re-injecting workspace
+    // files on subsequent messages to reduce token waste by ~93% (#9157).
+    const contextInjection = params.config?.agents?.defaults?.contextInjection ?? "always";
+    const skipContextInjection =
+      contextInjection === "first-message-only" &&
+      (await fs
+        .stat(params.sessionFile)
+        .then(() => true)
+        .catch(() => false));
+    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } = skipContextInjection
+      ? { bootstrapFiles: [], contextFiles: [] }
+      : await resolveBootstrapContextForRun({
+          workspaceDir: effectiveWorkspace,
+          config: params.config,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+          contextMode: params.bootstrapContextMode,
+          runKind: params.bootstrapContextRunKind,
+        });
     const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
     const bootstrapAnalysis = analyzeBootstrapBudget({

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -136,6 +136,14 @@ export type AgentDefaultsConfig = {
   repoRoot?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
   skipBootstrap?: boolean;
+  /**
+   * Controls when workspace context files (AGENTS.md, SOUL.md, etc.) are
+   * injected into the system prompt:
+   * - always: inject on every message (current default, backwards-compatible)
+   * - first-message-only: inject only on the first message of a session,
+   *   reducing token costs by ~93% for multi-message conversations
+   */
+  contextInjection?: "always" | "first-message-only";
   /** Max chars for injected bootstrap files before truncation (default: 20000). */
   bootstrapMaxChars?: number;
   /** Max total chars across all injected bootstrap files (default: 150000). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -38,6 +38,7 @@ export const AgentDefaultsSchema = z
     workspace: z.string().optional(),
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
+    contextInjection: z.union([z.literal("always"), z.literal("first-message-only")]).optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
     bootstrapPromptTruncationWarning: z


### PR DESCRIPTION
## Summary

Fixes #9157 — workspace files (AGENTS.md, SOUL.md, USER.md, etc.) are re-injected into the system prompt on **every single message**, wasting ~35,600 tokens per turn (~93.5% of the token budget).

**The fix:** Add a `contextInjection` config option under `agents.defaults`:

```json
{
  "agents": {
    "defaults": {
      "contextInjection": "first-message-only"
    }
  }
}
```

- `"always"` (default): current behavior — zero breaking changes
- `"first-message-only"`: skip workspace file injection when the session file already exists

## Measured impact (from issue reporter)

| Message | Without fix | With fix |
|---------|------------|----------|
| #1 | 8,260 tokens (cache write) | 8,260 tokens (same) |
| #2 | 8,260 tokens (re-injected) | 1,488 tokens (new content only) |
| #3+ | 8,260 tokens (re-injected) | ~1,500 tokens (cached) |

**~93% token reduction** over a conversation. ~$1.51 saved per 100-message session.

## Changes

- `src/agents/pi-embedded-runner/run/attempt.ts`: Check session file existence + config before calling `resolveBootstrapContextForRun`
- `src/config/types.agent-defaults.ts`: Add `contextInjection` type
- `src/config/zod-schema.agent-defaults.ts`: Add Zod validation

## Test plan

- [x] All existing tests pass (6 pre-existing failures in `attempt.spawn-workspace.test.ts` — same on `main`)
- [x] Lint and format clean
- [x] Default `"always"` preserves current behavior — zero breaking changes
- [ ] Manual: Set `contextInjection: "first-message-only"` → verify workspace files injected on msg 1, skipped on msg 2+
- [ ] Manual: Verify agent can still `read` workspace files on subsequent messages

## Related

- Closes #9157 (12 thumbs-up, 12 comments)
- Supersedes closed PR #28072