### PR TITLE
fix: update haiku model aliases to claude-haiku-4-5 to avoid deprecated 404 (closes #26018)

### DIFF
--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -28,9 +28,9 @@ const CLAUDE_MODEL_ALIASES: Record<string, string> = {
   "claude-sonnet-4-5": "sonnet",
   "claude-sonnet-4-1": "sonnet",
   "claude-sonnet-4-0": "sonnet",
-  haiku: "haiku",
-  "haiku-3.5": "haiku",
-  "claude-haiku-3-5": "haiku",
+  haiku: "claude-haiku-4-5",
+  "haiku-3.5": "claude-haiku-4-5",
+  "claude-haiku-3-5": "claude-haiku-4-5",
 };
 
 const CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG = "--dangerously-skip-permissions";

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -22,6 +22,7 @@ const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   // Anthropic (pi-ai catalog uses "latest" ids without date suffix)
   opus: "anthropic/claude-opus-4-6",
   sonnet: "anthropic/claude-sonnet-4-6",
+  haiku: "anthropic/claude-haiku-4-5",
 
   // OpenAI
   gpt: "openai/gpt-5.4",


### PR DESCRIPTION
## Summary

- Problem: The "haiku" model alias in `CLAUDE_MODEL_ALIASES` resolves to the bare string `"haiku"`, which Anthropic server-side maps to the deprecated snapshot `claude-3-5-haiku-20241022`, returning HTTP 404 on every request.
- Why it matters: Every bot response using the haiku alias is fully broken — users see a 404 error instead of a reply.
- What changed: Updated all three haiku alias values in `CLAUDE_MODEL_ALIASES` (`src/agents/cli-backends.ts`) from `"haiku"` to `"claude-haiku-4-5"`. Added `haiku: "anthropic/claude-haiku-4-5"` to `DEFAULT_MODEL_ALIASES` (`src/config/defaults.ts`) for gateway-level resolution.
- What did NOT change (scope boundary): No other model aliases were modified. The opus/sonnet aliases remain unchanged. No test files were modified.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #26018

## User-visible / Behavior Changes

Users who specify `haiku`, `haiku-3.5`, or `claude-haiku-3-5` as their model will now correctly route to `claude-haiku-4-5` instead of the deprecated `claude-3-5-haiku-20241022` that returns 404.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js
- Model/provider: Anthropic
- Integration/channel: Any channel using haiku alias

### Steps

1. Configure openclaw with model alias "haiku"
2. Send a message through the gateway
3. Observe the HTTP 404 error from Anthropic API

### Expected

- Request routes to `claude-haiku-4-5` and returns a valid response

### Actual

- Request resolves to deprecated `claude-3-5-haiku-20241022` and returns HTTP 404

## Evidence

- [x] Failing test/log before + passing after

All 13 related tests pass (`cli-backends.test.ts`: 6 tests, `model-alias-defaults.test.ts`: 7 tests).

## Human Verification (required)

- Verified scenarios: `pnpm tsgo` type check passes with no new errors; `pnpm format:fix` clean; oxlint clean on changed files; all related tests pass
- Edge cases checked: All three haiku alias variants (haiku, haiku-3.5, claude-haiku-3-5) are updated consistently
- What you did **not** verify: Runtime end-to-end testing with actual Anthropic API

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: `src/agents/cli-backends.ts`, `src/config/defaults.ts`
- Known bad symptoms reviewers should watch for: Model resolution failures for haiku aliases

## Risks and Mitigations

None