### PR TITLE
fix(whatsapp): use globalThis for active-listener singleton to survive chunk splitting

### DIFF
--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -28,11 +28,6 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-// Use globalThis to ensure a single shared instance across bundled chunks.
-// The bundler may duplicate this module into multiple output files, and each
-// copy would get its own module-scoped Map — causing setActiveWebListener
-// (in chunk A) to register a listener that requireActiveWebListener (in chunk B)
-// cannot find. Storing on globalThis avoids this.
 const GLOBAL_KEY = "__openclaw_whatsapp_listeners__" as const;
 
 type ListenerGlobals = {

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -28,9 +28,25 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-let _currentListener: ActiveWebListener | null = null;
+// Use globalThis to ensure a single shared instance across bundled chunks.
+// The bundler may duplicate this module into multiple output files, and each
+// copy would get its own module-scoped Map — causing setActiveWebListener
+// (in chunk A) to register a listener that requireActiveWebListener (in chunk B)
+// cannot find. Storing on globalThis avoids this.
+const GLOBAL_KEY = "__openclaw_whatsapp_listeners__" as const;
+const GLOBAL_CURRENT_KEY = "__openclaw_whatsapp_current_listener__" as const;
 
-const listeners = new Map<string, ActiveWebListener>();
+type ListenerGlobals = {
+  [GLOBAL_KEY]?: Map<string, ActiveWebListener>;
+  [GLOBAL_CURRENT_KEY]?: ActiveWebListener | null;
+};
+
+const g = globalThis as unknown as ListenerGlobals;
+if (!g[GLOBAL_KEY]) {
+  g[GLOBAL_KEY] = new Map<string, ActiveWebListener>();
+}
+
+const listeners = g[GLOBAL_KEY];
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;
@@ -74,7 +90,7 @@ export function setActiveWebListener(
     listeners.set(id, listener);
   }
   if (id === DEFAULT_ACCOUNT_ID) {
-    _currentListener = listener;
+    g[GLOBAL_CURRENT_KEY] = listener;
   }
 }
 

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -34,19 +34,13 @@ export type ActiveWebListener = {
 // (in chunk A) to register a listener that requireActiveWebListener (in chunk B)
 // cannot find. Storing on globalThis avoids this.
 const GLOBAL_KEY = "__openclaw_whatsapp_listeners__" as const;
-const GLOBAL_CURRENT_KEY = "__openclaw_whatsapp_current_listener__" as const;
 
 type ListenerGlobals = {
   [GLOBAL_KEY]?: Map<string, ActiveWebListener>;
-  [GLOBAL_CURRENT_KEY]?: ActiveWebListener | null;
 };
 
 const g = globalThis as unknown as ListenerGlobals;
-if (!g[GLOBAL_KEY]) {
-  g[GLOBAL_KEY] = new Map<string, ActiveWebListener>();
-}
-
-const listeners = g[GLOBAL_KEY];
+const listeners = (g[GLOBAL_KEY] ??= new Map<string, ActiveWebListener>());
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;
@@ -88,9 +82,6 @@ export function setActiveWebListener(
     listeners.delete(id);
   } else {
     listeners.set(id, listener);
-  }
-  if (id === DEFAULT_ACCOUNT_ID) {
-    g[GLOBAL_CURRENT_KEY] = listener;
   }
 }
 


### PR DESCRIPTION
## Problem

The bundler may split `active-listener.ts` into multiple output chunks. When this happens, `setActiveWebListener` (in chunk A) and `requireActiveWebListener` (in chunk B) each get their own module-scoped `Map` / variable — so a listener registered by one function is invisible to the other.

This causes **subagent announce delivery to fail silently**: the gateway registers the WhatsApp listener on connect, but the announce code path resolves a different (empty) `Map` and throws `No active WhatsApp Web listener`, dropping the proactive message.

### Symptoms
- Subagent tasks complete successfully but the announcement never arrives on WhatsApp
- Gateway logs show `No active WhatsApp Web listener` errors during proactive delivery
- Restarting the gateway temporarily fixes it (until chunks diverge again)

## Fix

Store the listeners `Map` and current-listener reference on `globalThis` behind well-namespaced keys (`__openclaw_whatsapp_listeners__`, `__openclaw_whatsapp_current_listener__`), so all chunks share a single instance regardless of how the bundler splits the module.

This is the standard pattern for singleton state in bundled environments.

## Key phrase
lobster-biscuit