### PR TITLE
fix(release): block oversized npm packs that regress low-memory startup

### DIFF
--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -251,17 +251,28 @@ function formatPackUnpackedSizeBudgetError(params: {
 }
 
 export function collectPackUnpackedSizeErrors(results: Iterable<PackResult>): string[] {
+  const entries = Array.from(results);
   const errors: string[] = [];
-  for (const [index, entry] of Array.from(results).entries()) {
+  let checkedCount = 0;
+
+  for (const [index, entry] of entries.entries()) {
     if (typeof entry.unpackedSize !== "number" || !Number.isFinite(entry.unpackedSize)) {
       continue;
     }
+    checkedCount += 1;
     if (entry.unpackedSize <= npmPackUnpackedSizeBudgetBytes) {
       continue;
     }
     const label = resolvePackResultLabel(entry, index);
     errors.push(formatPackUnpackedSizeBudgetError({ label, unpackedSize: entry.unpackedSize }));
   }
+
+  if (entries.length > 0 && checkedCount === 0) {
+    errors.push(
+      "npm pack --dry-run produced no unpackedSize data; pack size budget was not verified.",
+    );
+  }
+
   return errors;
 }
 

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -15,7 +15,7 @@ import { sparkleBuildFloorsFromShortVersion, type SparkleBuildFloors } from "./s
 export { collectBundledExtensionManifestErrors } from "./lib/bundled-extension-manifest.ts";
 
 type PackFile = { path: string };
-type PackResult = { files?: PackFile[] };
+type PackResult = { files?: PackFile[]; filename?: string; unpackedSize?: number };
 
 const requiredPathGroups = [
   ["dist/index.js", "dist/index.mjs"],
@@ -112,6 +112,10 @@ const requiredPathGroups = [
   "dist/build-info.json",
 ];
 const forbiddenPrefixes = ["dist/OpenClaw.app/"];
+// 2026.3.12 ballooned to ~213.6 MiB unpacked and correlated with low-memory
+// startup/doctor OOM reports. Keep enough headroom for the current pack while
+// failing fast if duplicate/shim content sneaks back into the release artifact.
+const npmPackUnpackedSizeBudgetBytes = 160 * 1024 * 1024;
 const appcastPath = resolve("appcast.xml");
 const laneBuildMin = 1_000_000_000;
 const laneFloorAdoptionDateKey = 20260227;
@@ -226,6 +230,39 @@ export function collectForbiddenPackPaths(paths: Iterable<string>): string[] {
         /(^|\/)node_modules\//.test(path),
     )
     .toSorted();
+}
+
+function formatMiB(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function resolvePackResultLabel(entry: PackResult, index: number): string {
+  return entry.filename?.trim() || `pack result #${index + 1}`;
+}
+
+function formatPackUnpackedSizeBudgetError(params: {
+  label: string;
+  unpackedSize: number;
+}): string {
+  return [
+    `${params.label} unpackedSize ${params.unpackedSize} bytes (${formatMiB(params.unpackedSize)}) exceeds budget ${npmPackUnpackedSizeBudgetBytes} bytes (${formatMiB(npmPackUnpackedSizeBudgetBytes)}).`,
+    "Investigate duplicate channel shims, copied extension trees, or other accidental pack bloat before release.",
+  ].join(" ");
+}
+
+export function collectPackUnpackedSizeErrors(results: Iterable<PackResult>): string[] {
+  const errors: string[] = [];
+  for (const [index, entry] of Array.from(results).entries()) {
+    if (typeof entry.unpackedSize !== "number" || !Number.isFinite(entry.unpackedSize)) {
+      continue;
+    }
+    if (entry.unpackedSize <= npmPackUnpackedSizeBudgetBytes) {
+      continue;
+    }
+    const label = resolvePackResultLabel(entry, index);
+    errors.push(formatPackUnpackedSizeBudgetError({ label, unpackedSize: entry.unpackedSize }));
+  }
+  return errors;
 }
 
 function checkPluginVersions() {
@@ -433,8 +470,9 @@ function main() {
     })
     .toSorted();
   const forbidden = collectForbiddenPackPaths(paths);
+  const sizeErrors = collectPackUnpackedSizeErrors(results);
 
-  if (missing.length > 0 || forbidden.length > 0) {
+  if (missing.length > 0 || forbidden.length > 0 || sizeErrors.length > 0) {
     if (missing.length > 0) {
       console.error("release-check: missing files in npm pack:");
       for (const path of missing) {
@@ -445,6 +483,12 @@ function main() {
       console.error("release-check: forbidden files in npm pack:");
       for (const path of forbidden) {
         console.error(`  - ${path}`);
+      }
+    }
+    if (sizeErrors.length > 0) {
+      console.error("release-check: npm pack unpacked size budget exceeded:");
+      for (const error of sizeErrors) {
+        console.error(`  - ${error}`);
       }
     }
     process.exit(1);

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -183,4 +183,15 @@ describe("collectPackUnpackedSizeErrors", () => {
       "openclaw-2026.3.12.tgz unpackedSize 224002564 bytes (213.6 MiB) exceeds budget 167772160 bytes (160.0 MiB). Investigate duplicate channel shims, copied extension trees, or other accidental pack bloat before release.",
     ]);
   });
+
+  it("fails closed when npm pack output omits unpackedSize for every result", () => {
+    expect(
+      collectPackUnpackedSizeErrors([
+        { filename: "openclaw-2026.3.14.tgz" },
+        { filename: "openclaw-extra.tgz", unpackedSize: Number.NaN },
+      ]),
+    ).toEqual([
+      "npm pack --dry-run produced no unpackedSize data; pack size budget was not verified.",
+    ]);
+  });
 });

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -4,10 +4,15 @@ import {
   collectBundledExtensionManifestErrors,
   collectBundledExtensionRootDependencyGapErrors,
   collectForbiddenPackPaths,
+  collectPackUnpackedSizeErrors,
 } from "../scripts/release-check.ts";
 
 function makeItem(shortVersion: string, sparkleVersion: string): string {
   return `<item><title>${shortVersion}</title><sparkle:shortVersionString>${shortVersion}</sparkle:shortVersionString><sparkle:version>${sparkleVersion}</sparkle:version></item>`;
+}
+
+function makePackResult(filename: string, unpackedSize: number) {
+  return { filename, unpackedSize };
 }
 
 describe("collectAppcastSparkleVersionErrors", () => {
@@ -161,5 +166,21 @@ describe("collectForbiddenPackPaths", () => {
         "node_modules/.bin/openclaw",
       ]),
     ).toEqual(["extensions/tlon/node_modules/.bin/tlon", "node_modules/.bin/openclaw"]);
+  });
+});
+
+describe("collectPackUnpackedSizeErrors", () => {
+  it("accepts pack results within the unpacked size budget", () => {
+    expect(
+      collectPackUnpackedSizeErrors([makePackResult("openclaw-2026.3.14.tgz", 120_354_302)]),
+    ).toEqual([]);
+  });
+
+  it("flags oversized pack results that risk low-memory startup failures", () => {
+    expect(
+      collectPackUnpackedSizeErrors([makePackResult("openclaw-2026.3.12.tgz", 224_002_564)]),
+    ).toEqual([
+      "openclaw-2026.3.12.tgz unpackedSize 224002564 bytes (213.6 MiB) exceeds budget 167772160 bytes (160.0 MiB). Investigate duplicate channel shims, copied extension trees, or other accidental pack bloat before release.",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: during the #45962 window, the published npm artifact jumped from `133,372,429` bytes unpacked in `2026.3.8` to `224,002,564` bytes in `2026.3.12`.
- Why it matters: the increase was concentrated in built output, especially `dist/plugin-sdk` (`~44.4 MiB` -> `~136.7 MiB`), which is a strong release-time signal that we shipped a much larger bundled graph than intended.
- What changed: add a `pnpm release:check` budget for `npm pack --dry-run` unpacked size, with a fail-closed path if npm omits size metadata and an error message that points at likely causes such as duplicate channel shims or copied extension trees.
- Scope boundary: this PR does not claim to be the runtime root-cause fix for #45962; it hardens an existing CI/release gate so this artifact regression class is easier to catch before shipping.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #45962

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.17.1, pnpm 10
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): none

### Steps

1. Compare published npm metadata for `openclaw@2026.3.8` and `openclaw@2026.3.12`.
2. Add a release-check guard that fails when `npm pack --dry-run` exceeds a budget.
3. Verify the guard with both a healthy fixture and the oversized historical fixture.
4. Verify the check fails closed if `npm pack --dry-run --json` returns no finite `unpackedSize` values.
5. Run the real release check against the current artifact.

### Expected

- Oversized npm artifacts fail `pnpm release:check` before release.
- Missing size metadata does not silently bypass the guard.
- Current artifact stays under budget.

### Actual

- Added a 160 MiB unpacked-size budget to `scripts/release-check.ts`.
- Added a fail-closed error when `npm pack --dry-run --json` returns results but none include finite `unpackedSize` data.
- Current local pack is `96,056,886` bytes unpacked, so the guard passes with headroom.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- test/release-check.test.ts`
  - `pnpm build`
  - `pnpm release:check`
  - `npm pack --dry-run --json --ignore-scripts`
- Edge cases checked:
  - oversized `2026.3.12`-sized fixture fails
  - missing-size fixture fails closed
  - current-size fixture passes
- What you did **not** verify:
  - I did not reproduce the original OOM on a 2 GB host in this PR

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or raise/remove the budget in `scripts/release-check.ts`
- Files/config to restore: `scripts/release-check.ts`, `test/release-check.test.ts`
- Known bad symptoms reviewers should watch for: false-positive CI failures if the package legitimately grows past the budget

## Risks and Mitigations

- Risk: the budget could become too strict if the release artifact grows for legitimate reasons.
  - Mitigation: the threshold has substantial headroom over the current artifact and the failure message points at likely regression sources.
