### PR TITLE
fix: show reachable (limited) instead of unreachable for scope-limited gateway (closes #46072)

### DIFF
--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -134,6 +134,11 @@ export async function statusAllCommand(
       timeoutMs: Math.min(5000, opts?.timeoutMs ?? 10_000),
     }).catch(() => null);
     const gatewayReachable = gatewayProbe?.ok === true;
+    // The gateway is reachable if we connected, even if RPC calls failed due
+    // to scope limitations (e.g. missing operator.read).
+    const gatewayConnected =
+      gatewayReachable ||
+      (gatewayProbe?.connectLatencyMs != null && gatewayProbe.connectLatencyMs >= 0);
     const gatewaySelf = pickGatewaySelfPresence(gatewayProbe?.presence ?? null);
     progress.tick();
 
@@ -253,10 +258,12 @@ export async function statusAllCommand(
     const gatewayTarget = remoteUrlMissing ? `fallback ${connection.url}` : connection.url;
     const gatewayStatus = gatewayReachable
       ? `reachable ${formatDurationPrecise(gatewayProbe?.connectLatencyMs ?? 0)}`
-      : gatewayProbe?.error
-        ? `unreachable (${gatewayProbe.error})`
-        : "unreachable";
-    const gatewayAuth = gatewayReachable ? ` · auth ${formatGatewayAuthUsed(probeAuth)}` : "";
+      : gatewayConnected
+        ? `reachable (limited: ${gatewayProbe?.error ?? "unknown"}) ${formatDurationPrecise(gatewayProbe?.connectLatencyMs ?? 0)}`
+        : gatewayProbe?.error
+          ? `unreachable (${gatewayProbe.error})`
+          : "unreachable";
+    const gatewayAuth = gatewayConnected ? ` · auth ${formatGatewayAuthUsed(probeAuth)}` : "";
     const gatewaySelfLine =
       gatewaySelf?.host || gatewaySelf?.ip || gatewaySelf?.version || gatewaySelf?.platform
         ? [

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -121,6 +121,7 @@ export async function statusCommand(
     gatewayProbeAuthWarning,
     gatewayProbe,
     gatewayReachable,
+    gatewayConnected,
     gatewaySelf,
     channelIssues,
     agentStatus,
@@ -261,9 +262,13 @@ export async function statusCommand(
       ? warn("misconfigured (remote.url missing)")
       : gatewayReachable
         ? ok(`reachable ${formatDuration(gatewayProbe?.connectLatencyMs)}`)
-        : warn(gatewayProbe?.error ? `unreachable (${gatewayProbe.error})` : "unreachable");
+        : gatewayConnected
+          ? warn(
+              `reachable (limited: ${gatewayProbe?.error ?? "unknown"}) ${formatDuration(gatewayProbe?.connectLatencyMs)}`,
+            )
+          : warn(gatewayProbe?.error ? `unreachable (${gatewayProbe.error})` : "unreachable");
     const auth =
-      gatewayReachable && !remoteUrlMissing
+      gatewayConnected && !remoteUrlMissing
         ? ` · auth ${formatGatewayAuthUsed(gatewayProbeAuth)}`
         : "";
     const self =

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -145,6 +145,7 @@ export type StatusScanResult = {
   gatewayProbeAuthWarning?: string;
   gatewayProbe: Awaited<ReturnType<typeof probeGateway>> | null;
   gatewayReachable: boolean;
+  gatewayConnected: boolean;
   gatewaySelf: ReturnType<typeof pickGatewaySelfPresence>;
   channelIssues: ReturnType<typeof collectChannelStatusIssues>;
   agentStatus: Awaited<ReturnType<typeof getAgentLocalStatuses>>;
@@ -232,6 +233,9 @@ async function scanStatusJsonFast(opts: {
     gatewayProbe,
   } = gatewaySnapshot;
   const gatewayReachable = gatewayProbe?.ok === true;
+  const gatewayConnected =
+    gatewayReachable ||
+    (gatewayProbe?.connectLatencyMs != null && gatewayProbe.connectLatencyMs >= 0);
   const gatewaySelf = gatewayProbe?.presence
     ? pickGatewaySelfPresence(gatewayProbe.presence)
     : null;
@@ -257,6 +261,7 @@ async function scanStatusJsonFast(opts: {
     gatewayProbeAuthWarning,
     gatewayProbe,
     gatewayReachable,
+    gatewayConnected,
     gatewaySelf,
     channelIssues,
     agentStatus,
@@ -342,6 +347,9 @@ export async function scanStatus(
         gatewayProbe,
       } = await resolveGatewayProbeSnapshot({ cfg, opts });
       const gatewayReachable = gatewayProbe?.ok === true;
+      const gatewayConnected =
+        gatewayReachable ||
+        (gatewayProbe?.connectLatencyMs != null && gatewayProbe.connectLatencyMs >= 0);
       const gatewaySelf = gatewayProbe?.presence
         ? pickGatewaySelfPresence(gatewayProbe.presence)
         : null;
@@ -389,6 +397,7 @@ export async function scanStatus(
         gatewayProbeAuthWarning,
         gatewayProbe,
         gatewayReachable,
+        gatewayConnected,
         gatewaySelf,
         channelIssues,
         agentStatus,


### PR DESCRIPTION
## Summary
- Problem: `openclaw status` shows `unreachable (missing scope: operator.read)` when the gateway is actually reachable but RPC calls fail due to missing auth scopes. This is misleading since `openclaw gateway probe` correctly shows `Reachable: yes`.
- Why it matters: Users interpret `unreachable` as a connectivity failure and waste time debugging network/SSH issues after a successful gateway update.
- What changed: Added `gatewayConnected` flag in `status.scan.ts`, `status-all.ts`, and `status.command.ts` that checks `connectLatencyMs` to determine if the gateway was reachable regardless of RPC success. When connected but RPCs fail, status now shows `reachable (limited: <reason>)` instead of `unreachable`.
- What did NOT change (scope boundary): No changes to probe logic, gateway client, or auth handling. Only the display label was updated.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #46072

## User-visible / Behavior Changes
When the gateway connects but RPC calls fail due to scope limitations, `openclaw status` now shows:
`Gateway: local - ws://127.0.0.1:19011 (local loopback) - reachable (limited: missing scope: operator.read)`
instead of:
`Gateway: local - ws://127.0.0.1:19011 (local loopback) - unreachable (missing scope: operator.read)`

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Use a local client/auth context that can connect but lacks operator.read
2. Run `openclaw status`
### Expected
- Shows `reachable (limited: missing scope: operator.read)`
### Actual (before fix)
- Shows `unreachable (missing scope: operator.read)`

## Evidence
- [x] Failing test/log before + passing after
- oxlint clean, tsgo clean, status.scan.test passes; 1 pre-existing test failure unrelated to this change

## Human Verification
- Verified scenarios: oxlint clean, tsgo clean, status scan test passes
- Edge cases checked: full probe ok still shows `reachable`; no connectLatencyMs still shows `unreachable`
- What you did NOT verify: runtime end-to-end testing with actual scope-limited auth

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None