### PR TITLE
fix: strip thinking/redacted_thinking blocks before compaction summarization (closes #45558)

### DIFF
--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -5,6 +5,7 @@ import type { AgentCompactionIdentifierPolicy } from "../config/types.agent-defa
 import { retryAsync } from "../infra/retry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
+import { dropThinkingBlocks } from "./pi-embedded-runner/thinking.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
 
 const log = createSubsystemLogger("compaction");
@@ -224,7 +225,9 @@ async function summarizeChunks(params: {
   }
 
   // SECURITY: never feed toolResult.details into summarization prompts.
-  const safeMessages = stripToolResultDetails(params.messages);
+  // Strip thinking/redacted_thinking blocks before summarization — Anthropic rejects
+  // modified thinking blocks, and they carry no semantic value for the summarizer.
+  const safeMessages = dropThinkingBlocks(stripToolResultDetails(params.messages));
   const chunks = chunkMessagesByMaxTokens(safeMessages, params.maxChunkTokens);
   let summary = params.previousSummary;
   const effectiveInstructions = buildCompactionSummarizationInstructions(

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -58,4 +58,21 @@ describe("dropThinkingBlocks", () => {
     const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
     expect(assistant.content).toEqual([{ type: "text", text: "" }]);
   });
+
+  it("drops redacted_thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "opaque-encrypted" },
+          { type: "text", text: "visible" },
+        ],
+      }),
+    ];
+
+    const result = dropThinkingBlocks(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(result).not.toBe(messages);
+    expect(assistant.content).toEqual([{ type: "text", text: "visible" }]);
+  });
 });

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -13,7 +13,8 @@ export function isAssistantMessageWithContent(message: AgentMessage): message is
 }
 
 /**
- * Strip all `type: "thinking"` content blocks from assistant messages.
+ * Strip all `type: "thinking"` and `type: "redacted_thinking"` content blocks
+ * from assistant messages.
  *
  * If an assistant message becomes empty after stripping, it is replaced with
  * a synthetic `{ type: "text", text: "" }` block to preserve turn structure
@@ -33,7 +34,12 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
     const nextContent: AssistantContentBlock[] = [];
     let changed = false;
     for (const block of msg.content) {
-      if (block && typeof block === "object" && (block as { type?: unknown }).type === "thinking") {
+      if (
+        block &&
+        typeof block === "object" &&
+        ((block as { type?: unknown }).type === "thinking" ||
+          (block as { type?: unknown }).type === "redacted_thinking")
+      ) {
         touched = true;
         changed = true;
         continue;


### PR DESCRIPTION
## Summary
- Problem: During session compaction, assistant messages containing `thinking` or `redacted_thinking` content blocks are modified (summarized/trimmed). The Anthropic API rejects this with: "thinking or redacted_thinking blocks in the latest assistant message cannot be modified."
- Why it matters: Compaction failures block LLM responses until the session is reset. Users see raw API error messages. This happens frequently with large sessions and adaptive thinking enabled (claude-opus-4-6, claude-sonnet-4-6).
- What changed: (1) `dropThinkingBlocks` now strips both `thinking` and `redacted_thinking` blocks from assistant messages. (2) The compaction summarizer calls `dropThinkingBlocks` before feeding messages to the LLM, ensuring thinking blocks never enter the compacted transcript.
- What did NOT change (scope boundary): The existing send-time thinking block stripping in `transcript-policy.ts` is unchanged. Tool result stripping and other compaction logic is unchanged.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #45558

## User-visible / Behavior Changes
Compaction no longer fails when assistant messages contain thinking or redacted_thinking blocks. Sessions with adaptive thinking enabled can compact without API rejection errors.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Use claude-opus-4-6 with `thinking=adaptive`
2. Build up a large session to trigger compaction
3. Compaction summarizes assistant messages with thinking blocks
### Expected
- Compaction succeeds; thinking blocks are stripped before summarization
### Actual (before fix)
- Anthropic API rejects the request: "thinking or redacted_thinking blocks cannot be modified"

## Evidence
- [x] Failing test/log before + passing after
- All 15 thinking + compaction tests pass, including new test for `redacted_thinking` block stripping

## Human Verification
- Verified scenarios: pnpm format:fix + oxlint + pnpm tsgo + vitest all passing; reviewed diff matches issue description
- Edge cases checked: `redacted_thinking` blocks (opaque encrypted content) also stripped; assistant messages that are all-thinking get placeholder text block to preserve turn structure
- What you did NOT verify: runtime end-to-end testing with actual Anthropic adaptive thinking session

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None