### PR TITLE
fix: correct toolCall type check and treat HTTP 500 as failover-eligible

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -71,7 +71,7 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
     expect(resolveFailoverReasonFromError({ status: 422 })).toBe("format");
     // Keep the status-only path behavior-preserving and conservative.
-    expect(resolveFailoverReasonFromError({ status: 500 })).toBeNull();
+    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -426,6 +426,9 @@ export function classifyFailoverReasonFromHttpStatus(
     return "timeout";
   }
   if (status === 500) {
+    if (message && isOverloadedErrorMessage(message)) {
+      return "overloaded";
+    }
     return "timeout";
   }
   if (status === 502 || status === 504) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -425,6 +425,9 @@ export function classifyFailoverReasonFromHttpStatus(
     }
     return "timeout";
   }
+  if (status === 500) {
+    return "timeout";
+  }
   if (status === 502 || status === 504) {
     return "timeout";
   }

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 type AnthropicContentBlock = {
-  type: "text" | "toolUse" | "toolResult";
+  type: "text" | "toolCall" | "toolResult";
   text?: string;
   id?: string;
   name?: string;
@@ -65,7 +65,7 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       if (!block) {
         return false;
       }
-      if (block.type !== "toolUse") {
+      if (block.type !== "toolCall") {
         return true;
       }
       // Keep tool_use if its id is in the valid set

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -9,9 +9,9 @@ type AnthropicContentBlock = {
 };
 
 /**
- * Strips dangling tool_use blocks from assistant messages when the immediately
+ * Strips dangling toolCall blocks from assistant messages when the immediately
  * following user message does not contain a matching tool_result block.
- * This fixes the "tool_use ids found without tool_result blocks" error from Anthropic.
+ * This fixes the "tool_use ids found without tool_result blocks" error from the provider API.
  */
 function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[] {
   const result: AgentMessage[] = [];
@@ -68,7 +68,7 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       if (block.type !== "toolCall") {
         return true;
       }
-      // Keep tool_use if its id is in the valid set
+      // Keep toolCall block if its id is in the valid set
       return validToolUseIds.has(block.id || "");
     });
 
@@ -187,7 +187,7 @@ export function mergeConsecutiveUserTurns(
  * Validates and fixes conversation turn sequences for Anthropic API.
  * Anthropic requires strict alternating user→assistant pattern.
  * Merges consecutive user messages together.
- * Also strips dangling tool_use blocks that lack corresponding tool_result blocks.
+ * Also strips dangling toolCall blocks that lack corresponding tool_result blocks.
  */
 export function validateAnthropicTurns(messages: AgentMessage[]): AgentMessage[] {
   // First, strip dangling tool_use blocks from assistant messages


### PR DESCRIPTION
## Summary

- **Fix dangling tool-use stripping:** `stripDanglingAnthropicToolUses` checked `block.type !== "toolUse"` but pi-agent-core stores tool calls as `type: "toolCall"`. The mismatch made the function a no-op, leaving dangling blocks that cause `"tool_use ids found without tool_result blocks"` errors from the provider API in long-running sessions.
- **Fix HTTP 500 failover:** HTTP 500 (`server_error`) was not recognized as failover-eligible, so the model fallback chain did not trigger. Users had to manually switch models via `/model` instead of getting automatic failover.

Closes #41571, closes #35119

## Test plan

- [x] Updated `failover-error.test.ts` to expect `"timeout"` for status 500
- [ ] Verify existing tests pass with `toolCall` type correction
- [ ] Confirm long-running sessions no longer produce dangling tool_use errors after context truncation