### PR TITLE
feat(whatsapp): forward reaction events to agent

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -451,6 +451,10 @@ export async function monitorWebInbox(options: {
       const from = group ? remoteJid : (senderE164 ?? reactorJid ?? remoteJid);
       if (!from) continue;
 
+      // Deduplicate reaction events (e.g. reconnect re-delivery).
+      const dedupeKey = `${options.accountId}:${remoteJid}:${reactorJid ?? ""}:${emoji}:${key?.id ?? ""}`;
+      if (isRecentInboundMessage(dedupeKey)) continue;
+
       const access = await checkInboundAccessControl({
         accountId: options.accountId,
         from,
@@ -458,7 +462,7 @@ export async function monitorWebInbox(options: {
         senderE164,
         group,
         pushName: undefined,
-        isFromMe: false,
+        isFromMe: Boolean(key?.fromMe),
         messageTimestampMs: Date.now(),
         connectedAtMs,
         sock: { sendMessage: (jid, content) => sock.sendMessage(jid, content) },
@@ -474,7 +478,7 @@ export async function monitorWebInbox(options: {
       );
 
       const reactionMessage: WebInboundMessage = {
-        id: reactedMessageId,
+        id: undefined,
         from,
         conversationId: group ? remoteJid : from,
         to: selfE164 ?? "me",
@@ -487,7 +491,7 @@ export async function monitorWebInbox(options: {
         senderE164: senderE164 ?? undefined,
         selfJid,
         selfE164,
-        fromMe: false,
+        fromMe: Boolean(key?.fromMe),
         reactionEmoji: emoji,
         reactionMessageId: reactedMessageId,
         sendComposing: async () => {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -403,11 +403,6 @@ export async function monitorWebInbox(options: {
       if (!inbound) {
         continue;
       }
-      recordChannelActivity({
-        channel: "whatsapp",
-        accountId: options.accountId,
-        direction: "inbound",
-      });
 
       await maybeMarkInboundAsRead(inbound);
 
@@ -415,6 +410,13 @@ export async function monitorWebInbox(options: {
       if (upsert.type === "append") {
         continue;
       }
+
+      // Only record activity for real new messages, not deduped or history catch-up.
+      recordChannelActivity({
+        channel: "whatsapp",
+        accountId: options.accountId,
+        direction: "inbound",
+      });
 
       const enriched = await enrichInboundMessage(msg);
       if (!enriched) {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -460,6 +460,11 @@ export async function monitorWebInbox(options: {
       const dedupeKey = `${options.accountId}:${remoteJid}:${reactorJid ?? ""}:${emoji}:${key?.id ?? ""}`;
       if (isRecentInboundMessage(dedupeKey)) continue;
 
+      // Derive isFromMe from reactor identity, not key.fromMe.
+      // key.fromMe on a reaction refers to whether the *reacted-to message* was from us,
+      // not whether the reactor is us. Compare JIDs directly instead.
+      const isFromMe = reactorJid != null && selfJid != null && reactorJid === selfJid;
+
       const access = await checkInboundAccessControl({
         accountId: options.accountId,
         from,
@@ -467,7 +472,7 @@ export async function monitorWebInbox(options: {
         senderE164,
         group,
         pushName: undefined,
-        isFromMe: Boolean(key?.fromMe),
+        isFromMe,
         messageTimestampMs: Date.now(),
         connectedAtMs,
         sock: { sendMessage: (jid, content) => sock.sendMessage(jid, content) },
@@ -496,7 +501,7 @@ export async function monitorWebInbox(options: {
         senderE164: senderE164 ?? undefined,
         selfJid,
         selfE164,
-        fromMe: Boolean(key?.fromMe),
+        fromMe: isFromMe,
         reactionEmoji: emoji,
         reactionMessageId: reactedMessageId,
         sendComposing: async () => {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -448,6 +448,8 @@ export async function monitorWebInbox(options: {
 
       const group = isJidGroup(remoteJid) === true;
       const reactorJid = userJid ?? key?.participant ?? (group ? undefined : remoteJid);
+      // In groups, reactor identity is required — skip unattributable reactions.
+      if (group && !reactorJid) continue;
       const senderE164 = reactorJid ? await resolveInboundJid(reactorJid) : null;
       // In DMs, `from` must be the E.164 of the conversation peer, not the reactor.
       // Mirror normalizeInboundMessage: drop the event if E.164 resolution fails rather than

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -560,7 +560,9 @@ export async function monitorWebInbox(options: {
         const connectionUpdateHandler = handleConnectionUpdate as unknown as (
           ...args: unknown[]
         ) => void;
-        const messagesReactionHandler = handleMessagesReaction as unknown as (...args: unknown[]) => void;
+        const messagesReactionHandler = handleMessagesReaction as unknown as (
+          ...args: unknown[]
+        ) => void;
         if (typeof ev.off === "function") {
           ev.off("messages.upsert", messagesUpsertHandler);
           ev.off("connection.update", connectionUpdateHandler);

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -453,6 +453,11 @@ export async function monitorWebInbox(options: {
       const reactorJid = userJid ?? (group ? undefined : remoteJid);
       // In groups, reactor identity is required — skip unattributable reactions.
       if (group && !reactorJid) continue;
+
+      // Deduplicate before expensive async JID resolution — dedupeKey uses only sync fields.
+      const dedupeKey = `${options.accountId}:${remoteJid}:${reactorJid ?? ""}:${emoji}:${key?.id ?? ""}`;
+      if (isRecentInboundMessage(dedupeKey)) continue;
+
       const senderE164 = reactorJid ? await resolveInboundJid(reactorJid) : null;
       // In DMs, `from` must be the E.164 of the conversation peer, not the reactor.
       // Mirror normalizeInboundMessage: drop the event if E.164 resolution fails rather than
@@ -460,10 +465,6 @@ export async function monitorWebInbox(options: {
       const resolvedFrom = group ? remoteJid : await resolveInboundJid(remoteJid);
       if (!resolvedFrom) continue;
       const from = resolvedFrom;
-
-      // Deduplicate reaction events (e.g. reconnect re-delivery).
-      const dedupeKey = `${options.accountId}:${remoteJid}:${reactorJid ?? ""}:${emoji}:${key?.id ?? ""}`;
-      if (isRecentInboundMessage(dedupeKey)) continue;
 
       recordChannelActivity({
         channel: "whatsapp",
@@ -487,7 +488,9 @@ export async function monitorWebInbox(options: {
         group,
         pushName: undefined,
         isFromMe,
-        messageTimestampMs: Date.now(),
+        // Reactions carry no timestamp from Baileys. Passing 0 ensures suppressPairingReply is
+        // always true, so unknown DM senders who react never trigger a pairing-challenge reply.
+        messageTimestampMs: 0,
         connectedAtMs,
         sock: { sendMessage: (jid, content) => sock.sendMessage(jid, content) },
         remoteJid,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -424,7 +424,97 @@ export async function monitorWebInbox(options: {
       await enqueueInboundMessage(msg, inbound, enriched);
     }
   };
+  const handleMessagesReaction = async (
+    reactions: Array<{
+      key: { remoteJid?: string | null; id?: string | null; participant?: string | null };
+      reaction: { text?: string | null };
+      userJid?: string | null;
+    }>,
+  ) => {
+    for (const { key, reaction, userJid } of reactions) {
+      const emoji = reaction?.text;
+      if (!emoji) continue; // empty string = reaction removed, skip
+
+      const remoteJid = key?.remoteJid;
+      if (!remoteJid) continue;
+      if (remoteJid.endsWith("@status") || remoteJid.endsWith("@broadcast")) continue;
+
+      recordChannelActivity({
+        channel: "whatsapp",
+        accountId: options.accountId,
+        direction: "inbound",
+      });
+
+      const group = isJidGroup(remoteJid) === true;
+      const reactorJid = userJid ?? key?.participant ?? (group ? undefined : remoteJid);
+      const senderE164 = reactorJid ? await resolveInboundJid(reactorJid) : null;
+      const from = group ? remoteJid : (senderE164 ?? reactorJid ?? remoteJid);
+      if (!from) continue;
+
+      const access = await checkInboundAccessControl({
+        accountId: options.accountId,
+        from,
+        selfE164,
+        senderE164,
+        group,
+        pushName: undefined,
+        isFromMe: false,
+        messageTimestampMs: Date.now(),
+        connectedAtMs,
+        sock: { sendMessage: (jid, content) => sock.sendMessage(jid, content) },
+        remoteJid,
+      });
+      if (!access.allowed) continue;
+
+      const reactedMessageId = key?.id ?? undefined;
+      const chatJid = remoteJid;
+
+      inboundConsoleLog.info(
+        `Reaction ${emoji} on message ${reactedMessageId ?? "unknown"} from ${from}`,
+      );
+
+      const reactionMessage: WebInboundMessage = {
+        id: reactedMessageId,
+        from,
+        conversationId: group ? remoteJid : from,
+        to: selfE164 ?? "me",
+        accountId: access.resolvedAccountId,
+        body: emoji,
+        timestamp: Date.now(),
+        chatType: group ? "group" : "direct",
+        chatId: remoteJid,
+        senderJid: reactorJid ?? undefined,
+        senderE164: senderE164 ?? undefined,
+        selfJid,
+        selfE164,
+        fromMe: false,
+        reactionEmoji: emoji,
+        reactionMessageId: reactedMessageId,
+        sendComposing: async () => {
+          try {
+            await sock.sendPresenceUpdate("composing", chatJid);
+          } catch (err) {
+            logVerbose(`Presence update failed: ${String(err)}`);
+          }
+        },
+        reply: async (text: string) => {
+          await sock.sendMessage(chatJid, { text });
+        },
+        sendMedia: async (payload: AnyMessageContent) => {
+          await sock.sendMessage(chatJid, payload);
+        },
+      };
+
+      try {
+        await options.onMessage(reactionMessage);
+      } catch (err) {
+        inboundLogger.error({ error: String(err) }, "failed handling inbound reaction");
+        inboundConsoleLog.error(`Failed handling inbound reaction: ${String(err)}`);
+      }
+    }
+  };
   sock.ev.on("messages.upsert", handleMessagesUpsert);
+  sock.ev.on("messages.reaction", handleMessagesReaction);
 
   const handleConnectionUpdate = (
     update: Partial<import("@whiskeysockets/baileys").ConnectionState>,
@@ -466,12 +556,15 @@ export async function monitorWebInbox(options: {
         const connectionUpdateHandler = handleConnectionUpdate as unknown as (
           ...args: unknown[]
         ) => void;
+        const messagesReactionHandler = handleMessagesReaction as unknown as (...args: unknown[]) => void;
         if (typeof ev.off === "function") {
           ev.off("messages.upsert", messagesUpsertHandler);
           ev.off("connection.update", connectionUpdateHandler);
+          ev.off("messages.reaction", messagesReactionHandler);
         } else if (typeof ev.removeListener === "function") {
           ev.removeListener("messages.upsert", messagesUpsertHandler);
           ev.removeListener("connection.update", connectionUpdateHandler);
+          ev.removeListener("messages.reaction", messagesReactionHandler);
         }
         sock.ws?.close();
       } catch (err) {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -492,7 +492,7 @@ export async function monitorWebInbox(options: {
       const chatJid = remoteJid;
 
       inboundConsoleLog.info(
-        `Reaction ${emoji} on message ${reactedMessageId ?? "unknown"} from ${from}`,
+        `Reaction ${emoji} on message ${reactedMessageId ?? "unknown"} from ${senderE164 ?? reactorJid ?? "unknown"}`,
       );
 
       const reactionMessage: WebInboundMessage = {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -449,11 +449,12 @@ export async function monitorWebInbox(options: {
       const group = isJidGroup(remoteJid) === true;
       const reactorJid = userJid ?? key?.participant ?? (group ? undefined : remoteJid);
       const senderE164 = reactorJid ? await resolveInboundJid(reactorJid) : null;
-      // In DMs, `from` must represent the conversation peer (remoteJid), not the reactor.
-      // Using reactorJid here would make self-reactions appear as isSamePhone and leak to onMessage.
-      // This matches how normalizeInboundMessage derives `from` for regular messages.
-      const from = group ? remoteJid : (await resolveInboundJid(remoteJid) ?? remoteJid);
-      if (!from) continue;
+      // In DMs, `from` must be the E.164 of the conversation peer, not the reactor.
+      // Mirror normalizeInboundMessage: drop the event if E.164 resolution fails rather than
+      // falling back to a raw JID, which would break isSamePhone and allowlist checks downstream.
+      const resolvedFrom = group ? remoteJid : await resolveInboundJid(remoteJid);
+      if (!resolvedFrom) continue;
+      const from = resolvedFrom;
 
       // Deduplicate reaction events (e.g. reconnect re-delivery).
       const dedupeKey = `${options.accountId}:${remoteJid}:${reactorJid ?? ""}:${emoji}:${key?.id ?? ""}`;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -449,7 +449,10 @@ export async function monitorWebInbox(options: {
       const group = isJidGroup(remoteJid) === true;
       const reactorJid = userJid ?? key?.participant ?? (group ? undefined : remoteJid);
       const senderE164 = reactorJid ? await resolveInboundJid(reactorJid) : null;
-      const from = group ? remoteJid : (senderE164 ?? reactorJid ?? remoteJid);
+      // In DMs, `from` must represent the conversation peer (remoteJid), not the reactor.
+      // Using reactorJid here would make self-reactions appear as isSamePhone and leak to onMessage.
+      // This matches how normalizeInboundMessage derives `from` for regular messages.
+      const from = group ? remoteJid : (await resolveInboundJid(remoteJid) ?? remoteJid);
       if (!from) continue;
 
       // Deduplicate reaction events (e.g. reconnect re-delivery).

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -447,7 +447,10 @@ export async function monitorWebInbox(options: {
       if (remoteJid.endsWith("@status") || remoteJid.endsWith("@broadcast")) continue;
 
       const group = isJidGroup(remoteJid) === true;
-      const reactorJid = userJid ?? key?.participant ?? (group ? undefined : remoteJid);
+      // key.participant is the original message sender (the reacted-to message key's participant),
+      // not the reactor. Only userJid carries the actual reactor identity; for DMs fall back to
+      // remoteJid (the peer) when userJid is absent. Never use key.participant as reactor.
+      const reactorJid = userJid ?? (group ? undefined : remoteJid);
       // In groups, reactor identity is required — skip unattributable reactions.
       if (group && !reactorJid) continue;
       const senderE164 = reactorJid ? await resolveInboundJid(reactorJid) : null;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -399,15 +399,15 @@ export async function monitorWebInbox(options: {
       return;
     }
     for (const msg of upsert.messages ?? []) {
+      const inbound = await normalizeInboundMessage(msg);
+      if (!inbound) {
+        continue;
+      }
       recordChannelActivity({
         channel: "whatsapp",
         accountId: options.accountId,
         direction: "inbound",
       });
-      const inbound = await normalizeInboundMessage(msg);
-      if (!inbound) {
-        continue;
-      }
 
       await maybeMarkInboundAsRead(inbound);
 

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -466,12 +466,6 @@ export async function monitorWebInbox(options: {
       if (!resolvedFrom) continue;
       const from = resolvedFrom;
 
-      recordChannelActivity({
-        channel: "whatsapp",
-        accountId: options.accountId,
-        direction: "inbound",
-      });
-
       // Derive isFromMe from reactor identity, not key.fromMe.
       // key.fromMe on a reaction refers to whether the *reacted-to message* was from us,
       // not whether the reactor is us. Compare JIDs directly instead.
@@ -496,6 +490,14 @@ export async function monitorWebInbox(options: {
         remoteJid,
       });
       if (!access.allowed) continue;
+
+      // Only record activity for reactions that pass access control — consistent with
+      // handleMessagesUpsert and prevents blocked/self reactions from inflating inbound metrics.
+      recordChannelActivity({
+        channel: "whatsapp",
+        accountId: options.accountId,
+        direction: "inbound",
+      });
 
       const reactedMessageId = key?.id ?? undefined;
       const chatJid = remoteJid;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -426,7 +426,12 @@ export async function monitorWebInbox(options: {
   };
   const handleMessagesReaction = async (
     reactions: Array<{
-      key: { remoteJid?: string | null; id?: string | null; participant?: string | null };
+      key: {
+        remoteJid?: string | null;
+        id?: string | null;
+        participant?: string | null;
+        fromMe?: boolean | null;
+      };
       reaction: { text?: string | null };
       userJid?: string | null;
     }>,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -444,12 +444,6 @@ export async function monitorWebInbox(options: {
       if (!remoteJid) continue;
       if (remoteJid.endsWith("@status") || remoteJid.endsWith("@broadcast")) continue;
 
-      recordChannelActivity({
-        channel: "whatsapp",
-        accountId: options.accountId,
-        direction: "inbound",
-      });
-
       const group = isJidGroup(remoteJid) === true;
       const reactorJid = userJid ?? key?.participant ?? (group ? undefined : remoteJid);
       const senderE164 = reactorJid ? await resolveInboundJid(reactorJid) : null;
@@ -459,6 +453,12 @@ export async function monitorWebInbox(options: {
       // Deduplicate reaction events (e.g. reconnect re-delivery).
       const dedupeKey = `${options.accountId}:${remoteJid}:${reactorJid ?? ""}:${emoji}:${key?.id ?? ""}`;
       if (isRecentInboundMessage(dedupeKey)) continue;
+
+      recordChannelActivity({
+        channel: "whatsapp",
+        accountId: options.accountId,
+        direction: "inbound",
+      });
 
       // Derive isFromMe from reactor identity, not key.fromMe.
       // key.fromMe on a reaction refers to whether the *reacted-to message* was from us,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1,5 +1,5 @@
 import type { AnyMessageContent, proto, WAMessage } from "@whiskeysockets/baileys";
-import { DisconnectReason, isJidGroup } from "@whiskeysockets/baileys";
+import { DisconnectReason, isJidGroup, jidNormalizedUser } from "@whiskeysockets/baileys";
 import { createInboundDebouncer } from "../../../../src/auto-reply/inbound-debounce.js";
 import { formatLocationText } from "../../../../src/channels/location.js";
 import { logVerbose, shouldLogVerbose } from "../../../../src/globals.js";
@@ -463,7 +463,10 @@ export async function monitorWebInbox(options: {
       // Derive isFromMe from reactor identity, not key.fromMe.
       // key.fromMe on a reaction refers to whether the *reacted-to message* was from us,
       // not whether the reactor is us. Compare JIDs directly instead.
-      const isFromMe = reactorJid != null && selfJid != null && reactorJid === selfJid;
+      const isFromMe =
+        reactorJid != null &&
+        selfJid != null &&
+        jidNormalizedUser(reactorJid) === jidNormalizedUser(selfJid);
 
       const access = await checkInboundAccessControl({
         accountId: options.accountId,

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -40,7 +40,7 @@ export type WebInboundMessage = {
   mediaType?: string;
   mediaFileName?: string;
   mediaUrl?: string;
-  reactionEmoji?: string;       // the emoji used in the reaction
-  reactionMessageId?: string;   // ID of the message that was reacted to
+  reactionEmoji?: string; // the emoji used in the reaction
+  reactionMessageId?: string; // ID of the message that was reacted to
   wasMentioned?: boolean;
 };

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -40,5 +40,7 @@ export type WebInboundMessage = {
   mediaType?: string;
   mediaFileName?: string;
   mediaUrl?: string;
+  reactionEmoji?: string;       // the emoji used in the reaction
+  reactionMessageId?: string;   // ID of the message that was reacted to
   wasMentioned?: boolean;
 };


### PR DESCRIPTION
## Summary

- Add `reactionEmoji` and `reactionMessageId` fields to `WebInboundMessage` type
- Add `handleMessagesReaction` handler that processes incoming WhatsApp reaction events and forwards them to the agent via `onMessage`
- Register/deregister the `messages.reaction` Baileys event listener alongside existing listeners

## Test plan

- [ ] Send a reaction on a WhatsApp message to the connected account and verify the agent receives a message with `reactionEmoji` and `reactionMessageId` populated
- [ ] Verify that reaction-removed events (empty emoji string) are silently skipped
- [ ] Verify status JIDs (`@status`, `@broadcast`) are filtered out
- [ ] Verify the listener is cleaned up on `close()`