### PR TITLE
fix: trigger session-memory hook on session archive/delete (closes #37027)

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -7,6 +7,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { GATEWAY_CLIENT_IDS } from "../protocol/client-info.js";
 import {
@@ -299,6 +300,20 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return hadEntry;
     });
 
+    const emitLifecycleHooks = p.emitLifecycleHooks !== false;
+
+    // Await session:archived hook BEFORE transcript archival so hook consumers
+    // (e.g. transcript export) complete before the data is deleted.
+    if (deleted && emitLifecycleHooks) {
+      await triggerInternalHook(
+        createInternalHookEvent("session", "archived", target.canonicalKey ?? key, {
+          sessionEntry: entry,
+          previousSessionEntry: entry,
+          cfg,
+        }),
+      );
+    }
+
     const archived =
       deleted && deleteTranscript
         ? archiveSessionTranscriptsForSession({
@@ -310,7 +325,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           })
         : [];
     if (deleted) {
-      const emitLifecycleHooks = p.emitLifecycleHooks !== false;
       await emitSessionUnboundLifecycleEvent({
         targetSessionKey: target.canonicalKey ?? key,
         reason: "session-delete",

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -1,13 +1,13 @@
 ---
 name: session-memory
-description: "Save session context to memory when /new or /reset command is issued"
+description: "Save session context to memory on /new, /reset, or session archive/delete"
 homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new", "command:reset"],
+        "events": ["command:new", "command:reset", "session:archived"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },
@@ -16,11 +16,11 @@ metadata:
 
 # Session Memory Hook
 
-Automatically saves session context to your workspace memory when you issue `/new` or `/reset`.
+Automatically saves session context to your workspace memory when you issue `/new` or `/reset`, or when a session is archived/deleted (e.g. non-TUI channel idle timeout).
 
 ## What It Does
 
-When you run `/new` or `/reset` to start a fresh session:
+When you run `/new` or `/reset` to start a fresh session, or when a session is archived/deleted:
 
 1. **Finds the previous session** - Uses the pre-reset session entry to locate the correct transcript
 2. **Extracts conversation** - Reads the last N user/assistant messages from the session (default: 15, configurable)

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -250,6 +250,38 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Captured before reset");
   });
 
+  it("creates memory file on session:archived event", async () => {
+    const tempDir = await createCaseWorkspace("workspace");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "archived-session.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Chat via Feishu" },
+        { role: "assistant", content: "Session about to be archived" },
+      ]),
+    });
+
+    const event = createHookEvent("session", "archived", "agent:main:main", {
+      cfg: {
+        agents: { defaults: { workspace: tempDir } },
+      } satisfies OpenClawConfig,
+      sessionEntry: { sessionId: "archived-session", sessionFile },
+      previousSessionEntry: { sessionId: "archived-session", sessionFile },
+    });
+
+    await handler(event);
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+    expect(files.length).toBe(1);
+    const memoryContent = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+    expect(memoryContent).toContain("user: Chat via Feishu");
+    expect(memoryContent).toContain("assistant: Session about to be archived");
+  });
+
   it("prefers workspaceDir from hook context when sessionKey points at main", async () => {
     const mainWorkspace = await createCaseWorkspace("workspace-main");
     const naviWorkspace = await createCaseWorkspace("workspace-navi");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -194,17 +194,19 @@ async function findPreviousSessionFile(params: {
 }
 
 /**
- * Save session context to memory when /new or /reset command is triggered
+ * Save session context to memory when /new, /reset command is triggered,
+ * or when a session is archived/deleted (e.g. non-TUI channel idle timeout).
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on reset/new commands
-  const isResetCommand = event.action === "new" || event.action === "reset";
-  if (event.type !== "command" || !isResetCommand) {
+  const isResetCommand =
+    event.type === "command" && (event.action === "new" || event.action === "reset");
+  const isSessionArchived = event.type === "session" && event.action === "archived";
+  if (!isResetCommand && !isSessionArchived) {
     return;
   }
 
   try {
-    log.debug("Hook triggered for reset/new command", { action: event.action });
+    log.debug("Hook triggered", { type: event.type, action: event.action });
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;


### PR DESCRIPTION
## Summary
- Problem: The session-memory hook only triggers on `/new` or `/reset` commands, but not when sessions are automatically archived or deleted. This causes cross-session memory loss for non-TUI channels (Feishu, Telegram, Discord, etc.) where sessions expire via idle timeout.
- Why it matters: Users on non-TUI channels permanently lose session context when sessions auto-archive, while TUI users with manual `/new` or `/reset` retain memory.
- What changed: Added a `session:archived` internal hook event in the `sessions.delete` handler, and updated the session-memory hook to also trigger on `session:archived` events.
- What did NOT change (scope boundary): The existing `/new` and `/reset` command-triggered memory save behavior is unchanged. No changes to session deletion logic itself.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #37027

## User-visible / Behavior Changes
Session context is now saved to memory when sessions are archived or deleted (e.g. via non-TUI channel idle timeout), not just on explicit `/new` or `/reset` commands.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Chat via Feishu (or any non-TUI channel) for a while
2. Session auto-archives after idle timeout
3. New message creates new session
### Expected
- Previous session context is saved to memory before archiving
### Actual (before fix)
- Previous context is lost because session-memory hook was not triggered

## Evidence
- [x] Failing test/log before + passing after
- Added new test case `creates memory file on session:archived event` — all 18 session-memory handler tests pass

## Human Verification
- Verified scenarios: pnpm format:fix + oxlint + pnpm tsgo + vitest all passing; reviewed diff matches issue description
- Edge cases checked: Non-command events and unrelated commands still correctly skipped
- What you did NOT verify: runtime end-to-end testing with actual non-TUI channel

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None