### PR TITLE
fix: update Ollama embedding provider to use /api/embed endpoint (closes #39983)

### DIFF
--- a/src/memory/embeddings-ollama.test.ts
+++ b/src/memory/embeddings-ollama.test.ts
@@ -3,10 +3,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createOllamaEmbeddingProvider } from "./embeddings-ollama.js";
 
 describe("embeddings-ollama", () => {
-  it("calls /api/embeddings and returns normalized vectors", async () => {
+  it("calls /api/embed and returns normalized vectors", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ embedding: [3, 4] }), {
+        new Response(JSON.stringify({ embeddings: [[3, 4]] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -31,7 +31,7 @@ describe("embeddings-ollama", () => {
   it("resolves baseUrl/apiKey/headers from models.providers.ollama and strips /v1", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ embedding: [1, 0] }), {
+        new Response(JSON.stringify({ embeddings: [[1, 0]] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -60,7 +60,7 @@ describe("embeddings-ollama", () => {
     await provider.embedQuery("hello");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:11434/api/embeddings",
+      "http://127.0.0.1:11434/api/embed",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -90,7 +90,7 @@ describe("embeddings-ollama", () => {
   it("falls back to env key when models.providers.ollama.apiKey is an unresolved SecretRef", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ embedding: [1, 0] }), {
+        new Response(JSON.stringify({ embeddings: [[1, 0]] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -118,7 +118,7 @@ describe("embeddings-ollama", () => {
     await provider.embedQuery("hello");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:11434/api/embeddings",
+      "http://127.0.0.1:11434/api/embed",
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer ollama-env",

--- a/src/memory/embeddings-ollama.ts
+++ b/src/memory/embeddings-ollama.ts
@@ -73,7 +73,7 @@ export async function createOllamaEmbeddingProvider(
   options: EmbeddingProviderOptions,
 ): Promise<{ provider: EmbeddingProvider; client: OllamaEmbeddingClient }> {
   const client = resolveOllamaEmbeddingClient(options);
-  const embedUrl = `${client.baseUrl.replace(/\/$/, "")}/api/embeddings`;
+  const embedUrl = `${client.baseUrl.replace(/\/$/, "")}/api/embed`;
 
   const embedOne = async (text: string): Promise<number[]> => {
     const json = await withRemoteHttpResponse({
@@ -82,19 +82,19 @@ export async function createOllamaEmbeddingProvider(
       init: {
         method: "POST",
         headers: client.headers,
-        body: JSON.stringify({ model: client.model, prompt: text }),
+        body: JSON.stringify({ model: client.model, input: text }),
       },
       onResponse: async (res) => {
         if (!res.ok) {
           throw new Error(`Ollama embeddings HTTP ${res.status}: ${await res.text()}`);
         }
-        return (await res.json()) as { embedding?: number[] };
+        return (await res.json()) as { embeddings?: number[][] };
       },
     });
-    if (!Array.isArray(json.embedding)) {
-      throw new Error(`Ollama embeddings response missing embedding[]`);
+    if (!Array.isArray(json.embeddings?.[0])) {
+      throw new Error(`Ollama embeddings response missing embeddings[]`);
     }
-    return sanitizeAndNormalizeEmbedding(json.embedding);
+    return sanitizeAndNormalizeEmbedding(json.embeddings[0]);
   };
 
   const provider: EmbeddingProvider = {
@@ -102,8 +102,26 @@ export async function createOllamaEmbeddingProvider(
     model: client.model,
     embedQuery: embedOne,
     embedBatch: async (texts: string[]) => {
-      // Ollama /api/embeddings accepts one prompt per request.
-      return await Promise.all(texts.map(embedOne));
+      // Ollama /api/embed supports batched input natively.
+      const json = await withRemoteHttpResponse({
+        url: embedUrl,
+        ssrfPolicy: client.ssrfPolicy,
+        init: {
+          method: "POST",
+          headers: client.headers,
+          body: JSON.stringify({ model: client.model, input: texts }),
+        },
+        onResponse: async (res) => {
+          if (!res.ok) {
+            throw new Error(`Ollama embeddings HTTP ${res.status}: ${await res.text()}`);
+          }
+          return (await res.json()) as { embeddings?: number[][] };
+        },
+      });
+      if (!Array.isArray(json.embeddings)) {
+        throw new Error(`Ollama embeddings response missing embeddings[]`);
+      }
+      return json.embeddings.map(sanitizeAndNormalizeEmbedding);
     },
   };
 


### PR DESCRIPTION
## Summary

- Problem: Ollama embedding provider uses the deprecated `/api/embeddings` endpoint with `prompt` parameter, causing `memory_search` to fail with timeout errors.
- Why it matters: Memory search is completely broken for all Ollama embedding users — the deprecated endpoint returns empty embeddings.
- What changed: Updated `src/memory/embeddings-ollama.ts` to use `/api/embed` endpoint with `input` parameter and parse the new `embeddings[][]` response format. Also leveraged the batch-capable `/api/embed` endpoint for `embedBatch`.
- What did NOT change (scope boundary): No other embedding providers were modified. Client configuration (baseUrl, apiKey, headers) is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage
- [x] Integrations

## Linked Issue/PR

- Closes #39983

## User-visible / Behavior Changes

Ollama embedding provider now uses the current `/api/embed` endpoint instead of the deprecated `/api/embeddings`. Memory search works correctly with Ollama again.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same host, updated path)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 / macOS
- Runtime/container: Node.js
- Model/provider: Ollama
- Integration/channel: memory_search tool

### Steps

1. Configure OpenClaw with Ollama as embedding provider
2. Use `memory_search` tool
3. Observe timeout error with old endpoint

### Expected

- `memory_search` returns relevant results using Ollama embeddings

### Actual

- `memory_search` fails with timeout error because deprecated `/api/embeddings` returns empty embeddings

## Evidence

- [x] Failing test/log before + passing after

All 4 tests in `embeddings-ollama.test.ts` pass. Tests updated to verify new endpoint URL (`/api/embed`) and response format (`embeddings[][]`).

## Human Verification (required)

- Verified scenarios: `pnpm tsgo` type check passes; `pnpm format:fix` clean; oxlint clean on changed files; all 4 related tests pass
- Edge cases checked: embedQuery (single text) and embedBatch (multiple texts) both use the new endpoint correctly
- What you did **not** verify: Runtime end-to-end testing with actual Ollama server

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? Yes (requires Ollama version that supports /api/embed)
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: `src/memory/embeddings-ollama.ts`
- Known bad symptoms reviewers should watch for: Ollama embedding failures if running very old Ollama version without /api/embed support

## Risks and Mitigations

- Risk: Very old Ollama versions may not support `/api/embed`
  - Mitigation: `/api/embed` has been the recommended endpoint for over a year; `/api/embeddings` is deprecated and returns empty results