### PR TITLE
docs: add zh-CN Agent Bootstrapping doc

### DIFF
--- a/docs/zh-CN/start/bootstrapping.md
+++ b/docs/zh-CN/start/bootstrapping.md
@@ -1,9 +1,35 @@
 ---
-summary: 智能体引导流程：首次运行时如何初始化工作区与身份文件
-title: 智能体引导
-sidebarTitle: 引导
+summary: "智能体引导流程：初始化工作区并写入身份文件的首次运行仪式"
+read_when:
+  - 了解智能体首次运行时会发生什么
+  - 说明引导文件存放在哪里
+  - 调试 onboarding 身份初始化
+title: "智能体引导"
+sidebarTitle: "引导"
 ---
 
 # 智能体引导
 
-该页面是英文文档的中文占位版本，完整内容请先参考英文版：[Agent Bootstrapping](/start/bootstrapping)。
+引导是智能体的**首次运行**仪式，用来准备工作区并收集身份信息。它发生在 onboarding 之后，也就是智能体第一次启动时。
+
+## 引导会做什么
+
+在智能体第一次运行时，OpenClaw 会对工作区进行引导（默认是 `~/.openclaw/workspace`）：
+
+- 初始化 `AGENTS.md`、`BOOTSTRAP.md`、`IDENTITY.md`、`USER.md`
+- 运行一个简短的问答流程（一次只问一个问题）
+- 将身份信息和偏好写入 `IDENTITY.md`、`USER.md`、`SOUL.md`
+- 完成后删除 `BOOTSTRAP.md`，确保这个流程只运行一次
+
+## 它在哪里运行
+
+引导始终运行在**网关主机**上。如果 macOS app 连接到远程 Gateway，那么工作区和引导文件也会位于那台远程机器上。
+
+<Note>
+当 Gateway 运行在另一台机器上时，请在网关主机上编辑工作区文件，例如 `user@gateway-host:~/.openclaw/workspace`。
+</Note>
+
+## 相关文档
+
+- macOS app onboarding：[Onboarding](/start/onboarding)
+- 工作区布局：[Agent workspace](/concepts/agent-workspace)


### PR DESCRIPTION
## Summary

- Problem: `docs/zh-CN/start/bootstrapping.md` was still a Chinese placeholder page instead of a translated document.
- Why it matters: Chinese readers could not access the actual `Agent Bootstrapping` guidance in their locale.
- What changed: replaced the placeholder with a translated version of the current English `Agent Bootstrapping` doc, including frontmatter, first-run behavior, runtime location, and related links.
- What did NOT change (scope boundary): no English docs, code, or other translated pages were changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Chinese readers now have a full translated `Agent Bootstrapping` page instead of a placeholder.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): Docs / Mintlify markdown
- Relevant config (redacted): N/A

### Steps

1. Open `docs/start/bootstrapping.md` and `docs/zh-CN/start/bootstrapping.md`.
2. Confirm the Chinese page is only a placeholder.
3. Translate and align the Chinese page with the current English source.

### Expected

- The Chinese doc should contain the same user-facing guidance as the English bootstrapping page.

### Actual

- After the edit, the Chinese page now contains the full translated content.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: compared the English and Chinese pages and previewed the updated Chinese content locally.
- Edge cases checked: kept the change scoped to the single placeholder page.
- What you did **not** verify: full docs build and the generated zh-CN pipeline were not run because this was a targeted manual doc completion.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `a0e2dcf`.
- Files/config to restore: `docs/zh-CN/start/bootstrapping.md`
- Known bad symptoms reviewers should watch for: none beyond translation drift.

## Risks and Mitigations

- Risk: translation wording may differ from a future generated zh-CN pass.
  - Mitigation: content is now present and aligned to the current English source; future i18n runs can normalize wording if needed.
