### PR TITLE
fix: move Azure OpenAI api-version from header to URL query param (closes #46676)

### DIFF
--- a/src/agents/pi-embedded-runner/model.provider-normalization.ts
+++ b/src/agents/pi-embedded-runner/model.provider-normalization.ts
@@ -73,6 +73,68 @@ function normalizeOpenAITransport(params: { provider: string; model: Model<Api> 
   } as Model<Api>;
 }
 
+/**
+ * Azure OpenAI requires `api-version` as a URL query parameter, not a header.
+ * When the base URL targets Azure (*.openai.azure.com) and the model headers
+ * contain `api-version`, move it from headers to a query parameter on the URL.
+ */
+function normalizeAzureApiVersion(model: Model<Api>): Model<Api> {
+  const baseUrl = model.baseUrl?.trim();
+  if (!baseUrl) {
+    return model;
+  }
+
+  let isAzure: boolean;
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    isAzure = hostname.endsWith(".openai.azure.com") || hostname.endsWith(".services.ai.azure.com");
+  } catch {
+    const lower = baseUrl.toLowerCase();
+    isAzure = lower.includes(".openai.azure.com") || lower.includes(".services.ai.azure.com");
+  }
+  if (!isAzure) {
+    return model;
+  }
+
+  const headers = (model as unknown as { headers?: Record<string, string> }).headers;
+  if (!headers) {
+    return model;
+  }
+
+  const versionKey = Object.keys(headers).find((k) => k.toLowerCase() === "api-version");
+  if (!versionKey) {
+    return model;
+  }
+
+  const versionValue = String(headers[versionKey] ?? "").trim();
+  if (!versionValue) {
+    return model;
+  }
+
+  // Append api-version as a query param to the base URL.
+  let nextBaseUrl: string;
+  try {
+    const url = new URL(baseUrl);
+    if (!url.searchParams.has("api-version")) {
+      url.searchParams.set("api-version", versionValue);
+    }
+    nextBaseUrl = url.toString();
+  } catch {
+    // Fallback: simple string append.
+    const separator = baseUrl.includes("?") ? "&" : "?";
+    nextBaseUrl = `${baseUrl}${separator}api-version=${encodeURIComponent(versionValue)}`;
+  }
+
+  // Remove api-version from headers.
+  const { [versionKey]: _removed, ...remainingHeaders } = headers;
+
+  return {
+    ...model,
+    baseUrl: nextBaseUrl,
+    headers: Object.keys(remainingHeaders).length > 0 ? remainingHeaders : undefined,
+  } as Model<Api>;
+}
+
 export function normalizeResolvedProviderModel(params: {
   provider: string;
   model: Model<Api>;
@@ -82,5 +144,6 @@ export function normalizeResolvedProviderModel(params: {
     provider: params.provider,
     model: normalizedOpenAI,
   });
-  return normalizeModelCompat(normalizedCodex);
+  const normalizedAzure = normalizeAzureApiVersion(normalizedCodex);
+  return normalizeModelCompat(normalizedAzure);
 }

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1024,6 +1024,32 @@ describe("resolveModel", () => {
     });
   });
 
+  it("moves api-version header to query param for Azure OpenAI URLs", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "azure-gpt53-chat": {
+            baseUrl: "https://my-resource.openai.azure.com/openai/deployments/gpt-5.3-chat",
+            api: "openai-completions",
+            headers: {
+              "api-version": "2024-12-01-preview",
+              "api-key": "test-key",
+            },
+            models: [makeModel("gpt-5.3-chat")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("azure-gpt53-chat", "gpt-5.3-chat", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.baseUrl).toContain("api-version=2024-12-01-preview");
+    const headers = (result.model as unknown as { headers?: Record<string, string> }).headers;
+    expect(headers?.["api-version"]).toBeUndefined();
+    expect(headers?.["api-key"]).toBe("test-key");
+  });
+
   it("does not override when no provider config exists", () => {
     mockDiscoveredModel({
       provider: "anthropic",


### PR DESCRIPTION
## Summary
- Problem: Azure OpenAI requires `api-version` as a URL query parameter, but the runtime sends it as an HTTP header (from user config), causing 404 errors
- Why it matters: All Azure OpenAI requests fail with 404 even though onboarding succeeds (onboard probe correctly uses query param)
- What changed: Added `normalizeAzureApiVersion` in `model.provider-normalization.ts` that detects Azure OpenAI base URLs (`*.openai.azure.com`) and moves `api-version` from headers to a URL query parameter
- What did NOT change (scope boundary): No changes to onboarding, config schema, or non-Azure providers

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #46676

## User-visible / Behavior Changes
Azure OpenAI provider requests now correctly include `api-version` as a URL query parameter instead of a header, resolving 404 errors.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same request, different param placement)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure an Azure OpenAI provider with `headers: { "api-version": "2024-12-01-preview" }`
2. Send a chat completion request
### Expected
- Request URL includes `?api-version=2024-12-01-preview` as query param
### Actual
- `api-version` sent as header, Azure returns 404

## Evidence
- [x] Failing test/log before + passing after
- Added test: "moves api-version header to query param for Azure OpenAI URLs" — all 46 model tests pass

## Human Verification
- Verified scenarios: pnpm tsgo passing; 46/46 model tests passing; reviewed diff matches issue description
- Edge cases checked: Non-Azure URLs unaffected; URL already containing query params handled correctly; missing api-version header is a no-op
- What you did NOT verify: runtime end-to-end testing with actual Azure OpenAI service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes — users with api-version in headers will have it automatically moved to query param
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None