### PR TITLE
fix(agents): strip poll params from message send action instead of rejecting

### DIFF
--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -339,6 +339,8 @@ describe("runMessageAction context isolation", () => {
     expect(result.kind).toBe("send");
   });
 
+  // LLMs frequently hallucinate poll params on send calls (#41199).
+  // The runner now silently strips them instead of rejecting.
   it.each([
     {
       name: "structured poll params",
@@ -380,14 +382,13 @@ describe("runMessageAction context isolation", () => {
         pollDurationSeconds: -5,
       },
     },
-  ])("rejects send actions that include $name", async ({ actionParams }) => {
-    await expect(
-      runDrySend({
-        cfg: slackConfig,
-        actionParams,
-        toolContext: { currentChannelId: "C12345678" },
-      }),
-    ).rejects.toThrow(/use action "poll" instead of "send"/i);
+  ])("strips $name from send actions and proceeds normally", async ({ actionParams }) => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams,
+      toolContext: { currentChannelId: "C12345678" },
+    });
+    expect(result.kind).toBe("send");
   });
 
   it.each([

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -19,7 +19,7 @@ import {
   getAgentScopedMediaLocalRoots,
   getAgentScopedMediaLocalRootsForSources,
 } from "../../media/local-roots.js";
-import { hasPollCreationParams } from "../../poll-params.js";
+import { hasPollCreationParams, stripPollCreationParams } from "../../poll-params.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -780,8 +780,11 @@ export async function runMessageAction(
     cfg,
   });
 
+  // LLMs frequently hallucinate poll-creation fields when the intended action
+  // is "send".  Instead of rejecting the call, silently strip the stray params
+  // so the send proceeds as the caller intended.  See #41199.
   if (action === "send" && hasPollCreationParams(params)) {
-    throw new Error('Poll fields require action "poll"; use action "poll" instead of "send".');
+    stripPollCreationParams(params);
   }
 
   const gateway = resolveGateway(input);

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { hasPollCreationParams, resolveTelegramPollVisibility } from "./poll-params.js";
+import {
+  hasPollCreationParams,
+  resolveTelegramPollVisibility,
+  stripPollCreationParams,
+} from "./poll-params.js";
 
 describe("poll params", () => {
   it("does not treat explicit false booleans as poll creation params", () => {
@@ -67,5 +71,50 @@ describe("poll params", () => {
     expect(() => resolveTelegramPollVisibility({ pollAnonymous: true, pollPublic: true })).toThrow(
       /mutually exclusive/i,
     );
+  });
+
+  describe("stripPollCreationParams", () => {
+    it("removes all camelCase poll params and preserves other keys", () => {
+      const params: Record<string, unknown> = {
+        channel: "slack",
+        message: "hello",
+        pollQuestion: "Lunch?",
+        pollOption: ["Pizza", "Sushi"],
+        pollMulti: true,
+        pollDurationHours: 1,
+        pollDurationSeconds: 60,
+        pollAnonymous: true,
+        pollPublic: false,
+      };
+      stripPollCreationParams(params);
+      expect(params).toEqual({ channel: "slack", message: "hello" });
+    });
+
+    it("removes snake_case poll params", () => {
+      const params: Record<string, unknown> = {
+        channel: "telegram",
+        poll_question: "Dinner?",
+        poll_option: ["Tacos", "Ramen"],
+        poll_multi: true,
+      };
+      stripPollCreationParams(params);
+      expect(params).toEqual({ channel: "telegram" });
+    });
+
+    it("removes both camelCase and snake_case variants simultaneously", () => {
+      const params: Record<string, unknown> = {
+        message: "test",
+        pollQuestion: "Q?",
+        poll_option: ["A", "B"],
+      };
+      stripPollCreationParams(params);
+      expect(params).toEqual({ message: "test" });
+    });
+
+    it("is a no-op when no poll params are present", () => {
+      const params: Record<string, unknown> = { channel: "slack", message: "hi" };
+      stripPollCreationParams(params);
+      expect(params).toEqual({ channel: "slack", message: "hi" });
+    });
   });
 });

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -1,4 +1,4 @@
-import { readSnakeCaseParamRaw } from "./param-key.js";
+import { readSnakeCaseParamRaw, toSnakeCaseKey } from "./param-key.js";
 
 export type PollCreationParamKind = "string" | "stringArray" | "number" | "boolean";
 
@@ -35,6 +35,21 @@ export const SHARED_POLL_CREATION_PARAM_NAMES = Object.keys(
 export const TELEGRAM_POLL_CREATION_PARAM_NAMES = Object.keys(
   TELEGRAM_POLL_CREATION_PARAM_DEFS,
 ) as TelegramPollCreationParamName[];
+
+/**
+ * Remove all poll-creation params (camelCase and snake_case variants) from a
+ * mutable params object.  LLMs frequently hallucinate poll fields when the
+ * intended action is "send"; stripping them lets the send proceed normally.
+ */
+export function stripPollCreationParams(params: Record<string, unknown>): void {
+  for (const key of POLL_CREATION_PARAM_NAMES) {
+    delete params[key];
+    const snake = toSnakeCaseKey(key);
+    if (snake !== key) {
+      delete params[snake];
+    }
+  }
+}
 
 function readPollParamRaw(params: Record<string, unknown>, key: string): unknown {
   return readSnakeCaseParamRaw(params, key);


### PR DESCRIPTION
## Summary

- Problem: When LLMs call the `message` tool with `action: "send"`, they frequently hallucinate poll-creation params (`pollQuestion`, `pollOption`, etc.), triggering the error `"Poll fields require action "poll"; use action "poll" instead of "send"."`. This breaks agent-to-agent communication across GPT-5.4, Kimi-k2.5, and DeepSeek-reasoner.
- Why it matters: Multi-agent workflows are effectively broken because every major LLM exhibits this behavior and no prompt engineering workaround is reliable.
- What changed: When `action === "send"` and poll-creation params are detected, the runner now silently strips them (both camelCase and snake_case variants) instead of throwing. A new `stripPollCreationParams` helper in `src/poll-params.ts` handles the deletion.
- What did NOT change (scope boundary): Poll validation for `action: "poll"` is untouched. The `hasPollCreationParams` detection logic is unchanged. Part 1 of #41199 (`sessions_send` sessionKey/label conflict) is not addressed here (covered by PR #39551 / #41255).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #41199
- Part 1 is covered by #39551

## User-visible / Behavior Changes

`message` tool calls with `action: "send"` that include stray poll params (e.g. `pollQuestion`, `pollOption`) now succeed instead of failing with an error. The poll params are silently discarded.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.2.0)
- Runtime/container: Node 22+ / Bun
- Model/provider: GPT-5.4, Kimi-k2.5, DeepSeek-reasoner (all reproduce)
- Integration/channel (if any): All messaging channels (Slack, Telegram, etc.)
- Relevant config (redacted): Multi-agent config with `agentToAgent.enabled: true`

### Steps

1. Configure two agents with agent-to-agent communication
2. Instruct agent to send a message using the `message` tool with `action: "send"`
3. Observe that the LLM adds poll params like `pollQuestion`, `pollOption`

### Expected

- Send proceeds normally; poll params are ignored

### Actual

- Before fix: throws `"Poll fields require action "poll"; use action "poll" instead of "send"."`
- After fix: poll params stripped, send succeeds

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Existing tests in `message-action-runner.context.test.ts` previously asserted the throw; they now assert the send proceeds (`result.kind === "send"`). New unit tests in `poll-params.test.ts` verify `stripPollCreationParams` removes camelCase, snake_case, and mixed variants while preserving non-poll keys.

## Human Verification (required)

- Verified scenarios: `pnpm build` passes; `pnpm check` passes; `pnpm test -- src/poll-params.test.ts` (13 tests), `pnpm test -- src/infra/outbound/message-action-runner.poll.test.ts` (6 tests), `pnpm test -- src/infra/outbound/message-action-runner.context.test.ts` (22 tests) all pass.
- Edge cases checked: snake_case variants, mixed camelCase+snake_case in same call, no-op when no poll params present, `false` boolean poll params (already handled by `hasPollCreationParams` returning false).
- What you did **not** verify: Live multi-agent communication with real LLM providers.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; restore the `throw` in `message-action-runner.ts` line 775.
- Files/config to restore: `src/poll-params.ts`, `src/infra/outbound/message-action-runner.ts`
- Known bad symptoms reviewers should watch for: If poll params somehow affect send behavior (they should not, since `handleSendAction` never reads poll params).

## Risks and Mitigations

- Risk: Silently discarding params could mask a genuine user intent to create a poll.
  - Mitigation: The user explicitly set `action: "send"`, so poll intent is contradictory. If the user wanted a poll, they would set `action: "poll"`. The previous behavior of rejecting was worse because it broke all send calls from LLMs that hallucinate optional params.
