### PR TITLE
fix: doctor false API key warning for ollama memory search provider

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -290,6 +290,57 @@ describe("noteMemorySearchHealth", () => {
     const providersChecked = providerCalls.map(([arg]) => arg.provider);
     expect(providersChecked).toEqual(["openai", "google", "voyage", "mistral"]);
   });
+
+  it("does not warn when ollama provider is set and gateway probe is ready", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "ollama",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: { checked: true, ready: true },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("shows informational note when ollama provider is set and gateway probe is not ready", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "ollama",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: { checked: true, ready: false, error: "connection refused" },
+    });
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("ollama");
+    expect(message).toContain("does not require an API key");
+    expect(message).toContain("connection refused");
+    expect(message).not.toContain("API key was not found");
+    expect(note.mock.calls[0]?.[1]).toBe("Memory search");
+  });
+
+  it("shows informational note when ollama provider is set and no gateway probe", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "ollama",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg);
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("ollama");
+    expect(message).toContain("does not require an API key");
+    expect(message).not.toContain("API key was not found");
+    expect(note.mock.calls[0]?.[1]).toBe("Memory search");
+  });
 });
 
 describe("detectLegacyWorkspaceDirs", () => {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -320,12 +320,12 @@ describe("noteMemorySearchHealth", () => {
     const message = String(note.mock.calls[0]?.[0] ?? "");
     expect(message).toContain("ollama");
     expect(message).toContain("does not require an API key");
-    expect(message).toContain("connection refused");
+    expect(message).toContain("Gateway probe: connection refused");
     expect(message).not.toContain("API key was not found");
     expect(note.mock.calls[0]?.[1]).toBe("Memory search");
   });
 
-  it("shows informational note when ollama provider is set and no gateway probe", async () => {
+  it("does not warn when ollama provider is set and no gateway probe is available", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "ollama",
       local: {},
@@ -334,12 +334,7 @@ describe("noteMemorySearchHealth", () => {
 
     await noteMemorySearchHealth(cfg);
 
-    expect(note).toHaveBeenCalledTimes(1);
-    const message = String(note.mock.calls[0]?.[0] ?? "");
-    expect(message).toContain("ollama");
-    expect(message).toContain("does not require an API key");
-    expect(message).not.toContain("API key was not found");
-    expect(note.mock.calls[0]?.[1]).toBe("Memory search");
+    expect(note).not.toHaveBeenCalled();
   });
 });
 

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -81,24 +81,24 @@ export async function noteMemorySearchHealth(
     }
     if (resolved.provider === "ollama") {
       // Ollama runs locally and does not require an API key.
-      // If a gateway probe confirmed embeddings are ready, all good.
-      if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
-        return;
+      // Only warn when the gateway probe explicitly reports not-ready;
+      // if no probe ran we cannot tell whether the service is up, so
+      // stay silent (consistent with the "local" branch above).
+      if (opts?.gatewayMemoryProbe?.checked && !opts.gatewayMemoryProbe.ready) {
+        const detail = opts.gatewayMemoryProbe.error?.trim();
+        note(
+          [
+            'Memory search provider is set to "ollama".',
+            "Ollama does not require an API key, but the ollama service must be running.",
+            detail ? `Gateway probe: ${detail}` : null,
+            "",
+            `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+          "Memory search",
+        );
       }
-      // No probe or probe not ready — nudge the user to verify the service.
-      const detail = opts?.gatewayMemoryProbe?.error?.trim();
-      note(
-        [
-          'Memory search provider is set to "ollama".',
-          "Ollama does not require an API key, but the ollama service must be running.",
-          detail ? `Gateway probe: ${detail}` : null,
-          "",
-          `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
-        ]
-          .filter(Boolean)
-          .join("\n"),
-        "Memory search",
-      );
       return;
     }
     // Remote provider — check for API key

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -79,6 +79,28 @@ export async function noteMemorySearchHealth(
       );
       return;
     }
+    if (resolved.provider === "ollama") {
+      // Ollama runs locally and does not require an API key.
+      // If a gateway probe confirmed embeddings are ready, all good.
+      if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
+        return;
+      }
+      // No probe or probe not ready — nudge the user to verify the service.
+      const detail = opts?.gatewayMemoryProbe?.error?.trim();
+      note(
+        [
+          'Memory search provider is set to "ollama".',
+          "Ollama does not require an API key, but the ollama service must be running.",
+          detail ? `Gateway probe: ${detail}` : null,
+          "",
+          `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        "Memory search",
+      );
+      return;
+    }
     // Remote provider — check for API key
     if (hasRemoteApiKey || (await hasApiKeyForProvider(resolved.provider, cfg, agentDir))) {
       return;


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` falsely reports "API key was not found" when memory search provider is explicitly set to `ollama`, even though Ollama does not require an API key.
- Why it matters: Users who configure Ollama for memory search see a misleading diagnostic warning that suggests their setup is broken when it is actually working correctly.
- What changed: Added an `ollama`-specific branch in `noteMemorySearchHealth()` that skips the API key check. It only warns when the gateway probe explicitly reports not-ready; otherwise it stays silent.
- What did NOT change (scope boundary): Runtime embedding behavior, other provider checks, and `auto` mode logic are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46584

## User-visible / Behavior Changes

- `openclaw doctor` no longer falsely warns about a missing API key when `memorySearch.provider` is set to `"ollama"`.
- When gateway probe explicitly reports embeddings not ready, a new informational note is shown: "Ollama does not require an API key, but the ollama service must be running."

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: Ollama (memory search embeddings)
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.memorySearch.provider: "ollama"`

### Steps

1. Set `agents.defaults.memorySearch.provider` to `"ollama"` in config
2. Run `openclaw doctor`

### Expected

- No API key warning for ollama (ollama does not require one)

### Actual (before fix)

- Doctor reports: `Memory search provider is set to "ollama" but no API key was found.`

## Evidence

- [x] Failing test/log before + passing after

3 new tests were written first (TDD), confirmed failing before implementation, then passing after:

```
Before fix: 3 failed | 16 passed (19)
After fix:  19 passed (19)
```

- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: All 3 ollama branch paths (probe ready, probe not ready, no probe) via unit tests
- Edge cases checked: `auto` mode with only ollama credentials (existing test confirms ollama is excluded from auto-detection loop, unaffected by this change)
- What you did **not** verify: Live Ollama instance end-to-end (no Ollama server available in test environment)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; ollama would revert to the old (false warning) behavior
- Files/config to restore: `src/commands/doctor-memory-search.ts`
- Known bad symptoms reviewers should watch for: Any provider other than ollama getting its API key check skipped

## Risks and Mitigations

- Risk: Authenticated Ollama endpoints (e.g., cloud-hosted with API key) would not get a "missing key" warning from doctor.
  - Mitigation: The gateway probe would report not-ready for auth failures, triggering the informational note. The runtime (`embeddings-ollama.ts`) handles optional keys correctly regardless.

> This PR was authored with AI assistance (Claude Code).