### PR TITLE
fix: add google-antigravity provider to forward-compat model resolution (closes #27311)

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -199,7 +199,7 @@ function resolveAnthropic46ForwardCompatModel(params: {
 }): Model<Api> | undefined {
   const { provider, modelId, modelRegistry, dashModelId, dotModelId } = params;
   const normalizedProvider = normalizeProviderId(provider);
-  if (normalizedProvider !== "anthropic") {
+  if (normalizedProvider !== "anthropic" && normalizedProvider !== "google-antigravity") {
     return undefined;
   }
 
@@ -275,7 +275,11 @@ function resolveGoogle31ForwardCompatModel(
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
   const normalizedProvider = normalizeProviderId(provider);
-  if (normalizedProvider !== "google" && normalizedProvider !== "google-gemini-cli") {
+  if (
+    normalizedProvider !== "google" &&
+    normalizedProvider !== "google-gemini-cli" &&
+    normalizedProvider !== "google-antigravity"
+  ) {
     return undefined;
   }
   const trimmed = modelId.trim();


### PR DESCRIPTION
## Summary

- Problem: `google-antigravity/claude-sonnet-4-6` and `google-antigravity/gemini-3.1-pro-preview` are rejected with "Unknown model" because forward-compat resolution only accepts `anthropic` and `google`/`google-gemini-cli` providers.
- Why it matters: Users using the Antigravity backend cannot access Sonnet 4.6 or Gemini 3.1 models, getting an error instead of automatic forward-compat fallback.
- What changed: Added `"google-antigravity"` to the provider checks in `resolveAnthropic46ForwardCompatModel` and `resolveGoogle31ForwardCompatModel` in `src/agents/model-forward-compat.ts`.
- What did NOT change (scope boundary): No model templates, fallback chains, or other provider configurations were modified.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #27311

## User-visible / Behavior Changes

Users can now use `google-antigravity/claude-sonnet-4-6`, `google-antigravity/gemini-3.1-pro-preview` and related models without getting "Unknown model" errors.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node.js
- Model/provider: google-antigravity

### Steps

1. Configure `google-antigravity/claude-sonnet-4-6` as model
2. Send a message
3. Get "Unknown model" error

### Expected

- Model resolves via forward-compat to claude-sonnet-4-5 template

### Actual

- "Unknown model" error because provider check excludes google-antigravity

## Evidence

- [x] Failing test/log before + passing after

All 11 tests in `model.forward-compat.test.ts` pass. Type check and lint clean.

## Human Verification (required)

- Verified scenarios: `pnpm tsgo` passes; format/lint clean; forward-compat tests pass
- Edge cases checked: Both Anthropic models (opus/sonnet 4.6) and Gemini 3.1 models now accept google-antigravity
- What you did **not** verify: Runtime end-to-end testing with actual Antigravity backend

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: `src/agents/model-forward-compat.ts`
- Known bad symptoms reviewers should watch for: Incorrect model template selection for google-antigravity

## Risks and Mitigations

None