### PR TITLE
fix(gateway): allow backend self-pairing bypass when auth.mode is none

### DIFF
--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -125,4 +125,85 @@ describe("handshake auth helpers", () => {
       }),
     ).toBe(false);
   });
+
+  it("skips backend self-pairing when authMode is none for local backend clients", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      },
+    } as ConnectParams;
+
+    // Local backend client with authMode "none" should bypass pairing
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "none",
+        authMode: "none",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects non-backend clients even when authMode is none", () => {
+    const connectParams = {
+      client: {
+        id: "some-other-client",
+        mode: "interactive",
+      },
+    } as unknown as ConnectParams;
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "none",
+        authMode: "none",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects remote backend clients even when authMode is none", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      },
+    } as ConnectParams;
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "none",
+        authMode: "none",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects backend clients with browser origin even when authMode is none", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      },
+    } as ConnectParams;
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: true,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: false,
+        authMethod: "none",
+        authMode: "none",
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -66,6 +66,7 @@ export function shouldSkipBackendSelfPairing(params: {
   hasBrowserOriginHeader: boolean;
   sharedAuthOk: boolean;
   authMethod: GatewayAuthResult["method"];
+  authMode?: string;
 }): boolean {
   const isGatewayBackendClient =
     params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
@@ -75,13 +76,18 @@ export function shouldSkipBackendSelfPairing(params: {
   }
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   const usesDeviceTokenAuth = params.authMethod === "device-token";
+  // When auth.mode is "none" there are no shared secrets to prove, so requiring
+  // proof of shared-secret auth is nonsensical. The three safety constraints
+  // (isGatewayBackendClient + isLocalClient + !hasBrowserOriginHeader) still
+  // prevent external or browser-based clients from bypassing pairing.
+  const authDisabled = params.authMode === "none";
   // `authMethod === "device-token"` only reaches this helper after the caller
   // has already accepted auth (`authOk === true`), so a separate
   // `deviceTokenAuthOk` flag would be redundant here.
   return (
     params.isLocalClient &&
     !params.hasBrowserOriginHeader &&
-    ((params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth)
+    ((params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth || authDisabled)
   );
 }
 

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -1,6 +1,6 @@
 import { verifyDeviceSignature } from "../../../infra/device-identity.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
-import type { GatewayAuthResult } from "../../auth.js";
+import type { GatewayAuthResult, ResolvedGatewayAuthMode } from "../../auth.js";
 import { buildDeviceAuthPayload, buildDeviceAuthPayloadV3 } from "../../device-auth.js";
 import { isLoopbackAddress } from "../../net.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
@@ -66,7 +66,7 @@ export function shouldSkipBackendSelfPairing(params: {
   hasBrowserOriginHeader: boolean;
   sharedAuthOk: boolean;
   authMethod: GatewayAuthResult["method"];
-  authMode?: string;
+  authMode?: ResolvedGatewayAuthMode;
 }): boolean {
   const isGatewayBackendClient =
     params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -692,6 +692,7 @@ export function attachGatewayWsMessageHandler(params: {
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,
+            authMode: resolvedAuth.mode,
           }) ||
           shouldSkipControlUiPairing(
             controlUiAuthPolicy,


### PR DESCRIPTION
## Summary

- Problem: `sessions_send` fails with "pairing required" for cross-agent communication when `auth.mode` is `"none"` (or auth is not configured). The gateway's own internal `callGateway()` backend calls are rejected because `shouldSkipBackendSelfPairing()` requires proof of shared-secret or device-token auth, which does not exist when auth is disabled.
- Why it matters: Users running multi-agent setups on a single gateway with no auth cannot use cross-agent messaging at all. Affects at least 5 related issues.
- What changed: Added `authMode` parameter to `shouldSkipBackendSelfPairing()`. When `authMode === "none"`, the function allows bypass without requiring shared-secret proof, since there is no secret to prove. The three safety constraints (backend client ID + loopback + no browser Origin header) remain enforced.
- What did NOT change (scope boundary): No other pairing paths are modified. External browser clients, remote clients, and non-backend clients are still fully gated. This is fundamentally different from the reverted commit 9bffa34 (PR #43478) which disabled pairing for ALL websocket clients when `auth.mode=none`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42612
- Related #30151, #23206, #22160, #25667, #24084

## User-visible / Behavior Changes

Cross-agent `sessions_send` now works when `auth.mode` is `"none"` (the default when no auth is configured). Previously, these calls failed with `gateway closed (1008): pairing required`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

**Security analysis:** The fix adds an `authDisabled` path to `shouldSkipBackendSelfPairing()` that only activates when `authMode === "none"`. The function still enforces THREE safety constraints that must ALL be true:

1. **`isGatewayBackendClient`**: Client must identify as `GATEWAY_CLIENT` with mode `BACKEND`. Browsers, mobile apps, and CLI use different client IDs and cannot spoof this without modifying the gateway code itself.
2. **`isLocalClient`**: Connection must originate from loopback (`127.0.0.1` / `::1`). Prevents any remote attacker from exploiting this path.
3. **`!hasBrowserOriginHeader`**: Request must have no `Origin` header. Prevents browser-based CSRF attacks, since all browser WebSocket connections include an Origin header.

Adding `authDisabled` merely removes the fourth requirement (proof of shared secret) when there IS no shared secret -- which is logically correct. This is fundamentally different from the reverted blanket `auth.mode=none` bypass (commit 9bffa34, PR #43478) which skipped pairing for ALL clients regardless of client ID, locality, or Origin header.

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket (sessions_send)
- Relevant config (redacted): `auth.mode: "none"` (default), two agent profiles as siblings

### Steps

1. Configure two agent profiles (`main` and `wren`) as siblings on a single gateway
2. Start gateway with default auth (no auth configured, `auth.mode` resolves to `"none"`)
3. From agent `main`, call `sessions_send(sessionKey="agent:wren:main", message="hello")`

### Expected

- Message is delivered to agent `wren` session

### Actual

- Gateway closes connection with code 1008 and "pairing required" error

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Four new test cases added to `handshake-auth-helpers.test.ts`:
- Backend client + local + no browser origin + authMode "none" -> returns true (bypass allowed)
- Non-backend client + authMode "none" -> returns false (still rejected)
- Remote backend client + authMode "none" -> returns false (still rejected)
- Backend client + browser origin + authMode "none" -> returns false (still rejected)

## Human Verification (required)

- Verified scenarios: All 9 tests pass (5 existing + 4 new). `pnpm build` and `pnpm check` pass cleanly.
- Edge cases checked: Non-backend client, remote client, and browser-origin client are all still rejected even with `authMode: "none"`. Existing shared-secret and device-token paths remain unchanged.
- What you did **not** verify: Live multi-agent gateway setup (requires two running agent profiles).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; the `authMode` parameter is optional so removing it from the call site is sufficient.
- Files/config to restore: `src/gateway/server/ws-connection/handshake-auth-helpers.ts`, `src/gateway/server/ws-connection/message-handler.ts`
- Known bad symptoms reviewers should watch for: Unpaired external clients being able to skip pairing when `auth.mode=none`. The three constraints (backend client ID + loopback + no Origin) should prevent this.

## Risks and Mitigations

- Risk: A non-browser, non-backend local client could theoretically craft a WebSocket connection with `GATEWAY_CLIENT` ID and `BACKEND` mode to bypass pairing when auth is disabled.
  - Mitigation: When `auth.mode=none`, there is no auth to enforce anyway -- the gateway is already configured for open local access. The pairing bypass only affects the device-pairing step, not authorization. Any local process can already connect with `auth.mode=none`.