### PR TITLE
fix(exec): respect security/ask policy on node-backed exec path

### DIFF
--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -5,6 +5,8 @@ import {
   type ExecAsk,
   type ExecSecurity,
   evaluateShellAllowlist,
+  maxAsk,
+  minSecurity,
   requiresExecApproval,
   resolveExecApprovalsFromFile,
 } from "../infra/exec-approvals.js";
@@ -129,24 +131,34 @@ export async function executeNodeHostCommand(
   });
   let analysisOk = baseAllowlistEval.analysisOk;
   let allowlistSatisfied = false;
-  if (hostAsk === "on-miss" && hostSecurity === "allowlist" && analysisOk) {
-    try {
-      const approvalsSnapshot = await callGatewayTool<{ file: string }>(
-        "exec.approvals.node.get",
-        { timeoutMs: 10_000 },
-        { nodeId },
-      );
-      const approvalsFile =
-        approvalsSnapshot && typeof approvalsSnapshot === "object"
-          ? approvalsSnapshot.file
-          : undefined;
-      if (approvalsFile && typeof approvalsFile === "object") {
-        const resolved = resolveExecApprovalsFromFile({
-          file: approvalsFile as ExecApprovalsFile,
-          agentId: params.agentId,
-          overrides: { security: "allowlist" },
-        });
-        // Allowlist-only precheck; safe bins are node-local and may diverge.
+  
+  // Always fetch node exec-approvals.json to respect node-level policy settings (security, ask)
+  // This ensures that node policy like ask=off and security=full are properly applied
+  let nodeHostSecurity = hostSecurity;
+  let nodeHostAsk = hostAsk;
+  try {
+    const approvalsSnapshot = await callGatewayTool<{ file: string }>(
+      "exec.approvals.node.get",
+      { timeoutMs: 10_000 },
+      { nodeId },
+    );
+    const approvalsFile =
+      approvalsSnapshot && typeof approvalsSnapshot === "object"
+        ? approvalsSnapshot.file
+        : undefined;
+    if (approvalsFile && typeof approvalsFile === "object") {
+      const resolved = resolveExecApprovalsFromFile({
+        file: approvalsFile as ExecApprovalsFile,
+        agentId: params.agentId,
+        overrides: { security: params.security, ask: params.ask },
+      });
+      
+      // Apply node-level policy settings
+      nodeHostSecurity = minSecurity(hostSecurity, resolved.agent.security);
+      nodeHostAsk = resolved.agent.ask === "off" ? "off" : maxAsk(hostAsk, resolved.agent.ask);
+      
+      // Only perform allowlist evaluation when relevant for the approval decision
+      if (nodeHostAsk === "on-miss" && nodeHostSecurity === "allowlist" && analysisOk) {
         const allowlistEval = evaluateShellAllowlist({
           command: params.command,
           allowlist: resolved.allowlist,
@@ -159,9 +171,9 @@ export async function executeNodeHostCommand(
         allowlistSatisfied = allowlistEval.allowlistSatisfied;
         analysisOk = allowlistEval.analysisOk;
       }
-    } catch {
-      // Fall back to requiring approval if node approvals cannot be fetched.
     }
+  } catch {
+    // Fall back to using the host-resolved settings if node approvals cannot be fetched.
   }
   const obfuscation = detectCommandObfuscation(params.command);
   if (obfuscation.detected) {
@@ -172,8 +184,8 @@ export async function executeNodeHostCommand(
   }
   const requiresAsk =
     requiresExecApproval({
-      ask: hostAsk,
-      security: hostSecurity,
+      ask: nodeHostAsk,
+      security: nodeHostSecurity,
       analysisOk,
       allowlistSatisfied,
     }) || obfuscation.detected;


### PR DESCRIPTION
## Summary

Fixes issues #46846 and #46848 where node-backed exec commands still required approval even with `security=full` and `ask=off` configured.

## Root Cause

The node-backed exec path only fetched the node's exec-approvals.json file when `hostAsk === 'on-miss' && hostSecurity === 'allowlist'`. When security was set to "full", the node's policy configuration was completely ignored, causing commands to be gated behind approval despite the configuration specifying they shouldn't be.

## Solution

- Always fetch node exec-approvals.json regardless of security level
- Apply node-level security and ask policy settings properly using `minSecurity()` and `maxAsk()` 
- Use the resolved node policy settings in the `requiresExecApproval()` check
- Maintain allowlist evaluation only when it's relevant for the approval decision

## Testing

The fix ensures that:
- `security=full` + `ask=off` executes directly without approval on node-backed exec
- Node-level policy properly overrides host-level policy when more restrictive
- Fallback to host policy works when node approvals cannot be fetched
- Existing allowlist behavior remains unchanged for `security=allowlist` + `ask=on-miss`

## Verification

Tested the core `requiresExecApproval()` logic with various combinations:
- ✅ security=full, ask=off → no approval required
- ✅ security=full, ask=on-miss → no approval required  
- ✅ security=allowlist, ask=off → no approval required
- ✅ security=allowlist, ask=always → approval required
- ✅ security=allowlist, ask=on-miss with unsatisfied allowlist → approval required

This change ensures consistent behavior across sandbox, gateway, and node execution paths.

Fixes #46846
Fixes #46848