### PR TITLE
fix(nodes): inherit exec approvals full/off defaults

### DIFF
--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -261,6 +261,68 @@ describe("nodes-cli coverage", () => {
     expect(getApprovalRequestCall()).toBeNull();
   });
 
+  it("inherits security=full from local exec approvals when tools.exec.security is unset", async () => {
+    localExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "full",
+        ask: "off",
+        askFallback: "deny",
+      },
+      agents: {},
+    };
+    nodeExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "full",
+        ask: "off",
+        askFallback: "deny",
+      },
+      agents: {},
+    };
+
+    const invoke = await runNodesCommand(["nodes", "run", "--node", "mac-1", "echo", "hi"]);
+
+    expect(invoke).toBeTruthy();
+    expect(invoke?.params?.command).toBe("system.run");
+    expect(invoke?.params?.params).toMatchObject({
+      command: ["echo", "hi"],
+      approved: false,
+    });
+    expect(getApprovalRequestCall()).toBeNull();
+  });
+
+  it("respects remote ask=off when node exec approvals override a stricter local ask", async () => {
+    localExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "full",
+        ask: "on-miss",
+        askFallback: "deny",
+      },
+      agents: {},
+    };
+    nodeExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "full",
+        ask: "off",
+        askFallback: "deny",
+      },
+      agents: {},
+    };
+
+    const invoke = await runNodesCommand(["nodes", "run", "--node", "mac-1", "echo", "hi"]);
+
+    expect(invoke).toBeTruthy();
+    expect(invoke?.params?.command).toBe("system.run");
+    expect(invoke?.params?.params).toMatchObject({
+      command: ["echo", "hi"],
+      approved: false,
+    });
+    expect(getApprovalRequestCall()).toBeNull();
+  });
+
   it("invokes system.notify with provided fields", async () => {
     const invoke = await runNodesCommand([
       "nodes",

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -92,7 +92,8 @@ function requirePreparedRunPayload(payload: unknown) {
 }
 
 function resolveNodesRunPolicy(opts: NodesRunOpts, execDefaults: ExecDefaults | undefined) {
-  const configuredSecurity = normalizeExecSecurity(execDefaults?.security) ?? "allowlist";
+  const configuredSecurity =
+    normalizeExecSecurity(execDefaults?.security) ?? loadExecApprovals().defaults?.security ?? "allowlist";
   const requestedSecurity = normalizeExecSecurity(opts.security);
   if (opts.security && !requestedSecurity) {
     throw new Error("invalid --security (use deny|allowlist|full)");
@@ -180,7 +181,7 @@ async function resolveNodeApprovals(params: {
   return {
     approvals,
     hostSecurity: minSecurity(params.security, approvals.agent.security),
-    hostAsk: maxAsk(params.ask, approvals.agent.ask),
+    hostAsk: approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask),
     askFallback: approvals.agent.askFallback,
   };
 }


### PR DESCRIPTION
## Summary
- inherit `security` from local `exec-approvals.json` when `tools.exec.security` is unset
- preserve remote `ask=off` for node-backed exec approvals instead of re-escalating to a prompt
- add coverage tests for both cases

## Why
Fixes #46848 and #46846. Node-backed exec was still prompting for approval because the nodes CLI only synced `ask` from local exec approvals defaults, not `security`, and later merged remote approvals with `maxAsk(...)` without preserving an explicit `off` override.

## Validation
- added regression tests for inherited `security=full`
- added regression tests for remote `ask=off` override