### PR TITLE
fix(plugins): route send-deps imports through plugin-sdk for Docker compat

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -1,3 +1,4 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk";
 import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   buildAccountScopedDmSecurityPolicy,
@@ -37,7 +38,6 @@ import {
   type ChannelPlugin,
   type ResolvedDiscordAccount,
 } from "openclaw/plugin-sdk/discord";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { getDiscordRuntime } from "./runtime.js";
 
 type DiscordSendFn = ReturnType<

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -1,8 +1,8 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk";
 import { sendTextMediaPayload } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import type { OutboundIdentity } from "../../../src/infra/outbound/identity.js";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { getThreadBindingManager, type ThreadBindingRecord } from "./monitor/thread-bindings.js";
 import { normalizeDiscordOutboundTarget } from "./normalize.js";
 import { sendMessageDiscord, sendPollDiscord, sendWebhookMessageDiscord } from "./send.js";

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -1,3 +1,4 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk";
 import {
   buildAccountScopedDmSecurityPolicy,
   collectAllowlistProviderRestrictSendersWarnings,
@@ -29,7 +30,6 @@ import {
   type ChannelPlugin,
   type ResolvedIMessageAccount,
 } from "openclaw/plugin-sdk/imessage";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { buildPassiveProbedChannelStatusSummary } from "../../shared/channel-status-summary.js";
 import { getIMessageRuntime } from "./runtime.js";
 

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -1,5 +1,5 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/matrix";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { sendMessageMatrix, sendPollMatrix } from "./matrix/send.js";
 import { getMatrixRuntime } from "./runtime.js";
 

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -1,5 +1,5 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/msteams";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { createMSTeamsPollStoreFs } from "./polls.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMessageMSTeams, sendPollMSTeams } from "./send.js";

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -1,3 +1,4 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk";
 import {
   buildAccountScopedDmSecurityPolicy,
   createScopedAccountConfigAccessors,
@@ -30,7 +31,6 @@ import {
   type ChannelPlugin,
   type ResolvedSignalAccount,
 } from "openclaw/plugin-sdk/signal";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { getSignalRuntime } from "./runtime.js";
 
 const signalMessageActions: ChannelMessageActionAdapter = {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -1,3 +1,4 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk";
 import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   buildAccountScopedDmSecurityPolicy,
@@ -38,7 +39,6 @@ import {
   type ChannelPlugin,
   type ResolvedSlackAccount,
 } from "openclaw/plugin-sdk/slack";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { buildPassiveProbedChannelStatusSummary } from "../../shared/channel-status-summary.js";
 import { getSlackRuntime } from "./runtime.js";
 

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1,3 +1,4 @@
+import { type OutboundSendDeps, resolveOutboundSendDep } from "openclaw/plugin-sdk";
 import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   collectAllowlistProviderGroupPolicyWarnings,
@@ -40,10 +41,6 @@ import {
   type ResolvedTelegramAccount,
   type TelegramProbe,
 } from "openclaw/plugin-sdk/telegram";
-import {
-  type OutboundSendDeps,
-  resolveOutboundSendDep,
-} from "../../../src/infra/outbound/send-deps.js";
 import { getTelegramRuntime } from "./runtime.js";
 
 type TelegramSendFn = ReturnType<

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -1,13 +1,10 @@
+import { resolveOutboundSendDep, type OutboundSendDeps } from "openclaw/plugin-sdk";
 import type { ReplyPayload } from "../../../src/auto-reply/types.js";
 import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequence,
 } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
-import {
-  resolveOutboundSendDep,
-  type OutboundSendDeps,
-} from "../../../src/infra/outbound/send-deps.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { markdownToTelegramHtmlChunks } from "./format.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -1,8 +1,8 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk";
 import { chunkText } from "../../../src/auto-reply/chunk.js";
 import { sendTextMediaPayload } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
 import { shouldLogVerbose } from "../../../src/globals.js";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { resolveWhatsAppOutboundTarget } from "../../../src/whatsapp/resolve-outbound-target.js";
 import { sendMessageWhatsApp, sendPollWhatsApp } from "./send.js";
 

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -617,6 +617,8 @@ export type { HookEntry } from "../hooks/types.js";
 export { clamp, escapeRegExp, normalizeE164, safeParseJson, sleep } from "../utils.js";
 export { stripAnsi } from "../terminal/ansi.js";
 export { missingTargetError } from "../infra/outbound/target-errors.js";
+export { resolveOutboundSendDep } from "../infra/outbound/send-deps.js";
+export type { OutboundSendDeps } from "../infra/outbound/send-deps.js";
 export { registerLogTransport } from "../logging/logger.js";
 export type { LogTransport, LogTransportRecord } from "../logging/logger.js";
 export {


### PR DESCRIPTION
## Summary
- #46301 extracted `resolveOutboundSendDep` into `src/infra/outbound/send-deps.ts` but kept raw relative `../../../src/` imports in all 10 extension files. In Docker multi-stage builds the final image only ships `dist/`, so the `src/` path doesn't resolve at runtime.
- Export `resolveOutboundSendDep` and `OutboundSendDeps` from `openclaw/plugin-sdk` and update all extension imports to use the SDK path.

Fixes #46609
Fixes #46443

## Test plan
- [x] `pnpm build` passes (plugin-sdk DTS + bundle include the new export)
- [x] Verified `resolveOutboundSendDep` appears in `dist/plugin-sdk/index.js` built output
- [x] All 10 extension files updated, no remaining `send-deps.js` relative imports