### PR TITLE
fix: rename heartbeat skip reason target-none to delivery-disabled (closes #44534)

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -229,7 +229,7 @@ describe("resolveHeartbeatDeliveryTarget", () => {
         entry: baseEntry,
         expected: {
           channel: "none",
-          reason: "target-none",
+          reason: "delivery-disabled",
           accountId: undefined,
           lastChannel: undefined,
           lastAccountId: undefined,
@@ -241,7 +241,7 @@ describe("resolveHeartbeatDeliveryTarget", () => {
         entry: { ...baseEntry, lastChannel: "whatsapp", lastTo: "120363401234567890@g.us" },
         expected: {
           channel: "none",
-          reason: "target-none",
+          reason: "delivery-disabled",
           accountId: undefined,
           lastChannel: "whatsapp",
           lastAccountId: undefined,
@@ -270,7 +270,7 @@ describe("resolveHeartbeatDeliveryTarget", () => {
         entry: { ...baseEntry, lastChannel: "webchat", lastTo: "web" },
         expected: {
           channel: "none",
-          reason: "target-none",
+          reason: "delivery-disabled",
           accountId: undefined,
           lastChannel: undefined,
           lastAccountId: undefined,

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -261,7 +261,7 @@ export function resolveHeartbeatDeliveryTarget(params: {
   if (target === "none") {
     const base = resolveSessionDeliveryTarget({ entry });
     return buildNoHeartbeatDeliveryTarget({
-      reason: "target-none",
+      reason: "delivery-disabled",
       lastChannel: base.lastChannel,
       lastAccountId: base.lastAccountId,
     });


### PR DESCRIPTION
## Summary
- Problem: Heartbeat skip reason `target-none` is misleading. Users interpret it as a routing/recipient resolution failure rather than intentional behavior when heartbeat delivery is disabled by configuration.
- Why it matters: Users waste time debugging channels, presence, allowlists, and session routing when the behavior is by-design.
- What changed: Renamed the skip reason from `target-none` to `delivery-disabled` in `src/infra/outbound/targets.ts`.
- What did NOT change (scope boundary): No changes to heartbeat logic, delivery behavior, or configuration handling. Only the reason string was renamed.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #44534

## User-visible / Behavior Changes
`openclaw system heartbeat last` now shows `reason: "delivery-disabled"` instead of `reason: "target-none"` when heartbeat delivery target is set to `none` (the default).

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Run with default heartbeat config (target=none)
2. Check `openclaw system heartbeat last`
### Expected
- Shows `reason: "delivery-disabled"`
### Actual (before fix)
- Shows `reason: "target-none"`

## Evidence
- [x] Failing test/log before + passing after
- All 25 heartbeat tests pass with updated expectations

## Human Verification
- Verified scenarios: oxlint clean, all heartbeat tests pass (25/25)
- Edge cases checked: only the reason string changed, no logic changes
- What you did NOT verify: runtime end-to-end testing with actual service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (reason string is informational, not used for logic)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None