### PR TITLE
fix: preserve alias in required[] when patching tool schemas for Claude compatibility (closes #37645)

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -101,7 +101,7 @@ describe("createOpenClawCodingTools", () => {
 
       expect(props.file_path).toEqual(props.path);
       expect(params.required ?? []).not.toContain("path");
-      expect(params.required ?? []).not.toContain("file_path");
+      expect(params.required ?? []).toContain("file_path");
     });
 
     it("normalizes file_path to path and enforces required groups at runtime", async () => {

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -146,7 +146,7 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
     }
     const idx = required.indexOf(original);
     if (idx !== -1) {
-      required.splice(idx, 1);
+      required.splice(idx, 1, alias);
       changed = true;
     }
   }


### PR DESCRIPTION
## Summary

- Problem: `patchToolSchemaForClaudeCompatibility` removes original param names from `required[]` via `splice(idx, 1)` without adding the alias back. This empties `required` for read/edit/write tools.
- Why it matters: Non-Claude models (Kimi, Grok, Gemini) that respect the `required` array interpret all params as optional and send `arguments: {}` or empty strings, breaking tool calls.
- What changed: Changed `required.splice(idx, 1)` to `required.splice(idx, 1, alias)` in `src/agents/pi-tools.params.ts` so the alias name replaces the original in the required array. Updated the corresponding test assertion.
- What did NOT change (scope boundary): No other tool schema patching logic was modified. The runtime normalization layer (`normalizeToolParams`) is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #37645

## User-visible / Behavior Changes

Non-Claude models will now correctly receive `required: ["file_path"]` (etc.) in tool schemas, preventing empty argument submissions.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node.js
- Model/provider: Any non-Claude model (Kimi K2.5, Grok, Gemini)

### Steps

1. Use a non-Claude model with tool calling
2. Invoke a file tool (read, write, edit)
3. Model sends empty arguments because required[] is empty

### Expected

- `required` array includes alias names (`file_path`, `old_string`, `new_string`)

### Actual

- `required` array is `[]`; model sends empty or missing arguments

## Evidence

- [x] Failing test/log before + passing after

Test "adds Claude-style aliases to schemas without dropping metadata" passes. 23/25 tests pass; the 2 failures (`filters session tools`, `uses stored spawnDepth`) are pre-existing on main and unrelated to this change.

## Human Verification (required)

- Verified scenarios: `pnpm tsgo` passes; format/lint clean; confirmed 2 test failures exist on baseline (main) as well
- Edge cases checked: The splice replacement correctly inserts the alias at the same index position
- What you did **not** verify: Runtime end-to-end testing with non-Claude models

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: `src/agents/pi-tools.params.ts`
- Known bad symptoms reviewers should watch for: If alias names in required cause unexpected validation behavior

## Risks and Mitigations

None